### PR TITLE
Fix mobile nav not closing when item selected

### DIFF
--- a/src/components/navigation/NavMain.vue
+++ b/src/components/navigation/NavMain.vue
@@ -54,8 +54,8 @@ const handleClick = () => {
                 : 'no-underline font-medium text-sm',
               item.disabled ? 'opacity-50 cursor-not-allowed' : '',
             ]"
-            @click="item.disabled ? undefined : handleClick"
-          >
+            @click="handleClick"
+            >
             <component
               :is="item.icon"
               v-if="item.icon"


### PR DESCRIPTION
### Summary
When you select a menu item, when using mobile, the navigation sidebar does not collapse.

### Notes
* Adding "()" to the "handleClick" method would also fix the bug. It must need them when using ternary operators in the click event.
* The ternary operator check to see if the item is disabled is redundant here as the button isn't clickable when its disabled flag is set on line 50.

### Videos

Before Fix:
https://github.com/user-attachments/assets/67833bf9-ec99-4ffb-b3cc-eafce5baa16f

After Fix:
https://github.com/user-attachments/assets/0a8a0d2d-d2cc-456c-bbe0-621aa3a809cb

 