### PR TITLE
Fix favicon in index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,6 @@
     <meta charset="utf-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width,initial-scale=1.0" />
-    <link rel="icon" href="favicon.svg" type="image/svg+xml">
     <link rel="alternate icon" href="favicon.ico" type="image/png" sizes="16x16">
     <link rel="apple-touch-icon" href="apple-touch-icon.png" sizes="180x180">
     <link rel="mask-icon" href="favicon.svg" color="#FFFFFF">


### PR DESCRIPTION
I've wondered, why the favicon (the small icon in the tab) is not shown in Firefox

I've removed the line with favicon.svg, as that file doesn't exist.
In line 13 is already an entry for favicon.ico which should be correct (at least it exists in public/favicon.ico and is shown correctly in Firefox)

Just realized, that Chrome displays the favicon correctly (it seems to somehow ignore the first wrong "link rel=icon" entry or maybe always uses the last entry).