### PR TITLE
Make the icon in the "Play modal dialog" not interactive

### DIFF
--- a/src/layouts/default/PlayItemDialog.vue
+++ b/src/layouts/default/PlayItemDialog.vue
@@ -16,10 +16,18 @@
     "
   >
     <v-card>
-      <v-toolbar color="transparent" style="padding: 10px 0px" density="compact" class="titlebar">
-        <v-btn icon="mdi-play-circle-outline" />
-        <v-toolbar-title style="padding-left: 10px">
-          <b>{{ header }}</b>
+      <v-toolbar color="transparent" density="compact" class="titlebar">
+        <template #prepend>
+          <v-icon
+            size="large"
+            class="ml-4 d-none d-sm-block"
+            style="vertical-align: initial"
+            icon="mdi-play-circle-outline"
+            aria-hidden="true"
+          />
+        </template>
+        <v-toolbar-title>
+          <h2 class="font-weight-bold">{{ header }}</h2>
         </v-toolbar-title>
         <v-btn icon="mdi-close" dark @click="close()" />
       </v-toolbar>


### PR DESCRIPTION
I've made the following changes:

- Dont' wrap the icon in a button. This removes the hover and interactive behaviour
- Slightly decreased the spacing between the icon and the title
- Added `aria-hidden` to remove the icon from the accessibility tree as it doesn't add value
- Changed the modal title to use a `<h2>` rather than only styling it to improve semantic
- Hide the icon on small screens

## Screenshots 

### Desktop

Before
<img width="1280" alt="before" src="https://github.com/music-assistant/frontend/assets/30210785/cfe8c58f-b0ea-4885-a119-f4ec05484b58">


After
<img width="1280" alt="after" src="https://github.com/music-assistant/frontend/assets/30210785/a3fe9a95-e935-4f3e-9203-cd0297fc2ee8">


### Mobile

Before
<img width="381" alt="before-mobile" src="https://github.com/music-assistant/frontend/assets/30210785/4ca7c99f-b380-448c-99f3-be11e6171101">


After
<img width="380" alt="after-mobile" src="https://github.com/music-assistant/frontend/assets/30210785/0abdd87c-750c-4aef-ad4f-d2371c8243f7">
