### PR TITLE
Fix "This player is disabled" banner flash

### DIFF
--- a/src/views/settings/EditPlayer.vue
+++ b/src/views/settings/EditPlayer.vue
@@ -130,7 +130,7 @@
 
     <!-- Disabled banner -->
     <v-alert
-      v-if="!config?.enabled"
+      v-if="config && !config.enabled"
       type="warning"
       variant="tonal"
       class="mb-4"


### PR DESCRIPTION
Fixes a bug where clicking a player in settings briefly shows "This player is disabled" before loading the settings page.