### PR TITLE
Match menu to tooltip

### DIFF
--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -477,6 +477,6 @@
     "create_playlist_on": "Create new playlist on {0}",
     "view": {
         "list": "List view",
-        "panel": "Panel view"
+        "panel": "Thumbs view"
     }
 }


### PR DESCRIPTION
I noticed that the tooltip says Toggle view mode list/thumbs but the menu was different.