### PR TITLE
Fix: missing playername on webkit/safari

### DIFF
--- a/src/layouts/default/PlayerOSD/PlayerTrackDetails.vue
+++ b/src/layouts/default/PlayerOSD/PlayerTrackDetails.vue
@@ -294,4 +294,10 @@ const streamDetails = computed(() => {
   background-color: rgba(0, 0, 0, 0.3);
   display: inline-table;
 }
+
+/* this fixes missing subtitle items on webkit*/
+.v-list-item-subtitle {
+  -webkit-line-clamp: unset !important;
+  line-clamp: unset !important;
+}
 </style>


### PR DESCRIPTION
#767 introduced a regression on webkit/safari, where the player name is not visible.

# Screenshot before
![image](https://github.com/user-attachments/assets/0d6e48fa-d444-446f-876c-f3cfed847996)
In the order: Chromium (Brave), Firefox, and Webkit (GNOME Web)

# Screenshot with this PR

![image](https://github.com/user-attachments/assets/bb2330a2-2f4d-4ee5-93b2-8b6d72f9141b)
In the order: Chromium (Brave), Firefox, and Webkit (GNOME Web)