### PR TITLE
Small refactor of theme colors

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -4,67 +4,11 @@
 
 <script setup lang="ts">
 import { api } from './plugins/api';
-import { computed, onMounted, watch } from 'vue';
+import { onMounted } from 'vue';
 import { useTheme } from 'vuetify';
 import { store } from './plugins/store';
-import { ColorCoverPalette, getContrastingTextColor } from '@/helpers/utils';
 
 const theme = useTheme();
-let lightTheme = theme.themes.value.light;
-let darkTheme = theme.themes.value.dark;
-
-const themeColor = function (colors: ColorCoverPalette) {
-  lightTheme.colors['primary'] = colors.lightColor || '#03a9f4';
-  lightTheme.colors['on-primary'] = getContrastingTextColor(colors.lightColor) || '#fff';
-  lightTheme.colors['secondary'] = colors.darkColor || '#ff9800';
-  lightTheme.colors['on-secondary'] = getContrastingTextColor(colors.darkColor) || '#fff';
-  lightTheme.variables['medium-emphasis-opacity'] = 1;
-
-  darkTheme.colors['primary'] = colors.darkColor || '#0288d1';
-  darkTheme.colors['on-primary'] = getContrastingTextColor(colors.darkColor) || '#fff';
-  darkTheme.colors['secondary'] = colors.lightColor || '#ff9800';
-  darkTheme.colors['on-secondary'] = getContrastingTextColor(colors.lightColor) || '#fff';
-  darkTheme.variables['medium-emphasis-opacity'] = 1;
-};
-
-// computed properties
-const activePlayerQueue = computed(() => {
-  if (store.selectedPlayer) {
-    return api.queues[store.selectedPlayer.active_source];
-  }
-  return undefined;
-});
-const curQueueItem = computed(() => {
-  if (activePlayerQueue.value) return activePlayerQueue.value.current_item;
-  return undefined;
-});
-
-//functions
-function changeThemeColor() {
-  if (!curQueueItem.value) {
-    themeColor({
-      lightColor: '',
-      darkColor: '',
-    });
-  } else {
-    themeColor(store.coverImageColorCode);
-  }
-}
-
-// watchers
-watch(
-  () => activePlayerQueue.value?.display_name,
-  () => {
-    changeThemeColor();
-  },
-);
-
-watch(
-  () => store.coverImageColorCode,
-  () => {
-    changeThemeColor();
-  },
-);
 
 onMounted(() => {
   // @ts-ignore

--- a/src/components/ItemsListing.vue
+++ b/src/components/ItemsListing.vue
@@ -282,39 +282,39 @@ const toggleSearch = function () {
 };
 
 const panelViewItemResponsive = function (displaySize: number) {
-  if (getBreakpointValue({ breakpoint: 'bp1', condition: 'lt', offset: store.sizeNavigationMenu })) {
+  if (getBreakpointValue({ breakpoint: 'bp1', condition: 'lt', offset: store.navigationMenuSize })) {
     return 2;
   } else if (
-    getBreakpointValue({ breakpoint: 'bp1', condition: 'gt', offset: store.sizeNavigationMenu }) &&
-    getBreakpointValue({ breakpoint: 'bp4', condition: 'lt', offset: store.sizeNavigationMenu })
+    getBreakpointValue({ breakpoint: 'bp1', condition: 'gt', offset: store.navigationMenuSize }) &&
+    getBreakpointValue({ breakpoint: 'bp4', condition: 'lt', offset: store.navigationMenuSize })
   ) {
     return 3;
   } else if (
-    getBreakpointValue({ breakpoint: 'bp4', condition: 'gt', offset: store.sizeNavigationMenu }) &&
-    getBreakpointValue({ breakpoint: 'bp6', condition: 'lt', offset: store.sizeNavigationMenu })
+    getBreakpointValue({ breakpoint: 'bp4', condition: 'gt', offset: store.navigationMenuSize }) &&
+    getBreakpointValue({ breakpoint: 'bp6', condition: 'lt', offset: store.navigationMenuSize })
   ) {
     return 4;
   } else if (
-    getBreakpointValue({ breakpoint: 'bp6', condition: 'gt', offset: store.sizeNavigationMenu }) &&
-    getBreakpointValue({ breakpoint: 'bp7', condition: 'lt', offset: store.sizeNavigationMenu })
+    getBreakpointValue({ breakpoint: 'bp6', condition: 'gt', offset: store.navigationMenuSize }) &&
+    getBreakpointValue({ breakpoint: 'bp7', condition: 'lt', offset: store.navigationMenuSize })
   ) {
     return 5;
   } else if (
-    getBreakpointValue({ breakpoint: 'bp7', condition: 'gt', offset: store.sizeNavigationMenu }) &&
-    getBreakpointValue({ breakpoint: 'bp8', condition: 'lt', offset: store.sizeNavigationMenu })
+    getBreakpointValue({ breakpoint: 'bp7', condition: 'gt', offset: store.navigationMenuSize }) &&
+    getBreakpointValue({ breakpoint: 'bp8', condition: 'lt', offset: store.navigationMenuSize })
   ) {
     return 6;
   } else if (
-    getBreakpointValue({ breakpoint: 'bp8', condition: 'gt', offset: store.sizeNavigationMenu }) &&
-    getBreakpointValue({ breakpoint: 'bp9', condition: 'lt', offset: store.sizeNavigationMenu })
+    getBreakpointValue({ breakpoint: 'bp8', condition: 'gt', offset: store.navigationMenuSize }) &&
+    getBreakpointValue({ breakpoint: 'bp9', condition: 'lt', offset: store.navigationMenuSize })
   ) {
     return 7;
   } else if (
-    getBreakpointValue({ breakpoint: 'bp9', condition: 'gt', offset: store.sizeNavigationMenu }) &&
-    getBreakpointValue({ breakpoint: 'bp10', condition: 'lt', offset: store.sizeNavigationMenu })
+    getBreakpointValue({ breakpoint: 'bp9', condition: 'gt', offset: store.navigationMenuSize }) &&
+    getBreakpointValue({ breakpoint: 'bp10', condition: 'lt', offset: store.navigationMenuSize })
   ) {
     return 8;
-  } else if (getBreakpointValue({ breakpoint: 'bp10', condition: 'gt', offset: store.sizeNavigationMenu })) {
+  } else if (getBreakpointValue({ breakpoint: 'bp10', condition: 'gt', offset: store.navigationMenuSize })) {
     return 9;
   } else {
     return 0;

--- a/src/components/ItemsListing.vue
+++ b/src/components/ItemsListing.vue
@@ -5,33 +5,59 @@
     <v-toolbar color="transparent">
       <template #title>
         {{ title }}
-        <v-badge v-if="getBreakpointValue('bp11')" color="grey"
-          :content="selectedItems.length ? `${selectedItems.length}/${totalItems}` : totalItems" inline />
+        <v-badge
+          v-if="getBreakpointValue('bp11')"
+          color="grey"
+          :content="selectedItems.length ? `${selectedItems.length}/${totalItems}` : totalItems"
+          inline
+        />
       </template>
 
       <template #append>
         <!-- toggle select button -->
-        <Button v-if="showSelectButton != undefined ? showSelectButton : getBreakpointValue('bp1')" v-bind="props"
-          variant="list" :title="$t('tooltip.select_items')" :disabled="!expanded" @click="toggleCheckboxes"><v-icon
-            :icon="showCheckboxes ? 'mdi-checkbox-multiple-outline' : 'mdi-checkbox-multiple-blank-outline'" /></Button>
+        <Button
+          v-if="showSelectButton != undefined ? showSelectButton : getBreakpointValue('bp1')"
+          v-bind="props"
+          variant="list"
+          :title="$t('tooltip.select_items')"
+          :disabled="!expanded"
+          @click="toggleCheckboxes"
+          ><v-icon :icon="showCheckboxes ? 'mdi-checkbox-multiple-outline' : 'mdi-checkbox-multiple-blank-outline'"
+        /></Button>
 
         <!-- favorites only filter -->
-        <Button v-if="showFavoritesOnlyFilter != undefined ? showFavoritesOnlyFilter : getBreakpointValue('bp1')"
-          v-bind="props" variant="list" :title="$t('tooltip.filter_favorites')" :disabled="!expanded"
-          @click="toggleFavoriteFilter">
+        <Button
+          v-if="showFavoritesOnlyFilter != undefined ? showFavoritesOnlyFilter : getBreakpointValue('bp1')"
+          v-bind="props"
+          variant="list"
+          :title="$t('tooltip.filter_favorites')"
+          :disabled="!expanded"
+          @click="toggleFavoriteFilter"
+        >
           <v-icon :icon="favoritesOnly ? 'mdi-heart' : 'mdi-heart-outline'" />
         </Button>
 
         <!-- album artists only filter -->
-        <Button v-if="showAlbumArtistsOnlyFilter" v-bind="props" variant="list" :title="$t('tooltip.album_artist_filter')"
-          :disabled="!expanded" @click="toggleAlbumArtistsFilter">
+        <Button
+          v-if="showAlbumArtistsOnlyFilter"
+          v-bind="props"
+          variant="list"
+          :title="$t('tooltip.album_artist_filter')"
+          :disabled="!expanded"
+          @click="toggleAlbumArtistsFilter"
+        >
           <v-icon :icon="albumArtistsOnlyFilter ? 'mdi-account-music' : 'mdi-account-music-outline'" />
         </Button>
 
         <!-- refresh button-->
-        <Button v-if="showRefreshButton != undefined ? showRefreshButton : getBreakpointValue('bp1')" v-bind="props"
-          variant="list" :title="updateAvailable ? $t('tooltip.refresh_new_content') : $t('tooltip.refresh')"
-          :disabled="!expanded || loading" @click="onRefreshClicked()">
+        <Button
+          v-if="showRefreshButton != undefined ? showRefreshButton : getBreakpointValue('bp1')"
+          v-bind="props"
+          variant="list"
+          :title="updateAvailable ? $t('tooltip.refresh_new_content') : $t('tooltip.refresh')"
+          :disabled="!expanded || loading"
+          @click="onRefreshClicked()"
+        >
           <v-badge :model-value="updateAvailable" color="error" dot>
             <v-icon icon="mdi-refresh" />
           </v-badge>
@@ -60,14 +86,26 @@
         </v-menu>
 
         <!-- toggle search button -->
-        <Button v-if="showSearchButton != undefined ? showSearchButton : getBreakpointValue('bp1')" v-bind="props"
-          variant="list" :title="$t('tooltip.search')" :disabled="!expanded" @click="toggleSearch()">
+        <Button
+          v-if="showSearchButton != undefined ? showSearchButton : getBreakpointValue('bp1')"
+          v-bind="props"
+          variant="list"
+          :title="$t('tooltip.search')"
+          :disabled="!expanded"
+          @click="toggleSearch()"
+        >
           <v-icon icon="mdi-magnify" />
         </Button>
 
         <!-- toggle view mode button -->
-        <Button v-bind="props" variant="list" :title="$t('tooltip.toggle_view_mode')" :disabled="!expanded"
-          @click="toggleViewMode()"><v-icon :icon="viewMode == 'panel' ? 'mdi-view-list' : 'mdi-grid'" /></Button>
+        <Button
+          v-bind="props"
+          variant="list"
+          :title="$t('tooltip.toggle_view_mode')"
+          :disabled="!expanded"
+          @click="toggleViewMode()"
+          ><v-icon :icon="viewMode == 'panel' ? 'mdi-view-list' : 'mdi-grid'"
+        /></Button>
 
         <!-- provider filter dropdown -->
         <v-menu v-if="providerFilter && providerFilter.length > 1" location="bottom end" :close-on-content-click="true">
@@ -105,9 +143,13 @@
             </Button>
           </template>
           <v-list>
-            <ListItem v-for="(item, index) in contextMenuItems.filter((x) => x.hide != true)" :key="index"
-              :title="$t(item.label, item.labelArgs)" :disabled="item.disabled == true"
-              @click="item.action ? item.action() : ''">
+            <ListItem
+              v-for="(item, index) in contextMenuItems.filter((x) => x.hide != true)"
+              :key="index"
+              :title="$t(item.label, item.labelArgs)"
+              :disabled="item.disabled == true"
+              @click="item.action ? item.action() : ''"
+            >
               <template #prepend>
                 <v-avatar :icon="item.icon" />
               </template>
@@ -116,36 +158,70 @@
         </v-menu>
 
         <!-- expand/collapse button -->
-        <Button v-if="allowCollapse" variant="list" :title="$t('tooltip.collapse_expand')" @click="toggleExpand"><v-icon
-            :icon="expanded ? 'mdi-chevron-up' : 'mdi-chevron-down'" /></Button>
+        <Button v-if="allowCollapse" variant="list" :title="$t('tooltip.collapse_expand')" @click="toggleExpand"
+          ><v-icon :icon="expanded ? 'mdi-chevron-up' : 'mdi-chevron-down'"
+        /></Button>
       </template>
     </v-toolbar>
     <v-divider />
 
-    <v-text-field v-if="showSearch && expanded" id="searchInput" v-model="search" clearable
-      prepend-inner-icon="mdi-magnify" :label="$t('search')" hide-details variant="filled"
-      style="width: auto; margin-top: 10px" @focus="searchHasFocus = true" @blur="searchHasFocus = false" />
+    <v-text-field
+      v-if="showSearch && expanded"
+      id="searchInput"
+      v-model="search"
+      clearable
+      prepend-inner-icon="mdi-magnify"
+      :label="$t('search')"
+      hide-details
+      variant="filled"
+      style="width: auto; margin-top: 10px"
+      @focus="searchHasFocus = true"
+      @blur="searchHasFocus = false"
+    />
     <Container v-if="expanded" :variant="viewMode == 'panel' ? 'panel' : 'default'">
       <!-- loading animation -->
       <v-progress-linear v-if="loading" indeterminate />
 
       <!-- panel view -->
       <v-row v-if="viewMode == 'panel'">
-        <v-col v-for="item in allItems" :key="item.uri" :class="`col-${panelViewItemResponsive($vuetify.display.width)}`">
-          <PanelviewItem :item="item" :is-selected="isSelected(item)" :show-checkboxes="showCheckboxes"
-            :show-track-number="showTrackNumber" @select="onSelect" @menu="onMenu" @click="onClick" />
+        <v-col
+          v-for="item in allItems"
+          :key="item.uri"
+          :class="`col-${panelViewItemResponsive($vuetify.display.width)}`"
+        >
+          <PanelviewItem
+            :item="item"
+            :is-selected="isSelected(item)"
+            :show-checkboxes="showCheckboxes"
+            :show-track-number="showTrackNumber"
+            @select="onSelect"
+            @menu="onMenu"
+            @click="onClick"
+          />
         </v-col>
       </v-row>
 
       <!-- list view -->
-      <v-virtual-scroll :height="70" :items="allItems" v-if="viewMode == 'list'" style="height:100%;">
-        <template v-slot:default="{ item }">
-          <ListviewItem :item="item" :show-track-number="showTrackNumber" :show-disc-number="showTrackNumber"
-            :show-duration="showDuration" :show-favorite="showFavoritesOnlyFilter" :show-menu="showMenu"
-            :show-provider="showProvider" :show-album="showAlbum" :show-checkboxes="showCheckboxes"
-            :is-selected="isSelected(item)" :show-details="itemtype.includes('versions')" :parent-item="parentItem"
-            :context-menu-items="showMenu ? getContextMenuItems([item], parentItem) : []" @select="onSelect"
-            @menu="onMenu" @click="onClick" />
+      <v-virtual-scroll v-if="viewMode == 'list'" :height="70" :items="allItems" style="height: 100%">
+        <template #default="{ item }">
+          <ListviewItem
+            :item="item"
+            :show-track-number="showTrackNumber"
+            :show-disc-number="showTrackNumber"
+            :show-duration="showDuration"
+            :show-favorite="showFavoritesOnlyFilter"
+            :show-menu="showMenu"
+            :show-provider="showProvider"
+            :show-album="showAlbum"
+            :show-checkboxes="showCheckboxes"
+            :is-selected="isSelected(item)"
+            :show-details="itemtype.includes('versions')"
+            :parent-item="parentItem"
+            :context-menu-items="showMenu ? getContextMenuItems([item], parentItem) : []"
+            @select="onSelect"
+            @menu="onMenu"
+            @click="onClick"
+          />
         </template>
       </v-virtual-scroll>
 
@@ -612,7 +688,7 @@ export const filteredItems = function (
   }
   // sort
   if (params.sortBy == 'name') {
-    result.sort((a, b) => (a.sort_name).localeCompare(b.sort_name));
+    result.sort((a, b) => a.sort_name.localeCompare(b.sort_name));
   }
   if (params.sortBy == 'album') {
     result.sort((a, b) => (a as Track).album?.sort_name.localeCompare((b as Track).album?.sort_name));
@@ -665,7 +741,7 @@ export const filteredItems = function (
 </script>
 
 <style>
-.v-toolbar>.v-toolbar__content>.v-toolbar__append {
+.v-toolbar > .v-toolbar__content > .v-toolbar__append {
   margin-right: 5px;
 }
 </style>

--- a/src/components/MediaItemThumb.vue
+++ b/src/components/MediaItemThumb.vue
@@ -57,9 +57,8 @@ const theme = useTheme();
 const fallbackImage = computed(() => {
   if (props.fallback) return props.fallback;
   if (!props.item) return '';
-  return getAvatarImage(props.item.name, theme.current.value.dark, thumbSize.value)
+  return getAvatarImage(props.item.name, theme.current.value.dark, thumbSize.value);
 });
-
 
 const thumbSize = computed(() => {
   if (typeof props.size == 'number') return props.size;
@@ -87,18 +86,12 @@ watch(
 <script lang="ts">
 //// utility functions for images
 
-export const getAvatarImage = function (name: string, dark = false, size = 256) : string {
+export const getAvatarImage = function (name: string, dark = false, size = 256): string {
   // get url to avatar image for a string or sentence
   if (dark)
-    return `https://ui-avatars.com/api/?name=${name}&size=${
-      size || 256
-    }&bold=true&background=1d1d1d&color=383838`;
-  else
-    return `https://ui-avatars.com/api/?name=${name}&size=${
-      size || 256
-    }&bold=true&background=a0a0a0&color=cccccc`;
-
-}
+    return `https://ui-avatars.com/api/?name=${name}&size=${size || 256}&bold=true&background=1d1d1d&color=383838`;
+  else return `https://ui-avatars.com/api/?name=${name}&size=${size || 256}&bold=true&background=a0a0a0&color=cccccc`;
+};
 
 export const getMediaItemImage = function (
   mediaItem?: MediaItemType | ItemMapping | QueueItem,

--- a/src/components/PanelviewItem.vue
+++ b/src/components/PanelviewItem.vue
@@ -119,7 +119,7 @@ const emit = defineEmits<{
   height: 100%;
   padding: 10px;
   border: none;
-  border-style: none !important
+  border-style: none !important;
 }
 
 .panel-item-checkbox {

--- a/src/helpers/utils.ts
+++ b/src/helpers/utils.ts
@@ -279,7 +279,7 @@ export function darkenBrightColors(color: string, thresholdBrightness = 100, col
   return color;
 }
 
-export function getColorCode(img: HTMLImageElement): ColorCoverPalette {
+export function getColorPalette(img: HTMLImageElement): ColorCoverPalette {
   const colorThief = new ColorThief();
   const colorNumberPalette: RGBColor[] = colorThief.getPalette(img, 5);
   const colorHexPalette: string[] = colorNumberPalette.map((color) => rgbToHex(color));

--- a/src/layouts/default/BottomNavigation.vue
+++ b/src/layouts/default/BottomNavigation.vue
@@ -1,7 +1,7 @@
 <template>
   <v-bottom-navigation height="80" grow>
     <v-tabs stacked :show-arrows="false" :model-value="activeTab" center-active nav color="accent">
-      <v-tab v-for="menuItem of mainMenuItems" :to="menuItem.path" :value="menuItem.path" :key="menuItem.path">
+      <v-tab v-for="menuItem of mainMenuItems" :key="menuItem.path" :to="menuItem.path" :value="menuItem.path">
         <v-icon size="xx-large">{{ menuItem.icon }}</v-icon>
         <span class="menuButton">{{ $t(menuItem.label) }}</span>
       </v-tab>
@@ -25,9 +25,8 @@ const activeTab = computed(() => {
       return menuItem.path;
     }
   }
-  return ""
+  return '';
 });
-
 </script>
 
 <style>

--- a/src/layouts/default/DrawerNavigation.vue
+++ b/src/layouts/default/DrawerNavigation.vue
@@ -54,7 +54,7 @@ const showLogo = computed(() => {
 watch(
   () => showNavigationMenu.value,
   (isShown) => {
-    isShown ? (store.sizeNavigationMenu = !getBreakpointValue('mobile') ? 200 : 250) : (store.sizeNavigationMenu = 55);
+    isShown ? (store.navigationMenuSize = !getBreakpointValue('mobile') ? 200 : 250) : (store.navigationMenuSize = 55);
   },
 );
 

--- a/src/layouts/default/DrawerNavigation.vue
+++ b/src/layouts/default/DrawerNavigation.vue
@@ -1,37 +1,68 @@
 <template>
-  <v-navigation-drawer v-if="getBreakpointValue({ breakpoint: 'bp3' })" ref="resizeComponent" app
-    :permanent="!$vuetify.display.mobile" :rail="!$vuetify.display.mobile && !showNavigationMenu"
+  <v-navigation-drawer
+    v-if="getBreakpointValue({ breakpoint: 'bp3' })"
+    ref="resizeComponent"
+    app
+    :permanent="!$vuetify.display.mobile"
+    :rail="!$vuetify.display.mobile && !showNavigationMenu"
     :model-value="($vuetify.display.mobile && showNavigationMenu) || !$vuetify.display.mobile"
-    :width="!getBreakpointValue('mobile') ? 200 : 250" @update:model-value="(e) => {
-      if ($vuetify.display.mobile) showNavigationMenu = e;
-    }
-      ">
-
-    <v-list-item dark style="height: 52px;" :active="false">
-      <template #prepend v-if="showLogo">
-        <img class="logo_icon" :style="$vuetify.theme.current.dark ? 'filter: invert(100%);' : ''" width="35"
-          src="@/assets/logo.svg" />
+    :width="!getBreakpointValue('mobile') ? 200 : 250"
+    @update:model-value="
+      (e) => {
+        if ($vuetify.display.mobile) showNavigationMenu = e;
+      }
+    "
+  >
+    <v-list-item dark style="height: 52px" :active="false">
+      <template v-if="showLogo" #prepend>
+        <img
+          class="logo_icon"
+          :style="$vuetify.theme.current.dark ? 'filter: invert(100%);' : ''"
+          width="35"
+          src="@/assets/logo.svg"
+        />
       </template>
-      <template #title v-if="showLogo">
-        <div class="logo_text">Music
-          Assistant</div>
+      <template v-if="showLogo" #title>
+        <div class="logo_text">Music Assistant</div>
       </template>
     </v-list-item>
     <!-- back button -->
     <!-- NOTE: we only allow/show the back button at one of the nested levels (item details) -->
-    <Button v-if="showBackButton" :height="15" :width="40" style="position: absolute; right: 4px;top: 14px;"
-      @click.stop="router.go(-1)" icon="mdi-arrow-left" :title="$t('tooltip.back')" />
+    <Button
+      v-if="showBackButton"
+      :height="15"
+      :width="40"
+      style="position: absolute; right: 4px; top: 14px"
+      icon="mdi-arrow-left"
+      :title="$t('tooltip.back')"
+      @click.stop="router.go(-1)"
+    />
     <v-divider />
 
     <!-- menu items -->
     <v-list lines="one" density="compact" nav>
-      <v-list-item v-for="menuItem of mainMenuItems" :key="menuItem.path" nav density="compact" :height="15"
-        :title="$t(menuItem.label)" :prepend-icon="menuItem.icon" :to="menuItem.path" />
+      <v-list-item
+        v-for="menuItem of mainMenuItems"
+        :key="menuItem.path"
+        nav
+        density="compact"
+        :height="15"
+        :title="$t(menuItem.label)"
+        :prepend-icon="menuItem.icon"
+        :to="menuItem.path"
+      />
     </v-list>
     <!-- button at bottom to collapse/expand the navigation drawer-->
-    <Button nav :height="15" :width="40" style="position: relative; float: right;right: 10px;top: 20px;" :ripple="false"
-      :icon="showNavigationMenu ? 'mdi-chevron-left' : 'mdi-chevron-right'" :title="$t('tooltip.show_menu')"
-      @click.stop="showNavigationMenu = !showNavigationMenu" />
+    <Button
+      nav
+      :height="15"
+      :width="40"
+      style="position: relative; float: right; right: 10px; top: 20px"
+      :ripple="false"
+      :icon="showNavigationMenu ? 'mdi-chevron-left' : 'mdi-chevron-right'"
+      :title="$t('tooltip.show_menu')"
+      @click.stop="showNavigationMenu = !showNavigationMenu"
+    />
   </v-navigation-drawer>
 </template>
 
@@ -45,7 +76,9 @@ import router from '@/plugins/router';
 const showNavigationMenu = ref(false);
 
 const showBackButton = computed(() => {
-  return store.prevRoutes.length > 0 && backButtonAllowedRouteNames.includes(router.currentRoute.value.name!.toString())
+  return (
+    store.prevRoutes.length > 0 && backButtonAllowedRouteNames.includes(router.currentRoute.value.name!.toString())
+  );
 });
 const showLogo = computed(() => {
   return !(showBackButton.value && !showNavigationMenu.value);
@@ -57,11 +90,20 @@ watch(
     isShown ? (store.navigationMenuSize = !getBreakpointValue('mobile') ? 200 : 250) : (store.navigationMenuSize = 55);
   },
 );
-
 </script>
 
 <script lang="ts">
-export const backButtonAllowedRouteNames = ["track", "artist", "album", "playlist", "radio", "addprovider", "editprovider", "editplayer", "editcore"]
+export const backButtonAllowedRouteNames = [
+  'track',
+  'artist',
+  'album',
+  'playlist',
+  'radio',
+  'addprovider',
+  'editprovider',
+  'editplayer',
+  'editcore',
+];
 
 export interface MenuItem {
   label: string;
@@ -124,7 +166,7 @@ export const mainMenuItems: MenuItem[] = [
   margin-left: 10px;
   font-family: 'JetBrains Mono Medium';
   font-size: 55;
-  font-weight: 500
+  font-weight: 500;
 }
 
 .logo_icon {

--- a/src/layouts/default/Footer.vue
+++ b/src/layouts/default/Footer.vue
@@ -13,7 +13,7 @@
     app
     :dark="true"
   >
-  <Player />
+    <Player />
   </v-footer>
 </template>
 

--- a/src/layouts/default/PlayerOSD/Player.vue
+++ b/src/layouts/default/PlayerOSD/Player.vue
@@ -9,7 +9,7 @@
     }px;`">
     <div :class="`mediacontrols-left-${getBreakpointValue('bp3') ? '1' : '2'}`">
       <PlayerTrackDetails :show-quality-details-btn="getBreakpointValue('bp7') ? true : false" :show-only-artist="true" :color-palette="coverImageColorPalette"
-        :color="!$vuetify.theme.current.dark && getBreakpointValue({ breakpoint: 'bp3', condition: 'lt' })
+        :primary-color="!$vuetify.theme.current.dark && getBreakpointValue({ breakpoint: 'bp3', condition: 'lt' })
             ? '#fff'
             : $vuetify.theme.current.dark && getBreakpointValue({ breakpoint: 'bp3', condition: 'gt' })
               ? '#fff'

--- a/src/layouts/default/PlayerOSD/Player.vue
+++ b/src/layouts/default/PlayerOSD/Player.vue
@@ -1,84 +1,112 @@
 <template>
-  <div v-if="primaryCoverImageColor" :class="`mediacontrols-bg-${getBreakpointValue('bp3') ? '1' : '2'}`" :style="`background: linear-gradient(90deg, ${primaryCoverImageColor}${$vuetify.theme.current.dark ? '4D' : 'B3'
-    } 0%, ${primaryCoverImageColor}00 100%);`"></div>
-  <PlayerTimeline v-breakpoint="{ breakpoint: 'bp3', condition: 'lt' }"
+  <div
+    v-if="primaryCoverImageColor"
+    :class="`mediacontrols-bg-${getBreakpointValue('bp3') ? '1' : '2'}`"
+    :style="`background: linear-gradient(90deg, ${primaryCoverImageColor}${
+      $vuetify.theme.current.dark ? '4D' : 'B3'
+    } 0%, ${primaryCoverImageColor}00 100%);`"
+  ></div>
+  <PlayerTimeline
+    v-breakpoint="{ breakpoint: 'bp3', condition: 'lt' }"
     :color="$vuetify.theme.current.dark ? coverImageColorPalette.lightColor : coverImageColorPalette.darkColor"
-    :is-progress-bar="true" />
+    :is-progress-bar="true"
+  />
 
-  <div class="mediacontrols" :style="`padding: ${getBreakpointValue({ breakpoint: 'phone' }) ? 3 : 10}px ${getBreakpointValue({ breakpoint: 'phone' }) ? 10 : 10
-    }px;`">
+  <div
+    class="mediacontrols"
+    :style="`padding: ${getBreakpointValue({ breakpoint: 'phone' }) ? 3 : 10}px ${
+      getBreakpointValue({ breakpoint: 'phone' }) ? 10 : 10
+    }px;`"
+  >
     <div :class="`mediacontrols-left-${getBreakpointValue('bp3') ? '1' : '2'}`">
-      <PlayerTrackDetails :show-quality-details-btn="getBreakpointValue('bp7') ? true : false" :show-only-artist="true" :color-palette="coverImageColorPalette"
-        :primary-color="!$vuetify.theme.current.dark && getBreakpointValue({ breakpoint: 'bp3', condition: 'lt' })
+      <PlayerTrackDetails
+        :show-quality-details-btn="getBreakpointValue('bp7') ? true : false"
+        :show-only-artist="true"
+        :color-palette="coverImageColorPalette"
+        :primary-color="
+          !$vuetify.theme.current.dark && getBreakpointValue({ breakpoint: 'bp3', condition: 'lt' })
             ? '#fff'
             : $vuetify.theme.current.dark && getBreakpointValue({ breakpoint: 'bp3', condition: 'gt' })
-              ? '#fff'
-              : '#000'
-          " />
+            ? '#fff'
+            : '#000'
+        "
+      />
     </div>
     <div :class="`mediacontrols-bottom-center-${getBreakpointValue('bp3') ? '1' : '2'}`">
       <div style="width: 100%">
         <!-- player control buttons -->
-        <PlayerControls :visible-components="{
-          repeat: { isVisible: getBreakpointValue('bp3') },
-          shuffle: { isVisible: getBreakpointValue('bp3') },
-          play: {
-            isVisible: true,
-            icon: {
-              staticWidth: '50px',
-              staticHeight: '50px',
+        <PlayerControls
+          :visible-components="{
+            repeat: { isVisible: getBreakpointValue('bp3') },
+            shuffle: { isVisible: getBreakpointValue('bp3') },
+            play: {
+              isVisible: true,
+              icon: {
+                staticWidth: '50px',
+                staticHeight: '50px',
+              },
             },
-          },
-          previous: { isVisible: getBreakpointValue('bp3') },
-          next: { isVisible: getBreakpointValue('bp3') },
-        }" />
+            previous: { isVisible: getBreakpointValue('bp3') },
+            next: { isVisible: getBreakpointValue('bp3') },
+          }"
+        />
         <!-- progress bar -->
-        <PlayerTimeline v-breakpoint="{ breakpoint: 'mobile', condition: 'gt' }" :color="$vuetify.theme.current.dark ? coverImageColorPalette.darkColor : coverImageColorPalette.lightColor
-          " :is-progress-bar="false" />
+        <PlayerTimeline
+          v-breakpoint="{ breakpoint: 'mobile', condition: 'gt' }"
+          :color="$vuetify.theme.current.dark ? coverImageColorPalette.darkColor : coverImageColorPalette.lightColor"
+          :is-progress-bar="false"
+        />
       </div>
     </div>
     <div class="mediacontrols-bottom-right">
       <div>
         <!-- player mobile extended control buttons -->
-        <PlayerExtendedControls :queue="{ isVisible: getBreakpointValue('bp3') }" :player="{
-          isVisible: true,
-          color:
-            !$vuetify.theme.current.dark && getBreakpointValue({ breakpoint: 'bp3', condition: 'lt' })
-              ? '#fff'
-              : $vuetify.theme.current.dark && getBreakpointValue({ breakpoint: 'bp3', condition: 'gt' })
+        <PlayerExtendedControls
+          :queue="{ isVisible: getBreakpointValue('bp3') }"
+          :player="{
+            isVisible: true,
+            color:
+              !$vuetify.theme.current.dark && getBreakpointValue({ breakpoint: 'bp3', condition: 'lt' })
+                ? '#fff'
+                : $vuetify.theme.current.dark && getBreakpointValue({ breakpoint: 'bp3', condition: 'gt' })
                 ? '#fff'
                 : '#000',
-        }" :volume="{
-  isVisible: true,
-  color:
-    !$vuetify.theme.current.dark && getBreakpointValue({ breakpoint: 'bp3', condition: 'lt' })
-      ? '#fff'
-      : $vuetify.theme.current.dark && getBreakpointValue({ breakpoint: 'bp3', condition: 'gt' })
-        ? '#fff'
-        : '#000',
-}" />
+          }"
+          :volume="{
+            isVisible: true,
+            color:
+              !$vuetify.theme.current.dark && getBreakpointValue({ breakpoint: 'bp3', condition: 'lt' })
+                ? '#fff'
+                : $vuetify.theme.current.dark && getBreakpointValue({ breakpoint: 'bp3', condition: 'gt' })
+                ? '#fff'
+                : '#000',
+          }"
+        />
         <!-- player mobile control buttons -->
 
-        <PlayerControls style="padding-right: 5px" :visible-components="{
-          repeat: { isVisible: false },
-          shuffle: { isVisible: false },
-          play: {
-            isVisible: getBreakpointValue({ breakpoint: 'bp3', condition: 'lt' }),
-            withCircle: false,
-            icon: {
-              staticWidth: '48px',
-              staticHeight: '48px',
-              color:
-                !$vuetify.theme.current.dark && getBreakpointValue({ breakpoint: 'bp3', condition: 'lt' })
-                  ? '#fff'
-                  : $vuetify.theme.current.dark && getBreakpointValue({ breakpoint: 'bp3', condition: 'gt' })
+        <PlayerControls
+          style="padding-right: 5px"
+          :visible-components="{
+            repeat: { isVisible: false },
+            shuffle: { isVisible: false },
+            play: {
+              isVisible: getBreakpointValue({ breakpoint: 'bp3', condition: 'lt' }),
+              withCircle: false,
+              icon: {
+                staticWidth: '48px',
+                staticHeight: '48px',
+                color:
+                  !$vuetify.theme.current.dark && getBreakpointValue({ breakpoint: 'bp3', condition: 'lt' })
+                    ? '#fff'
+                    : $vuetify.theme.current.dark && getBreakpointValue({ breakpoint: 'bp3', condition: 'gt' })
                     ? '#fff'
                     : '#000',
+              },
             },
-          },
-          previous: { isVisible: false },
-          next: { isVisible: false },
-        }" />
+            previous: { isVisible: false },
+            next: { isVisible: false },
+          }"
+        />
       </div>
     </div>
   </div>
@@ -108,15 +136,15 @@ const theme = useTheme();
 // local refs
 const primaryCoverImageColor = ref<string>();
 const coverImageColorPalette = ref<ColorCoverPalette>({
-    '0': '',
-    '1': '',
-    '2': '',
-    '3': '',
-    '4': '',
-    '5': '',
-    lightColor: '',
-    darkColor: '',
-  });
+  '0': '',
+  '1': '',
+  '2': '',
+  '3': '',
+  '4': '',
+  '5': '',
+  lightColor: '',
+  darkColor: '',
+});
 
 // utility feature to extract the dominant colors from the cover image
 // we use this color palette to colorize the playerbar/OSD
@@ -150,11 +178,11 @@ watch(
     // load cover image for the (new) QueueItem
     // make sure that the image selection is exactly the same as on the player OSD thumb
     if (curQueueItem.value?.media_item) {
-      img.src = getImageThumbForItem(curQueueItem.value.media_item , ImageType.THUMB) || imgCoverDark;
+      img.src = getImageThumbForItem(curQueueItem.value.media_item, ImageType.THUMB) || imgCoverDark;
     } else if (curQueueItem.value) {
-      img.src = getImageThumbForItem(curQueueItem.value , ImageType.THUMB) || imgCoverDark;
+      img.src = getImageThumbForItem(curQueueItem.value, ImageType.THUMB) || imgCoverDark;
     } else {
-      img.src = imgCoverDark
+      img.src = imgCoverDark;
     }
   },
 );
@@ -163,20 +191,23 @@ const applyThemeColors = function () {
   // set some theme variables based on the coverImageColorPalette so UI elements can react
   // on the color schema of the currently loaded/playing item
   let lightTheme = theme.themes.value.light;
-  let darkTheme = theme.themes.value.dark;  
+  let darkTheme = theme.themes.value.dark;
   lightTheme.colors['osd-primary'] = coverImageColorPalette.value.lightColor || lightTheme.colors['primary'];
-  lightTheme.colors['osd-on-primary'] = getContrastingTextColor(coverImageColorPalette.value.lightColor) || lightTheme.colors['on-primary'];
+  lightTheme.colors['osd-on-primary'] =
+    getContrastingTextColor(coverImageColorPalette.value.lightColor) || lightTheme.colors['on-primary'];
   lightTheme.colors['osd-secondary'] = coverImageColorPalette.value.darkColor || lightTheme.colors['secondary'];
-  lightTheme.colors['osd-on-secondary'] = getContrastingTextColor(coverImageColorPalette.value.darkColor) || lightTheme.colors['on-secondary'];
+  lightTheme.colors['osd-on-secondary'] =
+    getContrastingTextColor(coverImageColorPalette.value.darkColor) || lightTheme.colors['on-secondary'];
   // lightTheme.variables['medium-emphasis-opacity'] = 1;
 
   darkTheme.colors['osd-primary'] = coverImageColorPalette.value.darkColor || darkTheme.colors['primary'];
-  darkTheme.colors['osd-on-primary'] = getContrastingTextColor(coverImageColorPalette.value.darkColor) || darkTheme.colors['on-primary'];
+  darkTheme.colors['osd-on-primary'] =
+    getContrastingTextColor(coverImageColorPalette.value.darkColor) || darkTheme.colors['on-primary'];
   darkTheme.colors['osd-secondary'] = coverImageColorPalette.value.lightColor || darkTheme.colors['secondary'];
-  darkTheme.colors['osd-on-secondary'] = getContrastingTextColor(coverImageColorPalette.value.lightColor) || darkTheme.colors['on-secondary'];
+  darkTheme.colors['osd-on-secondary'] =
+    getContrastingTextColor(coverImageColorPalette.value.lightColor) || darkTheme.colors['on-secondary'];
   // darkTheme.variables['medium-emphasis-opacity'] = 1;
 };
-
 </script>
 
 <style scoped>
@@ -221,11 +252,11 @@ const applyThemeColors = function () {
   vertical-align: middle;
 }
 
-.mediacontrols-left-1>div {
+.mediacontrols-left-1 > div {
   padding: 0px !important;
 }
 
-.mediacontrols-left-2>div {
+.mediacontrols-left-2 > div {
   padding: 0px !important;
 }
 
@@ -247,7 +278,7 @@ const applyThemeColors = function () {
   vertical-align: middle;
 }
 
-.mediacontrols-bottom-right>div {
+.mediacontrols-bottom-right > div {
   display: inline-flex;
   align-items: center;
 }

--- a/src/layouts/default/PlayerOSD/Player.vue
+++ b/src/layouts/default/PlayerOSD/Player.vue
@@ -1,14 +1,14 @@
 <template>
-  <div v-if="coverImageColorCode" :class="`mediacontrols-bg-${getBreakpointValue('bp3') ? '1' : '2'}`" :style="`background: linear-gradient(90deg, ${coverImageColorCode}${$vuetify.theme.current.dark ? '4D' : 'B3'
-    } 0%, ${coverImageColorCode}00 100%);`"></div>
+  <div v-if="primaryCoverImageColor" :class="`mediacontrols-bg-${getBreakpointValue('bp3') ? '1' : '2'}`" :style="`background: linear-gradient(90deg, ${primaryCoverImageColor}${$vuetify.theme.current.dark ? '4D' : 'B3'
+    } 0%, ${primaryCoverImageColor}00 100%);`"></div>
   <PlayerTimeline v-breakpoint="{ breakpoint: 'bp3', condition: 'lt' }"
-    :color="$vuetify.theme.current.dark ? store.coverImageColorCode.lightColor : store.coverImageColorCode.darkColor"
+    :color="$vuetify.theme.current.dark ? coverImageColorPalette.lightColor : coverImageColorPalette.darkColor"
     :is-progress-bar="true" />
 
   <div class="mediacontrols" :style="`padding: ${getBreakpointValue({ breakpoint: 'phone' }) ? 3 : 10}px ${getBreakpointValue({ breakpoint: 'phone' }) ? 10 : 10
     }px;`">
     <div :class="`mediacontrols-left-${getBreakpointValue('bp3') ? '1' : '2'}`">
-      <PlayerTrackDetails :show-quality-details-btn="getBreakpointValue('bp7') ? true : false" :show-only-artist="true"
+      <PlayerTrackDetails :show-quality-details-btn="getBreakpointValue('bp7') ? true : false" :show-only-artist="true" :color-palette="coverImageColorPalette"
         :color="!$vuetify.theme.current.dark && getBreakpointValue({ breakpoint: 'bp3', condition: 'lt' })
             ? '#fff'
             : $vuetify.theme.current.dark && getBreakpointValue({ breakpoint: 'bp3', condition: 'gt' })
@@ -33,7 +33,7 @@
           next: { isVisible: getBreakpointValue('bp3') },
         }" />
         <!-- progress bar -->
-        <PlayerTimeline v-breakpoint="{ breakpoint: 'mobile', condition: 'gt' }" :color="$vuetify.theme.current.dark ? store.coverImageColorCode.darkColor : store.coverImageColorCode.lightColor
+        <PlayerTimeline v-breakpoint="{ breakpoint: 'mobile', condition: 'gt' }" :color="$vuetify.theme.current.dark ? coverImageColorPalette.darkColor : coverImageColorPalette.lightColor
           " :is-progress-bar="false" />
       </div>
     </div>
@@ -98,21 +98,37 @@ import PlayerTrackDetails from './PlayerTrackDetails.vue';
 import PlayerExtendedControls from './PlayerExtendedControls.vue';
 import { getBreakpointValue } from '@/plugins/breakpoint';
 import vuetify from '@/plugins/vuetify';
-import { getColorCode } from '@/helpers/utils';
+import { ColorCoverPalette, getColorPalette, getContrastingTextColor } from '@/helpers/utils';
 import { imgCoverDark } from '@/components/QualityDetailsBtn.vue';
+import { useTheme } from 'vuetify/lib/framework.mjs';
+
+// global refs
+const theme = useTheme();
 
 // local refs
-const coverImageColorCode = ref();
+const primaryCoverImageColor = ref<string>();
+const coverImageColorPalette = ref<ColorCoverPalette>({
+    '0': '',
+    '1': '',
+    '2': '',
+    '3': '',
+    '4': '',
+    '5': '',
+    lightColor: '',
+    darkColor: '',
+  });
 
+// utility feature to extract the dominant colors from the cover image
+// we use this color palette to colorize the playerbar/OSD
 const img = new Image();
 img.src = imgCoverDark;
 img.crossOrigin = 'Anonymous';
-
 img.addEventListener('load', function () {
-  store.coverImageColorCode = getColorCode(img);
-  coverImageColorCode.value = vuetify.theme.current.value.dark
-    ? store.coverImageColorCode.darkColor
-    : store.coverImageColorCode.lightColor;
+  coverImageColorPalette.value = getColorPalette(img);
+  applyThemeColors();
+  primaryCoverImageColor.value = vuetify.theme.current.value.dark
+    ? coverImageColorPalette.value.darkColor
+    : coverImageColorPalette.value.lightColor;
 });
 
 // computed properties
@@ -131,6 +147,7 @@ const curQueueItem = computed(() => {
 watch(
   () => curQueueItem.value?.queue_item_id,
   () => {
+    // load cover image for the (new) QueueItem
     // make sure that the image selection is exactly the same as on the player OSD thumb
     if (curQueueItem.value?.media_item) {
       img.src = getImageThumbForItem(curQueueItem.value.media_item , ImageType.THUMB) || imgCoverDark;
@@ -141,6 +158,25 @@ watch(
     }
   },
 );
+
+const applyThemeColors = function () {
+  // set some theme variables based on the coverImageColorPalette so UI elements can react
+  // on the color schema of the currently loaded/playing item
+  let lightTheme = theme.themes.value.light;
+  let darkTheme = theme.themes.value.dark;  
+  lightTheme.colors['osd-primary'] = coverImageColorPalette.value.lightColor || lightTheme.colors['primary'];
+  lightTheme.colors['osd-on-primary'] = getContrastingTextColor(coverImageColorPalette.value.lightColor) || lightTheme.colors['on-primary'];
+  lightTheme.colors['osd-secondary'] = coverImageColorPalette.value.darkColor || lightTheme.colors['secondary'];
+  lightTheme.colors['osd-on-secondary'] = getContrastingTextColor(coverImageColorPalette.value.darkColor) || lightTheme.colors['on-secondary'];
+  // lightTheme.variables['medium-emphasis-opacity'] = 1;
+
+  darkTheme.colors['osd-primary'] = coverImageColorPalette.value.darkColor || darkTheme.colors['primary'];
+  darkTheme.colors['osd-on-primary'] = getContrastingTextColor(coverImageColorPalette.value.darkColor) || darkTheme.colors['on-primary'];
+  darkTheme.colors['osd-secondary'] = coverImageColorPalette.value.lightColor || darkTheme.colors['secondary'];
+  darkTheme.colors['osd-on-secondary'] = getContrastingTextColor(coverImageColorPalette.value.lightColor) || darkTheme.colors['on-secondary'];
+  // darkTheme.variables['medium-emphasis-opacity'] = 1;
+};
+
 </script>
 
 <style scoped>

--- a/src/layouts/default/PlayerOSD/PlayerControlBtn/SpeakerBtn.vue
+++ b/src/layouts/default/PlayerOSD/PlayerControlBtn/SpeakerBtn.vue
@@ -6,11 +6,7 @@
     :icon="getBreakpointValue('bp6') ? false : true"
     @click="store.showPlayersMenu = true"
   >
-    <v-badge
-      v-if="store.selectedPlayer?.group_childs.length"
-      size="small"
-      :content="curGroupPlayers"
-    >
+    <v-badge v-if="store.selectedPlayer?.group_childs.length" size="small" :content="curGroupPlayers">
       <v-icon :color="props.color ? color : ''" :size="24">mdi-speaker-multiple</v-icon>
     </v-badge>
     <v-icon v-else :color="props.color ? color : ''" :size="24">mdi-speaker</v-icon>
@@ -51,7 +47,7 @@ const curGroupPlayers = computed(() => {
   for (const groupChildId of store.selectedPlayer.group_childs) {
     const volumeChild = api?.players[groupChildId];
     if (volumeChild && volumeChild.available && volumeChild.powered) {
-      count ++;
+      count++;
     }
   }
   return count;
@@ -59,7 +55,6 @@ const curGroupPlayers = computed(() => {
 </script>
 
 <style>
-
 .no_transform {
   text-transform: none;
 }

--- a/src/layouts/default/PlayerOSD/PlayerControlBtn/VolumeBtn.vue
+++ b/src/layouts/default/PlayerOSD/PlayerControlBtn/VolumeBtn.vue
@@ -103,6 +103,7 @@ const props = withDefaults(defineProps<Props>(), {
   volumeSize: '150px',
   responsiveVolumeSize: true,
   isVisible: true,
+  color: '',
 });
 
 //refs

--- a/src/layouts/default/PlayerOSD/PlayerControls.vue
+++ b/src/layouts/default/PlayerOSD/PlayerControls.vue
@@ -31,9 +31,8 @@
 import { computed } from 'vue';
 
 import api from '@/plugins/api';
-import { PlayerState, RepeatMode } from '@/plugins/api/interfaces';
 import { store } from '@/plugins/store';
-import ResponsiveIcon, { ResponsiveIconProps } from '@/components/mods/ResponsiveIcon.vue';
+import { ResponsiveIconProps } from '@/components/mods/ResponsiveIcon.vue';
 import RepeatBtn from '@/layouts/default/PlayerOSD/PlayerControlBtn/RepeatBtn.vue';
 import ShuffleBtn from './PlayerControlBtn/ShuffleBtn.vue';
 import PlayBtn from './PlayerControlBtn/PlayBtn.vue';

--- a/src/layouts/default/PlayerOSD/PlayerFullscreen.vue
+++ b/src/layouts/default/PlayerOSD/PlayerFullscreen.vue
@@ -1,6 +1,11 @@
 <template>
-  <v-dialog v-model="store.showFullscreenPlayer" fullscreen :scrim="false" style="overflow: hidden"
-    transition="dialog-bottom-transition">
+  <v-dialog
+    v-model="store.showFullscreenPlayer"
+    fullscreen
+    :scrim="false"
+    style="overflow: hidden"
+    transition="dialog-bottom-transition"
+  >
     <v-card :color="darkenBrightColors(coverImageColorCode, 77, 40)">
       <v-toolbar class="v-toolbar-default" color="transparent">
         <template #prepend>
@@ -23,64 +28,93 @@
       <Container class="fullscreen-container">
         <div class="fullscreen-media-space"></div>
         <div class="fullscreen-row-centered">
-          <Flicking v-if="curQueueItem &&
-            getBreakpointValue({ breakpoint: 'mobile' }) &&
-            getBreakpointValue({ breakpoint: 'bp3', condition: 'lt' }) &&
-            false
-            " :options="{
-    align: 'center',
-    defaultIndex: 1,
-    moveType: 'strict',
-    panelsPerView: 1,
-    useResizeObserver: true,
-    circular: true,
-  }" @moveEnd="handleFlickingMoveEnd">
+          <Flicking
+            v-if="
+              curQueueItem &&
+              getBreakpointValue({ breakpoint: 'mobile' }) &&
+              getBreakpointValue({ breakpoint: 'bp3', condition: 'lt' }) &&
+              false
+            "
+            :options="{
+              align: 'center',
+              defaultIndex: 1,
+              moveType: 'strict',
+              panelsPerView: 1,
+              useResizeObserver: true,
+              circular: true,
+            }"
+            @moveEnd="handleFlickingMoveEnd"
+          >
             <div v-for="config in 3" :key="config" style="margin-right: 10px; margin-left: 10px; display: flex">
-              <MediaItemThumb :item="curQueueItem?.media_item || curQueueItem"
+              <MediaItemThumb
+                :item="curQueueItem?.media_item || curQueueItem"
                 :width="getBreakpointValue({ breakpoint: 'bp3', condition: 'lt' }) ? 512 : 1024"
-                :height="getBreakpointValue({ breakpoint: 'bp3', condition: 'lt' }) ? 512 : 1024" style="
+                :height="getBreakpointValue({ breakpoint: 'bp3', condition: 'lt' }) ? 512 : 1024"
+                style="
                   height: min(calc(100vw - 40px), calc(100vh - 340px));
                   width: min(calc(100vw - 40px), calc(100vh - 340px));
-                " />
+                "
+              />
             </div>
           </Flicking>
-          <MediaItemThumb v-else-if="curQueueItem" :item="curQueueItem.media_item || curQueueItem"
+          <MediaItemThumb
+            v-else-if="curQueueItem"
+            :item="curQueueItem.media_item || curQueueItem"
             :width="getBreakpointValue({ breakpoint: 'bp3', condition: 'lt' }) ? 512 : 1024"
-            :height="getBreakpointValue({ breakpoint: 'bp3', condition: 'lt' }) ? 512 : 1024" style="
+            :height="getBreakpointValue({ breakpoint: 'bp3', condition: 'lt' }) ? 512 : 1024"
+            style="
               height: min(calc(100vw - 40px), calc(100vh - 340px));
               width: min(calc(100vw - 40px), calc(100vh - 340px));
-            " />
-          <v-img v-else :src="defaultImage" style="
+            "
+          />
+          <v-img
+            v-else
+            :src="defaultImage"
+            style="
               height: min(calc(100vw - 40px), calc(100vh - 340px));
               width: min(calc(100vw - 40px), calc(100vh - 340px));
-            " />
+            "
+          />
         </div>
         <div class="fullscreen-row">
           <div v-if="curQueueItem && curQueueItem.media_item" class="fullscreen-track-info">
             <!-- title -->
-            <h2 style="cursor: pointer; width: fit-content; display: inline" class="title line-clamp-1"
-              @click="curQueueItem?.media_item ? trackClick(curQueueItem.media_item as Track) : ''">
+            <h2
+              style="cursor: pointer; width: fit-content; display: inline"
+              class="title line-clamp-1"
+              @click="curQueueItem?.media_item ? trackClick(curQueueItem.media_item as Track) : ''"
+            >
               <!-- name + version (if present) -->
               {{
-                `${curQueueItem.media_item.name} ${'version' in curQueueItem.media_item && curQueueItem.media_item.version
+                `${curQueueItem.media_item.name} ${
+                  'version' in curQueueItem.media_item && curQueueItem.media_item.version
                     ? '(' + curQueueItem.media_item.version + ')'
                     : ''
-                  }`
+                }`
               }}
             </h2>
 
             <!-- subtitle -->
             <!-- track: artists(s) -->
-            <div v-if="curQueueItem.media_item?.media_type == MediaType.TRACK &&
+            <div
+              v-if="
+                curQueueItem.media_item?.media_type == MediaType.TRACK &&
                 'album' in curQueueItem.media_item &&
                 curQueueItem.media_item.album
-                " style="cursor: pointer" class="line-clamp-1"
-              @click="curQueueItem?.media_item ? artistClick((curQueueItem.media_item as Track).artists[0]) : ''">
+              "
+              style="cursor: pointer"
+              class="line-clamp-1"
+              @click="curQueueItem?.media_item ? artistClick((curQueueItem.media_item as Track).artists[0]) : ''"
+            >
               <!-- track/album falback: artist present -->
-              <h4 v-if="curQueueItem.media_item &&
-                curQueueItem.media_item?.media_type == MediaType.TRACK &&
-                (curQueueItem.media_item as Track).artists.length > 0
-                " class="fullscreen-track-info-subtitle">
+              <h4
+                v-if="
+                  curQueueItem.media_item &&
+                  curQueueItem.media_item?.media_type == MediaType.TRACK &&
+                  (curQueueItem.media_item as Track).artists.length > 0
+                "
+                class="fullscreen-track-info-subtitle"
+              >
                 {{ (curQueueItem.media_item as Track).artists[0].name }}
               </h4>
               <!-- radio live metadata -->
@@ -88,8 +122,10 @@
                 {{ curQueueItem?.streamdetails?.stream_title }}
               </h4>
               <!-- other description -->
-              <h4 v-else-if="curQueueItem && curQueueItem.media_item?.metadata.description"
-                class="fullscreen-track-info-subtitle">
+              <h4
+                v-else-if="curQueueItem && curQueueItem.media_item?.metadata.description"
+                class="fullscreen-track-info-subtitle"
+              >
                 {{ curQueueItem.media_item.metadata.description }}
               </h4>
               <!-- queue empty message -->
@@ -97,51 +133,79 @@
                 {{ $t('queue_empty') }}
               </h4>
               <!-- 3rd party source active -->
-              <h4 v-else-if="store.selectedPlayer?.active_source != store.selectedPlayer?.player_id"
-                class="fullscreen-track-info-subtitle">
+              <h4
+                v-else-if="store.selectedPlayer?.active_source != store.selectedPlayer?.player_id"
+                class="fullscreen-track-info-subtitle"
+              >
                 {{ $t('external_source_active', [store.selectedPlayer?.active_source]) }}
               </h4>
             </div>
           </div>
         </div>
         <div class="fullscreen-row" style="margin: 0 10px">
-          <PlayerTimeline :is-progress-bar="false" :color="$vuetify.theme.current.dark ? props.colorPalette.lightColor : props.colorPalette.darkColor
-            " />
+          <PlayerTimeline
+            :is-progress-bar="false"
+            :color="$vuetify.theme.current.dark ? props.colorPalette.lightColor : props.colorPalette.darkColor"
+          />
         </div>
         <div v-if="false">
-          <div style="height: 50px; width: 50px" :style="{
-            background: `${props.colorPalette[0]}`,
-          }"></div>
+          <div
+            style="height: 50px; width: 50px"
+            :style="{
+              background: `${props.colorPalette[0]}`,
+            }"
+          ></div>
           <a style="color: #000"> {{ props.colorPalette[0] }}</a>
-          <div style="height: 50px; width: 50px" :style="{
-            background: `${props.colorPalette[1]}`,
-          }"></div>
+          <div
+            style="height: 50px; width: 50px"
+            :style="{
+              background: `${props.colorPalette[1]}`,
+            }"
+          ></div>
           <a style="color: #000"> {{ props.colorPalette[1] }}</a>
-          <div style="height: 50px; width: 50px" :style="{
-            background: `${props.colorPalette[2]}`,
-          }"></div>
+          <div
+            style="height: 50px; width: 50px"
+            :style="{
+              background: `${props.colorPalette[2]}`,
+            }"
+          ></div>
           <a style="color: #000"> {{ props.colorPalette[2] }}</a>
-          <div style="height: 50px; width: 50px" :style="{
-            background: `${props.colorPalette[3]}`,
-          }"></div>
+          <div
+            style="height: 50px; width: 50px"
+            :style="{
+              background: `${props.colorPalette[3]}`,
+            }"
+          ></div>
           <a style="color: #000"> {{ props.colorPalette[3] }}</a>
-          <div style="height: 50px; width: 50px" :style="{
-            background: `${props.colorPalette[4]}`,
-          }"></div>
+          <div
+            style="height: 50px; width: 50px"
+            :style="{
+              background: `${props.colorPalette[4]}`,
+            }"
+          ></div>
           <a style="color: #000"> {{ props.colorPalette[4] }}</a>
-          <div style="height: 50px; width: 50px" :style="{
-            background: `${props.colorPalette.darkColor}`,
-          }"></div>
+          <div
+            style="height: 50px; width: 50px"
+            :style="{
+              background: `${props.colorPalette.darkColor}`,
+            }"
+          ></div>
           <a style="color: #000"> DarkColor </a>
-          <div style="height: 50px; width: 50px" :style="{
-            background: `${props.colorPalette.lightColor}`,
-          }"></div>
+          <div
+            style="height: 50px; width: 50px"
+            :style="{
+              background: `${props.colorPalette.lightColor}`,
+            }"
+          ></div>
           <a style="color: #000"> LightColor </a>
         </div>
         <div class="fullscreen-row">
-          <PlayerExtendedControls v-if="getBreakpointValue({ breakpoint: 'bp3', condition: 'lt' })"
-            :queue="{ isVisible: false }" :player="{ isVisible: false }"
-            :volume="{ isVisible: true, volumeSize: '100%', responsiveVolumeSize: false }" />
+          <PlayerExtendedControls
+            v-if="getBreakpointValue({ breakpoint: 'bp3', condition: 'lt' })"
+            :queue="{ isVisible: false }"
+            :player="{ isVisible: false }"
+            :volume="{ isVisible: true, volumeSize: '100%', responsiveVolumeSize: false }"
+          />
         </div>
         <div v-if="getBreakpointValue({ breakpoint: 'bp3', condition: 'lt' })" class="fullscreen-media-controls">
           <ShuffleBtn class="media-controls-item" max-height="24px" />
@@ -154,55 +218,67 @@
 
           <RepeatBtn class="media-controls-item" max-height="24px" />
         </div>
-        <div v-else class="fullscreen-media-controls" :style="{
-          paddingTop: '1vh',
-          flex: getBreakpointValue({ breakpoint: 'bp3', condition: 'lt' }) ? '1 1 auto' : '0 1 auto',
-        }">
+        <div
+          v-else
+          class="fullscreen-media-controls"
+          :style="{
+            paddingTop: '1vh',
+            flex: getBreakpointValue({ breakpoint: 'bp3', condition: 'lt' }) ? '1 1 auto' : '0 1 auto',
+          }"
+        >
           <div class="media-controls-item" style="display: grid; align-content: center">
             <QualityDetailsBtn />
           </div>
           <div class="media-controls-item fullscreen-row-centered">
             <div style="width: 100%">
               <!-- player control buttons -->
-              <PlayerControls :visible-components="{
-                repeat: { isVisible: getBreakpointValue('bp3') },
-                shuffle: { isVisible: getBreakpointValue('bp3') },
-                play: {
-                  isVisible: true,
-                  icon: {
-                    staticWidth: '50px',
-                    staticHeight: '50px',
+              <PlayerControls
+                :visible-components="{
+                  repeat: { isVisible: getBreakpointValue('bp3') },
+                  shuffle: { isVisible: getBreakpointValue('bp3') },
+                  play: {
+                    isVisible: true,
+                    icon: {
+                      staticWidth: '50px',
+                      staticHeight: '50px',
+                    },
                   },
-                },
-                previous: { isVisible: getBreakpointValue('bp3') },
-                next: { isVisible: getBreakpointValue('bp3') },
-              }" />
+                  previous: { isVisible: getBreakpointValue('bp3') },
+                  next: { isVisible: getBreakpointValue('bp3') },
+                }"
+              />
             </div>
           </div>
           <div class="fullscreen-mediacontrols-right media-controls-item">
             <div>
               <!-- player mobile control buttons -->
-              <PlayerControls style="padding-right: 5px" :visible-components="{
-                repeat: { isVisible: false },
-                shuffle: { isVisible: false },
-                play: { isVisible: getBreakpointValue({ breakpoint: 'bp3', condition: 'lt' }) },
-                previous: { isVisible: false },
-                next: { isVisible: false },
-              }" />
+              <PlayerControls
+                style="padding-right: 5px"
+                :visible-components="{
+                  repeat: { isVisible: false },
+                  shuffle: { isVisible: false },
+                  play: { isVisible: getBreakpointValue({ breakpoint: 'bp3', condition: 'lt' }) },
+                  previous: { isVisible: false },
+                  next: { isVisible: false },
+                }"
+              />
               <!-- player mobile extended control buttons -->
-              <PlayerExtendedControls :queue="{ isVisible: getBreakpointValue('bp3') }" :player="{ isVisible: true }"
-                :volume="{ isVisible: getBreakpointValue('bp0') }" />
+              <PlayerExtendedControls
+                :queue="{ isVisible: getBreakpointValue('bp3') }"
+                :player="{ isVisible: true }"
+                :volume="{ isVisible: getBreakpointValue('bp0') }"
+              />
             </div>
           </div>
         </div>
         <div class="fullscreen-media-controls-bottom" if="activePlayerQueue">
           <div v-if="getBreakpointValue({ breakpoint: 'bp3', condition: 'lt' })">
             <Button @click="store.showPlayersMenu = true">
-              <v-badge v-if="curGroupPlayers && curGroupPlayers.length > 0"
-                :content="store.selectedPlayer?.group_childs.length" :color="$vuetify.theme.current.dark
-                    ? props.colorPalette.lightColor
-                    : props.colorPalette.darkColor
-                  ">
+              <v-badge
+                v-if="curGroupPlayers && curGroupPlayers.length > 0"
+                :content="store.selectedPlayer?.group_childs.length"
+                :color="$vuetify.theme.current.dark ? props.colorPalette.lightColor : props.colorPalette.darkColor"
+              >
                 <v-icon :size="30">mdi-speaker</v-icon>
               </v-badge>
               <v-icon v-else :size="30">mdi-speaker</v-icon>
@@ -210,9 +286,13 @@
             </Button>
           </div>
           <div style="text-align: end">
-            <PlayerExtendedControls :queue="{
-              isVisible: getBreakpointValue({ breakpoint: 'bp3', condition: 'lt' }),
-            }" :player="{ isVisible: false }" :volume="{ isVisible: false }" />
+            <PlayerExtendedControls
+              :queue="{
+                isVisible: getBreakpointValue({ breakpoint: 'bp3', condition: 'lt' }),
+              }"
+              :player="{ isVisible: false }"
+              :volume="{ isVisible: false }"
+            />
           </div>
         </div>
       </Container>
@@ -378,7 +458,7 @@ watch(
   align-items: center;
 }
 
-.fullscreen-media-controls>button {
+.fullscreen-media-controls > button {
   flex: 1 1 auto;
 }
 
@@ -389,13 +469,13 @@ watch(
   align-items: center;
 }
 
-.fullscreen-media-controls-bottom>div {
+.fullscreen-media-controls-bottom > div {
   flex-basis: 0;
   flex-grow: 1;
   max-width: 100%;
 }
 
-.fullscreen-media-controls>div {
+.fullscreen-media-controls > div {
   width: calc(100% / 3);
 }
 
@@ -405,7 +485,7 @@ watch(
   vertical-align: middle;
 }
 
-.fullscreen-mediacontrols-right>div {
+.fullscreen-mediacontrols-right > div {
   display: inline-flex;
   align-items: center;
 }

--- a/src/layouts/default/PlayerOSD/PlayerFullscreen.vue
+++ b/src/layouts/default/PlayerOSD/PlayerFullscreen.vue
@@ -146,7 +146,7 @@
           <PlayerTimeline
             :is-progress-bar="false"
             :color="
-              $vuetify.theme.current.dark ? store.coverImageColorCode.lightColor : store.coverImageColorCode.darkColor
+              $vuetify.theme.current.dark ? props.colorPalette.lightColor : props.colorPalette.darkColor
             "
           />
         </div>
@@ -154,49 +154,49 @@
           <div
             style="height: 50px; width: 50px"
             :style="{
-              background: `${store.coverImageColorCode[0]}`,
+              background: `${props.colorPalette[0]}`,
             }"
           ></div>
-          <a style="color: #000"> {{ store.coverImageColorCode[0] }}</a>
+          <a style="color: #000"> {{ props.colorPalette[0] }}</a>
           <div
             style="height: 50px; width: 50px"
             :style="{
-              background: `${store.coverImageColorCode[1]}`,
+              background: `${props.colorPalette[1]}`,
             }"
           ></div>
-          <a style="color: #000"> {{ store.coverImageColorCode[1] }}</a>
+          <a style="color: #000"> {{ props.colorPalette[1] }}</a>
           <div
             style="height: 50px; width: 50px"
             :style="{
-              background: `${store.coverImageColorCode[2]}`,
+              background: `${props.colorPalette[2]}`,
             }"
           ></div>
-          <a style="color: #000"> {{ store.coverImageColorCode[2] }}</a>
+          <a style="color: #000"> {{ props.colorPalette[2] }}</a>
           <div
             style="height: 50px; width: 50px"
             :style="{
-              background: `${store.coverImageColorCode[3]}`,
+              background: `${props.colorPalette[3]}`,
             }"
           ></div>
-          <a style="color: #000"> {{ store.coverImageColorCode[3] }}</a>
+          <a style="color: #000"> {{ props.colorPalette[3] }}</a>
           <div
             style="height: 50px; width: 50px"
             :style="{
-              background: `${store.coverImageColorCode[4]}`,
+              background: `${props.colorPalette[4]}`,
             }"
           ></div>
-          <a style="color: #000"> {{ store.coverImageColorCode[4] }}</a>
+          <a style="color: #000"> {{ props.colorPalette[4] }}</a>
           <div
             style="height: 50px; width: 50px"
             :style="{
-              background: `${store.coverImageColorCode.darkColor}`,
+              background: `${props.colorPalette.darkColor}`,
             }"
           ></div>
           <a style="color: #000"> DarkColor </a>
           <div
             style="height: 50px; width: 50px"
             :style="{
-              background: `${store.coverImageColorCode.lightColor}`,
+              background: `${props.colorPalette.lightColor}`,
             }"
           ></div>
           <a style="color: #000"> LightColor </a>
@@ -281,8 +281,8 @@
                 :content="store.selectedPlayer?.group_childs.length"
                 :color="
                   $vuetify.theme.current.dark
-                    ? store.coverImageColorCode.lightColor
-                    : store.coverImageColorCode.darkColor
+                    ? props.colorPalette.lightColor
+                    : props.colorPalette.darkColor
                 "
               >
                 <v-icon :size="30">mdi-speaker</v-icon>
@@ -329,10 +329,15 @@ import PlayerControls from './PlayerControls.vue';
 import QualityDetailsBtn from '@/components/QualityDetailsBtn.vue';
 import router from '@/plugins/router';
 import Flicking from '@egjs/vue3-flicking';
-import { darkenBrightColors } from '@/helpers/utils';
+import { ColorCoverPalette, darkenBrightColors } from '@/helpers/utils';
+
+interface Props {
+  colorPalette: ColorCoverPalette;
+}
+const props = defineProps<Props>();
 
 const coverImageColorCode = ref(
-  vuetify.theme.current.value.dark ? store.coverImageColorCode.darkColor : store.coverImageColorCode.lightColor,
+  vuetify.theme.current.value.dark ? props.colorPalette.darkColor : props.colorPalette.lightColor,
 );
 // Local refs
 const fullTrackDetails = ref<Track>();
@@ -398,7 +403,7 @@ watch(
 );
 
 watch(
-  () => store.coverImageColorCode,
+  () => props.colorPalette,
   (result) => {
     if (!result.darkColor || !result.lightColor) {
       coverImageColorCode.value = vuetify.theme.current.value.dark ? '#000' : '#fff';

--- a/src/layouts/default/PlayerOSD/PlayerFullscreen.vue
+++ b/src/layouts/default/PlayerOSD/PlayerFullscreen.vue
@@ -1,11 +1,6 @@
 <template>
-  <v-dialog
-    v-model="store.showFullscreenPlayer"
-    fullscreen
-    :scrim="false"
-    style="overflow: hidden"
-    transition="dialog-bottom-transition"
-  >
+  <v-dialog v-model="store.showFullscreenPlayer" fullscreen :scrim="false" style="overflow: hidden"
+    transition="dialog-bottom-transition">
     <v-card :color="darkenBrightColors(coverImageColorCode, 77, 40)">
       <v-toolbar class="v-toolbar-default" color="transparent">
         <template #prepend>
@@ -28,93 +23,64 @@
       <Container class="fullscreen-container">
         <div class="fullscreen-media-space"></div>
         <div class="fullscreen-row-centered">
-          <Flicking
-            v-if="
-              curQueueItem &&
-              getBreakpointValue({ breakpoint: 'mobile' }) &&
-              getBreakpointValue({ breakpoint: 'bp3', condition: 'lt' }) &&
-              false
-            "
-            :options="{
-              align: 'center',
-              defaultIndex: 1,
-              moveType: 'strict',
-              panelsPerView: 1,
-              useResizeObserver: true,
-              circular: true,
-            }"
-            @moveEnd="handleFlickingMoveEnd"
-          >
+          <Flicking v-if="curQueueItem &&
+            getBreakpointValue({ breakpoint: 'mobile' }) &&
+            getBreakpointValue({ breakpoint: 'bp3', condition: 'lt' }) &&
+            false
+            " :options="{
+    align: 'center',
+    defaultIndex: 1,
+    moveType: 'strict',
+    panelsPerView: 1,
+    useResizeObserver: true,
+    circular: true,
+  }" @moveEnd="handleFlickingMoveEnd">
             <div v-for="config in 3" :key="config" style="margin-right: 10px; margin-left: 10px; display: flex">
-              <MediaItemThumb
-                :item="curQueueItem?.media_item || curQueueItem"
+              <MediaItemThumb :item="curQueueItem?.media_item || curQueueItem"
                 :width="getBreakpointValue({ breakpoint: 'bp3', condition: 'lt' }) ? 512 : 1024"
-                :height="getBreakpointValue({ breakpoint: 'bp3', condition: 'lt' }) ? 512 : 1024"
-                style="
+                :height="getBreakpointValue({ breakpoint: 'bp3', condition: 'lt' }) ? 512 : 1024" style="
                   height: min(calc(100vw - 40px), calc(100vh - 340px));
                   width: min(calc(100vw - 40px), calc(100vh - 340px));
-                "
-              />
+                " />
             </div>
           </Flicking>
-          <MediaItemThumb
-            v-else-if="curQueueItem"
-            :item="curQueueItem.media_item || curQueueItem"
+          <MediaItemThumb v-else-if="curQueueItem" :item="curQueueItem.media_item || curQueueItem"
             :width="getBreakpointValue({ breakpoint: 'bp3', condition: 'lt' }) ? 512 : 1024"
-            :height="getBreakpointValue({ breakpoint: 'bp3', condition: 'lt' }) ? 512 : 1024"
-            style="
+            :height="getBreakpointValue({ breakpoint: 'bp3', condition: 'lt' }) ? 512 : 1024" style="
               height: min(calc(100vw - 40px), calc(100vh - 340px));
               width: min(calc(100vw - 40px), calc(100vh - 340px));
-            "
-          />
-          <v-img
-            v-else
-            :src="defaultImage"
-            style="
+            " />
+          <v-img v-else :src="defaultImage" style="
               height: min(calc(100vw - 40px), calc(100vh - 340px));
               width: min(calc(100vw - 40px), calc(100vh - 340px));
-            "
-          />
+            " />
         </div>
         <div class="fullscreen-row">
           <div v-if="curQueueItem && curQueueItem.media_item" class="fullscreen-track-info">
             <!-- title -->
-            <h2
-              style="cursor: pointer; width: fit-content; display: inline"
-              class="title line-clamp-1"
-              @click="curQueueItem?.media_item ? trackClick(curQueueItem.media_item as Track) : ''"
-            >
+            <h2 style="cursor: pointer; width: fit-content; display: inline" class="title line-clamp-1"
+              @click="curQueueItem?.media_item ? trackClick(curQueueItem.media_item as Track) : ''">
               <!-- name + version (if present) -->
               {{
-                `${curQueueItem.media_item.name} ${
-                  'version' in curQueueItem.media_item && curQueueItem.media_item.version
+                `${curQueueItem.media_item.name} ${'version' in curQueueItem.media_item && curQueueItem.media_item.version
                     ? '(' + curQueueItem.media_item.version + ')'
                     : ''
-                }`
+                  }`
               }}
             </h2>
 
             <!-- subtitle -->
             <!-- track: artists(s) -->
-            <div
-              v-if="
-                curQueueItem.media_item?.media_type == MediaType.TRACK &&
+            <div v-if="curQueueItem.media_item?.media_type == MediaType.TRACK &&
                 'album' in curQueueItem.media_item &&
                 curQueueItem.media_item.album
-              "
-              style="cursor: pointer"
-              class="line-clamp-1"
-              @click="curQueueItem?.media_item ? artistClick((curQueueItem.media_item as Track).artists[0]) : ''"
-            >
+                " style="cursor: pointer" class="line-clamp-1"
+              @click="curQueueItem?.media_item ? artistClick((curQueueItem.media_item as Track).artists[0]) : ''">
               <!-- track/album falback: artist present -->
-              <h4
-                v-if="
-                  curQueueItem.media_item &&
-                  curQueueItem.media_item?.media_type == MediaType.TRACK &&
-                  (curQueueItem.media_item as Track).artists.length > 0
-                "
-                class="fullscreen-track-info-subtitle"
-              >
+              <h4 v-if="curQueueItem.media_item &&
+                curQueueItem.media_item?.media_type == MediaType.TRACK &&
+                (curQueueItem.media_item as Track).artists.length > 0
+                " class="fullscreen-track-info-subtitle">
                 {{ (curQueueItem.media_item as Track).artists[0].name }}
               </h4>
               <!-- radio live metadata -->
@@ -122,10 +88,8 @@
                 {{ curQueueItem?.streamdetails?.stream_title }}
               </h4>
               <!-- other description -->
-              <h4
-                v-else-if="curQueueItem && curQueueItem.media_item?.metadata.description"
-                class="fullscreen-track-info-subtitle"
-              >
+              <h4 v-else-if="curQueueItem && curQueueItem.media_item?.metadata.description"
+                class="fullscreen-track-info-subtitle">
                 {{ curQueueItem.media_item.metadata.description }}
               </h4>
               <!-- queue empty message -->
@@ -133,81 +97,51 @@
                 {{ $t('queue_empty') }}
               </h4>
               <!-- 3rd party source active -->
-              <h4
-                v-else-if="store.selectedPlayer?.active_source != store.selectedPlayer?.player_id"
-                class="fullscreen-track-info-subtitle"
-              >
+              <h4 v-else-if="store.selectedPlayer?.active_source != store.selectedPlayer?.player_id"
+                class="fullscreen-track-info-subtitle">
                 {{ $t('external_source_active', [store.selectedPlayer?.active_source]) }}
               </h4>
             </div>
           </div>
         </div>
         <div class="fullscreen-row" style="margin: 0 10px">
-          <PlayerTimeline
-            :is-progress-bar="false"
-            :color="
-              $vuetify.theme.current.dark ? props.colorPalette.lightColor : props.colorPalette.darkColor
-            "
-          />
+          <PlayerTimeline :is-progress-bar="false" :color="$vuetify.theme.current.dark ? props.colorPalette.lightColor : props.colorPalette.darkColor
+            " />
         </div>
         <div v-if="false">
-          <div
-            style="height: 50px; width: 50px"
-            :style="{
-              background: `${props.colorPalette[0]}`,
-            }"
-          ></div>
+          <div style="height: 50px; width: 50px" :style="{
+            background: `${props.colorPalette[0]}`,
+          }"></div>
           <a style="color: #000"> {{ props.colorPalette[0] }}</a>
-          <div
-            style="height: 50px; width: 50px"
-            :style="{
-              background: `${props.colorPalette[1]}`,
-            }"
-          ></div>
+          <div style="height: 50px; width: 50px" :style="{
+            background: `${props.colorPalette[1]}`,
+          }"></div>
           <a style="color: #000"> {{ props.colorPalette[1] }}</a>
-          <div
-            style="height: 50px; width: 50px"
-            :style="{
-              background: `${props.colorPalette[2]}`,
-            }"
-          ></div>
+          <div style="height: 50px; width: 50px" :style="{
+            background: `${props.colorPalette[2]}`,
+          }"></div>
           <a style="color: #000"> {{ props.colorPalette[2] }}</a>
-          <div
-            style="height: 50px; width: 50px"
-            :style="{
-              background: `${props.colorPalette[3]}`,
-            }"
-          ></div>
+          <div style="height: 50px; width: 50px" :style="{
+            background: `${props.colorPalette[3]}`,
+          }"></div>
           <a style="color: #000"> {{ props.colorPalette[3] }}</a>
-          <div
-            style="height: 50px; width: 50px"
-            :style="{
-              background: `${props.colorPalette[4]}`,
-            }"
-          ></div>
+          <div style="height: 50px; width: 50px" :style="{
+            background: `${props.colorPalette[4]}`,
+          }"></div>
           <a style="color: #000"> {{ props.colorPalette[4] }}</a>
-          <div
-            style="height: 50px; width: 50px"
-            :style="{
-              background: `${props.colorPalette.darkColor}`,
-            }"
-          ></div>
+          <div style="height: 50px; width: 50px" :style="{
+            background: `${props.colorPalette.darkColor}`,
+          }"></div>
           <a style="color: #000"> DarkColor </a>
-          <div
-            style="height: 50px; width: 50px"
-            :style="{
-              background: `${props.colorPalette.lightColor}`,
-            }"
-          ></div>
+          <div style="height: 50px; width: 50px" :style="{
+            background: `${props.colorPalette.lightColor}`,
+          }"></div>
           <a style="color: #000"> LightColor </a>
         </div>
         <div class="fullscreen-row">
-          <PlayerExtendedControls
-            v-if="getBreakpointValue({ breakpoint: 'bp3', condition: 'lt' })"
-            :queue="{ isVisible: false }"
-            :player="{ isVisible: false }"
-            :volume="{ isVisible: true, volumeSize: '100%', responsiveVolumeSize: false }"
-          />
+          <PlayerExtendedControls v-if="getBreakpointValue({ breakpoint: 'bp3', condition: 'lt' })"
+            :queue="{ isVisible: false }" :player="{ isVisible: false }"
+            :volume="{ isVisible: true, volumeSize: '100%', responsiveVolumeSize: false }" />
         </div>
         <div v-if="getBreakpointValue({ breakpoint: 'bp3', condition: 'lt' })" class="fullscreen-media-controls">
           <ShuffleBtn class="media-controls-item" max-height="24px" />
@@ -220,71 +154,55 @@
 
           <RepeatBtn class="media-controls-item" max-height="24px" />
         </div>
-        <div
-          v-else
-          class="fullscreen-media-controls"
-          :style="{
-            paddingTop: '1vh',
-            flex: getBreakpointValue({ breakpoint: 'bp3', condition: 'lt' }) ? '1 1 auto' : '0 1 auto',
-          }"
-        >
+        <div v-else class="fullscreen-media-controls" :style="{
+          paddingTop: '1vh',
+          flex: getBreakpointValue({ breakpoint: 'bp3', condition: 'lt' }) ? '1 1 auto' : '0 1 auto',
+        }">
           <div class="media-controls-item" style="display: grid; align-content: center">
             <QualityDetailsBtn />
           </div>
           <div class="media-controls-item fullscreen-row-centered">
             <div style="width: 100%">
               <!-- player control buttons -->
-              <PlayerControls
-                :visible-components="{
-                  repeat: { isVisible: getBreakpointValue('bp3') },
-                  shuffle: { isVisible: getBreakpointValue('bp3') },
-                  play: {
-                    isVisible: true,
-                    icon: {
-                      staticWidth: '50px',
-                      staticHeight: '50px',
-                    },
+              <PlayerControls :visible-components="{
+                repeat: { isVisible: getBreakpointValue('bp3') },
+                shuffle: { isVisible: getBreakpointValue('bp3') },
+                play: {
+                  isVisible: true,
+                  icon: {
+                    staticWidth: '50px',
+                    staticHeight: '50px',
                   },
-                  previous: { isVisible: getBreakpointValue('bp3') },
-                  next: { isVisible: getBreakpointValue('bp3') },
-                }"
-              />
+                },
+                previous: { isVisible: getBreakpointValue('bp3') },
+                next: { isVisible: getBreakpointValue('bp3') },
+              }" />
             </div>
           </div>
           <div class="fullscreen-mediacontrols-right media-controls-item">
             <div>
               <!-- player mobile control buttons -->
-              <PlayerControls
-                style="padding-right: 5px"
-                :visible-components="{
-                  repeat: { isVisible: false },
-                  shuffle: { isVisible: false },
-                  play: { isVisible: getBreakpointValue({ breakpoint: 'bp3', condition: 'lt' }) },
-                  previous: { isVisible: false },
-                  next: { isVisible: false },
-                }"
-              />
+              <PlayerControls style="padding-right: 5px" :visible-components="{
+                repeat: { isVisible: false },
+                shuffle: { isVisible: false },
+                play: { isVisible: getBreakpointValue({ breakpoint: 'bp3', condition: 'lt' }) },
+                previous: { isVisible: false },
+                next: { isVisible: false },
+              }" />
               <!-- player mobile extended control buttons -->
-              <PlayerExtendedControls
-                :queue="{ isVisible: getBreakpointValue('bp3') }"
-                :player="{ isVisible: true }"
-                :volume="{ isVisible: getBreakpointValue('bp0') }"
-              />
+              <PlayerExtendedControls :queue="{ isVisible: getBreakpointValue('bp3') }" :player="{ isVisible: true }"
+                :volume="{ isVisible: getBreakpointValue('bp0') }" />
             </div>
           </div>
         </div>
         <div class="fullscreen-media-controls-bottom" if="activePlayerQueue">
           <div v-if="getBreakpointValue({ breakpoint: 'bp3', condition: 'lt' })">
             <Button @click="store.showPlayersMenu = true">
-              <v-badge
-                v-if="curGroupPlayers && curGroupPlayers.length > 0"
-                :content="store.selectedPlayer?.group_childs.length"
-                :color="
-                  $vuetify.theme.current.dark
+              <v-badge v-if="curGroupPlayers && curGroupPlayers.length > 0"
+                :content="store.selectedPlayer?.group_childs.length" :color="$vuetify.theme.current.dark
                     ? props.colorPalette.lightColor
                     : props.colorPalette.darkColor
-                "
-              >
+                  ">
                 <v-icon :size="30">mdi-speaker</v-icon>
               </v-badge>
               <v-icon v-else :size="30">mdi-speaker</v-icon>
@@ -292,13 +210,9 @@
             </Button>
           </div>
           <div style="text-align: end">
-            <PlayerExtendedControls
-              :queue="{
-                isVisible: getBreakpointValue({ breakpoint: 'bp3', condition: 'lt' }),
-              }"
-              :player="{ isVisible: false }"
-              :volume="{ isVisible: false }"
-            />
+            <PlayerExtendedControls :queue="{
+              isVisible: getBreakpointValue({ breakpoint: 'bp3', condition: 'lt' }),
+            }" :player="{ isVisible: false }" :volume="{ isVisible: false }" />
           </div>
         </div>
       </Container>
@@ -336,9 +250,7 @@ interface Props {
 }
 const props = defineProps<Props>();
 
-const coverImageColorCode = ref(
-  vuetify.theme.current.value.dark ? props.colorPalette.darkColor : props.colorPalette.lightColor,
-);
+const coverImageColorCode = ref<string>('');
 // Local refs
 const fullTrackDetails = ref<Track>();
 
@@ -466,7 +378,7 @@ watch(
   align-items: center;
 }
 
-.fullscreen-media-controls > button {
+.fullscreen-media-controls>button {
   flex: 1 1 auto;
 }
 
@@ -477,13 +389,13 @@ watch(
   align-items: center;
 }
 
-.fullscreen-media-controls-bottom > div {
+.fullscreen-media-controls-bottom>div {
   flex-basis: 0;
   flex-grow: 1;
   max-width: 100%;
 }
 
-.fullscreen-media-controls > div {
+.fullscreen-media-controls>div {
   width: calc(100% / 3);
 }
 
@@ -493,7 +405,7 @@ watch(
   vertical-align: middle;
 }
 
-.fullscreen-mediacontrols-right > div {
+.fullscreen-mediacontrols-right>div {
   display: inline-flex;
   align-items: center;
 }

--- a/src/layouts/default/PlayerOSD/PlayerTrackDetails.vue
+++ b/src/layouts/default/PlayerOSD/PlayerTrackDetails.vue
@@ -14,7 +14,7 @@
     <template #title>
       <div :style="{
         cursor: 'pointer',
-        color: props.color ? color : '',
+        color: primaryColor,
       }">
         <div v-if="curQueueItem && curQueueItem.media_item"
           @click="curQueueItem?.media_item ? itemClick(curQueueItem.media_item) : ''">
@@ -51,7 +51,7 @@
       <!-- track: artists(s) + album -->
       <div :style="{
         cursor: 'pointer',
-        color: props.color ? color : '',
+        color: primaryColor,
       }" class="line-clamp-1">
         <div v-if="curQueueItem &&
           curQueueItem.media_item?.media_type == MediaType.TRACK &&
@@ -116,12 +116,13 @@ interface Props {
   showOnlyArtist?: boolean;
   showQualityDetailsBtn?: boolean;
   colorPalette: ColorCoverPalette;
-  color?: string;
+  primaryColor: string;
 }
 
 const props = withDefaults(defineProps<Props>(), {
   showOnlyArtist: false,
   showQualityDetailsBtn: true,
+  primaryColor: ''
 });
 
 // computed properties

--- a/src/layouts/default/PlayerOSD/PlayerTrackDetails.vue
+++ b/src/layouts/default/PlayerOSD/PlayerTrackDetails.vue
@@ -4,7 +4,7 @@
     <template #prepend>
       <div class="media-thumb player-media-thumb" :style="`height: ${getBreakpointValue({ breakpoint: 'phone' }) ? 50 : 64}px; width: ${getBreakpointValue({ breakpoint: 'phone' }) ? 50 : 64
         }px; `">
-        <PlayerFullscreen :show-fullscreen="store.showFullscreenPlayer" />
+        <PlayerFullscreen :show-fullscreen="store.showFullscreenPlayer" :color-palette="colorPalette" />
         <MediaItemThumb :item="curQueueItem?.media_item || curQueueItem" :fallback="imgCoverDark" style="cursor: pointer" 
           @click="store.showFullscreenPlayer = true"  />
       </div>
@@ -102,7 +102,7 @@ import api from '@/plugins/api';
 import { MediaType, MediaItemType, ItemMapping } from '@/plugins/api/interfaces';
 import { store } from '@/plugins/store';
 import MediaItemThumb from '@/components/MediaItemThumb.vue';
-import { getArtistsString } from '@/helpers/utils';
+import { ColorCoverPalette, getArtistsString } from '@/helpers/utils';
 import { useRouter } from 'vue-router';
 import PlayerFullscreen from './PlayerFullscreen.vue';
 import { imgCoverDark } from '@/components/QualityDetailsBtn.vue';
@@ -115,6 +115,7 @@ const router = useRouter();
 interface Props {
   showOnlyArtist?: boolean;
   showQualityDetailsBtn?: boolean;
+  colorPalette: ColorCoverPalette;
   color?: string;
 }
 

--- a/src/layouts/default/PlayerOSD/PlayerTrackDetails.vue
+++ b/src/layouts/default/PlayerOSD/PlayerTrackDetails.vue
@@ -2,25 +2,38 @@
   <!-- now playing media -->
   <ListItem style="height: auto; width: fit-content; margin: 0px; padding: 0px" lines="two">
     <template #prepend>
-      <div class="media-thumb player-media-thumb" :style="`height: ${getBreakpointValue({ breakpoint: 'phone' }) ? 50 : 64}px; width: ${getBreakpointValue({ breakpoint: 'phone' }) ? 50 : 64
-        }px; `">
+      <div
+        class="media-thumb player-media-thumb"
+        :style="`height: ${getBreakpointValue({ breakpoint: 'phone' }) ? 50 : 64}px; width: ${
+          getBreakpointValue({ breakpoint: 'phone' }) ? 50 : 64
+        }px; `"
+      >
         <PlayerFullscreen :show-fullscreen="store.showFullscreenPlayer" :color-palette="colorPalette" />
-        <MediaItemThumb :item="curQueueItem?.media_item || curQueueItem" :fallback="imgCoverDark" style="cursor: pointer" 
-          @click="store.showFullscreenPlayer = true"  />
+        <MediaItemThumb
+          :item="curQueueItem?.media_item || curQueueItem"
+          :fallback="imgCoverDark"
+          style="cursor: pointer"
+          @click="store.showFullscreenPlayer = true"
+        />
       </div>
     </template>
 
     <!-- title -->
     <template #title>
-      <div :style="{
-        cursor: 'pointer',
-        color: primaryColor,
-      }">
-        <div v-if="curQueueItem && curQueueItem.media_item"
-          @click="curQueueItem?.media_item ? itemClick(curQueueItem.media_item) : ''">
+      <div
+        :style="{
+          cursor: 'pointer',
+          color: primaryColor,
+        }"
+      >
+        <div
+          v-if="curQueueItem && curQueueItem.media_item"
+          @click="curQueueItem?.media_item ? itemClick(curQueueItem.media_item) : ''"
+        >
           {{ curQueueItem.media_item.name }}
-          <span v-if="'version' in curQueueItem.media_item && curQueueItem.media_item.version">({{
-            curQueueItem.media_item.version }})</span>
+          <span v-if="'version' in curQueueItem.media_item && curQueueItem.media_item.version"
+            >({{ curQueueItem.media_item.version }})</span
+          >
         </div>
         <div v-else-if="curQueueItem">
           {{ curQueueItem.name }}
@@ -33,14 +46,23 @@
     <!-- append -->
     <template #append>
       <!-- format -->
-      <v-chip v-if="streamDetails?.audio_format.content_type &&
-        !getBreakpointValue({ breakpoint: 'phone' }) &&
-        showQualityDetailsBtn
-        " :disabled="!activePlayerQueue || !activePlayerQueue?.active || activePlayerQueue?.items == 0"
-        class="player-track-content-type" :style="$vuetify.theme.current.dark
+      <v-chip
+        v-if="
+          streamDetails?.audio_format.content_type &&
+          !getBreakpointValue({ breakpoint: 'phone' }) &&
+          showQualityDetailsBtn
+        "
+        :disabled="!activePlayerQueue || !activePlayerQueue?.active || activePlayerQueue?.items == 0"
+        class="player-track-content-type"
+        :style="
+          $vuetify.theme.current.dark
             ? 'color: #000; background: #fff; margin-left: 15px;'
             : 'color: #fff; background: #000; margin-left: 15px;'
-          " label :ripple="false" v-bind="props">
+        "
+        label
+        :ripple="false"
+        v-bind="props"
+      >
         <div class="d-flex justify-center" style="width: 100%">
           {{ streamDetails.audio_format.content_type.toUpperCase() }}
         </div>
@@ -49,29 +71,40 @@
     <!-- subtitle -->
     <template #subtitle>
       <!-- track: artists(s) + album -->
-      <div :style="{
-        cursor: 'pointer',
-        color: primaryColor,
-      }" class="line-clamp-1">
-        <div v-if="curQueueItem &&
-          curQueueItem.media_item?.media_type == MediaType.TRACK &&
-          'album' in curQueueItem.media_item &&
-          curQueueItem.media_item.album &&
-          !props.showOnlyArtist
-          " @click="curQueueItem?.media_item ? itemClick(curQueueItem.media_item) : ''">
+      <div
+        :style="{
+          cursor: 'pointer',
+          color: primaryColor,
+        }"
+        class="line-clamp-1"
+      >
+        <div
+          v-if="
+            curQueueItem &&
+            curQueueItem.media_item?.media_type == MediaType.TRACK &&
+            'album' in curQueueItem.media_item &&
+            curQueueItem.media_item.album &&
+            !props.showOnlyArtist
+          "
+          @click="curQueueItem?.media_item ? itemClick(curQueueItem.media_item) : ''"
+        >
           {{ getArtistsString(curQueueItem.media_item.artists) }} •
           {{ curQueueItem.media_item.album.name }}
         </div>
         <!-- track/album falback: artist present -->
-        <div v-else-if="curQueueItem &&
-          curQueueItem.media_item &&
-          'artists' in curQueueItem.media_item &&
-          curQueueItem.media_item.artists.length > 0
-          " @click="
-    curQueueItem?.media_item && 'artists' in curQueueItem.media_item
-      ? itemClick(curQueueItem.media_item.artists[0])
-      : ''
-    ">
+        <div
+          v-else-if="
+            curQueueItem &&
+            curQueueItem.media_item &&
+            'artists' in curQueueItem.media_item &&
+            curQueueItem.media_item.artists.length > 0
+          "
+          @click="
+            curQueueItem?.media_item && 'artists' in curQueueItem.media_item
+              ? itemClick(curQueueItem.media_item.artists[0])
+              : ''
+          "
+        >
           {{ curQueueItem.media_item.artists[0].name }}
         </div>
         <!-- radio live metadata -->
@@ -122,7 +155,7 @@ interface Props {
 const props = withDefaults(defineProps<Props>(), {
   showOnlyArtist: false,
   showQualityDetailsBtn: true,
-  primaryColor: ''
+  primaryColor: '',
 });
 
 // computed properties

--- a/src/plugins/store.ts
+++ b/src/plugins/store.ts
@@ -1,19 +1,13 @@
-import type { Player, QueueItem } from './api/interfaces';
+import type { Player } from './api/interfaces';
 import { reactive } from 'vue';
 import type { LocationQuery, RouteParams, RouteMeta } from 'vue-router';
 
-import type { ContextMenuItem } from '@/helpers/contextmenu';
-import { ColorCoverPalette } from '@/helpers/utils';
-
 interface Store {
   selectedPlayer?: Player;
-  currentItemType?: string;
   isInStandaloneMode: boolean;
   showPlayersMenu: boolean;
-  sizeNavigationMenu: number;
+  navigationMenuSize: number;
   showFullscreenPlayer: boolean;
-  coverImageColorCode: ColorCoverPalette;
-  alwaysShowMenuButton: boolean;
   apiInitialized: boolean;
   apiBaseUrl: string;
   dialogActive: boolean;
@@ -28,22 +22,10 @@ interface Store {
 
 export const store: Store = reactive({
   selectedPlayer: undefined,
-  currentItemType: undefined,
   isInStandaloneMode: false,
   showPlayersMenu: false,
-  sizeNavigationMenu: 300,
+  navigationMenuSize: 300,
   showFullscreenPlayer: false,
-  coverImageColorCode: {
-    '0': '',
-    '1': '',
-    '2': '',
-    '3': '',
-    '4': '',
-    '5': '',
-    lightColor: '',
-    darkColor: '',
-  },
-  alwaysShowMenuButton: false,
   apiInitialized: false,
   apiBaseUrl: '',
   dialogActive: false,

--- a/src/views/BrowseView.vue
+++ b/src/views/BrowseView.vue
@@ -12,13 +12,23 @@
       <!-- loading animation -->
       <v-progress-linear v-if="loading" indeterminate />
       <!-- back button -->
-      <v-btn v-if="props.path" variant="plain" icon="mdi-arrow-left"
-        :to="{ name: 'browse', query: { path: backPath } }" />
+      <v-btn
+        v-if="props.path"
+        variant="plain"
+        icon="mdi-arrow-left"
+        :to="{ name: 'browse', query: { path: backPath } }"
+      />
 
-      <v-virtual-scroll :height="66" :items="browseItem?.items || []" style="height:100%">
-        <template v-slot:default="{ item }">
-          <ListviewItem :item="item" :show-library="false" :show-menu="false" :show-provider="false" :is-selected="false"
-            @click="onClick" />
+      <v-virtual-scroll :height="66" :items="browseItem?.items || []" style="height: 100%">
+        <template #default="{ item }">
+          <ListviewItem
+            :item="item"
+            :show-library="false"
+            :show-menu="false"
+            :show-provider="false"
+            :is-selected="false"
+            @click="onClick"
+          />
         </template>
       </v-virtual-scroll>
     </Container>

--- a/src/views/LibraryAlbums.vue
+++ b/src/views/LibraryAlbums.vue
@@ -25,12 +25,12 @@ const items = ref<Album[]>([]);
 const updateAvailable = ref<boolean>(false);
 
 const sortKeys: Record<string, string> = {
-  'name': 'sort_name',
-  'recent': 'timestamp_added DESC',
-  'artist': 'sort_artist, sort_name',
-  'year': 'year',
-  'year_desc': 'year DESC'
-}
+  name: 'sort_name',
+  recent: 'timestamp_added DESC',
+  artist: 'sort_artist, sort_name',
+  year: 'year',
+  year_desc: 'year DESC',
+};
 
 onMounted(() => {
   // signal if/when items get added/updated/removed within this library

--- a/src/views/LibraryArtists.vue
+++ b/src/views/LibraryArtists.vue
@@ -26,9 +26,9 @@ const items = ref<Artist[]>([]);
 const updateAvailable = ref(false);
 
 const sortKeys: Record<string, string> = {
-  'name': 'sort_name',
-  'recent': 'timestamp_added DESC',
-}
+  name: 'sort_name',
+  recent: 'timestamp_added DESC',
+};
 
 const loadItems = async function (params: LoadDataParams) {
   if (params.refresh) {
@@ -49,7 +49,7 @@ const loadItems = async function (params: LoadDataParams) {
     params.limit,
     params.offset,
     sortKeys[params.sortBy],
-    params.albumArtistsFilter
+    params.albumArtistsFilter,
   );
 };
 

--- a/src/views/LibraryPlaylists.vue
+++ b/src/views/LibraryPlaylists.vue
@@ -32,9 +32,9 @@ const updateAvailable = ref(false);
 const contextMenuItems = ref<ContextMenuItem[]>([]);
 
 const sortKeys: Record<string, string> = {
-  'name': 'sort_name',
-  'recent': 'timestamp_added DESC'
-}
+  name: 'sort_name',
+  recent: 'timestamp_added DESC',
+};
 
 const loadItems = async function (params: LoadDataParams) {
   if (params.refresh) {

--- a/src/views/LibraryRadios.vue
+++ b/src/views/LibraryRadios.vue
@@ -38,9 +38,9 @@ const items = ref<Radio[]>([]);
 const updateAvailable = ref<boolean>(false);
 
 const sortKeys: Record<string, string> = {
-  'name': 'sort_name',
-  'recent': 'timestamp_added DESC',
-}
+  name: 'sort_name',
+  recent: 'timestamp_added DESC',
+};
 
 onMounted(() => {
   // signal if/when items get added/updated/removed within this library

--- a/src/views/LibraryTracks.vue
+++ b/src/views/LibraryTracks.vue
@@ -39,13 +39,13 @@ const items = ref<Track[]>([]);
 const updateAvailable = ref<boolean>(false);
 
 const sortKeys: Record<string, string> = {
-  'name': 'sort_name',
-  'recent': 'timestamp_added DESC',
-  'artist': 'sort_artist, sort_name',
-  'album': 'albums.sort_name, tracks.sort_name',
-  'duration': 'duration',
-  'duration_desc': 'duration DESC',
-}
+  name: 'sort_name',
+  recent: 'timestamp_added DESC',
+  artist: 'sort_artist, sort_name',
+  album: 'albums.sort_name, tracks.sort_name',
+  duration: 'duration',
+  duration_desc: 'duration DESC',
+};
 
 onMounted(() => {
   // signal if/when items get added/updated/removed within this library
@@ -75,7 +75,13 @@ const loadItems = async function (params: LoadDataParams) {
     await sleep(500);
   }
   updateAvailable.value = false;
-  return await api.getLibraryTracks(params.favoritesOnly, params.search, params.limit, params.offset, sortKeys[params.sortBy]);
+  return await api.getLibraryTracks(
+    params.favoritesOnly,
+    params.search,
+    params.limit,
+    params.offset,
+    sortKeys[params.sortBy],
+  );
 };
 
 const addUrl = async function () {

--- a/src/views/PlayerQueue.vue
+++ b/src/views/PlayerQueue.vue
@@ -54,53 +54,53 @@
         >
       </Alert>
 
-      <v-virtual-scroll :height="66" :items="tabItems" style="height:100%">
-        <template v-slot:default="{ item }">
+      <v-virtual-scroll :height="66" :items="tabItems" style="height: 100%">
+        <template #default="{ item }">
           <ListviewItem
-          v-if="item.media_item"
-          :key="item.queue_item_id"
-          :item="item.media_item || item"
-          :show-disc-number="false"
-          :show-track-number="false"
-          :show-duration="true"
-          :show-library="true"
-          :show-menu="true"
-          :show-provider="false"
-          :show-album="false"
-          :show-checkboxes="false"
-          :is-selected="false"
-          :show-details="false"
-          :is-disabled="item.queue_item_id == curQueueItem?.queue_item_id"
-          ripple
-          @menu="onClick(item)"
-          @click="queueCommand(item, 'play_now')"
-          @click.right.prevent="onClick(item)"
-        >
-          <template #append>
-            <!-- move up -->
-            <v-btn
-              v-if="getBreakpointValue('bp1')"
-              variant="plain"
-              ripple
-              icon="mdi-arrow-up"
-              :title="$t('queue_move_up')"
-              @click="api.queueCommandMoveUp(activePlayerQueue!.queue_id, item.queue_item_id)"
-              @click.prevent
-              @click.stop
-            />
+            v-if="item.media_item"
+            :key="item.queue_item_id"
+            :item="item.media_item || item"
+            :show-disc-number="false"
+            :show-track-number="false"
+            :show-duration="true"
+            :show-library="true"
+            :show-menu="true"
+            :show-provider="false"
+            :show-album="false"
+            :show-checkboxes="false"
+            :is-selected="false"
+            :show-details="false"
+            :is-disabled="item.queue_item_id == curQueueItem?.queue_item_id"
+            ripple
+            @menu="onClick(item)"
+            @click="queueCommand(item, 'play_now')"
+            @click.right.prevent="onClick(item)"
+          >
+            <template #append>
+              <!-- move up -->
+              <v-btn
+                v-if="getBreakpointValue('bp1')"
+                variant="plain"
+                ripple
+                icon="mdi-arrow-up"
+                :title="$t('queue_move_up')"
+                @click="api.queueCommandMoveUp(activePlayerQueue!.queue_id, item.queue_item_id)"
+                @click.prevent
+                @click.stop
+              />
 
-            <!-- move down -->
-            <v-btn
-              icon="mdi-arrow-down"
-              :title="$t('queue_move_down')"
-              @click.prevent="api.queueCommandMoveDown(activePlayerQueue!.queue_id, item.queue_item_id)"
-            />
-          </template>
-        </ListviewItem>
-        <ListItem v-else>
-          <!-- edge case: QueueItem without MediaItem attached-->
-          <template #title>{{ item.name }}</template>
-        </ListItem>
+              <!-- move down -->
+              <v-btn
+                icon="mdi-arrow-down"
+                :title="$t('queue_move_down')"
+                @click.prevent="api.queueCommandMoveDown(activePlayerQueue!.queue_id, item.queue_item_id)"
+              />
+            </template>
+          </ListviewItem>
+          <ListItem v-else>
+            <!-- edge case: QueueItem without MediaItem attached-->
+            <template #title>{{ item.name }}</template>
+          </ListItem>
         </template>
       </v-virtual-scroll>
 

--- a/src/views/Search.vue
+++ b/src/views/Search.vue
@@ -6,9 +6,17 @@
       </template>
     </v-toolbar>
     <v-divider />
-    <v-text-field id="searchInput" v-model="search" clearable prepend-inner-icon="mdi-magnify"
-      :label="$t('type_to_search')" hide-details variant="filled" @focus="searchHasFocus = true"
-      @blur="searchHasFocus = false" />
+    <v-text-field
+      id="searchInput"
+      v-model="search"
+      clearable
+      prepend-inner-icon="mdi-magnify"
+      :label="$t('type_to_search')"
+      hide-details
+      variant="filled"
+      @focus="searchHasFocus = true"
+      @blur="searchHasFocus = false"
+    />
     <div>
       <v-chip-group v-model="viewFilter" column style="margin-top: 15px; margin-left: 10px">
         <v-chip v-for="item in viewFilters" :key="item" filter outlined>
@@ -21,22 +29,40 @@
 
       <!-- panel view -->
       <v-row v-if="viewMode == 'panel'">
-        <v-col v-for="item in filteredItems" :key="item.uri"
-          :class="`col-${panelViewItemResponsive($vuetify.display.width)}`">
-          <PanelviewItem :item="item" :size="thumbSize" :is-selected="false" :show-checkboxes="false" @menu="onMenu"
-            @click="onClick" />
+        <v-col
+          v-for="item in filteredItems"
+          :key="item.uri"
+          :class="`col-${panelViewItemResponsive($vuetify.display.width)}`"
+        >
+          <PanelviewItem
+            :item="item"
+            :size="thumbSize"
+            :is-selected="false"
+            :show-checkboxes="false"
+            @menu="onMenu"
+            @click="onClick"
+          />
         </v-col>
       </v-row>
 
       <!-- list view -->
-      <v-virtual-scroll :height="60" :items="filteredItems" v-if="viewMode == 'list'" style="height:100%">
-        <template v-slot:default="{ item }">
-          <ListviewItem :item="item" :show-track-number="false" :show-duration="true" :show-library="false"
-            :show-menu="true" :show-provider="true" :show-checkboxes="false" :is-selected="false" :show-details="true"
-            @menu="onMenu" @click="onClick" />
+      <v-virtual-scroll v-if="viewMode == 'list'" :height="60" :items="filteredItems" style="height: 100%">
+        <template #default="{ item }">
+          <ListviewItem
+            :item="item"
+            :show-track-number="false"
+            :show-duration="true"
+            :show-library="false"
+            :show-menu="true"
+            :show-provider="true"
+            :show-checkboxes="false"
+            :is-selected="false"
+            :show-details="true"
+            @menu="onMenu"
+            @click="onClick"
+          />
         </template>
       </v-virtual-scroll>
-
 
       <v-toolbar density="compact" variant="flat" color="transparent" height="45">
         <span style="margin-left: 15px">{{ $t('items_total', [filteredItems.length]) }}</span>
@@ -44,8 +70,12 @@
 
         <v-tooltip location="bottom">
           <template #activator="{ props }">
-            <v-btn v-bind="props" :icon="viewMode == 'panel' ? 'mdi-view-list' : 'mdi-grid'" variant="plain"
-              @click="toggleViewMode()" />
+            <v-btn
+              v-bind="props"
+              :icon="viewMode == 'panel' ? 'mdi-view-list' : 'mdi-grid'"
+              variant="plain"
+              @click="toggleViewMode()"
+            />
           </template>
           <span>{{ $t('tooltip.toggle_view_mode') }}</span>
         </v-tooltip>

--- a/src/views/settings/Players.vue
+++ b/src/views/settings/Players.vue
@@ -9,53 +9,61 @@
       </template>
     </v-toolbar>
     <Container>
-      <ListItem v-for="item in playerConfigs" :key="item.player_id" v-hold="() => {
-        editPlayer(item.player_id);
-      }
-        " link :context-menu-items="[
-    {
-      label: 'settings.configure',
-      labelArgs: [],
-      action: () => {
-        editPlayer(item.player_id);
-      },
-      icon: 'mdi-cog',
-    },
-    {
-      label: 'settings.edit_group_members',
-      labelArgs: [],
-      action: () => {
-        editGroupMembers(item.player_id);
-      },
-      icon: 'mdi-speaker-multiple',
-      hide: item.provider != 'ugp',
-    },
-    {
-      label: item.enabled ? 'settings.disable' : 'settings.enable',
-      labelArgs: [],
-      action: () => {
-        toggleEnabled(item);
-      },
-      icon: 'mdi-cancel',
-    },
-    {
-      label: 'settings.documentation',
-      labelArgs: [],
-      action: () => {
-        openLinkInNewTab(api.providerManifests[item.provider].documentation!);
-      },
-      icon: 'mdi-bookshelf',
-      disabled: !api.providerManifests[item.provider].documentation,
-    },
-    {
-      label: 'settings.delete',
-      labelArgs: [],
-      action: () => {
-        removePlayerConfig(item.player_id);
-      },
-      icon: 'mdi-delete',
-    },
-  ]" @click="editPlayer(item.player_id)">
+      <ListItem
+        v-for="item in playerConfigs"
+        :key="item.player_id"
+        v-hold="
+          () => {
+            editPlayer(item.player_id);
+          }
+        "
+        link
+        :context-menu-items="[
+          {
+            label: 'settings.configure',
+            labelArgs: [],
+            action: () => {
+              editPlayer(item.player_id);
+            },
+            icon: 'mdi-cog',
+          },
+          {
+            label: 'settings.edit_group_members',
+            labelArgs: [],
+            action: () => {
+              editGroupMembers(item.player_id);
+            },
+            icon: 'mdi-speaker-multiple',
+            hide: item.provider != 'ugp',
+          },
+          {
+            label: item.enabled ? 'settings.disable' : 'settings.enable',
+            labelArgs: [],
+            action: () => {
+              toggleEnabled(item);
+            },
+            icon: 'mdi-cancel',
+          },
+          {
+            label: 'settings.documentation',
+            labelArgs: [],
+            action: () => {
+              openLinkInNewTab(api.providerManifests[item.provider].documentation!);
+            },
+            icon: 'mdi-bookshelf',
+            disabled: !api.providerManifests[item.provider].documentation,
+          },
+          {
+            label: 'settings.delete',
+            labelArgs: [],
+            action: () => {
+              removePlayerConfig(item.player_id);
+            },
+            icon: 'mdi-delete',
+          },
+        ]"
+        @click="editPlayer(item.player_id)"
+      >
         <template #prepend>
           <provider-icon :domain="item.provider" :size="40" class="listitem-media-thumb" />
         </template>
@@ -109,9 +117,7 @@ onBeforeUnmount(unsub);
 
 // methods
 const loadItems = async function () {
-  playerConfigs.value = (await api.getPlayerConfigs()).sort((a, b) =>
-    getPlayerName(a).localeCompare(getPlayerName(b))
-  );;
+  playerConfigs.value = (await api.getPlayerConfigs()).sort((a, b) => getPlayerName(a).localeCompare(getPlayerName(b)));
 };
 
 const removePlayerConfig = function (playerId: string) {

--- a/src/views/settings/Settings.vue
+++ b/src/views/settings/Settings.vue
@@ -17,7 +17,7 @@
     </v-toolbar>
     <v-divider />
     <!-- some spacing -->
-    <div style="height:15px" />
+    <div style="height: 15px"></div>
     <router-view v-slot="{ Component }" app>
       <component :is="Component" />
       <!-- transition temporary disabled as it renders the view unusable somehow? -->


### PR DESCRIPTION
- Centralize the colorlogic from the active queue item into the player file
- Use props instead of store to share the color palette
- Rename some variables
- Do not apply colors from the cover image globally 