### PR TITLE
Fix: Improved colors in fullscreen player

### DIFF
--- a/src/helpers/utils.ts
+++ b/src/helpers/utils.ts
@@ -303,35 +303,6 @@ export function findDarkColor(colors: RGBColor[]): string {
   return mostPleasantColor;
 }
 
-export function darkenBrightColors(
-  color: string,
-  thresholdBrightness = 100,
-  colorPartReduction = 50,
-): string {
-  const hexColor = color.replace(/^#/, "");
-  const r = parseInt(hexColor.substring(0, 2), 16);
-  const g = parseInt(hexColor.substring(2, 4), 16);
-  const b = parseInt(hexColor.substring(4, 6), 16);
-
-  const brightness = (r + g + b) / 7;
-
-  if (brightness > thresholdBrightness) {
-    const darkenedR = Math.max(0, r - colorPartReduction);
-    const darkenedG = Math.max(0, g - colorPartReduction);
-    const darkenedB = Math.max(0, b - colorPartReduction);
-
-    const darkenedColor = `#${darkenedR
-      .toString(16)
-      .padStart(2, "0")}${darkenedG.toString(16).padStart(2, "0")}${darkenedB
-      .toString(16)
-      .padStart(2, "0")}`;
-
-    return darkenedColor;
-  }
-
-  return color;
-}
-
 export function getColorPalette(img: HTMLImageElement): ImageColorPalette {
   const colorThief = new ColorThief();
   const colorNumberPalette: RGBColor[] = colorThief.getPalette(img, 5);

--- a/src/layouts/default/PlayerOSD/Player.vue
+++ b/src/layouts/default/PlayerOSD/Player.vue
@@ -31,11 +31,6 @@
       <!-- progress bar -->
       <PlayerTimeline
         v-if="getBreakpointValue('bp6')"
-        :color="
-          $vuetify.theme.current.dark
-            ? coverImageColorPalette.lightColor || '#fff'
-            : coverImageColorPalette.darkColor || '#000'
-        "
         :is-progress-bar="false"
         :disabled="
           !store.activePlayerQueue?.active ||

--- a/src/layouts/default/PlayerOSD/PlayerFullscreen.vue
+++ b/src/layouts/default/PlayerOSD/PlayerFullscreen.vue
@@ -6,7 +6,7 @@
     transition="dialog-bottom-transition"
     z-index="9999"
   >
-    <v-card :color="darkenBrightColors(coverImageColorCode, 70, 80)">
+    <v-card :color="backgroundColor">
       <v-toolbar class="v-toolbar-default" color="transparent">
         <template #prepend>
           <Button icon @click="store.showFullscreenPlayer = false">
@@ -403,7 +403,7 @@
       <div class="player-bottom">
         <!-- timeline / progressbar-->
         <div class="row" style="margin-left: 5%; margin-right: 5%">
-          <PlayerTimeline :show-labels="true" />
+          <PlayerTimeline :show-labels="true" :color="sliderColor" />
         </div>
 
         <!-- main media control buttons (play, next, previous etc.)-->
@@ -472,6 +472,7 @@
             :model-value="Math.round(store.activePlayer?.group_volume || 0)"
             prepend-icon="mdi-volume-minus"
             append-icon="mdi-volume-plus"
+            :color="sliderColor"
             :allow-wheel="true"
             @update:model-value="
               store.activePlayer!.group_childs.length > 0
@@ -567,7 +568,6 @@ import {
 import router from "@/plugins/router";
 import {
   ImageColorPalette,
-  darkenBrightColors,
   formatDuration,
   getPlayerName,
   sleep,
@@ -579,6 +579,7 @@ import { ContextMenuItem } from "../ItemContextMenu.vue";
 import { getPlayerMenuItems } from "@/helpers/player_menu_items";
 import { getSourceName } from "@/plugins/api/helpers";
 import { $t } from "@/plugins/i18n";
+import Color from "color";
 
 const { t } = useI18n();
 const { name } = useDisplay();
@@ -594,7 +595,6 @@ const hoveredMarqueeSync = new MarqueeTextSync();
 
 // Local refs
 const queueItems = ref<QueueItem[]>([]);
-const coverImageColorCode = ref<string>("");
 const activeQueuePanel = ref(0);
 const tempHide = ref(false);
 
@@ -952,17 +952,56 @@ watch(
   },
   { immediate: true },
 );
+const sliderColor = ref<string | undefined>(undefined);
+const backgroundColor = ref<string | undefined>(undefined);
 
 watchEffect(() => {
-  if (!compProps.colorPalette.darkColor || !compProps.colorPalette.lightColor) {
-    coverImageColorCode.value = vuetify.theme.current.value.dark
-      ? "#000"
-      : "#fff";
-  } else {
-    coverImageColorCode.value = vuetify.theme.current.value.dark
-      ? compProps.colorPalette.darkColor
-      : compProps.colorPalette.lightColor;
+  const LIGHT_TEXT_COLOR = Color("white");
+  const DARK_TEXT_COLOR = Color("black");
+  // Minimum WCAG contrast ration between the background and the text
+  // W3C recommends at least 4.5
+  const MIN_CONTRAST = 5;
+  const ADJUSTMENT_INCREMENT = 0.05;
+
+  // Determine the base color from palette or fallback to theme default
+  const coverImageColorCode = vuetify.theme.current.value.dark
+    ? compProps.colorPalette.darkColor || "#000"
+    : compProps.colorPalette.lightColor || "#fff";
+
+  // Start with the original cover color as background
+  let bgColor = Color(coverImageColorCode);
+
+  // Calculate contrast with white and black
+  const lightContrast = LIGHT_TEXT_COLOR.contrast(bgColor);
+  const darkContrast = DARK_TEXT_COLOR.contrast(bgColor);
+
+  // Choose the color with higher contrast as starting value
+  const isLight = lightContrast >= darkContrast;
+  let textColor = isLight ? LIGHT_TEXT_COLOR : DARK_TEXT_COLOR;
+  let contrast = Math.max(lightContrast, darkContrast);
+
+  // If the best contrast still doesn't meet requirements, adjust background
+  if (contrast < MIN_CONTRAST) {
+    // Darken light bg or lighten dark bg until contrast is good
+    let adjustment = ADJUSTMENT_INCREMENT;
+
+    while (contrast < MIN_CONTRAST && adjustment <= 0.5) {
+      if (isLight) {
+        bgColor = bgColor.darken(ADJUSTMENT_INCREMENT);
+      } else {
+        bgColor = bgColor.lighten(ADJUSTMENT_INCREMENT);
+      }
+
+      contrast = Color(textColor).contrast(bgColor);
+      adjustment += ADJUSTMENT_INCREMENT;
+    }
   }
+
+  // Keep color between text and sliders consistant.
+  // Also, this text color has a better contrast than the automatically selected one
+  document.documentElement.style.setProperty("--text-color", textColor.hex());
+  sliderColor.value = textColor.hex();
+  backgroundColor.value = bgColor.hex();
 });
 </script>
 
@@ -1140,5 +1179,10 @@ watchEffect(() => {
 .responsive-icon-holder-btn:focus,
 .responsive-icon-holder-btn:hover {
   opacity: 1;
+}
+
+div,
+button {
+  color: var(--text-color);
 }
 </style>

--- a/src/layouts/default/PlayerOSD/PlayerFullscreen.vue
+++ b/src/layouts/default/PlayerOSD/PlayerFullscreen.vue
@@ -519,7 +519,14 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed, watch, onMounted, onBeforeUnmount } from "vue";
+import {
+  ref,
+  computed,
+  watch,
+  onMounted,
+  onBeforeUnmount,
+  watchEffect,
+} from "vue";
 import MediaItemThumb from "@/components/MediaItemThumb.vue";
 import api from "@/plugins/api";
 import {
@@ -946,20 +953,17 @@ watch(
   { immediate: true },
 );
 
-watch(
-  () => compProps.colorPalette,
-  (result) => {
-    if (!result.darkColor || !result.lightColor) {
-      coverImageColorCode.value = vuetify.theme.current.value.dark
-        ? "#000"
-        : "#fff";
-    } else {
-      coverImageColorCode.value = vuetify.theme.current.value.dark
-        ? result.darkColor
-        : result.lightColor;
-    }
-  },
-);
+watchEffect(() => {
+  if (!compProps.colorPalette.darkColor || !compProps.colorPalette.lightColor) {
+    coverImageColorCode.value = vuetify.theme.current.value.dark
+      ? "#000"
+      : "#fff";
+  } else {
+    coverImageColorCode.value = vuetify.theme.current.value.dark
+      ? compProps.colorPalette.darkColor
+      : compProps.colorPalette.lightColor;
+  }
+});
 </script>
 
 <style scoped>

--- a/src/layouts/default/PlayerOSD/PlayerTimeline.vue
+++ b/src/layouts/default/PlayerOSD/PlayerTimeline.vue
@@ -19,6 +19,7 @@
         :show-ticks="chapterTicks ? 'always' : false"
         :ticks="chapterTicks"
         tick-size="4"
+        :color="color"
         @touchstart="isThumbHidden = false"
         @touchend="isThumbHidden = true"
         @mouseenter="isThumbHidden = false"
@@ -72,10 +73,12 @@ import { ref, computed, watch } from "vue";
 // properties
 export interface Props {
   showLabels?: boolean;
+  color?: string;
 }
 
 withDefaults(defineProps<Props>(), {
   showLabels: false,
+  color: undefined,
 });
 
 // local refs


### PR DESCRIPTION
The colors in the Fullscreen player where bothering me a bit so this PR makes a few adjustments:
- Watch for changes if the User Switches Dark mode on or off.
- Keep colors between the text and the slider consistent.
- Ensure that the text/slider always has a readable contrast ration for better accessibility (while keeping the color as close as possible to the album cover).

Currently, selection between black or white text is done by checking whatever gives a higher contrast.
But this could be changed, since the main contribution of this PR is verifying/adjusting the background colors readability/contrast.

# Screenshots

## Before
![before 1](https://github.com/user-attachments/assets/a7d1f417-3b48-4f0b-846c-8f9a10e3e4f4)

## After
![after 1](https://github.com/user-attachments/assets/c3bcaca2-7a4a-4404-b9e5-5db76b958752)

## Before
![before 2](https://github.com/user-attachments/assets/ccd7ca57-306c-48be-9c0c-17b50d3c3856)

## After
![after 2](https://github.com/user-attachments/assets/8d4f4da3-8391-4961-8971-214a753e0972)

## Before
![before 3](https://github.com/user-attachments/assets/bd78acbc-6558-43c9-8f95-e1a0d92677ba)

## After
![after 3](https://github.com/user-attachments/assets/198b6209-1e77-47c3-9a1e-6d46c8bffe30)
