### PR TITLE
Display the used volume normalization mode/values instead of target

### DIFF
--- a/src/components/QualityDetailsBtn.vue
+++ b/src/components/QualityDetailsBtn.vue
@@ -93,7 +93,7 @@ const streamDetails = computed(() => {
   return store.activePlayerQueue?.current_item?.streamdetails;
 });
 const loudness = computed(() => {
-  let sd = streamDetails.value;
+  const sd = streamDetails.value;
   if (!sd) return null;
 
   if (

--- a/src/components/QualityDetailsBtn.vue
+++ b/src/components/QualityDetailsBtn.vue
@@ -86,7 +86,7 @@ import ProviderIcon from "@/components/ProviderIcon.vue";
 import api from "@/plugins/api";
 import { store } from "@/plugins/store";
 import { ContentType, VolumeNormalizationMode } from "@/plugins/api/interfaces";
-import { $t } from '@/plugins/i18n';
+import { $t } from "@/plugins/i18n";
 
 // computed properties
 const streamDetails = computed(() => {
@@ -105,20 +105,20 @@ const loudness = computed(() => {
     sd.loudness !== null
   ) {
     if (sd.prefer_album_loudness && sd.loudness_album !== null) {
-      return $t('loudness_measurement_album', [sd.loudness_album?.toFixed(2)]);
+      return $t("loudness_measurement_album", [sd.loudness_album?.toFixed(2)]);
     } else {
-      return $t('loudness_measurement', [sd.loudness?.toFixed(2)]);
+      return $t("loudness_measurement", [sd.loudness?.toFixed(2)]);
     }
   } else if (
     sd.volume_normalization_mode == VolumeNormalizationMode.DYNAMIC ||
     sd.volume_normalization_mode == VolumeNormalizationMode.FALLBACK_DYNAMIC
   ) {
-    return $t('loudness_dynamic');
+    return $t("loudness_dynamic");
   } else if (
     sd.volume_normalization_mode == VolumeNormalizationMode.FIXED_GAIN ||
     sd.volume_normalization_mode == VolumeNormalizationMode.FALLBACK_FIXED_GAIN
   ) {
-    return $t('loudness_fixed');
+    return $t("loudness_fixed");
   } else {
     return null;
   }

--- a/src/components/QualityDetailsBtn.vue
+++ b/src/components/QualityDetailsBtn.vue
@@ -59,7 +59,7 @@
         </div>
 
         <div
-          v-if="streamDetails.target_loudness"
+          v-if="loudness"
           style="height: 50px; display: flex; align-items: center"
         >
           <img
@@ -73,7 +73,7 @@
                 : 'object-fit: contain;filter: invert(100%);'
             "
           />
-          {{ streamDetails.target_loudness }} dB
+          {{ loudness }}
         </div>
       </v-list>
     </v-card>
@@ -85,11 +85,43 @@ import { computed } from "vue";
 import ProviderIcon from "@/components/ProviderIcon.vue";
 import api from "@/plugins/api";
 import { store } from "@/plugins/store";
-import { ContentType } from "@/plugins/api/interfaces";
+import { ContentType, VolumeNormalizationMode } from "@/plugins/api/interfaces";
+import { $t } from '@/plugins/i18n';
 
 // computed properties
 const streamDetails = computed(() => {
   return store.activePlayerQueue?.current_item?.streamdetails;
+});
+const loudness = computed(() => {
+  let sd = streamDetails.value;
+  if (!sd) return null;
+
+  if (
+    (sd.volume_normalization_mode == VolumeNormalizationMode.MEASUREMENT_ONLY ||
+      sd.volume_normalization_mode ==
+        VolumeNormalizationMode.FALLBACK_FIXED_GAIN ||
+      sd.volume_normalization_mode ==
+        VolumeNormalizationMode.FALLBACK_DYNAMIC) &&
+    sd.loudness !== null
+  ) {
+    if (sd.prefer_album_loudness && sd.loudness_album !== null) {
+      return $t('loudness_measurement_album', [sd.loudness_album?.toFixed(2)]);
+    } else {
+      return $t('loudness_measurement', [sd.loudness?.toFixed(2)]);
+    }
+  } else if (
+    sd.volume_normalization_mode == VolumeNormalizationMode.DYNAMIC ||
+    sd.volume_normalization_mode == VolumeNormalizationMode.FALLBACK_DYNAMIC
+  ) {
+    return $t('loudness_dynamic');
+  } else if (
+    sd.volume_normalization_mode == VolumeNormalizationMode.FIXED_GAIN ||
+    sd.volume_normalization_mode == VolumeNormalizationMode.FALLBACK_FIXED_GAIN
+  ) {
+    return $t('loudness_fixed');
+  } else {
+    return null;
+  }
 });
 const getContentTypeIcon = function (contentType: ContentType) {
   if (contentType == ContentType.AAC) return iconAac;

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -602,5 +602,9 @@
     "mark_unplayed": "Mark as unplayed",
     "searchtype_all": "All",
     "global_search": "Global search",
-    "play_from_here": "Play from here"
+    "play_from_here": "Play from here",
+    "loudness_measurement": "{0} LUFS",
+    "loudness_measurement_album": "{0} LUFS (album)",
+    "loudness_dynamic": "Dynamic volume normalization",
+    "loudness_fixed": "Fixed gain correction"
 }


### PR DESCRIPTION
This is PR is a rebase of #651.

# Original description

Displaying the target loudness in the stream details display isn't very useful, since that's a user-configured setting and does not change depending on what is being played. In place of that number, show information about what volume normalization is currently being applied.

If measurements are available, and are being used, it will display either the track or album measured loudness depending on whether `prefer_album_loudness` is set.

Otherwise, it will display "Dynamic volume normalization" if loudnorm is being used in dynamic mode - or "Fixed gain correction" if fixed gain is being applied.

If no volume normalization is being applied, the loudness information row will not be displayed.

![image](https://github.com/user-attachments/assets/a0a3bb84-6071-4a66-bb3f-eaa749306204)