### PR TITLE
Reduce audio distortion with the Sendspin web player

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
         "@intlify/unplugin-vue-i18n": "11.0.3",
         "@mdi/font": "7.4.47",
         "@mdi/js": "7.4.47",
-        "@music-assistant/sendspin-js": "0.5.0",
+        "@music-assistant/sendspin-js": "1.0.0",
         "@scure/base": "^2.0.0",
         "@tabler/icons-vue": "^3.36.1",
         "@tailwindcss/vite": "^4.1.18",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
         "@intlify/unplugin-vue-i18n": "11.0.3",
         "@mdi/font": "7.4.47",
         "@mdi/js": "7.4.47",
-        "@music-assistant/sendspin-js": "1.0.0",
+        "@music-assistant/sendspin-js": "1.0.1",
         "@scure/base": "^2.0.0",
         "@tabler/icons-vue": "^3.36.1",
         "@tailwindcss/vite": "^4.1.18",

--- a/src/components/SendspinPlayer.vue
+++ b/src/components/SendspinPlayer.vue
@@ -239,10 +239,7 @@ onMounted(() => {
         player = new SendspinPlayer({
           playerId: props.playerId,
           baseUrl: "http://sendspin.local",
-          // Web player config
-          audioOutputMode: "media-element",
           audioElement,
-          isAndroid,
           clientName: getDeviceName(),
           codecs,
           syncDelay,

--- a/src/components/SendspinPlayer.vue
+++ b/src/components/SendspinPlayer.vue
@@ -231,7 +231,6 @@ onMounted(() => {
           audioOutputMode: "media-element",
           audioElement,
           isAndroid,
-          silentAudioSrc: almostSilentMp3,
           clientName: getDeviceName(),
           codecs,
           syncDelay,

--- a/src/components/SendspinPlayer.vue
+++ b/src/components/SendspinPlayer.vue
@@ -88,6 +88,14 @@ const metadataPlayerId = computed(() => {
   return undefined;
 });
 
+const correctionMode = computed(() => {
+  // Only do the more precise but distorting "full" correction when grouped
+  const thisPlayer = api.players[props.playerId];
+  const isGrouped =
+    thisPlayer && (thisPlayer.synced_to || thisPlayer.group_members.length > 0);
+  return isGrouped ? "sync" : "quality-local";
+});
+
 // Subscribe to metadata immediately (doesn't require user interaction)
 watch(
   metadataPlayerId,
@@ -176,6 +184,10 @@ watch(
   { immediate: true },
 );
 
+watch(correctionMode, (mode) => {
+  player?.setCorrectionMode(mode);
+});
+
 // Setup on mount
 onMounted(() => {
   console.debug("Sendspin: Component mounted, connecting...");
@@ -242,6 +254,7 @@ onMounted(() => {
             muted.value = state.muted;
             playerState.value = state.playerState;
           },
+          correctionMode: correctionMode.value,
         });
 
         // Register callback for real-time sync delay changes from settings

--- a/yarn.lock
+++ b/yarn.lock
@@ -1775,10 +1775,10 @@
   resolved "https://registry.yarnpkg.com/@mdi/js/-/js-7.4.47.tgz#7d8a4edc9631bffeed80d1ec784f9beae559a76a"
   integrity sha512-KPnNOtm5i2pMabqZxpUz7iQf+mfrYZyKCZ8QNz85czgEt7cuHcGorWfdzUMWYA0SD+a6Hn4FmJ+YhzzzjkTZrQ==
 
-"@music-assistant/sendspin-js@1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@music-assistant/sendspin-js/-/sendspin-js-1.0.0.tgz#17f72825c82d553fa4b3bfdb99d638b8631368dd"
-  integrity sha512-I65bH3aEtbWjZqHxPCxeEg/665JgHjxv4M8IAzwEhLU40s6WBdLHGPjhohT5aHFpUWtwu4md5hlQaYll+1UaPg==
+"@music-assistant/sendspin-js@1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@music-assistant/sendspin-js/-/sendspin-js-1.0.1.tgz#fafdb2119529cdd14832b6cba24274f878d5d907"
+  integrity sha512-4vhx7DYyWsVI/OUN2RwMHnBhJT/c+tDnzbp/MJS20jE/4NDZArZi4T4RiBdhjfE75wrQf2k7FwXSd1Wj7aclOQ==
   dependencies:
     opus-encdec "^0.1.1"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1775,10 +1775,10 @@
   resolved "https://registry.yarnpkg.com/@mdi/js/-/js-7.4.47.tgz#7d8a4edc9631bffeed80d1ec784f9beae559a76a"
   integrity sha512-KPnNOtm5i2pMabqZxpUz7iQf+mfrYZyKCZ8QNz85czgEt7cuHcGorWfdzUMWYA0SD+a6Hn4FmJ+YhzzzjkTZrQ==
 
-"@music-assistant/sendspin-js@0.5.0":
-  version "0.5.0"
-  resolved "https://registry.yarnpkg.com/@music-assistant/sendspin-js/-/sendspin-js-0.5.0.tgz#675f63f1882d343224ade6a56f374553255aaed3"
-  integrity sha512-aHgy49xBRrii3+9K3t6Wn4Quj4OTFGnPSMCfmxyFp3EanuvVnKpORq3XF8/dhHJhhdaNGejloihU3YL4FZk4wQ==
+"@music-assistant/sendspin-js@1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@music-assistant/sendspin-js/-/sendspin-js-1.0.0.tgz#17f72825c82d553fa4b3bfdb99d638b8631368dd"
+  integrity sha512-I65bH3aEtbWjZqHxPCxeEg/665JgHjxv4M8IAzwEhLU40s6WBdLHGPjhohT5aHFpUWtwu4md5hlQaYll+1UaPg==
   dependencies:
     opus-encdec "^0.1.1"
 


### PR DESCRIPTION
Upgrades `sendspin-js` to 1.0.1 which includes an improved syncing strategy that reduces pitch distortion during connection startup.

The web player now uses "quality-local" correction mode when playing solo and switches to "sync" mode only when grouped with other players. Solo playback no longer applies pitch shifting, eliminating unnecessary audio artifacts.

Also fixes syncing issues after ungrouping and regrouping a web player.