### PR TITLE
Add import and Export buttons to the Parametric Equalizer DSP

### DIFF
--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -441,6 +441,8 @@
                 "filter_type": "Filter Type",
                 "band": "Band {index}",
                 "enable_band": "Enable Band",
+                "import_apo": "Import APO/REW Preset",
+                "export_apo": "Export APO Preset",
                 "filter_types": {
                     "peak": "Peak",
                     "low_shelf": "Low Shelf",


### PR DESCRIPTION
## Overview

This PR adds support for importing and exporting Parametric Equalizer presets.

Equalizer APO's file format is widely adopted in various applications, and this import functionality also works seamlessly with REW's  `Export filter settings as text` file format.
While not all filter types are supported (Modal, BP, LSC x dB, HS x dB, AP, LS with dB slope, HS with dB slope), the most important ones are functional.

Currently, the `Preamp` option is not supported. This may change in the future.

## Testing

I tested this with:
- An Equalizer preset exported from REW
- An Equalizer preset exported from EasyEffects (as APO preset)
- An example REW-compatible preset from https://housecurve.com/
- Importing a Music Assistant exported preset into EasyEffects

## Screenshot

![image](https://github.com/user-attachments/assets/e3d4ba3d-9178-46d5-9d0e-6cfe53715dc1)
