### PR TITLE
Make DSP Configuration UI More Consistent

### DIFF
--- a/src/components/dsp/DSPParametricEQ.vue
+++ b/src/components/dsp/DSPParametricEQ.vue
@@ -1,21 +1,23 @@
 <template>
   <v-container class="pa-2">
     <!-- Frequency Response Graph with Dark Theme Support -->
-    <v-card class="mb-4" elevation="2">
+    <v-card elevation="0" color="transparent">
       <div ref="graphContainer" class="graph-container">
         <canvas ref="canvas" class="frequency-graph"></canvas>
       </div>
     </v-card>
 
     <!-- Band Management Section -->
-    <v-card class="mb-4" elevation="2">
-      <v-card-title class="d-flex align-center px-4 py-2" />
-
+    <v-card
+      elevation="0"
+      color="transparent"
+      class="border-t border-b rounded-0"
+    >
       <!-- Band Selection with Visual Indicators -->
       <v-card-text class="pa-0">
         <v-chip-group
           v-model="selectedBandIndex"
-          class="mb-4 pa-2"
+          class="mb-0 pa-2"
           mandatory
           selected-class="primary"
         >
@@ -38,7 +40,7 @@
     </v-card>
 
     <!-- Band Controls Card -->
-    <v-card v-if="selectedBand" elevation="2">
+    <v-card v-if="selectedBand" elevation="0" color="transparent">
       <v-card-text>
         <!-- Band Header -->
         <div class="d-flex align-center mb-4">
@@ -69,20 +71,15 @@
               :label="$t('settings.dsp.parametric_eq.filter_type')"
               variant="outlined"
               density="comfortable"
-              class="mb-4"
             />
           </v-col>
 
           <v-col cols="12">
-            <DSPSlider
-              v-model="selectedBand.frequency"
-              type="frequency"
-              class="mb-4"
-            />
+            <DSPSlider v-model="selectedBand.frequency" type="frequency" />
           </v-col>
 
           <v-col v-if="showGainParameter(selectedBand.type)" cols="12">
-            <DSPSlider v-model="selectedBand.gain" type="gain" class="mb-4" />
+            <DSPSlider v-model="selectedBand.gain" type="gain" />
           </v-col>
 
           <v-col cols="12">

--- a/src/components/dsp/DSPParametricEQ.vue
+++ b/src/components/dsp/DSPParametricEQ.vue
@@ -47,7 +47,7 @@
             :label="$t('settings.dsp.parametric_eq.enable_band')"
             density="comfortable"
             hide-details
-            inset
+            color="primary"
           />
           <v-spacer />
           <v-btn

--- a/src/components/dsp/DSPSlider.vue
+++ b/src/components/dsp/DSPSlider.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-card flat>
+  <v-card flat color="transparent">
     <v-card-text class="d-flex align-center gap-4">
       <v-slider
         v-model="model"

--- a/src/components/dsp/DSPSlider.vue
+++ b/src/components/dsp/DSPSlider.vue
@@ -10,6 +10,7 @@
         hide-details
         class="flex-grow-1 pr-4"
         density="compact"
+        color="primary"
       />
       <v-text-field
         v-model="displayValue"

--- a/src/views/settings/EditPlayerDsp.vue
+++ b/src/views/settings/EditPlayerDsp.vue
@@ -1,7 +1,12 @@
 <template>
   <section v-if="dsp">
     <v-toolbar color="transparent" class="border-b">
-      <v-switch v-model="dsp.enabled" hide-details class="pl-4" />
+      <v-switch
+        v-model="dsp.enabled"
+        hide-details
+        color="primary"
+        class="pl-4"
+      />
       <v-toolbar-title>{{
         $t("settings.dsp.configure_on", { name: playerName })
       }}</v-toolbar-title>
@@ -69,6 +74,7 @@
               v-if="typeof selectedStage === 'number'"
               v-model="dsp.filters[selectedStage].enabled"
               hide-details
+              color="primary"
               class="mr-4"
             />
             <v-btn

--- a/src/views/settings/EditPlayerDsp.vue
+++ b/src/views/settings/EditPlayerDsp.vue
@@ -37,7 +37,10 @@
         <!-- Filter Settings Panel -->
         <v-col v-if="selectedStage != null" style="min-width: 0">
           <!-- Toolbar of the selected item -->
-          <v-toolbar density="compact">
+          <v-toolbar
+            density="compact"
+            :color="$vuetify.theme.current.dark ? 'surface' : 'surface-light'"
+          >
             <v-btn
               v-if="mobile"
               class="hidden-xs-only"
@@ -87,12 +90,20 @@
           </v-toolbar>
 
           <!-- Settings of the Input stage -->
-          <v-card v-if="selectedStage === 'input'" flat>
+          <v-card
+            v-if="selectedStage === 'input'"
+            flat
+            :color="$vuetify.theme.current.dark ? 'surface' : 'surface-light'"
+          >
             <DSPSlider v-model="dsp.input_gain" type="gain" />
           </v-card>
 
           <!-- Settings of the Output stage -->
-          <v-card v-else-if="selectedStage === 'output'" flat>
+          <v-card
+            v-else-if="selectedStage === 'output'"
+            flat
+            :color="$vuetify.theme.current.dark ? 'surface' : 'surface-light'"
+          >
             <v-card-item>
               <DSPSlider v-model="dsp.output_gain" type="gain" />
               <v-checkbox
@@ -103,7 +114,11 @@
           </v-card>
 
           <!-- Settings of the selected DSP Filter -->
-          <v-card v-else flat>
+          <v-card
+            v-else
+            flat
+            :color="$vuetify.theme.current.dark ? 'surface' : 'surface-light'"
+          >
             <DSPParametricEQ
               v-if="
                 dsp.filters[selectedStage].type === DSPFilterType.PARAMETRIC_EQ

--- a/src/views/settings/EditPlayerDsp.vue
+++ b/src/views/settings/EditPlayerDsp.vue
@@ -40,6 +40,7 @@
           <v-toolbar
             density="compact"
             :color="$vuetify.theme.current.dark ? 'surface' : 'surface-light'"
+            class="border-b"
           >
             <v-btn
               v-if="mobile"


### PR DESCRIPTION
## Overview

This PR primarily makes sliders and switches use the primary color, as found in the rest of Music Assistant (notably the existing Settings Menu).

The other visual adjustments, as seen in the screenshots, increase the contrast between the primary color and the background (and include some margin adjustments resulting from these changes).

## Screenshots

![new-dark](https://github.com/user-attachments/assets/dfc18f0a-7d13-4fc4-8b0f-bdbc00facd46)

![new-light](https://github.com/user-attachments/assets/a1b27b55-2277-4f1f-86c5-0063f4f45189)

### Reference Screenshots before this PR

![old-dark](https://github.com/user-attachments/assets/30c5b773-5384-4afa-9402-26505de733aa)

![old-light](https://github.com/user-attachments/assets/a298442e-51ba-4550-b39b-4bd1f267af9a)
