### PR TITLE
add horizontal scrolling in carousel

### DIFF
--- a/src/components/Carousel.vue
+++ b/src/components/Carousel.vue
@@ -4,6 +4,10 @@
     :space-between="24"
     :free-mode="true"
     :navigation="getBreakpointValue({ breakpoint: 'mobile' }) ? false : true"
+    :mousewheel="{
+      forceToAxis: true,
+      releaseOnEdges: true
+    }"
   >
     <slot></slot>
   </swiper>

--- a/src/plugins/swiper.ts
+++ b/src/plugins/swiper.ts
@@ -1,14 +1,15 @@
 import { Swiper, SwiperSlide } from "swiper/vue";
 import SwiperCore from "swiper";
-import { Navigation, Pagination, FreeMode } from "swiper/modules";
+import { Navigation, Pagination, FreeMode, Mousewheel } from "swiper/modules";
 import "swiper/css";
 import "swiper/css/free-mode";
+import "swiper/css/mousewheel";
 import "swiper/swiper-bundle.css";
 import { App } from "vue";
 
 export default {
   install(app: App) {
-    SwiperCore.use([Pagination, Navigation, FreeMode]);
+    SwiperCore.use([Pagination, Navigation, FreeMode, Mousewheel]);
     app.component("Swiper", Swiper).component("SwiperSlide", SwiperSlide);
   },
 };


### PR DESCRIPTION
When scrolling horizontally on a laptop touchpad or on a second scroll wheel (like on the Logitech MX Master), the carousel on the Home page now scrolls horizontally.