### PR TITLE
Add year/release date display for albums and tracks

### DIFF
--- a/src/components/InfoHeader.vue
+++ b/src/components/InfoHeader.vue
@@ -141,6 +141,19 @@
               </MarqueeText>
             </v-card-subtitle>
 
+            <!-- album type and year -->
+            <v-card-subtitle
+              v-if="item.media_type == MediaType.ALBUM"
+              class="caption"
+            >
+              <span v-if="'album_type' in item && item.album_type !== 'unknown'">
+                {{ $t("album_type." + item.album_type) }}
+              </span>
+              <span v-if="'year' in item && item.year">
+                • {{ item.year }}
+              </span>
+            </v-card-subtitle>
+
             <!-- audiobook author(s) -->
             <v-card-subtitle
               v-if="'authors' in item && item.authors.length > 0"

--- a/src/components/InfoHeader.vue
+++ b/src/components/InfoHeader.vue
@@ -112,6 +112,22 @@
               </v-tooltip>
             </v-card-subtitle>
 
+            <!-- track release date -->
+            <v-card-subtitle
+              v-if="
+                item.media_type == MediaType.TRACK && item.metadata?.release_date
+              "
+              class="title d-flex"
+            >
+              <v-icon
+                style="margin-left: -3px; margin-right: 3px"
+                small
+                color="primary"
+                icon="mdi-calendar"
+              />
+              {{ new Date(item.metadata.release_date).getFullYear() }}
+            </v-card-subtitle>
+
             <!-- item artists -->
             <v-card-subtitle
               v-if="'artists' in item && item.artists"
@@ -146,7 +162,9 @@
               v-if="item.media_type == MediaType.ALBUM"
               class="caption"
             >
-              <span v-if="'album_type' in item && item.album_type !== 'unknown'">
+              <span
+                v-if="'album_type' in item && item.album_type !== 'unknown'"
+              >
                 {{ $t("album_type." + item.album_type) }}
               </span>
               <span v-if="'year' in item && item.year">
@@ -239,6 +257,8 @@
                   style="color: secondary"
                   @click="albumClick((item as Track)?.album)"
                   >{{ item.album.name }}</a
+                ><span v-if="'year' in item.album && item.album.year">
+                  • {{ item.album.year }}</span
                 ></MarqueeText
               >
             </v-card-subtitle>

--- a/src/components/ListviewItem.vue
+++ b/src/components/ListviewItem.vue
@@ -34,6 +34,13 @@
         <span v-if="'version' in item && item.version"
           >({{ item.version }})</span
         >
+        <span
+          v-if="
+            item.media_type == MediaType.TRACK && item.metadata?.release_date
+          "
+        >
+          ({{ new Date(item.metadata.release_date).getFullYear() }})</span
+        >
       </span>
       <!-- explicit icon -->
       <v-tooltip v-if="item && item.metadata" location="bottom">
@@ -61,7 +68,10 @@
             {{ getArtistsString(item.artists, 2) }}
           </v-item>
           <v-item v-if="showAlbum && 'album' in item && item.album">
-            • {{ item.album.name }}
+            • {{ item.album.name
+            }}<span v-if="'year' in item.album && item.album.year">
+              • {{ item.album.year }}</span
+            >
           </v-item>
           <v-item
             v-if="showDiscNumber && 'disc_number' in item && item.disc_number"

--- a/src/plugins/api/interfaces.ts
+++ b/src/plugins/api/interfaces.ts
@@ -583,6 +583,7 @@ export interface MediaItemMetadata {
   preview?: string;
   replaygain?: number;
   popularity?: number;
+  release_date?: string;
   cache_checksum?: string;
   chapters?: MediaItemChapter[];
 }
@@ -612,6 +613,7 @@ export interface MediaItem extends _MediaItemBase {
 export interface ItemMapping extends _MediaItemBase {
   available: boolean;
   image?: MediaItemImage;
+  year?: number;
 }
 
 export interface Artist extends MediaItem {}


### PR DESCRIPTION
## Summary
- Display album year on track listings (next to album name)
- Display track release date in track title (when available)
- Display track release date in InfoHeader for tracks
- Add `year` and `release_date` fields to TypeScript interfaces

## Changes
- **ListviewItem.vue**: Show album year after album name, track release date in title
- **InfoHeader.vue**: Show track release date with calendar icon, album year next to album link
- **interfaces.ts**: Add `year` to ItemMapping, `release_date` to MediaItemMetadata

## Related PRs
- Models: https://github.com/music-assistant/models/pull/164
- Server: https://github.com/music-assistant/server/pull/3085

Depends on models and server PRs being merged first.