### PR TITLE
Separate UI-only config entries from API schema; inject DSP link via UI entry helpers

### DIFF
--- a/src/helpers/config_entry_ui.ts
+++ b/src/helpers/config_entry_ui.ts
@@ -1,0 +1,54 @@
+import type { ConfigEntry, ConfigEntryType } from "@/plugins/api/interfaces";
+
+export type ConfigEntryUIOnlyType = "dsp_settings_link";
+export type ConfigEntryUIType = ConfigEntryType | ConfigEntryUIOnlyType;
+
+export type InjectedConfigEntry = Omit<ConfigEntry, "type"> & {
+  injected: true;
+  type: ConfigEntryUIOnlyType;
+  i18nParams?: Record<string, string | number>;
+};
+
+export type DspLinkConfigEntryUI = InjectedConfigEntry & {
+  type: "dsp_settings_link";
+  note_key?: string;
+};
+
+// server entries stay unchanged
+export type ServerConfigEntryUI = ConfigEntry & {
+  injected?: false;
+};
+
+export type ConfigEntryUI = ServerConfigEntryUI | InjectedConfigEntry;
+
+export const isInjected = (e: ConfigEntryUI): e is InjectedConfigEntry =>
+  "injected" in e && e.injected === true;
+
+export const isDspLinkEntry = (e: ConfigEntryUI): e is DspLinkConfigEntry =>
+  isInjected(e) && e.type === "dsp_settings_link";
+
+const DEFAULT_DSP_LINK_ENTRY: Omit<
+  DspLinkConfigEntryUI,
+  "value" | "default_value"
+> & {
+  value: boolean;
+  default_value: boolean;
+} = {
+  injected: true,
+  type: "dsp_settings_link",
+  key: "dsp_settings_link",
+  category: "audio",
+  label: "",
+  required: false,
+};
+
+export function makeDspLinkEntry(
+  overrides: Partial<DspLinkConfigEntryUI> = {},
+): DspLinkConfigEntryUI {
+  return {
+    ...DEFAULT_DSP_LINK_ENTRY,
+    ...overrides,
+    injected: true,
+    type: "dsp_settings_link",
+  };
+}

--- a/src/helpers/config_entry_ui.ts
+++ b/src/helpers/config_entry_ui.ts
@@ -1,54 +1,40 @@
 import type { ConfigEntry, ConfigEntryType } from "@/plugins/api/interfaces";
 
-export type ConfigEntryUIOnlyType = "dsp_settings_link";
-export type ConfigEntryUIType = ConfigEntryType | ConfigEntryUIOnlyType;
+export const CONFIG_KEY_UI = {
+  DSP_SETTINGS_LINK: "dsp_settings_link",
+} as const;
+
+export type UiOnlyKey = (typeof CONFIG_KEY_UI)[keyof typeof CONFIG_KEY_UI];
+export type ConfigKeyUI = string | UiOnlyKey;
+
+export const UI_ENTRY_TYPE = {
+  // entry type equals key for dsp_settings_link
+  DSP_SETTINGS_LINK: CONFIG_KEY_UI.DSP_SETTINGS_LINK,
+} as const;
+
+export type UiOnlyEntryType =
+  (typeof UI_ENTRY_TYPE)[keyof typeof UI_ENTRY_TYPE];
+export type ConfigEntryUIType = ConfigEntryType | UiOnlyEntryType;
 
 export type InjectedConfigEntry = Omit<ConfigEntry, "type"> & {
   injected: true;
-  type: ConfigEntryUIOnlyType;
+  type: ConfigEntryUIType;
+  read_only?: boolean;
   i18nParams?: Record<string, string | number>;
-};
-
-export type DspLinkConfigEntryUI = InjectedConfigEntry & {
-  type: "dsp_settings_link";
   note_key?: string;
 };
 
-// server entries stay unchanged
 export type ServerConfigEntryUI = ConfigEntry & {
   injected?: false;
+  note_key?: string;
 };
-
 export type ConfigEntryUI = ServerConfigEntryUI | InjectedConfigEntry;
 
 export const isInjected = (e: ConfigEntryUI): e is InjectedConfigEntry =>
-  "injected" in e && e.injected === true;
+  (e as InjectedConfigEntry).injected === true;
 
-export const isDspLinkEntry = (e: ConfigEntryUI): e is DspLinkConfigEntry =>
-  isInjected(e) && e.type === "dsp_settings_link";
-
-const DEFAULT_DSP_LINK_ENTRY: Omit<
-  DspLinkConfigEntryUI,
-  "value" | "default_value"
-> & {
-  value: boolean;
-  default_value: boolean;
-} = {
-  injected: true,
-  type: "dsp_settings_link",
-  key: "dsp_settings_link",
-  category: "audio",
-  label: "",
-  required: false,
-};
-
-export function makeDspLinkEntry(
-  overrides: Partial<DspLinkConfigEntryUI> = {},
-): DspLinkConfigEntryUI {
-  return {
-    ...DEFAULT_DSP_LINK_ENTRY,
-    ...overrides,
-    injected: true,
-    type: "dsp_settings_link",
-  };
-}
+export const isDspLinkEntry = (
+  e: ConfigEntryUI,
+): e is InjectedConfigEntry & {
+  type: typeof UI_ENTRY_TYPE.DSP_SETTINGS_LINK;
+} => isInjected(e) && e.type === UI_ENTRY_TYPE.DSP_SETTINGS_LINK;

--- a/src/plugins/api/interfaces.ts
+++ b/src/plugins/api/interfaces.ts
@@ -369,9 +369,6 @@ export enum ConfigEntryType {
   ACTION = "action",
   ICON = "icon",
   ALERT = "alert",
-
-  // Only used in the frontend
-  DSP_SETTINGS = "dsp_settings",
 }
 
 export enum VolumeNormalizationMode {

--- a/src/views/settings/ConfigEntryField.vue
+++ b/src/views/settings/ConfigEntryField.vue
@@ -271,10 +271,7 @@ import {
   ConfigValueType,
   SECURE_STRING_SUBSTITUTE,
 } from "@/plugins/api/interfaces";
-import {
-  ConfigEntryUI,
-  isDspLinkEntry,
-} from "@/helpers/config_entry_ui";
+import { ConfigEntryUI, isDspLinkEntry } from "@/helpers/config_entry_ui";
 import { $t } from "@/plugins/i18n";
 import { computed } from "vue";
 

--- a/src/views/settings/ConfigEntryField.vue
+++ b/src/views/settings/ConfigEntryField.vue
@@ -48,10 +48,7 @@
     </v-btn>
 
     <!-- DSP Config Button -->
-    <div
-      v-else-if="confEntry.type == ConfigEntryType.DSP_SETTINGS"
-      class="dsp-config"
-    >
+    <div v-else-if="isDspLinkEntry(confEntry)" class="dsp-config">
       <span class="dsp-status">
         {{
           confEntry.value
@@ -59,7 +56,11 @@
             : $t("settings.dsp_disabled")
         }}
       </span>
-      <v-btn variant="outlined" @click="$emit('openDsp')">
+      <v-btn
+        variant="outlined"
+        :disabled="isFieldDisabled"
+        @click="$emit('openDsp')"
+      >
         {{ $t("open_dsp_settings") }}
       </v-btn>
     </div>
@@ -270,11 +271,15 @@ import {
   ConfigValueType,
   SECURE_STRING_SUBSTITUTE,
 } from "@/plugins/api/interfaces";
+import {
+  ConfigEntryUI,
+  isDspLinkEntry,
+} from "@/helpers/config_entry_ui";
 import { $t } from "@/plugins/i18n";
 import { computed } from "vue";
 
 const props = defineProps<{
-  confEntry: ConfigEntry;
+  confEntry: ConfigEntryUI;
   showPasswordValues: boolean;
   disabled?: boolean;
 }>();

--- a/src/views/settings/EditConfig.vue
+++ b/src/views/settings/EditConfig.vue
@@ -608,7 +608,7 @@ const getProtocolDomain = function (category: string): string | undefined {
 
 const getProtocolEnabledEntry = function (
   category: string,
-): ConfigEntry | undefined {
+): ConfigEntryUI | undefined {
   if (!isProtocolCategory(category) || !entries.value) return undefined;
 
   // Look for an entry in this category with a key ending in "||protocol||enabled"
@@ -828,7 +828,7 @@ const getCategoryTranslation = function (category: string) {
   const entriesInCategory = entriesForCategory(category);
 
   // For protocol categories with no visible entries, check all entries (including enabled entry)
-  let entryWithTranslation: ConfigEntry | undefined = entriesInCategory[0];
+  let entryWithTranslation: ConfigEntryUI | undefined = entriesInCategory[0];
   if (!entryWithTranslation && isProtocolCategory(category) && entries.value) {
     entryWithTranslation = entries.value.find((e) => e.category === category);
   }

--- a/src/views/settings/EditConfig.vue
+++ b/src/views/settings/EditConfig.vue
@@ -481,6 +481,7 @@ import { $t } from "@/plugins/i18n";
 import { HelpCircle } from "lucide-vue-next";
 import { computed, onBeforeUnmount, ref, VNodeRef, watch } from "vue";
 import { onBeforeRouteLeave, useRouter } from "vue-router";
+import { ConfigEntryUI, isInjected } from "@/helpers/config_entry_ui";
 import ConfigEntryField from "./ConfigEntryField.vue";
 
 const router = useRouter();
@@ -488,7 +489,7 @@ const showUnsavedDialog = ref(false);
 const allowNavigation = ref(false);
 
 export interface Props {
-  configEntries: ConfigEntry[];
+  configEntries: ConfigEntryUI[];
   disabled: boolean;
 }
 
@@ -568,7 +569,8 @@ const hasUnsavedChanges = computed(() => {
       entry.type == ConfigEntryType.DIVIDER ||
       entry.type == ConfigEntryType.LABEL ||
       entry.type == ConfigEntryType.ALERT ||
-      entry.type == ConfigEntryType.ACTION
+      entry.type == ConfigEntryType.ACTION ||
+      isInjected(entry)
     ) {
       continue;
     }
@@ -855,6 +857,7 @@ const getCurrentValues = function () {
   // Note: entries.value contains the same object references as props.configEntries
   // (pushed in the watch), so user modifications via the form update both
   for (const entry of props.configEntries!) {
+    if (isInjected(entry)) continue;
     let value = entry.value;
     // filter out undefined values
     if (value == undefined) value = null;

--- a/src/views/settings/EditConfig.vue
+++ b/src/views/settings/EditConfig.vue
@@ -500,14 +500,14 @@ const emit = defineEmits<{
 }>();
 
 // global refs
-const entries = ref<ConfigEntry[]>();
+const entries = ref<ConfigEntryUI[]>();
 const valid = ref(false);
 const form = ref<VNodeRef>();
 const activePanel = ref<string[]>([]);
 const activeProtocolPanel = ref<string | undefined>(undefined);
 const showPasswordValues = ref(false);
 const showAdvancedSettings = ref(false);
-const showHelpInfo = ref<ConfigEntry>();
+const showHelpInfo = ref<ConfigEntryUI>();
 const oldValues = ref<Record<string, ConfigValueType>>({});
 const oldValuesInitialized = ref(false);
 
@@ -697,7 +697,7 @@ const action = async function (action: string) {
   emit("action", action, getCurrentValues());
 };
 
-const onValueUpdate = function (entry: ConfigEntry, value: ConfigValueType) {
+const onValueUpdate = function (entry: ConfigEntryUI, value: ConfigValueType) {
   entry.value = value;
   // If immediate_apply is set, emit the value change immediately
   if (entry.immediate_apply) {
@@ -770,11 +770,11 @@ const isNullOrUndefined = function (value: unknown) {
   return value === null || value === undefined;
 };
 
-const isVisible = function (entry: ConfigEntry) {
+const isVisible = function (entry: ConfigEntryUI) {
   return !entry.hidden;
 };
 
-const isDisabled = function (entry: ConfigEntry) {
+const isDisabled = function (entry: ConfigEntryUI) {
   if (!isNullOrUndefined(entry.depends_on)) {
     const dependentEntry = entries.value?.find(
       (x) => x.key == entry.depends_on,
@@ -797,7 +797,7 @@ const isDisabled = function (entry: ConfigEntry) {
 };
 
 const visibleEntriesByCategory = computed(() => {
-  const result: Record<string, ConfigEntry[]> = {};
+  const result: Record<string, ConfigEntryUI[]> = {};
   if (!entries.value) return result;
 
   for (const entry of entries.value) {
@@ -900,7 +900,7 @@ const getCategoryIcon = function (category: string): string {
   return iconMap[category] || "mdi-cog-outline";
 };
 
-const hasDescriptionOrHelpLink = function (conf_entry: ConfigEntry) {
+const hasDescriptionOrHelpLink = function (conf_entry: ConfigEntryUI) {
   // overly complicated way to determine we have a description for the entry
   // in either the translations (by entry key), on the entry itself as fallback
   // OR it has a help link

--- a/src/views/settings/EditPlayer.vue
+++ b/src/views/settings/EditPlayer.vue
@@ -245,7 +245,7 @@ const config_entries = computed(() => {
       injected: true,
       key: "dsp_settings",
       type: UI_ENTRY_TYPE.DSP_SETTINGS_LINK,
-      category: "audio",
+      category: "dsp",
       label: "",
       required: false,
       read_only: false,

--- a/src/views/settings/EditPlayer.vue
+++ b/src/views/settings/EditPlayer.vue
@@ -197,10 +197,7 @@ import EditConfig from "./EditConfig.vue";
 import { watch } from "vue";
 import { openLinkInNewTab } from "@/helpers/utils";
 import { nanoid } from "nanoid";
-import {
-  ConfigEntryUI,
-  makeDspLinkEntry
-} from "@/helpers/config_entry_ui";
+import { ConfigEntryUI, makeDspLinkEntry } from "@/helpers/config_entry_ui";
 // global refs
 const router = useRouter();
 const config = ref<PlayerConfig>();
@@ -240,14 +237,15 @@ const config_entries = computed(() => {
   if (!config.value) return [];
   const player = api.players[config.value.player_id];
   if (!player) return [];
-  
+
   // inject a link to the DSP config if the player is not a group
   const entries: ConfigEntryUI[] = Object.values(config.value.values);
   if (player.type !== PlayerType.GROUP) {
     entries.push(
       makeDspLinkEntry({
-      default_value: dspEnabled.value,
-    }));
+        default_value: dspEnabled.value,
+      }),
+    );
   } else if (
     player.type === PlayerType.GROUP &&
     player.supported_features.includes(PlayerFeature.MULTI_DEVICE_DSP)
@@ -259,9 +257,10 @@ const config_entries = computed(() => {
       default_value: null,
       required: false,
       category: "dsp",
-      injected: true
+      injected: true,
     });
-  } else if (player.type === PlayerType.GROUP &&
+  } else if (
+    player.type === PlayerType.GROUP &&
     !player.supported_features.includes(PlayerFeature.MULTI_DEVICE_DSP)
   ) {
     entries.push({
@@ -272,7 +271,7 @@ const config_entries = computed(() => {
       default_value: null,
       required: false,
       category: "dsp",
-      injected: true
+      injected: true,
     });
   }
   return entries;

--- a/src/views/settings/EditPlayer.vue
+++ b/src/views/settings/EditPlayer.vue
@@ -197,7 +197,10 @@ import EditConfig from "./EditConfig.vue";
 import { watch } from "vue";
 import { openLinkInNewTab } from "@/helpers/utils";
 import { nanoid } from "nanoid";
-
+import {
+  ConfigEntryUI,
+  makeDspLinkEntry
+} from "@/helpers/config_entry_ui";
 // global refs
 const router = useRouter();
 const config = ref<PlayerConfig>();
@@ -233,23 +236,19 @@ const unsub = api.subscribe(
 onBeforeUnmount(unsub);
 
 // computed properties
-
 const config_entries = computed(() => {
   if (!config.value) return [];
-  const entries = Object.values(config.value.values);
-  // inject a DSP config property if the player is not a group
   const player = api.players[config.value.player_id];
-  if (player && player.type !== PlayerType.GROUP) {
-    entries.push({
-      key: "dsp_settings",
-      type: ConfigEntryType.DSP_SETTINGS,
-      label: "",
+  if (!player) return [];
+  
+  // inject a link to the DSP config if the player is not a group
+  const entries: ConfigEntryUI[] = Object.values(config.value.values);
+  if (player.type !== PlayerType.GROUP) {
+    entries.push(
+      makeDspLinkEntry({
       default_value: dspEnabled.value,
-      required: false,
-      category: "dsp",
-    });
+    }));
   } else if (
-    player &&
     player.type === PlayerType.GROUP &&
     player.supported_features.includes(PlayerFeature.MULTI_DEVICE_DSP)
   ) {
@@ -260,10 +259,9 @@ const config_entries = computed(() => {
       default_value: null,
       required: false,
       category: "dsp",
+      injected: true
     });
-  } else if (
-    player &&
-    player.type === PlayerType.GROUP &&
+  } else if (player.type === PlayerType.GROUP &&
     !player.supported_features.includes(PlayerFeature.MULTI_DEVICE_DSP)
   ) {
     entries.push({
@@ -274,6 +272,7 @@ const config_entries = computed(() => {
       default_value: null,
       required: false,
       category: "dsp",
+      injected: true
     });
   }
   return entries;
@@ -325,7 +324,6 @@ const enablePlayer = function () {
 };
 
 const onSubmit = async function (values: Record<string, ConfigValueType>) {
-  delete values["dsp_settings"]; // delete the injected dsp_settings since its UI only
   values["enabled"] = config.value!.enabled;
   api.savePlayerConfig(props.playerId!, values);
   router.back();

--- a/src/views/settings/EditPlayer.vue
+++ b/src/views/settings/EditPlayer.vue
@@ -197,7 +197,7 @@ import EditConfig from "./EditConfig.vue";
 import { watch } from "vue";
 import { openLinkInNewTab } from "@/helpers/utils";
 import { nanoid } from "nanoid";
-import { ConfigEntryUI, makeDspLinkEntry } from "@/helpers/config_entry_ui";
+import { ConfigEntryUI, UI_ENTRY_TYPE } from "@/helpers/config_entry_ui";
 // global refs
 const router = useRouter();
 const config = ref<PlayerConfig>();
@@ -241,11 +241,16 @@ const config_entries = computed(() => {
   // inject a link to the DSP config if the player is not a group
   const entries: ConfigEntryUI[] = Object.values(config.value.values);
   if (player.type !== PlayerType.GROUP) {
-    entries.push(
-      makeDspLinkEntry({
-        default_value: dspEnabled.value,
-      }),
-    );
+    entries.push({
+      injected: true,
+      key: "dsp_settings",
+      type: UI_ENTRY_TYPE.DSP_SETTINGS_LINK,
+      category: "audio",
+      label: "",
+      required: false,
+      read_only: false,
+      default_value: dspEnabled.value,
+    });
   } else if (
     player.type === PlayerType.GROUP &&
     player.supported_features.includes(PlayerFeature.MULTI_DEVICE_DSP)


### PR DESCRIPTION
## Summary

This PR removes frontend-only config entry types from the API schema and introduces a UI-layer model for injected configuration entries.  
DSP settings are now exposed in the UI via injected entries instead of extending the server `ConfigEntryType`.

This keeps the API contract aligned with actual server responses while allowing the UI to render and handle additional, non-persisted settings cleanly.

---

## Changes

### API contract cleanup
- Removed the frontend-only `DSP_SETTINGS` value from `ConfigEntryType`
- Ensures the enum strictly reflects values sent by the backend

### UI config entry model
- Introduced `ConfigEntryUI` and injected entry helpers in `helpers/config_entry_ui`
- Added type guards (`isInjected`, `isDspLinkEntry`) for safe narrowing
- Added a factory (`makeDspLinkEntry`) to construct injected entries with proper defaults

### Settings UI updates
- `ConfigEntryField.vue` now renders DSP settings via `isDspLinkEntry` instead of checking an API enum
- DSP action button respects disabled/read-only state

### Form handling & persistence
- `EditConfig.vue` ignores injected entries when:
  - detecting unsaved changes
  - collecting values for submission
- Removed the previous workaround that deleted DSP keys before save

### Player settings injection
- `EditPlayer.vue` injects the DSP settings link using `makeDspLinkEntry`
- Group-related informational labels are now marked as injected UI entries

---

## Why

- Prevents UI-only concepts from leaking into the backend type system
- Makes injected UI elements explicit, type-safe, and non-persisted by design
- Eliminates special-case cleanup logic during save
- Improves long-term maintainability of the settings model

---

## Notes / Testing

- DSP settings link renders for non-group players and respects disabled state
- Injected entries do not trigger “unsaved changes” warnings
- Injected entries are never included in the payload sent to the backend
- Group informational labels continue to render correctly
