### PR TITLE
Allow RTSP URLs for Builtin Provider

### DIFF
--- a/src/components/AddManualLink.vue
+++ b/src/components/AddManualLink.vue
@@ -95,7 +95,7 @@ watch(
 );
 
 const fetchItemDetails = () => {
-  if (!url.value || !url.value.startsWith("http")) {
+  if (!url.value || !["http", "rtsp"].some((prefix) => url.value.startsWith(prefix))) {
     return;
   }
   loading.value = true;


### PR DESCRIPTION
The server already handles RTSP audio streams in the Builtin Provider but the UI does not accept RTSP URLs.