### PR TITLE
Hide volume control from fullscreen player when unsupported

### DIFF
--- a/src/layouts/default/PlayerOSD/PlayerFullscreen.vue
+++ b/src/layouts/default/PlayerOSD/PlayerFullscreen.vue
@@ -520,7 +520,10 @@
 
         <!-- volume control -->
         <div
-          v-if="store.activePlayer"
+          v-if="
+            store.activePlayer &&
+            store.activePlayer.volume_control != PLAYER_CONTROL_NONE
+          "
           class="row"
           style="margin-left: 5%; margin-right: 5%"
         >
@@ -618,6 +621,7 @@ import {
   QueueItem,
   QueueOption,
   Track,
+  PLAYER_CONTROL_NONE,
 } from "@/plugins/api/interfaces";
 import { getBreakpointValue } from "@/plugins/breakpoint";
 import { eventbus } from "@/plugins/eventbus";


### PR DESCRIPTION
Previously the volume slider was already hidden/disabled almost everywhere on players without volume control.
This PR completes that by also hiding the slider from the full screen player UI.

# Screenshot
Made with a Resonate client.
<img width="663" height="994" alt="image" src="https://github.com/user-attachments/assets/3d567d49-0c67-4e9f-aa5f-2deb19b574f0" />
