### PR TITLE
Fix: Improve spacing/padding consistency accross DSP Settings

### DIFF
--- a/src/components/dsp/DSPParametricEQ.vue
+++ b/src/components/dsp/DSPParametricEQ.vue
@@ -1,7 +1,7 @@
 <template>
   <v-container class="pa-2">
     <!-- Import/Export Buttons to Load/Save Equalizer APO Settings -->
-    <div class="d-flex justify-end">
+    <v-card-item class="d-flex justify-end">
       <v-btn variant="outlined" class="mr-2" @click="openApoFileImport">
         <v-icon start>mdi-file-import</v-icon>
         {{ $t("settings.dsp.parametric_eq.import_apo") }}
@@ -19,7 +19,7 @@
         class="d-none"
         @change="handleApoUpload"
       />
-    </div>
+    </v-card-item>
 
     <!-- Frequency Response Graph with Dark Theme Support -->
     <v-card elevation="0" color="transparent">
@@ -61,10 +61,10 @@
     </v-card>
 
     <!-- Band Controls Card -->
-    <v-card v-if="selectedBand" elevation="0" color="transparent">
-      <v-card-text>
+    <template v-if="selectedBand">
+      <v-card-item>
         <!-- Band Header -->
-        <div class="d-flex align-center mb-4">
+        <div class="d-flex align-center">
           <v-switch
             v-model="selectedBand.enabled"
             :label="$t('settings.dsp.parametric_eq.enable_band')"
@@ -82,33 +82,29 @@
             {{ $t("settings.dsp.parametric_eq.delete_band") }}
           </v-btn>
         </div>
+      </v-card-item>
 
-        <!-- Filter Controls -->
-        <v-row dense>
-          <v-col cols="12">
-            <v-select
-              v-model="selectedBand.type"
-              :items="filterTypes"
-              :label="$t('settings.dsp.parametric_eq.filter_type')"
-              variant="outlined"
-              density="comfortable"
-            />
-          </v-col>
+      <!-- Filter Controls -->
+      <v-select
+        v-model="selectedBand.type"
+        :items="filterTypes"
+        :label="$t('settings.dsp.parametric_eq.filter_type')"
+        variant="outlined"
+        density="comfortable"
+        class="pa-4"
+        hide-details
+      />
 
-          <v-col cols="12">
-            <DSPSlider v-model="selectedBand.frequency" type="frequency" />
-          </v-col>
+      <DSPSlider v-model="selectedBand.frequency" type="frequency" />
 
-          <v-col v-if="showGainParameter(selectedBand.type)" cols="12">
-            <DSPSlider v-model="selectedBand.gain" type="gain" />
-          </v-col>
+      <DSPSlider
+        v-if="showGainParameter(selectedBand.type)"
+        v-model="selectedBand.gain"
+        type="gain"
+      />
 
-          <v-col cols="12">
-            <DSPSlider v-model="selectedBand.q" type="q" />
-          </v-col>
-        </v-row>
-      </v-card-text>
-    </v-card>
+      <DSPSlider v-model="selectedBand.q" type="q" />
+    </template>
   </v-container>
 </template>
 <script setup lang="ts">

--- a/src/components/dsp/DSPSlider.vue
+++ b/src/components/dsp/DSPSlider.vue
@@ -1,12 +1,14 @@
 <template>
   <v-card flat color="transparent">
     <v-card-text class="d-flex align-center gap-4">
+      <span style="min-width: 100px" class="v-label pl-2">{{
+        config.label
+      }}</span>
       <v-slider
         v-model="model"
         :min="config.min"
         :max="config.max"
         :step="config.step"
-        :label="config.label"
         hide-details
         class="flex-grow-1 pr-4"
         density="compact"

--- a/src/components/dsp/DSPToneControl.vue
+++ b/src/components/dsp/DSPToneControl.vue
@@ -1,40 +1,34 @@
 <template>
-  <v-card-item>
-    <DSPSlider
-      v-model="tone_control.bass_level"
-      :type="{
-        min: -10,
-        max: 10,
-        step: 0.1,
-        label: $t('settings.dsp.tone_control.bass_level'),
-        unit: 'dB',
-      }"
-    />
-  </v-card-item>
-  <v-card-item>
-    <DSPSlider
-      v-model="tone_control.mid_level"
-      :type="{
-        min: -10,
-        max: 10,
-        step: 0.1,
-        label: $t('settings.dsp.tone_control.mid_level'),
-        unit: 'dB',
-      }"
-    />
-  </v-card-item>
-  <v-card-item>
-    <DSPSlider
-      v-model="tone_control.treble_level"
-      :type="{
-        min: -10,
-        max: 10,
-        step: 0.1,
-        label: $t('settings.dsp.tone_control.treble_level'),
-        unit: 'dB',
-      }"
-    />
-  </v-card-item>
+  <DSPSlider
+    v-model="tone_control.bass_level"
+    :type="{
+      min: -10,
+      max: 10,
+      step: 0.1,
+      label: $t('settings.dsp.tone_control.bass_level'),
+      unit: 'dB',
+    }"
+  />
+  <DSPSlider
+    v-model="tone_control.mid_level"
+    :type="{
+      min: -10,
+      max: 10,
+      step: 0.1,
+      label: $t('settings.dsp.tone_control.mid_level'),
+      unit: 'dB',
+    }"
+  />
+  <DSPSlider
+    v-model="tone_control.treble_level"
+    :type="{
+      min: -10,
+      max: 10,
+      step: 0.1,
+      label: $t('settings.dsp.tone_control.treble_level'),
+      unit: 'dB',
+    }"
+  />
 </template>
 <script setup lang="ts">
 import { ToneControlFilter } from "@/plugins/api/interfaces";

--- a/src/views/settings/EditPlayerDsp.vue
+++ b/src/views/settings/EditPlayerDsp.vue
@@ -105,8 +105,8 @@
             flat
             :color="$vuetify.theme.current.dark ? 'surface' : 'surface-light'"
           >
+            <DSPSlider v-model="dsp.output_gain" type="gain" />
             <v-card-item>
-              <DSPSlider v-model="dsp.output_gain" type="gain" />
               <v-checkbox
                 v-model="dsp.output_limiter"
                 :label="$t('settings.dsp.enable_output_limiter')"

--- a/src/views/settings/EditPlayerDsp.vue
+++ b/src/views/settings/EditPlayerDsp.vue
@@ -110,6 +110,7 @@
               <v-checkbox
                 v-model="dsp.output_limiter"
                 :label="$t('settings.dsp.enable_output_limiter')"
+                hide-details
               />
             </v-card-item>
           </v-card>


### PR DESCRIPTION
Previously Input settings had considerably less padding then Output settings and the Tone Controls filter. This PR adds the missing `<v-card-item>` to fix this.
Previously padding was inconsistent across the DSP Settings. 
This PR addresses this by using `<v-card-item>` for items inside the `<v-card>`, except `<DSPSlider>`, which already has padding on its own.
Additionally this PR makes labels of `<DSPSlider>` a constant width.

# Screenshot of current beta
![image](https://github.com/user-attachments/assets/493d1d2e-73f3-4162-b74c-16641d97b0bd)

# Screenshots with this PR

![input](https://github.com/user-attachments/assets/3e4f3caa-bdf3-411f-b367-f1f25a243a33)
![tone control](https://github.com/user-attachments/assets/8e967ee2-f6a1-49a1-b258-8f935ee7dd00)
![peq](https://github.com/user-attachments/assets/9481a3ce-fc5d-4858-a2d2-ef67f9980656)
![output](https://github.com/user-attachments/assets/255371f3-57b2-4316-8cd3-de0e3a70a8d4)
