### PR TITLE
Navigate from Now Playing View to detailed view if available otherwise search

### DIFF
--- a/src/layouts/default/PlayerOSD/PlayerFullscreen.vue
+++ b/src/layouts/default/PlayerOSD/PlayerFullscreen.vue
@@ -856,40 +856,53 @@ const onAlbumClick = function () {
   const currentMedia = store.activePlayer?.current_media;
   if (!currentMedia?.album) return;
 
-  // Try to get the album URI from the full media item (for library items)
+  // Try to get the album from the full media item (for library items)
   const mediaItem = store.curQueueItem?.media_item;
-  console.log("onAlbumClick - currentMedia:", currentMedia);
-  console.log("onAlbumClick - mediaItem:", mediaItem);
-  let albumUri: string | undefined;
 
   if (mediaItem && "album" in mediaItem && mediaItem.album) {
-    albumUri = mediaItem.album.uri;
-    console.log("onAlbumClick - albumUri:", albumUri);
+    // Navigate directly to album detail page
+    store.showFullscreenPlayer = false;
+    router.push({
+      name: "album",
+      params: {
+        itemId: mediaItem.album.item_id,
+        provider: mediaItem.album.provider,
+      },
+    });
+  } else {
+    // Fall back to global search (for radio, etc.)
+    const searchTerm = currentMedia.artist
+      ? `${currentMedia.artist} - ${currentMedia.album}`
+      : currentMedia.album || "";
+    store.globalSearchTerm = searchTerm;
+    router.push({ name: "search" });
+    store.showFullscreenPlayer = false;
   }
-
-  const searchTerm = currentMedia.artist
-    ? `${currentMedia.artist} - ${currentMedia.album}`
-    : currentMedia.album || "";
-
-  navigateOrSearch(searchTerm, albumUri);
 };
 
 const onArtistClick = function () {
   const currentMedia = store.activePlayer?.current_media;
   if (!currentMedia?.artist) return;
 
-  // Try to get the artist URI from the full media item (for library items)
+  // Try to get the artist from the full media item (for library items)
   const mediaItem = store.curQueueItem?.media_item;
-  console.log("onArtistClick - currentMedia:", currentMedia);
-  console.log("onArtistClick - mediaItem:", mediaItem);
-  let artistUri: string | undefined;
 
   if (mediaItem && "artists" in mediaItem && mediaItem.artists && mediaItem.artists.length > 0) {
-    artistUri = mediaItem.artists[0].uri;
-    console.log("onArtistClick - artistUri:", artistUri);
+    // Navigate directly to artist detail page
+    store.showFullscreenPlayer = false;
+    router.push({
+      name: "artist",
+      params: {
+        itemId: mediaItem.artists[0].item_id,
+        provider: mediaItem.artists[0].provider,
+      },
+    });
+  } else {
+    // Fall back to global search (for radio, etc.)
+    store.globalSearchTerm = currentMedia.artist;
+    router.push({ name: "search" });
+    store.showFullscreenPlayer = false;
   }
-
-  navigateOrSearch(currentMedia.artist, artistUri);
 };
 
 const openQueueItemMenu = function (evt: Event, item: QueueItem) {

--- a/src/layouts/default/PlayerOSD/PlayerFullscreen.vue
+++ b/src/layouts/default/PlayerOSD/PlayerFullscreen.vue
@@ -850,8 +850,13 @@ const onTitleClick = async function () {
   // Try to get the track from the full media item (for library items)
   const mediaItem = store.curQueueItem?.media_item;
 
+  console.log("onTitleClick - currentMedia:", currentMedia);
+  console.log("onTitleClick - mediaItem:", mediaItem);
+  console.log("onTitleClick - mediaItem.media_type:", mediaItem?.media_type);
+
   if (mediaItem && mediaItem.media_type === MediaType.TRACK) {
     // Navigate directly to track detail page
+    console.log("onTitleClick - navigating to track:", mediaItem.item_id, mediaItem.provider);
     store.showFullscreenPlayer = false;
     router.push({
       name: "track",
@@ -866,14 +871,19 @@ const onTitleClick = async function () {
       ? `${currentMedia.artist} - ${currentMedia.title}`
       : currentMedia.title || "";
 
+    console.log("onTitleClick - searching library with term:", searchTerm);
+
     try {
       const results = await api.getLibraryTracks({
         search: searchTerm,
         limit: 1,
       });
 
+      console.log("onTitleClick - library search results:", results);
+
       if (results.length > 0) {
         // Found in library! Navigate to it
+        console.log("onTitleClick - found in library, navigating to:", results[0].item_id, results[0].provider);
         store.showFullscreenPlayer = false;
         router.push({
           name: "track",
@@ -889,6 +899,7 @@ const onTitleClick = async function () {
     }
 
     // Not found in library - fall back to global search
+    console.log("onTitleClick - not found in library, falling back to search:", searchTerm);
     store.globalSearchTerm = searchTerm;
     router.push({ name: "search" });
     store.showFullscreenPlayer = false;

--- a/src/layouts/default/PlayerOSD/PlayerFullscreen.vue
+++ b/src/layouts/default/PlayerOSD/PlayerFullscreen.vue
@@ -843,7 +843,7 @@ const navigateOrSearch = function (searchTerm: string, uri?: string) {
   }
 };
 
-const onTitleClick = function () {
+const onTitleClick = async function () {
   const currentMedia = store.activePlayer?.current_media;
   if (!currentMedia) return;
 
@@ -861,17 +861,41 @@ const onTitleClick = function () {
       },
     });
   } else {
-    // Fall back to global search (for radio, etc.)
+    // Radio or non-library item - try to find in library first
     const searchTerm = currentMedia.artist
       ? `${currentMedia.artist} - ${currentMedia.title}`
       : currentMedia.title || "";
+
+    try {
+      const results = await api.getLibraryTracks({
+        search: searchTerm,
+        limit: 1,
+      });
+
+      if (results.length > 0) {
+        // Found in library! Navigate to it
+        store.showFullscreenPlayer = false;
+        router.push({
+          name: "track",
+          params: {
+            itemId: results[0].item_id,
+            provider: results[0].provider,
+          },
+        });
+        return;
+      }
+    } catch (error) {
+      console.error("Error searching library for track:", error);
+    }
+
+    // Not found in library - fall back to global search
     store.globalSearchTerm = searchTerm;
     router.push({ name: "search" });
     store.showFullscreenPlayer = false;
   }
 };
 
-const onAlbumClick = function () {
+const onAlbumClick = async function () {
   const currentMedia = store.activePlayer?.current_media;
   if (!currentMedia?.album) return;
 
@@ -889,17 +913,57 @@ const onAlbumClick = function () {
       },
     });
   } else {
-    // Fall back to global search (for radio, etc.)
+    // Radio or non-library item - try to find in library first
     const searchTerm = currentMedia.artist
       ? `${currentMedia.artist} - ${currentMedia.album}`
       : currentMedia.album || "";
+
+    try {
+      const results = await api.getLibraryAlbums({
+        search: currentMedia.album,
+        limit: 5, // Get a few results to find best match
+      });
+
+      // Try to find exact or close match
+      if (results.length > 0) {
+        let bestMatch = results[0];
+
+        // If we have artist info, try to find album by same artist
+        if (currentMedia.artist) {
+          const matchWithArtist = results.find(album =>
+            album.artists?.some(artist =>
+              artist.name.toLowerCase().includes(currentMedia.artist!.toLowerCase()) ||
+              currentMedia.artist!.toLowerCase().includes(artist.name.toLowerCase())
+            )
+          );
+          if (matchWithArtist) {
+            bestMatch = matchWithArtist;
+          }
+        }
+
+        // Found in library! Navigate to it
+        store.showFullscreenPlayer = false;
+        router.push({
+          name: "album",
+          params: {
+            itemId: bestMatch.item_id,
+            provider: bestMatch.provider,
+          },
+        });
+        return;
+      }
+    } catch (error) {
+      console.error("Error searching library for album:", error);
+    }
+
+    // Not found in library - fall back to global search
     store.globalSearchTerm = searchTerm;
     router.push({ name: "search" });
     store.showFullscreenPlayer = false;
   }
 };
 
-const onArtistClick = function () {
+const onArtistClick = async function () {
   const currentMedia = store.activePlayer?.current_media;
   if (!currentMedia?.artist) return;
 
@@ -917,7 +981,30 @@ const onArtistClick = function () {
       },
     });
   } else {
-    // Fall back to global search (for radio, etc.)
+    // Radio or non-library item - try to find in library first
+    try {
+      const results = await api.getLibraryArtists({
+        search: currentMedia.artist,
+        limit: 1,
+      });
+
+      if (results.length > 0) {
+        // Found in library! Navigate to it
+        store.showFullscreenPlayer = false;
+        router.push({
+          name: "artist",
+          params: {
+            itemId: results[0].item_id,
+            provider: results[0].provider,
+          },
+        });
+        return;
+      }
+    } catch (error) {
+      console.error("Error searching library for artist:", error);
+    }
+
+    // Not found in library - fall back to global search
     store.globalSearchTerm = currentMedia.artist;
     router.push({ name: "search" });
     store.showFullscreenPlayer = false;

--- a/src/layouts/default/PlayerOSD/PlayerFullscreen.vue
+++ b/src/layouts/default/PlayerOSD/PlayerFullscreen.vue
@@ -843,20 +843,15 @@ const navigateOrSearch = function (searchTerm: string, uri?: string) {
   }
 };
 
-const onTitleClick = async function () {
+const onTitleClick = function () {
   const currentMedia = store.activePlayer?.current_media;
   if (!currentMedia) return;
 
   // Try to get the track from the full media item (for library items)
   const mediaItem = store.curQueueItem?.media_item;
 
-  console.log("onTitleClick - currentMedia:", currentMedia);
-  console.log("onTitleClick - mediaItem:", mediaItem);
-  console.log("onTitleClick - mediaItem.media_type:", mediaItem?.media_type);
-
   if (mediaItem && mediaItem.media_type === MediaType.TRACK) {
     // Navigate directly to track detail page
-    console.log("onTitleClick - navigating to track:", mediaItem.item_id, mediaItem.provider);
     store.showFullscreenPlayer = false;
     router.push({
       name: "track",
@@ -866,47 +861,17 @@ const onTitleClick = async function () {
       },
     });
   } else {
-    // Radio or non-library item - try to find in library first
+    // Radio or non-library item - fall back to global search
     const searchTerm = currentMedia.artist
       ? `${currentMedia.artist} - ${currentMedia.title}`
       : currentMedia.title || "";
-
-    console.log("onTitleClick - searching library with term:", searchTerm);
-
-    try {
-      const results = await api.getLibraryTracks({
-        search: searchTerm,
-        limit: 1,
-      });
-
-      console.log("onTitleClick - library search results:", results);
-
-      if (results.length > 0) {
-        // Found in library! Navigate to it
-        console.log("onTitleClick - found in library, navigating to:", results[0].item_id, results[0].provider);
-        store.showFullscreenPlayer = false;
-        router.push({
-          name: "track",
-          params: {
-            itemId: results[0].item_id,
-            provider: results[0].provider,
-          },
-        });
-        return;
-      }
-    } catch (error) {
-      console.error("Error searching library for track:", error);
-    }
-
-    // Not found in library - fall back to global search
-    console.log("onTitleClick - not found in library, falling back to search:", searchTerm);
     store.globalSearchTerm = searchTerm;
     router.push({ name: "search" });
     store.showFullscreenPlayer = false;
   }
 };
 
-const onAlbumClick = async function () {
+const onAlbumClick = function () {
   const currentMedia = store.activePlayer?.current_media;
   if (!currentMedia?.album) return;
 
@@ -924,57 +889,17 @@ const onAlbumClick = async function () {
       },
     });
   } else {
-    // Radio or non-library item - try to find in library first
+    // Radio or non-library item - fall back to global search
     const searchTerm = currentMedia.artist
       ? `${currentMedia.artist} - ${currentMedia.album}`
       : currentMedia.album || "";
-
-    try {
-      const results = await api.getLibraryAlbums({
-        search: currentMedia.album,
-        limit: 5, // Get a few results to find best match
-      });
-
-      // Try to find exact or close match
-      if (results.length > 0) {
-        let bestMatch = results[0];
-
-        // If we have artist info, try to find album by same artist
-        if (currentMedia.artist) {
-          const matchWithArtist = results.find(album =>
-            album.artists?.some(artist =>
-              artist.name.toLowerCase().includes(currentMedia.artist!.toLowerCase()) ||
-              currentMedia.artist!.toLowerCase().includes(artist.name.toLowerCase())
-            )
-          );
-          if (matchWithArtist) {
-            bestMatch = matchWithArtist;
-          }
-        }
-
-        // Found in library! Navigate to it
-        store.showFullscreenPlayer = false;
-        router.push({
-          name: "album",
-          params: {
-            itemId: bestMatch.item_id,
-            provider: bestMatch.provider,
-          },
-        });
-        return;
-      }
-    } catch (error) {
-      console.error("Error searching library for album:", error);
-    }
-
-    // Not found in library - fall back to global search
     store.globalSearchTerm = searchTerm;
     router.push({ name: "search" });
     store.showFullscreenPlayer = false;
   }
 };
 
-const onArtistClick = async function () {
+const onArtistClick = function () {
   const currentMedia = store.activePlayer?.current_media;
   if (!currentMedia?.artist) return;
 
@@ -992,30 +917,7 @@ const onArtistClick = async function () {
       },
     });
   } else {
-    // Radio or non-library item - try to find in library first
-    try {
-      const results = await api.getLibraryArtists({
-        search: currentMedia.artist,
-        limit: 1,
-      });
-
-      if (results.length > 0) {
-        // Found in library! Navigate to it
-        store.showFullscreenPlayer = false;
-        router.push({
-          name: "artist",
-          params: {
-            itemId: results[0].item_id,
-            provider: results[0].provider,
-          },
-        });
-        return;
-      }
-    } catch (error) {
-      console.error("Error searching library for artist:", error);
-    }
-
-    // Not found in library - fall back to global search
+    // Radio or non-library item - fall back to global search
     store.globalSearchTerm = currentMedia.artist;
     router.push({ name: "search" });
     store.showFullscreenPlayer = false;

--- a/src/layouts/default/PlayerOSD/PlayerFullscreen.vue
+++ b/src/layouts/default/PlayerOSD/PlayerFullscreen.vue
@@ -855,16 +855,35 @@ const onTitleClick = function () {
 const onAlbumClick = function () {
   const currentMedia = store.activePlayer?.current_media;
   if (!currentMedia?.album) return;
+
+  // Try to get the album URI from the full media item (for library items)
+  const mediaItem = store.curQueueItem?.media_item;
+  let albumUri: string | undefined;
+
+  if (mediaItem && "album" in mediaItem && mediaItem.album) {
+    albumUri = mediaItem.album.uri;
+  }
+
   const searchTerm = currentMedia.artist
     ? `${currentMedia.artist} - ${currentMedia.album}`
-    : currentMedia.title || "";
-  navigateOrSearch(searchTerm, currentMedia.uri);
+    : currentMedia.album || "";
+
+  navigateOrSearch(searchTerm, albumUri);
 };
 
 const onArtistClick = function () {
   const currentMedia = store.activePlayer?.current_media;
   if (!currentMedia?.artist) return;
-  navigateOrSearch(currentMedia.artist, currentMedia.uri);
+
+  // Try to get the artist URI from the full media item (for library items)
+  const mediaItem = store.curQueueItem?.media_item;
+  let artistUri: string | undefined;
+
+  if (mediaItem && "artists" in mediaItem && mediaItem.artists && mediaItem.artists.length > 0) {
+    artistUri = mediaItem.artists[0].uri;
+  }
+
+  navigateOrSearch(currentMedia.artist, artistUri);
 };
 
 const openQueueItemMenu = function (evt: Event, item: QueueItem) {

--- a/src/layouts/default/PlayerOSD/PlayerFullscreen.vue
+++ b/src/layouts/default/PlayerOSD/PlayerFullscreen.vue
@@ -858,10 +858,13 @@ const onAlbumClick = function () {
 
   // Try to get the album URI from the full media item (for library items)
   const mediaItem = store.curQueueItem?.media_item;
+  console.log("onAlbumClick - currentMedia:", currentMedia);
+  console.log("onAlbumClick - mediaItem:", mediaItem);
   let albumUri: string | undefined;
 
   if (mediaItem && "album" in mediaItem && mediaItem.album) {
     albumUri = mediaItem.album.uri;
+    console.log("onAlbumClick - albumUri:", albumUri);
   }
 
   const searchTerm = currentMedia.artist
@@ -877,10 +880,13 @@ const onArtistClick = function () {
 
   // Try to get the artist URI from the full media item (for library items)
   const mediaItem = store.curQueueItem?.media_item;
+  console.log("onArtistClick - currentMedia:", currentMedia);
+  console.log("onArtistClick - mediaItem:", mediaItem);
   let artistUri: string | undefined;
 
   if (mediaItem && "artists" in mediaItem && mediaItem.artists && mediaItem.artists.length > 0) {
     artistUri = mediaItem.artists[0].uri;
+    console.log("onArtistClick - artistUri:", artistUri);
   }
 
   navigateOrSearch(currentMedia.artist, artistUri);

--- a/src/layouts/default/PlayerOSD/PlayerFullscreen.vue
+++ b/src/layouts/default/PlayerOSD/PlayerFullscreen.vue
@@ -919,6 +919,12 @@ const onAlbumClick = async function () {
   // Try to get the album from the full media item (for library items)
   const mediaItem = store.curQueueItem?.media_item;
 
+  // Check if "album" is actually the radio station name - if so, do nothing
+  if (mediaItem && currentMedia.album === mediaItem.name) {
+    // Album field contains the station name, not a real album - ignore click
+    return;
+  }
+
   if (mediaItem && "album" in mediaItem && mediaItem.album) {
     // Navigate directly to album detail page
     store.showFullscreenPlayer = false;

--- a/src/layouts/default/PlayerOSD/PlayerFullscreen.vue
+++ b/src/layouts/default/PlayerOSD/PlayerFullscreen.vue
@@ -846,10 +846,29 @@ const navigateOrSearch = function (searchTerm: string, uri?: string) {
 const onTitleClick = function () {
   const currentMedia = store.activePlayer?.current_media;
   if (!currentMedia) return;
-  const searchTerm = currentMedia.artist
-    ? `${currentMedia.artist} - ${currentMedia.title}`
-    : currentMedia.title || "";
-  navigateOrSearch(searchTerm, currentMedia.uri);
+
+  // Try to get the track from the full media item (for library items)
+  const mediaItem = store.curQueueItem?.media_item;
+
+  if (mediaItem && mediaItem.media_type === MediaType.TRACK) {
+    // Navigate directly to track detail page
+    store.showFullscreenPlayer = false;
+    router.push({
+      name: "track",
+      params: {
+        itemId: mediaItem.item_id,
+        provider: mediaItem.provider,
+      },
+    });
+  } else {
+    // Fall back to global search (for radio, etc.)
+    const searchTerm = currentMedia.artist
+      ? `${currentMedia.artist} - ${currentMedia.title}`
+      : currentMedia.title || "";
+    store.globalSearchTerm = searchTerm;
+    router.push({ name: "search" });
+    store.showFullscreenPlayer = false;
+  }
 };
 
 const onAlbumClick = function () {


### PR DESCRIPTION
This change adds the following functionality when clicking on:
* Track/Artist/Album which is in any connected provider's library or the MA library→ Navigate to that provider's detail page
* Track/Artist/Album when a radio station is playing → Lookup up the item in the MA library. If found navigate to the items detail view
* Track/Artist/Album not in any library  → Fall back to global search
* Album field which shows the radio station name → Do nothing