### PR TITLE
Add Spanish and add missing key

### DIFF
--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -55,6 +55,7 @@
     "play_on": "Play on: {0}",
     "play_playlist_from": "Play Playlist from here",
     "play_radio": "Start Radio",
+    "played": "Played",
     "player_type": {
         "group": "Group",
         "player": "Player",
@@ -363,6 +364,7 @@
                 "en": "English",
                 "en_AU": "English (Australian)",
                 "en_GB": "English (United Kingdom)",                
+                "es": "Spanish",
                 "fr": "French",
                 "nl": "Dutch",
                 "pl": "Polish",


### PR DESCRIPTION
Spanish has been completed so adding that.

Santiago has noticed that the key for "Played" on the Now Playing screen is missing. I have added that as I think it is here?? https://github.com/music-assistant/frontend/blob/8d0e5794a88be7d50e7f07bb66b361df1bcae3f8/src/layouts/default/PlayerOSD/PlayerFullscreen.vue#L177