### PR TITLE
Fix validation for dropdowns when the selection value is 0

### DIFF
--- a/src/views/settings/EditConfig.vue
+++ b/src/views/settings/EditConfig.vue
@@ -197,7 +197,7 @@
                 :required="conf_entry.required"
                 :rules="[
                   (v) =>
-                    !(!v && conf_entry.required) ||
+                    !((v === null || v === undefined) && conf_entry.required) ||
                     $t('settings.invalid_input'),
                 ]"
                 variant="outlined"


### PR DESCRIPTION
  The validation rule was using a falsy check (!v) which incorrectly
  treated the integer value 0 as invalid for required fields. This
  affected sync interval dropdowns where "Disable automatic sync"
  has a value of 0.

<img width="716" height="217" alt="image" src="https://github.com/user-attachments/assets/1eef95cf-43e2-4d94-af3f-64cb49eb4851" />
