### PR TITLE
Fix: Allow opening of DSP Settings on unavailable players

### DIFF
--- a/src/views/settings/Players.vue
+++ b/src/views/settings/Players.vue
@@ -169,7 +169,6 @@ const onMenu = function (evt: Event, playerConfig: PlayerConfig) {
         editPlayerDsp(playerConfig.player_id);
       },
       icon: "mdi-equalizer",
-      disabled: !api.players[playerConfig.player_id]?.available,
       hide: api.players[playerConfig.player_id]?.type === PlayerType.GROUP,
     },
     {


### PR DESCRIPTION
We have no reason to block the user from opening the DSP Settings on unavailable Players.