### PR TITLE
Fix: make the play actions consistent

### DIFF
--- a/src/components/HomeWidgetRow.vue
+++ b/src/components/HomeWidgetRow.vue
@@ -75,19 +75,18 @@ interface Props {
 const { widgetRow } = defineProps<Props>();
 
 const onMenu = function (
-  evt: PointerEvent | TouchEvent,
   item: MediaItemType | MediaItemType[],
+  posX: number,
+  posY: number,
 ) {
   const mediaItems: MediaItemType[] = Array.isArray(item) ? item : [item];
-  const posX = 'clientX' in evt ? evt.clientX : evt.touches[0].clientX;
-  const posY = 'clientY' in evt ? evt.clientY : evt.touches[0].clientY;
   showContextMenuForMediaItem(mediaItems, undefined, posX, posY);
 };
 
-const onClick = function (evt: Event, item: MediaItemType) {
+const onClick = function (item: MediaItemType, posX: number, posY: number) {
   // mediaItem in the list is clicked
   if (!itemIsAvailable(item)) {
-    onMenu(evt as PointerEvent, item);
+    onMenu(item, posX, posY);
     return;
   }
   if (item.media_type == MediaType.FOLDER) {
@@ -108,10 +107,10 @@ const onClick = function (evt: Event, item: MediaItemType) {
   }
 };
 
-const onPlayClick = function (evt: Event, item: MediaItemType) {
+const onPlayClick = function (item: MediaItemType, posX: number, posY: number) {
   // play button on item is clicked
   if (!itemIsAvailable(item)) {
-    onMenu(evt, item);
+    onMenu(item, posX, posY);
     return;
   }
   if (!store.activePlayerId) {

--- a/src/components/HomeWidgetRow.vue
+++ b/src/components/HomeWidgetRow.vue
@@ -74,20 +74,20 @@ interface Props {
 
 const { widgetRow } = defineProps<Props>();
 
-const onMenu = function (evt: Event, item: MediaItemType | MediaItemType[]) {
+const onMenu = function (
+  evt: PointerEvent | TouchEvent,
+  item: MediaItemType | MediaItemType[],
+) {
   const mediaItems: MediaItemType[] = Array.isArray(item) ? item : [item];
-  showContextMenuForMediaItem(
-    mediaItems,
-    undefined,
-    (evt as PointerEvent).clientX,
-    (evt as PointerEvent).clientY,
-  );
+  const posX = 'clientX' in evt ? evt.clientX : evt.touches[0].clientX;
+  const posY = 'clientY' in evt ? evt.clientY : evt.touches[0].clientY;
+  showContextMenuForMediaItem(mediaItems, undefined, posX, posY);
 };
 
 const onClick = function (evt: Event, item: MediaItemType) {
   // mediaItem in the list is clicked
   if (!itemIsAvailable(item)) {
-    onMenu(evt, item);
+    onMenu(evt as PointerEvent, item);
     return;
   }
   if (item.media_type == MediaType.FOLDER) {

--- a/src/components/HomeWidgetRow.vue
+++ b/src/components/HomeWidgetRow.vue
@@ -37,6 +37,7 @@
           "
           @menu="onMenu"
           @click="onClick"
+          @play="onPlayClick"
         />
       </swiper-slide>
     </carousel>
@@ -47,6 +48,7 @@
 import Carousel from '@/components/Carousel.vue';
 import PanelviewItemCompact from '@/components/PanelviewItemCompact.vue';
 import { showContextMenuForMediaItem } from '@/layouts/default/ItemContextMenu.vue';
+import api from '@/plugins/api';
 import { itemIsAvailable } from '@/plugins/api/helpers';
 import {
   BrowseFolder,
@@ -55,6 +57,7 @@ import {
   PlayerQueue,
 } from '@/plugins/api/interfaces';
 import router from '@/plugins/router';
+import { store } from '@/plugins/store';
 
 export interface WidgetRow {
   label: string;
@@ -94,7 +97,7 @@ const onClick = function (evt: Event, item: MediaItemType) {
         path: (item as BrowseFolder).path,
       },
     });
-  } else if (['artist', 'album', 'playlist'].includes(item.media_type)) {
+  } else {
     router.push({
       name: item.media_type,
       params: {
@@ -102,9 +105,20 @@ const onClick = function (evt: Event, item: MediaItemType) {
         provider: item.provider,
       },
     });
-  } else {
-    onMenu(evt, item);
   }
+};
+
+const onPlayClick = function (evt: Event, item: MediaItemType) {
+  // play button on item is clicked
+  if (!itemIsAvailable(item)) {
+    onMenu(evt, item);
+    return;
+  }
+  if (!store.activePlayerId) {
+    store.showPlayersMenu = true;
+    return;
+  }
+  api.playMedia(item.uri, undefined);
 };
 </script>
 

--- a/src/components/ItemsListing.vue
+++ b/src/components/ItemsListing.vue
@@ -393,6 +393,18 @@ const onClick = function (evt: Event, item: MediaItemType) {
   }
 };
 
+const onPlayClick = function (evt: Event, item: MediaItemType) {
+  if (!itemIsAvailable(item)) {
+    onMenu(evt, item);
+    return;
+  }
+  if (!store.activePlayerId) {
+    store.showPlayersMenu = true;
+    return;
+  }
+  api.playMedia(item.uri, undefined);
+};
+
 const onClear = function () {
   params.value.search = '';
   showSearch.value = false;
@@ -610,9 +622,6 @@ const loadData = async function (clear = false, refresh = false) {
         allItems.value.push(...(nextItems.items as MediaItemType[]));
         if (nextItems.total != null) {
           total.value = nextItems.total;
-        } else if (allItems.value.length != params.value.limit) {
-          total.value = allItems.value.length;
-          break;
         }
         if (total.value != null && allItems.value.length >= total.value) {
           break;

--- a/src/components/ItemsListing.vue
+++ b/src/components/ItemsListing.vue
@@ -379,6 +379,13 @@ const onClick = function (evt: Event, item: MediaItemType) {
         path: (item as BrowseFolder).path,
       },
     });
+  } else if (
+    viewMode.value == 'list' &&
+    item.media_type == MediaType.TRACK &&
+    props.parentItem
+  ) {
+    // track clicked in a sublisting (e.g. album/playlist) listview
+    onPlayClick(evt, item);
   } else {
     router.push({
       name: item.media_type,

--- a/src/components/ItemsListing.vue
+++ b/src/components/ItemsListing.vue
@@ -356,14 +356,14 @@ const onRefreshClicked = function () {
   loadData(true, true);
 };
 
-const onMenu = function (evt: Event, item: MediaItemType | MediaItemType[]) {
+const onMenu = function (
+  evt: PointerEvent | TouchEvent,
+  item: MediaItemType | MediaItemType[],
+) {
   const mediaItems: MediaItemType[] = Array.isArray(item) ? item : [item];
-  showContextMenuForMediaItem(
-    mediaItems,
-    props.parentItem,
-    (evt as PointerEvent).clientX,
-    (evt as PointerEvent).clientY,
-  );
+  const posX = 'clientX' in evt ? evt.clientX : evt.touches[0].clientX;
+  const posY = 'clientY' in evt ? evt.clientY : evt.touches[0].clientY;
+  showContextMenuForMediaItem(mediaItems, props.parentItem, posX, posY);
 };
 
 const onClick = function (evt: Event, item: MediaItemType) {
@@ -400,7 +400,7 @@ const onClick = function (evt: Event, item: MediaItemType) {
 const onPlayClick = function (evt: Event, item: MediaItemType) {
   // play button on item is clicked
   if (!itemIsAvailable(item)) {
-    onMenu(evt, item);
+    onMenu(evt as PointerEvent, item);
     return;
   }
   if (!store.activePlayerId) {

--- a/src/components/ItemsListing.vue
+++ b/src/components/ItemsListing.vue
@@ -126,7 +126,10 @@
             <v-btn
               color="primary"
               variant="text"
-              @click="(evt: Event) => onMenu(evt, selectedItems)"
+              @click="
+                (evt: PointerEvent) =>
+                  onMenu(selectedItems, evt.clientX, evt.clientY)
+              "
             >
               {{ $t('actions') }}
             </v-btn>
@@ -357,19 +360,18 @@ const onRefreshClicked = function () {
 };
 
 const onMenu = function (
-  evt: PointerEvent | TouchEvent,
   item: MediaItemType | MediaItemType[],
+  posX: number,
+  posY: number,
 ) {
   const mediaItems: MediaItemType[] = Array.isArray(item) ? item : [item];
-  const posX = 'clientX' in evt ? evt.clientX : evt.touches[0].clientX;
-  const posY = 'clientY' in evt ? evt.clientY : evt.touches[0].clientY;
   showContextMenuForMediaItem(mediaItems, props.parentItem, posX, posY);
 };
 
-const onClick = function (evt: Event, item: MediaItemType) {
+const onClick = function (item: MediaItemType, posX: number, posY: number) {
   // mediaItem in the list is clicked
   if (!itemIsAvailable(item)) {
-    onMenu(evt, item);
+    onMenu(item, posX, posY);
     return;
   }
   if (item.media_type == MediaType.FOLDER) {
@@ -385,7 +387,7 @@ const onClick = function (evt: Event, item: MediaItemType) {
     props.parentItem
   ) {
     // track clicked in a sublisting (e.g. album/playlist) listview
-    onPlayClick(evt, item);
+    onPlayClick(item, posX, posY);
   } else {
     router.push({
       name: item.media_type,
@@ -397,10 +399,10 @@ const onClick = function (evt: Event, item: MediaItemType) {
   }
 };
 
-const onPlayClick = function (evt: Event, item: MediaItemType) {
+const onPlayClick = function (item: MediaItemType, posX: number, posY: number) {
   // play button on item is clicked
   if (!itemIsAvailable(item)) {
-    onMenu(evt as PointerEvent, item);
+    onMenu(item, posX, posY);
     return;
   }
   if (!store.activePlayerId) {

--- a/src/components/ItemsListing.vue
+++ b/src/components/ItemsListing.vue
@@ -55,12 +55,11 @@
                 :item="item"
                 :is-selected="isSelected(item)"
                 :show-checkboxes="showCheckboxes"
-                :show-track-number="showTrackNumber"
-                :show-favorite="showFavoritesOnlyFilter"
                 :show-actions="['tracks', 'albums'].includes(itemtype)"
                 @select="onSelect"
                 @menu="onMenu"
                 @click="onClick"
+                @play="onPlayClick"
               />
             </v-col>
           </v-row>
@@ -352,6 +351,11 @@ const toggleCheckboxes = function () {
   showCheckboxes.value = !showCheckboxes.value;
 };
 
+const onRefreshClicked = function () {
+  emit('refreshClicked');
+  loadData(true, true);
+};
+
 const onMenu = function (evt: Event, item: MediaItemType | MediaItemType[]) {
   const mediaItems: MediaItemType[] = Array.isArray(item) ? item : [item];
   showContextMenuForMediaItem(
@@ -360,11 +364,6 @@ const onMenu = function (evt: Event, item: MediaItemType | MediaItemType[]) {
     (evt as PointerEvent).clientX,
     (evt as PointerEvent).clientY,
   );
-};
-
-const onRefreshClicked = function () {
-  emit('refreshClicked');
-  loadData(true, true);
 };
 
 const onClick = function (evt: Event, item: MediaItemType) {
@@ -380,7 +379,7 @@ const onClick = function (evt: Event, item: MediaItemType) {
         path: (item as BrowseFolder).path,
       },
     });
-  } else if (['artist', 'album', 'playlist'].includes(item.media_type)) {
+  } else {
     router.push({
       name: item.media_type,
       params: {
@@ -388,12 +387,11 @@ const onClick = function (evt: Event, item: MediaItemType) {
         provider: item.provider,
       },
     });
-  } else {
-    onMenu(evt, item);
   }
 };
 
 const onPlayClick = function (evt: Event, item: MediaItemType) {
+  // play button on item is clicked
   if (!itemIsAvailable(item)) {
     onMenu(evt, item);
     return;

--- a/src/components/ListviewItem.vue
+++ b/src/components/ListviewItem.vue
@@ -228,7 +228,7 @@ export interface Props {
 // global refs
 const { t } = useI18n();
 
-const props = withDefaults(defineProps<Props>(), {
+const compProps = withDefaults(defineProps<Props>(), {
   showTrackNumber: true,
   showDiscNumber: true,
   showProvider: true,
@@ -243,8 +243,8 @@ const props = withDefaults(defineProps<Props>(), {
 
 // computed properties
 const HiResDetails = computed(() => {
-  if (!('provider_mappings' in props.item)) return '';
-  for (const prov of props.item.provider_mappings) {
+  if (!('provider_mappings' in compProps.item)) return '';
+  for (const prov of compProps.item.provider_mappings) {
     if (!prov.audio_format) continue;
     if (prov.audio_format.content_type == undefined) continue;
     if (
@@ -269,24 +269,21 @@ const HiResDetails = computed(() => {
 });
 
 // emits
-/* eslint-disable no-unused-vars */
 const emit = defineEmits<{
-  (e: 'menu', event: Event, item: MediaItemType): void;
-  (e: 'click', event: Event, item: MediaItemType): void;
+  (e: 'menu', item: MediaItemType, posX: number, posY: number): void;
+  (e: 'click', item: MediaItemType, posX: number, posY: number): void;
   (e: 'select', item: MediaItemType, selected: boolean): void;
 }>();
-/* eslint-enable no-unused-vars */
 
-// methods
-
-const onMenu = function (event: Event) {
-  if (props.showCheckboxes) return;
-  emit('menu', event, props.item);
+const onMenu = function (evt: PointerEvent | TouchEvent) {
+  const posX = 'clientX' in evt ? evt.clientX : evt.touches[0].clientX;
+  const posY = 'clientY' in evt ? evt.clientY : evt.touches[0].clientY;
+  emit('menu', compProps.item, posX, posY);
 };
 
-const onClick = function (event: Event) {
-  if (props.showCheckboxes) return;
-  emit('click', event, props.item);
+const onClick = function (evt: PointerEvent) {
+  if (compProps.showCheckboxes) return;
+  emit('click', compProps.item, evt.clientX, evt.clientY);
 };
 </script>
 

--- a/src/components/ListviewItem.vue
+++ b/src/components/ListviewItem.vue
@@ -1,196 +1,186 @@
 <!-- eslint-disable vue/no-template-shadow -->
 <template>
-  <div>
-    <ListItem
-      link
-      :disabled="!itemIsAvailable(item) || isDisabled"
-      :show-menu-btn="showMenu"
-      @click.stop="onClick"
-      @menu.stop="onMenu"
-    >
-      <template #prepend>
-        <div v-if="showCheckboxes" class="media-thumb listitem-media-thumb">
-          <v-checkbox
-            :model-value="isSelected"
-            @click.stop
-            @update:model-value="
-              (x: boolean | null) => {
-                if (x != null) emit('select', item, x);
-              }
-            "
-          />
-        </div>
-        <div v-else class="media-thumb listitem-media-thumb">
-          <MediaItemThumb size="50" :item="item" />
-        </div>
-      </template>
-
-      <!-- title -->
-      <template #title>
-        <span v-if="item.media_type == MediaType.FOLDER">
-          <span>{{ getBrowseFolderName(item as BrowseFolder, t) }}</span>
-        </span>
-        <span v-else>
-          {{ item.name }}
-          <span v-if="'version' in item && item.version"
-            >({{ item.version }})</span
-          >
-        </span>
-        <!-- explicit icon -->
-        <v-tooltip v-if="item && item.metadata" location="bottom">
-          <template #activator="{ props }">
-            <v-icon
-              v-if="parseBool(item.metadata.explicit || false)"
-              v-bind="props"
-              icon="mdi-alpha-e-box"
-              width="35"
-            />
-          </template>
-          <span>{{ $t('tooltip.explicit') }}</span>
-        </v-tooltip>
-      </template>
-
-      <!-- subtitle -->
-      <template #subtitle>
-        <!-- track: artists(s) + album (check for provider_mappings to filter out ItemMapping) -->
-        <div
-          v-if="
-            item.media_type == MediaType.TRACK && 'provider_mappings' in item
+  <ListItem
+    link
+    :disabled="!itemIsAvailable(item) || isDisabled"
+    :show-menu-btn="showMenu"
+    @click.stop="onClick"
+    @menu.stop="onMenu"
+  >
+    <template #prepend>
+      <div v-if="showCheckboxes" class="media-thumb listitem-media-thumb">
+        <v-checkbox
+          :model-value="isSelected"
+          @click.stop
+          @update:model-value="
+            (x: boolean | null) => {
+              if (x != null) emit('select', item, x);
+            }
           "
-          class="line-clamp-1"
-        >
-          <v-item-group>
-            <v-item v-if="'artists' in item">
-              {{ getArtistsString(item.artists, 2) }}
-            </v-item>
-            <v-item v-if="showAlbum && 'album' in item && item.album">
-              • {{ item.album.name }}
-            </v-item>
-            <v-item
-              v-if="
-                showDiscNumber &&
-                'disc_number' in item &&
-                item.disc_number != null
-              "
-            >
-              <v-icon style="margin-left: 5px" icon="md:album" />
-              {{ item.disc_number }}
-            </v-item>
-            <v-item
-              v-if="
-                showTrackNumber &&
-                'track_number' in item &&
-                item.track_number != null
-              "
-            >
-              <v-icon
-                style="margin-left: 5px"
-                icon="mdi-music-circle-outline"
-              />
-              {{ item.track_number }}
-            </v-item>
-            <v-item
-              v-else-if="
-                showPosition && 'position' in item && item.position != null
-              "
-            >
-              <v-icon
-                style="margin-left: 5px"
-                icon="mdi-music-circle-outline"
-              />
-              {{ item.position }}
-            </v-item>
-          </v-item-group>
-        </div>
-
-        <!-- album: albumtype + artists + year -->
-        <div v-else-if="item.media_type == MediaType.ALBUM && 'year' in item">
-          <span v-if="item.album_type != AlbumType.UNKNOWN"
-            >{{ $t('album_type.' + item.album_type) }} •
-          </span>
-          <span>{{ getArtistsString(item.artists) }}</span>
-          <span v-if="item.year"> • {{ item.year }}</span>
-        </div>
-        <!-- track/album fallback: artist present -->
-        <div v-else-if="'artists' in item && item.artists">
-          {{ getArtistsString(item.artists) }}
-        </div>
-        <!-- playlist owner -->
-        <div v-else-if="'owner' in item && item.owner">
-          {{ item.owner }}
-        </div>
-        <!-- radio description -->
-        <div
-          v-else-if="
-            item.media_type == MediaType.RADIO && item.metadata.description
-          "
-        >
-          {{ item.metadata.description }}
-        </div>
-        <!-- media type label -->
-        <div v-else-if="'media_type' in item && !item.provider_mappings">
-          {{ $t(item.media_type) }}
-        </div>
-      </template>
-
-      <!-- actions -->
-      <template #append>
-        <!-- hi res icon -->
-        <v-img
-          v-if="HiResDetails"
-          :src="iconHiRes"
-          width="30"
-          :class="$vuetify.theme.current.dark ? 'hiresicondark' : 'hiresicon'"
-        >
-          <v-tooltip activator="parent" location="bottom">
-            {{ HiResDetails }}
-          </v-tooltip>
-        </v-img>
-
-        <!-- provider icon -->
-        <provider-icon
-          v-if="getBreakpointValue('bp2') && showProvider"
-          :domain="
-            item.media_type == MediaType.PLAYLIST
-              ? item.provider_mappings[0].provider_domain
-              : item.provider
-          "
-          :size="24"
         />
+      </div>
+      <div v-else class="media-thumb listitem-media-thumb">
+        <MediaItemThumb size="50" :item="item" />
+      </div>
+    </template>
 
-        <!-- favorite (heart) icon -->
-        <div
-          v-if="
-            getBreakpointValue('bp3') &&
-            'favorite' in item &&
-            showFavorite &&
-            !$vuetify.display.mobile
-          "
+    <!-- title -->
+    <template #title>
+      <span v-if="item.media_type == MediaType.FOLDER">
+        <span>{{ getBrowseFolderName(item as BrowseFolder, t) }}</span>
+      </span>
+      <span v-else>
+        {{ item.name }}
+        <span v-if="'version' in item && item.version"
+          >({{ item.version }})</span
         >
-          <FavouriteButton :item="item" />
-        </div>
+      </span>
+      <!-- explicit icon -->
+      <v-tooltip v-if="item && item.metadata" location="bottom">
+        <template #activator="{ props }">
+          <v-icon
+            v-if="parseBool(item.metadata.explicit || false)"
+            v-bind="props"
+            icon="mdi-alpha-e-box"
+            width="35"
+          />
+        </template>
+        <span>{{ $t('tooltip.explicit') }}</span>
+      </v-tooltip>
+    </template>
 
-        <!-- track duration -->
-        <div
-          v-if="
-            showDuration &&
-            item.media_type == MediaType.TRACK &&
-            'duration' in item &&
-            item.duration != undefined &&
-            getBreakpointValue('bp0')
-          "
-        >
-          <div>
-            <span
-              class="text-caption"
-              style="padding-right: 10px; padding-left: 10px"
-              >{{ formatDuration(item.duration) }}</span
-            >
-          </div>
+    <!-- subtitle -->
+    <template #subtitle>
+      <!-- track: artists(s) + album (check for provider_mappings to filter out ItemMapping) -->
+      <div
+        v-if="item.media_type == MediaType.TRACK && 'provider_mappings' in item"
+        class="line-clamp-1"
+      >
+        <v-item-group>
+          <v-item v-if="'artists' in item">
+            {{ getArtistsString(item.artists, 2) }}
+          </v-item>
+          <v-item v-if="showAlbum && 'album' in item && item.album">
+            • {{ item.album.name }}
+          </v-item>
+          <v-item
+            v-if="
+              showDiscNumber &&
+              'disc_number' in item &&
+              item.disc_number != null
+            "
+          >
+            <v-icon style="margin-left: 5px" icon="md:album" />
+            {{ item.disc_number }}
+          </v-item>
+          <v-item
+            v-if="
+              showTrackNumber &&
+              'track_number' in item &&
+              item.track_number != null
+            "
+          >
+            <v-icon style="margin-left: 5px" icon="mdi-music-circle-outline" />
+            {{ item.track_number }}
+          </v-item>
+          <v-item
+            v-else-if="
+              showPosition && 'position' in item && item.position != null
+            "
+          >
+            <v-icon style="margin-left: 5px" icon="mdi-music-circle-outline" />
+            {{ item.position }}
+          </v-item>
+        </v-item-group>
+      </div>
+
+      <!-- album: albumtype + artists + year -->
+      <div v-else-if="item.media_type == MediaType.ALBUM && 'year' in item">
+        <span v-if="item.album_type != AlbumType.UNKNOWN"
+          >{{ $t('album_type.' + item.album_type) }} •
+        </span>
+        <span>{{ getArtistsString(item.artists) }}</span>
+        <span v-if="item.year"> • {{ item.year }}</span>
+      </div>
+      <!-- track/album fallback: artist present -->
+      <div v-else-if="'artists' in item && item.artists">
+        {{ getArtistsString(item.artists) }}
+      </div>
+      <!-- playlist owner -->
+      <div v-else-if="'owner' in item && item.owner">
+        {{ item.owner }}
+      </div>
+      <!-- radio description -->
+      <div
+        v-else-if="
+          item.media_type == MediaType.RADIO && item.metadata.description
+        "
+      >
+        {{ item.metadata.description }}
+      </div>
+      <!-- media type label -->
+      <div v-else-if="'media_type' in item && !item.provider_mappings">
+        {{ $t(item.media_type) }}
+      </div>
+    </template>
+
+    <!-- actions -->
+    <template #append>
+      <!-- hi res icon -->
+      <v-img
+        v-if="HiResDetails"
+        :src="iconHiRes"
+        width="30"
+        :class="$vuetify.theme.current.dark ? 'hiresicondark' : 'hiresicon'"
+      >
+        <v-tooltip activator="parent" location="bottom">
+          {{ HiResDetails }}
+        </v-tooltip>
+      </v-img>
+
+      <!-- provider icon -->
+      <provider-icon
+        v-if="getBreakpointValue('bp2') && showProvider"
+        :domain="
+          item.media_type == MediaType.PLAYLIST
+            ? item.provider_mappings[0].provider_domain
+            : item.provider
+        "
+        :size="24"
+      />
+
+      <!-- favorite (heart) icon -->
+      <div
+        v-if="
+          getBreakpointValue('bp3') &&
+          'favorite' in item &&
+          showFavorite &&
+          !$vuetify.display.mobile
+        "
+      >
+        <FavouriteButton :item="item" />
+      </div>
+
+      <!-- track duration -->
+      <div
+        v-if="
+          showDuration &&
+          item.media_type == MediaType.TRACK &&
+          'duration' in item &&
+          item.duration != undefined &&
+          getBreakpointValue('bp0')
+        "
+      >
+        <div>
+          <span
+            class="text-caption"
+            style="padding-right: 10px; padding-left: 10px"
+            >{{ formatDuration(item.duration) }}</span
+          >
         </div>
-      </template>
-    </ListItem>
-  </div>
+      </div>
+    </template>
+  </ListItem>
 </template>
 
 <script setup lang="ts">

--- a/src/components/PanelviewItem.vue
+++ b/src/components/PanelviewItem.vue
@@ -1,118 +1,131 @@
 <template>
-  <v-card
-    v-hold="onMenu"
-    tile
-    hover
-    class="panel-item"
-    :disabled="!itemIsAvailable(item)"
-    @click="onClick"
-    @click.right.prevent="onMenu"
-    @mouseover="showMenuBtn = true"
-    @mouseleave="showMenuBtn = false"
-  >
-    <v-overlay
-      v-if="showCheckboxes"
-      :model-value="showCheckboxes"
-      contained
-      :scrim="
-        isSelected
-          ? $vuetify.theme.current.dark
-            ? 'rgba(0,0,0,.75)'
-            : 'rgba(255,255,255,.75)'
-          : '#ffffff00'
-      "
-      @click="
-        (x: boolean) => {
-          emit('select', item, isSelected ? false : true);
-        }
-      "
-    >
-      <v-checkbox
-        class="panel-item-checkbox"
-        :ripple="false"
-        :model-value="isSelected"
-      />
-    </v-overlay>
-
-    <MediaItemThumb :item="item" style="height: auto" />
-
-    <v-list-item
-      variant="text"
-      slim
+  <v-hover v-slot="{ isHovering, props }">
+    <v-card
+      v-hold="onMenu"
+      v-bind="props"
       tile
-      density="compact"
-      class="panel-item-details"
+      hover
+      class="panel-item"
+      :disabled="!itemIsAvailable(item)"
+      @click="onClick"
+      @click.right.prevent="onMenu"
+      @mouseover="showMenuBtn = true"
+      @mouseleave="showMenuBtn = false"
     >
-      <v-list-item-title>
-        <span v-if="item.media_type == MediaType.FOLDER">
-          <span>{{ getBrowseFolderName(item as BrowseFolder, $t) }}</span>
-        </span>
-        <span v-else>{{ item.name }}</span>
-        <span v-if="'version' in item && item.version">
-          - {{ item.version }}</span
-        >
-      </v-list-item-title>
-      <v-list-item-subtitle
-        v-if="'artists' in item && item.artists"
-        class="line-clamp-1"
+      <v-overlay
+        v-if="showCheckboxes"
+        :model-value="showCheckboxes"
+        contained
+        :scrim="
+          isSelected
+            ? $vuetify.theme.current.dark
+              ? 'rgba(0,0,0,.75)'
+              : 'rgba(255,255,255,.75)'
+            : '#ffffff00'
+        "
+        @click="
+          (x: boolean) => {
+            emit('select', item, isSelected ? false : true);
+          }
+        "
       >
-        {{ getArtistsString(item.artists, 1) }}
-      </v-list-item-subtitle>
-      <v-list-item-subtitle
-        v-else-if="'owner' in item && item.owner"
-        class="line-clamp-1"
-      >
-        {{ item.owner }}
-      </v-list-item-subtitle>
-      <v-list-item-subtitle v-else-if="showMediaType" class="line-clamp-1">
-        {{ $t(item.media_type) }}
-      </v-list-item-subtitle>
-      <v-list-item-subtitle v-else class="line-clamp-1" />
-    </v-list-item>
+        <v-checkbox
+          class="panel-item-checkbox"
+          :ripple="false"
+          :model-value="isSelected"
+        />
+      </v-overlay>
 
-    <v-card-actions v-if="showActions" class="panel-item-actions">
-      <v-item-group style="padding: 0">
-        <v-item v-if="parseBool(item.metadata.explicit || false)">
-          <v-icon size="30" icon="mdi-alpha-e-box" />
-        </v-item>
-        <!-- hi res icon -->
-        <v-item v-if="HiResDetails">
-          <v-icon
-            :class="
-              $vuetify.theme.current.dark ? 'hiresicon' : 'hiresiconinverted'
+      <MediaItemThumb :item="item" style="height: auto" />
+
+      <!-- play button -->
+      <v-btn
+        v-if="isHovering || $vuetify.display.mobile"
+        icon="mdi-play"
+        color="primary"
+        fab
+        style="position: absolute; right: 15px; margin-top: -25px; opacity: 0.8"
+        @click.stop="onPlayClick"
+      />
+
+      <v-list-item
+        variant="text"
+        slim
+        tile
+        density="compact"
+        class="panel-item-details"
+      >
+        <v-list-item-title>
+          <span v-if="item.media_type == MediaType.FOLDER">
+            <span>{{ getBrowseFolderName(item as BrowseFolder, $t) }}</span>
+          </span>
+          <span v-else>{{ item.name }}</span>
+          <span v-if="'version' in item && item.version">
+            - {{ item.version }}</span
+          >
+        </v-list-item-title>
+        <v-list-item-subtitle
+          v-if="'artists' in item && item.artists"
+          class="line-clamp-1"
+        >
+          {{ getArtistsString(item.artists, 1) }}
+        </v-list-item-subtitle>
+        <v-list-item-subtitle
+          v-else-if="'owner' in item && item.owner"
+          class="line-clamp-1"
+        >
+          {{ item.owner }}
+        </v-list-item-subtitle>
+        <v-list-item-subtitle v-else-if="showMediaType" class="line-clamp-1">
+          {{ $t(item.media_type) }}
+        </v-list-item-subtitle>
+        <v-list-item-subtitle v-else class="line-clamp-1" />
+      </v-list-item>
+
+      <v-card-actions v-if="showActions" class="panel-item-actions">
+        <v-item-group style="padding: 0">
+          <v-item v-if="parseBool(item.metadata.explicit || false)">
+            <v-icon size="30" icon="mdi-alpha-e-box" />
+          </v-item>
+          <!-- hi res icon -->
+          <v-item v-if="HiResDetails">
+            <v-icon
+              :class="
+                $vuetify.theme.current.dark ? 'hiresicon' : 'hiresiconinverted'
+              "
+            >
+              <img :src="iconHiRes" width="30" />
+              <v-tooltip activator="parent" location="bottom">
+                {{ HiResDetails }}
+              </v-tooltip>
+            </v-icon>
+          </v-item>
+          <!-- disc/track number/position-->
+          <v-item
+            v-if="
+              ('track_number' in item && item.track_number) ||
+              ('position' in item && item.position)
             "
           >
-            <img :src="iconHiRes" width="30" />
-            <v-tooltip activator="parent" location="bottom">
-              {{ HiResDetails }}
-            </v-tooltip>
-          </v-icon>
-        </v-item>
-        <!-- disc/track number/position-->
-        <v-item
-          v-if="
-            ('track_number' in item && item.track_number) ||
-            ('position' in item && item.position)
-          "
-        >
-          <v-icon size="small" icon="mdi-music-circle-outline" />
-          <span v-if="item.disc_number">{{ item.disc_number }}/</span
-          >{{ item.track_number || item.position }}
-        </v-item>
-        <v-item v-if="getBreakpointValue('bp3')">
-          <FavouriteButton :item="item" />
-        </v-item>
-      </v-item-group>
-      <v-spacer />
-      <MAButton
-        v-if="showMenuBtn"
-        variant="list"
-        icon="mdi-dots-vertical"
-        style="padding-right: 0; margin-right: -5px"
-        @click.stop="(v: any) => $emit('menu', v, item)"
-      />
-    </v-card-actions>
-  </v-card>
+            <v-icon size="small" icon="mdi-music-circle-outline" />
+            <span v-if="item.disc_number">{{ item.disc_number }}/</span
+            >{{ item.track_number || item.position }}
+          </v-item>
+          <v-item v-if="getBreakpointValue('bp3')">
+            <FavouriteButton :item="item" />
+          </v-item>
+        </v-item-group>
+        <v-spacer />
+        <MAButton
+          v-if="showMenuBtn"
+          variant="list"
+          icon="mdi-dots-vertical"
+          style="padding-right: 0; margin-right: -5px"
+          @click.stop="(v: any) => $emit('menu', v, item)"
+        />
+      </v-card-actions>
+    </v-card>
+  </v-hover>
 </template>
 
 <script setup lang="ts">
@@ -145,7 +158,7 @@ export interface Props {
   showMediaType?: boolean;
   showActions?: boolean;
 }
-const props = withDefaults(defineProps<Props>(), {
+const compProps = withDefaults(defineProps<Props>(), {
   size: 200,
   showCheckboxes: false,
   showActions: false,
@@ -158,7 +171,7 @@ const showMenuBtn = ref(false);
 
 // computed properties
 const HiResDetails = computed(() => {
-  for (const prov of props.item.provider_mappings) {
+  for (const prov of compProps.item.provider_mappings) {
     if (!prov.audio_format) continue;
     if (prov.audio_format.content_type == undefined) continue;
     if (
@@ -188,17 +201,23 @@ const HiResDetails = computed(() => {
 const emit = defineEmits<{
   (e: 'menu', event: Event, item: MediaItemType): void;
   (e: 'click', event: Event, item: MediaItemType): void;
+  (e: 'play', event: Event, item: MediaItemType): void;
   (e: 'select', item: MediaItem, selected: boolean): void;
 }>();
 
 const onMenu = function (event: Event) {
-  if (props.showCheckboxes) return;
-  emit('menu', event, props.item);
+  if (compProps.showCheckboxes) return;
+  emit('menu', event, compProps.item);
 };
 
 const onClick = function (event: Event) {
-  if (props.showCheckboxes) return;
-  emit('click', event, props.item);
+  if (compProps.showCheckboxes) return;
+  emit('click', event, compProps.item);
+};
+
+const onPlayClick = function (event: Event) {
+  if (compProps.showCheckboxes) return;
+  emit('play', event, compProps.item);
 };
 </script>
 

--- a/src/components/PanelviewItem.vue
+++ b/src/components/PanelviewItem.vue
@@ -9,8 +9,6 @@
       :disabled="!itemIsAvailable(item)"
       @click="onClick"
       @click.right.prevent="onMenu"
-      @mouseover="showMenuBtn = true"
-      @mouseleave="showMenuBtn = false"
     >
       <v-overlay
         v-if="showCheckboxes"
@@ -37,16 +35,6 @@
       </v-overlay>
 
       <MediaItemThumb :item="item" style="height: auto" />
-
-      <!-- play button -->
-      <v-btn
-        v-if="isHovering || $vuetify.display.mobile"
-        icon="mdi-play"
-        color="primary"
-        fab
-        style="position: absolute; right: 15px; margin-top: -25px; opacity: 0.8"
-        @click.stop="onPlayClick"
-      />
 
       <v-list-item
         variant="text"
@@ -81,6 +69,16 @@
         </v-list-item-subtitle>
         <v-list-item-subtitle v-else class="line-clamp-1" />
       </v-list-item>
+
+      <!-- play button -->
+      <v-btn
+        v-if="isHovering || $vuetify.display.mobile"
+        icon="mdi-play"
+        color="primary"
+        fab
+        :style="`position: absolute; right: 15px; bottom: ${showActions ? 90 : 35}px; opacity: 0.8`"
+        @click.stop="onPlayClick"
+      />
 
       <v-card-actions v-if="showActions" class="panel-item-actions">
         <v-item-group style="padding: 0">
@@ -117,7 +115,7 @@
         </v-item-group>
         <v-spacer />
         <MAButton
-          v-if="showMenuBtn"
+          v-if="isHovering || $vuetify.display.mobile"
           variant="list"
           icon="mdi-dots-vertical"
           style="padding-right: 0; margin-right: -5px"
@@ -164,10 +162,6 @@ const compProps = withDefaults(defineProps<Props>(), {
   showActions: false,
   showMediaType: false,
 });
-
-// refs
-
-const showMenuBtn = ref(false);
 
 // computed properties
 const HiResDetails = computed(() => {

--- a/src/components/PanelviewItem.vue
+++ b/src/components/PanelviewItem.vue
@@ -119,7 +119,9 @@
           variant="list"
           icon="mdi-dots-vertical"
           style="padding-right: 0; margin-right: -5px"
-          @click.stop="(v: any) => $emit('menu', v, item)"
+          @click.stop="
+            (evt: PointerEvent) => $emit('menu', item, evt.clientX, evt.clientY)
+          "
         />
       </v-card-actions>
     </v-card>
@@ -190,28 +192,28 @@ const HiResDetails = computed(() => {
 });
 
 // emits
-
-/* eslint-disable no-unused-vars */
 const emit = defineEmits<{
-  (e: 'menu', event: Event, item: MediaItemType): void;
-  (e: 'click', event: Event, item: MediaItemType): void;
-  (e: 'play', event: Event, item: MediaItemType): void;
-  (e: 'select', item: MediaItem, selected: boolean): void;
+  (e: 'menu', item: MediaItemType, posX: number, posY: number): void;
+  (e: 'click', item: MediaItemType, posX: number, posY: number): void;
+  (e: 'play', item: MediaItemType, posX: number, posY: number): void;
+  (e: 'select', item: MediaItemType, selected: boolean): void;
 }>();
 
-const onMenu = function (event: Event) {
+const onMenu = function (evt: PointerEvent | TouchEvent) {
   if (compProps.showCheckboxes) return;
-  emit('menu', event, compProps.item);
+  const posX = 'clientX' in evt ? evt.clientX : evt.touches[0].clientX;
+  const posY = 'clientY' in evt ? evt.clientY : evt.touches[0].clientY;
+  emit('menu', compProps.item, posX, posY);
 };
 
-const onClick = function (event: Event) {
+const onClick = function (evt: PointerEvent) {
   if (compProps.showCheckboxes) return;
-  emit('click', event, compProps.item);
+  emit('click', compProps.item, evt.clientX, evt.clientY);
 };
 
-const onPlayClick = function (event: Event) {
+const onPlayClick = function (evt: PointerEvent) {
   if (compProps.showCheckboxes) return;
-  emit('play', event, compProps.item);
+  emit('play', compProps.item, evt.clientX, evt.clientY);
 };
 </script>
 

--- a/src/components/PanelviewItemCompact.vue
+++ b/src/components/PanelviewItemCompact.vue
@@ -82,23 +82,25 @@ const compProps = withDefaults(defineProps<Props>(), {
   permanentOverlay: false,
 });
 
-/* eslint-disable no-unused-vars */
+// emits
 const emit = defineEmits<{
-  (e: 'menu', event: Event, item: MediaItemType): void;
-  (e: 'click', event: Event, item: MediaItemType): void;
-  (e: 'play', event: Event, item: MediaItemType): void;
+  (e: 'menu', item: MediaItemType, posX: number, posY: number): void;
+  (e: 'click', item: MediaItemType, posX: number, posY: number): void;
+  (e: 'play', item: MediaItemType, posX: number, posY: number): void;
 }>();
 
-const onMenu = function (event: Event) {
-  emit('menu', event, compProps.item);
+const onMenu = function (evt: PointerEvent | TouchEvent) {
+  const posX = 'clientX' in evt ? evt.clientX : evt.touches[0].clientX;
+  const posY = 'clientY' in evt ? evt.clientY : evt.touches[0].clientY;
+  emit('menu', compProps.item, posX, posY);
 };
 
-const onClick = function (event: Event) {
-  emit('click', event, compProps.item);
+const onClick = function (evt: PointerEvent) {
+  emit('click', compProps.item, evt.clientX, evt.clientY);
 };
 
-const onPlayClick = function (event: Event) {
-  emit('play', event, compProps.item);
+const onPlayClick = function (evt: PointerEvent) {
+  emit('play', compProps.item, evt.clientX, evt.clientY);
 };
 </script>
 

--- a/src/components/PanelviewItemCompact.vue
+++ b/src/components/PanelviewItemCompact.vue
@@ -54,6 +54,7 @@
         icon="mdi-play"
         color="primary"
         fab
+        size="small"
         style="position: absolute; right: 10px; bottom: 35px; opacity: 0.8"
         @click.stop="onPlayClick"
       />
@@ -97,8 +98,7 @@ const onClick = function (event: Event) {
 };
 
 const onPlayClick = function (event: Event) {
-  if (props.showCheckboxes) return;
-  emit('play', event, props.item);
+  emit('play', event, compProps.item);
 };
 </script>
 

--- a/src/components/PanelviewItemCompact.vue
+++ b/src/components/PanelviewItemCompact.vue
@@ -9,16 +9,11 @@
       @click.right.prevent="onMenu"
     >
       <MediaItemThumb :item="item" />
-      <v-overlay
-        :model-value="isHovering || $vuetify.display.mobile || permanentOverlay"
-        style="height: 35%; top: 65%; border-radius: 0"
-        contained
-        flat
-        :scrim="
-          $vuetify.theme.current.dark
-            ? 'rgba(0,0,0,.95)'
-            : 'rgba(255,255,255,.95)'
+      <div
+        :class="
+          $vuetify.theme.current.dark ? 'paneldetails-dark' : 'paneldetails'
         "
+        :model-value="isHovering || $vuetify.display.mobile || permanentOverlay"
       >
         <v-list-item
           variant="text"
@@ -52,7 +47,16 @@
             {{ $t(item.media_type) }}
           </v-list-item-subtitle>
         </v-list-item>
-      </v-overlay>
+      </div>
+      <!-- play button -->
+      <v-btn
+        v-if="isHovering || $vuetify.display.mobile"
+        icon="mdi-play"
+        color="primary"
+        fab
+        style="position: absolute; right: 10px; bottom: 35px; opacity: 0.8"
+        @click.stop="onPlayClick"
+      />
     </v-card>
   </v-hover>
 </template>
@@ -81,6 +85,7 @@ const compProps = withDefaults(defineProps<Props>(), {
 const emit = defineEmits<{
   (e: 'menu', event: Event, item: MediaItemType): void;
   (e: 'click', event: Event, item: MediaItemType): void;
+  (e: 'play', event: Event, item: MediaItemType): void;
 }>();
 
 const onMenu = function (event: Event) {
@@ -89,6 +94,11 @@ const onMenu = function (event: Event) {
 
 const onClick = function (event: Event) {
   emit('click', event, compProps.item);
+};
+
+const onPlayClick = function (event: Event) {
+  if (props.showCheckboxes) return;
+  emit('play', event, props.item);
 };
 </script>
 
@@ -105,7 +115,7 @@ const onClick = function (event: Event) {
 
 .panel-item-details {
   padding: 5px !important;
-  height: 40px;
+  height: 55px;
 }
 
 .hiresicon {
@@ -117,5 +127,21 @@ const onClick = function (event: Event) {
   margin-left: 10px;
   margin-right: 10px;
   filter: invert(100%);
+}
+</style>
+
+<style lang="scss" scoped>
+.paneldetails {
+  background-color: rgba(255, 255, 255, 0.75);
+  position: absolute;
+  width: 100%;
+  height: 55px;
+  bottom: 0px;
+  border-radius: 0;
+}
+
+.paneldetails-dark {
+  @extend .paneldetails;
+  background-color: rgba(0, 0, 0, 0.75);
 }
 </style>

--- a/src/layouts/default/ItemContextMenu.vue
+++ b/src/layouts/default/ItemContextMenu.vue
@@ -122,13 +122,7 @@ export const getPlayMenuItems = function (
   if (items.length == 0 || !itemIsAvailable(items[0])) {
     return playMenuItems;
   }
-  let queueOptNext = QueueOption.NEXT;
-  if (
-    items.length > 10 ||
-    [MediaType.ALBUM, MediaType.PLAYLIST].includes(items[0].media_type)
-  ) {
-    queueOptNext = QueueOption.REPLACE_NEXT;
-  }
+
   // Play from here...
   if (items.length == 1 && parentItem && parentItem.uri != items[0].uri) {
     // Play from here (playlist track)
@@ -163,7 +157,21 @@ export const getPlayMenuItems = function (
     action: () => {
       api.playMedia(
         items.map((x) => x.uri),
-        undefined,
+        QueueOption.PLAY,
+      );
+    },
+    icon: 'mdi-play-circle-outline',
+    labelArgs: [],
+    disabled: !store.activePlayerQueue,
+  });
+
+  // replace now
+  playMenuItems.push({
+    label: 'play_replace',
+    action: () => {
+      api.playMedia(
+        items.map((x) => x.uri),
+        QueueOption.REPLACE,
       );
     },
     icon: 'mdi-play-circle-outline',
@@ -178,7 +186,7 @@ export const getPlayMenuItems = function (
       action: () => {
         api.playMedia(
           items.map((x) => x.uri),
-          queueOptNext,
+          QueueOption.NEXT,
         );
       },
       icon: 'mdi-skip-next-circle-outline',

--- a/src/plugins/touchEvents.ts
+++ b/src/plugins/touchEvents.ts
@@ -18,6 +18,17 @@ const TouchEvents = {
     const touchEndEvent = 'touchend';
     const touchMoveEvent = 'touchmove';
 
+    let supportsPassive = false;
+    try {
+      addEventListener('test', null, {
+        // eslint-disable-next-line
+        get passive() {
+          supportsPassive = true;
+        },
+      });
+      // eslint-disable-next-line
+    } catch (e) { }
+
     // Hold Directive
     app.directive('hold', {
       mounted(el, binding) {
@@ -67,9 +78,21 @@ const TouchEvents = {
           }
         };
 
-        el.addEventListener(touchStartEvent, handleTouchStart);
-        el.addEventListener(touchEndEvent, handleTouchEnd);
-        el.addEventListener(touchMoveEvent, handleTouchMove);
+        el.addEventListener(
+          touchStartEvent,
+          handleTouchStart,
+          supportsPassive ? { passive: true } : false,
+        );
+        el.addEventListener(
+          touchEndEvent,
+          handleTouchEnd,
+          supportsPassive ? { passive: true } : false,
+        );
+        el.addEventListener(
+          touchMoveEvent,
+          handleTouchMove,
+          supportsPassive ? { passive: true } : false,
+        );
 
         el._hold = {
           handleTouchStart,
@@ -101,8 +124,16 @@ const TouchEvents = {
           }
         };
 
-        el.addEventListener(touchStartEvent, handleTouchStart);
-        el.addEventListener(touchEndEvent, handleTouchEnd);
+        el.addEventListener(
+          touchStartEvent,
+          handleTouchStart,
+          supportsPassive ? { passive: true } : false,
+        );
+        el.addEventListener(
+          touchEndEvent,
+          handleTouchEnd,
+          supportsPassive ? { passive: true } : false,
+        );
 
         el._tap = {
           handleTouchStart,
@@ -173,8 +204,16 @@ const TouchEvents = {
           }
         };
 
-        el.addEventListener(touchStartEvent, handleTouchStart);
-        el.addEventListener(touchEndEvent, handleTouchEnd);
+        el.addEventListener(
+          touchStartEvent,
+          handleTouchStart,
+          supportsPassive ? { passive: true } : false,
+        );
+        el.addEventListener(
+          touchEndEvent,
+          handleTouchEnd,
+          supportsPassive ? { passive: true } : false,
+        );
 
         el._swipe = {
           handleTouchStart,
@@ -228,9 +267,21 @@ const TouchEvents = {
           dragging = false;
         };
 
-        el.addEventListener(touchStartEvent, handleTouchStart);
-        el.addEventListener(touchMoveEvent, handleTouchMove);
-        el.addEventListener(touchEndEvent, handleTouchEnd);
+        el.addEventListener(
+          touchStartEvent,
+          handleTouchStart,
+          supportsPassive ? { passive: true } : false,
+        );
+        el.addEventListener(
+          touchMoveEvent,
+          handleTouchMove,
+          supportsPassive ? { passive: true } : false,
+        );
+        el.addEventListener(
+          touchEndEvent,
+          handleTouchEnd,
+          supportsPassive ? { passive: true } : false,
+        );
 
         el._drag = {
           handleTouchStart,
@@ -257,7 +308,11 @@ const TouchEvents = {
           binding.value(event);
         };
 
-        el.addEventListener(touchStartEvent, handleTouchStart);
+        el.addEventListener(
+          touchStartEvent,
+          handleTouchStart,
+          supportsPassive ? { passive: true } : false,
+        );
 
         el._press = {
           handleTouchStart,
@@ -279,7 +334,11 @@ const TouchEvents = {
           binding.value(event);
         };
 
-        el.addEventListener(touchEndEvent, handleTouchEnd);
+        el.addEventListener(
+          touchEndEvent,
+          handleTouchEnd,
+          supportsPassive ? { passive: true } : false,
+        );
 
         el._release = {
           handleTouchEnd,
@@ -309,7 +368,11 @@ const TouchEvents = {
           lastTapTime = currentTime;
         };
 
-        el.addEventListener(touchStartEvent, handleTouchEnd);
+        el.addEventListener(
+          touchStartEvent,
+          handleTouchEnd,
+          supportsPassive ? { passive: true } : false,
+        );
 
         el._doubletap = {
           handleTouchEnd,

--- a/src/plugins/touchEvents.ts
+++ b/src/plugins/touchEvents.ts
@@ -18,16 +18,18 @@ const TouchEvents = {
     const touchEndEvent = 'touchend';
     const touchMoveEvent = 'touchmove';
 
+    // test if this browser supports passive mode
+    // https://chromestatus.com/feature/5745543795965952
     let supportsPassive = false;
     try {
-      addEventListener('test', null, {
-        // eslint-disable-next-line
+      addEventListener('test', () => {}, {
         get passive() {
           supportsPassive = true;
+          return undefined;
         },
       });
-      // eslint-disable-next-line
-    } catch (e) { }
+      // eslint-disable-next-line no-empty
+    } catch (e) {}
 
     // Hold Directive
     app.directive('hold', {

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -52,6 +52,7 @@
     "play_album_from": "Play Album from here",
     "play_next": "Play Next",
     "play_now": "Play Now",
+    "play_replace": "Play Now (clear queue)",
     "play_on": "Play on: {0}",
     "play_playlist_from": "Play Playlist from here",
     "play_radio": "Start Radio",


### PR DESCRIPTION
Clicking an item was a bit inconsistent throughout the app, this is now solved  

- Show play button to direct play an item
- Click on item --> show details
- Click on **list** item in albums or playlist tracks --> play item
- Click on menu / right click / touch hold --> show contextmenu
- Play button is shown on mouseover, on mobile devices the play button will always be shown