### PR TITLE
Optimize all paged listings

### DIFF
--- a/src/components/HomeWidgetRows.vue
+++ b/src/components/HomeWidgetRows.vue
@@ -6,9 +6,9 @@
 
 <script setup lang="ts">
 import api from '@/plugins/api';
+import { store } from '@/plugins/store';
 import HomeWidgetRow, { WidgetRow } from '@/components/HomeWidgetRow.vue';
 import { ref } from 'vue';
-import { MediaItemType } from '@/plugins/api/interfaces';
 import { onActivated } from 'vue';
 
 const widgetRows = ref<Record<string, WidgetRow>>({
@@ -56,65 +56,67 @@ const widgetRows = ref<Record<string, WidgetRow>>({
 });
 
 const loadData = async function () {
+  store.libraryArtistsCount = await api.getLibraryArtistsCount();
+  store.libraryAlbumsCount = await api.getLibraryAlbumsCount();
+  store.libraryPlaylistsCount = await api.getLibraryPlaylistsCount();
+  store.libraryRadiosCount = await api.getLibraryRadiosCount();
+  store.libraryTracksCount = await api.getLibraryTracksCount();
+
   // recently played widget row
   widgetRows.value.recently_played.items = await api.getRecentlyPlayedItems(10);
 
   // library artists widget row
   // TODO: Find a way to make the images for this row eager load
-  const artistItems = await api.getLibraryArtists(
+  widgetRows.value.artists.items = await api.getLibraryArtists(
     undefined,
     undefined,
     20,
     undefined,
     'random',
   );
-  widgetRows.value.artists.items = artistItems.items as MediaItemType[];
-  widgetRows.value.artists.count = artistItems.total;
+  widgetRows.value.artists.count = store.libraryArtistsCount;
 
   // library albums widget row
   // TODO: Find a way to make the images for this row eager load
-  const albumItems = await api.getLibraryAlbums(
+
+  widgetRows.value.albums.items = await api.getLibraryAlbums(
     undefined,
     undefined,
     20,
     undefined,
     'timestamp_added_desc',
   );
-  widgetRows.value.albums.items = albumItems.items as MediaItemType[];
-  widgetRows.value.albums.count = albumItems.total;
+  widgetRows.value.albums.count = store.libraryAlbumsCount;
 
   // library playlist widget row
-  const playlistItems = await api.getLibraryPlaylists(
+  widgetRows.value.playlists.items = await api.getLibraryPlaylists(
     undefined,
     undefined,
     20,
     undefined,
     'timestamp_added_desc',
   );
-  widgetRows.value.playlists.items = playlistItems.items as MediaItemType[];
-  widgetRows.value.playlists.count = playlistItems.total;
+  widgetRows.value.playlists.count = store.libraryPlaylistsCount;
 
   // library radios widget row
-  const radioItems = await api.getLibraryRadios(
+  widgetRows.value.radios.items = await api.getLibraryRadios(
     undefined,
     undefined,
     20,
     undefined,
     'timestamp_added_desc',
   );
-  widgetRows.value.radios.items = radioItems.items as MediaItemType[];
-  widgetRows.value.radios.count = radioItems.total;
+  widgetRows.value.radios.count = store.libraryRadiosCount;
 
   // tracks widget
-  const trackItems = await api.getLibraryTracks(
+  widgetRows.value.tracks.items = await api.getLibraryTracks(
     undefined,
     undefined,
     20,
     undefined,
     'timestamp_added_desc',
   );
-  widgetRows.value.tracks.items = trackItems.items as MediaItemType[];
-  widgetRows.value.tracks.count = trackItems.total;
+  widgetRows.value.tracks.count = store.libraryTracksCount;
 };
 
 await loadData();

--- a/src/components/ItemsListing.vue
+++ b/src/components/ItemsListing.vue
@@ -695,6 +695,7 @@ const loadData = async function (
     }
     // mark allItemsReceived if we have all items
     allItemsReceived.value = nextItems.length < props.limit;
+    console.log('allItems', allItems.value);
   } else if (props.loadPagedData != null) {
     // server side paged listing (with filter support)
     const nextItems = await props.loadPagedData(params.value);
@@ -969,7 +970,7 @@ const getFilteredItems = function (
       }
     }
   } else {
-    result = items;
+    result = [...items];
   }
   // sort
   if (params.sortBy == 'name') {

--- a/src/components/ProviderDetails.vue
+++ b/src/components/ProviderDetails.vue
@@ -15,7 +15,7 @@
             />
           </template>
           <template #title>
-            {{ api.providerManifests[providerMapping.provider_domain].name }}
+            {{ api.providerManifests[providerMapping.provider_domain]?.name }}
           </template>
           <template #subtitle>
             <span

--- a/src/layouts/default/AddToPlaylistDialog.vue
+++ b/src/layouts/default/AddToPlaylistDialog.vue
@@ -128,7 +128,7 @@ const fetchPlaylists = async function () {
   const refItem = selectedItems.value.length
     ? selectedItems.value[0]
     : undefined;
-  for (const playlist of playlistResults.items as Playlist[]) {
+  for (const playlist of playlistResults) {
     // skip unavailable playlists
     if (!playlist.provider_mappings.filter((x) => x.available).length) continue;
     // skip non-editable playlists

--- a/src/layouts/default/PlayerOSD/PlayerFullscreen.vue
+++ b/src/layouts/default/PlayerOSD/PlayerFullscreen.vue
@@ -6,7 +6,7 @@
     transition="dialog-bottom-transition"
     z-index="9999"
   >
-    <v-card :color="darkenBrightColors(coverImageColorCode, 77, 40)">
+    <v-card :color="darkenBrightColors(coverImageColorCode, 70, 80)">
       <v-toolbar class="v-toolbar-default" color="transparent">
         <template #prepend>
           <Button icon @click="store.showFullscreenPlayer = false">
@@ -317,7 +317,7 @@
         >
           <v-btn
             variant="outlined"
-            color="secondary"
+            color="accent"
             @click="store.showPlayersMenu = true"
           >
             <v-icon :icon="store.activePlayer?.icon || 'mdi-speaker'" />
@@ -617,7 +617,7 @@ const loadItems = async function (clear = false) {
       limit,
       offset,
     );
-    queueItems.value.push(...(result.items as QueueItem[]));
+    queueItems.value.push(...result);
   }
 };
 

--- a/src/plugins/api/index.ts
+++ b/src/plugins/api/index.ts
@@ -19,7 +19,6 @@ import {
   type Playlist,
   type Player,
   type PlayerQueue,
-  type PagedItems,
   type MediaItemType,
   MediaType,
   type QueueItem,
@@ -183,7 +182,7 @@ export class MusicAssistantApi {
     limit?: number,
     offset?: number,
     order_by?: string,
-  ): Promise<PagedItems> {
+  ): Promise<Track[]> {
     return this.getData('music/tracks/library_items', {
       favorite,
       search,
@@ -235,6 +234,36 @@ export class MusicAssistantApi {
     return `${api.baseUrl}/preview?item_id=${encItemId}&provider=${provider_instance_id_or_domain}`;
   }
 
+  public getLibraryArtistsCount(
+    favorite_only: boolean = false,
+    album_artists_only: boolean = false,
+  ): Promise<number> {
+    return this.getData('music/artists/count', {
+      favorite_only,
+      album_artists_only,
+    });
+  }
+  public getLibraryAlbumsCount(
+    favorite_only: boolean = false,
+  ): Promise<number> {
+    return this.getData('music/albums/count', { favorite_only });
+  }
+  public getLibraryTracksCount(
+    favorite_only: boolean = false,
+  ): Promise<number> {
+    return this.getData('music/tracks/count', { favorite_only });
+  }
+  public getLibraryPlaylistsCount(
+    favorite_only: boolean = false,
+  ): Promise<number> {
+    return this.getData('music/playlists/count', { favorite_only });
+  }
+  public getLibraryRadiosCount(
+    favorite_only: boolean = false,
+  ): Promise<number> {
+    return this.getData('music/radios/count', { favorite_only });
+  }
+
   public getLibraryArtists(
     favorite?: boolean,
     search?: string,
@@ -242,7 +271,7 @@ export class MusicAssistantApi {
     offset?: number,
     order_by?: string,
     album_artists_only?: boolean,
-  ): Promise<PagedItems> {
+  ): Promise<Artist[]> {
     return this.getData('music/artists/library_items', {
       favorite,
       search,
@@ -293,7 +322,7 @@ export class MusicAssistantApi {
     limit?: number,
     offset?: number,
     order_by?: string,
-  ): Promise<PagedItems> {
+  ): Promise<Album[]> {
     return this.getData('music/albums/library_items', {
       favorite,
       search,
@@ -341,7 +370,7 @@ export class MusicAssistantApi {
     limit?: number,
     offset?: number,
     order_by?: string,
-  ): Promise<PagedItems> {
+  ): Promise<Playlist[]> {
     return this.getData('music/playlists/library_items', {
       favorite,
       search,
@@ -371,7 +400,7 @@ export class MusicAssistantApi {
     force_refresh?: boolean,
     limit?: number,
     offset?: number,
-  ): Promise<PagedItems> {
+  ): Promise<Track[]> {
     return this.getData('music/playlists/playlist_tracks', {
       item_id,
       provider_instance_id_or_domain,
@@ -414,7 +443,7 @@ export class MusicAssistantApi {
     limit?: number,
     offset?: number,
     order_by?: string,
-  ): Promise<PagedItems> {
+  ): Promise<Radio[]> {
     return this.getData('music/radios/library_items', {
       favorite,
       search,
@@ -533,7 +562,7 @@ export class MusicAssistantApi {
     offset: number,
     limit: number,
     path?: string,
-  ): Promise<PagedItems> {
+  ): Promise<MediaItemType[]> {
     // Browse Music providers.
     return this.getData('music/browse', { offset, limit, path });
   }
@@ -568,7 +597,7 @@ export class MusicAssistantApi {
     queue_id: string,
     limit: number,
     offset: number,
-  ): Promise<PagedItems> {
+  ): Promise<QueueItem[]> {
     // Get all QueueItems for given PlayerQueue
     return this.getData('player_queues/items', {
       queue_id,

--- a/src/plugins/api/interfaces.ts
+++ b/src/plugins/api/interfaces.ts
@@ -461,14 +461,6 @@ export interface BrowseFolder extends MediaItem {
   items?: Array<MediaItemType | BrowseFolder>;
 }
 
-export interface PagedItems {
-  items: Array<MediaItemType | ItemMapping | QueueItem>;
-  count: number;
-  limit: number;
-  offset: number;
-  total?: number;
-}
-
 export interface SearchResults {
   artists: Artist[];
   albums: Album[];

--- a/src/plugins/store.ts
+++ b/src/plugins/store.ts
@@ -35,6 +35,11 @@ interface Store {
   allowExternalImageRetrieval: boolean;
   activeAlert?: Alert;
   prevRoute?: string;
+  libraryArtistsCount?: number;
+  libraryAlbumsCount?: number;
+  libraryTracksCount?: number;
+  libraryPlaylistsCount?: number;
+  libraryRadiosCount?: number;
 }
 
 export const store: Store = reactive({
@@ -72,4 +77,9 @@ export const store: Store = reactive({
   allowExternalImageRetrieval: true,
   activeAlert: undefined,
   prevRoute: undefined,
+  libraryArtistsCount: undefined,
+  libraryAlbumsCount: undefined,
+  libraryTracksCount: undefined,
+  libraryPlaylistsCount: undefined,
+  libraryRadiosCount: undefined,
 });

--- a/src/views/BrowseView.vue
+++ b/src/views/BrowseView.vue
@@ -7,9 +7,7 @@
       :show-favorites-only-filter="false"
       :show-track-number="false"
       :load-paged-data="loadItems"
-      :sort-keys="
-        allItemsReceived ? ['original', 'name', 'name_desc'] : ['original']
-      "
+      :sort-keys="['original', 'name', 'name_desc']"
       :title="header"
       :path="path"
       :allow-key-hooks="true"
@@ -31,7 +29,6 @@ export interface Props {
 }
 const props = defineProps<Props>();
 const { t } = useI18n();
-const allItemsReceived = ref(false);
 
 const header = computed(() => {
   if (!props.path || props.path == 'root') return t('browse');
@@ -41,8 +38,6 @@ const header = computed(() => {
 });
 
 const loadItems = async function (params: LoadDataParams) {
-  const result = await api.browse(params.offset, params.limit, props.path);
-  allItemsReceived.value = result.total != null;
-  return result;
+  return await api.browse(params.offset, params.limit, props.path);
 };
 </script>

--- a/src/views/LibraryAlbums.vue
+++ b/src/views/LibraryAlbums.vue
@@ -11,6 +11,7 @@
     :show-search-button="true"
     icon="mdi-album"
     :restore-state="true"
+    :total="total"
   />
 </template>
 
@@ -20,12 +21,14 @@ import ItemsListing, { LoadDataParams } from '@/components/ItemsListing.vue';
 import api from '@/plugins/api';
 import { MediaType, EventMessage, EventType } from '@/plugins/api/interfaces';
 import { sleep } from '@/helpers/utils';
+import { store } from '@/plugins/store';
 
 defineOptions({
   name: 'Albums',
 });
 
 const updateAvailable = ref<boolean>(false);
+const total = ref(store.libraryAlbumsCount);
 
 const sortKeys = [
   'name',
@@ -79,6 +82,7 @@ const loadItems = async function (params: LoadDataParams) {
     await sleep(500);
   }
   updateAvailable.value = false;
+  total.value = await api.getLibraryAlbumsCount(params.favoritesOnly || false);
   return await api.getLibraryAlbums(
     params.favoritesOnly || undefined,
     params.search,

--- a/src/views/LibraryArtists.vue
+++ b/src/views/LibraryArtists.vue
@@ -1,7 +1,6 @@
 <template>
   <ItemsListing
     itemtype="artists"
-    :items="items"
     :show-provider="false"
     :show-favorites-only-filter="true"
     :load-paged-data="loadItems"
@@ -13,6 +12,7 @@
     :sort-keys="sortKeys"
     icon="mdi-account-outline"
     :restore-state="true"
+    :total="total"
   />
 </template>
 
@@ -20,20 +20,16 @@
 import { onBeforeUnmount, onMounted, ref } from 'vue';
 import ItemsListing, { LoadDataParams } from '@/components/ItemsListing.vue';
 import api from '@/plugins/api';
-import {
-  MediaType,
-  type Artist,
-  EventMessage,
-  EventType,
-} from '@/plugins/api/interfaces';
+import { MediaType, EventMessage, EventType } from '@/plugins/api/interfaces';
 import { sleep } from '@/helpers/utils';
+import { store } from '@/plugins/store';
 
 defineOptions({
   name: 'Artists',
 });
 
-const items = ref<Artist[]>([]);
 const updateAvailable = ref(false);
+const total = ref(store.libraryArtistsCount);
 
 const sortKeys = [
   'name',
@@ -65,6 +61,10 @@ const loadItems = async function (params: LoadDataParams) {
     }
   }
   updateAvailable.value = false;
+  total.value = await api.getLibraryArtistsCount(
+    params.favoritesOnly || false,
+    params.albumArtistsFilter || false,
+  );
   return await api.getLibraryArtists(
     params.favoritesOnly || undefined,
     params.search,

--- a/src/views/LibraryPlaylists.vue
+++ b/src/views/LibraryPlaylists.vue
@@ -1,7 +1,6 @@
 <template>
   <ItemsListing
     itemtype="playlists"
-    :items="items"
     :show-duration="false"
     :show-provider="true"
     :show-favorites-only-filter="true"
@@ -15,6 +14,7 @@
     :extra-menu-items="extraMenuItems"
     icon="mdi-playlist-play"
     :restore-state="true"
+    :total="total"
   />
 </template>
 
@@ -25,21 +25,21 @@ import ItemsListing, { LoadDataParams } from '@/components/ItemsListing.vue';
 import api from '@/plugins/api';
 import {
   ProviderFeature,
-  type Playlist,
   EventMessage,
   EventType,
   MediaType,
 } from '@/plugins/api/interfaces';
 import { ToolBarMenuItem } from '@/components/Toolbar.vue';
 import { sleep } from '@/helpers/utils';
+import { store } from '@/plugins/store';
 
 defineOptions({
   name: 'Playlists',
 });
 
 const { t } = useI18n();
-const items = ref<Playlist[]>([]);
 const updateAvailable = ref(false);
+const total = ref(store.libraryPlaylistsCount);
 const extraMenuItems = ref<ToolBarMenuItem[]>([]);
 
 const sortKeys = [
@@ -75,6 +75,9 @@ const loadItems = async function (params: LoadDataParams) {
     await sleep(500);
   }
   updateAvailable.value = false;
+  total.value = await api.getLibraryPlaylistsCount(
+    params.favoritesOnly || false,
+  );
   return await api.getLibraryPlaylists(
     params.favoritesOnly || undefined,
     params.search,

--- a/src/views/LibraryRadios.vue
+++ b/src/views/LibraryRadios.vue
@@ -1,7 +1,6 @@
 <template>
   <ItemsListing
     itemtype="radios"
-    :items="items"
     :show-duration="false"
     :show-provider="false"
     :show-favorites-only-filter="true"
@@ -23,6 +22,7 @@
     ]"
     icon="mdi-access-point"
     :restore-state="true"
+    :total="total"
   />
 </template>
 
@@ -36,18 +36,18 @@ import {
   EventType,
   ImageType,
   MediaType,
-  type Radio,
 } from '@/plugins/api/interfaces';
 import { sleep } from '@/helpers/utils';
 import router from '@/plugins/router';
+import { store } from '@/plugins/store';
 
 defineOptions({
   name: 'Radios',
 });
 
 const { t } = useI18n();
-const items = ref<Radio[]>([]);
 const updateAvailable = ref<boolean>(false);
+const total = ref(store.libraryRadiosCount);
 
 const sortKeys = [
   'name',
@@ -98,6 +98,7 @@ const loadItems = async function (params: LoadDataParams) {
     await sleep(500);
   }
   updateAvailable.value = false;
+  total.value = await api.getLibraryRadiosCount(params.favoritesOnly || false);
   return await api.getLibraryRadios(
     params.favoritesOnly || undefined,
     params.search,

--- a/src/views/LibraryTracks.vue
+++ b/src/views/LibraryTracks.vue
@@ -1,7 +1,6 @@
 <template>
   <ItemsListing
     itemtype="tracks"
-    :items="items"
     :show-provider="false"
     :show-favorites-only-filter="true"
     :show-track-number="false"
@@ -24,6 +23,7 @@
     ]"
     icon="mdi-music-note"
     :restore-state="true"
+    :total="total"
   />
 </template>
 
@@ -37,18 +37,18 @@ import {
   EventType,
   ImageType,
   MediaType,
-  type Track,
 } from '@/plugins/api/interfaces';
 import { sleep } from '@/helpers/utils';
 import router from '@/plugins/router';
+import { store } from '@/plugins/store';
 
 defineOptions({
   name: 'Tracks',
 });
 
 const { t } = useI18n();
-const items = ref<Track[]>([]);
 const updateAvailable = ref<boolean>(false);
+const total = ref(store.libraryTracksCount);
 
 const sortKeys = [
   'name',
@@ -106,6 +106,7 @@ const loadItems = async function (params: LoadDataParams) {
     await sleep(500);
   }
   updateAvailable.value = false;
+  total.value = await api.getLibraryTracksCount(params.favoritesOnly || false);
   return await api.getLibraryTracks(
     params.favoritesOnly,
     params.search,

--- a/src/views/settings/CoreConfigs.vue
+++ b/src/views/settings/CoreConfigs.vue
@@ -84,23 +84,23 @@
           </tr>
           <tr>
             <td>{{ $t('settings.artists_in_library') }}</td>
-            <td>{{ totalLibraryArtists }}</td>
+            <td>{{ store.libraryArtistsCount }}</td>
           </tr>
           <tr>
             <td>{{ $t('settings.albums_in_library') }}</td>
-            <td>{{ totalLibraryAlbums }}</td>
+            <td>{{ store.libraryAlbumsCount }}</td>
           </tr>
           <tr>
             <td>{{ $t('settings.tracks_in_library') }}</td>
-            <td>{{ totalLibraryTracks }}</td>
+            <td>{{ store.libraryTracksCount }}</td>
           </tr>
           <tr>
             <td>{{ $t('settings.playlists_in_library') }}</td>
-            <td>{{ totalLibraryPlaylists }}</td>
+            <td>{{ store.libraryPlaylistsCount }}</td>
           </tr>
           <tr>
             <td>{{ $t('settings.radio_in_library') }}</td>
-            <td>{{ totalLibraryRadio }}</td>
+            <td>{{ store.libraryRadiosCount }}</td>
           </tr>
           <tr>
             <td>{{ $t('settings.server_logging') }}</td>
@@ -125,17 +125,13 @@ import ListItem from '@/components/mods/ListItem.vue';
 import Container from '@/components/mods/Container.vue';
 import { useRouter } from 'vue-router';
 import { eventbus } from '@/plugins/eventbus';
+import { store } from '@/plugins/store';
 
 // global refs
 const router = useRouter();
 
 // local refs
 const coreConfigs = ref<CoreConfig[]>([]);
-const totalLibraryArtists = ref(0);
-const totalLibraryAlbums = ref(0);
-const totalLibraryTracks = ref(0);
-const totalLibraryPlaylists = ref(0);
-const totalLibraryRadio = ref(0);
 
 // methods
 const editCoreConfig = function (domain: string) {
@@ -175,15 +171,11 @@ const onMenu = function (evt: Event, item: CoreConfig) {
 
 onMounted(async () => {
   coreConfigs.value = await api.getCoreConfigs();
-  totalLibraryArtists.value =
-    (await api.getLibraryArtists(undefined, undefined, 1)).total || 0;
-  totalLibraryAlbums.value =
-    (await api.getLibraryAlbums(undefined, undefined, 1)).total || 0;
-  totalLibraryTracks.value =
-    (await api.getLibraryTracks(undefined, undefined, 1)).total || 0;
-  totalLibraryPlaylists.value =
-    (await api.getLibraryPlaylists(undefined, undefined, 1)).total || 0;
-  totalLibraryRadio.value =
-    (await api.getLibraryRadios(undefined, undefined, 1)).total || 0;
+  // refresh/read the library counts
+  store.libraryArtistsCount = await api.getLibraryArtistsCount();
+  store.libraryAlbumsCount = await api.getLibraryAlbumsCount();
+  store.libraryTracksCount = await api.getLibraryTracksCount();
+  store.libraryPlaylistsCount = await api.getLibraryPlaylistsCount();
+  store.libraryRadiosCount = await api.getLibraryRadiosCount();
 });
 </script>


### PR DESCRIPTION
Frontend belonging to https://github.com/music-assistant/server/pull/1356

- Fixes issues with paged listings that have no server side filtering
- Allow filtering/sorting of playlist tracks
- Speedup list retrievals