### PR TITLE
Auto-reload on stale chunks after frontend update

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -254,8 +254,12 @@ const completeInitialization = async () => {
 };
 
 onMounted(async () => {
-  // @ts-ignore
-  store.isInStandaloneMode = window.navigator.standalone || false;
+  // Detect if running as installed PWA (works across iOS, Android, and desktop)
+  const nav = window.navigator as Navigator & { standalone?: boolean };
+  store.isInPWAMode =
+    nav.standalone === true ||
+    window.matchMedia("(display-mode: standalone)").matches ||
+    window.matchMedia("(display-mode: fullscreen)").matches;
 
   // Cache language settings
   const langPref = localStorage.getItem("frontend.settings.language") || "auto";

--- a/src/layouts/default/Default.vue
+++ b/src/layouts/default/Default.vue
@@ -7,7 +7,7 @@
       <Footer />
     </template>
   </v-app>
-  <reload-prompt v-if="store.isInStandaloneMode" />
+  <reload-prompt />
 </template>
 
 <script lang="ts" setup>

--- a/src/layouts/default/Footer.vue
+++ b/src/layouts/default/Footer.vue
@@ -34,7 +34,7 @@ import BottomNavigation from "@/components/navigation/BottomNavigation.vue";
 import { parseBool } from "@/helpers/utils";
 
 const bottomNavHeight = computed(() => {
-  if (store.isInStandaloneMode) {
+  if (store.isInPWAMode) {
     // for iOS standalone we need extra padding at the bottom due to the apphandle
     return 100;
   }

--- a/src/plugins/router.ts
+++ b/src/plugins/router.ts
@@ -362,6 +362,29 @@ const router = createRouter({
   routes,
 });
 
+// Handle chunk loading errors (e.g., after frontend update with stale cache)
+// When a dynamic import fails with a 404, it means the chunk no longer exists
+// on the server (likely due to a new deployment with different hashes).
+// In this case, we reload the page to get the fresh assets.
+router.onError((error, to) => {
+  // Check if this is a chunk loading error
+  const isChunkLoadError =
+    error.message.includes("Failed to fetch dynamically imported module") ||
+    error.message.includes("Loading chunk") ||
+    error.message.includes("Loading CSS chunk") ||
+    (error.name === "TypeError" && error.message.includes("fetch"));
+
+  if (isChunkLoadError) {
+    console.warn(
+      "Chunk loading failed, likely due to app update. Reloading page...",
+      error,
+    );
+    // Use location.href to do a full reload to the intended route
+    // This ensures we get fresh HTML and assets from the server
+    window.location.href = window.location.origin + window.location.pathname + "#" + to.fullPath;
+  }
+});
+
 // Navigation guard for admin-only routes
 router.beforeEach((to, _from, next) => {
   // Check admin-only routes - check all matched routes for requiresAdmin meta

--- a/src/plugins/store.ts
+++ b/src/plugins/store.ts
@@ -26,7 +26,7 @@ const DEVICE_TYPE: DeviceType = md.tablet()
 
 interface Store {
   activePlayerId?: string;
-  isInStandaloneMode: boolean;
+  isInPWAMode: boolean;
   showPlayersMenu: boolean;
   showFullscreenPlayer: boolean;
   frameless: boolean;
@@ -63,7 +63,7 @@ interface Store {
 
 export const store: Store = reactive({
   activePlayerId: undefined,
-  isInStandaloneMode: false,
+  isInPWAMode: false,
   showPlayersMenu: false,
   showFullscreenPlayer: false,
   frameless: false,


### PR DESCRIPTION
- Add router error handler to automatically reload the page when chunk loading fails (e.g., after a frontend update with changed asset hashes)
- Show the PWA update toast for all users, not just installed PWA mode
- Fix cross-platform PWA detection (was iOS-only, now works on Android/desktop too)
- Rename isInStandaloneMode to isInPWAMode for clarity

This fixes issues that the page doesn't respond after a new frontend version got deployed