### PR TITLE
Remove unused ellipsis

### DIFF
--- a/src/layouts/default/PlayerOSD/PlayerFullscreen.vue
+++ b/src/layouts/default/PlayerOSD/PlayerFullscreen.vue
@@ -18,11 +18,6 @@
           <h3 class="line-clamp-1">{{ $t('currently_playing') }}</h3>
         </template>
 
-        <template #append>
-          <Button icon>
-            <v-icon icon="mdi-dots-vertical" />
-          </Button>
-        </template>
       </v-toolbar>
 
       <Container class="fullscreen-container">


### PR DESCRIPTION
The vertical three dot menu is shown in the top right of the NOW PLAYING view. It doesn't do anything and therefore should be removed.