### PR TITLE
Implement consistent behavior for clicking an item or play button

### DIFF
--- a/src/components/HomeWidgetRow.vue
+++ b/src/components/HomeWidgetRow.vue
@@ -40,9 +40,6 @@
           "
           :is-available="itemIsAvailable(item)"
           :is-playable="itemIsPlayable(item)"
-          @menu="onMenu"
-          @click="onClick"
-          @play="onPlayClick"
         />
       </swiper-slide>
     </carousel>
@@ -53,16 +50,12 @@
 import Carousel from "@/components/Carousel.vue";
 import PanelviewItemCompact from "@/components/PanelviewItemCompact.vue";
 import { showContextMenuForMediaItem } from "@/layouts/default/ItemContextMenu.vue";
-import api from "@/plugins/api";
 import { itemIsAvailable, itemIsPlayable } from "@/plugins/api/helpers";
 import {
-  BrowseFolder,
   MediaItemTypeOrItemMapping,
   MediaType,
   PlayerQueue,
 } from "@/plugins/api/interfaces";
-import router from "@/plugins/router";
-import { store } from "@/plugins/store";
 
 export interface WidgetRow {
   label: string;
@@ -78,62 +71,6 @@ interface Props {
 }
 
 const { widgetRow } = defineProps<Props>();
-
-const onMenu = function (
-  item: MediaItemTypeOrItemMapping | MediaItemTypeOrItemMapping[],
-  posX: number,
-  posY: number,
-) {
-  const mediaItems: MediaItemTypeOrItemMapping[] = Array.isArray(item)
-    ? item
-    : [item];
-  showContextMenuForMediaItem(mediaItems, undefined, posX, posY);
-};
-
-const onClick = function (
-  item: MediaItemTypeOrItemMapping,
-  posX: number,
-  posY: number,
-) {
-  // mediaItem in the list is clicked
-  if (!itemIsAvailable(item)) {
-    onMenu(item, posX, posY);
-    return;
-  }
-  if (item.media_type == MediaType.FOLDER) {
-    router.push({
-      name: "browse",
-      query: {
-        path: (item as BrowseFolder).path,
-      },
-    });
-  } else {
-    router.push({
-      name: item.media_type,
-      params: {
-        itemId: item.item_id,
-        provider: item.provider,
-      },
-    });
-  }
-};
-
-const onPlayClick = function (
-  item: MediaItemTypeOrItemMapping,
-  posX: number,
-  posY: number,
-) {
-  // play button on item is clicked
-  if (!itemIsAvailable(item)) {
-    onMenu(item, posX, posY);
-    return;
-  }
-  if (!store.activePlayerId) {
-    store.showPlayersMenu = true;
-    return;
-  }
-  api.playMedia(item.uri, undefined);
-};
 </script>
 
 <style scoped>

--- a/src/components/ListviewItem.vue
+++ b/src/components/ListviewItem.vue
@@ -19,9 +19,31 @@
           "
         />
       </div>
-      <div v-else class="media-thumb listitem-media-thumb">
-        <MediaItemThumb size="50" :item="isAvailable ? item : undefined" />
+      <div
+        v-else
+        class="media-thumb listitem-media-thumb"
+        @mouseenter="showPlayBtn = true"
+        @mouseleave="showPlayBtn = false"
+      >
+        <MediaItemThumb
+          size="50"
+          :item="isAvailable ? item : undefined"
+          :class="{ dimmed: showPlayBtn }"
+        />
       </div>
+      <!-- play button -->
+      <v-btn
+        v-if="!showCheckboxes"
+        :class="{ hidden: !showPlayBtn }"
+        icon="mdi-play"
+        color="primary"
+        fab
+        size="small"
+        style="position: absolute; left: 12px; bottom: 12px"
+        @click.stop="onPlayClick"
+        @mouseenter="showPlayBtn = true"
+        @mouseleave="showPlayBtn = false"
+      />
     </template>
 
     <!-- title -->
@@ -200,7 +222,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed } from "vue";
+import { computed, ref } from "vue";
 import { VTooltip } from "vuetify/components";
 import MediaItemThumb from "./MediaItemThumb.vue";
 import { iconHiRes } from "./QualityDetailsBtn.vue";
@@ -218,6 +240,9 @@ import {
   getArtistsString,
   getBrowseFolderName,
   truncateString,
+  handlePlayBtnClick,
+  handleMediaItemClick,
+  handleMenuBtnClick,
 } from "@/helpers/utils";
 import { useI18n } from "vue-i18n";
 import { getBreakpointValue } from "@/plugins/breakpoint";
@@ -240,10 +265,12 @@ export interface Props {
   isAvailable?: boolean;
   showCheckboxes?: boolean;
   showDetails?: boolean;
+  parentItem?: MediaItemType;
 }
 
 // global refs
 const { t } = useI18n();
+const showPlayBtn = ref(false);
 
 const compProps = withDefaults(defineProps<Props>(), {
   showTrackNumber: true,
@@ -257,6 +284,7 @@ const compProps = withDefaults(defineProps<Props>(), {
   showCheckboxes: false,
   isDisabled: false,
   isAvailable: true,
+  parentItem: undefined,
 });
 
 // computed properties
@@ -288,26 +316,47 @@ const HiResDetails = computed(() => {
 
 // emits
 const emit = defineEmits<{
-  (e: "menu", item: MediaItemType, posX: number, posY: number): void;
-  (e: "click", item: MediaItemType, posX: number, posY: number): void;
   (e: "select", item: MediaItemType, selected: boolean): void;
 }>();
 
 const onMenu = function (evt: PointerEvent | TouchEvent) {
   const posX = "clientX" in evt ? evt.clientX : evt.touches[0].clientX;
   const posY = "clientY" in evt ? evt.clientY : evt.touches[0].clientY;
-  emit("menu", compProps.item, posX, posY);
+  handleMenuBtnClick(compProps.item, posX, posY, compProps.parentItem);
 };
 
 const onClick = function (evt: PointerEvent) {
   if (compProps.showCheckboxes) return;
-  emit("click", compProps.item, evt.clientX, evt.clientY);
+  handleMediaItemClick(
+    compProps.item,
+    evt.clientX,
+    evt.clientY,
+    compProps.parentItem,
+  );
+};
+
+const onPlayClick = function (evt: PointerEvent) {
+  if (compProps.showCheckboxes) return;
+  handlePlayBtnClick(
+    compProps.item,
+    evt.clientX,
+    evt.clientY,
+    compProps.parentItem,
+  );
 };
 </script>
 
 <style scoped>
 .unavailable {
   opacity: 0.3;
+}
+
+.dimmed {
+  opacity: 0.3;
+}
+
+.hidden {
+  opacity: 0;
 }
 
 .hiresicon {

--- a/src/components/MenuButton.vue
+++ b/src/components/MenuButton.vue
@@ -1,18 +1,8 @@
 <template>
   <div :style="`width: ${width}px; height: 30px;`">
-    <v-menu
-      v-model="showMenu"
-      :close-on-content-click="true"
-      :nudge-width="200"
-      offset-x
-      scrim="!store.showPlayersMenu"
-      z-index="100"
-    >
-      <template #activator="{ props }">
-        <v-btn
-          variant="tonal"
-          v-bind="props"
-          :style="`
+    <v-btn
+      variant="tonal"
+      :style="`
             width: ${width}px;
             position: absolute;
             border: 1px solid #cccccc4d;
@@ -20,24 +10,22 @@
             margin-top: -1px;
             margin-left: -1px;
           `"
-        >
-          <v-icon
-            icon="mdi-menu-down"
-            size="xx-large"
-            :style="`width: 20px; margin-left: ${width - 42}px`"
-          />
-        </v-btn>
-      </template>
+      @click="emit('menu')"
+    >
+      <v-icon
+        icon="mdi-menu-down"
+        size="xx-large"
+        :style="`width: 20px; margin-left: ${width - 42}px`"
+      />
+    </v-btn>
 
-      <slot name="menu"></slot>
-    </v-menu>
     <v-btn
       color="primary"
       flat
       :disabled="disabled"
       :style="`width: ${width - 40}px; justify-content: left;`"
       :text="text"
-      @click="openMenuOnClick ? (showMenu = !showMenu) : emit('click')"
+      @click="emit('click')"
     >
       <template v-if="icon && text!.length < 12" #prepend>
         <v-icon :icon="icon" size="x-large" />
@@ -47,29 +35,23 @@
 </template>
 
 <script setup lang="ts">
-import { ref } from "vue";
-import { store } from "@/plugins/store";
-
 // properties
 export interface Props {
   icon?: string;
   text?: string;
   disabled?: boolean;
   width?: number;
-  openMenuOnClick?: boolean;
 }
 withDefaults(defineProps<Props>(), {
   icon: undefined,
   text: undefined,
   disabled: false,
   width: 200,
-  openMenuOnClick: false,
 });
-
-const showMenu = ref(false);
 
 // emitters
 const emit = defineEmits<{
   (e: "click"): void;
+  (e: "menu"): void;
 }>();
 </script>

--- a/src/components/PanelviewItem.vue
+++ b/src/components/PanelviewItem.vue
@@ -129,9 +129,7 @@
           variant="list"
           icon="mdi-dots-vertical"
           style="padding-right: 0; margin-right: -5px"
-          @click.stop="
-            (evt: PointerEvent) => $emit('menu', item, evt.clientX, evt.clientY)
-          "
+          @click.stop="onMenu"
         />
       </v-card-actions>
     </v-card>

--- a/src/components/PanelviewItem.vue
+++ b/src/components/PanelviewItem.vue
@@ -151,6 +151,9 @@ import {
 import {
   getArtistsString,
   getBrowseFolderName,
+  handleMediaItemClick,
+  handleMenuBtnClick,
+  handlePlayBtnClick,
   parseBool,
 } from "@/helpers/utils";
 import { iconHiRes } from "./QualityDetailsBtn.vue";
@@ -167,6 +170,7 @@ export interface Props {
   showMediaType?: boolean;
   showActions?: boolean;
   isAvailable?: boolean;
+  parentItem?: MediaItemType;
 }
 const compProps = withDefaults(defineProps<Props>(), {
   size: 200,
@@ -174,6 +178,7 @@ const compProps = withDefaults(defineProps<Props>(), {
   showActions: false,
   showMediaType: false,
   isAvailable: true,
+  parentItem: undefined,
 });
 
 // computed properties
@@ -204,9 +209,6 @@ const HiResDetails = computed(() => {
 
 // emits
 const emit = defineEmits<{
-  (e: "menu", item: MediaItemType, posX: number, posY: number): void;
-  (e: "click", item: MediaItemType, posX: number, posY: number): void;
-  (e: "play", item: MediaItemType, posX: number, posY: number): void;
   (e: "select", item: MediaItemType, selected: boolean): void;
 }>();
 
@@ -214,7 +216,7 @@ const onMenu = function (evt: PointerEvent | TouchEvent) {
   if (compProps.showCheckboxes) return;
   const posX = "clientX" in evt ? evt.clientX : evt.touches[0].clientX;
   const posY = "clientY" in evt ? evt.clientY : evt.touches[0].clientY;
-  emit("menu", compProps.item, posX, posY);
+  handleMenuBtnClick(compProps.item, posX, posY, compProps.parentItem);
 };
 
 const onClick = function (evt: PointerEvent) {
@@ -222,12 +224,22 @@ const onClick = function (evt: PointerEvent) {
     emit("select", compProps.item, compProps.isSelected ? false : true);
     return;
   }
-  emit("click", compProps.item, evt.clientX, evt.clientY);
+  handleMediaItemClick(
+    compProps.item,
+    evt.clientX,
+    evt.clientY,
+    compProps.parentItem,
+  );
 };
 
 const onPlayClick = function (evt: PointerEvent) {
   if (compProps.showCheckboxes) return;
-  emit("play", compProps.item, evt.clientX, evt.clientY);
+  handlePlayBtnClick(
+    compProps.item,
+    evt.clientX,
+    evt.clientY,
+    compProps.parentItem,
+  );
 };
 </script>
 

--- a/src/components/PanelviewItemCompact.vue
+++ b/src/components/PanelviewItemCompact.vue
@@ -103,7 +103,13 @@ import {
   type MediaItemType,
   MediaType,
 } from "@/plugins/api/interfaces";
-import { getArtistsString, getBrowseFolderName } from "@/helpers/utils";
+import {
+  getArtistsString,
+  getBrowseFolderName,
+  handleMediaItemClick,
+  handleMenuBtnClick,
+  handlePlayBtnClick,
+} from "@/helpers/utils";
 import { store } from "@/plugins/store";
 
 // properties
@@ -115,6 +121,7 @@ export interface Props {
   permanentOverlay?: boolean;
   isAvailable?: boolean;
   isPlayable?: boolean;
+  parentItem?: MediaItemType;
 }
 const compProps = withDefaults(defineProps<Props>(), {
   size: 200,
@@ -123,28 +130,11 @@ const compProps = withDefaults(defineProps<Props>(), {
   permanentOverlay: false,
   isAvailable: true,
   isPlayable: true,
+  parentItem: undefined,
 });
 
 // emits
 const emit = defineEmits<{
-  (
-    e: "menu",
-    item: MediaItemType | ItemMapping,
-    posX: number,
-    posY: number,
-  ): void;
-  (
-    e: "click",
-    item: MediaItemType | ItemMapping,
-    posX: number,
-    posY: number,
-  ): void;
-  (
-    e: "play",
-    item: MediaItemType | ItemMapping,
-    posX: number,
-    posY: number,
-  ): void;
   (e: "select", item: MediaItemType | ItemMapping, selected: boolean): void;
 }>();
 
@@ -152,7 +142,7 @@ const onMenu = function (evt: PointerEvent | TouchEvent) {
   if (compProps.showCheckboxes) return;
   const posX = "clientX" in evt ? evt.clientX : evt.touches[0].clientX;
   const posY = "clientY" in evt ? evt.clientY : evt.touches[0].clientY;
-  emit("menu", compProps.item, posX, posY);
+  handleMenuBtnClick(compProps.item, posX, posY, compProps.parentItem);
 };
 
 const onClick = function (evt: PointerEvent) {
@@ -160,12 +150,22 @@ const onClick = function (evt: PointerEvent) {
     emit("select", compProps.item, compProps.isSelected ? false : true);
     return;
   }
-  emit("click", compProps.item, evt.clientX, evt.clientY);
+  handleMediaItemClick(
+    compProps.item,
+    evt.clientX,
+    evt.clientY,
+    compProps.parentItem,
+  );
 };
 
 const onPlayClick = function (evt: PointerEvent) {
   if (compProps.showCheckboxes) return;
-  emit("play", compProps.item, evt.clientX, evt.clientY);
+  handlePlayBtnClick(
+    compProps.item,
+    evt.clientX,
+    evt.clientY,
+    compProps.parentItem,
+  );
 };
 </script>
 

--- a/src/components/PlayerCard.vue
+++ b/src/components/PlayerCard.vue
@@ -214,7 +214,6 @@ import { getPlayerName } from "@/helpers/utils";
 import Button from "@/components/mods/Button.vue";
 import VolumeControl from "@/components/VolumeControl.vue";
 import { eventbus } from "@/plugins/eventbus";
-import PlayBtn from "@/layouts/default/PlayerOSD/PlayerControlBtn/PlayBtn.vue";
 import { getPlayerMenuItems } from "@/helpers/player_menu_items";
 // properties
 export interface Props {
@@ -250,10 +249,12 @@ const curQueueItem = computed(() => {
 });
 
 const openPlayerMenu = function (evt: Event) {
+  console.log("openPlayerMenu");
   eventbus.emit("contextmenu", {
     items: getPlayerMenuItems(compProps.player, playerQueue.value),
     posX: (evt as PointerEvent).clientX,
     posY: (evt as PointerEvent).clientY,
+    zIndex: 9999999,
   });
 };
 </script>

--- a/src/helpers/utils.ts
+++ b/src/helpers/utils.ts
@@ -582,7 +582,7 @@ export const handleMediaItemClick = function (
   ) {
     // track clicked in a sublisting (e.g. album/playlist) listview
     // open menu to show play options
-    handlePlayBtnClick(item, posX, posY);
+    handlePlayBtnClick(item, posX, posY, parentItem, true);
   } else {
     router.push({
       name: item.media_type,

--- a/src/layouts/default/PlayerSelect.vue
+++ b/src/layouts/default/PlayerSelect.vue
@@ -8,8 +8,7 @@
     app
     clipped
     temporary
-    touchless
-    :width="500"
+    :width="400"
     style="z-index: 99999"
     z-index="99999"
   >
@@ -138,6 +137,7 @@ import { store } from "@/plugins/store";
 import { ConnectionState, api } from "@/plugins/api";
 import PlayerCard from "@/components/PlayerCard.vue";
 import Button from "@/components/mods/Button.vue";
+import { playerActive } from "@/helpers/utils";
 
 const showSubPlayers = ref(false);
 const selectedPanel = ref<number | null>(null);
@@ -196,27 +196,6 @@ function playerClicked(player: Player, close: boolean = false) {
 onMounted(() => {
   checkDefaultPlayer();
 });
-
-const playerActive = function (
-  player: Player,
-  allowUnavailable = true,
-  allowSyncChild = false,
-  allowHidden = false,
-): boolean {
-  // perform some basic checks if we may use/show the player
-  if (!player.enabled) return false;
-  if (!allowHidden && player.hidden) return false;
-  if (!allowUnavailable && !player.available) return false;
-  if (player.synced_to && !allowSyncChild) return false;
-  if (
-    !allowSyncChild &&
-    player.type == PlayerType.PLAYER &&
-    player.active_group
-  )
-    return false;
-
-  return true;
-};
 
 const checkDefaultPlayer = function () {
   if (

--- a/src/plugins/api/index.ts
+++ b/src/plugins/api/index.ts
@@ -1225,6 +1225,14 @@ export class MusicAssistantApi {
     return this.sendCommand("config/core/get", { domain });
   }
 
+  public async getCoreConfigValue(
+    domain: string,
+    key: string,
+  ): Promise<ConfigValueType> {
+    // Return value for a single core controller config entry.
+    return this.sendCommand("config/core/get_value", { domain, key });
+  }
+
   public async getCoreConfigEntries(
     domain: string,
     action?: string,

--- a/src/plugins/eventbus.ts
+++ b/src/plugins/eventbus.ts
@@ -9,22 +9,16 @@ export type PlaylistDialogEvent = {
   parentItem?: MediaItemType;
 };
 
-export type ItemContextMenuDialogEvent = {
+export type ContextMenuDialogEvent = {
   items: ContextMenuItem[];
   posX?: number;
   posY?: number;
-};
-
-export type MediaItemContextMenuDialogEvent = {
-  items: MediaItemType[];
-  parentItem?: MediaItemType;
-  showContextMenuItems?: boolean;
-  posX?: number;
-  posY?: number;
+  showPlayMenuHeader?: boolean;
+  zIndex?: number;
 };
 
 export type Events = {
-  contextmenu: ItemContextMenuDialogEvent;
+  contextmenu: ContextMenuDialogEvent;
   playlistdialog: PlaylistDialogEvent;
 };
 

--- a/src/plugins/store.ts
+++ b/src/plugins/store.ts
@@ -46,6 +46,7 @@ interface Store {
   libraryAudiobooksCount?: number;
   connected?: boolean;
   isTouchscreen: boolean;
+  playMenuShown: boolean;
 }
 
 export const store: Store = reactive({
@@ -99,4 +100,5 @@ export const store: Store = reactive({
   libraryRadiosCount: undefined,
   connected: false,
   isTouchscreen: isTouchscreenDevice(),
+  playMenuShown: false,
 });

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -547,6 +547,8 @@
     "type_to_search": "Type here to search...",
     "volume_normalization": "Volume normalization",
     "play_now_replace": "Play Now (clear queue)",
+    "play_replace_next": "Play Next (clear queue)",
+    "all_enqueue_options": "All enqueue options",
     "currently_playing": "Currently playing",
     "favorites_add": "Add to favorites",
     "favorites_remove": "Remove from favorites",


### PR DESCRIPTION
The logic to act on pressing a media item (or its play or menu button) was duplicated and scattered all over.
This unifies the behavior across components and introduces a change to the play menu/action.
When clicking the play button, we will now always show the play menu (including player selection) once to prevent accidentally starting playback on the wrong players.