### PR TITLE
Hide fullscreen player & player menu when player settings button clicked

### DIFF
--- a/src/layouts/default/PlayerSelect.vue
+++ b/src/layouts/default/PlayerSelect.vue
@@ -26,6 +26,7 @@
             v-if="authManager.isAdmin()"
             variant="icon"
             :to="{ name: 'playersettings' }"
+            @click="onPlayerSettingsClick"
           >
             <v-icon size="24">mdi-cog</v-icon>
           </Button>
@@ -274,6 +275,11 @@ function toggleGroupExpand(player: Player) {
       }
     });
   }
+}
+
+function onPlayerSettingsClick() {
+  store.showPlayersMenu = false
+  store.showFullscreenPlayer = false;
 }
 
 onMounted(() => {


### PR DESCRIPTION
### Summary
This fixes [Issue #42](https://github.com/orgs/music-assistant/projects/2/views/1?pane=issue&itemId=146456355&issue=music-assistant%7Cbacklog%7C42) in the backlog repo. 

When the fullscreen player is open and the players menu is open and the player settings button is clicked, the navigation happens in the background but the fullscreen player and the players menu remain open when they should both close.

See original Discord message [link](https://discord.com/channels/753947050995089438/1098879369792983071/1452978229739651194)

### Notes
* There is another bug where if the players settings page is already open, then pressing the players settings button in the players menu again does not close the menu. Adding line 281 in this PR ensures it always closes.