### PR TITLE
Fix login loop caused by authentication race condition

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -136,6 +136,10 @@ const handleRemoteAuthenticated = async (credentials: {
 };
 
 const handleLocalConnect = async (serverAddress: string) => {
+  if (api.state.value !== ConnectionState.DISCONNECTED) {
+    console.debug("[App] API already initialized, skipping");
+    return;
+  }
   const { authManager } = await import("@/plugins/auth");
   authManager.setBaseUrl(serverAddress);
   await api.initialize(serverAddress);
@@ -202,8 +206,12 @@ onMounted(async () => {
 
   watch(
     () => api.state.value,
-    async (newState) => {
-      if (newState === ConnectionState.CONNECTED) {
+    async (newState, oldState) => {
+      // Re-authenticate on reconnection (not initial connection - Login.vue handles that)
+      if (
+        newState === ConnectionState.CONNECTED &&
+        oldState === ConnectionState.RECONNECTING
+      ) {
         const { authManager } = await import("@/plugins/auth");
         const storedToken = authManager.getToken();
 
@@ -215,7 +223,11 @@ onMounted(async () => {
               store.currentUser = result.user;
             }
           } catch (error) {
-            console.error("[App] Auto-authentication failed:", error);
+            console.error(
+              "[App] Re-authentication after reconnect failed:",
+              error,
+            );
+            api.requireAuthentication();
           }
         } else {
           api.requireAuthentication();


### PR DESCRIPTION
Two issues were causing a login loop with "already initialized" errors:

1. Both App.vue and Login.vue were independently calling api.authenticateWithToken() when the connection state became CONNECTED, creating a race condition during initial connection
2. handleLocalConnect could be called multiple times before initialization completed, causing api.initialize() to throw "already initialized"

Solution:
- Add guard to handleLocalConnect to skip if not DISCONNECTED
- App.vue only re-authenticates on reconnection (oldState === RECONNECTING)
- Login.vue handles initial connection authentication (no race)