### PR TITLE
Disable podcasts and audiobooks in main menu when library is empty

### DIFF
--- a/src/components/navigation/AppSidebar.vue
+++ b/src/components/navigation/AppSidebar.vue
@@ -28,6 +28,7 @@ const navItems = computed(() => {
       title: t(item.label),
       url: item.path,
       icon: item.icon,
+      disabled: item.disabled,
     }));
 });
 

--- a/src/components/navigation/NavMain.vue
+++ b/src/components/navigation/NavMain.vue
@@ -17,6 +17,7 @@ interface NavItem {
   title: string;
   url: string;
   icon?: Component;
+  disabled?: boolean;
 }
 
 const props = defineProps<{
@@ -42,16 +43,18 @@ const handleClick = () => {
       <SidebarMenu>
         <SidebarMenuItem v-for="item in items" :key="item.title" class="mr-1.5">
           <SidebarMenuButton
-            :as="RouterLinkComponent"
-            v-bind="{ to: item.url }"
+            :as="item.disabled ? 'button' : RouterLinkComponent"
+            v-bind="item.disabled ? {} : { to: item.url }"
             :is-active="isActive(item.url)"
             :tooltip="item.title"
-            :class="
+            :disabled="item.disabled"
+            :class="[
               isActive(item.url)
                 ? 'no-underline font-bold text-sm'
-                : 'no-underline font-medium text-sm'
-            "
-            @click="handleClick"
+                : 'no-underline font-medium text-sm',
+              item.disabled ? 'opacity-50 cursor-not-allowed' : '',
+            ]"
+            @click="item.disabled ? undefined : handleClick"
           >
             <component
               :is="item.icon"

--- a/src/components/navigation/utils/getMenuItems.ts
+++ b/src/components/navigation/utils/getMenuItems.ts
@@ -22,6 +22,7 @@ export interface MenuItem {
   path: string;
   isLibraryNode: boolean;
   hidden?: boolean;
+  disabled?: boolean;
 }
 
 export const getMenuItems = function () {
@@ -86,7 +87,7 @@ export const getMenuItems = function () {
         icon: BookAudio,
         path: "/audiobooks",
         isLibraryNode: true,
-        hidden: store.libraryAudiobooksCount === 0,
+        disabled: store.libraryAudiobooksCount === 0,
       });
     }
     if (enabledMenuItemStr === "podcasts") {
@@ -95,7 +96,7 @@ export const getMenuItems = function () {
         icon: Podcast,
         path: "/podcasts",
         isLibraryNode: true,
-        hidden: store.libraryPodcastsCount === 0,
+        disabled: store.libraryPodcastsCount === 0,
       });
     }
     if (enabledMenuItemStr === "radios") {

--- a/src/components/navigation/utils/getMenuItems.ts
+++ b/src/components/navigation/utils/getMenuItems.ts
@@ -54,7 +54,6 @@ export const getMenuItems = function () {
         icon: ArtistIcon,
         path: "/artists",
         isLibraryNode: true,
-        hidden: store.libraryArtistsCount === 0,
       });
     }
     if (enabledMenuItemStr === "albums") {
@@ -63,7 +62,6 @@ export const getMenuItems = function () {
         icon: Disc3,
         path: "/albums",
         isLibraryNode: true,
-        hidden: store.libraryAlbumsCount === 0,
       });
     }
     if (enabledMenuItemStr === "tracks") {
@@ -72,7 +70,6 @@ export const getMenuItems = function () {
         icon: Music2,
         path: "/tracks",
         isLibraryNode: true,
-        hidden: store.libraryTracksCount === 0,
       });
     }
     if (enabledMenuItemStr === "playlists") {
@@ -81,7 +78,6 @@ export const getMenuItems = function () {
         icon: ListMusic,
         path: "/playlists",
         isLibraryNode: true,
-        hidden: store.libraryPlaylistsCount === 0,
       });
     }
     if (enabledMenuItemStr === "audiobooks") {
@@ -108,7 +104,6 @@ export const getMenuItems = function () {
         icon: Radio,
         path: "/radios",
         isLibraryNode: true,
-        hidden: store.libraryRadiosCount === 0,
       });
     }
     if (enabledMenuItemStr === "genres") {
@@ -117,7 +112,6 @@ export const getMenuItems = function () {
         icon: Tag,
         path: "/genres",
         isLibraryNode: true,
-        hidden: store.libraryGenresCount === 0,
       });
     }
     if (enabledMenuItemStr === "browse") {


### PR DESCRIPTION
Previously all library menu items (artists, albums, tracks, playlists, radios, genres, podcasts, audiobooks) were hidden when their count was 0. Now only podcasts and audiobooks are hidden when empty — all other items are always shown in the menu.

Discussed here https://discord.com/channels/753947050995089438/1476323267513028714