### PR TITLE
Handle player controls for power and volume

### DIFF
--- a/src/components/PlayerCard.vue
+++ b/src/components/PlayerCard.vue
@@ -5,9 +5,10 @@
     :class="{
       'panel-item-selected': player.player_id == store.activePlayerId,
       'panel-item-idle': player.state == PlayerState.IDLE,
-      'panel-item-off': !player.powered,
+      'panel-item-off': player.powered == false,
     }"
     :ripple="false"
+    :disabled="!player.available"
   >
     <!-- now playing media -->
     <v-list-item class="panel-item-details" flat :ripple="false">
@@ -16,7 +17,7 @@
         <div class="player-media-thumb">
           <MediaItemThumb
             v-if="
-              (player.powered && curQueueItem?.media_item) ||
+              (player.powered != false && curQueueItem?.media_item) ||
               curQueueItem?.image
             "
             class="media-thumb"
@@ -26,7 +27,9 @@
           />
           <div
             v-else-if="
-              player.powered && !playerQueue && player.current_media?.image_url
+              player.powered != false &&
+              !playerQueue &&
+              player.current_media?.image_url
             "
           >
             <v-img
@@ -57,7 +60,7 @@
       <!-- subtitle: media item title -->
       <template #subtitle>
         <div
-          v-if="player.powered"
+          v-if="player.powered != false"
           style="font-size: 0.85rem; font-weight: 500; white-space: nowrap"
         >
           <div v-if="curQueueItem?.media_item">
@@ -83,7 +86,7 @@
       <template #default>
         <div class="v-list-item-subtitle" style="white-space: nowrap">
           <!-- player powered off -->
-          <div v-if="!player.powered">
+          <div v-if="player.powered == false">
             {{ $t("off") }}
           </div>
           <!-- track: artists(s) + album -->
@@ -131,20 +134,6 @@
 
       <!-- power/play/pause + menu button -->
       <template #append>
-        <!-- power button -->
-        <Button
-          v-if="player.supported_features.includes(PlayerFeature.POWER)"
-          variant="icon"
-          class="player-command-btn"
-          @click.stop="
-            api.playerCommandPowerToggle(player.player_id);
-            store.activePlayerId = player.player_id;
-          "
-          ><v-icon
-            :size="getBreakpointValue({ breakpoint: 'phone' }) ? '30' : '32'"
-            >mdi-power</v-icon
-          ></Button
-        >
         <!-- play/pause button -->
         <Button
           v-if="
@@ -164,6 +153,20 @@
               player.state == PlayerState.PLAYING ? 'mdi-pause' : 'mdi-play'
             "
         /></Button>
+        <!-- power button -->
+        <Button
+          v-if="player.power_control != PLAYER_CONTROL_NONE"
+          variant="icon"
+          class="player-command-btn"
+          @click.stop="
+            api.playerCommandPowerToggle(player.player_id);
+            store.activePlayerId = player.player_id;
+          "
+          ><v-icon
+            :size="getBreakpointValue({ breakpoint: 'phone' }) ? '30' : '32'"
+            >mdi-power</v-icon
+          ></Button
+        >
 
         <!-- menu button -->
         <Button
@@ -186,7 +189,7 @@
       :show-sync-controls="showSyncControls"
       :show-heading-row="false"
       :show-sub-players="showSubPlayers"
-      :show-volume-control="player.powered"
+      :show-volume-control="player.powered != false"
       :allow-wheel="false"
     />
   </v-card>
@@ -199,7 +202,7 @@ import {
   Player,
   PlayerState,
   PlayerType,
-  PlayerFeature,
+  PLAYER_CONTROL_NONE,
 } from "@/plugins/api/interfaces";
 import { store } from "@/plugins/store";
 import MediaItemThumb from "@/components/MediaItemThumb.vue";

--- a/src/components/PlayerCard.vue
+++ b/src/components/PlayerCard.vue
@@ -227,7 +227,11 @@ export interface Props {
 const compProps = defineProps<Props>();
 
 const playerQueue = computed(() => {
-  if (compProps.player && compProps.player.active_source in api.queues) {
+  if (
+    compProps.player &&
+    compProps.player.active_source &&
+    compProps.player.active_source in api.queues
+  ) {
     return api.queues[compProps.player.active_source];
   }
   if (

--- a/src/helpers/player_menu_items.ts
+++ b/src/helpers/player_menu_items.ts
@@ -8,6 +8,7 @@ import {
   PlayerFeature,
   PlayerType,
   RepeatMode,
+  PLAYER_CONTROL_NONE,
 } from "@/plugins/api/interfaces";
 import router from "@/plugins/router";
 import { store } from "@/plugins/store";
@@ -16,17 +17,18 @@ export const getPlayerMenuItems = (
   player: Player,
   playerQueue?: PlayerQueue,
 ): ContextMenuItem[] => {
+  const menuItems: ContextMenuItem[] = [];
   // power off/on
-  const menuItems: ContextMenuItem[] = [
-    {
+  if (player?.power_control != PLAYER_CONTROL_NONE) {
+    menuItems.push({
       label: player.powered ? "power_off_player" : "power_on_player",
       labelArgs: [],
       action: () => {
         api.playerCommandPowerToggle(player.player_id);
       },
       icon: "mdi-power",
-    },
-  ];
+    });
+  }
   // add stop playback menu item
   if (player?.state == "playing") {
     menuItems.push({

--- a/src/layouts/default/PlayerOSD/Player.vue
+++ b/src/layouts/default/PlayerOSD/Player.vue
@@ -57,7 +57,10 @@
             color: $vuetify.theme.current.dark ? '#fff' : '#000',
           }"
           :volume="{
-            isVisible: !mobile,
+            isVisible:
+              !mobile &&
+              (store.activePlayer?.volume_control != PLAYER_CONTROL_NONE ||
+                store.activePlayer?.group_childs.length > 0),
             color: $vuetify.theme.current.dark ? '#fff' : '#000',
           }"
         />
@@ -86,12 +89,19 @@
       </div>
     </div>
   </div>
-  <div v-if="mobile" class="volume-slider">
+  <div
+    v-if="
+      mobile &&
+      (store.activePlayer?.volume_control != PLAYER_CONTROL_NONE ||
+        store.activePlayer?.group_childs.length > 0)
+    "
+    class="volume-slider"
+  >
     <PlayerVolume
       width="100%"
       color="secondary"
-      :is-powered="store.activePlayer?.powered"
-      :disabled="!store.activePlayer || !store.activePlayer?.powered"
+      :is-powered="store.activePlayer?.powered != false"
+      :disabled="!store.activePlayer || !store.activePlayer?.available"
       :model-value="Math.round(store.activePlayer?.group_volume || 0)"
       prepend-icon="mdi-volume-minus"
       append-icon="mdi-volume-plus"
@@ -102,25 +112,13 @@
       "
       @click:prepend="
         store.activePlayer!.group_childs.length > 0
-          ? api.playerCommandGroupVolume(
-              store.activePlayerId!,
-              store.activePlayer!.group_volume - 5,
-            )
-          : api.playerCommandVolumeSet(
-              store.activePlayerId!,
-              store.activePlayer!.volume_level - 5,
-            )
+          ? api.playerCommandGroupVolumeDown(store.activePlayerId!)
+          : api.playerCommandVolumeDown(store.activePlayerId!)
       "
       @click:append="
         store.activePlayer!.group_childs.length > 0
-          ? api.playerCommandGroupVolume(
-              store.activePlayerId!,
-              store.activePlayer!.group_volume + 5,
-            )
-          : api.playerCommandVolumeSet(
-              store.activePlayerId!,
-              store.activePlayer!.volume_level + 5,
-            )
+          ? api.playerCommandGroupVolumeUp(store.activePlayerId!)
+          : api.playerCommandVolumeUp(store.activePlayerId!)
       "
     />
   </div>
@@ -130,7 +128,11 @@
 import { computed, ref, watch } from "vue";
 //@ts-ignore
 
-import { ImageType, MediaType } from "@/plugins/api/interfaces";
+import {
+  ImageType,
+  MediaType,
+  PLAYER_CONTROL_NONE,
+} from "@/plugins/api/interfaces";
 import { store } from "@/plugins/store";
 import { getImageThumbForItem } from "@/components/MediaItemThumb.vue";
 import PlayerTimeline from "./PlayerTimeline.vue";

--- a/src/layouts/default/PlayerOSD/PlayerFullscreen.vue
+++ b/src/layouts/default/PlayerOSD/PlayerFullscreen.vue
@@ -57,6 +57,7 @@
           >
             <v-img
               v-if="
+                store.activePlayer?.powered != false &&
                 store.curQueueItem?.streamdetails?.stream_metadata?.image_url
               "
               style="max-width: 100%; width: auto; border-radius: 4px"
@@ -64,6 +65,7 @@
             />
             <v-img
               v-else-if="
+                store.activePlayer?.powered != false &&
                 !store.curQueueItem?.image &&
                 store.activePlayer?.current_media?.image_url
               "
@@ -71,13 +73,18 @@
               :src="store.activePlayer.current_media.image_url"
             />
             <MediaItemThumb
-              v-else
+              v-else-if="store.activePlayer?.powered != false"
               :item="store.curQueueItem"
               :thumbnail="false"
               style="max-width: 100%; width: auto"
               :fallback="
                 $vuetify.theme.current.dark ? imgCoverDark : imgCoverLight
               "
+            />
+            <v-img
+              v-else
+              style="max-width: 100%; width: auto; border-radius: 4px"
+              :src="$vuetify.theme.current.dark ? imgCoverDark : imgCoverLight"
             />
           </div>
           <div class="main-media-details-track-info">
@@ -143,7 +150,7 @@
 
             <!-- SUBTITLE: player powered off -->
             <v-card-subtitle
-              v-if="!store.activePlayer?.powered"
+              v-if="store.activePlayer?.powered == false"
               class="text-h6 text-md-h5 text-lg-h4"
             >
               {{ $t("off") }}
@@ -151,7 +158,10 @@
 
             <!-- subtitle: radio station stream title -->
             <v-card-subtitle
-              v-if="store.curQueueItem?.streamdetails?.stream_metadata?.title"
+              v-if="
+                store.curQueueItem?.streamdetails?.stream_metadata?.title &&
+                store.activePlayer?.powered != false
+              "
               class="text-h6 text-md-h5 text-lg-h4"
               @click="
                 radioTitleClick(
@@ -179,7 +189,8 @@
               v-if="
                 store.curQueueItem?.media_item &&
                 'album' in store.curQueueItem.media_item &&
-                store.curQueueItem.media_item.album
+                store.curQueueItem.media_item.album &&
+                store.activePlayer?.powered != false
               "
               :style="`font-size: ${subTitleFontSize};cursor:pointer;`"
               @click="itemClick(store.curQueueItem.media_item.album as Album)"
@@ -195,7 +206,8 @@
               v-if="
                 store.curQueueItem?.media_item &&
                 'artists' in store.curQueueItem.media_item &&
-                store.curQueueItem.media_item.artists.length
+                store.curQueueItem.media_item.artists.length &&
+                store.activePlayer?.powered != false
               "
               :style="`font-size: ${subTitleFontSize};cursor:pointer;`"
               @click="
@@ -241,7 +253,8 @@
             <v-card-subtitle
               v-else-if="
                 store.activePlayer?.active_source !=
-                store.activePlayer?.player_id
+                  store.activePlayer?.player_id &&
+                store.activePlayer?.powered != false
               "
             >
               {{
@@ -254,7 +267,9 @@
             <!-- subtitle: queue empty -->
             <v-card-subtitle
               v-else-if="
-                store.activePlayerQueue && store.activePlayerQueue.items == 0
+                store.activePlayerQueue &&
+                store.activePlayerQueue.items == 0 &&
+                store.activePlayer?.powered != false
               "
               :style="`font-size: ${subTitleFontSize}`"
             >
@@ -262,7 +277,10 @@
             </v-card-subtitle>
 
             <!-- streamdetails/contenttype button-->
-            <div style="margin: auto; padding-top: 20px">
+            <div
+              v-if="store.activePlayer?.powered != false"
+              style="margin: auto; padding-top: 20px"
+            >
               <QualityDetailsBtn />
             </div>
           </div>
@@ -461,8 +479,8 @@
         >
           <PlayerVolume
             width="100%"
-            :is-powered="store.activePlayer?.powered"
-            :disabled="!store.activePlayer || !store.activePlayer?.powered"
+            :is-powered="store.activePlayer?.powered != false"
+            :disabled="!store.activePlayer || !store.activePlayer?.available"
             :model-value="Math.round(store.activePlayer?.group_volume || 0)"
             prepend-icon="mdi-volume-minus"
             append-icon="mdi-volume-plus"

--- a/src/layouts/default/PlayerOSD/PlayerTimeline.vue
+++ b/src/layouts/default/PlayerOSD/PlayerTimeline.vue
@@ -7,7 +7,8 @@
           !store.curQueueItem ||
           !store.curQueueItem.media_item ||
           !store.curQueueItem.duration ||
-          store.curQueueItem.media_item.media_type == MediaType.RADIO
+          store.curQueueItem.media_item.media_type == MediaType.RADIO ||
+          store.activePlayer?.powered == false
         "
         style="width: 100%"
         :min="0"

--- a/src/layouts/default/PlayerOSD/PlayerTrackDetails.vue
+++ b/src/layouts/default/PlayerOSD/PlayerTrackDetails.vue
@@ -16,7 +16,7 @@
       >
         <div
           v-if="
-            store.activePlayer?.powered &&
+            store.activePlayer?.powered != false &&
             store.curQueueItem?.streamdetails?.stream_metadata?.image_url
           "
         >
@@ -29,14 +29,15 @@
         </div>
         <MediaItemThumb
           v-else-if="
-            store.curQueueItem?.media_item || store.curQueueItem?.image
+            store.activePlayer?.powered != false &&
+            (store.curQueueItem?.media_item || store.curQueueItem?.image)
           "
           :item="store.curQueueItem?.media_item || store.curQueueItem"
           :fallback="imgCoverDark"
         />
         <div
           v-else-if="
-            store.activePlayer?.powered &&
+            store.activePlayer?.powered != false &&
             store.activePlayer?.current_media?.image_url
           "
         >
@@ -141,7 +142,7 @@
       >
         <MarqueeText :sync="marqueeSync">
           <!-- player powered off -->
-          <div v-if="!store.activePlayer?.powered">
+          <div v-if="store.activePlayer?.powered == false">
             {{ $t("off") }}
           </div>
           <!-- track: artists(s) + album -->
@@ -236,7 +237,7 @@
           </div>
         </MarqueeText>
         <!-- active player -->
-        <div v-if="store.activePlayer && store.activePlayer?.powered">
+        <div v-if="store.activePlayer && store.activePlayer?.powered != false">
           {{ getPlayerName(store.activePlayer) }}
         </div>
       </div>

--- a/src/layouts/default/PlayerOSD/PlayerVolume.vue
+++ b/src/layouts/default/PlayerOSD/PlayerVolume.vue
@@ -27,7 +27,6 @@ export default {
     height: String,
     // eslint-disable-next-line vue/require-default-prop
     style: String,
-    isPowered: Boolean,
     allowWheel: Boolean,
   },
   emits: ["update:model-value"],
@@ -42,7 +41,6 @@ export default {
       step: 2,
       elevation: 0,
       style: `width: ${props.width}; height:${props.height}; display: inline-grid; ${props.style}`,
-      disabled: !props.isPowered,
     }));
 
     const playerVolumeProps = computed(() => ({

--- a/src/layouts/default/PlayerSelect.vue
+++ b/src/layouts/default/PlayerSelect.vue
@@ -38,9 +38,8 @@
         <PlayerCard
           v-for="player in sortedPlayers.filter(
             (x) =>
-              [PlayerState.PLAYING, PlayerState.PAUSED].includes(x.state) ||
-              (api.queues[x.player_id]?.items > 0 && x.powered) ||
-              x.player_id == store.activePlayerId,
+              [PlayerState.PLAYING, PlayerState.PAUSED].includes(x.state!) ||
+              (api.queues[x.player_id]?.items > 0 && x.powered != false),
           )"
           :id="player.player_id"
           :key="player.player_id"
@@ -81,9 +80,7 @@
                 :show-volume-control="true"
                 :show-menu-button="true"
                 :show-sub-players="
-                  showSubPlayers &&
-                  player.player_id == store.activePlayerId &&
-                  player.group_childs.length > 0
+                  showSubPlayers && player.player_id == store.activePlayerId
                 "
                 :show-sync-controls="
                   player.supported_features.includes(PlayerFeature.SET_MEMBERS)
@@ -93,7 +90,10 @@
             </v-list>
           </v-expansion-panel-text>
         </v-expansion-panel>
-        <v-expansion-panel style="padding: 0">
+        <v-expansion-panel
+          v-if="sortedPlayers.filter((x) => x.type == PlayerType.GROUP).length"
+          style="padding: 0"
+        >
           <v-expansion-panel-title
             ><h3>
               {{ $t("all_groups") }}

--- a/src/plugins/api/index.ts
+++ b/src/plugins/api/index.ts
@@ -1054,7 +1054,7 @@ export class MusicAssistantApi {
   ): Promise<void> {
     if (
       !queue_id &&
-      store.activePlayer &&
+      store.activePlayer?.active_source &&
       store.activePlayer?.active_source in this.queues
     ) {
       queue_id = store.activePlayer?.active_source;

--- a/src/plugins/api/interfaces.ts
+++ b/src/plugins/api/interfaces.ts
@@ -4,9 +4,9 @@ import { ComputedRef } from "vue";
 export const SECURE_STRING_SUBSTITUTE = "this_value_is_encrypted";
 export const MASS_LOGO_ONLINE =
   "https://github.com/home-assistant/brands/raw/master/custom_integrations/mass/icon%402x.png";
+export const PLAYER_CONTROL_NONE = "none";
 
 /// dsp
-
 export enum DSPFilterType {
   PARAMETRIC_EQ = "parametric_eq",
   TONE_CONTROL = "tone_control",
@@ -769,28 +769,31 @@ export interface Player {
   type: PlayerType;
   name: string;
   available: boolean;
-  powered: boolean;
   device_info: DeviceInfo;
   supported_features: PlayerFeature[];
-  elapsed_time: number;
-  elapsed_time_last_updated: number;
-  current_media?: PlayerMedia;
-  state: PlayerState;
+  can_group_with: string[];
+  enabled: boolean;
 
-  volume_level: number;
-  volume_muted: boolean;
+  elapsed_time?: number;
+  elapsed_time_last_updated?: number;
+  current_media?: PlayerMedia;
+  state?: PlayerState;
+  powered?: boolean;
+  volume_level?: number;
+  volume_muted?: boolean;
   group_childs: string[];
-  active_source: string;
+  active_source?: string;
   source_list: PlayerSource[];
   active_group?: string;
-  synced_to: string;
-  can_group_with: string[];
+  synced_to?: string;
 
-  enabled: boolean;
   group_volume: number;
   display_name: string;
   hidden: boolean;
   icon: string;
+  power_control: string;
+  volume_control: string;
+  mute_control: string;
 }
 
 // provider

--- a/src/plugins/store.ts
+++ b/src/plugins/store.ts
@@ -66,7 +66,10 @@ export const store: Store = reactive({
     return undefined;
   }),
   activePlayerQueue: computed(() => {
-    if (store.activePlayer && store.activePlayer.active_source in api.queues) {
+    if (
+      store.activePlayer?.active_source &&
+      store.activePlayer.active_source in api.queues
+    ) {
       return api.queues[store.activePlayer.active_source];
     }
     if (

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -301,7 +301,8 @@
             "advanced": "Advanced settings",
             "generic": "Generic settings",
             "announcements": "Announcements configuration",
-            "airplay": "Airplay specific settings"
+            "airplay": "Airplay specific settings",
+            "player_controls": "Player controls"
         },
         "tts_pre_announce": {
             "label": "Pre-announce TTS announcements",
@@ -428,6 +429,18 @@
         "dynamic_members": {
             "label": "Dynamic group members",
             "description": "Allow members to (temporarily) join/leave the group dynamically, so the group more or less behaves the same as manually syncing players together, with the main difference being that the group player will hold the queue."
+        },
+        "power_control": {
+            "label": "Power control",
+            "description": "Define/override the power control behavior for this player.\nIt allows you for example to redirect the power on/off commands to a different appliance, or use a fake power control if your player does not support power on/off commands but you like to have a dedicated state for a player not in use."
+        },
+        "volume_control": {
+            "label": "Volume control",
+            "description": "Define/override the volume control behavior for this player.\nIt allows you for example to redirect the volume control commands to a different appliance, or disable it completely."
+        },
+        "mute_control": {
+            "label": "Mute control",
+            "description": "Define/override the mute control behavior for this player.\nIt allows you for example to redirect the muting control commands to a different appliance, or disable it completely.\n\nWe offer a 'fake' mute control option, which will simulate muting by setting the volume to 0 and restoring the volume when unmuting."
         },
         "dsp": {
             "configure_on": "Configuring DSP on: {name}",

--- a/src/views/settings/AddPlayerGroup.vue
+++ b/src/views/settings/AddPlayerGroup.vue
@@ -21,7 +21,7 @@
             clearable
             :items="groupTypes"
             item-title="name"
-            item-value="instance_id"
+            item-value="lookup_key"
             :label="$t('settings.group_type')"
             required
             :disabled="members.length > 0"
@@ -98,7 +98,7 @@ const valid = ref<boolean>(false);
 // computed properties
 const groupTypes = computed(() => {
   return [
-    { name: "Universal", instance_id: "universal" },
+    { name: "Universal", lookup_key: "universal" },
     ...Object.values(api.providers).filter((x) =>
       x.supported_features.includes(ProviderFeature.SYNC_PLAYERS),
     ),

--- a/src/views/settings/Players.vue
+++ b/src/views/settings/Players.vue
@@ -123,7 +123,7 @@ const removePlayerConfig = function (playerId: string) {
 };
 
 const editPlayer = function (playerId: string, provider: string) {
-  if (provider in api.providers) {
+  if (api.getProvider(provider)) {
     // only allow edit if provider is available
     router.push(`/settings/editplayer/${playerId}`);
   }


### PR DESCRIPTION
Companion PR to https://github.com/music-assistant/server/pull/1925

Both maintenance and feature as this ensures the UI behaves consistently when a player has power/mute/volume control or not. So the controls will be hidden if the player lacks support. Also it will better account for the fact that some players do not have power control and have a null value for power state