### PR TITLE
EditPlayer: Fix typo in configEntry/translation key

### DIFF
--- a/src/views/settings/EditPlayer.vue
+++ b/src/views/settings/EditPlayer.vue
@@ -222,7 +222,7 @@ const config_entries = computed(() => {
     !player.supported_features.includes(PlayerFeature.MULTI_DEVICE_DSP)
   ) {
     entries.push({
-      key: "dsp_note_multi_device_group_not_supported",
+      key: "dsp_note_multi_device_group_unsupported",
       type: ConfigEntryType.LABEL,
       label:
         "This group type does not support DSP when playing to multiple devices.",


### PR DESCRIPTION
Currently there is key mismatch between the ConfigEntry key for the 'DSP not supported in group' banner and the translation keys. As it is only an ui helper configEntry this PR simply changes the key of the configEntry itself to match the translation keys.