### PR TITLE
default artist view change

### DIFF
--- a/src/views/ArtistDetails.vue
+++ b/src/views/ArtistDetails.vue
@@ -7,12 +7,13 @@
       grow
       hide-slider
     >
+      <v-tab value="albums">
+        {{ $t("albums") }}
+      </v-tab>  
       <v-tab value="tracks">
         {{ $t("tracks") }}
       </v-tab>
-      <v-tab value="albums">
-        {{ $t("albums") }}
-      </v-tab>
+      
     </v-tabs>
     <v-divider />
     <ItemsListing
@@ -67,7 +68,7 @@ const itemDetails = ref<Artist>();
 
 const loadItemDetails = async function () {
   itemDetails.value = await api.getArtist(props.itemId, props.provider);
-  activeTab.value = "tracks";
+  activeTab.value = "albums";
 };
 
 


### PR DESCRIPTION
https://github.com/orgs/music-assistant/projects/2/views/1?pane=issue&itemId=24019153

Changed order and default view of tabs in artist view:
Previous:
Tracks | Albums -> Tracks as defult
New:
Albums | Tracks -> Albums as default
