### PR TITLE
chore: Hide double scroll

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -200,7 +200,7 @@ h6 {
   margin-bottom: 0;
 }
 
-/* Workaround for vuetify issue https://github.com/vuetifyjs/vuetify/issues/16994 */
+/* Workaround for vuetify issue https://github.com/vuetifyjs/vuetify/issues/1197 */
 html {
   overflow-y: hidden !important;
 }

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -36,18 +36,29 @@ html {
 }
 
 * {
-  -webkit-user-drag: none; /* iOS Safari */
-  -khtml-user-drag: none; /* Konqueror HTML */
-  -moz-user-drag: none; /* Old versions of Firefox */
-  -o-user-drag: none; /* Internet Explorer/Edge */
-  user-drag: none; /* Non-prefixed version, currently supported by Chrome, Edge, Opera and Firefox */
+  -webkit-user-drag: none;
+  /* iOS Safari */
+  -khtml-user-drag: none;
+  /* Konqueror HTML */
+  -moz-user-drag: none;
+  /* Old versions of Firefox */
+  -o-user-drag: none;
+  /* Internet Explorer/Edge */
+  user-drag: none;
+  /* Non-prefixed version, currently supported by Chrome, Edge, Opera and Firefox */
 
-  -webkit-touch-callout: none; /* iOS Safari */
-  -webkit-user-select: none; /* Safari */
-  -khtml-user-select: none; /* Konqueror HTML */
-  -moz-user-select: none; /* Old versions of Firefox */
-  -ms-user-select: none; /* Internet Explorer/Edge */
-  user-select: none; /* Non-prefixed version, currently supported by Chrome, Edge, Opera and Firefox */
+  -webkit-touch-callout: none;
+  /* iOS Safari */
+  -webkit-user-select: none;
+  /* Safari */
+  -khtml-user-select: none;
+  /* Konqueror HTML */
+  -moz-user-select: none;
+  /* Old versions of Firefox */
+  -ms-user-select: none;
+  /* Internet Explorer/Edge */
+  user-select: none;
+  /* Non-prefixed version, currently supported by Chrome, Edge, Opera and Firefox */
 }
 
 a {
@@ -187,4 +198,9 @@ h6 {
 .mh6 {
   margin-top: 1rem;
   margin-bottom: 0;
+}
+
+/* Workaround for vuetify issue https://github.com/vuetifyjs/vuetify/issues/16994 */
+html {
+  overflow-y: hidden !important;
 }


### PR DESCRIPTION
Vuetify forces `overflow-y` in the HTML element.

Not a popular choice

https://github.com/vuetifyjs/vuetify/issues/16994
https://github.com/vuetifyjs/vuetify/issues/1197

This overrides it back to `hidden`

apparently they will remove it soon
