### PR TITLE
Fix: use the user set player name in the Audio Pipeline

### DIFF
--- a/src/components/QualityDetailsBtn.vue
+++ b/src/components/QualityDetailsBtn.vue
@@ -459,7 +459,7 @@
                     class="streamdetails-icon"
                     :monochrome="true"
                   />
-                  {{ api.players[player].name }}
+                  {{ api.players[player].display_name }}
                 </template>
                 <template v-else>
                   <!-- This should not happen -->


### PR DESCRIPTION
Previously the incorrect player name was used in the StreamDetails/Audio Pipeline.