### PR TITLE
Remove arbitrary limit

### DIFF
--- a/src/components/ItemsListing.vue
+++ b/src/components/ItemsListing.vue
@@ -249,7 +249,7 @@ const props = withDefaults(defineProps<Props>(), {
   showSelectButton: undefined,
   allowCollapse: false,
   allowKeyHooks: false,
-  limit: 50,
+  limit: undefined,
   total: undefined,
   infiniteScroll: true,
   title: undefined,
@@ -270,7 +270,7 @@ const { t } = useI18n();
 // local refs
 const params = ref<LoadDataParams>({
   offset: 0,
-  limit: 50,
+  limit: undefined,
   sortBy: 'name',
   search: '',
   libraryOnly: false,

--- a/src/components/ItemsListing.vue
+++ b/src/components/ItemsListing.vue
@@ -192,7 +192,7 @@ import { useI18n } from 'vue-i18n';
 
 export interface LoadDataParams {
   offset: number;
-  limit: number;
+  limit?: number;
   sortBy: string;
   search: string;
   favoritesOnly?: boolean;


### PR DESCRIPTION
I believe this limit is arbitrary. It shouldn't be there by default. If you're doing paged loading at any point, then I think that individual view ought to set it.

This should fix the fact that large albums limit at 50 tracks, and should also fix https://github.com/music-assistant/hass-music-assistant/issues/2411