### PR TITLE
Fix race condition in global search

### DIFF
--- a/src/views/Search.vue
+++ b/src/views/Search.vue
@@ -33,7 +33,7 @@
         <ItemsListing
           v-if="filteredItems(resultKey).length"
           :itemtype="`search.${resultKey}`"
-          :path="`search.${search}`"
+          :path="`search.${deferredSearch}`"
           :show-provider="true"
           :show-favorites-only-filter="false"
           :show-select-button="false"
@@ -81,6 +81,7 @@ const compProps = defineProps<Props>();
 
 // local refs
 const search = ref('');
+const deferredSearch = ref('');
 const searchHasFocus = ref(false);
 const searchResult = ref<SearchResults>();
 const loading = ref(false);
@@ -107,6 +108,7 @@ const loadSearchResults = async function () {
     searchResult.value = undefined;
   }
   loading.value = false;
+  deferredSearch.value = search.value;
 };
 
 const filteredItems = function (itemType: string) {


### PR DESCRIPTION
I noticed global search always seemed to act a bit oddly and out of step with the search term, but it's often hard to notice when typing a character at a time.  It's easier to see if you cut n paste the search terms in place - so search for Artist1 -> Artist2 -> Artist3 etc and note the search results are always lagging behind by a search.

I think it's due to a race condition - when the reactive search term changes:
1. Fetch the search results from providers after a 200ms setTimeout 
2. Rerender the search inteface components

but 2 is happening before 1 finishes so the component is using the previous search result data when rerendering.

Added a small tweak to trigger 2 after 1 finishes.
