### PR TITLE
Add helpers/logic to handle companion app(s)

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -19,8 +19,13 @@
       webPlayer.interacted == true
     "
   />
+  <!-- Sendspin web player is disabled when running in companion mode (native app handles audio) -->
   <SendspinPlayer
-    v-if="webPlayer.tabMode === WebPlayerMode.SENDSPIN && webPlayer.player_id"
+    v-if="
+      webPlayer.tabMode === WebPlayerMode.SENDSPIN &&
+      webPlayer.player_id &&
+      !companionMode
+    "
     :player-id="webPlayer.player_id"
   />
 </template>
@@ -42,6 +47,10 @@ import PlayerBrowserMediaControls from "./layouts/default/PlayerOSD/PlayerBrowse
 import { remoteConnectionManager } from "./plugins/remote";
 import { httpProxyBridge } from "./plugins/remote/http-proxy";
 import type { ITransport } from "./plugins/remote/transport";
+import {
+  initializeCompanionIntegration,
+  companionMode,
+} from "./plugins/companion";
 import { webPlayer, WebPlayerMode } from "./plugins/web_player";
 import Login from "./views/Login.vue";
 
@@ -218,6 +227,11 @@ const completeInitialization = async () => {
     router.push("/settings/providers");
   }
   api.state.value = ConnectionState.INITIALIZED;
+
+  // Initialize companion app integration
+  if (api.baseUrl) {
+    initializeCompanionIntegration(api.baseUrl);
+  }
 };
 
 onMounted(async () => {

--- a/src/components/PlayerCard.vue
+++ b/src/components/PlayerCard.vue
@@ -45,7 +45,10 @@
       <template #title>
         <!-- special builtin player (web player or companion native player) -->
         <div
-          v-if="webPlayer.player_id === player.player_id || store.companionPlayerId === player.player_id"
+          v-if="
+            webPlayer.player_id === player.player_id ||
+            store.companionPlayerId === player.player_id
+          "
           style="margin-bottom: 3px"
         >
           <span>{{

--- a/src/components/PlayerCard.vue
+++ b/src/components/PlayerCard.vue
@@ -43,9 +43,9 @@
 
       <!-- playername -->
       <template #title>
-        <!-- special builtin player -->
+        <!-- special builtin player (web player or companion native player) -->
         <div
-          v-if="webPlayer.player_id === player.player_id"
+          v-if="webPlayer.player_id === player.player_id || store.companionPlayerId === player.player_id"
           style="margin-bottom: 3px"
         >
           <span>{{

--- a/src/components/SendspinPlayer.vue
+++ b/src/components/SendspinPlayer.vue
@@ -18,7 +18,7 @@ import almostSilentMp3 from "@/assets/almost_silent.mp3";
 import api from "@/plugins/api";
 import { PlaybackState } from "@/plugins/api/interfaces";
 import { store } from "@/plugins/store";
-import { webPlayer, WebPlayerMode } from "@/plugins/web_player";
+import { webPlayer } from "@/plugins/web_player";
 import {
   prepareSendspinSession,
   isDirectConnection,
@@ -191,10 +191,6 @@ watch(correctionMode, (mode) => {
 // Setup on mount
 onMounted(() => {
   console.debug("Sendspin: Component mounted, connecting...");
-
-  // Set audio source to indicate this tab is handling audio
-  // (for coordination with other tabs via web_player.ts)
-  webPlayer.audioSource = WebPlayerMode.SENDSPIN;
 
   // If already showing active player metadata, play silent audio now that silentAudioRef exists
   if (

--- a/src/layouts/default/PlayerSelect.vue
+++ b/src/layouts/default/PlayerSelect.vue
@@ -169,8 +169,11 @@ const getPlayerPriority = (player: Player): number => {
     score += 2;
   }
 
-  // "This device" web player = 2 points
-  if (player.player_id === webPlayer.player_id) {
+  // "This device" web/companion player = 2 points
+  if (
+    player.player_id === webPlayer.player_id ||
+    player.player_id === store.companionPlayerId
+  ) {
     score += 2;
   }
 
@@ -322,7 +325,7 @@ onMounted(() => {
 });
 
 const checkDefaultPlayer = function () {
-  if (store.activePlayer && playerVisible(store.activePlayer)) return;
+  if (store.activePlayer) return;
   const newDefaultPlayerId = selectDefaultPlayer();
   if (newDefaultPlayerId) {
     store.activePlayerId = newDefaultPlayerId;
@@ -336,15 +339,24 @@ const selectDefaultPlayer = function () {
   const lastPlayerId =
     localStorage.getItem("activePlayerId") ||
     getPreference<string>("activePlayerId").value;
-  if (
-    lastPlayerId &&
-    lastPlayerId in api.players &&
-    api.players[lastPlayerId].available
-  ) {
+  if (lastPlayerId && lastPlayerId in api.players) {
     return lastPlayerId;
   }
-  if (webPlayer.player_id) {
+  // select webPlayer if available (only if we do not have a previous player stored)
+  if (
+    !lastPlayerId &&
+    webPlayer.player_id &&
+    webPlayer.player_id in api.players
+  ) {
     return webPlayer.player_id;
+  }
+  // select companionPlayer if available (only if we do not have a previous player stored)
+  if (
+    !lastPlayerId &&
+    store.companionPlayerId &&
+    store.companionPlayerId in api.players
+  ) {
+    return store.companionPlayerId;
   }
 };
 </script>

--- a/src/plugins/auth.ts
+++ b/src/plugins/auth.ts
@@ -99,7 +99,18 @@ export class AuthManager {
     // Small delay to allow logout command to be sent
     await new Promise((resolve) => setTimeout(resolve, 100));
 
-    // Reload page to show Vue login screen
+    // Notify companion app launcher (if running in companion mode)
+    // This navigates back to the server selection screen
+    const { notifyCompanionLogout, isCompanionApp } = await import(
+      "@/plugins/companion"
+    );
+    if (isCompanionApp()) {
+      await notifyCompanionLogout();
+      // Navigation is handled by the companion app, don't reload
+      return;
+    }
+
+    // Reload page to show Vue login screen (browser mode)
     window.location.reload();
   }
 }

--- a/src/plugins/auth.ts
+++ b/src/plugins/auth.ts
@@ -101,9 +101,8 @@ export class AuthManager {
 
     // Notify companion app launcher (if running in companion mode)
     // This navigates back to the server selection screen
-    const { notifyCompanionLogout, isCompanionApp } = await import(
-      "@/plugins/companion"
-    );
+    const { notifyCompanionLogout, isCompanionApp } =
+      await import("@/plugins/companion");
     if (isCompanionApp()) {
       await notifyCompanionLogout();
       // Navigation is handled by the companion app, don't reload

--- a/src/plugins/companion.ts
+++ b/src/plugins/companion.ts
@@ -1,0 +1,408 @@
+/**
+ * Companion App Integration
+ *
+ * This module provides integration with Music Assistant Companion apps
+ * (desktop, mobile, etc.). When running in a companion app, it enables
+ * native features like:
+ * - Discord Rich Presence (shows currently playing track)
+ * - System tray with now-playing info
+ * - Native Sendspin audio player (companion app handles audio playback)
+ * - Future: Native notifications, media keys, etc.
+ *
+ * Detection: The companion app exposes a global object with an `invoke` function:
+ * - Tauri apps: window.__TAURI__ (automatically set by Tauri)
+ * - Other frameworks: window.__COMPANION__ (custom, must provide invoke function)
+ *
+ * The invoke function signature: invoke<T>(cmd: string, args?: object) => Promise<T>
+ *
+ * When not running in a companion app (e.g., in a browser), all functions are no-ops.
+ */
+
+import { getMediaImageUrl } from "@/helpers/utils";
+import { PlaybackState, Player, PlayerSource } from "@/plugins/api/interfaces";
+import { store } from "@/plugins/store";
+import { ref, watch } from "vue";
+
+/**
+ * Check if running in a companion app
+ * Detects either Tauri context (__TAURI__) or custom companion context (__COMPANION__)
+ */
+export const isCompanionApp = (): boolean => {
+  if (typeof window === "undefined") return false;
+
+  // Tauri companion app
+  if ("__TAURI__" in window) return true;
+
+  // Other companion app frameworks (e.g., Electron, React Native, etc.)
+  if ("__COMPANION__" in window) return true;
+
+  return false;
+};
+
+/**
+ * Whether the app is running in companion mode (native desktop/mobile app)
+ * When true, the frontend should NOT start its built-in Sendspin player
+ * and may enable other companion-specific behaviors
+ */
+export const companionMode = ref(isCompanionApp());
+
+// Type for the invoke function
+type CompanionInvoke = <T>(
+  cmd: string,
+  args?: Record<string, unknown>,
+) => Promise<T>;
+
+/**
+ * Get the invoke function from the companion app context
+ * Returns null if not running in a companion app
+ */
+const getCompanionInvoke = (): CompanionInvoke | null => {
+  if (typeof window === "undefined") return null;
+
+  // Tauri companion app
+  if ("__TAURI__" in window) {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const tauri = (window as any).__TAURI__;
+    return tauri?.core?.invoke || tauri?.invoke || null;
+  }
+
+  // Other companion app frameworks
+  if ("__COMPANION__" in window) {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const companion = (window as any).__COMPANION__;
+    return companion?.invoke || null;
+  }
+
+  return null;
+};
+/**
+ * Now-playing information for the desktop app
+ */
+export interface NowPlaying {
+  /** Whether something is currently playing */
+  is_playing: boolean;
+  /** Track name */
+  track: string | null;
+  /** Artist name */
+  artist: string | null;
+  /** Album name */
+  album: string | null;
+  /** Image URL */
+  image_url: string | null;
+  /** Player name */
+  player_name: string | null;
+  /** Player ID */
+  player_id: string | null;
+  /** Duration in seconds */
+  duration: number | null;
+  /** Elapsed time in seconds */
+  elapsed: number | null;
+  /** Whether play action is available */
+  can_play: boolean;
+  /** Whether pause action is available */
+  can_pause: boolean;
+  /** Whether next track action is available */
+  can_next: boolean;
+  /** Whether previous track action is available */
+  can_previous: boolean;
+}
+
+/**
+ * Get the companion app version
+ */
+export const getCompanionAppVersion = async (): Promise<string | null> => {
+  const invoke = getCompanionInvoke();
+  if (!invoke) return null;
+
+  try {
+    return await invoke<string>("get_app_version");
+  } catch {
+    return null;
+  }
+};
+
+
+/**
+ * Get the companion app's Sendspin player ID
+ * This can be used to show a "This Device" badge in the player list
+ */
+export const getCompanionPlayerId = async (): Promise<string | null> => {
+  const invoke = getCompanionInvoke();
+  if (!invoke) return null;
+
+  try {
+    return await invoke<string | null>("get_sendspin_player_id");
+  } catch {
+    return null;
+  }
+};
+
+/**
+ * Configure the companion app's Sendspin client with the MA server URL
+ * This allows the native player to connect to Sendspin
+ *
+ * @param serverBaseUrl - The base URL of the MA server (e.g., "http://192.168.1.100:8095")
+ * @param authToken - Auth token for the MA server proxy (required)
+ * @returns The player ID if the client was started, null otherwise
+ */
+export const configureSendspin = async (
+  serverBaseUrl: string,
+  authToken: string,
+): Promise<string | null> => {
+  const invoke = getCompanionInvoke();
+  if (!invoke) return null;
+
+  try {
+    console.log(
+      "[Companion] Configuring Sendspin with server URL:",
+      serverBaseUrl,
+    );
+    const playerId = await invoke<string | null>("configure_sendspin", {
+      serverBaseUrl,
+      authToken,
+    });
+    if (playerId) {
+      console.log("[Companion] Sendspin client started with ID:", playerId);
+    }
+    return playerId;
+  } catch (error) {
+    console.warn("[Companion] Failed to configure Sendspin:", error);
+    return null;
+  }
+};
+
+/**
+ * Update the now-playing information in the desktop app
+ * This updates the system tray tooltip and Discord Rich Presence
+ */
+const updateNowPlaying = async (nowPlaying: NowPlaying): Promise<void> => {
+  const invoke = getCompanionInvoke();
+  if (!invoke) return;
+
+  try {
+    await invoke("update_now_playing", { nowPlaying });
+  } catch (error) {
+    console.warn("[Companion] Failed to update now-playing:", error);
+  }
+};
+
+/**
+ * Get the active source from a player (for capabilities)
+ */
+const getActiveSource = (player: Player): PlayerSource | undefined => {
+  if (!player.active_source || !player.source_list) return undefined;
+  return player.source_list.find((source) => source.id === player.active_source);
+};
+
+/**
+ * Extract now-playing info from the active player
+ */
+const extractNowPlaying = (player: Player | undefined): NowPlaying => {
+  if (!player) {
+    return {
+      is_playing: false,
+      track: null,
+      artist: null,
+      album: null,
+      image_url: null,
+      player_name: null,
+      player_id: null,
+      duration: null,
+      elapsed: null,
+      can_play: false,
+      can_pause: false,
+      can_next: false,
+      can_previous: false,
+    };
+  }
+
+  const media = player.current_media;
+  const activeSource = getActiveSource(player);
+  const isPlaying = player.playback_state === PlaybackState.PLAYING;
+
+  // Get capabilities from active source
+  const canPlayPause = activeSource?.can_play_pause ?? !!media;
+  const canNextPrev = activeSource?.can_next_previous ?? false;
+
+  // Get album art URL (convert to full URL if needed)
+  let imageUrl: string | null = null;
+  if (media?.image_url) {
+    imageUrl = getMediaImageUrl(media.image_url);
+  }
+
+  return {
+    is_playing: isPlaying,
+    track: media?.title || null,
+    artist: media?.artist || null,
+    album: media?.album || null,
+    image_url: imageUrl,
+    player_name: player.name,
+    player_id: player.player_id,
+    duration: media?.duration || null,
+    elapsed: Math.round(player.elapsed_time || 0),
+    // Play is available when not playing, pause when playing (if source supports it)
+    can_play: !isPlaying && canPlayPause,
+    can_pause: isPlaying && canPlayPause,
+    can_next: canNextPrev,
+    can_previous: canNextPrev,
+  };
+};
+
+// Store the unwatch function for cleanup
+let unwatchNowPlaying: (() => void) | null = null;
+
+/**
+ * Start watching the active player and push updates to Tauri
+ */
+const startNowPlayingWatcher = (): void => {
+  // Don't start if already watching
+  if (unwatchNowPlaying) return;
+
+  const invoke = getCompanionInvoke();
+  if (!invoke) {
+    console.warn("[Companion] No invoke function available");
+    return;
+  }
+
+  // First, start the companion services (Discord RPC, etc.)
+  invoke("start_desktop_services").catch((e) =>
+    console.warn("[Companion] Failed to start services:", e),
+  );
+
+  // Watch for changes in track or playback state
+  unwatchNowPlaying = watch(
+    () => ({
+      uri: store.activePlayer?.current_media?.uri,
+      state: store.activePlayer?.playback_state,
+      playerId: store.activePlayer?.player_id,
+    }),
+    (newVal, oldVal) => {
+      // Skip if nothing meaningful changed
+      if (
+        oldVal &&
+        newVal.uri === oldVal.uri &&
+        newVal.state === oldVal.state &&
+        newVal.playerId === oldVal.playerId
+      ) {
+        return;
+      }
+
+      const nowPlaying = extractNowPlaying(store.activePlayer);
+      updateNowPlaying(nowPlaying);
+    },
+    { immediate: true },
+  );
+};
+
+/**
+ * Stop watching the active player queue
+ */
+const stopNowPlayingWatcher = (): void => {
+  if (unwatchNowPlaying) {
+    unwatchNowPlaying();
+    unwatchNowPlaying = null;
+  }
+};
+
+/**
+ * Initialize companion app integration
+ * Call this once the app is connected and authenticated to the MA server
+ *
+ * @param serverAddress - The MA server base URL (e.g., "http://192.168.1.100:8095")
+ */
+export const initializeCompanionIntegration = async (
+  serverAddress: string,
+): Promise<void> => {
+  if (!isCompanionApp()) {
+    return;
+  }
+
+  console.log(
+    "[Companion] Companion app detected, initializing integrations...",
+  );
+
+  // Enable companion mode - this disables the frontend's built-in Sendspin player
+  companionMode.value = true;
+  console.log("[Companion] Companion mode enabled");
+
+  // Configure native Sendspin player (backend will check if enabled)
+  if (serverAddress) {
+    const { authManager } = await import("@/plugins/auth");
+    const token = authManager.getToken();
+    if (token) {
+      const playerId = await configureSendspin(serverAddress, token);
+      // Store companion player ID so UI can show "This device" badge
+      if (playerId) {
+        store.companionPlayerId = playerId;
+      }
+    }
+  }
+
+  // Start watching now-playing and pushing to Tauri
+  startNowPlayingWatcher();
+
+  // Signal to companion app that we're ready
+  // This prevents the "outdated server" warning
+  const invoke = getCompanionInvoke();
+  if (invoke) {
+    try {
+      await invoke("companion_ready");
+    } catch {
+      // Ignore - older companion app versions may not have this command
+    }
+  }
+
+  // Log app version for debugging
+  const version = await getCompanionAppVersion();
+  if (version) {
+    console.log("[Companion] App version:", version);
+  }
+};
+
+
+/**
+ * Clean up companion app integration
+ * Call this when disconnecting from the MA server
+ */
+export const cleanupCompanionIntegration = (): void => {
+  if (!isCompanionApp()) {
+    return;
+  }
+
+  stopNowPlayingWatcher();
+  companionMode.value = false;
+  store.companionPlayerId = undefined;
+
+  // Clear now-playing state
+  updateNowPlaying({
+    is_playing: false,
+    track: null,
+    artist: null,
+    album: null,
+    image_url: null,
+    player_name: null,
+    player_id: null,
+    duration: null,
+    elapsed: null,
+    can_play: false,
+    can_pause: false,
+    can_next: false,
+    can_previous: false,
+  });
+};
+
+
+/**
+ * Notify the companion app that the user has logged out
+ * This navigates back to the server selection screen
+ */
+export const notifyCompanionLogout = async (): Promise<void> => {
+  const invoke = getCompanionInvoke();
+  if (!invoke) return;
+
+  try {
+    await invoke("navigate_to_launcher");
+  } catch (error) {
+    console.warn("[Companion] Failed to navigate to launcher:", error);
+  }
+};

--- a/src/plugins/companion.ts
+++ b/src/plugins/companion.ts
@@ -317,8 +317,12 @@ const unregisterPlayerCommandHandler = (): void => {
  */
 const startNowPlayingWatcher = (): void => {
   // Don't start if already watching
-  if (unwatchNowPlaying) return;
+  if (unwatchNowPlaying) {
+    console.log("[Companion] Now-playing watcher already active, skipping");
+    return;
+  }
 
+  console.log("[Companion] Starting now-playing watcher...");
   const invoke = getCompanionInvoke();
   if (!invoke) {
     console.warn("[Companion] No invoke function available");
@@ -360,6 +364,7 @@ const startNowPlayingWatcher = (): void => {
  */
 const stopNowPlayingWatcher = (): void => {
   if (unwatchNowPlaying) {
+    console.log("[Companion] Stopping existing now-playing watcher");
     unwatchNowPlaying();
     unwatchNowPlaying = null;
   }
@@ -377,6 +382,10 @@ export const initializeCompanionIntegration = async (
   if (!isCompanionApp()) {
     return;
   }
+
+  // Clean up any existing state first (handles reconnection case)
+  stopNowPlayingWatcher();
+  unregisterPlayerCommandHandler();
 
   console.log(
     "[Companion] Companion app detected, initializing integrations...",

--- a/src/plugins/companion.ts
+++ b/src/plugins/companion.ts
@@ -121,7 +121,6 @@ export const getCompanionAppVersion = async (): Promise<string | null> => {
   }
 };
 
-
 /**
  * Get the companion app's Sendspin player ID
  * This can be used to show a "This Device" badge in the player list
@@ -191,7 +190,9 @@ const updateNowPlaying = async (nowPlaying: NowPlaying): Promise<void> => {
  */
 const getActiveSource = (player: Player): PlayerSource | undefined => {
   if (!player.active_source || !player.source_list) return undefined;
-  return player.source_list.find((source) => source.id === player.active_source);
+  return player.source_list.find(
+    (source) => source.id === player.active_source,
+  );
 };
 
 /**
@@ -359,7 +360,6 @@ export const initializeCompanionIntegration = async (
   }
 };
 
-
 /**
  * Clean up companion app integration
  * Call this when disconnecting from the MA server
@@ -390,7 +390,6 @@ export const cleanupCompanionIntegration = (): void => {
     can_previous: false,
   });
 };
-
 
 /**
  * Notify the companion app that the user has logged out

--- a/src/plugins/store.ts
+++ b/src/plugins/store.ts
@@ -58,6 +58,7 @@ interface Store {
   serverInfo?: ServerInfoMessage;
   isIngressSession: boolean;
   isOnboarding: boolean;
+  companionPlayerId?: string;
 }
 
 export const store: Store = reactive({

--- a/src/plugins/web_player.ts
+++ b/src/plugins/web_player.ts
@@ -6,12 +6,14 @@ import { resetSendspinConnection } from "./sendspin-connection";
 export enum WebPlayerMode {
   DISABLED = "disabled",
   CONTROLS_ONLY = "controls_only",
-  SENDSPIN = "sendspin",
+  SENDSPIN_ONLY = "sendspin_only",
+  SENDSPIN_WITH_CONTROLS = "sendspin_with_controls",
 }
 
 // Helper to check if a mode is a playback mode (handles actual audio)
 export const isPlaybackMode = (mode: WebPlayerMode) =>
-  mode === WebPlayerMode.SENDSPIN;
+  mode === WebPlayerMode.SENDSPIN_ONLY ||
+  mode === WebPlayerMode.SENDSPIN_WITH_CONTROLS;
 
 let unsubSubscriptions: (() => void)[] = [];
 
@@ -206,9 +208,13 @@ export const webPlayer = reactive({
       }
     }
 
-    if (mode === WebPlayerMode.SENDSPIN) {
+    if (isPlaybackMode(mode)) {
       // Sendspin player is handled separately through the SendspinPlayer component
-      this.audioSource = WebPlayerMode.CONTROLS_ONLY;
+      // audioSource determines whether browser media controls are shown
+      this.audioSource =
+        mode === WebPlayerMode.SENDSPIN_WITH_CONTROLS
+          ? WebPlayerMode.CONTROLS_ONLY
+          : WebPlayerMode.DISABLED;
       const saved_player_id = window.localStorage.getItem(
         "sendspin_webplayer_id",
       );

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -657,13 +657,9 @@
         "players_total": "{0} total player{1}",
         "api_docs": "API Documentation",
         "no_group_providers": "You currently do not have any providers that support creating groups",
-        "web_player_mode": {
-            "label": "Web player mode",
-            "description": "Choose how this browser handles audio playback.",
-            "options": {
-                "sendspin": "Sendspin (experimental)",
-                "disabled": "Disabled (controls only)"
-            }
+        "web_player_enabled": {
+            "label": "Enable built-in (Sendspin) Web Player",
+            "description": "Allow playback to this device/browser using the built-in Sendspin web player."
         },
         "sendspin_sync_delay": {
             "label": "Sendspin sync delay (ms)",
@@ -672,6 +668,10 @@
         "sendspin_output_latency_compensation": {
             "label": "Use browser latency detection",
             "description": "Automatically compensate for hardware audio latency (e.g., Bluetooth headphones) using the browser's output latency API. This API is fairly new and may not work reliably on all browsers and operating systems."
+        },
+        "enable_browser_controls": {
+            "label": "Enable browser media controls",
+            "description": "Allow control of playback using the browser's built-in media controls (e.g., media keys on your keyboard)."
         },
         "provider_codeowners": "This provider is contributed\/maintained by",
         "provider_credits": "Made possible by",


### PR DESCRIPTION
Add a tiny bit of handling to allow companion apps to leverage the frontend (or just components of it).

- Allow send messages to/from companion app (native) layer to the frontend
- Disable sendspin player and browser controls in companion mode
- Allow companion app running sendspin to be detected as "this device" - just like web player
- Fix a bug in remembering last used player so we can correctly remember the last used player (even if its temporary unavailable)


@maximmaxim345 @formatBCE 