### PR TITLE
Fix: Improve Audio Pipeline menu on phones

### DIFF
--- a/src/components/QualityDetailsBtn.vue
+++ b/src/components/QualityDetailsBtn.vue
@@ -5,6 +5,7 @@
     location="top center"
     :close-on-content-click="false"
     scrim
+    :max-height="$vuetify.display.height - 150"
   >
     <template #activator="{ props }">
       <v-chip

--- a/src/components/QualityDetailsBtn.vue
+++ b/src/components/QualityDetailsBtn.vue
@@ -819,6 +819,18 @@ export const iconFolder = new URL("@/assets/folder.svg", import.meta.url).href;
   align-items: center;
 }
 
+@media (max-width: 400px) {
+  .streamdetails-item {
+    font-size: 0.9rem;
+  }
+}
+
+@media (max-width: 370px) {
+  .streamdetails-item {
+    font-size: 0.8rem;
+  }
+}
+
 .streamdetails-icon {
   height: 30px;
   width: 50px;

--- a/src/components/QualityDetailsBtn.vue
+++ b/src/components/QualityDetailsBtn.vue
@@ -30,7 +30,7 @@
         <div v-else-if="maxOutputQualityTier == QualityTier.HIRES">HR</div>
       </v-chip>
     </template>
-    <v-card class="mx-auto" width="380">
+    <v-card class="mx-auto" :width="Math.min($vuetify.display.width - 25, 380)">
       <v-list style="overflow: hidden">
         <div class="d-flex ml-2 mr-2">
           <!-- Second line showing audio stream shared by multiple players -->


### PR DESCRIPTION
Adaptively decreases width, height and text size of the Audio Pipeline menu for a better experience on phones.

The height is decreased to always have a section on screen to close this menu.

# Screenshots on a simulated IPhone 12/13 mini

Before this PR:
![Screen Shot 2025-02-05 at 11 18 04](https://github.com/user-attachments/assets/ab2fabc0-8cbb-4ade-87c1-f330663fe09a)

With this PR:

![Screen Shot 2025-02-05 at 11 24 13](https://github.com/user-attachments/assets/2ae8236d-f43b-4b8e-916f-896d1b30316b)
