### PR TITLE
Fix: Invalid URL with the built-in Web Player

### DIFF
--- a/src/plugins/web_player.ts
+++ b/src/plugins/web_player.ts
@@ -79,6 +79,7 @@ export const webPlayer = reactive({
     this.setMode(WebPlayerMode.CONTROLS_ONLY);
   },
   setBaseUrl(url: string) {
+    if (url.endsWith("/")) url = url.slice(0, -1);
     if (url === this.baseUrl) {
       return;
     }


### PR DESCRIPTION
Missed removing the trailing slash from the base URL.