### PR TITLE
Fix: Show the web player on all tabs of MA

### DIFF
--- a/src/plugins/web_player.ts
+++ b/src/plugins/web_player.ts
@@ -184,6 +184,12 @@ export const webPlayer = reactive({
 
       this.player_id = player_id;
     } else if (mode == WebPlayerMode.CONTROLS_ONLY) {
+      // TODO: this is a bit hacky, will fix that soon
+      // We need this to properly test the multi tab selecting leader logic
+      const saved_player_id = window.localStorage.getItem(
+        "builtin_webplayer_id",
+      );
+      this.player_id = saved_player_id;
       this.audioSource = WebPlayerMode.CONTROLS_ONLY;
     } else {
       this.audioSource = WebPlayerMode.DISABLED;


### PR DESCRIPTION
This is a quick workaround to make the "This Device" player show up on all tabs when hidden (so with default setting).
Will do a proper solution soon, but this should be enough for testing.