### PR TITLE
Fix issues with progress bar jumps and time overflow

### DIFF
--- a/src/layouts/default/PlayerOSD/PlayerTimeline.vue
+++ b/src/layouts/default/PlayerOSD/PlayerTimeline.vue
@@ -182,7 +182,7 @@ const computedElapsedTime = computed(() => {
     const computed = computeElapsedTime(
       queue.elapsed_time,
       queue.elapsed_time_last_updated,
-      store.activePlayer?.playback_state,
+      queue.state,
     );
     return computed ?? 0;
   }

--- a/src/plugins/api/index.ts
+++ b/src/plugins/api/index.ts
@@ -20,6 +20,7 @@ import {
   type Playlist,
   type ProviderInstance,
   type QueueItem,
+  type QueueTimeUpdate,
   type Radio,
   type ServerInfoMessage,
   type SuccessResultMessage,
@@ -1730,8 +1731,12 @@ export class MusicAssistantApi {
       else this.queues[queue.queue_id] = queue;
     } else if (msg.event == EventType.QUEUE_TIME_UPDATED) {
       const queueId = msg.object_id as string;
-      if (queueId in this.queues)
-        this.queues[queueId].elapsed_time = msg.data as unknown as number;
+      if (queueId in this.queues) {
+        const data = msg.data as QueueTimeUpdate;
+        this.queues[queueId].elapsed_time = data.elapsed_time;
+        this.queues[queueId].elapsed_time_last_updated =
+          data.elapsed_time_last_updated;
+      }
     } else if (msg.event == EventType.PLAYER_ADDED) {
       const player = msg.data as Player;
       this.players[player.player_id] = player;

--- a/src/plugins/api/index.ts
+++ b/src/plugins/api/index.ts
@@ -1733,7 +1733,7 @@ export class MusicAssistantApi {
       const queueId = msg.object_id as string;
       if (queueId in this.queues) {
         // TODO: Remove number check in 2.8
-        if (typeof msg.data === 'number') {
+        if (typeof msg.data === "number") {
           this.queues[queueId].elapsed_time = msg.data;
         } else {
           const data = msg.data as QueueTimeUpdate;

--- a/src/plugins/api/index.ts
+++ b/src/plugins/api/index.ts
@@ -20,7 +20,6 @@ import {
   type Playlist,
   type ProviderInstance,
   type QueueItem,
-  type QueueTimeUpdate,
   type Radio,
   type ServerInfoMessage,
   type SuccessResultMessage,
@@ -1732,15 +1731,8 @@ export class MusicAssistantApi {
     } else if (msg.event == EventType.QUEUE_TIME_UPDATED) {
       const queueId = msg.object_id as string;
       if (queueId in this.queues) {
-        // TODO: Remove number check in 2.8
-        if (typeof msg.data === "number") {
-          this.queues[queueId].elapsed_time = msg.data;
-        } else {
-          const data = msg.data as QueueTimeUpdate;
-          this.queues[queueId].elapsed_time = data.elapsed_time;
-          this.queues[queueId].elapsed_time_last_updated =
-            data.elapsed_time_last_updated;
-        }
+        this.queues[queueId].elapsed_time = msg.data as unknown as number
+        this.queues[queueId].elapsed_time_last_updated = Date.now() / 1000;
       }
     } else if (msg.event == EventType.PLAYER_ADDED) {
       const player = msg.data as Player;

--- a/src/plugins/api/index.ts
+++ b/src/plugins/api/index.ts
@@ -1731,7 +1731,7 @@ export class MusicAssistantApi {
     } else if (msg.event == EventType.QUEUE_TIME_UPDATED) {
       const queueId = msg.object_id as string;
       if (queueId in this.queues) {
-        this.queues[queueId].elapsed_time = msg.data as unknown as number
+        this.queues[queueId].elapsed_time = msg.data as unknown as number;
         this.queues[queueId].elapsed_time_last_updated = Date.now() / 1000;
       }
     } else if (msg.event == EventType.PLAYER_ADDED) {

--- a/src/plugins/api/index.ts
+++ b/src/plugins/api/index.ts
@@ -1732,10 +1732,15 @@ export class MusicAssistantApi {
     } else if (msg.event == EventType.QUEUE_TIME_UPDATED) {
       const queueId = msg.object_id as string;
       if (queueId in this.queues) {
-        const data = msg.data as QueueTimeUpdate;
-        this.queues[queueId].elapsed_time = data.elapsed_time;
-        this.queues[queueId].elapsed_time_last_updated =
-          data.elapsed_time_last_updated;
+        // TODO: Remove number check in 2.8
+        if (typeof msg.data === 'number') {
+          this.queues[queueId].elapsed_time = msg.data;
+        } else {
+          const data = msg.data as QueueTimeUpdate;
+          this.queues[queueId].elapsed_time = data.elapsed_time;
+          this.queues[queueId].elapsed_time_last_updated =
+            data.elapsed_time_last_updated;
+        }
       }
     } else if (msg.event == EventType.PLAYER_ADDED) {
       const player = msg.data as Player;

--- a/src/plugins/api/interfaces.ts
+++ b/src/plugins/api/interfaces.ts
@@ -768,6 +768,11 @@ export interface QueueItem {
 
 // player_queue
 
+export interface QueueTimeUpdate {
+  elapsed_time: number;
+  elapsed_time_last_updated: number;
+}
+
 export interface PlayerQueue {
   queue_id: string;
   active: boolean;

--- a/src/plugins/api/interfaces.ts
+++ b/src/plugins/api/interfaces.ts
@@ -768,11 +768,6 @@ export interface QueueItem {
 
 // player_queue
 
-export interface QueueTimeUpdate {
-  elapsed_time: number;
-  elapsed_time_last_updated: number;
-}
-
 export interface PlayerQueue {
   queue_id: string;
   active: boolean;


### PR DESCRIPTION
This PR:
- Updates `elapsed_timestamp_last_updated` ~~from server for accurate extrapolation in the frontend. Wrote in in a nonbreaking way so app.music-asssitant.io still works for the old backend.~~ by using `Date.now()`
- Uses queue state to avoid jumps in case the state has not cascaded to the queue yet