### PR TITLE
Add interactive breadcrumb navigation to Browse section

### DIFF
--- a/src/components/ItemsListing.vue
+++ b/src/components/ItemsListing.vue
@@ -9,7 +9,11 @@
       color="transparent"
       :menu-items="menuItems"
       @title-clicked="toggleExpand"
-    />
+    >
+      <template #title>
+        <slot name="title">{{ title }}</slot>
+      </template>
+    </Toolbar>
 
     <v-divider />
 
@@ -174,40 +178,40 @@
 <script setup lang="ts">
 /* eslint-disable @typescript-eslint/no-unused-vars,vue/no-setup-props-destructure */
 
+import Container from "@/components/mods/Container.vue";
+import Toolbar, { ToolBarMenuItem } from "@/components/Toolbar.vue";
 import {
-  computed,
-  ref,
-  onBeforeUnmount,
-  nextTick,
-  onMounted,
-  watch,
-  watchEffect,
-} from "vue";
+  handleMenuBtnClick,
+  panelViewItemResponsive,
+  scrollElement,
+} from "@/helpers/utils";
+import { api } from "@/plugins/api";
+import { itemIsAvailable } from "@/plugins/api/helpers";
 import {
+  EventMessage,
+  EventType,
+  ItemMapping,
+  MediaItemTypeOrItemMapping,
   MediaType,
   type Album,
   type MediaItemType,
   type Track,
-  ItemMapping,
-  MediaItemTypeOrItemMapping,
-  EventMessage,
-  EventType,
 } from "@/plugins/api/interfaces";
 import { store } from "@/plugins/store";
+import {
+  computed,
+  nextTick,
+  onBeforeUnmount,
+  onMounted,
+  ref,
+  watch,
+  watchEffect,
+} from "vue";
+import { useI18n } from "vue-i18n";
+import { useRouter } from "vue-router";
 import ListviewItem from "./ListviewItem.vue";
 import PanelviewItem from "./PanelviewItem.vue";
 import PanelviewItemCompact from "./PanelviewItemCompact.vue";
-import { useRouter } from "vue-router";
-import { api } from "@/plugins/api";
-import Container from "@/components/mods/Container.vue";
-import Toolbar, { ToolBarMenuItem } from "@/components/Toolbar.vue";
-import { itemIsAvailable } from "@/plugins/api/helpers";
-import {
-  panelViewItemResponsive,
-  scrollElement,
-  handleMenuBtnClick,
-} from "@/helpers/utils";
-import { useI18n } from "vue-i18n";
 
 export interface LoadDataParams {
   offset: number;
@@ -252,6 +256,7 @@ export interface Props {
   path?: string;
   icon?: string;
   restoreState?: boolean;
+  onTitleClick?: () => void;
 }
 const props = withDefaults(defineProps<Props>(), {
   sortKeys: () => ["name", "sort_name"],
@@ -279,6 +284,8 @@ const props = withDefaults(defineProps<Props>(), {
   path: undefined,
   icon: undefined,
   restoreState: false,
+  onTitleClick: undefined,
+  customTitleRenderer: undefined,
 });
 
 // global refs
@@ -327,6 +334,13 @@ const toggleSearch = function () {
 };
 
 const toggleExpand = function () {
+  // If a custom title click handler is provided, use it
+  if (props.onTitleClick) {
+    props.onTitleClick();
+    return;
+  }
+
+  // Otherwise, use the default expand/collapse behavior
   expanded.value = !expanded.value;
   const storKey = `${props.path}.${props.itemtype}`;
   localStorage.setItem(`expand.${storKey}`, expanded.value.toString());

--- a/src/components/Toolbar.vue
+++ b/src/components/Toolbar.vue
@@ -10,16 +10,18 @@
       />
     </template>
 
-    <template v-if="title" #title>
-      <button @click="emit('titleClicked')">
-        {{ title }}
-        <v-badge
-          v-if="count && getBreakpointValue('bp4')"
-          color="grey"
-          :content="count"
-          inline
-        />
-      </button>
+    <template #title>
+      <slot name="title">
+        <button v-if="title" @click="emit('titleClicked')">
+          {{ title }}
+          <v-badge
+            v-if="count && getBreakpointValue('bp4')"
+            color="grey"
+            :content="count"
+            inline
+          />
+        </button>
+      </slot>
     </template>
 
     <template v-if="menuItems?.length" #append>
@@ -177,8 +179,8 @@
 
 <script setup lang="ts">
 import { ContextMenuItem } from "@/layouts/default/ItemContextMenu.vue";
-import { getBreakpointValue } from "../plugins/breakpoint";
 import { api } from "@/plugins/api";
+import { getBreakpointValue } from "../plugins/breakpoint";
 
 // properties
 export interface Props {

--- a/src/layouts/default/ItemContextMenu.vue
+++ b/src/layouts/default/ItemContextMenu.vue
@@ -147,9 +147,9 @@ const menuItemClicked = function (
   if (menuItem.subItems) {
     evt.preventDefault();
     subMenuItems.value = menuItem.subItems;
-    (subMenuPosX.value = (evt as PointerEvent).clientX),
+    ((subMenuPosX.value = (evt as PointerEvent).clientX),
       (subMenuPosY.value = (evt as PointerEvent).clientY),
-      (showSubmenu.value = true);
+      (showSubmenu.value = true));
     return;
   } else if (menuItem.action) {
     menuItem.action();
@@ -192,9 +192,9 @@ const playMenuHeaderClicked = function (evt: MouseEvent | KeyboardEvent) {
   }
 
   subMenuItems.value = _subItems;
-  (subMenuPosX.value = (evt as PointerEvent).clientX),
+  ((subMenuPosX.value = (evt as PointerEvent).clientX),
     (subMenuPosY.value = (evt as PointerEvent).clientY),
-    (showSubmenu.value = true);
+    (showSubmenu.value = true));
 };
 </script>
 

--- a/src/views/BrowseView.vue
+++ b/src/views/BrowseView.vue
@@ -72,7 +72,7 @@ const breadcrumbSegments = computed((): BreadcrumbSegment[] => {
   segments.push({
     text: t("browse"),
     path: null,
-    clickable: props.path && props.path !== "root",
+    clickable: (props.path && props.path !== "root") || false,
   });
 
   if (props.path && props.path !== "root") {
@@ -83,7 +83,7 @@ const breadcrumbSegments = computed((): BreadcrumbSegment[] => {
       segments.push({
         text: provider,
         path: provider,
-        clickable: pathPart && pathPart.length > 0,
+        clickable: (pathPart && pathPart.length > 0) || false,
       });
 
       if (pathPart && pathPart.length > 0) {

--- a/src/views/BrowseView.vue
+++ b/src/views/BrowseView.vue
@@ -9,35 +9,171 @@
       :show-select-button="path && path != 'root' ? true : false"
       :load-items="loadItems"
       :sort-keys="['original', 'name', 'name_desc']"
-      :title="header"
       :path="path"
       :allow-key-hooks="true"
       icon="mdi-folder-outline"
-    />
+      :title="title"
+    >
+      <template #title>
+        <div class="breadcrumb-container">
+          <span
+            v-for="(segment, index) in breadcrumbSegments"
+            :key="index"
+            class="breadcrumb-segment"
+          >
+            <button
+              v-if="segment.clickable"
+              class="breadcrumb-link"
+              @click="navigateToSegment(segment.path)"
+            >
+              {{ segment.text }}
+            </button>
+            <span v-else class="breadcrumb-text">
+              {{ segment.text }}
+            </span>
+            <v-icon
+              v-if="index < breadcrumbSegments.length - 1"
+              icon="mdi-chevron-right"
+              size="small"
+              class="breadcrumb-separator"
+            />
+          </span>
+        </div>
+      </template>
+    </ItemsListing>
   </section>
 </template>
 
 <script setup lang="ts">
-import { computed, ref } from "vue";
-import { useI18n } from "vue-i18n";
-import { getBreakpointValue } from "@/plugins/breakpoint";
-import api from "@/plugins/api";
 import ItemsListing, { LoadDataParams } from "@/components/ItemsListing.vue";
+import api from "@/plugins/api";
+import router from "@/plugins/router";
+import { computed } from "vue";
+import { useI18n } from "vue-i18n";
 
 export interface Props {
   path?: string;
 }
+
+interface BreadcrumbSegment {
+  text: string;
+  path: string | null;
+  clickable: boolean;
+}
+
 const props = defineProps<Props>();
 const { t } = useI18n();
 
-const header = computed(() => {
-  if (!props.path || props.path == "root") return t("browse");
-  if (getBreakpointValue("bp6")) return t("browse") + " | " + props.path;
-  if (getBreakpointValue("bp3")) return props.path;
-  return t("browse");
+const title = computed(() => "");
+
+const breadcrumbSegments = computed((): BreadcrumbSegment[] => {
+  const segments: BreadcrumbSegment[] = [];
+
+  segments.push({
+    text: t("browse"),
+    path: null,
+    clickable: props.path && props.path !== "root",
+  });
+
+  if (props.path && props.path !== "root") {
+    if (props.path.includes("://")) {
+      const [providerPart, pathPart] = props.path.split("://");
+      const provider = providerPart + "://";
+
+      segments.push({
+        text: provider,
+        path: provider,
+        clickable: pathPart && pathPart.length > 0,
+      });
+
+      if (pathPart && pathPart.length > 0) {
+        const pathSegments = pathPart
+          .split("/")
+          .filter((segment) => segment.length > 0);
+
+        pathSegments.forEach((segment, index) => {
+          const fullPath =
+            provider + pathSegments.slice(0, index + 1).join("/");
+
+          segments.push({
+            text: segment,
+            path: fullPath,
+            clickable: index < pathSegments.length - 1,
+          });
+        });
+      }
+    } else {
+      const pathSegments = props.path
+        .split("/")
+        .filter((segment) => segment.length > 0);
+
+      pathSegments.forEach((segment, index) => {
+        const fullPath = pathSegments.slice(0, index + 1).join("/");
+
+        segments.push({
+          text: segment,
+          path: fullPath,
+          clickable: index < pathSegments.length - 1,
+        });
+      });
+    }
+  }
+
+  return segments;
 });
 
 const loadItems = async function (params: LoadDataParams) {
   return await api.browse(props.path);
 };
+
+const navigateToSegment = (path: string | null) => {
+  if (path === null) {
+    router.push({ name: "browse" });
+  } else {
+    router.push({
+      name: "browse",
+      query: { path },
+    });
+  }
+};
 </script>
+
+<style scoped>
+.breadcrumb-container {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 4px;
+}
+
+.breadcrumb-segment {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.breadcrumb-link {
+  background: none;
+  border: none;
+  color: inherit;
+  cursor: pointer;
+  text-decoration: underline;
+  font-family: inherit;
+  font-size: inherit;
+  padding: 0;
+  margin: 0;
+}
+
+.breadcrumb-link:hover {
+  opacity: 0.7;
+}
+
+.breadcrumb-text {
+  color: inherit;
+}
+
+.breadcrumb-separator {
+  opacity: 0.5;
+  margin: 0 2px;
+}
+</style>


### PR DESCRIPTION
## Interactive Breadcrumb Navigation for Browse Section

Adds clickable breadcrumb navigation to the Browse section, allowing users to jump directly to any path level instead of navigating back one step at a time.

### Features
- Click any breadcrumb segment to navigate to that specific path
- Last segment (current path) is not clickable
- Visual feedback with underlines and hover effects