### PR TITLE
Add missing genre route definitions and filters

### DIFF
--- a/src/helpers/genre.ts
+++ b/src/helpers/genre.ts
@@ -25,4 +25,6 @@ export const folderIdToRoute: Record<string, string> = {
   genre_track: "tracks",
   genre_playlist: "playlists",
   genre_radio: "radios",
+  genre_podcast: "podcasts",
+  genre_audiobook: "audiobooks",
 };

--- a/src/views/LibraryAudiobooks.vue
+++ b/src/views/LibraryAudiobooks.vue
@@ -16,6 +16,7 @@
     :restore-state="true"
     :total="total"
     :show-provider-filter="true"
+    :show-genre-filter="true"
   />
 </template>
 

--- a/src/views/LibraryPodcasts.vue
+++ b/src/views/LibraryPodcasts.vue
@@ -16,6 +16,7 @@
     :restore-state="true"
     :total="total"
     :show-provider-filter="true"
+    :show-genre-filter="true"
   />
 </template>
 


### PR DESCRIPTION
Podcast and Audiobook route definitions were missing for redirects to library pages, as were filters from said library pages.