### PR TITLE
Don't force reload on all config changes

### DIFF
--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -141,6 +141,7 @@
         "reload": "Reload",
         "save": "Save",
         "settings": "Settings",
+        "settings_saved": "Settings saved successfully",
         "setup_provider": "Setup provider: {0}",
         "sync": "Synchronize now",
         "sync_running": "This provider is now being synchronized",

--- a/src/views/settings/EditConfig.vue
+++ b/src/views/settings/EditConfig.vue
@@ -61,7 +61,7 @@
         block
         color="primary"
         size="large"
-        :disabled="!requiredValuesPresent"
+        :disabled="!requiredValuesPresent || !hasUnsavedChanges"
         @click="submit"
       >
         {{ $t("settings.save") }}
@@ -557,5 +557,10 @@ const hasDescriptionOrHelpLink = function (conf_entry: ConfigEntry) {
   gap: 12px;
   margin-top: 24px;
   padding-top: 16px;
+}
+
+.config-actions .v-btn--disabled {
+  background-color: rgba(var(--v-theme-on-surface), 0.12) !important;
+  color: rgba(var(--v-theme-on-surface), 0.38) !important;
 }
 </style>

--- a/src/views/settings/EditCoreConfig.vue
+++ b/src/views/settings/EditCoreConfig.vue
@@ -42,19 +42,14 @@
 
 <script setup lang="ts">
 import { ref, watch, computed } from "vue";
-import { useRouter } from "vue-router";
 import { useI18n } from "vue-i18n";
 import { api } from "@/plugins/api";
-import {
-  CoreConfig,
-  ConfigValueType,
-  ConfigEntry,
-} from "@/plugins/api/interfaces";
+import { CoreConfig, ConfigValueType } from "@/plugins/api/interfaces";
 import EditConfig from "./EditConfig.vue";
 import { nanoid } from "nanoid";
+import { toast } from "vuetify-sonner";
 
 // global refs
-const router = useRouter();
 const { t } = useI18n();
 const config = ref<CoreConfig>();
 const sessionId = nanoid(11);
@@ -114,17 +109,16 @@ const getCoreIcon = (domain: string): string => {
 };
 
 const onSubmit = async function (values: Record<string, ConfigValueType>) {
-  // save new provider config
+  // save core config
   loading.value = true;
   api
     .saveCoreConfig(config.value!.domain, values)
     .then(() => {
       loading.value = false;
-      router.push({ name: "providersettings" });
+      toast.success(t("settings.settings_saved"));
     })
     .catch((err) => {
-      // TODO: make this a bit more fancy someday
-      alert(err);
+      toast.error(err.message || err);
       loading.value = false;
     });
 };
@@ -153,8 +147,7 @@ const onAction = async function (
       loading.value = false;
     })
     .catch((err) => {
-      // TODO: make this a bit more fancy someday
-      alert(err);
+      toast.error(err.message || err);
       loading.value = false;
     });
 };


### PR DESCRIPTION
This PR pairs with the one of the same name in the server repository. The goal is to enable skipping a full reload on every config change, and improving the UI to handle it gracefully.

- Add success toast "Settings saved successfully" after saving
- Disable save button until changes are made
- Use toast for error messages instead of alert()
- Remove navigation that incorrectly went to provider settings