### PR TITLE
fix: increase Audio pipeline width

### DIFF
--- a/src/components/QualityDetailsBtn.vue
+++ b/src/components/QualityDetailsBtn.vue
@@ -30,7 +30,7 @@
         <div v-else-if="maxOutputQualityTier == QualityTier.HIRES">HR</div>
       </v-chip>
     </template>
-    <v-card class="mx-auto" width="350">
+    <v-card class="mx-auto" width="380">
       <v-list style="overflow: hidden">
         <div class="d-flex ml-2 mr-2">
           <!-- Second line showing audio stream shared by multiple players -->


### PR DESCRIPTION
Previously the width of the audio pipeline popup was not wide enough for fitting some (english) descriptions of Volume Normalization with multiple players.
This PR increases the width to fit that.

I will later open a PR to dynamically handle smaller devices (like phones).