### PR TITLE
Hide unavailable Sendspin web players from settings

### DIFF
--- a/src/components/PlayerFilters.vue
+++ b/src/components/PlayerFilters.vue
@@ -104,12 +104,7 @@ let typesDebounceTimeout: ReturnType<typeof setTimeout> | null = null;
 
 const availableProviders = computed(() => {
   const providers = Object.values(api.providers)
-    .filter(
-      (x) =>
-        x.available &&
-        x.type === ProviderType.PLAYER &&
-        x.domain !== "builtin_player",
-    )
+    .filter((x) => x.available && x.type === ProviderType.PLAYER)
     .map((x) => ({
       instance_id: x.instance_id,
       domain: x.domain,

--- a/src/helpers/utils.ts
+++ b/src/helpers/utils.ts
@@ -692,11 +692,10 @@ export const getSendspinDefaultSyncDelay = function (): number {
 
 /**
  * Check if a player config should be hidden from settings due to being a
- * web player that is currently unavailable.
+ * Sendspin web player that is currently unavailable.
  *
- * This prevents users from being confused by non-functional players.
- * We don't just hide them in general, since a core feature is grouping them
- * with other Sendspin players.
+ * This prevents users from being confused by a lot of auto-generated players
+ * in the Players and Providers settings pages.
  */
 export const isHiddenSendspinWebPlayer = function (
   playerConfig: PlayerConfig,

--- a/src/helpers/utils.ts
+++ b/src/helpers/utils.ts
@@ -7,6 +7,7 @@ import {
   MediaItemTypeOrItemMapping,
   MediaType,
   Player,
+  PlayerConfig,
   PlaybackState,
   PlayerType,
   ProviderMapping,
@@ -687,4 +688,29 @@ export const getSendspinDefaultSyncDelay = function (): number {
   }
   // Android, Firefox (desktop/mobile)
   return -200;
+};
+
+/**
+ * Check if a player config should be hidden from settings due to being a
+ * web player that is currently unavailable.
+ *
+ * This prevents users from being confused by non-functional players.
+ * We don't just hide them in general, since a core feature is grouping them
+ * with other Sendspin players.
+ */
+export const isHiddenSendspinWebPlayer = function (
+  playerConfig: PlayerConfig,
+): boolean {
+  if (playerConfig.provider !== "sendspin") return false;
+
+  const name = playerConfig.default_name || "";
+  if (
+    !name.startsWith("Music Assistant (") && // PWA app
+    !name.startsWith("Music Assistant Web (") // Regular web interface
+  ) {
+    return false;
+  }
+
+  const player = api.players[playerConfig.player_id];
+  return !player?.available;
 };

--- a/src/views/settings/Players.vue
+++ b/src/views/settings/Players.vue
@@ -202,7 +202,21 @@ const providersWithCreateGroupSupport = computed(() => {
 // methods
 const loadItems = async function () {
   playerConfigs.value = (await api.getPlayerConfigs())
-    .filter((x) => x.provider != "builtin_player")
+    .filter((x) => {
+      // Hide unavailable Sendspin web players
+      if (x.provider === "sendspin") {
+        const name = x.default_name || "";
+        if (
+          name.startsWith("Music Assistant (") ||
+          name.startsWith("Music Assistant Web (")
+        ) {
+          const player = api.players[x.player_id];
+          return player?.available ?? false;
+        }
+      }
+
+      return true;
+    })
     .sort((a, b) => getPlayerName(a).localeCompare(getPlayerName(b)));
 };
 

--- a/src/views/settings/Players.vue
+++ b/src/views/settings/Players.vue
@@ -144,7 +144,7 @@ import PlayerFilters from "@/components/PlayerFilters.vue";
 import ProviderIcon from "@/components/ProviderIcon.vue";
 import SettingsPlayerCard from "@/components/SettingsPlayerCard.vue";
 import { SYNCGROUP_PREFIX } from "@/constants";
-import { openLinkInNewTab } from "@/helpers/utils";
+import { isHiddenSendspinWebPlayer, openLinkInNewTab } from "@/helpers/utils";
 import { ContextMenuItem } from "@/layouts/default/ItemContextMenu.vue";
 import { api } from "@/plugins/api";
 import {
@@ -202,21 +202,7 @@ const providersWithCreateGroupSupport = computed(() => {
 // methods
 const loadItems = async function () {
   playerConfigs.value = (await api.getPlayerConfigs())
-    .filter((x) => {
-      // Hide unavailable Sendspin web players
-      if (x.provider === "sendspin") {
-        const name = x.default_name || "";
-        if (
-          name.startsWith("Music Assistant (") ||
-          name.startsWith("Music Assistant Web (")
-        ) {
-          const player = api.players[x.player_id];
-          return player?.available ?? false;
-        }
-      }
-
-      return true;
-    })
+    .filter((x) => !isHiddenSendspinWebPlayer(x))
     .sort((a, b) => getPlayerName(a).localeCompare(getPlayerName(b)));
 };
 

--- a/src/views/settings/Providers.vue
+++ b/src/views/settings/Providers.vue
@@ -373,7 +373,7 @@ import Container from "@/components/Container.vue";
 import ListItem from "@/components/ListItem.vue";
 import ProviderFilters from "@/components/ProviderFilters.vue";
 import ProviderIcon from "@/components/ProviderIcon.vue";
-import { openLinkInNewTab } from "@/helpers/utils";
+import { isHiddenSendspinWebPlayer, openLinkInNewTab } from "@/helpers/utils";
 import { api } from "@/plugins/api";
 import {
   EventType,
@@ -469,17 +469,7 @@ const getPlayerCount = function (providerConfig: ProviderConfig): number {
   if (!providerInstance) return 0;
 
   return playerConfigs.value.filter((playerConfig) => {
-    // Hide unavailable Sendspin web players
-    if (playerConfig.provider === "sendspin") {
-      const name = playerConfig.default_name || "";
-      if (
-        name.startsWith("Music Assistant (") ||
-        name.startsWith("Music Assistant Web (")
-      ) {
-        const player = api.players[playerConfig.player_id];
-        if (!player?.available) return false;
-      }
-    }
+    if (isHiddenSendspinWebPlayer(playerConfig)) return false;
 
     const playerProviderInstance = api.getProvider(playerConfig.provider);
     return (

--- a/src/views/settings/Providers.vue
+++ b/src/views/settings/Providers.vue
@@ -469,7 +469,18 @@ const getPlayerCount = function (providerConfig: ProviderConfig): number {
   if (!providerInstance) return 0;
 
   return playerConfigs.value.filter((playerConfig) => {
-    if (playerConfig.provider === "builtin_player") return false;
+    // Hide unavailable Sendspin web players
+    if (playerConfig.provider === "sendspin") {
+      const name = playerConfig.default_name || "";
+      if (
+        name.startsWith("Music Assistant (") ||
+        name.startsWith("Music Assistant Web (")
+      ) {
+        const player = api.players[playerConfig.player_id];
+        if (!player?.available) return false;
+      }
+    }
+
     const playerProviderInstance = api.getProvider(playerConfig.provider);
     return (
       playerProviderInstance?.instance_id === providerInstance.instance_id ||


### PR DESCRIPTION
Hide unavailable Sendspin web players from settings

This prevents users from being confused by a lot of auto generated players
in the Players and Providers settings pages.

This functions similarly to how builtin web players were hidden before the switch to Sendspin.