### PR TITLE
Fix Audio Output Device client settings for companion app

### DIFF
--- a/src/views/settings/ClientConfigs.vue
+++ b/src/views/settings/ClientConfigs.vue
@@ -78,7 +78,7 @@
                 label="Output device"
                 style="margin-top: 15px; height: 70px"
                 variant="outlined"
-                @change="outputDeviceConfig"
+                @update:modelValue="outputDeviceConfig"
               />
             </td>
           </tr>
@@ -249,6 +249,10 @@ onMounted(async () => {
     message.unshift('default');
 
     availableOutputDevices.value = message;
+    const savedOutputDevice = localStorage.getItem('outputDevice') || 'default';
+    if (message.indexOf(savedOutputDevice) > -1) {
+      outputDevice.value = savedOutputDevice;
+    }
   });
   discordRPCEnabled.value =
     localStorage.getItem('discordRPCEnabled') === 'true' || false;


### PR DESCRIPTION
There is an issue saving and loading the Audio Output Device in the Client settings page.

- Issue: The selected output device is not saved to local storage. The `@change` event was not being called when a new value was selected.
  - Fix: Use the `@update:modelValue` event to properly call the `outputDeviceConfig` callback function
- Issue: The outputDevice setting in local storage was not being loaded when the settings page is viewed.
  - Fix: Retrieve the outputDevice setting from local storage after the call to `get_output_devices` returns. The setting will be loaded if it exists in local storage and the device exists in the list of available output devices.