### PR TITLE
Move the count of the number of items next to the title of the row

### DIFF
--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -9,10 +9,11 @@
           @click="widgetRow.path ? $router.replace(widgetRow.path) : ''"
         >
           <template #prepend><v-icon :icon="widgetRow.icon" style="margin-left: 15px" /></template>
-          <template #title>{{ $t(widgetRow.label) }}</template>
-          <template v-if="widgetRow.path" #append
-            ><v-badge v-if="widgetRow.count" color="grey" :content="widgetRow.count"
-          /></template>
+          <template #title>
+            <v-badge inline v-if="widgetRow.count" color="grey" :content="widgetRow.count">
+              <span class="mr-3">{{ $t(widgetRow.label) }}</span>
+            </v-badge>
+          </template>
         </v-toolbar>
         <v-slide-group :show-arrows="false">
           <v-slide-group-item v-for="item in widgetRow.items" :key="item.uri">

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -13,6 +13,9 @@
             <v-badge inline v-if="widgetRow.count" color="grey" :content="widgetRow.count">
               <span class="mr-3">{{ $t(widgetRow.label) }}</span>
             </v-badge>
+            <template v-else>
+              <span class="mr-3">{{ $t(widgetRow.label) }}</span>
+            </template>
           </template>
         </v-toolbar>
         <v-slide-group :show-arrows="false">


### PR DESCRIPTION
Prior to this PR, the 'count' for the number of items in a row on the homepage was all the way to the right and was clipped off the screen. This PR moves the count next to the title of the row. Not only does this fix the issue of the count not being visible, it visually makes it a little clearer which row the count is for

## Screenshots
Before
<img width="1865" alt="Screenshot of a list of albums. The title of the row is 'Albums'. The badge showing the number of albums there are in total is off the screen to the right" src="https://github.com/music-assistant/frontend/assets/30210785/3b4cade2-637c-4496-912f-067c2c4ac25e">

After
<img width="1852" alt="Screenshot of a list of albums. The title of the row is 'Albums'. The badge showing the number of albums there are in total is beside the title of the row" src="https://github.com/music-assistant/frontend/assets/30210785/e97045b2-d8e5-4c05-b9a2-b5f451b05b83">
