### PR TITLE
Fix: Select all in search view

### DIFF
--- a/src/components/ItemsListing.vue
+++ b/src/components/ItemsListing.vue
@@ -788,8 +788,7 @@ const keyListener = function (e: KeyboardEvent) {
   if (loading.value) return;
   if (e.key === "a" && (e.ctrlKey || e.metaKey)) {
     e.preventDefault();
-    selectedItems.value = pagedItems.value;
-    showCheckboxes.value = true;
+    selectAll();
   } else if (!searchHasFocus.value && e.key == "Backspace") {
     params.value.search = params.value.search.slice(0, -1);
   } else if (!searchHasFocus.value && e.key.length == 1) {
@@ -1083,6 +1082,11 @@ const getFilteredItems = function (
     );
   }
   return result.slice(params.offset, params.offset + params.limit);
+};
+
+const selectAll = function () {
+  selectedItems.value = pagedItems.value;
+  showCheckboxes.value = true;
 };
 </script>
 

--- a/src/components/ItemsListing.vue
+++ b/src/components/ItemsListing.vue
@@ -477,6 +477,13 @@ const menuItems = computed(() => {
 
   // toggle select menu item
   if (props.showSelectButton !== false) {
+    if (showCheckboxes.value) {
+      items.push({
+        label: "tooltip.select_all",
+        icon: "mdi-select-all",
+        action: selectAll,
+      });
+    }
     items.push({
       label: "tooltip.select_items",
       icon: showCheckboxes.value

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -525,6 +525,7 @@
         "refresh_new_content": "New content is available, click to refresh the listing",
         "search": "Show\/hide search input",
         "select_items": "Select multiple items",
+        "select_all": "Select all items",
         "sort_options": "Sort options",
         "toggle_view_mode": "Toggle view mode list\/thumbs",
         "filter_favorites": "Only show favorites",

--- a/src/views/Search.vue
+++ b/src/views/Search.vue
@@ -198,6 +198,11 @@ onMounted(() => {
 
 // lifecycle hooks
 const keyListener = function (e: KeyboardEvent) {
+  // Ignore keyboard events with modifier keys
+  if (e.ctrlKey || e.altKey || e.metaKey) {
+    return;
+  }
+
   if (!searchHasFocus.value && e.key == "Backspace" && store.globalSearchTerm) {
     store.globalSearchTerm = store.globalSearchTerm.slice(0, -1);
   } else if (!searchHasFocus.value && e.key.length == 1) {


### PR DESCRIPTION
This PR fixes pressing CTRL-A in Search views.

Additionally this adds a button to allow selecting everything without a keyboard:
![image](https://github.com/user-attachments/assets/53e2e427-9a98-45fb-b955-0de444efa98c)