### PR TITLE
EditPlayer: If player is not available hide save button and show a banner instead

### DIFF
--- a/src/views/settings/EditPlayer.vue
+++ b/src/views/settings/EditPlayer.vue
@@ -94,8 +94,20 @@
       </v-card>
     </div>
 
+    <!-- Not available banner -->
+    <v-alert
+      v-if="!api.players[config.player_id]?.available"
+      type="warning"
+      variant="tonal"
+      class="mb-4"
+    >
+      <div class="disabled-banner">
+        <span>{{ $t("settings.player_not_available") }}</span>
+      </div>
+    </v-alert>
+
     <edit-config
-      v-if="config"
+      v-else-if="config"
       :disabled="!config.enabled"
       :config-entries="allConfigEntries"
       @submit="onSubmit"

--- a/src/views/settings/EditPlayer.vue
+++ b/src/views/settings/EditPlayer.vue
@@ -9,7 +9,7 @@
     >
       <!-- Disabled banner -->
       <v-alert
-        v-if="!config.enabled"
+        v-if="!config?.enabled"
         type="warning"
         variant="tonal"
         class="mb-4"
@@ -29,7 +29,7 @@
       </v-alert>
 
       <!-- Header card -->
-      <v-card class="header-card mb-4" elevation="0">
+      <v-card v-if="config" class="header-card mb-4" elevation="0">
         <div class="header-content">
           <div class="header-icon">
             <v-icon size="32" color="primary">mdi-speaker</v-icon>
@@ -96,7 +96,7 @@
 
     <!-- Not available banner -->
     <v-alert
-      v-if="!api.players[config.player_id]?.available"
+      v-if="config && !api.players[config.player_id]?.available"
       type="warning"
       variant="tonal"
       class="mb-4"
@@ -108,7 +108,7 @@
 
     <edit-config
       v-else-if="config"
-      :disabled="!config.enabled"
+      :disabled="!config?.enabled"
       :config-entries="allConfigEntries"
       @submit="onSubmit"
       @action="onAction"


### PR DESCRIPTION
If a player is not available, the Edit Player page currently does not show any configuration entries but still displays the Save, Close, and Restore Defaults buttons. This PR instead shows a banner informing the user that the player is currently unavailable and hides the edit configuration buttons.