### PR TITLE
Various small usability fixes

### DIFF
--- a/src/components/ItemsListing.vue
+++ b/src/components/ItemsListing.vue
@@ -37,13 +37,6 @@
       :variant="viewMode == 'list' ? 'default' : 'panel'"
       style="overflow: hidden"
     >
-      <v-progress-linear
-        v-if="loading"
-        color="accent"
-        height="4"
-        indeterminate
-        rounded
-      />
       <v-infinite-scroll
         v-if="!tempHide && !(pagedItems.length == 0 && allItemsReceived)"
         :onLoad="loadNextPage"

--- a/src/components/ListviewItem.vue
+++ b/src/components/ListviewItem.vue
@@ -19,29 +19,8 @@
           "
         />
       </div>
-      <div
-        v-else
-        class="media-thumb listitem-media-thumb"
-        @mouseenter="showPlayBtn = true"
-        @mouseleave="showPlayBtn = false"
-      >
+      <div v-else class="media-thumb listitem-media-thumb">
         <MediaItemThumb size="50" :item="isAvailable ? item : undefined" />
-        <!-- play button -->
-        <div
-          v-if="(showPlayBtn || store.isTouchscreen) && item.is_playable"
-          class="play-button-overlay"
-        >
-          <v-btn
-            icon="mdi-play"
-            color="white"
-            fab
-            size="x-small"
-            style="opacity: 0.6"
-            @click.stop="onPlayClick"
-          >
-            <v-icon size="26" style="margin-left: 3px">mdi-play</v-icon>
-          </v-btn>
-        </div>
       </div>
     </template>
 
@@ -221,6 +200,17 @@
           >
         </div>
       </div>
+
+      <!-- play button -->
+      <v-btn
+        v-if="item.is_playable && (showPlayButton ?? !$vuetify.display.mobile)"
+        icon
+        variant="text"
+        size="small"
+        @click.stop="onPlayClick"
+      >
+        <v-icon size="24">mdi-play-circle-outline</v-icon>
+      </v-btn>
     </template>
   </ListItem>
 </template>
@@ -247,8 +237,7 @@ import {
   type MediaItemType,
 } from "@/plugins/api/interfaces";
 import { getBreakpointValue } from "@/plugins/breakpoint";
-import { store } from "@/plugins/store";
-import { computed, ref } from "vue";
+import { computed } from "vue";
 import { useI18n } from "vue-i18n";
 import { VTooltip } from "vuetify/components";
 import MediaItemThumb from "./MediaItemThumb.vue";
@@ -272,12 +261,12 @@ export interface Props {
   isPlaying?: boolean;
   showCheckboxes?: boolean;
   showDetails?: boolean;
+  showPlayButton?: boolean;
   parentItem?: MediaItemType;
 }
 
 // global refs
 const { t } = useI18n();
-const showPlayBtn = ref(false);
 
 const compProps = withDefaults(defineProps<Props>(), {
   showTrackNumber: true,
@@ -289,6 +278,7 @@ const compProps = withDefaults(defineProps<Props>(), {
   showFavorite: false,
   showDuration: true,
   showCheckboxes: false,
+  showPlayButton: undefined,
   isDisabled: false,
   isAvailable: true,
   parentItem: undefined,
@@ -369,22 +359,6 @@ const onPlayClick = function (evt: PointerEvent) {
 
 .hidden {
   opacity: 0;
-}
-
-.play-button-overlay {
-  position: absolute;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  pointer-events: none;
-
-  .v-btn {
-    pointer-events: all;
-  }
 }
 
 .hiresicon {

--- a/src/components/Toolbar.vue
+++ b/src/components/Toolbar.vue
@@ -33,11 +33,7 @@
     </template>
     <template v-else-if="menuItems?.length" #append>
       <v-progress-circular
-        v-if="
-          showLoading &&
-          (api.fetchesInProgress.value.length > 0 ||
-            api.syncTasks.value.length > 0)
-        "
+        v-if="showLoading && api.syncTasks.value.length > 0"
         color="primary"
         indeterminate
         :title="$t('tooltip.loading')"

--- a/src/helpers/utils.ts
+++ b/src/helpers/utils.ts
@@ -750,14 +750,7 @@ export const handlePlayBtnClick = function (
   forceMenu?: boolean,
 ) {
   // we show the play menu for the item once
-  if (
-    !forceMenu &&
-    store.playMenuShown &&
-    store.activePlayer?.available &&
-    [PlaybackState.PLAYING, PlaybackState.PAUSED].includes(
-      store.activePlayer?.playback_state as PlaybackState,
-    )
-  ) {
+  if (!forceMenu && store.playerTipShown && store.activePlayer?.available) {
     store.playActionInProgress = true;
     api.playMedia(item).then(() => {
       store.playActionInProgress = false;

--- a/src/layouts/default/PlayerOSD/PlayerControlBtn/SpeakerBtn.vue
+++ b/src/layouts/default/PlayerOSD/PlayerControlBtn/SpeakerBtn.vue
@@ -1,35 +1,189 @@
 <template>
   <!-- active player -->
-  <Button
-    variant="icon"
-    :ripple="false"
-    icon
-    @click="store.showPlayersMenu = true"
-  >
-    <v-icon
-      :color="color ? color : ''"
-      :size="24"
-      :icon="
-        store.activePlayer?.group_members.length
-          ? 'mdi-speaker-multiple'
-          : 'mdi-speaker'
-      "
-    />
-  </Button>
+  <Popover v-model:open="showTip">
+    <PopoverTrigger as-child>
+      <Button variant="icon" :ripple="false" icon @click="openPlayersMenu">
+        <v-icon
+          :color="color ? color : ''"
+          :size="24"
+          :icon="
+            store.activePlayer?.group_members.length
+              ? 'mdi-speaker-multiple'
+              : 'mdi-speaker'
+          "
+        />
+      </Button>
+    </PopoverTrigger>
+    <PopoverContent
+      side="top"
+      :side-offset="8"
+      class="player-tip"
+      @pointer-down-outside="dismissTip"
+      @escape-key-down="dismissTip"
+      @focus-outside="dismissTip"
+    >
+      <div class="tip-content">
+        <div class="tip-label">
+          {{
+            isPlaying
+              ? $t("player_tip.currently_playing")
+              : $t("player_tip.selected_player")
+          }}
+        </div>
+        <div class="tip-player-name">{{ store.activePlayer?.name }}</div>
+        <div class="tip-hint">{{ $t("player_tip.click_to_change") }}</div>
+      </div>
+      <div class="tip-arrow"></div>
+    </PopoverContent>
+  </Popover>
 </template>
 
 <script setup lang="ts">
+import { computed, onMounted, onUnmounted, ref, watch } from "vue";
 import Button from "@/components/Button.vue";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
 import { store } from "@/plugins/store";
+import { webPlayer } from "@/plugins/web_player";
+import { PlaybackState } from "@/plugins/api/interfaces";
 
-// properties
 export interface Props {
   color?: string;
 }
 defineProps<Props>();
+
+const showTip = ref(false);
+let tipWasShown = false;
+
+const isPlaying = computed(() => {
+  return (
+    store.activePlayer?.playback_state === PlaybackState.PLAYING ||
+    store.activePlayer?.playback_state === PlaybackState.PAUSED
+  );
+});
+
+const shouldShowTip = computed(() => {
+  if (tipWasShown || store.playerTipShown) return false;
+  if (!store.activePlayer) return false;
+  if (store.activePlayerId === webPlayer.player_id) return false;
+  return true;
+});
+
+function dismissTip() {
+  showTip.value = false;
+  tipWasShown = true;
+  store.playerTipShown = true;
+}
+
+function openPlayersMenu() {
+  dismissTip();
+  store.showPlayersMenu = true;
+}
+
+function handleGlobalClick() {
+  if (showTip.value) {
+    dismissTip();
+  }
+}
+
+onMounted(() => {
+  if (store.playerTipShown) {
+    tipWasShown = true;
+    return;
+  }
+
+  setTimeout(() => {
+    if (shouldShowTip.value) {
+      showTip.value = true;
+      document.addEventListener("click", handleGlobalClick, { capture: true });
+    }
+  }, 1000);
+});
+
+onUnmounted(() => {
+  document.removeEventListener("click", handleGlobalClick, { capture: true });
+});
+
+watch(
+  () => store.playerTipShown,
+  (newVal) => {
+    if (newVal && showTip.value) {
+      showTip.value = false;
+      tipWasShown = true;
+    }
+  },
+);
+
+watch(showTip, (newVal, oldVal) => {
+  if (oldVal && !newVal) {
+    tipWasShown = true;
+    store.playerTipShown = true;
+  }
+});
 </script>
 
 <style>
+/* Player tip popover - global styles needed because PopoverContent renders in a portal */
+.player-tip {
+  width: auto !important;
+  max-width: 250px;
+  padding: 12px 16px !important;
+  text-align: center;
+  background: rgb(var(--v-theme-surface)) !important;
+  border: 1px solid rgb(var(--v-theme-primary)) !important;
+  z-index: 99999 !important;
+}
+
+.player-tip .tip-content {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.player-tip .tip-label {
+  font-size: 0.75rem;
+  opacity: 0.8;
+}
+
+.player-tip .tip-player-name {
+  font-weight: 600;
+  font-size: 0.95rem;
+  color: rgb(var(--v-theme-primary));
+}
+
+.player-tip .tip-hint {
+  font-size: 0.7rem;
+  opacity: 0.7;
+  margin-top: 4px;
+}
+
+.player-tip .tip-arrow {
+  position: absolute;
+  bottom: -7px;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 0;
+  height: 0;
+  border-left: 8px solid transparent;
+  border-right: 8px solid transparent;
+  border-top: 8px solid rgb(var(--v-theme-primary));
+}
+
+.player-tip .tip-arrow::after {
+  content: "";
+  position: absolute;
+  top: -9px;
+  left: -6px;
+  width: 0;
+  height: 0;
+  border-left: 6px solid transparent;
+  border-right: 6px solid transparent;
+  border-top: 6px solid rgb(var(--v-theme-surface));
+}
+
 .no_transform {
   text-transform: none;
 }

--- a/src/plugins/store.ts
+++ b/src/plugins/store.ts
@@ -49,7 +49,6 @@ interface Store {
   libraryPodcastsCount?: number;
   libraryAudiobooksCount?: number;
   isTouchscreen: boolean;
-  playMenuShown: boolean;
   playerTipShown: boolean;
   playActionInProgress: boolean;
   deviceType: DeviceType;

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -57,6 +57,11 @@
     "play_on": "Play on: {0}",
     "play_playlist_from": "Play Playlist from here",
     "play_radio": "Start Radio",
+    "player_tip": {
+        "selected_player": "Selected player",
+        "currently_playing": "Currently playing on",
+        "click_to_change": "Click below to change output device"
+    },
     "player_type": {
         "group": "Group",
         "player": "Player",
@@ -764,6 +769,7 @@
     "radiobrowser_by_tag": "By tag",
     "load_more_items": "Load more items...",
     "radio": "Radio",
+    "more_options": "More options",
     "muted": "muted",
     "enter_name": "Enter a new (custom) name",
     "image_url": "Input the URL to an image or icon (optional)",


### PR DESCRIPTION
Based on the feedback on discord, some usability/QoL improvements.
To be tested in the beta, awaiting beta feedback

- Show Popover for current active player at startup
- Show play actions first in contextmenu
- Remove duplicate loading spinner
- Show dedicated play button in list view (instead of overlay on thumb)
- Play radio/track on click immediately
- Only show spinner in top bar for syncs in progress