### PR TITLE
Fix back button in toolbar

### DIFF
--- a/src/components/Toolbar.vue
+++ b/src/components/Toolbar.vue
@@ -1,12 +1,7 @@
 <template>
   <v-toolbar :color="color" class="header">
     <template v-if="icon" #prepend>
-      <v-icon
-        :icon="icon"
-        size="large"
-        style="margin-left: 10px"
-        @click="emit('iconClicked')"
-      />
+      <v-btn :icon="icon" size="large" @click="emit('iconClicked')" />
     </template>
 
     <template v-if="title" #title>


### PR DESCRIPTION
The back button wasn't setup as button but clickable icon, so not very clear visible as a button.
This fixes that.

Fixes https://github.com/music-assistant/hass-music-assistant/issues/2217