### PR TITLE
Improve player popover responsive layout + refactor event handling

### DIFF
--- a/src/components/ActivePlayerPopover.vue
+++ b/src/components/ActivePlayerPopover.vue
@@ -194,25 +194,31 @@ watch(
   left: 50%;
 }
 
-@media screen and (max-width: 361px) {
+@media screen and (max-width: 313px) {
   .player-tip-end .tip-arrow {
-    left: 155px;
+    left: 176px;
   }
 }
 
-@media screen and (min-width: 360px) and (max-width: 406px) {
+@media screen and (min-width: 312px) and (max-width: 411px) {
   .player-tip-end .tip-arrow {
-    left: 148px;
+    left: 167px;
   }
 }
 
-@media screen and (min-width: 405px) and (max-width: 471px) {
+@media screen and (min-width: 410px) and (max-width: 511px) {
   .player-tip-end .tip-arrow {
-    left: 138px;
+    left: 154px;
   }
 }
 
-@media screen and (min-width: 470px) and (max-width: 770px) {
+@media screen and (min-width: 510px) and (max-width: 621px) {
+  .player-tip-end .tip-arrow {
+    left: 141px;
+  }
+}
+
+@media screen and (min-width: 620px) and (max-width: 770px) {
   .player-tip-end .tip-arrow {
     left: 128px;
   }

--- a/src/components/ActivePlayerPopover.vue
+++ b/src/components/ActivePlayerPopover.vue
@@ -1,7 +1,7 @@
 <template>
   <Popover v-model:open="showTip">
     <PopoverTrigger as-child>
-      <slot name="trigger" :on-click="handleClick"></slot>
+      <slot name="trigger"></slot>
     </PopoverTrigger>
     <PopoverContent
       side="top"
@@ -11,6 +11,7 @@
       @pointer-down-outside="dismissTip"
       @escape-key-down="dismissTip"
       @focus-outside="dismissTip"
+      @click="dismissTip"
     >
       <div class="tip-content">
         <div class="tip-label">
@@ -36,7 +37,6 @@ import {
   PopoverTrigger,
 } from "@/components/ui/popover";
 import { store } from "@/plugins/store";
-import { webPlayer } from "@/plugins/web_player";
 import { PlaybackState } from "@/plugins/api/interfaces";
 
 export interface Props {
@@ -56,7 +56,7 @@ const emit = defineEmits<{
 }>();
 
 const showTip = ref(false);
-let tipWasShown = false;
+
 let autoDismissTimeout: ReturnType<typeof setTimeout> | null = null;
 
 const isPlaying = computed(() => {
@@ -68,77 +68,49 @@ const isPlaying = computed(() => {
 
 const arrowStyle = computed(() => {
   if (!props.arrowOffset) return {};
-  return { right: props.arrowOffset };
+  return { left: props.arrowOffset };
 });
 
 const shouldShowTip = computed(() => {
   if (!props.autoShow) return false;
-  if (tipWasShown || store.playerTipShown) return false;
+  if (store.playerTipShown) return false;
   if (!store.activePlayer) return false;
-  if (store.activePlayerId === webPlayer.player_id) return false;
   if (store.showPlayersMenu) return false;
   return true;
 });
 
-function dismissTip() {
-  showTip.value = false;
-  tipWasShown = true;
-  store.playerTipShown = true;
+function showPopover(openDelay: number = 1000, dismissTimeout: number = 3000) {
+  if (!shouldShowTip.value) return;
+
+  setTimeout(() => {
+    showTip.value = true;
+
+    autoDismissTimeout = setTimeout(() => {
+      dismissTip();
+    }, dismissTimeout);
+  }, openDelay);
+}
+
+function clearAutoDismissTimeout() {
   if (autoDismissTimeout) {
     clearTimeout(autoDismissTimeout);
     autoDismissTimeout = null;
   }
 }
 
-function handleClick() {
-  dismissTip();
-  emit("click");
-}
+function dismissTip() {
+  showTip.value = false;
+  store.playerTipShown = true;
 
-function handleGlobalClick() {
-  if (showTip.value) {
-    dismissTip();
-  }
+  clearAutoDismissTimeout();
 }
 
 onMounted(() => {
-  if (store.playerTipShown) {
-    tipWasShown = true;
-    return;
-  }
-
-  if (!props.autoShow) return;
-
-  // Don't show if players menu is already open
-  if (store.showPlayersMenu) {
-    tipWasShown = true;
-    store.playerTipShown = true;
-    return;
-  }
-
-  setTimeout(() => {
-    // Double-check conditions right before showing
-    if (
-      shouldShowTip.value &&
-      !store.playerTipShown &&
-      !store.showPlayersMenu
-    ) {
-      showTip.value = true;
-      document.addEventListener("click", handleGlobalClick, { capture: true });
-      // Auto-dismiss after 2.5 seconds
-      autoDismissTimeout = setTimeout(() => {
-        dismissTip();
-      }, 2500);
-    }
-  }, 1000);
+  showPopover();
 });
 
 onUnmounted(() => {
-  document.removeEventListener("click", handleGlobalClick, { capture: true });
-  if (autoDismissTimeout) {
-    clearTimeout(autoDismissTimeout);
-    autoDismissTimeout = null;
-  }
+  clearAutoDismissTimeout();
 });
 
 watch(
@@ -146,14 +118,12 @@ watch(
   (newVal) => {
     if (newVal && showTip.value) {
       showTip.value = false;
-      tipWasShown = true;
     }
   },
 );
 
 watch(showTip, (newVal, oldVal) => {
   if (oldVal && !newVal) {
-    tipWasShown = true;
     store.playerTipShown = true;
   }
 });
@@ -212,20 +182,46 @@ watch(
   border-left: 8px solid transparent;
   border-right: 8px solid transparent;
   border-top: 8px solid rgb(var(--v-theme-primary));
-}
-
-/* Arrow positioning based on alignment */
-.player-tip-center .tip-arrow {
-  left: 50%;
   transform: translateX(-50%);
 }
 
-.player-tip-end .tip-arrow {
-  right: 55px;
+/* Arrow positioning based on alignment */
+.player-tip-start .tip-arrow {
+  left: 24px;
 }
 
-.player-tip-start .tip-arrow {
-  left: 30px;
+.player-tip-center .tip-arrow {
+  left: 50%;
+}
+
+@media screen and (max-width: 361px) {
+  .player-tip-end .tip-arrow {
+    left: 155px;
+  }
+}
+
+@media screen and (min-width: 360px) and (max-width: 406px) {
+  .player-tip-end .tip-arrow {
+    left: 148px;
+  }
+}
+
+@media screen and (min-width: 405px) and (max-width: 471px) {
+  .player-tip-end .tip-arrow {
+    left: 138px;
+  }
+}
+
+@media screen and (min-width: 470px) and (max-width: 770px) {
+  .player-tip-end .tip-arrow {
+    left: 128px;
+  }
+}
+
+@media screen and (min-width: 769px) {
+  .player-tip-end .tip-arrow {
+    left: 188px;
+  }
 }
 
 .player-tip .tip-arrow::after {

--- a/src/components/ActivePlayerPopover.vue
+++ b/src/components/ActivePlayerPopover.vue
@@ -43,12 +43,14 @@ export interface Props {
   autoShow?: boolean;
   align?: "start" | "center" | "end";
   arrowOffset?: string;
+  childElementId?: string;
 }
 
 const props = withDefaults(defineProps<Props>(), {
   autoShow: false,
   align: "center",
   arrowOffset: undefined,
+  childElementId: undefined,
 });
 
 const emit = defineEmits<{
@@ -103,6 +105,13 @@ function dismissTip() {
   store.playerTipShown = true;
 
   clearAutoDismissTimeout();
+
+  // Prevents the child element from gaining focus after the popover closes.
+  if (props.childElementId) {
+    setTimeout(() => {
+      document.getElementById(props.childElementId!)?.blur();
+    }, 250);
+  }
 }
 
 onMounted(() => {

--- a/src/components/navigation/BottomNavigation.vue
+++ b/src/components/navigation/BottomNavigation.vue
@@ -48,9 +48,14 @@
       >
     </v-btn>
 
-    <ActivePlayerPopover auto-show align="end">
+    <ActivePlayerPopover
+      auto-show
+      align="end"
+      child-element-id="active-player-popover"
+    >
       <template #trigger>
         <v-btn
+          id="active-player-popover"
           :aria-label="$t('players')"
           tabindex="0"
           variant="text"

--- a/src/components/navigation/BottomNavigation.vue
+++ b/src/components/navigation/BottomNavigation.vue
@@ -48,13 +48,13 @@
       >
     </v-btn>
 
-    <ActivePlayerPopover auto-show align="end" @click="handlePlayersClick">
-      <template #trigger="{ onClick }">
+    <ActivePlayerPopover auto-show align="end">
+      <template #trigger>
         <v-btn
           :aria-label="$t('players')"
           tabindex="0"
           variant="text"
-          @click="onClick"
+          @click="handlePlayersClick"
         >
           <Speaker class="w-5 h-5" />
           <span class="menuButton">{{ $t("players") }}</span>

--- a/src/layouts/default/PlayerOSD/PlayerExtendedControls.vue
+++ b/src/layouts/default/PlayerOSD/PlayerExtendedControls.vue
@@ -3,7 +3,6 @@
     v-if="!store.mobileLayout && player && player.isVisible"
     auto-show
     align="end"
-    arrow-offset="30px"
   >
     <template #trigger>
       <SpeakerBtn :color="player.color" />

--- a/src/layouts/default/PlayerSelect.vue
+++ b/src/layouts/default/PlayerSelect.vue
@@ -296,7 +296,7 @@ const checkDefaultPlayer = function () {
 
 const selectDefaultPlayer = function () {
   // check if we have a player stored that was last used
-  // we prefer localStorage over user preferences to allow having a prefered
+  // we prefer localStorage over user preferences to allow having a preferred
   // player per device - especially useful in case of using the built-in web player
   const lastPlayerId =
     localStorage.getItem("activePlayerId") ||


### PR DESCRIPTION
### Summary
The player popover tip arrow no longer lines up with the players button on the bottom controls both on desktop and mobile.

This change makes the arrow point as close to the players button as close as possible at all horizontal resolutions (within reason).

### Notes
* The global event handlers did not seem to be needed as the popover was using @focus-outside, @pointer-down-outside and @escape-key-down. This handler was also always being triggered even after the tip was closed.
* The local 'tipWasShown' was redundant as the 'store.playerTipShown' can handle this from a central place.
* I've removed the check to not show the tip when (store.activePlayerId === webPlayer.player_id) because it relies on a race condition. The webPlayer object isn't always populated by the time the tip is loaded, so it makes this check unreliable.
* The click handler on the BottomNavigation wasn't needed here as it can be handled internally on line 14 of ActivePlayerPopover.

### Videos

Before the change:

https://github.com/user-attachments/assets/0bc68505-ff3c-4aa9-b60c-4595bca89dc1

After the change:

https://github.com/user-attachments/assets/3e126750-ba53-4f79-bb26-d8019b583fe9