### PR TITLE
Fix: Safari provider icon rendering

### DIFF
--- a/src/components/ProviderIcon.vue
+++ b/src/components/ProviderIcon.vue
@@ -18,11 +18,15 @@
         providerDomain &&
         api.providerManifests[providerDomain].icon_svg_monochrome
       "
-      class="d-flex align-center justify-center"
-      :style="`width: ${size}px;height: ${size}px;align-content: center;${$vuetify.theme.current.dark ? '' : 'filter: invert(1);'}`"
+      class="d-flex align-center justify-center align-content-center justify-content-center"
+      :style="`width: ${size}px;height: ${size}px;${$vuetify.theme.current.dark ? '' : 'filter: invert(1);'}`"
       :title="api.providerManifests[providerDomain]!.name"
-      v-html="api.providerManifests[providerDomain]!.icon_svg_monochrome"
-    ></div>
+    >
+      <div
+        class="svg-wrapper"
+        v-html="api.providerManifests[providerDomain].icon_svg_monochrome"
+      ></div>
+    </div>
     <!-- dark mode and dark svg icon-->
     <div
       v-else-if="
@@ -30,21 +34,29 @@
         providerDomain &&
         api.providerManifests[providerDomain].icon_svg_dark
       "
-      class="d-flex align-center justify-center"
-      :style="`width: ${size}px;height: ${size}px;align-content: center;`"
+      class="d-flex align-center justify-center align-content-center justify-content-center"
+      :style="`width: ${size}px;height: ${size}px;`"
       :title="api.providerManifests[providerDomain]!.name"
-      v-html="api.providerManifests[providerDomain]!.icon_svg_dark"
-    ></div>
+    >
+      <div
+        class="svg-wrapper"
+        v-html="api.providerManifests[providerDomain].icon_svg_dark"
+      ></div>
+    </div>
     <!-- regular svg icon -->
     <div
       v-else-if="
         providerDomain && api.providerManifests[providerDomain].icon_svg
       "
-      class="d-flex align-center justify-center"
-      :style="`width: ${size}px;height: ${size}px;align-content: center;`"
+      class="d-flex align-center justify-center align-content-center justify-content-center"
+      :style="`width: ${size}px;height: ${size}px;`"
       :title="api.providerManifests[providerDomain]!.name"
-      v-html="api.providerManifests[providerDomain]!.icon_svg"
-    ></div>
+    >
+      <div
+        class="svg-wrapper"
+        v-html="api.providerManifests[providerDomain].icon_svg"
+      ></div>
+    </div>
     <!-- material design icon -->
     <v-icon
       v-else-if="providerDomain && api.providerManifests[providerDomain].icon"
@@ -82,3 +94,10 @@ const providerDomain = computed(() => {
   return undefined;
 });
 </script>
+<style>
+.svg-wrapper svg {
+  width: 100%;
+  height: 100%;
+  display: block;
+}
+</style>


### PR DESCRIPTION
Previously Safari had rendering issues with provider icons. This PR wraps SVG icons in a container to force the correct dimensions on all browsers.

Tested on Firefox, Brave, Safari, and GNOME Web.