### PR TITLE
Update play icon for tracks and for home page

### DIFF
--- a/src/components/ListviewItem.vue
+++ b/src/components/ListviewItem.vue
@@ -31,10 +31,15 @@
         v-if="!showCheckboxes && item.is_playable"
         :class="{ hidden: !showPlayBtn }"
         icon="mdi-play"
-        color="primary"
-        fab
+        variant="text"
         size="small"
-        style="position: absolute; left: 12px; bottom: 12px"
+        style="
+          position: absolute;
+          left: 14px;
+          bottom: 12px;
+          color: white;
+          font-size: 18px;
+        "
         @click.stop="onPlayClick"
         @mouseenter="showPlayBtn = true"
         @mouseleave="showPlayBtn = false"

--- a/src/components/PanelviewItemCompact.vue
+++ b/src/components/PanelviewItemCompact.vue
@@ -48,8 +48,7 @@
             icon="mdi-play"
             color="white"
             fab
-            size="small"
-            style="opacity: 0.4"
+            style="opacity: 0.6; font-size: 20px"
             @click.stop="onPlayClick"
           />
         </div>

--- a/src/components/PanelviewItemCompact.vue
+++ b/src/components/PanelviewItemCompact.vue
@@ -27,31 +27,33 @@
           :model-value="isSelected"
         />
       </v-overlay>
-      <MediaItemThumb :item="isAvailable ? item : undefined" />
-      <!-- Now Playing Badge -->
-      <NowPlayingBadge
-        v-if="isPlaying"
-        icon-style="position: absolute; right: 5px; bottom: 5px"
-        :show-badge="false"
-      />
-      <!-- play button -->
-      <v-btn
-        v-if="
-          (isHovering || store.isTouchscreen) && isAvailable && item.is_playable
-        "
-        icon="mdi-play"
-        color="white"
-        fab
-        size="small"
-        style="
-          position: absolute;
-          left: 50%;
-          top: 40%;
-          transform: translate(-50%, -50%);
-          opacity: 0.8;
-        "
-        @click.stop="onPlayClick"
-      />
+      <div class="thumb-container">
+        <MediaItemThumb :item="isAvailable ? item : undefined" />
+        <!-- Now Playing Badge -->
+        <NowPlayingBadge
+          v-if="isPlaying"
+          icon-style="position: absolute; right: 5px; bottom: 5px"
+          :show-badge="false"
+        />
+        <!-- play button -->
+        <div
+          v-if="
+            (isHovering || store.isTouchscreen) &&
+            isAvailable &&
+            item.is_playable
+          "
+          class="play-button-overlay"
+        >
+          <v-btn
+            icon="mdi-play"
+            color="white"
+            fab
+            size="small"
+            style="opacity: 0.4"
+            @click.stop="onPlayClick"
+          />
+        </div>
+      </div>
       <v-list-item
         variant="text"
         slim
@@ -109,13 +111,7 @@
 </template>
 
 <script setup lang="ts">
-import MediaItemThumb from "./MediaItemThumb.vue";
-import {
-  BrowseFolder,
-  ItemMapping,
-  type MediaItemType,
-  MediaType,
-} from "@/plugins/api/interfaces";
+import NowPlayingBadge from "@/components/NowPlayingBadge.vue";
 import {
   getArtistsString,
   getBrowseFolderName,
@@ -123,8 +119,14 @@ import {
   handleMenuBtnClick,
   handlePlayBtnClick,
 } from "@/helpers/utils";
+import {
+  BrowseFolder,
+  ItemMapping,
+  type MediaItemType,
+  MediaType,
+} from "@/plugins/api/interfaces";
 import { store } from "@/plugins/store";
-import NowPlayingBadge from "@/components/NowPlayingBadge.vue";
+import MediaItemThumb from "./MediaItemThumb.vue";
 
 // properties
 export interface Props {
@@ -184,6 +186,28 @@ const onPlayClick = function (evt: PointerEvent) {
 </script>
 
 <style scoped>
+.thumb-container {
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.play-button-overlay {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  pointer-events: none;
+
+  .v-btn {
+    pointer-events: all;
+  }
+}
 .v-card {
   background-color: rgb(var(--v-theme-panel));
   transition: opacity 0.4s ease-in-out;

--- a/src/layouts/default/Footer.vue
+++ b/src/layouts/default/Footer.vue
@@ -12,8 +12,8 @@
     `"
   ></div>
   <BottomNavigation
-    :height="bottomNavHeight"
     v-if="getBreakpointValue({ breakpoint: 'tablet' })"
+    :height="bottomNavHeight"
   />
   <v-footer
     app


### PR DESCRIPTION
The goal of this pr is to reduce the opacity of the play icon in the home page and also center it:
<img width="376" height="328" alt="Screenshot 2025-09-23 at 12 40 22" src="https://github.com/user-attachments/assets/07348175-a570-4c73-9c42-978b27c63f8e" />

And also to change the play button on the track cover from this:
<img width="311" height="138" alt="Screenshot 2025-09-23 at 12 44 21" src="https://github.com/user-attachments/assets/2b2486aa-fb3c-49ce-9c9b-cc443bf798da" />

To this: 
<img width="394" height="128" alt="Screenshot 2025-09-23 at 12 39 43" src="https://github.com/user-attachments/assets/606884ac-5a1c-4b04-acf4-ea954fe3f038" />