### PR TITLE
Feat: add support for monochrome provider icons

### DIFF
--- a/src/components/ProviderIcon.vue
+++ b/src/components/ProviderIcon.vue
@@ -18,7 +18,8 @@
         providerDomain &&
         api.providerManifests[providerDomain].icon_svg_dark
       "
-      :style="`width: ${size}px;align-content: center;`"
+      class="d-flex align-center justify-center"
+      :style="`width: ${size}px;height: ${size}px;align-content: center;`"
       :title="api.providerManifests[providerDomain]!.name"
       v-html="api.providerManifests[providerDomain]!.icon_svg_dark"
     ></div>
@@ -27,6 +28,7 @@
       v-else-if="
         providerDomain && api.providerManifests[providerDomain].icon_svg
       "
+      class="d-flex align-center justify-center"
       :style="`width: ${size}px;height: ${size}px;align-content: center;`"
       :title="api.providerManifests[providerDomain]!.name"
       v-html="api.providerManifests[providerDomain]!.icon_svg"

--- a/src/components/ProviderIcon.vue
+++ b/src/components/ProviderIcon.vue
@@ -11,6 +11,18 @@
       icon="mdi-bookshelf"
       :title="$t('item_in_library')"
     />
+    <!-- monochrome icon-->
+    <div
+      v-else-if="
+        props.monochrome &&
+        providerDomain &&
+        api.providerManifests[providerDomain].icon_svg_monochrome
+      "
+      class="d-flex align-center justify-center"
+      :style="`width: ${size}px;height: ${size}px;align-content: center;${$vuetify.theme.current.dark ? '' : 'filter: invert(1);'}`"
+      :title="api.providerManifests[providerDomain]!.name"
+      v-html="api.providerManifests[providerDomain]!.icon_svg_monochrome"
+    ></div>
     <!-- dark mode and dark svg icon-->
     <div
       v-else-if="
@@ -59,6 +71,7 @@ export interface Props {
   domain: string;
   size: number;
   dark?: boolean;
+  monochrome?: boolean;
 }
 const props = defineProps<Props>();
 

--- a/src/plugins/api/interfaces.ts
+++ b/src/plugins/api/interfaces.ts
@@ -760,6 +760,8 @@ export interface ProviderManifest {
   icon_svg?: string;
   // icon_svg_dark: optional separate dark svg icon (full xml string)
   icon_svg_dark?: string;
+  // icon_svg_dark: optional separate monochrome svg icon (full xml string)
+  icon_svg_monochrome?: string;
   // depends on: domain of another provider that is required for this provider
   depends_on?: string;
 }


### PR DESCRIPTION
This PR adds a `monochrome` property for `ProviderIcon`, to prefer using the with https://github.com/music-assistant/server/pull/1911 and https://github.com/music-assistant/server/pull/1910 added monochrome icon variants.

Additionally this PR fixes some potential issues to force the correct icon size.

The monochrome icon variants will be used in the upcoming redesign of the streamdetails.