### PR TITLE
Fix: Prevent player cards from collapsing in slider

### DIFF
--- a/src/components/PlayersWidgetRow.vue
+++ b/src/components/PlayersWidgetRow.vue
@@ -27,7 +27,7 @@
     </v-toolbar>
 
     <swiper
-      :slides-per-view="$vuetify.display.width / 340"
+      :slides-per-view="'auto'"
       :space-between="15"
       :free-mode="false"
       :navigation="getBreakpointValue({ breakpoint: 'mobile' }) ? false : true"
@@ -139,5 +139,9 @@ function playerSortScore(player: Player) {
 
 .v-slide-group__next.v-slide-group__next--disabled {
   visibility: hidden;
+}
+
+:deep(.swiper-slide) {
+  width: auto;
 }
 </style>


### PR DESCRIPTION
Fix for the issue: https://github.com/music-assistant/support/issues/3854 

- Fixed player card width to maintain consistent 305px size
- Adjusted swiper-slide width to auto for proper card spacing
- Removed calculated swiper slides-per-view to auto, cause forcing it to a calculated value made player cards collapse