### PR TITLE
Feature: search for radio stream title from full screen player

### DIFF
--- a/src/layouts/default/PlayerOSD/PlayerFullscreen.vue
+++ b/src/layouts/default/PlayerOSD/PlayerFullscreen.vue
@@ -121,7 +121,18 @@
                 store.curQueueItem?.streamdetails?.stream_title
               "
             >
-              <h4 class="fullscreen-track-info-subtitle">
+              <!-- radio live metadata -->
+              <h4
+                v-if="
+                  store.curQueueItem.streamdetails.stream_title &&
+                  store.curQueueItem.streamdetails.stream_title.includes(' - ')
+                "
+                class="fullscreen-track-info-subtitle"
+                style="cursor: pointer"
+                @click="
+                  radioTitleClick(store.curQueueItem.streamdetails.stream_title)
+                "
+              >
                 {{ store.curQueueItem.streamdetails.stream_title }}
               </h4>
             </div>
@@ -486,6 +497,13 @@ const radioNameClick = function (item: Radio | ItemMapping) {
       provider: item.provider,
     },
   });
+  store.showFullscreenPlayer = false;
+};
+
+const radioTitleClick = function (streamTitle: string) {
+  // radio station title clicked
+  store.globalSearchTerm = streamTitle;
+  router.push({ name: 'search' });
   store.showFullscreenPlayer = false;
 };
 

--- a/src/layouts/default/PlayerOSD/PlayerFullscreen.vue
+++ b/src/layouts/default/PlayerOSD/PlayerFullscreen.vue
@@ -124,7 +124,6 @@
               <!-- radio live metadata -->
               <h4
                 v-if="
-                  store.curQueueItem.streamdetails.stream_title &&
                   store.curQueueItem.streamdetails.stream_title.includes(' - ')
                 "
                 class="fullscreen-track-info-subtitle"
@@ -133,6 +132,9 @@
                   radioTitleClick(store.curQueueItem.streamdetails.stream_title)
                 "
               >
+                {{ store.curQueueItem.streamdetails.stream_title }}
+              </h4>
+              <h4 v-else class="fullscreen-track-info-subtitle">
                 {{ store.curQueueItem.streamdetails.stream_title }}
               </h4>
             </div>


### PR DESCRIPTION
This adds the feature to click the radio stream title in the full screen player and perform a global search for it.
 
I think this will be useful to have despite the varying quality and junk sometimes appearing in the stream title metadata!  Despite that, search makes a pretty good job and user can modify the search manually if needed.

Routing to /search when it's already the current route does nothing, so I used the eventbus to notify the seach component - couldn't think of a better way.