### PR TITLE
feat: make players list expandable in the Audio Pipeline

### DIFF
--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -625,6 +625,7 @@
         "input_header": "Input",
         "output_header": "Output",
         "output_format_info": "Audio is converted into the '{0}' format before being sent to the player.",
+        "click_to_expand": "Click to show all players",
         "eq_band_count": "{0} bands",
         "eq_band_count_singular": "1 band",
         "input_gain": "Input Gain ({0} dB)",


### PR DESCRIPTION
To reduce clutter when playing to many devices, the audio pipeline now collapses multiple players.
Pressing on a collapsed player will expand the list to show all group members, as was done previously.
Pressing again on the expanded list will collapse it again, showing only the first player.

# Screenshots

![Screenshot From 2025-02-03 19-06-04](https://github.com/user-attachments/assets/f952eb43-458a-4f90-93ff-9a3c034e759d)

![Screenshot From 2025-02-03 19-05-57](https://github.com/user-attachments/assets/4e967d48-06a4-4c53-a43c-f4de9e3414c4)
