### PR TITLE
fix: remove `is_leader` from `DSPDetails` model

### DIFF
--- a/src/plugins/api/interfaces.ts
+++ b/src/plugins/api/interfaces.ts
@@ -75,7 +75,6 @@ export enum DSPState {
 // output_format is the format that will be sent to the output device (if known).
 export interface DSPDetails {
   state: DSPState;
-  is_leader: boolean;
   input_gain: number;
   filters: DSPFilter[];
   output_gain: number;
@@ -698,8 +697,6 @@ export interface StreamDetails {
   volume_normalization_gain_correct?: number;
   // This contains the DSPDetails of all players in the group.
   // In case of single player playback, dict will contain only one entry.
-  // The leader will have is_leader set to True.
-  // (keep in mind that PlayerGroups have no (explicit) leader!)
   dsp?: Record<string, DSPDetails>;
 }
 


### PR DESCRIPTION
This should only be merged after https://github.com/music-assistant/server/pull/1940. See that PR for details.