### PR TITLE
Sanitize sdp

### DIFF
--- a/src/plugins/remote/crypto-utils.ts
+++ b/src/plugins/remote/crypto-utils.ts
@@ -40,7 +40,7 @@ export function verifyAndSanitizeSdp(
 
   // Remove all non-SHA-256 fingerprints from SDP to prevent algorithm substitution attacks
   // The browser might prefer sha-384/sha-512 which we cannot verify
-  const sanitizedSdp = sdp.replace(/^a=fingerprint:(?!sha-256).*$/gim, "");
+  const sanitizedSdp = sdp.replace(/^a=fingerprint:(?!sha-256).*\r?\n?/gim, "");
 
   // Extract ALL SHA-256 fingerprints from the sanitized SDP
   const allSha256Matches = [


### PR DESCRIPTION
This pull request strengthens the security of SDP fingerprint verification in the WebRTC transport layer by updating the verification logic to handle multiple fingerprints, sanitize the SDP, and ensure all fingerprints match the expected remote ID.

**Security improvements to SDP fingerprint verification:**

* Replaces the old `verifySdpFingerprint` function with a new `verifyAndSanitizeSdp` function in `crypto-utils.ts`, which:
  - Verifies all SHA-256 fingerprints in the SDP (not just the first one).
  - Sanitizes the SDP by removing non-SHA-256 fingerprints to prevent algorithm substitution attacks.
  - Throws errors for empty SDP, missing fingerprints, or mismatches, and returns the sanitized SDP.

* Updates `webrtc-transport.ts` to use `verifyAndSanitizeSdp` instead of the old verification method, ensuring only sanitized, verified SDPs are used.