### PR TITLE
Fix: Make audio pipeline processing descriptions more accurate

### DIFF
--- a/src/components/QualityDetailsBtn.vue
+++ b/src/components/QualityDetailsBtn.vue
@@ -458,11 +458,24 @@
                       >mdi-information</v-icon
                     >
                   </template>
-                  {{
-                    $t("streamdetails.output_format_info", [
-                      streamDetails.dsp[player_id].output_format.content_type,
-                    ])
-                  }}
+                  <template
+                    v-if="
+                      isPcm(
+                        streamDetails.dsp[player_id].output_format.content_type,
+                      )
+                    "
+                  >
+                    {{ $t("streamdetails.output_format_pcm_info") }}
+                  </template>
+                  <template v-else>
+                    {{
+                      $t("streamdetails.output_format_info", [
+                        streamDetails.dsp[
+                          player_id
+                        ].output_format.content_type.toUpperCase(),
+                      ])
+                    }}
+                  </template>
                 </v-tooltip>
               </div>
               <!-- Player -->

--- a/src/components/QualityDetailsBtn.vue
+++ b/src/components/QualityDetailsBtn.vue
@@ -256,6 +256,9 @@
                     ])
                   }}
                 </span>
+                <br />
+                <br />
+                {{ $t("streamdetails.file_info.processing_notice") }}
               </v-tooltip>
             </div>
             <!-- Volume Normalization -->

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -644,7 +644,8 @@
             "bit_rate": "Bit rate: {0} kbps",
             "sample_rate": "Sample rate: {0} kHz",
             "channels": "Channels: {0}",
-            "bit_depth": "Bit depth: {0}"
+            "bit_depth": "Bit depth: {0}",
+            "processing_notice": "Audio is processed internally as 32-bit float PCM"
         },
         "volume_normalization": {
             "target_level": "Target level: {0} LUFS",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -629,7 +629,7 @@
     "streamdetails": {
         "input_header": "Input",
         "output_header": "Output",
-        "output_format_info": "Audio is converted into the '{0}' format before being sent to the player.",
+        "output_format_info": "Audio is sent in the {0} format",
         "eq_band_count": "{0} bands",
         "eq_band_count_singular": "1 band",
         "input_gain": "Input Gain ({0} dB)",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -630,6 +630,7 @@
         "input_header": "Input",
         "output_header": "Output",
         "output_format_info": "Audio is sent in the {0} format",
+        "output_format_pcm_info": "Audio is passed as PCM to the player provider. The player provider may then convert the audio to a different format before sending it to the player.",
         "eq_band_count": "{0} bands",
         "eq_band_count_singular": "1 band",
         "input_gain": "Input Gain ({0} dB)",


### PR DESCRIPTION
Small tweaks to make the audio conversion steps more accurate:
- Add notice that the input file is processed as f32 PCM
- Just say "sent to the player in the ... format" if its not PCM
- Refer to just "PCM" instead of the full names like "s32le" or "s24be"
- Add explanation why the audio signal is not necessarily sent as PCM to the player

# Screenshots
![Screenshot From 2025-02-08 18-39-41](https://github.com/user-attachments/assets/08ad18b2-1f43-4517-8f08-f1840115b414)
![Screenshot From 2025-02-08 18-38-43](https://github.com/user-attachments/assets/38deb700-0e85-46e0-8a60-a0c5249b9fb8)
![Screenshot From 2025-02-08 18-15-27](https://github.com/user-attachments/assets/9445c7ff-4749-4d67-b8ae-a27e873242d6)
