### PR TITLE
Fix: Remove links to DSP Settings for PlayerGroups

### DIFF
--- a/src/helpers/player_menu_items.ts
+++ b/src/helpers/player_menu_items.ts
@@ -179,16 +179,18 @@ export const getPlayerMenuItems = (
   });
 
   // add shortcut to dsp settings
-  menuItems.push({
-    label: "open_dsp_settings",
-    labelArgs: [],
-    action: () => {
-      store.showFullscreenPlayer = false;
-      store.showPlayersMenu = false;
-      router.push(`/settings/editplayer/${player.player_id}/dsp`);
-    },
-    icon: "mdi-equalizer",
-  });
+  if (player.type !== PlayerType.GROUP) {
+    menuItems.push({
+      label: "open_dsp_settings",
+      labelArgs: [],
+      action: () => {
+        store.showFullscreenPlayer = false;
+        store.showPlayersMenu = false;
+        router.push(`/settings/editplayer/${player.player_id}/dsp`);
+      },
+      icon: "mdi-equalizer",
+    });
+  }
 
   return menuItems;
 };

--- a/src/views/settings/EditPlayer.vue
+++ b/src/views/settings/EditPlayer.vue
@@ -77,7 +77,10 @@
         />
 
         <!-- DSP Config Button -->
-        <v-btn @click="openDspConfig">
+        <v-btn
+          v-if="api.players[config.player_id].type !== PlayerType.GROUP"
+          @click="openDspConfig"
+        >
           {{ $t("open_dsp_settings") }}
         </v-btn>
       </div>
@@ -97,7 +100,11 @@
 import { ref } from "vue";
 import { useRouter } from "vue-router";
 import { api } from "@/plugins/api";
-import { ConfigValueType, PlayerConfig } from "@/plugins/api/interfaces";
+import {
+  ConfigValueType,
+  PlayerConfig,
+  PlayerType,
+} from "@/plugins/api/interfaces";
 import EditConfig from "./EditConfig.vue";
 import { watch } from "vue";
 import { openLinkInNewTab } from "@/helpers/utils";

--- a/src/views/settings/Players.vue
+++ b/src/views/settings/Players.vue
@@ -73,6 +73,7 @@ import { api } from "@/plugins/api";
 import {
   EventType,
   PlayerConfig,
+  PlayerType,
   ProviderFeature,
 } from "@/plugins/api/interfaces";
 import ProviderIcon from "@/components/ProviderIcon.vue";
@@ -169,6 +170,7 @@ const onMenu = function (evt: Event, playerConfig: PlayerConfig) {
       },
       icon: "mdi-equalizer",
       disabled: !api.players[playerConfig.player_id]?.available,
+      hide: api.players[playerConfig.player_id]?.type === PlayerType.GROUP,
     },
     {
       label: playerConfig.enabled ? "settings.disable" : "settings.enable",


### PR DESCRIPTION
Group players only use the DSP of the containing players.
Therefore this PR hides all links to the DSP settings on `PlayerGroup`s.