### PR TITLE
Fix: Search ignores last press sometimes

### DIFF
--- a/src/views/Search.vue
+++ b/src/views/Search.vue
@@ -151,9 +151,9 @@ const keyListener = function (e: KeyboardEvent) {
     store.globalSearchTerm += e.key;
   }
 };
-document.addEventListener('keydown', keyListener);
+document.addEventListener('keyup', keyListener);
 
 onBeforeUnmount(() => {
-  document.removeEventListener('keydown', keyListener);
+  document.removeEventListener('keyup', keyListener);
 });
 </script>


### PR DESCRIPTION
Sometimes when searching you have to press space for it to trigger the searching update. I think its better if the keypress event listens to `keyup` instead of `keydown` to allow it to always have the latest value when searching. Correct me if I am wrong.