### PR TITLE
Disable checkbox for static group members

### DIFF
--- a/src/components/VolumeControl.vue
+++ b/src/components/VolumeControl.vue
@@ -142,7 +142,11 @@
             <v-checkbox
               v-if="showSyncControls"
               :ripple="false"
-              :disabled="childPlayer.player_id == player.player_id"
+              :disabled="
+                childPlayer.player_id == player.player_id ||
+                (player.static_group_members.includes(childPlayer.player_id) &&
+                  player.group_members.includes(childPlayer.player_id))
+              "
               :model-value="
                 player.group_members.includes(childPlayer.player_id) ||
                 childPlayer.player_id == player.player_id

--- a/src/plugins/api/interfaces.ts
+++ b/src/plugins/api/interfaces.ts
@@ -849,6 +849,7 @@ export interface Player {
   volume_level?: number;
   volume_muted?: boolean;
   group_members: string[];
+  static_group_members: string[];
   active_source?: string;
   source_list: PlayerSource[];
   active_group?: string;


### PR DESCRIPTION
Disables the sync checkbox for static group members.

Depends on:
- https://github.com/music-assistant/models/pull/118
- https://github.com/music-assistant/server/pull/2429