### PR TITLE
Add dark mode theme-color for top bar on mobile browsers (and Safari desktop)

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,7 +9,8 @@
     <link rel="apple-touch-icon" href="apple-touch-icon.png" sizes="180x180">
     <link rel="mask-icon" href="favicon.svg" color="#FFFFFF">
     <link rel="manifest" href="manifest.webmanifest">
-    <meta name="theme-color" content="#ffffff">
+    <meta name="theme-color" media="(prefers-color-scheme: light)" content="#ffffff">
+    <meta name="theme-color" media="(prefers-color-scheme: dark)"  content="#121212">
     <link rel="icon" href="favicon.ico" />
     <title>Music Assistant</title>
     <meta name="description" content="Music Assistant - Music library manager for Home Assistant">

--- a/public/index.html
+++ b/public/index.html
@@ -10,7 +10,8 @@
     <link rel="mask-icon" href="favicon.svg" color="#FFFFFF">
     <link rel="manifest" href="manifest.webmanifest">
     <link rel="preload" as="font" href="./assets/JetBrainsMono-Medium.woff2" type="font/woff2" crossorigin="anonymous">
-    <meta name="theme-color" content="#ffffff">
+    <meta name="theme-color" media="(prefers-color-scheme: light)" content="#ffffff">
+    <meta name="theme-color" media="(prefers-color-scheme: dark)"  content="#121212">
     <title>Music Assistant</title>
     <meta name="description" content="Music Assistant - Music library manager for Home Assistant">
   </head>


### PR DESCRIPTION
On the [most common mobile browsers](https://caniuse.com/?search=theme-color) it's possible to theme the top bar colour to match the content. Currently in MA the `theme-color` is set to `#ffffff` (white) at all times, which doesn't adapt to dark mode like the rest of the UI.

This PR fixes that by adding an extra `meta` tag and giving them both media queries, so the browser will choose the appropriate colour based on the OS theme preference. This is currently [standard practice](https://web.dev/add-manifest/#theme-color) as multiple theme colours are not yet supported in manifests.