### PR TITLE
Feat: Improve DSP Settings link in the Player Settings

### DIFF
--- a/src/plugins/api/interfaces.ts
+++ b/src/plugins/api/interfaces.ts
@@ -340,6 +340,9 @@ export enum ConfigEntryType {
   ACTION = "action",
   ICON = "icon",
   ALERT = "alert",
+
+  // Only used in the frontend
+  DSP_SETTINGS = "dsp_settings",
 }
 
 export enum VolumeNormalizationMode {

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -146,6 +146,8 @@
         "add_new_provider_button": "Add {0} provider",
         "add_group_player": "Add group player",
         "group_members": "Group members",
+        "dsp_enabled": "DSP is enabled",
+        "dsp_disabled": "DSP is disabled",
         "log_level": {
             "label": "Log level",
             "description": "Set the log verbosity for this provider.",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -326,6 +326,12 @@
             "label": "Icon",
             "description": "Material design icon for this player.\n\nSee https:\/\/pictogrammers.com\/library\/mdi\/."
         },
+        "dsp_note_multi_device_group": {
+            "label": "You can configure the DSP for each player individually."
+        },
+        "dsp_note_multi_device_group_unsupported": {
+            "label": "This group type does not support DSP when playing to multiple devices."
+        },
         "frontend": "User Interface",
         "frontend_desc": "Configuration settings for the Music Assistant User Interface (frontend). Note that these settings are stored at a device level.",
         "theme": {

--- a/src/views/settings/EditConfig.vue
+++ b/src/views/settings/EditConfig.vue
@@ -94,6 +94,14 @@
                 </v-btn>
               </div>
 
+              <!-- DSP Config Button -->
+              <div v-else-if="conf_entry.type == ConfigEntryType.DSP_SETTINGS">
+                <br />
+                <v-btn class="actionbutton" @click="openDspConfig">
+                  {{ $t("open_dsp_settings") }}
+                </v-btn>
+              </div>
+
               <!-- boolean value: toggle switch -->
               <v-switch
                 v-else-if="conf_entry.type == ConfigEntryType.BOOLEAN"
@@ -475,6 +483,10 @@ const openLink = function (url: string) {
   a.setAttribute("href", url);
   a.setAttribute("target", "_blank");
   a.click();
+};
+
+const openDspConfig = function () {
+  router.push(`${router.currentRoute.value.path}/dsp`);
 };
 const isNullOrUndefined = function (value: unknown) {
   return value === null || value === undefined;

--- a/src/views/settings/EditConfig.vue
+++ b/src/views/settings/EditConfig.vue
@@ -97,6 +97,11 @@
               <!-- DSP Config Button -->
               <div v-else-if="conf_entry.type == ConfigEntryType.DSP_SETTINGS">
                 <br />
+                {{
+                  conf_entry.value
+                    ? $t("settings.dsp_enabled")
+                    : $t("settings.dsp_disabled")
+                }}
                 <v-btn class="actionbutton" @click="openDspConfig">
                   {{ $t("open_dsp_settings") }}
                 </v-btn>

--- a/src/views/settings/EditPlayer.vue
+++ b/src/views/settings/EditPlayer.vue
@@ -111,6 +111,19 @@ const props = defineProps<{
   playerId?: string;
 }>();
 
+const dspEnabled = ref(false);
+
+const loadDSPEnabled = async () => {
+  if (props.playerId) {
+    try {
+      dspEnabled.value = (await api.getDSPConfig(props.playerId)).enabled;
+    } catch (error) {
+      console.error("Error fetching DSP config:", error);
+    }
+  }
+};
+loadDSPEnabled();
+
 // computed properties
 
 const config_entries = computed(() => {
@@ -125,7 +138,7 @@ const config_entries = computed(() => {
       key: "dsp_settings",
       type: ConfigEntryType.DSP_SETTINGS,
       label: "",
-      default_value: null,
+      default_value: dspEnabled.value,
       required: false,
       category: "audio",
     });

--- a/src/views/settings/EditPlayer.vue
+++ b/src/views/settings/EditPlayer.vue
@@ -96,6 +96,7 @@ import {
   ConfigEntryType,
   ConfigValueType,
   PlayerConfig,
+  PlayerFeature,
   PlayerType,
 } from "@/plugins/api/interfaces";
 import EditConfig from "./EditConfig.vue";
@@ -130,15 +131,40 @@ const config_entries = computed(() => {
   if (!config.value) return [];
   const entries = Object.values(config.value.values);
   // inject a DSP config property if the player is not a group
-  if (
-    api.players[config.value.player_id] &&
-    api.players[config.value.player_id].type !== PlayerType.GROUP
-  ) {
+  const player = api.players[config.value.player_id];
+  if (player && player.type !== PlayerType.GROUP) {
     entries.push({
       key: "dsp_settings",
       type: ConfigEntryType.DSP_SETTINGS,
       label: "",
       default_value: dspEnabled.value,
+      required: false,
+      category: "audio",
+    });
+  } else if (
+    player &&
+    player.type === PlayerType.GROUP &&
+    player.supported_features.includes(PlayerFeature.MULTI_DEVICE_DSP)
+  ) {
+    entries.push({
+      key: "dsp_note_multi_device_group",
+      type: ConfigEntryType.LABEL,
+      label: "You can configure the DSP for each player individually.",
+      default_value: null,
+      required: false,
+      category: "audio",
+    });
+  } else if (
+    player &&
+    player.type === PlayerType.GROUP &&
+    !player.supported_features.includes(PlayerFeature.MULTI_DEVICE_DSP)
+  ) {
+    entries.push({
+      key: "dsp_note_multi_device_group_not_supported",
+      type: ConfigEntryType.LABEL,
+      label:
+        "This group type does not support DSP when playing to multiple devices.",
+      default_value: null,
       required: false,
       category: "audio",
     });


### PR DESCRIPTION
# Overview

The "OPEN DSP SETTINGS" button is now more helpful, placed in the audio category, and a explanation is shown if the DSP settings are not available.

# Screenshots

## Regular Player
![Screenshot From 2025-03-10 17-42-29](https://github.com/user-attachments/assets/0d272b41-d4e4-43c8-bf77-117baedd0ee6)

## AirPlay Group
![Screenshot From 2025-03-10 17-42-18](https://github.com/user-attachments/assets/c8f9a7de-be11-4bc5-89cd-04740d11da45)

## Snapcast Group
![Screenshot From 2025-03-10 17-42-02](https://github.com/user-attachments/assets/99f653e9-7a77-4ae0-a991-cedaf5afe87b)

# Known Issues

The DSP status is not updated when:
1. Opening the DSP Settings through the link
2. Enabling/Disabling the DSP
3. Going back

Will fix that later, this bug is also coupled with having the DSP Settings open on multiple devices.