### PR TITLE
Add flac and opus support to the Sendspin Web Player

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "@intlify/unplugin-vue-i18n": "11.0.1",
     "@mdi/font": "7.4.47",
     "@mdi/js": "7.4.47",
-    "@music-assistant/sendspin-js": "0.3.1",
+    "@music-assistant/sendspin-js": "0.4.0",
     "color": "5.0.3",
     "colorthief": "2.6.0",
     "marked": "^17.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1575,10 +1575,12 @@
   resolved "https://registry.yarnpkg.com/@mdi/js/-/js-7.4.47.tgz#7d8a4edc9631bffeed80d1ec784f9beae559a76a"
   integrity sha512-KPnNOtm5i2pMabqZxpUz7iQf+mfrYZyKCZ8QNz85czgEt7cuHcGorWfdzUMWYA0SD+a6Hn4FmJ+YhzzzjkTZrQ==
 
-"@music-assistant/sendspin-js@0.3.1":
-  version "0.3.1"
-  resolved "https://registry.yarnpkg.com/@music-assistant/sendspin-js/-/sendspin-js-0.3.1.tgz#50bfd90554720f66edabe697c19030f8fc040c42"
-  integrity sha512-R5F+FZ9qBcoMi3U/aH4Kp52H/4yRB/GZrantZgTzbEGTdwsrlECHLP/xo05Cc+X4sladaEc3GiYyPFaYPNy1cg==
+"@music-assistant/sendspin-js@0.4.0":
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/@music-assistant/sendspin-js/-/sendspin-js-0.4.0.tgz#b025622a6d0967a3b43ac86a8487dc3168924594"
+  integrity sha512-S84xxovPn5Ml8VNy3YZJgffIouK00f4OC/OfcGLYJ2iYq5KGG/GtHkk2FNtmxLG0c51QS3Wspg1HgQW3lmH5tA==
+  dependencies:
+    opus-encdec "^0.1.1"
 
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"
@@ -5061,6 +5063,11 @@ optionator@^0.9.3:
     prelude-ls "^1.2.1"
     type-check "^0.4.0"
     word-wrap "^1.2.5"
+
+opus-encdec@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/opus-encdec/-/opus-encdec-0.1.1.tgz#8b6f9ccbb2e97bc0ae0dac2966111937b6aedcf9"
+  integrity sha512-TDzyGqYqrwn5UEUNaLsfLGu8Ma+HRNrgLYj7Vx5wfTnafAA21G6Bnm/qTIa3orQi/yZPZYmkdpO/gez4nfA1Rw==
 
 p-limit@^3.0.2:
   version "3.1.0"


### PR DESCRIPTION
## Summary

With this PR, the web player no longer uses PCM. The new codec selection depends on connection type:

- **Remote connections** (via Home Assistant or https://app.music-assistant.io/) → **Opus** over WebRTC
- **Local connections** (when on the same network as Music Assistant, or direct access on port 8095) → **FLAC** where supported, otherwise Opus

Due to browser compatibility constraints and API limitations, the actual codec used varies by browser and platform, see tables below.

---

## Codec Support by Connection Type

### Remote (WebRTC)

| Browser          | Platform                   | Codec           |
|------------------|----------------------------|-----------------|
| Chromium-based   | All                        | Opus            |
| Safari           | All                        | Opus            |
| Firefox          | Linux / macOS / Windows    | Opus            |
| Firefox          | iOS / iPadOS               | Opus            |
| Firefox          | Android                    | ❌ Not supported |

### Local

| Browser          | Platform                        | Codec |
|------------------|---------------------------------|-------|
| Chromium-based   | Linux / macOS / Windows / Android | FLAC  |
| Chromium-based   | iOS / iPadOS                    | Opus  |
| Safari           | All                             | Opus  |
| Firefox          | Linux / macOS / Windows / Android | FLAC  |
| Firefox          | iOS / iPadOS                    | Opus  |