### PR TITLE
Refacto players and providers settings screen

### DIFF
--- a/src/components/FacetedFilter.vue
+++ b/src/components/FacetedFilter.vue
@@ -1,0 +1,196 @@
+<template>
+  <Popover>
+    <PopoverTrigger as-child>
+      <Button variant="outline" class="border-dashed">
+        <PlusCircle class="h-4 w-4" />
+        {{ title }}
+        <template v-if="selectedCount > 0">
+          <Separator orientation="vertical" class="mx-2 h-4" />
+          <Badge class="lg:hidden font-medium rounded-[6px]">
+            {{ selectedCount }}
+          </Badge>
+          <div class="hidden space-x-1 lg:flex">
+            <Badge v-if="selectedCount > 2" class="rounded-[6px] gap-2">
+              {{ selectedCount }} selected
+              <button
+                type="button"
+                class="flex items-center justify-center cursor-pointer hover:opacity-70"
+                @click.stop="clear"
+              >
+                <X class="size-2.5" />
+              </button>
+            </Badge>
+            <template v-else>
+              <Badge
+                v-for="opt in selectedOptionLabels"
+                :key="opt.value"
+                class="font-medium rounded-[6px] gap-2"
+              >
+                {{ opt.label }}
+                <button
+                  type="button"
+                  class="flex items-center justify-center cursor-pointer hover:opacity-70"
+                  @click.stop="removeFilter(opt.value)"
+                >
+                  <X class="size-2.5" />
+                </button>
+              </Badge>
+            </template>
+          </div>
+        </template>
+      </Button>
+    </PopoverTrigger>
+    <PopoverContent class="w-[220px] p-0" align="start">
+      <div class="faceted-filter-content">
+        <Input v-model="search" :placeholder="title" class="mb-2 h-8" />
+        <div class="faceted-filter-list">
+          <label
+            v-for="option in filteredOptions"
+            :key="`${option.value}-${selectedSet.has(option.value)}`"
+            class="faceted-filter-item"
+          >
+            <Checkbox
+              :checked="selectedSet.has(option.value)"
+              :default-value="selectedSet.has(option.value)"
+              class="mr-2"
+              @click.stop="toggle(option.value)"
+            />
+            <span
+              class="truncate cursor-pointer"
+              @click.stop="toggle(option.value)"
+            >
+              {{ option.label }}
+            </span>
+          </label>
+        </div>
+        <button
+          v-if="selectedCount > 0"
+          type="button"
+          class="faceted-filter-clear"
+          @click="clear"
+        >
+          Clear filters
+        </button>
+      </div>
+    </PopoverContent>
+  </Popover>
+</template>
+
+<script setup lang="ts">
+import { PlusCircle, X } from "lucide-vue-next";
+import type { HTMLAttributes } from "vue";
+import { computed, ref } from "vue";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Input } from "@/components/ui/input";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import { Separator } from "@/components/ui/separator";
+
+interface FacetedOption {
+  label: string;
+  value: string;
+}
+
+const props = defineProps<{
+  title: string;
+  options: FacetedOption[];
+  modelValue: string[];
+  class?: HTMLAttributes["class"];
+}>();
+
+const emit = defineEmits<{
+  (e: "update:modelValue", value: string[]): void;
+}>();
+
+const search = ref("");
+
+const selectedSet = computed(() => new Set(props.modelValue || []));
+
+const selectedCount = computed(() => selectedSet.value.size);
+
+const selectedOptionLabels = computed(() =>
+  props.options.filter((opt) => selectedSet.value.has(opt.value)),
+);
+
+const filteredOptions = computed(() => {
+  const term = search.value.toLowerCase().trim();
+  if (!term) return props.options;
+  return props.options.filter((opt) => opt.label.toLowerCase().includes(term));
+});
+
+const toggle = (value: string) => {
+  const next = new Set(selectedSet.value);
+  if (next.has(value)) {
+    next.delete(value);
+  } else {
+    next.add(value);
+  }
+  emit("update:modelValue", Array.from(next));
+};
+
+const removeFilter = (value: string) => {
+  const next = new Set(selectedSet.value);
+  next.delete(value);
+  emit("update:modelValue", Array.from(next));
+};
+
+const clear = () => {
+  emit("update:modelValue", []);
+};
+</script>
+
+<style scoped>
+.faceted-filter-content {
+  padding: 8px 10px 10px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.faceted-filter-list {
+  max-height: 260px;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.faceted-filter-item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  padding: 4px 6px;
+  border-radius: 4px;
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  text-align: left;
+}
+
+.faceted-filter-item:hover {
+  background-color: rgba(var(--v-theme-on-surface), 0.04);
+}
+
+.faceted-filter-clear {
+  margin-top: 4px;
+  width: 100%;
+  padding: 4px 6px;
+  font-size: 0.8rem;
+  border-radius: 4px;
+  border: none;
+  background: transparent;
+  color: rgba(var(--v-theme-on-surface), 0.7);
+  cursor: pointer;
+}
+
+.faceted-filter-clear:hover {
+  background-color: rgba(var(--v-theme-on-surface), 0.04);
+}
+</style>

--- a/src/components/PlayerFilters.vue
+++ b/src/components/PlayerFilters.vue
@@ -1,93 +1,38 @@
 <template>
   <div class="filters-container">
-    <v-text-field
-      v-model="searchQuery"
-      prepend-inner-icon="mdi-magnify"
-      :label="$t('search')"
-      variant="outlined"
-      density="compact"
-      clearable
-      hide-details
-      class="search-field"
-    />
+    <InputGroup class="search-field">
+      <InputGroupInput v-model="searchQuery" :placeholder="$t('search')" />
+      <InputGroupAddon>
+        <Search />
+      </InputGroupAddon>
+    </InputGroup>
     <div class="d-flex ga-2 filter-buttons">
-      <v-btn
-        height="40"
-        elevation="0"
-        variant="outlined"
-        density="compact"
-        class="filter-btn"
-      >
-        {{ $t("settings.player_provider") }}
-        <v-icon end>mdi-chevron-down</v-icon>
-        <span v-if="hasActiveProviders" class="filter-dot"></span>
-        <v-menu activator="parent" :close-on-content-click="false">
-          <v-list class="provider-filter-list">
-            <v-list-item
-              v-for="provider in availableProviders"
-              :key="provider.instance_id"
-              :value="provider.instance_id"
-              @click="toggleProvider(provider.instance_id)"
-            >
-              <template #prepend>
-                <provider-icon
-                  :domain="provider.domain"
-                  :size="26"
-                  class="media-thumb"
-                  style="margin-right: 12px"
-                />
-              </template>
-              <template #append>
-                <v-checkbox-btn
-                  :model-value="
-                    selectedProviders.includes(provider.instance_id)
-                  "
-                  @click.stop="toggleProvider(provider.instance_id)"
-                />
-              </template>
-              <v-list-item-title>{{ provider.name }}</v-list-item-title>
-            </v-list-item>
-          </v-list>
-        </v-menu>
-      </v-btn>
-      <v-btn
-        height="40"
-        elevation="0"
-        variant="outlined"
-        density="compact"
-        class="filter-btn"
-      >
-        {{ $t("settings.player_type_label") }}
-        <v-icon end>mdi-chevron-down</v-icon>
-        <span v-if="hasActivePlayerTypes" class="filter-dot"></span>
-        <v-menu activator="parent" :close-on-content-click="false">
-          <v-list>
-            <v-list-item
-              v-for="(playerType, index) in playerTypes"
-              :key="index"
-              :value="index"
-              @click="togglePlayerType(playerType.value)"
-            >
-              <template #append>
-                <v-checkbox-btn
-                  :model-value="selectedPlayerTypes.includes(playerType.value)"
-                  @click.stop="togglePlayerType(playerType.value)"
-                />
-              </template>
-              <v-list-item-title>{{ playerType.title }}</v-list-item-title>
-            </v-list-item>
-          </v-list>
-        </v-menu>
-      </v-btn>
+      <FacetedFilter
+        v-model="selectedProviders"
+        :title="$t('settings.player_provider')"
+        :options="providerOptions"
+      />
+      <FacetedFilter
+        v-model="selectedPlayerTypes"
+        :title="$t('settings.player_type_label')"
+        :options="playerTypeOptions"
+      />
     </div>
   </div>
 </template>
 
 <script setup lang="ts">
+import FacetedFilter from "@/components/FacetedFilter.vue";
 import ProviderIcon from "@/components/ProviderIcon.vue";
+import {
+  InputGroup,
+  InputGroupAddon,
+  InputGroupInput,
+} from "@/components/ui/input-group";
 import { api } from "@/plugins/api";
 import { PlayerType, ProviderType } from "@/plugins/api/interfaces";
 import { $t } from "@/plugins/i18n";
+import { Search } from "lucide-vue-next";
 import { computed, ref, watch } from "vue";
 import { useRoute, useRouter } from "vue-router";
 
@@ -120,9 +65,20 @@ const playerTypes = computed(() => [
   { title: $t("player_type.stereo_pair"), value: PlayerType.STEREO_PAIR },
 ]);
 
-const hasActiveProviders = computed(() => selectedProviders.value.length > 0);
-const hasActivePlayerTypes = computed(
-  () => selectedPlayerTypes.value.length > 0,
+const providerOptions = computed(() =>
+  availableProviders.value.map((p) => ({
+    label: p.name,
+    value: p.instance_id,
+    icon: ProviderIcon,
+    domain: p.domain,
+  })),
+);
+
+const playerTypeOptions = computed(() =>
+  playerTypes.value.map((p) => ({
+    label: p.title,
+    value: p.value,
+  })),
 );
 
 // Emits

--- a/src/components/navigation/AppSidebar.vue
+++ b/src/components/navigation/AppSidebar.vue
@@ -12,7 +12,6 @@ import { computed } from "vue";
 import { useI18n } from "vue-i18n";
 import { useRouter } from "vue-router";
 import { getMenuItems } from "./utils/getMenuItems";
-import { useSidebar } from "@/components/ui/sidebar/utils";
 
 const router = useRouter();
 const { t } = useI18n();
@@ -28,15 +27,13 @@ const navItems = computed(() => {
       icon: item.icon,
     }));
 });
-
-const { toggleSidebar } = useSidebar();
 </script>
 
 <template>
   <Sidebar collapsible="icon">
     <SidebarHeader>
       <SidebarMenu>
-        <div class="sidebar-header" @click="toggleSidebar">
+        <div class="sidebar-header" @click="router.push('/')">
           <img
             src="@/assets/icon.svg"
             alt="Music Assistant"

--- a/src/components/ui/button/index.ts
+++ b/src/components/ui/button/index.ts
@@ -24,6 +24,7 @@ export const buttonVariants = cva(
         sm: "h-8 rounded-md gap-1.5 px-3 has-[>svg]:px-2.5",
         lg: "h-10 rounded-md px-6 has-[>svg]:px-4",
         icon: "size-9",
+        "icon-xs": "size-2",
         "icon-sm": "size-8",
         "icon-lg": "size-10",
       },

--- a/src/components/ui/input-group/InputGroupInput.vue
+++ b/src/components/ui/input-group/InputGroupInput.vue
@@ -1,15 +1,23 @@
 <script setup lang="ts">
-import type { HTMLAttributes } from "vue";
-import { cn } from "@/lib/utils";
 import { Input } from "@/components/ui/input";
+import { cn } from "@/lib/utils";
+import type { HTMLAttributes } from "vue";
+import { useAttrs } from "vue";
+
+defineOptions({
+  inheritAttrs: false,
+});
 
 const props = defineProps<{
   class?: HTMLAttributes["class"];
 }>();
+
+const attrs = useAttrs();
 </script>
 
 <template>
   <Input
+    v-bind="attrs"
     data-slot="input-group-control"
     :class="
       cn(

--- a/src/translations/en_GB.json
+++ b/src/translations/en_GB.json
@@ -144,7 +144,7 @@
         "download_log": "Download logfile",
         "edit_group_members": "Edit group members",
         "add_new_provider_button": "Add {0} provider",
-        "add_group_player": "Add group player",
+        "add_group_player": "Add player group",
         "group_members": "Group members",
         "log_level": {
             "label": "Log level",

--- a/src/views/settings/AddPlayerGroupDialog.vue
+++ b/src/views/settings/AddPlayerGroupDialog.vue
@@ -1,79 +1,62 @@
 <template>
-  <v-dialog
-    :model-value="show"
-    max-width="800px"
-    scrollable
-    @update:model-value="
-      (v) => {
-        store.dialogActive = v;
-        emit('update:show', v);
-      }
-    "
-  >
-    <v-card class="add-player-group-dialog">
-      <v-card-title class="d-flex align-center justify-space-between pa-4">
-        <span class="text-h6">{{ $t("settings.add_group_player") }}</span>
-        <v-btn icon="mdi-close" variant="text" size="small" @click="close" />
-      </v-card-title>
+  <Dialog :open="show" @update:open="handleOpenChange">
+    <DialogContent
+      class="add-player-group-dialog max-w-[800px] h-[60vh] max-h-[60vh] flex flex-col p-0"
+    >
+      <DialogHeader class="px-6 pt-4 pb-4 flex-shrink-0">
+        <DialogTitle>{{ $t("settings.add_group_player") }}</DialogTitle>
+      </DialogHeader>
 
-      <v-card-text class="pa-4">
-        <div class="provider-list-container">
-          <v-list v-if="availableProviders.length > 0" class="provider-list">
-            <v-list-item
-              v-for="provider in availableProviders"
-              :key="provider.instance_id"
-              style="padding: 0"
-              class="provider-item"
-              rounded="lg"
-              @click="addPlayerGroup(provider.instance_id)"
-            >
-              <template #prepend>
-                <provider-icon
-                  :domain="provider.domain"
-                  :size="40"
-                  class="provider-icon"
-                />
-              </template>
-
-              <template #title>
-                <div class="provider-name">{{ provider.name }}</div>
-              </template>
-
-              <template #subtitle>
-                <div class="provider-description">
-                  {{ provider.description }}
-                </div>
-              </template>
-
-              <template #append>
-                <v-icon icon="mdi-chevron-right" size="small" />
-              </template>
-            </v-list-item>
-          </v-list>
-
-          <div v-else class="empty-state">
-            <v-icon
-              icon="mdi-account-group-outline"
-              size="48"
-              class="empty-icon"
+      <div
+        class="provider-list-container px-6 pt-2 pb-6 flex-1 min-h-0 overflow-y-auto"
+      >
+        <div v-if="availableProviders.length > 0" class="provider-list">
+          <div
+            v-for="provider in availableProviders"
+            :key="provider.instance_id"
+            class="provider-item"
+            @click="addPlayerGroup(provider.instance_id)"
+          >
+            <provider-icon
+              :domain="provider.domain"
+              :size="40"
+              class="provider-icon"
             />
-            <div class="empty-title">{{ $t("no_content") }}</div>
-            <div class="empty-message">
-              {{ $t("settings.no_group_providers") }}
+            <div class="provider-content">
+              <div class="provider-name">{{ provider.name }}</div>
+              <div class="provider-description">
+                {{ provider.description }}
+              </div>
             </div>
+            <ChevronRight class="h-4 w-4 flex-shrink-0" />
           </div>
         </div>
-      </v-card-text>
-    </v-card>
-  </v-dialog>
+
+        <div v-else class="empty-state">
+          <Users class="empty-icon" />
+          <div class="empty-title">{{ $t("no_content") }}</div>
+          <div class="empty-message">
+            {{ $t("settings.no_group_providers") }}
+          </div>
+        </div>
+      </div>
+    </DialogContent>
+  </Dialog>
 </template>
 
 <script setup lang="ts">
 import ProviderIcon from "@/components/ProviderIcon.vue";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
 import { api } from "@/plugins/api";
 import { ProviderFeature } from "@/plugins/api/interfaces";
 import { $t } from "@/plugins/i18n";
 import { store } from "@/plugins/store";
+import { ChevronRight, Users } from "lucide-vue-next";
 import { computed, watch } from "vue";
 import { useRouter } from "vue-router";
 
@@ -115,6 +98,11 @@ const addPlayerGroup = function (instanceId: string) {
   close();
 };
 
+const handleOpenChange = (open: boolean) => {
+  store.dialogActive = open;
+  emit("update:show", open);
+};
+
 const close = function () {
   emit("update:show", false);
 };
@@ -128,25 +116,22 @@ watch(
 
 <style scoped>
 .add-player-group-dialog {
-  height: 600px;
-  display: flex;
-  flex-direction: column;
-}
-
-.provider-list-container {
-  height: 500px;
   display: flex;
   flex-direction: column;
 }
 
 .provider-list {
-  flex: 1;
-  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
 }
 
 .provider-item {
-  height: 80px;
-  margin-bottom: 4px;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 12px;
+  border-radius: 8px;
   transition: all 0.2s ease;
   cursor: pointer;
 }
@@ -157,7 +142,12 @@ watch(
 }
 
 .provider-icon {
-  margin-right: 12px;
+  flex-shrink: 0;
+}
+
+.provider-content {
+  flex: 1;
+  min-width: 0;
 }
 
 .provider-name {
@@ -185,12 +175,14 @@ watch(
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  height: 100%;
+  min-height: 300px;
   text-align: center;
   padding: 40px 20px;
 }
 
 .empty-icon {
+  width: 48px;
+  height: 48px;
   color: rgba(var(--v-theme-on-surface), 0.3);
   margin-bottom: 16px;
 }
@@ -206,15 +198,5 @@ watch(
   font-size: 14px;
   color: rgba(var(--v-theme-on-surface), 0.5);
   line-height: 1.4;
-}
-
-@media (max-width: 600px) {
-  .add-player-group-dialog {
-    height: 500px;
-  }
-
-  .provider-list-container {
-    height: 300px;
-  }
 }
 </style>

--- a/src/views/settings/Players.vue
+++ b/src/views/settings/Players.vue
@@ -7,16 +7,14 @@
         @update:types="selectedPlayerTypes = $event"
       />
       <div class="header-actions">
-        <v-btn
+        <Button
           v-if="providersWithCreateGroupSupport.length > 0"
-          color="primary"
-          variant="outlined"
-          height="40"
           class="add-player-group-btn"
           @click="showAddPlayerGroupDialog = true"
         >
+          <Plus class="size-4" />
           {{ $t("settings.add_group_player") }}
-        </v-btn>
+        </Button>
       </div>
     </div>
 
@@ -143,6 +141,7 @@ import ListItem from "@/components/ListItem.vue";
 import PlayerFilters from "@/components/PlayerFilters.vue";
 import ProviderIcon from "@/components/ProviderIcon.vue";
 import SettingsPlayerCard from "@/components/SettingsPlayerCard.vue";
+import { Button } from "@/components/ui/button";
 import { SYNCGROUP_PREFIX } from "@/constants";
 import { isHiddenSendspinWebPlayer, openLinkInNewTab } from "@/helpers/utils";
 import { ContextMenuItem } from "@/layouts/default/ItemContextMenu.vue";
@@ -154,6 +153,7 @@ import {
   ProviderFeature,
 } from "@/plugins/api/interfaces";
 import { eventbus } from "@/plugins/eventbus";
+import { Plus } from "lucide-vue-next";
 import { computed, inject, onBeforeUnmount, ref, watch } from "vue";
 import { useRouter } from "vue-router";
 import AddPlayerGroupDialog from "./AddPlayerGroupDialog.vue";

--- a/src/views/settings/Providers.vue
+++ b/src/views/settings/Providers.vue
@@ -65,15 +65,10 @@
       @update:search="searchQuery = $event"
       @update:types="selectedProviderTypes = $event"
     />
-    <v-btn
-      color="primary"
-      variant="outlined"
-      height="40"
-      class="add-provider-btn"
-      @click="showAddProviderDialog = true"
-    >
+    <Button class="add-provider-btn" @click="showAddProviderDialog = true">
+      <Plus class="size-4" />
       {{ $t("settings.add_provider") }}
-    </v-btn>
+    </Button>
   </div>
 
   <div class="pl-5 font-weight-medium">
@@ -417,6 +412,7 @@ import Container from "@/components/Container.vue";
 import ListItem from "@/components/ListItem.vue";
 import ProviderFilters from "@/components/ProviderFilters.vue";
 import ProviderIcon from "@/components/ProviderIcon.vue";
+import { Button } from "@/components/ui/button";
 import { isHiddenSendspinWebPlayer, openLinkInNewTab } from "@/helpers/utils";
 import { api } from "@/plugins/api";
 import {
@@ -429,6 +425,7 @@ import {
 import { eventbus } from "@/plugins/eventbus";
 import { $t } from "@/plugins/i18n";
 import { store } from "@/plugins/store";
+import { Plus } from "lucide-vue-next";
 import { match } from "ts-pattern";
 import { computed, inject, onBeforeUnmount, ref, watch } from "vue";
 import { useRouter } from "vue-router";


### PR DESCRIPTION
<img width="1304" height="492" alt="Screenshot 2025-12-23 at 18 53 42" src="https://github.com/user-attachments/assets/ace04ca5-da83-436b-86bb-a54633b2950a" />
<img width="1319" height="439" alt="Screenshot 2025-12-23 at 18 53 57" src="https://github.com/user-attachments/assets/63b4a695-162b-4eba-9e88-5f6c530eaf11" />
<img width="1371" height="414" alt="Screenshot 2025-12-23 at 18 54 10" src="https://github.com/user-attachments/assets/2da65b56-d79e-4469-95e8-6ee79e72f74d" />
<img width="998" height="789" alt="Screenshot 2025-12-23 at 18 54 22" src="https://github.com/user-attachments/assets/ab9b47d5-83bd-4069-8c99-c1e684617f84" />

Same thing for players.
Also added a redirect to home page when clicking on the MA sidebar icon