### PR TITLE
Implement control of other sources playing on a player

### DIFF
--- a/src/helpers/elapsed.test.ts
+++ b/src/helpers/elapsed.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import computeElapsedTime from "./elapsed";
+import { PlaybackState } from "../plugins/api/interfaces";
+
+describe("computeElapsedTime", () => {
+  const REAL_DATE_NOW = Date.now;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    // @ts-ignore
+    Date.now = REAL_DATE_NOW;
+  });
+
+  it("returns undefined when elapsed_time undefined", () => {
+    expect(computeElapsedTime(undefined, undefined)).toBeUndefined();
+  });
+
+  it("returns same value when playback is paused", () => {
+    const t0 = 1000; // seconds
+    const ts = 1600000000; // seconds
+    expect(computeElapsedTime(t0, ts, PlaybackState.PAUSED)).toBe(t0);
+  });
+
+  it("advances elapsed when playing using timestamp difference", () => {
+    const t0 = 10; // seconds
+    const ts = 1_600_000_000; // seconds
+    // move time forward by 5.5 seconds
+    vi.setSystemTime(ts * 1000 + 5500);
+
+    const result = computeElapsedTime(t0, ts, PlaybackState.PLAYING);
+    // allow small float delta
+    expect(result).toBeGreaterThanOrEqual(15.499);
+    expect(result).toBeLessThanOrEqual(15.501);
+  });
+
+  it("handles elapsed_time_last_updated provided in seconds (not ms)", () => {
+    const t0 = 30; // seconds
+    const ts_seconds = 1_600_000_000; // seconds
+    // set now to ts_seconds + 2.5 seconds
+    vi.setSystemTime(ts_seconds * 1000 + 2500);
+
+    const result = computeElapsedTime(t0, ts_seconds, PlaybackState.PLAYING);
+    expect(result).toBeGreaterThanOrEqual(32.499);
+    expect(result).toBeLessThanOrEqual(32.501);
+  });
+
+  it("handles elapsed_time provided in milliseconds (not seconds)", () => {
+    // server sends seconds; elapsed_time in seconds
+    const t0 = 30; // seconds
+    const ts = 1_600_000_000; // seconds
+    vi.setSystemTime(ts * 1000 + 1000);
+
+    const result = computeElapsedTime(t0, ts, PlaybackState.PLAYING);
+    expect(result).toBeGreaterThanOrEqual(31.0 - 0.001);
+    expect(result).toBeLessThanOrEqual(31.0 + 0.001);
+  });
+});

--- a/src/helpers/elapsed.ts
+++ b/src/helpers/elapsed.ts
@@ -1,0 +1,41 @@
+/**
+ * computeElapsedTime
+ *
+ * Calculate the current elapsed playback time in seconds from a stored
+ * `elapsed_time` value and the `elapsed_time_last_updated` UTC timestamp
+ * (milliseconds since epoch). The function assumes:
+ *  - elapsed_time: seconds (may be fractional)
+ *  - elapsed_time_last_updated: ms since epoch (UTC)
+ *
+ * If `playbackState` is not PLAYING, the function returns the provided
+ * `elapsed_time` without applying the time-delta. This avoids advancing the
+ * position while paused/stopped.
+ */
+import { PlaybackState } from "../plugins/api/interfaces";
+
+export function computeElapsedTime(
+  elapsed_time: number | undefined,
+  elapsed_time_last_updated: number | undefined,
+  playbackState?: PlaybackState,
+): number | undefined {
+  if (elapsed_time === undefined || elapsed_time_last_updated === undefined) {
+    return elapsed_time;
+  }
+
+  // Only advance the elapsed time when the player is actually playing.
+  if (playbackState !== undefined && playbackState !== PlaybackState.PLAYING) {
+    return elapsed_time;
+  }
+  // The server sends `elapsed_time_last_updated` in seconds since epoch.
+  // Convert to milliseconds for Date.now() math.
+  const lastUpdatedMs = elapsed_time_last_updated * 1000;
+
+  const nowMs = Date.now();
+  const deltaMs = Math.max(0, nowMs - lastUpdatedMs);
+  const deltaSeconds = deltaMs / 1000;
+
+  // elapsed_time is expected to be in seconds.
+  return elapsed_time + deltaSeconds;
+}
+
+export default computeElapsedTime;

--- a/src/helpers/useMediaBrowserMetaData.ts
+++ b/src/helpers/useMediaBrowserMetaData.ts
@@ -113,7 +113,12 @@ export function useMediaBrowserMetaData(player_id?: string) {
         return;
       }
       const duration = playerQueue.value?.current_item?.duration || 1;
-      const position = Math.min(duration, playerQueue.value?.elapsed_time || 0);
+      const position = Math.min(
+        duration,
+        playerQueue.value?.elapsed_time != null
+          ? playerQueue.value?.elapsed_time
+          : 0,
+      );
       navigator.mediaSession.setPositionState({
         duration: duration,
         playbackRate: 1.0,

--- a/src/layouts/default/PlayerOSD/PlayerBrowserMediaControls.vue
+++ b/src/layouts/default/PlayerOSD/PlayerBrowserMediaControls.vue
@@ -107,8 +107,9 @@ const seekHandler = function (
     to = evt.seekTime;
   } else if (evt.action === "seekforward" || evt.action === "seekbackward") {
     const offset = evt.seekOffset || 10;
-    const elapsed_time = lastSeekPos || store.activePlayerQueue?.elapsed_time;
-    if (!elapsed_time) return;
+    const elapsed_time =
+      lastSeekPos != null ? lastSeekPos : store.activePlayerQueue?.elapsed_time;
+    if (elapsed_time == null) return;
     if (evt.action === "seekbackward") {
       to = elapsed_time - offset;
     } else {

--- a/src/layouts/default/PlayerOSD/PlayerFullscreen.vue
+++ b/src/layouts/default/PlayerOSD/PlayerFullscreen.vue
@@ -638,6 +638,7 @@ import {
   computed,
   onBeforeUnmount,
   onMounted,
+  onUnmounted,
   ref,
   watch,
   watchEffect,

--- a/src/layouts/default/PlayerOSD/PlayerTimeline.vue
+++ b/src/layouts/default/PlayerOSD/PlayerTimeline.vue
@@ -6,7 +6,10 @@
         :disabled="!canSeek"
         style="width: 100%"
         :min="0"
-        :max="store.curQueueItem?.duration"
+        :max="
+          store.curQueueItem?.duration ||
+          store.activePlayer?.current_media?.duration
+        "
         hide-details
         :track-size="4"
         :thumb-size="isThumbHidden ? 0 : 10"
@@ -63,7 +66,8 @@ import { MediaType } from "@/plugins/api/interfaces";
 import { store } from "@/plugins/store";
 import { useActiveSource } from "@/composables/activeSource";
 import { formatDuration } from "@/helpers/utils";
-import { ref, computed, watch, toRef } from "vue";
+import { ref, computed, watch, toRef, onMounted, onUnmounted } from "vue";
+import computeElapsedTime from "@/helpers/elapsed";
 
 // properties
 export interface Props {
@@ -84,20 +88,65 @@ const isThumbHidden = ref(true);
 const isDragging = ref(false);
 const curTimeValue = ref(0);
 const tempTime = ref(0);
+// ticking ref to force recompute of elapsed time (Date.now() is non-reactive)
+const nowTick = ref(0);
+let tickTimer: ReturnType<typeof setInterval> | null = null;
+
+const startTick = (interval = 500) => {
+  if (!tickTimer)
+    tickTimer = setInterval(() => (nowTick.value = Date.now()), interval);
+};
+
+const stopTick = () => {
+  if (tickTimer) {
+    clearInterval(tickTimer);
+    tickTimer = null;
+  }
+};
+
+onUnmounted(() => {
+  stopTick();
+});
 
 // computed properties
 const canSeek = computed(() => {
   // Check if active source allows seeking
-  // commented out to fix issue first with actually retrieving the elapsed time of the source
-  // if (activeSource.value) {
-  //   return activeSource.value.can_seek;
-  // }
+  if (activeSource.value) {
+    // When an active external source is present, only allow seeking if the
+    // source reports that it supports seeking (can_seek) AND the current
+    // media (or queue item) has a known duration. We also keep checks for
+    // powered state and radio streams.
+    if (store.activePlayer?.powered === false) return false;
+
+    // If queue is active prefer queue duration
+    const queueHasDuration = !!store.curQueueItem?.duration;
+    const currentMediaDuration = store.activePlayer?.current_media?.duration;
+    const currentMediaHasDuration = !!currentMediaDuration;
+
+    // Disallow seeking for radio streams
+    const isRadio =
+      store.curQueueItem?.media_item?.media_type == MediaType.RADIO ||
+      store.activePlayer?.current_media?.media_type == MediaType.RADIO;
+    if (isRadio) return false;
+
+    // If the active source reports can_seek, allow seeking when there is a
+    // duration available (either queue item or current_media).
+    if (
+      activeSource.value.can_seek &&
+      (queueHasDuration || currentMediaHasDuration)
+    )
+      return true;
+
+    return false;
+  }
 
   if (store.curQueueItem?.media_item?.media_type == MediaType.RADIO)
     return false;
   if (store.activePlayer?.powered == false) return false;
   if (!store.curQueueItem) return false;
   if (!store.curQueueItem.media_item) return false;
+  // Duration must be present and truthy (non-zero) for seeking when using the
+  // local queue. Elapsed_time may be 0, but duration of 0 isn't seekable.
   if (!store.curQueueItem.duration) return false;
 
   // Default to true if no active source (queue control)
@@ -105,31 +154,107 @@ const canSeek = computed(() => {
 });
 
 const playerCurTimeStr = computed(() => {
-  if (!store.curQueueItem) return "0:00";
-  if (showRemainingTime.value) {
-    return `-${formatDuration(
-      store.curQueueItem.duration - curQueueItemTime.value,
-    )}`;
-  } else {
+  // If there's an active queue item use its duration arithmetic
+  if (store.curQueueItem) {
+    if (showRemainingTime.value) {
+      return `-${formatDuration(
+        store.curQueueItem.duration - curQueueItemTime.value,
+      )}`;
+    }
     return `${formatDuration(curQueueItemTime.value)}`;
   }
+
+  // No queue item: prefer current_media elapsed when available
+  if (
+    store.activePlayer?.current_media?.elapsed_time != null ||
+    store.activePlayer?.elapsed_time != null
+  ) {
+    const val = curQueueItemTime.value || 0;
+    if (showRemainingTime.value && store.activePlayer?.current_media?.duration)
+      return `-${formatDuration(
+        store.activePlayer.current_media.duration - val,
+      )}`;
+    return `${formatDuration(val)}`;
+  }
+
+  return "0:00";
 });
 
 const playerTotalTimeStr = computed(() => {
-  if (!store.curQueueItem) return "";
-  if (!store.curQueueItem.duration) return "";
-  if (store.curQueueItem.media_item?.media_type == MediaType.RADIO) return "";
-  const totalSecs = store.curQueueItem.duration;
-  return formatDuration(totalSecs);
+  // Prefer queue item duration, fall back to current_media duration for external sources
+  const duration =
+    store.curQueueItem?.duration || store.activePlayer?.current_media?.duration;
+  if (!duration) return "";
+  // If radio/streaming with unknown duration, don't show
+  const isRadio =
+    store.curQueueItem?.media_item?.media_type == MediaType.RADIO ||
+    store.activePlayer?.current_media?.media_type == MediaType.RADIO;
+  if (isRadio) return "";
+  return formatDuration(duration);
 });
 
 const curQueueItemTime = computed(() => {
+  // include nowTick.value so this computed re-evaluates periodically while mounted
+  // and updates UI for fallback player-level current_media that relies on Date.now()
+  void nowTick.value;
+
+  // Adaptive tick: only run the timer when we have a playing source that relies on time progression
+  const isPlaying = store.activePlayer?.playback_state === "playing";
+  const usingQueue = !!(
+    store.activePlayerQueue && store.activePlayerQueue.active
+  );
+  const hasCurrentMedia =
+    store.activePlayer?.current_media?.elapsed_time != null;
+
+  // Start ticking when playing and either using queue or external current_media
+  if (isPlaying && (usingQueue || hasCurrentMedia)) startTick();
+  else stopTick();
   if (isDragging.value) {
     // eslint-disable-next-line vue/no-side-effects-in-computed-properties
     tempTime.value = curTimeValue.value;
     return curTimeValue.value;
   }
-  if (store.activePlayerQueue) return store.activePlayerQueue.elapsed_time;
+
+  // Prefer queue-level elapsed_time if available
+  const queue = store.activePlayerQueue;
+  if (queue?.elapsed_time != null && queue?.elapsed_time_last_updated != null) {
+    const computed = computeElapsedTime(
+      queue.elapsed_time,
+      queue.elapsed_time_last_updated,
+      store.activePlayer?.playback_state,
+    );
+    return computed ?? 0;
+  }
+
+  // Fallback to player-level elapsed_time. This is used for external/3rd-party
+  // sources currently playing on the player (not for Music Assistant queue
+  // playback). Use the player-level fields when no activePlayerQueue is set.
+  // Prefer current_media timing when available (external source playing on the player)
+  if (
+    store.activePlayer?.current_media?.elapsed_time != null &&
+    store.activePlayer?.current_media?.elapsed_time_last_updated != null
+  ) {
+    const computed = computeElapsedTime(
+      store.activePlayer.current_media.elapsed_time,
+      store.activePlayer.current_media.elapsed_time_last_updated,
+      store.activePlayer?.playback_state,
+    );
+    return computed ?? 0;
+  }
+
+  // Fall back to player-level elapsed_time (legacy / provider-level value)
+  if (
+    store.activePlayer?.elapsed_time != null &&
+    store.activePlayer?.elapsed_time_last_updated != null
+  ) {
+    const computed = computeElapsedTime(
+      store.activePlayer.elapsed_time,
+      store.activePlayer.elapsed_time_last_updated,
+      store.activePlayer?.playback_state,
+    );
+    return computed ?? 0;
+  }
+
   return 0;
 });
 

--- a/src/plugins/api/index.ts
+++ b/src/plugins/api/index.ts
@@ -1470,9 +1470,7 @@ export class MusicAssistantApi {
       this.providers = providers;
     }
     // signal + log all events
-    if (msg.event !== EventType.QUEUE_TIME_UPDATED) {
-      if (DEBUG) console.log("[event]", msg);
-    }
+    if (DEBUG) console.log("[event]", msg);
     this.signalEvent(msg);
   }
 

--- a/src/plugins/api/interfaces.ts
+++ b/src/plugins/api/interfaces.ts
@@ -788,6 +788,18 @@ export interface PlayerQueue {
   current_index?: number;
   index_in_buffer?: number;
   elapsed_time: number;
+  /**
+   * UTC timestamp (seconds since epoch) when `elapsed_time` was last updated.
+   *
+   * Semantics/units:
+   * - `elapsed_time` is expressed in seconds (number, can be fractional).
+   * - `elapsed_time_last_updated` is a UTC timestamp in seconds since epoch.
+   *   Convert to milliseconds (multiply by 1000) when comparing to Date.now().
+   *
+   * Use this timestamp to compute the current progress while playback is
+   * ongoing by adding (now - elapsed_time_last_updated*1000)/1000 to
+   * `elapsed_time`.
+   */
   elapsed_time_last_updated: number;
   state: PlaybackState;
   current_item?: QueueItem;
@@ -815,6 +827,9 @@ export interface PlayerMedia {
   album?: string; // optional
   image_url?: string; // optional
   duration?: number; // optional
+  source_id?: string; // optional
+  elapsed_time?: number; // optional
+  elapsed_time_last_updated?: number; // optional
   queue_id?: string; // only present for requests from queue controller
   queue_item_id?: string; // only present for requests from queue controller
 }


### PR DESCRIPTION
Adds support for control of a non-MA source active on a player (seek, play, pause) if the source accepts that.
Changes to the seek bar to calculate the elapsed time from the timestamp and also support both a MA queue active and a player's alternative source.