### PR TITLE
Fix playing indicator for playlist, album, and artist tracks

### DIFF
--- a/src/components/ItemsListing.vue
+++ b/src/components/ItemsListing.vue
@@ -449,7 +449,10 @@ const isPlaying = function (item: MediaItemType, itemtype: string): boolean {
     | undefined;
   if (!current) return false;
   switch (itemtype) {
-    case "tracks": {
+    case "tracks":
+    case "playlisttracks":
+    case "albumtracks":
+    case "artisttracks": {
       return item.item_id === current.item_id;
     }
     case "albums": {


### PR DESCRIPTION
## Summary

The `isPlaying()` function in `ItemsListing.vue` only handled `itemtype="tracks"` but not the specialized track listing types used in detail views:
- `playlisttracks` (PlaylistDetails.vue)
- `albumtracks` (AlbumDetails.vue)
- `artisttracks` (ArtistDetails.vue)

This caused the "now playing" indicator to never show when viewing tracks within a playlist, album, or artist page.

## Fix

Added the missing itemtypes to the switch statement so they're handled the same as `tracks`.

## Test

1. Play a track from a playlist
2. Navigate to that playlist's detail page
3. Verify the playing track shows the "now playing" indicator

Suggested label: `bugfix`