### PR TITLE
Add Marquee to Make Long Text Readable

### DIFF
--- a/src/components/InfoHeader.vue
+++ b/src/components/InfoHeader.vue
@@ -83,7 +83,9 @@
             style="padding-left: 10px"
           />
           <v-card-title v-else>
-            {{ item.name }}
+            <MarqueeText :sync="marqueeSync">
+              {{ item.name }}
+            </MarqueeText>
           </v-card-title>
 
           <!-- other details -->
@@ -119,20 +121,22 @@
                 color="primary"
                 icon="mdi-account-music"
               />
-              <span
-                v-for="(artist, artistindex) in item.artists"
-                :key="artist.item_id"
-              >
-                <a style="color: accent" @click="artistClick(artist)">{{
-                  artist.name
-                }}</a>
+              <MarqueeText :sync="marqueeSync">
                 <span
-                  v-if="artistindex + 1 < item.artists.length"
-                  :key="artistindex"
-                  style="color: accent"
-                  >{{ " / " }}</span
+                  v-for="(artist, artistindex) in item.artists"
+                  :key="artist.item_id"
                 >
-              </span>
+                  <a style="color: accent" @click="artistClick(artist)">{{
+                    artist.name
+                  }}</a>
+                  <span
+                    v-if="artistindex + 1 < item.artists.length"
+                    :key="artistindex"
+                    style="color: accent"
+                    >{{ " / " }}</span
+                  >
+                </span>
+              </MarqueeText>
             </v-card-subtitle>
 
             <!-- playlist owner -->
@@ -146,7 +150,9 @@
                 small
                 icon="mdi-account-music"
               />
-              <a style="color: primary">{{ item.owner }}</a>
+              <MarqueeText :sync="marqueeSync">
+                <a style="color: primary">{{ item.owner }}</a>
+              </MarqueeText>
             </v-card-subtitle>
 
             <v-card-subtitle
@@ -159,10 +165,12 @@
                 small
                 icon="mdi-album"
               />
-              <a
-                style="color: secondary"
-                @click="albumClick((item as Track)?.album)"
-                >{{ item.album.name }}</a
+              <MarqueeText :sync="marqueeSync">
+                <a
+                  style="color: secondary"
+                  @click="albumClick((item as Track)?.album)"
+                  >{{ item.album.name }}</a
+                ></MarqueeText
               >
             </v-card-subtitle>
           </div>
@@ -331,6 +339,8 @@ import {
 } from "@/layouts/default/ItemContextMenu.vue";
 import Toolbar from "@/components/Toolbar.vue";
 import { useI18n } from "vue-i18n";
+import MarqueeText from "./MarqueeText.vue";
+import { MarqueeTextSync } from "@/helpers/marquee_text_sync";
 
 // properties
 export interface Props {
@@ -344,6 +354,7 @@ const { mobile } = useDisplay();
 const imgGradient = new URL("../assets/info_gradient.jpg", import.meta.url)
   .href;
 
+const marqueeSync = new MarqueeTextSync();
 const router = useRouter();
 const { t } = useI18n();
 

--- a/src/components/InfoHeader.vue
+++ b/src/components/InfoHeader.vue
@@ -40,6 +40,8 @@
           padding-left: 15px;
           align-items: center;
           padding-right: 15px;
+          display: flex;
+          width: 100%;
         "
       >
         <!-- left side: cover image -->
@@ -54,6 +56,7 @@
             margin-bottom: 15px;
             margin-right: 24px;
             align-content: center;
+            flex-shrink: 0;
           "
         >
           <div v-if="item.media_type && item.media_type == MediaType.ARTIST">
@@ -70,7 +73,7 @@
           </div>
         </div>
 
-        <div style="width: 100%; text-align: left">
+        <div style="min-width: 0">
           <!-- Main title -->
           <img
             v-if="artistLogo"

--- a/src/components/InfoHeader.vue
+++ b/src/components/InfoHeader.vue
@@ -108,7 +108,7 @@
             <!-- item artists -->
             <v-card-subtitle
               v-if="'artists' in item && item.artists"
-              class="title accent--text"
+              class="title accent--text d-flex"
             >
               <v-icon
                 style="margin-left: -3px; margin-right: 3px"
@@ -133,7 +133,10 @@
             </v-card-subtitle>
 
             <!-- playlist owner -->
-            <v-card-subtitle v-if="'owner' in item && item.owner" class="title">
+            <v-card-subtitle
+              v-if="'owner' in item && item.owner"
+              class="title d-flex"
+            >
               <v-icon
                 color="primary"
                 style="margin-left: -3px; margin-right: 3px"
@@ -143,7 +146,10 @@
               <a style="color: primary">{{ item.owner }}</a>
             </v-card-subtitle>
 
-            <v-card-subtitle v-if="'album' in item && item.album">
+            <v-card-subtitle
+              v-if="'album' in item && item.album"
+              class="d-flex"
+            >
               <v-icon
                 color="primary"
                 style="margin-left: -3px; margin-right: 3px"

--- a/src/components/MarqueeText.vue
+++ b/src/components/MarqueeText.vue
@@ -1,0 +1,256 @@
+<!--
+Creates a horizontally scrolling text effect when content exceeds container width
+
+Features:
+- Automatic scrolling for overflow content
+- Synchronization with other MarqueeText components for increased readability
+- Constant speed scrolling
+- Visibility-based animation control (so only visible elements are synced)
+-->
+<template>
+  <!-- Main container with hidden overflow -->
+  <div ref="containerRef" class="container">
+    <!-- Scrolling content wrapper with dynamic transform -->
+    <div ref="scrollingRef" class="scrolling" :style="scrollingStyle">
+      <slot></slot>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import {
+  ref,
+  onMounted,
+  computed,
+  onBeforeUnmount,
+  watch,
+  nextTick,
+} from "vue";
+import { MarqueeTextSync } from "@/helpers/marquee_text_sync";
+
+// Animation Constants
+const SCROLL_SPEED = 60; // Scrolling speed in pixels per second
+const START_DELAY = 2000; // Delay before starting scroll (milliseconds)
+const END_DELAY = 2000; // Delay after scroll completion (milliseconds)
+const RESET_ANIMATION_DURATION_MS = 1000; // Duration for reset animation (milliseconds)
+
+// DOM References and State Management
+const containerRef = ref<HTMLElement | null>(null);
+const scrollingRef = ref<HTMLElement | null>(null);
+const containerWidth = ref(0);
+const scrollingWidth = ref(0);
+const offsetPosition = ref(0);
+const isForwardScroll = ref(false);
+const isVisible = ref(false);
+
+// Props Definition
+const props = defineProps<{
+  sync?: MarqueeTextSync; // Optional sync helper for coordinating multiple marquees
+}>();
+
+// Register with the sync helper if provided
+let animationSync = props.sync?._registerAnimation();
+watch(
+  () => props.sync,
+  (newSync) => {
+    if (animationSync !== undefined) {
+      animationSync.unregister();
+    }
+    animationSync = newSync?._registerAnimation();
+    startScrollCycle();
+  },
+);
+
+// Computed Properties
+const maxOffsetPosition = computed(() => {
+  // Calculate maximum scroll distance needed to show the rightmost content
+  return Math.max(scrollingWidth.value - containerWidth.value, 0);
+});
+
+const scrollDuration = computed(() => {
+  // Calculate total scroll duration for constant speed
+  const scroll_duration = maxOffsetPosition.value / SCROLL_SPEED;
+  return scroll_duration * 1000; // Convert to milliseconds
+});
+
+const scrollingStyle = computed(() => ({
+  transform: `translateX(${-offsetPosition.value}px)`,
+  transition: isForwardScroll.value
+    ? `transform ${scrollDuration.value}ms linear` // Forward scroll
+    : `transform ${RESET_ANIMATION_DURATION_MS}ms ease-in-out`, // Reset animation
+}));
+
+// Animation Control for aborting the current animation
+let animationController: AbortController | null = null;
+
+// Utility function for creating cancelable delays
+const delay = (ms: number, signal: AbortSignal) =>
+  Promise.race([
+    new Promise((resolve) => setTimeout(resolve, ms)),
+    new Promise((_, reject) =>
+      signal.addEventListener("abort", reject, { once: true }),
+    ),
+  ]);
+
+// Main scrolling cycle implementation
+const startScrollCycle = async () => {
+  // Cancel any existing animation
+  if (animationController && !animationController.signal.aborted) {
+    animationController.abort();
+  }
+
+  isForwardScroll.value = false;
+  offsetPosition.value = 0;
+
+  // Check if scrolling is necessary
+  if (
+    maxOffsetPosition.value <= 0 ||
+    scrollDuration.value <= 0 ||
+    !isVisible.value
+  ) {
+    animationSync?.unregister();
+    return;
+  }
+
+  animationSync?.setScrollingDuration(scrollDuration.value);
+
+  animationController = new AbortController();
+  // Store the controller in a local variable, so we won't have
+  // race conditions when the controller is reset in the finally block
+  const ctrl = animationController;
+
+  try {
+    // Extra delay so other MarqueeText's can register their scrolling durations
+    // in case they are all loaded at roughly the same time
+    await delay(200, ctrl.signal);
+
+    while (!ctrl.signal.aborted) {
+      // Synchronization of all marquees
+      if (animationSync !== undefined) {
+        await Promise.race([
+          animationSync.sync(),
+          new Promise((_, reject) =>
+            ctrl.signal.addEventListener("abort", reject, { once: true }),
+          ),
+        ]);
+      }
+
+      // Reset position to start
+      isForwardScroll.value = false;
+      offsetPosition.value = 0;
+
+      // Calculate timing adjustments for sync, so all Marquees end at the same time
+      const maxDuration = animationSync?.maxDuration() ?? scrollDuration.value;
+      const extraStartDelay = maxDuration - scrollDuration.value;
+
+      // Hold at the start of the text (including time required for reset animation and sync)
+      await delay(
+        RESET_ANIMATION_DURATION_MS + START_DELAY + extraStartDelay,
+        ctrl.signal,
+      );
+
+      // Start the scrolling to the end
+      isForwardScroll.value = true;
+      offsetPosition.value = maxOffsetPosition.value;
+
+      // Wait for the scroll to finish, hold at the end, so the user can read the text
+      await delay(scrollDuration.value + END_DELAY, ctrl.signal);
+    }
+  } catch (err) {
+    // Animation aborted, reset position
+    isForwardScroll.value = false;
+    offsetPosition.value = 0;
+    // no need to cleanup `animationSync` here, since:
+    // - the new scroll cycle will be started, which will reset or use animationSync
+    // - the component will be unmounted, which will cleanup the animationSync
+  }
+};
+
+// Observers Setup
+
+// Detects changes in the width of this component
+const containerObserver = new ResizeObserver(() => {
+  if (!containerRef.value) return;
+  containerWidth.value = containerRef.value.clientWidth;
+});
+
+// Detects changes in the content of the scrolling element
+// (so also when the width of the content changes)
+const scrollingObserver = new MutationObserver(() => {
+  if (!scrollingRef.value) return;
+  scrollingWidth.value = scrollingRef.value.scrollWidth;
+});
+
+// Detects visibility changes of the container,
+// so we only animate when the element is visible
+const visibilityObserver = new IntersectionObserver(
+  (entries) => {
+    const [entry] = entries;
+    isVisible.value = entry.isIntersecting;
+  },
+  { threshold: 0 },
+);
+
+// Lifecycle Hooks
+onMounted(() => {
+  if (!containerRef.value || !scrollingRef.value) return;
+
+  nextTick(() => {
+    if (!containerRef.value || !scrollingRef.value) return;
+
+    // Initialize measurements after DOM update
+    scrollingWidth.value = scrollingRef.value.scrollWidth;
+    containerWidth.value = containerRef.value.clientWidth;
+  });
+
+  // Setup observers
+  scrollingObserver.observe(scrollingRef.value, {
+    childList: true,
+    subtree: true,
+    characterData: true,
+    attributes: true,
+    attributeFilter: ["style", "class"],
+  });
+  containerObserver.observe(containerRef.value);
+  visibilityObserver.observe(containerRef.value);
+});
+
+onBeforeUnmount(() => {
+  // Cleanup observers and animation
+  if (animationController) {
+    animationController.abort();
+    animationController = null;
+  }
+  animationSync?.unregister();
+  scrollingObserver.disconnect();
+  containerObserver.disconnect();
+  visibilityObserver.disconnect();
+});
+
+// Watch for changes that require animation restart
+watch(
+  [maxOffsetPosition, isVisible],
+  () => {
+    startScrollCycle();
+  },
+  { flush: "post" },
+);
+</script>
+
+<style scoped>
+.container {
+  position: relative;
+  overflow: hidden;
+  width: 100%;
+  min-height: 1.5em;
+}
+
+.scrolling {
+  white-space: nowrap;
+  display: inline-block;
+  will-change: transform;
+  position: relative;
+  left: 0;
+  top: 0;
+}
+</style>

--- a/src/components/MarqueeText.vue
+++ b/src/components/MarqueeText.vue
@@ -46,6 +46,7 @@ const isVisible = ref(false);
 // Props Definition
 const props = defineProps<{
   sync?: MarqueeTextSync; // Optional sync helper for coordinating multiple marquees
+  disabled?: boolean; // Disable scrolling animation
 }>();
 
 // Register with the sync helper if provided
@@ -104,6 +105,7 @@ const startScrollCycle = async () => {
 
   // Check if scrolling is necessary
   if (
+    props.disabled === true ||
     maxOffsetPosition.value <= 0 ||
     scrollDuration.value <= 0 ||
     !isVisible.value
@@ -229,7 +231,7 @@ onBeforeUnmount(() => {
 
 // Watch for changes that require animation restart
 watch(
-  [maxOffsetPosition, isVisible],
+  [maxOffsetPosition, isVisible, () => props.disabled],
   () => {
     startScrollCycle();
   },

--- a/src/components/MarqueeText.vue
+++ b/src/components/MarqueeText.vue
@@ -42,6 +42,7 @@ const scrollingWidth = ref(0);
 const offsetPosition = ref(0);
 const isForwardScroll = ref(false);
 const isVisible = ref(false);
+const justEnabled = ref(false);
 
 // Props Definition
 const props = defineProps<{
@@ -147,9 +148,11 @@ const startScrollCycle = async () => {
 
       // Hold at the start of the text (including time required for reset animation and sync)
       await delay(
-        RESET_ANIMATION_DURATION_MS + START_DELAY + extraStartDelay,
+        (justEnabled.value ? 0 : RESET_ANIMATION_DURATION_MS + START_DELAY) +
+          extraStartDelay,
         ctrl.signal,
       );
+      justEnabled.value = false;
 
       // Start the scrolling to the end
       isForwardScroll.value = true;
@@ -254,6 +257,7 @@ watch(
     if (props.disabled === true) {
       cleanup();
     } else {
+      justEnabled.value = true;
       setup();
     }
   },

--- a/src/components/MarqueeText.vue
+++ b/src/components/MarqueeText.vue
@@ -194,9 +194,9 @@ const visibilityObserver = new IntersectionObserver(
 );
 
 // Lifecycle Hooks
-onMounted(() => {
-  if (!containerRef.value || !scrollingRef.value) return;
 
+// Setup observers and initial measurements
+const setup = () => {
   nextTick(() => {
     if (!containerRef.value || !scrollingRef.value) return;
 
@@ -204,7 +204,7 @@ onMounted(() => {
     scrollingWidth.value = scrollingRef.value.scrollWidth;
     containerWidth.value = containerRef.value.clientWidth;
   });
-
+  if (!containerRef.value || !scrollingRef.value) return;
   // Setup observers
   scrollingObserver.observe(scrollingRef.value, {
     childList: true,
@@ -215,10 +215,10 @@ onMounted(() => {
   });
   containerObserver.observe(containerRef.value);
   visibilityObserver.observe(containerRef.value);
-});
+};
 
-onBeforeUnmount(() => {
-  // Cleanup observers and animation
+// Cleanup observers and animation
+const cleanup = () => {
   if (animationController) {
     animationController.abort();
     animationController = null;
@@ -227,6 +227,17 @@ onBeforeUnmount(() => {
   scrollingObserver.disconnect();
   containerObserver.disconnect();
   visibilityObserver.disconnect();
+  isVisible.value = false;
+};
+
+onMounted(() => {
+  if (props.disabled !== true) {
+    setup();
+  }
+});
+
+onBeforeUnmount(() => {
+  cleanup();
 });
 
 // Watch for changes that require animation restart
@@ -236,6 +247,16 @@ watch(
     startScrollCycle();
   },
   { flush: "post" },
+);
+watch(
+  () => props.disabled,
+  () => {
+    if (props.disabled === true) {
+      cleanup();
+    } else {
+      setup();
+    }
+  },
 );
 </script>
 

--- a/src/components/MarqueeText.vue
+++ b/src/components/MarqueeText.vue
@@ -29,9 +29,9 @@ import {
 import { MarqueeTextSync } from "@/helpers/marquee_text_sync";
 
 // Animation Constants
-const SCROLL_SPEED = 60; // Scrolling speed in pixels per second
+const SCROLL_SPEED = 30; // Scrolling speed in pixels per second
 const START_DELAY = 2000; // Delay before starting scroll (milliseconds)
-const END_DELAY = 2000; // Delay after scroll completion (milliseconds)
+const END_DELAY = 4000; // Delay after scroll completion (milliseconds)
 const RESET_ANIMATION_DURATION_MS = 1000; // Duration for reset animation (milliseconds)
 
 // DOM References and State Management

--- a/src/helpers/marquee_text_sync.ts
+++ b/src/helpers/marquee_text_sync.ts
@@ -1,0 +1,89 @@
+type ComponentId = symbol;
+type SyncResolver = () => void;
+
+class RunningAnimationSync {
+  private parentSync: MarqueeTextSync;
+  private readonly id: ComponentId;
+  // resolve method of the promise returned by `sync()`
+  private promiseResolver: SyncResolver | null = null;
+
+  constructor(parentSync: MarqueeTextSync) {
+    this.parentSync = parentSync;
+    this.id = Symbol();
+  }
+
+  // Call this when a animation is started with the time it will take to scroll
+  // the whole text (without constant delays)
+  // Must be called if you wan't to use `sync()`
+  setScrollingDuration(duration: number): void {
+    if (duration > 0) {
+      this.parentSync._componentDurations.set(this.id, duration);
+    } else {
+      this.unregister();
+    }
+  }
+
+  // Returns the maximum duration set by `setScrollingDuration` of all running animations
+  maxDuration(): number {
+    if (this.parentSync._componentDurations.size === 0) return 0;
+    return Math.max(...this.parentSync._componentDurations.values());
+  }
+
+  // Returns a promise that resolves when all currently running animations
+  // are awaiting this sync point
+  // the returned promise must be immediatly awaited
+  sync(): Promise<void> {
+    return new Promise<void>((resolve) => {
+      // If the user awaits sync(), we can assume that only a single promiseResolver
+      // exists at a time, so we can safely overwrite it
+      this.promiseResolver = resolve;
+      this.parentSync._pendingSync.push(resolve);
+      this.parentSync._tryResolveWaiting();
+    });
+  }
+
+  // Make sure to call this when:
+  // - the component is unmounted
+  // - no animation is playing anymore, i.e. the animation was aborted
+  // do not call `sync()` after calling this, first call `setScrollingDuration` again
+  unregister(): void {
+    if (this.promiseResolver) {
+      const index = this.parentSync._pendingSync.indexOf(this.promiseResolver);
+      if (index > -1) {
+        this.parentSync._pendingSync.splice(index, 1);
+      }
+      this.promiseResolver(); // resolve to avoid potential memory leaks
+      this.promiseResolver = null;
+    }
+    this.parentSync._componentDurations.delete(this.id);
+    // free up waiting syncs if needed (now that we compleatly removed ourself)
+    this.parentSync._tryResolveWaiting();
+  }
+}
+
+// Pass this to the `sync` prop of the MarqueeText component to sync all animations
+export class MarqueeTextSync {
+  _componentDurations: Map<ComponentId, number>; // durations of all running animations
+  _pendingSync: SyncResolver[]; // resolvers of all pending sync promises
+
+  constructor() {
+    this._componentDurations = new Map();
+    this._pendingSync = [];
+  }
+
+  _registerAnimation(): RunningAnimationSync {
+    return new RunningAnimationSync(this);
+  }
+
+  // Will resolve all pending syncs in case all animations are waiting for it
+  _tryResolveWaiting(): void {
+    if (this._pendingSync?.length === this._componentDurations.size) {
+      // Everyone is waiting for this sync point, resolve all
+      const pending = this._pendingSync; // to avoid race conditions
+      this._pendingSync = [];
+      for (const resolve of pending) {
+        resolve();
+      }
+    }
+  }
+}

--- a/src/layouts/default/PlayerOSD/PlayerFullscreen.vue
+++ b/src/layouts/default/PlayerOSD/PlayerFullscreen.vue
@@ -262,6 +262,8 @@
                     :show-menu-btn="true"
                     @click.stop="(e) => openQueueItemMenu(e, item)"
                     @menu.stop="(e) => openQueueItemMenu(e, item)"
+                    @mouseenter="hoveredQueueIndex = index"
+                    @mouseleave="hoveredQueueIndex = -1"
                   >
                     <template #prepend>
                       <div class="media-thumb listitem-media-thumb">
@@ -269,10 +271,19 @@
                       </div>
                     </template>
                     <template #title>
-                      <!-- only scroll the currently playing track -->
+                      <!-- only scroll the currently playing track, or when hovered with a separete sync group -->
                       <MarqueeText
-                        :sync="playerMarqueeSync"
-                        :disabled="index != 0 || activeQueuePanel != 0"
+                        :sync="
+                          index == 0 && activeQueuePanel == 0
+                            ? playerMarqueeSync
+                            : hoveredMarqueeSync
+                        "
+                        :disabled="
+                          !(
+                            (index == 0 && activeQueuePanel == 0) ||
+                            hoveredQueueIndex == index
+                          )
+                        "
                       >
                         {{ item.name }}
                       </MarqueeText>
@@ -283,8 +294,17 @@
                           {{ formatDuration(item.duration) }} |
                         </span>
                         <MarqueeText
-                          :sync="playerMarqueeSync"
-                          :disabled="index != 0 || activeQueuePanel != 0"
+                          :sync="
+                            index == 0 && activeQueuePanel == 0
+                              ? playerMarqueeSync
+                              : hoveredMarqueeSync
+                          "
+                          :disabled="
+                            !(
+                              (index == 0 && activeQueuePanel == 0) ||
+                              hoveredQueueIndex == index
+                            )
+                          "
                         >
                           <span
                             v-if="
@@ -498,6 +518,8 @@ interface Props {
 const compProps = defineProps<Props>();
 
 const playerMarqueeSync = new MarqueeTextSync();
+const hoveredQueueIndex = ref(-1);
+const hoveredMarqueeSync = new MarqueeTextSync();
 
 // Local refs
 const queueItems = ref<QueueItem[]>([]);

--- a/src/layouts/default/PlayerOSD/PlayerFullscreen.vue
+++ b/src/layouts/default/PlayerOSD/PlayerFullscreen.vue
@@ -256,7 +256,7 @@
                 max-height="90%"
                 :items="activeQueuePanel == 0 ? nextItems : previousItems"
               >
-                <template #default="{ item }">
+                <template #default="{ item, index }">
                   <ListItem
                     link
                     :show-menu-btn="true"
@@ -269,19 +269,34 @@
                       </div>
                     </template>
                     <template #title>
-                      {{ item.name }}
+                      <!-- only scroll the currently playing track -->
+                      <MarqueeText
+                        :sync="playerMarqueeSync"
+                        :disabled="index != 0 || activeQueuePanel != 0"
+                      >
+                        {{ item.name }}
+                      </MarqueeText>
                     </template>
                     <template #subtitle>
-                      {{ formatDuration(item.duration) }}
-                      <span
-                        v-if="
-                          item.media_item &&
-                          'album' in item.media_item &&
-                          item.media_item.album
-                        "
-                      >
-                        | {{ item.media_item.album.name }}</span
-                      >
+                      <div class="d-flex">
+                        <span style="white-space: nowrap" class="pr-1">
+                          {{ formatDuration(item.duration) }} |
+                        </span>
+                        <MarqueeText
+                          :sync="playerMarqueeSync"
+                          :disabled="index != 0 || activeQueuePanel != 0"
+                        >
+                          <span
+                            v-if="
+                              item.media_item &&
+                              'album' in item.media_item &&
+                              item.media_item.album
+                            "
+                          >
+                            {{ item.media_item.album.name }}
+                          </span>
+                        </MarqueeText>
+                      </div>
                     </template>
                   </ListItem>
                 </template>

--- a/src/layouts/default/PlayerOSD/PlayerFullscreen.vue
+++ b/src/layouts/default/PlayerOSD/PlayerFullscreen.vue
@@ -85,26 +85,32 @@
               :style="`font-size: ${titleFontSize};cursor:pointer;`"
               @click="itemClick(store.curQueueItem.media_item as MediaItemType)"
             >
-              {{ store.curQueueItem.media_item.name }}
-              <span
-                v-if="
-                  'version' in store.curQueueItem.media_item &&
-                  store.curQueueItem.media_item.version
-                "
-                >({{ store.curQueueItem.media_item.version }})</span
-              >
+              <MarqueeText :sync="playerMarqueeSync">
+                {{ store.curQueueItem.media_item.name }}
+                <span
+                  v-if="
+                    'version' in store.curQueueItem.media_item &&
+                    store.curQueueItem.media_item.version
+                  "
+                  >({{ store.curQueueItem.media_item.version }})</span
+                >
+              </MarqueeText>
             </v-card-title>
 
             <!-- external source current media item present -->
             <v-card-title v-else-if="store.activePlayer?.current_media?.title">
               <div v-if="store.activePlayer?.current_media?.artist">
-                {{ store.activePlayer?.current_media?.artist }}
+                <MarqueeText :sync="playerMarqueeSync">
+                  {{ store.activePlayer?.current_media?.artist }}
+                </MarqueeText>
               </div>
               <div
                 v-if="store.activePlayer?.current_media?.title"
                 :style="`font-size: ${subTitleFontSize};`"
               >
-                {{ store.activePlayer?.current_media?.title }}
+                <MarqueeText :sync="playerMarqueeSync">
+                  {{ store.activePlayer?.current_media?.title }}
+                </MarqueeText>
               </div>
             </v-card-title>
 
@@ -114,7 +120,9 @@
               :style="`font-size: ${titleFontSize};cursor:pointer;`"
               @click="store.showPlayersMenu = true"
             >
-              {{ store.activePlayer?.display_name || $t("no_player") }}
+              <MarqueeText :sync="playerMarqueeSync">
+                {{ store.activePlayer?.display_name || $t("no_player") }}
+              </MarqueeText>
             </v-card-title>
 
             <!-- SUBTITLE -->
@@ -138,7 +146,9 @@
                 radioTitleClick(store.curQueueItem.streamdetails.stream_title)
               "
             >
-              {{ store.curQueueItem.streamdetails.stream_title }}
+              <MarqueeText :sync="playerMarqueeSync">
+                {{ store.curQueueItem.streamdetails.stream_title }}
+              </MarqueeText>
             </v-card-subtitle>
 
             <!-- subtitle: album -->
@@ -151,7 +161,9 @@
               :style="`font-size: ${subTitleFontSize};cursor:pointer;`"
               @click="itemClick(store.curQueueItem.media_item.album as Album)"
             >
-              {{ store.curQueueItem.media_item.album.name }}
+              <MarqueeText :sync="playerMarqueeSync">
+                {{ store.curQueueItem.media_item.album.name }}
+              </MarqueeText>
             </v-card-subtitle>
 
             <!-- subtitle: artist(s) -->
@@ -167,7 +179,9 @@
                 itemClick(store.curQueueItem.media_item.artists[0] as Artist)
               "
             >
-              {{ store.curQueueItem.media_item.artists[0].name }}
+              <MarqueeText :sync="playerMarqueeSync">
+                {{ store.curQueueItem.media_item.artists[0].name }}
+              </MarqueeText>
             </v-card-subtitle>
 
             <!-- subtitle: other source active -->
@@ -440,6 +454,8 @@ import RepeatBtn from "@/layouts/default/PlayerOSD/PlayerControlBtn/RepeatBtn.vu
 import PlayerVolume from "@/layouts/default/PlayerOSD/PlayerVolume.vue";
 import QueueBtn from "./PlayerControlBtn/QueueBtn.vue";
 import QualityDetailsBtn from "@/components/QualityDetailsBtn.vue";
+import MarqueeText from "@/components/MarqueeText.vue";
+import { MarqueeTextSync } from "@/helpers/marquee_text_sync";
 import {
   imgCoverLight,
   imgCoverDark,
@@ -465,6 +481,8 @@ interface Props {
   colorPalette: ImageColorPalette;
 }
 const compProps = defineProps<Props>();
+
+const playerMarqueeSync = new MarqueeTextSync();
 
 // Local refs
 const queueItems = ref<QueueItem[]>([]);

--- a/src/layouts/default/PlayerOSD/PlayerTrackDetails.vue
+++ b/src/layouts/default/PlayerOSD/PlayerTrackDetails.vue
@@ -67,14 +67,16 @@
           v-else-if="store.curQueueItem?.media_item"
           @click="store.showFullscreenPlayer = true"
         >
-          {{ store.curQueueItem.media_item.name }}
-          <span
-            v-if="
-              'version' in store.curQueueItem.media_item &&
-              store.curQueueItem.media_item.version
-            "
-            >({{ store.curQueueItem.media_item.version }})</span
-          >
+          <MarqueeText :sync="marqueeSync">
+            {{ store.curQueueItem.media_item.name }}
+            <span
+              v-if="
+                'version' in store.curQueueItem.media_item &&
+                store.curQueueItem.media_item.version
+              "
+              >({{ store.curQueueItem.media_item.version }})</span
+            >
+          </MarqueeText>
         </div>
         <!-- queue item fallback: queue item name -->
         <div v-else-if="store.curQueueItem">
@@ -141,66 +143,68 @@
         class="line-clamp-1"
         @click="store.showFullscreenPlayer = true"
       >
-        <!-- player powered off -->
-        <div v-if="!store.activePlayer?.powered">
-          {{ $t("off") }}
-        </div>
-        <!-- track: artists(s) + album -->
-        <div
-          v-else-if="
-            store.curQueueItem &&
-            store.curQueueItem.media_item?.media_type == MediaType.TRACK &&
-            'album' in store.curQueueItem.media_item &&
-            store.curQueueItem.media_item.album &&
-            !props.showOnlyArtist
-          "
-        >
-          {{ getArtistsString(store.curQueueItem.media_item.artists) }} •
-          {{ store.curQueueItem.media_item.album.name }}
-        </div>
-        <!-- track fallback: (only artist, no album) -->
-        <div
-          v-else-if="
-            store.curQueueItem &&
-            store.curQueueItem.media_item &&
-            'artists' in store.curQueueItem.media_item &&
-            store.curQueueItem.media_item.artists.length > 0
-          "
-        >
-          {{ store.curQueueItem.media_item.artists[0].name }}
-        </div>
-        <!-- radio live metadata -->
-        <div
-          v-else-if="store.curQueueItem?.streamdetails?.stream_title"
-          class="line-clamp-1"
-        >
-          {{ store.curQueueItem?.streamdetails?.stream_title }}
-        </div>
-        <!-- other description -->
-        <div
-          v-else-if="
-            store.curQueueItem &&
-            store.curQueueItem.media_item?.metadata.description
-          "
-          class="line-clamp-1"
-        >
-          {{ store.curQueueItem.media_item.metadata.description }}
-        </div>
-        <!-- external source artist -->
-        <div v-else-if="store.activePlayer?.current_media?.artist">
-          {{ store.activePlayer.current_media.artist }}
-        </div>
-        <!-- 3rd party source active -->
-        <div
-          v-else-if="
-            store.activePlayer?.active_source != store.activePlayer?.player_id
-          "
-          class="line-clamp-1"
-        >
-          {{
-            $t("external_source_active", [store.activePlayer?.active_source])
-          }}
-        </div>
+        <MarqueeText :sync="marqueeSync">
+          <!-- player powered off -->
+          <div v-if="!store.activePlayer?.powered">
+            {{ $t("off") }}
+          </div>
+          <!-- track: artists(s) + album -->
+          <div
+            v-else-if="
+              store.curQueueItem &&
+              store.curQueueItem.media_item?.media_type == MediaType.TRACK &&
+              'album' in store.curQueueItem.media_item &&
+              store.curQueueItem.media_item.album &&
+              !props.showOnlyArtist
+            "
+          >
+            {{ getArtistsString(store.curQueueItem.media_item.artists) }} •
+            {{ store.curQueueItem.media_item.album.name }}
+          </div>
+          <!-- track fallback: (only artist, no album) -->
+          <div
+            v-else-if="
+              store.curQueueItem &&
+              store.curQueueItem.media_item &&
+              'artists' in store.curQueueItem.media_item &&
+              store.curQueueItem.media_item.artists.length > 0
+            "
+          >
+            {{ store.curQueueItem.media_item.artists[0].name }}
+          </div>
+          <!-- radio live metadata -->
+          <div
+            v-else-if="store.curQueueItem?.streamdetails?.stream_title"
+            class="line-clamp-1"
+          >
+            {{ store.curQueueItem?.streamdetails?.stream_title }}
+          </div>
+          <!-- other description -->
+          <div
+            v-else-if="
+              store.curQueueItem &&
+              store.curQueueItem.media_item?.metadata.description
+            "
+            class="line-clamp-1"
+          >
+            {{ store.curQueueItem.media_item.metadata.description }}
+          </div>
+          <!-- external source artist -->
+          <div v-else-if="store.activePlayer?.current_media?.artist">
+            {{ store.activePlayer.current_media.artist }}
+          </div>
+          <!-- 3rd party source active -->
+          <div
+            v-else-if="
+              store.activePlayer?.active_source != store.activePlayer?.player_id
+            "
+            class="line-clamp-1"
+          >
+            {{
+              $t("external_source_active", [store.activePlayer?.active_source])
+            }}
+          </div>
+        </MarqueeText>
         <!-- active player -->
         <div v-if="store.activePlayer && store.activePlayer?.powered">
           {{ getPlayerName(store.activePlayer) }}
@@ -228,6 +232,10 @@ import {
 import PlayerFullscreen from "./PlayerFullscreen.vue";
 import { imgCoverDark } from "@/components/QualityDetailsBtn.vue";
 import { getBreakpointValue } from "@/plugins/breakpoint";
+import MarqueeText from "@/components/MarqueeText.vue";
+import { MarqueeTextSync } from "@/helpers/marquee_text_sync";
+
+const marqueeSync = new MarqueeTextSync();
 
 // properties
 interface Props {


### PR DESCRIPTION
# Current Situation

Currently, Music Assistant on mobile devices cuts off long titles, albums, and artist names, making it impossible to read them completely.
This is especially problematic with Classical Music, where titles often include the composer, composition name, and movement.

# Overview

To address this issue, this PR adds a `MarqueeText` component, which automatically scrolls text that doesn't fit on screen.

To improve readability, `MarqueeText` includes the following features for use in Music Assistant:
- Constant Scrolling Speed: Text scrolls at a consistent speed, regardless of length
- Synchronization: Multiple instances of `MarqueeText` can be synchronized with `MarqueeTextSync` for coordinated scrolling

# MarqueeTextSync

When a `MarqueeTextSync` object is passed through the `sync` prop of `MarqueeText`, the reset animation will be synchronized across all instances using the same `MarqueeTextSync` object.
Additional delay is added at the start of the animation, so waiting widgets will pause with the text at the beginning.

This provides the following advantages:
- Reset animation is shared across all widgets to prevent chaotic jumping
- The constant scrolling speed makes reading with multiple marquees on screen considerably easier
- When waiting is required (for sync), the screen time for the beginning of the text is maximized, as it's often the most important part

Only visible `MarqueeText` widgets will be animated, ensuring animations won't be slowed down by off-screen `MarqueeText` components with very long text.

# Use of MarqueeText in this PR

In this PR, MarqueeText is added in the following places:
- Fullscreen Player Queue (For currently playing track, and on mouse hover)
- Fullscreen Player (Title, Artist, and Album Name, with different `MarqueeTextSync` than the Queue)
- Minimized Player (Artist and Title)
- InfoHeader (when viewing an Album/Artist/Playlist/...)

Scrolling is done using CSS, while CPU usage seems to be minimal (tested using Firefox Profiler).

# Screen Recordings of this PR in Action

https://github.com/user-attachments/assets/fb28e671-b439-4394-be90-115d49cc409e

https://github.com/user-attachments/assets/4ec67339-57c1-48bc-877d-80a00231582c

https://github.com/user-attachments/assets/35e06376-0952-477f-a5a9-ced10f073cc9
