### PR TITLE
feat: Add a frameless param

### DIFF
--- a/src/layouts/default/Default.vue
+++ b/src/layouts/default/Default.vue
@@ -1,12 +1,12 @@
-<template>  
-  <v-app  v-if="store.connected">
+<template>
+  <v-app v-if="store.connected">
     <MainView v-if="framelessState" />
     <template v-else>
       <PlayerSelect />
       <MainView />
       <Footer />
     </template>
-    </v-app>
+  </v-app>
   <v-overlay
     v-else
     class="centeredoverlay"
@@ -29,45 +29,54 @@ import { store } from "@/plugins/store";
 import { toRefs, watch, ref } from "vue";
 import api from "@/plugins/api";
 
-
 export interface Props {
-  targetPlayer?: string;
+  showFullscreenPlayer?: boolean;
   player?: string;
-  frameless?: boolean
+  frameless?: boolean;
 }
 
 const props = defineProps<Props>();
 
 // keep this in a ref so that we keep it while navigating. But restart it if page is fully reloaded
-const framelessState = ref(false)
+const framelessState = ref(false);
 
-const { targetPlayer, player, frameless } = toRefs(props);
+const { showFullscreenPlayer, player, frameless } = toRefs(props);
 
-watch([targetPlayer, player], ([targetPlayer, player]) => {
-  // give preference for player if it's a string
-  const newActivePlayer = typeof player === "string" ? player : targetPlayer
-  if (!newActivePlayer) return;
-      // newActivePlayer can be either player id or player name
-      const newPlayerId = Object.values(api.players).find(p =>{
-        return p.player_id === newActivePlayer || p.display_name.toLowerCase() === newActivePlayer.toLowerCase()
-      })?.player_id
+watch(
+  player,
+  (newActivePlayer) => {
+    if (!newActivePlayer) return;
+    // newActivePlayer can be either player id or player name
+    const newPlayerId = Object.values(api.players).find((p) => {
+      return (
+        p.player_id === newActivePlayer ||
+        p.display_name.toLowerCase() === newActivePlayer.toLowerCase()
+      );
+    })?.player_id;
 
-      if(newPlayerId){
-        store.activePlayerId = newPlayerId;
-
-      }
-
-    // showFullscreenPlayer if the param player is defined at all
-    store.showFullscreenPlayer = !!player;
+    if (newPlayerId) {
+      store.activePlayerId = newPlayerId;
+    }
   },
   { immediate: true },
 );
-
-watch(frameless, (frameless)=>{
-  if(frameless){
-    framelessState.value = true
-  }
-}, { immediate: true })
+watch(
+  showFullscreenPlayer,
+  (showFullscreenPlayer) => {
+    // showFullscreenPlayer if the param player is defined at all
+    store.showFullscreenPlayer = !!showFullscreenPlayer;
+  },
+  { immediate: true },
+);
+watch(
+  frameless,
+  (frameless) => {
+    if (frameless) {
+      framelessState.value = true;
+    }
+  },
+  { immediate: true },
+);
 </script>
 
 <style scoped>

--- a/src/layouts/default/Default.vue
+++ b/src/layouts/default/Default.vue
@@ -63,7 +63,6 @@ watch(
 watch(
   showFullscreenPlayer,
   (showFullscreenPlayer) => {
-    // showFullscreenPlayer if the param player is defined at all
     store.showFullscreenPlayer = !!showFullscreenPlayer;
   },
   { immediate: true },

--- a/src/layouts/default/Default.vue
+++ b/src/layouts/default/Default.vue
@@ -1,9 +1,12 @@
-<template>
-  <v-app v-if="store.connected">
-    <PlayerSelect />
-    <MainView />
-    <Footer />
-  </v-app>
+<template>  
+  <v-app  v-if="store.connected">
+    <MainView v-if="framelessState" />
+    <template v-else>
+      <PlayerSelect />
+      <MainView />
+      <Footer />
+    </template>
+    </v-app>
   <v-overlay
     v-else
     class="centeredoverlay"
@@ -23,6 +26,48 @@ import Footer from "./Footer.vue";
 import PlayerSelect from "./PlayerSelect.vue";
 import ReloadPrompt from "./ReloadPrompt.vue";
 import { store } from "@/plugins/store";
+import { toRefs, watch, ref } from "vue";
+import api from "@/plugins/api";
+
+
+export interface Props {
+  targetPlayer?: string;
+  player?: string;
+  frameless?: boolean
+}
+
+const props = defineProps<Props>();
+
+// keep this in a ref so that we keep it while navigating. But restart it if page is fully reloaded
+const framelessState = ref(false)
+
+const { targetPlayer, player, frameless } = toRefs(props);
+
+watch([targetPlayer, player], ([targetPlayer, player]) => {
+  // give preference for player if it's a string
+  const newActivePlayer = typeof player === "string" ? player : targetPlayer
+  if (!newActivePlayer) return;
+      // newActivePlayer can be either player id or player name
+      const newPlayerId = Object.values(api.players).find(p =>{
+        return p.player_id === newActivePlayer || p.display_name.toLowerCase() === newActivePlayer.toLowerCase()
+      })?.player_id
+
+      if(newPlayerId){
+        store.activePlayerId = newPlayerId;
+
+      }
+
+    //showFullscreenPlayer if the param player is defined at all
+    store.showFullscreenPlayer = !!player;
+  },
+  { immediate: true },
+);
+
+watch(frameless, (frameless)=>{
+  if(frameless){
+    framelessState.value = true
+  }
+}, {immediate: true})
 </script>
 
 <style scoped>

--- a/src/layouts/default/Default.vue
+++ b/src/layouts/default/Default.vue
@@ -67,7 +67,7 @@ watch(frameless, (frameless)=>{
   if(frameless){
     framelessState.value = true
   }
-}, {immediate: true})
+}, { immediate: true })
 </script>
 
 <style scoped>

--- a/src/layouts/default/Default.vue
+++ b/src/layouts/default/Default.vue
@@ -57,7 +57,7 @@ watch([targetPlayer, player], ([targetPlayer, player]) => {
 
       }
 
-    //showFullscreenPlayer if the param player is defined at all
+    // showFullscreenPlayer if the param player is defined at all
     store.showFullscreenPlayer = !!player;
   },
   { immediate: true },

--- a/src/plugins/router.ts
+++ b/src/plugins/router.ts
@@ -258,22 +258,6 @@ const router = createRouter({
   routes,
 });
 
-// // Global navigation guard to preserve query params
-// router.beforeEach((to, from, next) => {
-//   // we want to keep frameless between navigation
-//   console.log(JSON.stringify(from.query) !== JSON.stringify(to.query), from, to)
-//   if (to.path && JSON.stringify(from.query) !== JSON.stringify(to.query)) {
-//     const frameless = to.query?.frameless || from.query?.frameless
-//     // Merge current query params with the new ones if they exist
-//     const mergedQuery = !!frameless ? { ...to.query, frameless } : to.query ;
-//     console.log({mergedQuery})
-//     next({ path: to.path, query: mergedQuery });
-//   } else {
-//     next()
-//   }
-
-// });
-
 router.afterEach((to, from) => {
   if (!from?.path) return;
   console.debug("navigating from ", from.path, " to ", to.path);

--- a/src/plugins/router.ts
+++ b/src/plugins/router.ts
@@ -5,6 +5,7 @@ const routes = [
   {
     path: "/",
     component: () => import("@/layouts/default/Default.vue"),
+    props: (route: { query: Record<string, any> }) => ({ ...route.query }),
     children: [
       {
         path: "",
@@ -256,6 +257,22 @@ const router = createRouter({
   history: createWebHashHistory(),
   routes,
 });
+
+// // Global navigation guard to preserve query params
+// router.beforeEach((to, from, next) => {
+//   // we want to keep frameless between navigation
+//   console.log(JSON.stringify(from.query) !== JSON.stringify(to.query), from, to)
+//   if (to.path && JSON.stringify(from.query) !== JSON.stringify(to.query)) {
+//     const frameless = to.query?.frameless || from.query?.frameless
+//     // Merge current query params with the new ones if they exist
+//     const mergedQuery = !!frameless ? { ...to.query, frameless } : to.query ;
+//     console.log({mergedQuery})
+//     next({ path: to.path, query: mergedQuery });
+//   } else {
+//     next()
+//   }
+
+// });
 
 router.afterEach((to, from) => {
   if (!from?.path) return;

--- a/src/plugins/store.ts
+++ b/src/plugins/store.ts
@@ -41,7 +41,6 @@ interface Store {
   libraryPlaylistsCount?: number;
   libraryRadiosCount?: number;
   connected?: boolean;
-  frameless?: boolean;
   isTouchscreen: boolean;
 }
 
@@ -90,6 +89,5 @@ export const store: Store = reactive({
   libraryPlaylistsCount: undefined,
   libraryRadiosCount: undefined,
   connected: false,
-  frameless: false,
   isTouchscreen: isTouchscreenDevice(),
 });

--- a/src/plugins/store.ts
+++ b/src/plugins/store.ts
@@ -41,6 +41,7 @@ interface Store {
   libraryPlaylistsCount?: number;
   libraryRadiosCount?: number;
   connected?: boolean;
+  frameless?: boolean;
   isTouchscreen: boolean;
 }
 
@@ -89,5 +90,6 @@ export const store: Store = reactive({
   libraryPlaylistsCount: undefined,
   libraryRadiosCount: undefined,
   connected: false,
+  frameless: false,
   isTouchscreen: isTouchscreenDevice(),
 });

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -43,7 +43,6 @@ const props = defineProps<Props>();
 const hideSettings = ref(
   localStorage.getItem("frontend.settings.hide_settings") == "true",
 );
-
 </script>
 
 <style scoped>

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -33,9 +33,7 @@
 import Container from "@/components/mods/Container.vue";
 import HomeWidgetRows from "@/components/HomeWidgetRows.vue";
 import Toolbar from "@/components/Toolbar.vue";
-import { ref, watch } from "vue";
-import { store } from "@/plugins/store";
-import api from "@/plugins/api";
+import { ref } from "vue";
 
 export interface Props {
   player?: string;
@@ -46,31 +44,6 @@ const hideSettings = ref(
   localStorage.getItem("frontend.settings.hide_settings") == "true",
 );
 
-const urlParams = new URLSearchParams(window.location.search);
-console.log(urlParams.toString());
-
-watch(
-  () => props.player,
-  (val) => {
-    console.error("props.player", val);
-    if (!val || val == "false") return;
-    if (typeof val === "string") {
-      // val can be either player id or player name
-      if (val in api.players) {
-        store.activePlayerId = api.players[val].player_id;
-      } else {
-        for (const player of Object.values(api.players)) {
-          if (player.display_name.toLowerCase() === val.toLowerCase()) {
-            store.activePlayerId = player.player_id;
-            break;
-          }
-        }
-      }
-    }
-    store.showFullscreenPlayer = true;
-  },
-  { immediate: true },
-);
 </script>
 
 <style scoped>


### PR DESCRIPTION
I'm adding a param called frameless

So that different view of MASS can be used in cards ([original suggestion](https://github.com/orgs/music-assistant/discussions/954#discussioncomment-11348170))

- Added 2 new params
  - frameless: Load just the content without the footer and navigation. It won't be saved in the store so that it goes away everytime we reload
  - targetPlayer: using that to select the activePlayer. I know we have a `player` param already. Put that param open the fullscreen player. And it might not be what we want.

- Moved code that handled `player` to the defaultView so that everything is in the same place

https://github.com/user-attachments/assets/9091d7b5-3901-453c-a4c6-ac9c18896079


