### PR TITLE
Fix: More search fixes

### DIFF
--- a/src/components/ItemsListing.vue
+++ b/src/components/ItemsListing.vue
@@ -178,6 +178,7 @@ import {
   nextTick,
   onMounted,
   watch,
+  watchEffect,
 } from "vue";
 import {
   MediaType,
@@ -470,6 +471,12 @@ const isSearchActive = computed(() => {
 
 const showSearchInput = computed(() => {
   return showSearch.value && expanded.value;
+});
+
+watchEffect(() => {
+  if (!showSearchInput.value) {
+    searchHasFocus.value = false;
+  }
 });
 
 const menuItems = computed(() => {

--- a/src/components/ItemsListing.vue
+++ b/src/components/ItemsListing.vue
@@ -14,7 +14,7 @@
     <v-divider />
 
     <v-text-field
-      v-if="showSearch && expanded"
+      v-if="showSearchInput"
       id="searchInput"
       v-model="params.search"
       clearable
@@ -466,6 +466,10 @@ const isSearchActive = computed(() => {
     searchActive = true;
   }
   return searchActive;
+});
+
+const showSearchInput = computed(() => {
+  return showSearch.value && expanded.value;
 });
 
 const menuItems = computed(() => {

--- a/src/components/ItemsListing.vue
+++ b/src/components/ItemsListing.vue
@@ -304,9 +304,14 @@ const initialDataReceived = ref(false);
 const tempHide = ref(false);
 
 // methods
+const closeSearch = function () {
+  params.value.search = "";
+  showSearch.value = false;
+};
 const toggleSearch = function () {
-  if (showSearch.value) showSearch.value = false;
-  else {
+  if (showSearch.value) {
+    closeSearch();
+  } else {
     showSearch.value = true;
     nextTick(() => {
       document.getElementById("searchInput")?.focus();

--- a/src/components/ItemsListing.vue
+++ b/src/components/ItemsListing.vue
@@ -802,14 +802,17 @@ const keyListener = function (e: KeyboardEvent) {
   if (store.dialogActive) return;
   if (loading.value) return;
   if (e.key === "Escape") closeSearch();
+  // Let searchInput handle this.
+  if (searchHasFocus.value) return;
+
   if (e.key === "a" && (e.ctrlKey || e.metaKey)) {
     e.preventDefault();
     selectAll();
   } else if (!searchHasFocus.value && e.key == "Backspace") {
-    params.value.search = params.value.search.slice(0, -1);
+    focusSearch();
   } else if (!searchHasFocus.value && e.key.length == 1) {
-    params.value.search += e.key;
     showSearch.value = true;
+    focusSearch();
   }
 };
 

--- a/src/components/ItemsListing.vue
+++ b/src/components/ItemsListing.vue
@@ -1122,9 +1122,27 @@ const getFilteredItems = function (
 };
 
 const selectAll = async function () {
-  await loadAllItems();
-  selectedItems.value = pagedItems.value;
-  showCheckboxes.value = true;
+  let confirmed = true;
+  // We use the total length even when searching, since we can't know
+  // how many items will be loaded after filtering
+  const itemCount = props.total || allItems.value.length;
+  if (itemCount > 250) {
+    // This could be a large selection. Prevent accidental activation
+    // by asking the user for a confirmation
+    confirmed = await new Promise((resolve) => {
+      if (confirm(t("select_all_confirmation"))) {
+        resolve(true);
+      } else {
+        resolve(false);
+      }
+    });
+  }
+
+  if (confirmed) {
+    await loadAllItems();
+    selectedItems.value = pagedItems.value;
+    showCheckboxes.value = true;
+  }
 };
 </script>
 

--- a/src/components/ItemsListing.vue
+++ b/src/components/ItemsListing.vue
@@ -461,6 +461,12 @@ const loadNextPage = async function ({ done }: { done: any }) {
   done("ok");
 };
 
+const loadAllItems = async function () {
+  while (!allItemsReceived.value) {
+    await loadNextPage({ done: function () {} });
+  }
+};
+
 // computed properties
 const isSearchActive = computed(() => {
   var searchActive = false;
@@ -1115,7 +1121,8 @@ const getFilteredItems = function (
   return result.slice(params.offset, params.offset + params.limit);
 };
 
-const selectAll = function () {
+const selectAll = async function () {
+  await loadAllItems();
   selectedItems.value = pagedItems.value;
   showCheckboxes.value = true;
 };

--- a/src/components/ItemsListing.vue
+++ b/src/components/ItemsListing.vue
@@ -801,6 +801,7 @@ const restoreSettings = async function () {
 const keyListener = function (e: KeyboardEvent) {
   if (store.dialogActive) return;
   if (loading.value) return;
+  if (e.key === "Escape") closeSearch();
   if (e.key === "a" && (e.ctrlKey || e.metaKey)) {
     e.preventDefault();
     selectAll();

--- a/src/components/ItemsListing.vue
+++ b/src/components/ItemsListing.vue
@@ -308,14 +308,17 @@ const closeSearch = function () {
   params.value.search = "";
   showSearch.value = false;
 };
+const focusSearch = function () {
+  nextTick(() => {
+    document.getElementById("searchInput")?.focus();
+  });
+};
 const toggleSearch = function () {
   if (showSearch.value) {
     closeSearch();
   } else {
     showSearch.value = true;
-    nextTick(() => {
-      document.getElementById("searchInput")?.focus();
-    });
+    focusSearch();
   }
 };
 

--- a/src/components/ItemsListing.vue
+++ b/src/components/ItemsListing.vue
@@ -445,19 +445,20 @@ const redirectSearch = function () {
 };
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-const loadNextPage = function ({ done }: { done: any }) {
+const loadNextPage = async function ({ done }: { done: any }) {
   if (allItemsReceived.value) {
     done("empty");
     return;
   }
-  loadData(
+
+  await loadData(
     undefined,
     undefined,
     undefined,
     params.value.offset + props.limit,
-  ).then(() => {
-    done("ok");
-  });
+  );
+
+  done("ok");
 };
 
 // computed properties

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -541,6 +541,7 @@
         "primary_image": "This is the primary image for this image type",
         "copy_uri": "Copy URI to clipboard"
     },
+    "select_all_confirmation": "Select all items? This operation may take a moment to load all data.",
     "topresult": "Top result",
     "track": "Track",
     "track_number": "Disc {0} Track {1}",

--- a/src/views/AlbumDetails.vue
+++ b/src/views/AlbumDetails.vue
@@ -11,6 +11,7 @@
         itemDetails.provider == 'library' && api.hasStreamingProviders.value
       "
       :show-refresh-button="false"
+      :allow-key-hooks="true"
       :load-items="loadAlbumTracks"
       :sort-keys="[
         'track_number',


### PR DESCRIPTION
Fixes a few more bugs around the search/select-all I missed with https://github.com/music-assistant/frontend/pull/887.
Like:
- enables type to search for tracks in an album
- clear search when closing the search box
- pressing escape now closes the search box
- pass text handling to the text box, allowing ctrl a, ctrl c, and similar
- Make select all really select everything by loading all items first, asking for confirmation for large selections over 250 items