### PR TITLE
fix: enable scrolling on login page

### DIFF
--- a/src/views/Login.vue
+++ b/src/views/Login.vue
@@ -1590,6 +1590,9 @@ onMounted(() => {
   color: var(--fg);
   opacity: 0;
   animation: fadeIn 0.3s ease-in forwards;
+  height: 100vh;
+  overflow-y: auto;
+  overflow-x: hidden;
 }
 
 @keyframes fadeIn {


### PR DESCRIPTION
Fixes an issue where the login page was not scrollable on desktop when the content exceeded the viewport height (e.g., with multiple OAuth providers or on smaller screens).

Changes:
- Add height: 100vh and overflow-y: auto to existing .login-background class
- Keeps all changes scoped to Login component
- No additional DOM elements or global CSS changes