### PR TITLE
Feat: Add a secondary Speaker button in the fullscreen player.

### DIFF
--- a/src/layouts/default/PlayerOSD/PlayerFullscreen.vue
+++ b/src/layouts/default/PlayerOSD/PlayerFullscreen.vue
@@ -36,6 +36,8 @@
             </v-card>
           </v-menu>
 
+          <SpeakerBtn v-if="!showExpandedPlayerSelectButton" />
+
           <Button icon @click.stop="openQueueMenu">
             <v-icon icon="mdi-dots-vertical" />
           </Button>
@@ -504,6 +506,7 @@ import PlayerVolume from "@/layouts/default/PlayerOSD/PlayerVolume.vue";
 import QueueBtn from "./PlayerControlBtn/QueueBtn.vue";
 import QualityDetailsBtn from "@/components/QualityDetailsBtn.vue";
 import MarqueeText from "@/components/MarqueeText.vue";
+import SpeakerBtn from "./PlayerControlBtn/SpeakerBtn.vue";
 import { MarqueeTextSync } from "@/helpers/marquee_text_sync";
 import {
   imgCoverLight,

--- a/src/layouts/default/PlayerOSD/PlayerFullscreen.vue
+++ b/src/layouts/default/PlayerOSD/PlayerFullscreen.vue
@@ -448,7 +448,7 @@
 
         <!-- player select button -->
         <div
-          v-if="$vuetify.display.height > 800"
+          v-if="showExpandedPlayerSelectButton"
           class="row"
           style="
             height: 70px;
@@ -590,6 +590,10 @@ const subTitleFontSize = computed(() => {
     default:
       return "1.0em.";
   }
+});
+
+const showExpandedPlayerSelectButton = computed(() => {
+  return vuetify.display.height.value > 800;
 });
 
 // methods


### PR DESCRIPTION
Previously, on small enough screens (phones), changing the selected player required minimizing the player first.
This PR adds a smaller variant of the select player button to the toolbar, that is only shown on small enough screens.

# Screenshots

## Small screen
![image](https://github.com/user-attachments/assets/46ba26cb-02fd-4a75-a76c-4b470814856c)

## Slightly larger screen
![image](https://github.com/user-attachments/assets/26d7f1ec-7765-420e-8eb3-5fd412c5a6f2)
