### PR TITLE
Add unsaved settings guard

### DIFF
--- a/src/views/settings/ConfigEntryField.vue
+++ b/src/views/settings/ConfigEntryField.vue
@@ -286,8 +286,12 @@ const onUpdateValue = (value: ConfigValueType) => {
 };
 
 const onClear = () => {
-  // Explicitly emit the default value when clear button is clicked
-  emit("update:value", props.confEntry.default_value);
+  // If the field is required, restore the default value; otherwise set to null
+  if (props.confEntry.required) {
+    emit("update:value", props.confEntry.default_value);
+  } else {
+    emit("update:value", null);
+  }
 };
 
 const translatedOptions = computed(() => {


### PR DESCRIPTION
Show a confirmation to the user when there are unsaved changes to settings and you either click the close button or try to navigate away from the settings page