### PR TITLE
fix: DSP editing bugs with multiple players

### DIFF
--- a/src/views/settings/EditPlayerDsp.vue
+++ b/src/views/settings/EditPlayerDsp.vue
@@ -269,6 +269,8 @@ const windowWidth = ref(window.innerWidth);
 const { mobile } = useDisplay();
 let updatedFromServer = false;
 
+let unsubPlayerDSP: (() => void) | undefined = undefined;
+
 const filterTypes = Object.values(DSPFilterType).map((value) => {
   return {
     value: value,
@@ -398,20 +400,20 @@ const playerName = computed(() =>
 watch(
   () => props.playerId,
   async (val) => {
+    if (unsubPlayerDSP) unsubPlayerDSP();
     if (val) {
       dsp.value = await api.getDSPConfig(val);
     }
+    unsubPlayerDSP = api.subscribe(
+      EventType.PLAYER_DSP_CONFIG_UPDATED,
+      (evt: { data: DSPConfig }) => {
+        updatedFromServer = true;
+        dsp.value = evt.data;
+      },
+      props.playerId,
+    );
   },
   { immediate: true },
-);
-
-const unsubPlayerDSP = api.subscribe(
-  EventType.PLAYER_DSP_CONFIG_UPDATED,
-  (evt: { data: DSPConfig }) => {
-    updatedFromServer = true;
-    dsp.value = evt.data;
-  },
-  props.playerId,
 );
 
 const unsubDSPPresets = api.subscribe(
@@ -426,7 +428,7 @@ onMounted(async () => {
 });
 
 onBeforeUnmount(() => {
-  unsubPlayerDSP();
+  if (unsubPlayerDSP) unsubPlayerDSP();
   unsubDSPPresets();
 });
 

--- a/src/views/settings/EditPlayerDsp.vue
+++ b/src/views/settings/EditPlayerDsp.vue
@@ -401,6 +401,8 @@ watch(
   () => props.playerId,
   async (val) => {
     if (unsubPlayerDSP) unsubPlayerDSP();
+    // Don't overwrite the config for the newly selected player
+    updatedFromServer = true;
     if (val) {
       dsp.value = await api.getDSPConfig(val);
     }

--- a/src/views/settings/EditPlayerDsp.vue
+++ b/src/views/settings/EditPlayerDsp.vue
@@ -411,6 +411,7 @@ const unsubPlayerDSP = api.subscribe(
     updatedFromServer = true;
     dsp.value = evt.data;
   },
+  props.playerId,
 );
 
 const unsubDSPPresets = api.subscribe(


### PR DESCRIPTION
# Overview

It appears the DSP Settings were not functioning correctly when editing the DSP for more than one player.

## Fixed issues
More specifically:
- If the DSP settings of player A were already open, opening the DSP settings of player B would overwrite player B's settings with player A's settings on the first change.
- If multiple DSP settings for different players were open simultaneously (in different tabs or on different devices), the displayed settings for all players were copied from the settings of the player that was last changed (and would be overwritten when anything was changed).