### PR TITLE
fix: Use a better solution to watch params

### DIFF
--- a/src/layouts/default/Default.vue
+++ b/src/layouts/default/Default.vue
@@ -28,23 +28,16 @@ import ReloadPrompt from "./ReloadPrompt.vue";
 import { store } from "@/plugins/store";
 import { toRefs, watch, ref } from "vue";
 import api from "@/plugins/api";
-
-export interface Props {
-  showFullscreenPlayer?: boolean;
-  player?: string;
-  frameless?: boolean;
-}
-
-const props = defineProps<Props>();
+import { useRoute } from "vue-router";
 
 // keep this in a ref so that we keep it while navigating. But restart it if page is fully reloaded
 const framelessState = ref(false);
 
-const { showFullscreenPlayer, player, frameless } = toRefs(props);
-
+const route = useRoute();
 watch(
-  player,
+  () => route.query.player,
   (newActivePlayer) => {
+    console.log(newActivePlayer, "newActivePlayer");
     if (!newActivePlayer) return;
     // newActivePlayer can be either player id or player name
     const newPlayerId = Object.values(api.players).find((p) => {
@@ -61,14 +54,14 @@ watch(
   { immediate: true },
 );
 watch(
-  showFullscreenPlayer,
+  () => route.query.showFullscreenPlayer,
   (showFullscreenPlayer) => {
     store.showFullscreenPlayer = !!showFullscreenPlayer;
   },
   { immediate: true },
 );
 watch(
-  frameless,
+  () => route.query.frameless,
   (frameless) => {
     if (frameless) {
       framelessState.value = true;

--- a/src/layouts/default/Default.vue
+++ b/src/layouts/default/Default.vue
@@ -37,13 +37,13 @@ const route = useRoute();
 watch(
   () => route.query.player,
   (newActivePlayer) => {
-    console.log(newActivePlayer, "newActivePlayer");
     if (!newActivePlayer) return;
     // newActivePlayer can be either player id or player name
     const newPlayerId = Object.values(api.players).find((p) => {
       return (
         p.player_id === newActivePlayer ||
-        p.display_name.toLowerCase() === newActivePlayer.toLowerCase()
+        p.display_name.toLowerCase() ===
+          newActivePlayer.toString().toLowerCase()
       );
     })?.player_id;
 

--- a/src/plugins/router.ts
+++ b/src/plugins/router.ts
@@ -5,7 +5,6 @@ const routes = [
   {
     path: "/",
     component: () => import("@/layouts/default/Default.vue"),
-    props: (route: { query: Record<string, any> }) => ({ ...route.query }),
     children: [
       {
         path: "",
@@ -16,7 +15,6 @@ const routes = [
         name: "home",
         component: () =>
           import(/* webpackChunkName: "home" */ "@/views/HomeView.vue"),
-        props: (route: { query: Record<string, any> }) => ({ ...route.query }),
       },
       {
         path: "/search",

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -35,11 +35,6 @@ import HomeWidgetRows from "@/components/HomeWidgetRows.vue";
 import Toolbar from "@/components/Toolbar.vue";
 import { ref } from "vue";
 
-export interface Props {
-  player?: string;
-}
-const props = defineProps<Props>();
-
 const hideSettings = ref(
   localStorage.getItem("frontend.settings.hide_settings") == "true",
 );


### PR DESCRIPTION
As [mentioned here](https://github.com/orgs/music-assistant/discussions/954#discussioncomment-11758079), sometimes the URL query params are not updating correctly unless the cache is cleaned.

I'm changing the way we watch for params changes to use the [way vue-router recommends.](https://router.vuejs.org/guide/essentials/dynamic-matching.html#Reacting-to-Params-Changes)
I believe this should solve the issue.

