### PR TITLE
feat: Add Safari 15 / iOS 15 compatibility

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -4,6 +4,19 @@
  * Bootstraps Vuetify and other plugins then mounts the App`
  */
 
+// Polyfill for Safari 15 / iOS 15 (AbortSignal.timeout not supported)
+if (typeof AbortSignal !== "undefined" && !AbortSignal.timeout) {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (AbortSignal as any).timeout = (ms: number): AbortSignal => {
+    const controller = new AbortController();
+    setTimeout(
+      () => controller.abort(new DOMException("TimeoutError", "TimeoutError")),
+      ms,
+    );
+    return controller.signal;
+  };
+}
+
 // Global styles
 import "@/styles/global.css";
 

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -206,3 +206,11 @@ html {
   color: rgb(var(--v-theme-primary));
   font-weight: 800;
 }
+
+/* iOS Safari 15 scroll momentum */
+.scroll-container,
+.v-list,
+.v-navigation-drawer__content,
+.v-main__wrap {
+  -webkit-overflow-scrolling: touch;
+}


### PR DESCRIPTION
## Summary
Adds compatibility for Safari 15 and iOS 15, enabling the frontend to work on older iOS devices (e.g., iPad Air 2).

## Changes
- **Minimal `AbortSignal.timeout` polyfill** (~200 bytes) - Safari 15 doesn't support this API
- **`-webkit-overflow-scrolling: touch`** - Progressive enhancement for scroll momentum on older iOS

## Why minimal polyfill?
Previous approach used full `core-js/stable` which added 259kB to the bundle. After testing on an actual iOS 15 device, only `AbortSignal.timeout()` needed polyfilling.

## Testing
- Tested on iOS 15 Safari (iPad Air 2)
- All unit tests pass