### PR TITLE
Feature: audiobook/podcast skip controls

### DIFF
--- a/src/layouts/default/PlayerOSD/PlayerBrowserMediaControls.vue
+++ b/src/layouts/default/PlayerOSD/PlayerBrowserMediaControls.vue
@@ -14,7 +14,7 @@
 import audio from "@/assets/almost_silent.mp3";
 import { useMediaBrowserMetaData } from "@/helpers/useMediaBrowserMetaData";
 import api from "@/plugins/api";
-import { PlaybackState } from "@/plugins/api/interfaces";
+import { MediaType, PlaybackState } from "@/plugins/api/interfaces";
 import { store } from "@/plugins/store";
 import { onMounted, ref, watch } from "vue";
 
@@ -106,7 +106,20 @@ const seekHandler = function (
   if (evt.action === "seekto" && evt.seekTime) {
     to = evt.seekTime;
   } else if (evt.action === "seekforward" || evt.action === "seekbackward") {
-    const offset = evt.seekOffset || 10;
+    // Use configurable skip amount for audiobooks/podcasts, fallback to 10 seconds for music
+    const mediaType = store.curQueueItem?.media_item?.media_type;
+    const isAudiobookOrPodcast =
+      mediaType === MediaType.AUDIOBOOK ||
+      mediaType === MediaType.PODCAST ||
+      mediaType === MediaType.PODCAST_EPISODE;
+    const defaultSkipAmount = isAudiobookOrPodcast
+      ? parseInt(
+          localStorage.getItem("frontend.settings.audiobook_skip_seconds") ||
+            "30",
+        )
+      : 10;
+
+    const offset = evt.seekOffset || defaultSkipAmount;
     const elapsed_time =
       lastSeekPos != null ? lastSeekPos : store.activePlayerQueue?.elapsed_time;
     if (elapsed_time == null) return;

--- a/src/layouts/default/PlayerOSD/PlayerControlBtn/SkipBackBtn.vue
+++ b/src/layouts/default/PlayerOSD/PlayerControlBtn/SkipBackBtn.vue
@@ -1,0 +1,34 @@
+<template>
+  <!-- skip back button -->
+  <Icon
+    v-if="isVisible"
+    v-bind="icon"
+    :disabled="!playerQueue?.active || !curQueueItem"
+    icon="mdi-rewind"
+    variant="button"
+    :title="$t('skip_backward_seconds', [skipAmount])"
+    @click="
+      playerQueue && api.queueCommandSkip(playerQueue.queue_id, -skipAmount)
+    "
+  />
+</template>
+
+<script setup lang="ts">
+import Icon, { IconProps } from "@/components/Icon.vue";
+import api from "@/plugins/api";
+import { PlayerQueue, QueueItem } from "@/plugins/api/interfaces";
+import { $t } from "@/plugins/i18n";
+
+// properties
+export interface Props {
+  playerQueue: PlayerQueue | undefined;
+  curQueueItem: QueueItem | undefined;
+  skipAmount: number;
+  isVisible?: boolean;
+  icon?: IconProps;
+}
+withDefaults(defineProps<Props>(), {
+  isVisible: true,
+  icon: undefined,
+});
+</script>

--- a/src/layouts/default/PlayerOSD/PlayerControlBtn/SkipForwardBtn.vue
+++ b/src/layouts/default/PlayerOSD/PlayerControlBtn/SkipForwardBtn.vue
@@ -1,0 +1,34 @@
+<template>
+  <!-- skip forward button -->
+  <Icon
+    v-if="isVisible"
+    v-bind="icon"
+    :disabled="!playerQueue?.active || !curQueueItem"
+    icon="mdi-fast-forward"
+    variant="button"
+    :title="$t('skip_forward_seconds', [skipAmount])"
+    @click="
+      playerQueue && api.queueCommandSkip(playerQueue.queue_id, skipAmount)
+    "
+  />
+</template>
+
+<script setup lang="ts">
+import Icon, { IconProps } from "@/components/Icon.vue";
+import api from "@/plugins/api";
+import { PlayerQueue, QueueItem } from "@/plugins/api/interfaces";
+import { $t } from "@/plugins/i18n";
+
+// properties
+export interface Props {
+  playerQueue: PlayerQueue | undefined;
+  curQueueItem: QueueItem | undefined;
+  skipAmount: number;
+  isVisible?: boolean;
+  icon?: IconProps;
+}
+withDefaults(defineProps<Props>(), {
+  isVisible: true,
+  icon: undefined,
+});
+</script>

--- a/src/layouts/default/PlayerOSD/PlayerControls.vue
+++ b/src/layouts/default/PlayerOSD/PlayerControls.vue
@@ -23,6 +23,15 @@
         :icon="visibleComponents.previous.icon"
       />
     </div>
+    <!-- skip back button for audiobooks/podcasts -->
+    <div v-if="isAudiobookOrPodcast" class="player-controls-elements">
+      <SkipBackBtn
+        :player-queue="store.activePlayerQueue"
+        :cur-queue-item="store.curQueueItem"
+        :skip-amount="skipAmount"
+        class="media-controls-item"
+      />
+    </div>
     <!-- play/pause button -->
     <div v-if="visibleComponents && visibleComponents.play?.isVisible">
       <PlayBtn
@@ -31,6 +40,15 @@
         class="media-controls-item"
         icon-style="circle"
         :icon="visibleComponents.play.icon"
+      />
+    </div>
+    <!-- skip forward button for audiobooks/podcasts -->
+    <div v-if="isAudiobookOrPodcast" class="player-controls-elements">
+      <SkipForwardBtn
+        :player-queue="store.activePlayerQueue"
+        :cur-queue-item="store.curQueueItem"
+        :skip-amount="skipAmount"
+        class="media-controls-item"
       />
     </div>
     <!-- next button -->
@@ -69,6 +87,10 @@ import NextBtn from "./PlayerControlBtn/NextBtn.vue";
 import PlayBtn from "./PlayerControlBtn/PlayBtn.vue";
 import PreviousBtn from "./PlayerControlBtn/PreviousBtn.vue";
 import ShuffleBtn from "./PlayerControlBtn/ShuffleBtn.vue";
+import SkipForwardBtn from "./PlayerControlBtn/SkipForwardBtn.vue";
+import SkipBackBtn from "./PlayerControlBtn/SkipBackBtn.vue";
+import { MediaType } from "@/plugins/api/interfaces";
+import { computed } from "vue";
 
 // properties
 export interface Props {
@@ -104,6 +126,23 @@ withDefaults(defineProps<Props>(), {
     previous: { isVisible: true },
     next: { isVisible: true },
   }),
+});
+
+// Check if current media is audiobook or podcast
+const isAudiobookOrPodcast = computed(() => {
+  const mediaType = store.curQueueItem?.media_item?.media_type;
+  return (
+    mediaType === MediaType.AUDIOBOOK ||
+    mediaType === MediaType.PODCAST ||
+    mediaType === MediaType.PODCAST_EPISODE
+  );
+});
+
+// Get configured skip amount from settings
+const skipAmount = computed(() => {
+  return parseInt(
+    localStorage.getItem("frontend.settings.audiobook_skip_seconds") || "30",
+  );
 });
 </script>
 

--- a/src/layouts/default/PlayerOSD/PlayerFullscreen.vue
+++ b/src/layouts/default/PlayerOSD/PlayerFullscreen.vue
@@ -415,11 +415,27 @@
             class="media-controls-item"
             max-height="45px"
           />
+          <SkipBackBtn
+            v-if="isAudiobookOrPodcast"
+            :player-queue="store.activePlayerQueue"
+            :cur-queue-item="store.curQueueItem"
+            :skip-amount="skipAmount"
+            class="media-controls-item"
+            max-height="45px"
+          />
           <PlayBtn
             :player="store.activePlayer"
             :player-queue="store.activePlayerQueue"
             class="media-controls-item"
             max-height="70px"
+          />
+          <SkipForwardBtn
+            v-if="isAudiobookOrPodcast"
+            :player-queue="store.activePlayerQueue"
+            :cur-queue-item="store.curQueueItem"
+            :skip-amount="skipAmount"
+            class="media-controls-item"
+            max-height="45px"
           />
           <NextBtn
             :player="store.activePlayer"
@@ -553,6 +569,10 @@ import {
   Track,
 } from "@/plugins/api/interfaces";
 import { getBreakpointValue } from "@/plugins/breakpoint";
+import SkipForwardBtn from "@/layouts/default/PlayerOSD/PlayerControlBtn/SkipForwardBtn.vue";
+import SkipBackBtn from "@/layouts/default/PlayerOSD/PlayerControlBtn/SkipBackBtn.vue";
+import QueueBtn from "./PlayerControlBtn/QueueBtn.vue";
+import SpeakerBtn from "./PlayerControlBtn/SpeakerBtn.vue";
 import { eventbus } from "@/plugins/eventbus";
 import { $t } from "@/plugins/i18n";
 import router from "@/plugins/router";
@@ -569,8 +589,6 @@ import {
 } from "vue";
 import { useDisplay } from "vuetify";
 import { ContextMenuItem } from "../ItemContextMenu.vue";
-import QueueBtn from "./PlayerControlBtn/QueueBtn.vue";
-import SpeakerBtn from "./PlayerControlBtn/SpeakerBtn.vue";
 import PlayerTimeline from "./PlayerTimeline.vue";
 import { getSourceName } from "@/plugins/api/helpers";
 import computeElapsedTime from "@/helpers/elapsed";
@@ -726,6 +744,23 @@ watch(
     }
   },
 );
+
+// Check if current media is audiobook or podcast
+const isAudiobookOrPodcast = computed(() => {
+  const mediaType = store.curQueueItem?.media_item?.media_type;
+  return (
+    mediaType === MediaType.AUDIOBOOK ||
+    mediaType === MediaType.PODCAST ||
+    mediaType === MediaType.PODCAST_EPISODE
+  );
+});
+
+// Get configured skip amount from settings
+const skipAmount = computed(() => {
+  return parseInt(
+    localStorage.getItem("frontend.settings.audiobook_skip_seconds") || "30",
+  );
+});
 
 const titleFontSize = computed(() => {
   switch (name.value) {

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -326,7 +326,8 @@
             "web_player": "Web Player",
             "protocol_settings": "Protocol Settings",
             "protocol_output_settings": "Enable {0} support",
-            "dsp": "Digital Signal Processing (DSP)"
+            "dsp": "Digital Signal Processing (DSP)",
+            "audiobooks_podcasts": "Audiobooks & Podcasts"
         },
         "tts_pre_announce": {
             "label": "Pre-announce TTS announcements",
@@ -705,7 +706,11 @@
         "onboarding_add_player": "Add Players",
         "onboarding_footer": "You can always add more providers later from this settings page.",
         "remote_access_qr_code": "QR Code",
-        "remote_access_qr_code_description": "Scan with your phone camera to connect instantly."
+        "remote_access_qr_code_description": "Scan with your phone camera to connect instantly.",
+        "audiobook_skip_seconds": {
+            "label": "Audiobook\/Podcast skip amount",
+            "description": "Number of seconds to skip forward or backward when using skip controls during audiobook or podcast playback."
+        }
     },
     "show_info": "Show info",
     "show_select_boxes": "Show selection boxes",
@@ -835,6 +840,8 @@
     "dont_stop_the_music_enable": "Enable 'Don't stop the music!'",
     "dont_stop_the_music_disable": "Disable 'Don't stop the music!'",
     "open_dsp_settings": "Open DSP settings",
+    "skip_forward_seconds": "Skip forward {0} seconds",
+    "skip_backward_seconds": "Skip backward {0} seconds",
     "audiobook": "Audiobook",
     "audiobooks": "Audiobooks",
     "chapter": "Chapter",

--- a/src/views/settings/FrontendConfig.vue
+++ b/src/views/settings/FrontendConfig.vue
@@ -164,6 +164,25 @@ onMounted(() => {
       value:
         localStorage.getItem("frontend.settings.mobile_sidebar_side") || "left",
     },
+    {
+      key: "audiobook_skip_seconds",
+      type: ConfigEntryType.INTEGER,
+      label: "audiobook_skip_seconds",
+      default_value: 30,
+      required: false,
+      options: [
+        { title: "10", value: 10 },
+        { title: "15", value: 15 },
+        { title: "30", value: 30 },
+        { title: "60", value: 60 },
+      ],
+      multi_value: false,
+      category: "audiobooks_podcasts",
+      value: parseInt(
+        localStorage.getItem("frontend.settings.audiobook_skip_seconds") ||
+          "30",
+      ),
+    },
   ];
 
   // Add web player settings (if not running in companion mode)


### PR DESCRIPTION
 Adds configurable skip controls for audiobooks and podcasts with user-selectable skip amounts of 10, 15, 30, or 60 seconds.

 **Features**
-  Forward and backward skip buttons appear only when playing audiobooks or podcasts
-  Users can choose skip duration (10/15/30/60 seconds) in Settings > Audiobooks & Podcasts
-  Rapid clicking accumulates skip time instead of jumping to the same position
-  Works across mini player, fullscreen player, and browser media session controls
-  Automatically detects audiobooks, podcasts, and podcast episodes

 **Implementation Details**

-  Skip buttons positioned between previous/next and play controls
-  Generic fast-forward/rewind icons
-  Shared SkipControlManager handles throttling logic similar to existing media session controls
-  Browser media session uses configured amounts for keyboard/headphone controls
-  Falls back to 10 seconds for music content to maintain existing behaviour

 **Test Plan**
-  Skip buttons appear only for audiobooks and podcasts
-  Setting configurable in frontend settings under new "Audiobooks & Podcasts" category
-  Skip amount changes are applied immediately without page refresh
-  Rapid clicking accumulates skip time correctly
-  Browser media session (keyboard/headphone controls) uses configured amounts
-  No skip buttons shown for regular music content

 Fixes https://github.com/orgs/music-assistant/discussions/3745
