### PR TITLE
Let the user reduce the navbar

### DIFF
--- a/src/components/navigation/Navigation.vue
+++ b/src/components/navigation/Navigation.vue
@@ -1,12 +1,12 @@
 <template>
-  <nav class="sidebar">
-    <div class="sidebar-header">
+  <nav class="sidebar" :class="{ collapsed }">
+    <div class="sidebar-header" @click="router.push({ name: 'home' })">
       <img
         src="@/assets/icon.svg"
         alt="Music Assistant"
         class="sidebar-header-logo"
       />
-      <div class="sidebar-header-title">Music Assistant</div>
+      <div v-if="!collapsed" class="sidebar-header-title">Music Assistant</div>
     </div>
     <v-list class="sidebar-list">
       <v-list-item
@@ -17,30 +17,58 @@
         class="menuButton"
         :to="menuItem.path"
       >
-        <template #prepend>
+        <template v-if="!collapsed" #prepend>
           <v-icon :icon="menuItem.icon" size="24px" />
         </template>
-        <v-list-item-title v-text="$t(menuItem.label)" />
+        <v-icon v-if="collapsed" :icon="menuItem.icon" size="24px" />
+        <v-list-item-title v-if="!collapsed" v-text="$t(menuItem.label)" />
       </v-list-item>
     </v-list>
+    <div :class="!collapsed ? 'ml-auto' : 'd-flex justify-center'">
+      <v-btn
+        :icon="collapsed ? 'mdi-dock-left' : 'mdi-dock-right'"
+        class="cursor-pointer mt-1"
+        variant="plain"
+        @click="toggleCollapsed"
+      />
+    </div>
   </nav>
 </template>
 
 <script setup lang="ts">
+import { ref } from "vue";
+import { useRouter } from "vue-router";
 import { getMenuItems } from "./utils/getMenuItems";
 
+const router = useRouter();
 const menuItems = getMenuItems();
+
+const storedCollapsed = localStorage.getItem("frontend.settings.collapsed");
+const collapsed = ref(storedCollapsed === "true");
+
+const toggleCollapsed = () => {
+  collapsed.value = !collapsed.value;
+  localStorage.setItem(
+    "frontend.settings.collapsed",
+    collapsed.value.toString(),
+  );
+};
 </script>
 
 <style scoped>
 .menuButton {
   margin: 3px 10px;
   padding: 0px 15px;
+  border-radius: 15px;
 }
 
 .v-list-item-title {
   font-size: medium;
   font-weight: bold;
+}
+
+.v-list-item--density-default.v-list-item--one-line {
+  min-height: 44px;
 }
 
 .v-icon {
@@ -59,23 +87,48 @@ const menuItems = getMenuItems();
 <style scoped>
 .sidebar {
   background-color: rgb(var(--v-theme-panel));
+  width: 290px;
+  transition: width 0.3s ease;
+  display: flex;
+  flex-direction: column;
+  height: 100%;
 }
+
+.sidebar.collapsed {
+  width: 68px;
+}
+
 .sidebar-header {
   display: flex;
   align-items: center;
   gap: 6px;
-  margin: 15px 0px 0 22px;
+  margin: 15px 22px 0 22px;
+  transition: all 0.3s ease;
+  position: relative;
+  cursor: pointer;
 }
+
+.sidebar.collapsed .sidebar-header {
+  margin: 15px 10px 0 10px;
+  justify-content: center;
+}
+
 .sidebar-header-logo {
   width: 30px;
   height: 30px;
   border-radius: 6px;
+  flex-shrink: 0;
 }
+
 .sidebar-header-title {
   font-size: 1.2rem;
   font-weight: bold;
   margin: 3px 0 0 10px;
+  white-space: nowrap;
+  overflow: hidden;
+  transition: opacity 0.2s ease;
 }
+
 .sidebar-list {
   background-color: rgb(var(--v-theme-panel));
   list-style: none;
@@ -85,6 +138,21 @@ const menuItems = getMenuItems();
   flex: 1;
   padding-bottom: 30px;
 }
+
+.sidebar.collapsed .menuButton {
+  padding: 0;
+  margin: 3px 10px;
+}
+
+.sidebar.collapsed .menuButton :deep(.v-list-item__content) {
+  align-self: center;
+  grid-area: content-start;
+  overflow: hidden;
+  min-width: 40px;
+  display: flex;
+  justify-content: center;
+}
+
 .sidebar-list li {
   padding: 12px 16px;
 }

--- a/src/layouts/default/View.vue
+++ b/src/layouts/default/View.vue
@@ -24,7 +24,6 @@
 
 <script lang="ts" setup>
 import Navigation from "@/components/navigation/Navigation.vue";
-import { getBreakpointValue } from "@/plugins/breakpoint";
 import { store } from "@/plugins/store";
 import AddToPlaylistDialog from "./AddToPlaylistDialog.vue";
 import ItemContextMenu from "./ItemContextMenu.vue";
@@ -38,7 +37,9 @@ import ItemContextMenu from "./ItemContextMenu.vue";
 }
 
 .nav-section {
-  flex: 0 0 290px;
+  flex: 0 0 auto;
+  width: 290px;
+  transition: width 0.3s ease;
 }
 .content-section {
   flex: 1;

--- a/src/views/settings/Providers.vue
+++ b/src/views/settings/Providers.vue
@@ -349,6 +349,17 @@ const getProviderTypeIcon = function (type: ProviderType) {
   return iconMap[type] || "mdi-help-circle";
 };
 
+const getProviderTypeOrder = function (type: ProviderType) {
+  // Define sort order: player -> music -> metadata -> plugin
+  const order = {
+    [ProviderType.PLAYER]: 1,
+    [ProviderType.MUSIC]: 2,
+    [ProviderType.METADATA]: 3,
+    [ProviderType.PLUGIN]: 4,
+  };
+  return order[type] || 999;
+};
+
 const getAllFilteredProviders = function () {
   let filtered = [...providerConfigs.value];
 
@@ -373,9 +384,13 @@ const getAllFilteredProviders = function () {
     });
   }
 
-  return filtered.sort((a, b) =>
-    getProviderName(a).localeCompare(getProviderName(b)),
-  );
+  return filtered.sort((a, b) => {
+    const typeOrder =
+      getProviderTypeOrder(a.type) - getProviderTypeOrder(b.type);
+    if (typeOrder !== 0) return typeOrder;
+
+    return getProviderName(a).localeCompare(getProviderName(b));
+  });
 };
 </script>
 


### PR DESCRIPTION
The main enhancement here is the possibility to have a dock icon at the bottom of the nav to reduce teh navabar to only icons.
On top of that, i added the return to home when you click to the icon/title at the top of the navbar + some reorder for providers

- [x] Navbar can be resized using localStorage for now
- [x] Sort providers by title and provider type
- [x] Return to hom on lcicking at the logo + name

<img width="403" height="1038" alt="Screenshot 2025-10-06 at 13 04 57" src="https://github.com/user-attachments/assets/845bfcb9-a326-43ec-a045-0c939f5bb656" />
<img width="520" height="1039" alt="Screenshot 2025-10-06 at 13 04 45" src="https://github.com/user-attachments/assets/1b153925-6ae2-43e2-a501-85d1d614590b" />
