### PR TITLE
Fix Refresh Item not updating tracks for provider playlists

### DIFF
--- a/src/layouts/default/ItemContextMenu.vue
+++ b/src/layouts/default/ItemContextMenu.vue
@@ -235,6 +235,7 @@ import { itemIsAvailable } from "@/plugins/api/helpers";
 import {
   Album,
   BrowseFolder,
+  EventType,
   MediaItem,
   MediaItemType,
   MediaItemTypeOrItemMapping,
@@ -931,7 +932,13 @@ export const getContextMenuItems = async function (
       action: async () => {
         const updatedInfo = await api.refreshItem(items[0]);
         if (updatedInfo) {
-          Object.assign(items[0], updatedInfo);
+          // Emit synthetic MEDIA_ITEM_UPDATED event to trigger UI refresh
+          // This ensures child components (like track listings) also refresh
+          api.signalEvent({
+            event: EventType.MEDIA_ITEM_UPDATED,
+            object_id: updatedInfo.uri,
+            data: updatedInfo,
+          });
         }
       },
       icon: "mdi-refresh",

--- a/src/plugins/api/index.ts
+++ b/src/plugins/api/index.ts
@@ -1842,7 +1842,6 @@ export class MusicAssistantApi {
 
   /**
    * Signal an event to all registered listeners.
-   * Can be used to emit synthetic events from the frontend.
    */
   public signalEvent(evt: MassEvent) {
     // signal event to all listeners

--- a/src/plugins/api/index.ts
+++ b/src/plugins/api/index.ts
@@ -1840,7 +1840,11 @@ export class MusicAssistantApi {
     });
   }
 
-  private signalEvent(evt: MassEvent) {
+  /**
+   * Signal an event to all registered listeners.
+   * Can be used to emit synthetic events from the frontend.
+   */
+  public signalEvent(evt: MassEvent) {
     // signal event to all listeners
     for (const listener of this.eventCallbacks) {
       if (listener[0] === EventType.ALL || listener[0] === evt.event) {

--- a/src/views/PlaylistDetails.vue
+++ b/src/views/PlaylistDetails.vue
@@ -9,6 +9,7 @@
     :show-favorites-only-filter="false"
     :show-track-number="false"
     :show-refresh-button="true"
+    :refresh-on-parent-update="true"
     :load-items="loadPlaylistTracks"
     :sort-keys="[
       'position',


### PR DESCRIPTION
## Summary

When using "Refresh Item" from the context menu on provider playlists (like Deezer's dynamic playlists), the metadata/image would update but the **track listing would not refresh**.

## Root Cause

Non-library items (provider playlists that aren't added to the library) don't trigger `MEDIA_ITEM_UPDATED` events from the backend when refreshed. The backend's `refresh_item` method only emits events for library items:

```python
if library_id is None:
    return media_item  # No event emitted for non-library items
```

The previous frontend implementation used `Object.assign()` to update the item in-place, which:
1. Mutated the object without changing its reference
2. Vue's watcher didn't reliably detect the deep mutation
3. Child components (track listings) never knew to refresh

## Fix

1. **Made `signalEvent()` public** in the API class to allow emitting synthetic events
2. **Emit synthetic `MEDIA_ITEM_UPDATED` event** from the context menu after refresh completes
3. **Added `refresh-on-parent-update` prop** to PlaylistDetails to auto-reload tracks when parent item changes

This ensures the same event flow happens regardless of whether the item is in the library or not.

## Testing

Tested on dev environment with Deezer provider playlists - working as expected.

**To verify:**
1. Browse to a provider playlist (e.g., Deezer recommendations)
2. Open playlist details to see tracks
3. Right-click → "Refresh Item"
4. Verify tracks refresh automatically (no manual browser refresh needed)

Suggested label: `bugfix`