### PR TITLE
DSP Presets

### DIFF
--- a/src/plugins/api/index.ts
+++ b/src/plugins/api/index.ts
@@ -44,6 +44,7 @@ import {
   ItemMapping,
   AlbumType,
   DSPConfig,
+  DSPConfigPreset,
   Audiobook,
   Podcast,
   PodcastEpisode,
@@ -1255,6 +1256,25 @@ export class MusicAssistantApi {
     return this.sendCommand("config/players/dsp/save", {
       player_id,
       config,
+    });
+  }
+
+  public async getDSPPresets(): Promise<DSPConfigPreset[]> {
+    // Return all known DSP presets
+    return this.sendCommand("config/dsp_presets/get");
+  }
+
+  public async saveDSPPreset(
+    preset: DSPConfigPreset,
+  ): Promise<DSPConfigPreset> {
+    // Save a DSP preset.
+    return this.sendCommand("config/dsp_presets/save", { preset });
+  }
+
+  public async removeDSPPreset(presetId: string): Promise<void> {
+    // Remove a DSP preset.
+    return this.sendCommand("config/dsp_presets/remove", {
+      preset_id: presetId,
     });
   }
 

--- a/src/plugins/api/interfaces.ts
+++ b/src/plugins/api/interfaces.ts
@@ -68,6 +68,13 @@ export interface DSPConfig {
   output_gain: number;
 }
 
+// DSPConfigPreset represents a preset configuration for DSP
+export interface DSPConfigPreset {
+  preset_id?: string;
+  name: string;
+  config: DSPConfig;
+}
+
 // DSPDetails used in StreamDetails
 export enum DSPState {
   ENABLED = "enabled",
@@ -291,6 +298,7 @@ export enum EventType {
   PROVIDERS_UPDATED = "providers_updated",
   PLAYER_CONFIG_UPDATED = "player_config_updated",
   PLAYER_DSP_CONFIG_UPDATED = "player_dsp_config_updated",
+  DSP_PRESETS_UPDATED = "dsp_presets_updated",
   SYNC_TASKS_UPDATED = "sync_tasks_updated",
   AUTH_SESSION = "auth_session",
   BUILTIN_PLAYER = "builtin_player",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -478,6 +478,14 @@
             "channels_compact": {
                 "FL": "L",
                 "FR": "R"
+            },
+            "presets": {
+                "load": "Load DSP Preset",
+                "empty_warning": "No DSP presets available",
+                "save": "Save DSP Preset",
+                "name": "Preset Name",
+                "name_placeholder": "My new preset",
+                "remove_confirm": "Are you sure you want to remove this DSP preset?"
             }
         },
         "power_control": {

--- a/src/views/settings/EditPlayerDsp.vue
+++ b/src/views/settings/EditPlayerDsp.vue
@@ -10,7 +10,6 @@
       <v-toolbar-title>{{
         $t("settings.dsp.configure_on", { name: playerName })
       }}</v-toolbar-title>
-      <v-spacer />
       <v-menu offset-y transition="slide-y-transition">
         <template v-slot:activator="{ props }">
           <v-btn
@@ -19,7 +18,9 @@
             :class="getButtonClass()"
             prepend-icon="mdi-tray-arrow-down"
           >
-            {{ $t("settings.dsp.presets.load") }}
+            <span class="d-none d-md-inline">
+              {{ $t("settings.dsp.presets.load") }}
+            </span>
           </v-btn>
         </template>
         <v-list>
@@ -29,8 +30,8 @@
             </v-list-item-title>
           </v-list-item>
           <v-list-item
-            v-else
             v-for="preset in dspPresets"
+            v-else
             :key="preset.preset_id"
             @click="loadPreset(preset)"
           >
@@ -51,7 +52,9 @@
         prepend-icon="mdi-content-save"
         @click="showSavePresetDialog = true"
       >
-        {{ $t("settings.dsp.presets.save") }}
+        <span class="d-none d-md-inline">
+          {{ $t("settings.dsp.presets.save") }}
+        </span>
       </v-btn>
     </v-toolbar>
 
@@ -193,8 +196,8 @@
           </v-btn>
           <v-btn
             color="primary"
-            @click="savePreset"
             :disabled="!newPresetName.trim()"
+            @click="savePreset"
           >
             {{ $t("settings.dsp.presets.save") }}
           </v-btn>

--- a/src/views/settings/EditPlayerDsp.vue
+++ b/src/views/settings/EditPlayerDsp.vue
@@ -11,13 +11,9 @@
         $t("settings.dsp.configure_on", { name: playerName })
       }}</v-toolbar-title>
       <v-menu offset-y transition="slide-y-transition">
-        <template v-slot:activator="{ props }">
-          <v-btn
-            v-bind="props"
-            class="mr-4"
-            :class="getButtonClass()"
-            prepend-icon="mdi-tray-arrow-down"
-          >
+        <template #activator="{ props: menuProps }">
+          <v-btn v-bind="menuProps" class="mr-4" :class="getButtonClass()">
+            <v-icon class="p-0 ms-md-n1 me-md-2"> mdi-tray-arrow-down </v-icon>
             <span class="d-none d-md-inline">
               {{ $t("settings.dsp.presets.load") }}
             </span>
@@ -47,11 +43,8 @@
           </v-list-item>
         </v-list>
       </v-menu>
-      <v-btn
-        :class="getButtonClass()"
-        prepend-icon="mdi-content-save"
-        @click="showSavePresetDialog = true"
-      >
+      <v-btn :class="getButtonClass()" @click="showSavePresetDialog = true">
+        <v-icon class="p-0 ms-md-n1 me-md-2"> mdi-content-save </v-icon>
         <span class="d-none d-md-inline">
           {{ $t("settings.dsp.presets.save") }}
         </span>

--- a/src/views/settings/EditPlayerDsp.vue
+++ b/src/views/settings/EditPlayerDsp.vue
@@ -1,6 +1,6 @@
 <template>
   <section v-if="dsp">
-    <v-toolbar color="transparent" class="border-b">
+    <v-toolbar color="transparent" class="border-b pr-4">
       <v-switch
         v-model="dsp.enabled"
         hide-details
@@ -10,6 +10,49 @@
       <v-toolbar-title>{{
         $t("settings.dsp.configure_on", { name: playerName })
       }}</v-toolbar-title>
+      <v-spacer />
+      <v-menu offset-y transition="slide-y-transition">
+        <template v-slot:activator="{ props }">
+          <v-btn
+            v-bind="props"
+            class="mr-4"
+            :class="getButtonClass()"
+            prepend-icon="mdi-tray-arrow-down"
+          >
+            {{ $t("settings.dsp.presets.load") }}
+          </v-btn>
+        </template>
+        <v-list>
+          <v-list-item v-if="dspPresets.length === 0">
+            <v-list-item-title>
+              {{ $t("settings.dsp.presets.empty_warning") }}
+            </v-list-item-title>
+          </v-list-item>
+          <v-list-item
+            v-else
+            v-for="preset in dspPresets"
+            :key="preset.preset_id"
+            @click="loadPreset(preset)"
+          >
+            <v-list-item-title>{{ preset.name }}</v-list-item-title>
+            <template #append>
+              <v-btn
+                icon="mdi-delete"
+                variant="text"
+                density="compact"
+                @click.stop="removePreset(preset.preset_id)"
+              />
+            </template>
+          </v-list-item>
+        </v-list>
+      </v-menu>
+      <v-btn
+        :class="getButtonClass()"
+        prepend-icon="mdi-content-save"
+        @click="showSavePresetDialog = true"
+      >
+        {{ $t("settings.dsp.presets.save") }}
+      </v-btn>
     </v-toolbar>
 
     <v-container class="pa-4">
@@ -131,6 +174,34 @@
       </v-row>
     </v-container>
 
+    <!-- Save DSP Preset Dialog -->
+    <v-dialog v-model="showSavePresetDialog" max-width="300">
+      <v-card>
+        <v-card-title>{{ $t("settings.dsp.presets.save") }}</v-card-title>
+        <v-card-text>
+          <v-text-field
+            v-model="newPresetName"
+            :label="$t('settings.dsp.presets.name')"
+            :placeholder="$t('settings.dsp.presets.name_placeholder')"
+            variant="outlined"
+          />
+        </v-card-text>
+        <v-card-actions>
+          <v-spacer />
+          <v-btn @click="showSavePresetDialog = false">
+            {{ $t("cancel") }}
+          </v-btn>
+          <v-btn
+            color="primary"
+            @click="savePreset"
+            :disabled="!newPresetName.trim()"
+          >
+            {{ $t("settings.dsp.presets.save") }}
+          </v-btn>
+        </v-card-actions>
+      </v-card>
+    </v-dialog>
+
     <!-- Add Filter Dialog -->
     <v-dialog v-model="showAddFilterDialog" max-width="300">
       <v-card>
@@ -155,13 +226,21 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed, watch, onUnmounted, onBeforeUnmount } from "vue";
+import {
+  ref,
+  computed,
+  watch,
+  onUnmounted,
+  onBeforeUnmount,
+  onMounted,
+} from "vue";
 import { useI18n } from "vue-i18n";
 import { useRouter } from "vue-router";
-import { useDisplay } from "vuetify";
+import { useDisplay, useTheme } from "vuetify";
 import { api } from "@/plugins/api";
 import {
   DSPConfig,
+  DSPConfigPreset,
   ParametricEQBandType,
   DSPFilter,
   DSPFilterType,
@@ -177,15 +256,19 @@ import DSPToneControl from "@/components/dsp/DSPToneControl.vue";
 
 const { t } = useI18n();
 const router = useRouter();
+const theme = useTheme();
 
 const props = defineProps<{
   playerId?: string;
 }>();
 
 const dsp = ref<DSPConfig>();
+const dspPresets = ref<DSPConfigPreset[]>([]);
 const selectedStage = ref<number | null | "input" | "output">(null);
 const showAddFilterDialog = ref(false);
+const showSavePresetDialog = ref(false);
 const newFilterType = ref(DSPFilterType.PARAMETRIC_EQ);
+const newPresetName = ref("");
 const windowWidth = ref(window.innerWidth);
 const { mobile } = useDisplay();
 let updatedFromServer = false;
@@ -198,6 +281,12 @@ const filterTypes = Object.values(DSPFilterType).map((value) => {
 });
 
 // Methods
+const getButtonClass = (): string => {
+  return theme.global.current.value.dark
+    ? "bg-grey-darken-3"
+    : "bg-grey-lighten-3";
+};
+
 const selectStage = (index: number | "input" | "output") => {
   selectedStage.value = index;
 };
@@ -263,6 +352,38 @@ const removeFilter = (index: number) => {
   dsp.value?.filters.splice(index, 1);
 };
 
+const loadPreset = async (preset: DSPConfigPreset) => {
+  if (!preset || !preset.config) return;
+
+  selectedStage.value = "input";
+  // Deep copy the preset config to avoid reference issues
+  dsp.value = preset.config;
+};
+
+const savePreset = async () => {
+  if (!dsp.value || !newPresetName.value.trim()) return;
+
+  const preset: DSPConfigPreset = {
+    name: newPresetName.value.trim(),
+    config: dsp.value,
+  };
+
+  try {
+    await api.saveDSPPreset(preset);
+    newPresetName.value = "";
+    showSavePresetDialog.value = false;
+  } catch (error) {
+    console.error("Failed to save DSP preset:", error);
+  }
+};
+
+const removePreset = async (presetId: string | undefined) => {
+  if (!presetId || !confirm(t("settings.dsp.presets.remove_confirm"))) return;
+
+  await api.removeDSPPreset(presetId);
+  dspPresets.value = dspPresets.value.filter((p) => p.preset_id !== presetId);
+};
+
 // Watchers
 
 watch(
@@ -288,14 +409,29 @@ watch(
   { immediate: true },
 );
 
-const unsub = api.subscribe(
+const unsubPlayerDSP = api.subscribe(
   EventType.PLAYER_DSP_CONFIG_UPDATED,
   (evt: { data: DSPConfig }) => {
     updatedFromServer = true;
     dsp.value = evt.data;
   },
 );
-onBeforeUnmount(unsub);
+
+const unsubDSPPresets = api.subscribe(
+  EventType.DSP_PRESETS_UPDATED,
+  (evt: { data: DSPConfigPreset[] }) => {
+    dspPresets.value = evt.data;
+  },
+);
+
+onMounted(async () => {
+  dspPresets.value = await api.getDSPPresets();
+});
+
+onBeforeUnmount(() => {
+  unsubPlayerDSP();
+  unsubDSPPresets();
+});
 
 // Debounced save, to prevent too many requests, but still be responsive
 let saveTimeout: ReturnType<typeof setTimeout> | null = null;
@@ -310,14 +446,14 @@ const debouncedSave = (newVal: DSPConfig) => {
 
 watch(
   dsp,
-  (old_val, newVal) => {
+  (newVal, oldVal) => {
     if (updatedFromServer) {
       // Skip resending, since we just got the config
       if (saveTimeout) clearTimeout(saveTimeout);
       updatedFromServer = false;
       return;
     }
-    if (old_val === null) return; // We haven't changed anything yet
+    if (oldVal === null) return; // We haven't changed anything yet
     if (newVal) debouncedSave(newVal);
   },
   { deep: true },


### PR DESCRIPTION
This PR adds the needed features to the EditPlayerDSP page required for saving, loading, and deleting DSP presets.
It requires the PR to the server repository adding support for DSP presets: https://github.com/music-assistant/server/pull/2309