### PR TITLE
fix: allow selecting different audio output devices

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -291,8 +291,8 @@ const start = () => {
   if (squeezeliteEnabled.value == true) {
     invoke("start_sqzlite", {
       ip: ip.value.toString(),
-      // outputDevice: outputDevice.value.toString(),
-      outputDevice: "default",
+      outputDevice:
+        outputDevice.value.toString().split(" - ")?.[0] ?? "default",
       port: slimprotoPort.value.toString(),
     });
   }

--- a/src/App.vue
+++ b/src/App.vue
@@ -292,7 +292,7 @@ const start = () => {
     invoke("start_sqzlite", {
       ip: ip.value.toString(),
       outputDevice:
-        outputDevice.value.toString().split(" - ")?.[0] ?? "default",
+        outputDevice.value?.toString().split(" - ")?.[0]?.trim() ?? "default",
       port: slimprotoPort.value.toString(),
     });
   }


### PR DESCRIPTION
In the current version, I could not select a different audio output device, and have audio go through that device, it would always use my default device. This was because it seemed to be hardcoded, as squeezelite wasn't able to use the full device names.

squeezelite only wants the first part of the device string, after the " -  ", so only send that when starting the service. The second part is critical for humans to understand what's going on. Tested on Windows 10 and Ubuntu.

Example squeezelite -l output for Linux:
```
VirtualBox:~$ squeezelite -l

Output devices:

  null                           - Discard all samples (playback) or generate zero samples (capture)

  default                        - Playback/recording through the PulseAudio sound server

  sysdefault                     - Default Audio Device

  iec958                         - IEC958 (S/PDIF) Digital Audio Output

  samplerate                     - Rate Converter Plugin Using Samplerate Library

  speexrate                      - Rate Converter Plugin Using Speex Resampler

  jack                           - JACK Audio Connection Kit

  oss                            - Open Sound System

  pulse                          - PulseAudio Sound Server

  upmix                          - Plugin for channel upmix (4,6,8)

  vdownmix                       - Plugin for channel downmix (stereo) with a simple spacialization

  hw:CARD=I82801AAICH,DEV=0      - Intel 82801AA-ICH, Intel 82801AA-ICH - Direct hardware device without any conversions

  hw:CARD=I82801AAICH,DEV=1      - Intel 82801AA-ICH, Intel 82801AA-ICH - MIC ADC - Direct hardware device without any conversions

  plughw:CARD=I82801AAICH,DEV=0  - Intel 82801AA-ICH, Intel 82801AA-ICH - Hardware device with all software conversions

  plughw:CARD=I82801AAICH,DEV=1  - Intel 82801AA-ICH, Intel 82801AA-ICH - MIC ADC - Hardware device with all software conversions

  sysdefault:CARD=I82801AAICH    - Intel 82801AA-ICH, Intel 82801AA-ICH - Default Audio Device

  front:CARD=I82801AAICH,DEV=0   - Intel 82801AA-ICH, Intel 82801AA-ICH - Front output / input

  surround21:CARD=I82801AAICH,DEV=0 - Intel 82801AA-ICH, Intel 82801AA-ICH - 2.1 Surround output to Front and Subwoofer speakers

  surround40:CARD=I82801AAICH,DEV=0 - Intel 82801AA-ICH, Intel 82801AA-ICH - 4.0 Surround output to Front and Rear speakers

  surround41:CARD=I82801AAICH,DEV=0 - Intel 82801AA-ICH, Intel 82801AA-ICH - 4.1 Surround output to Front, Rear and Subwoofer speakers

  surround50:CARD=I82801AAICH,DEV=0 - Intel 82801AA-ICH, Intel 82801AA-ICH - 5.0 Surround output to Front, Center and Rear speakers

  surround51:CARD=I82801AAICH,DEV=0 - Intel 82801AA-ICH, Intel 82801AA-ICH - 5.1 Surround output to Front, Center, Rear and Subwoofer speakers

  iec958:CARD=I82801AAICH,DEV=0  - Intel 82801AA-ICH, Intel 82801AA-ICH - IEC958 (S/PDIF) Digital Audio Output

  dmix:CARD=I82801AAICH,DEV=0    - Intel 82801AA-ICH, Intel 82801AA-ICH - Direct sample mixing device

  dsnoop:CARD=I82801AAICH,DEV=0  - Intel 82801AA-ICH, Intel 82801AA-ICH - Direct sample snooping device

  dsnoop:CARD=I82801AAICH,DEV=1  - Intel 82801AA-ICH, Intel 82801AA-ICH - MIC ADC - Direct sample snooping device

  usbstream:CARD=I82801AAICH     - Intel 82801AA-ICH - USB Stream Output
```