### PR TITLE
Rounded style for overlayed menus

### DIFF
--- a/src/components/navigation/AppSidebar.vue
+++ b/src/components/navigation/AppSidebar.vue
@@ -142,19 +142,39 @@ onUnmounted(() => {
 :deep([data-sidebar="menu-button"]) {
   margin-left: 0.5rem !important;
   margin-right: 0.5rem !important;
-  min-height: 2.5rem !important;
+  min-height: 2rem !important;
+  padding-top: 0.25rem !important;
+  padding-bottom: 0.25rem !important;
 }
 
 :deep([data-sidebar="menu-button"] > svg) {
-  width: 2rem !important;
-  height: 2rem !important;
+  width: 1.6rem !important;
+  height: 1.6rem !important;
   margin-right: 0.5rem !important;
 }
 
 :deep([data-sidebar="menu-button"] > svg.artist-icon) {
-  width: 1.4rem !important;
-  height: 1.4rem !important;
+  width: 1.2rem !important;
+  height: 1.2rem !important;
   margin-right: 0.3rem !important;
+}
+
+@media (min-height: 700px) {
+  :deep([data-sidebar="menu-button"]) {
+    min-height: 2.5rem !important;
+    padding-top: 0.5rem !important;
+    padding-bottom: 0.5rem !important;
+  }
+
+  :deep([data-sidebar="menu-button"] > svg) {
+    width: 2rem !important;
+    height: 2rem !important;
+  }
+
+  :deep([data-sidebar="menu-button"] > svg.artist-icon) {
+    width: 1.4rem !important;
+    height: 1.4rem !important;
+  }
 }
 </style>
 

--- a/src/components/navigation/NavMain.vue
+++ b/src/components/navigation/NavMain.vue
@@ -39,7 +39,7 @@ const handleClick = () => {
 
 <template>
   <SidebarGroup>
-    <SidebarGroupContent class="flex flex-col gap-2">
+    <SidebarGroupContent class="flex flex-col gap-0.5">
       <SidebarMenu>
         <SidebarMenuItem v-for="item in items" :key="item.title" class="mr-1.5">
           <SidebarMenuButton

--- a/src/components/ui/sheet/SheetContent.vue
+++ b/src/components/ui/sheet/SheetContent.vue
@@ -41,9 +41,9 @@ const forwarded = useForwardPropsEmits(delegatedProps, emits);
         cn(
           'bg-background data-[state=open]:animate-in data-[state=closed]:animate-out fixed z-[100000] flex flex-col gap-4 shadow-lg transition ease-in-out data-[state=closed]:duration-300 data-[state=open]:duration-500',
           side === 'right' &&
-            'data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right inset-y-0 right-0 h-full w-3/4 sm:max-w-sm',
+            'data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right top-2 bottom-2 right-0 w-3/4 sm:max-w-sm rounded-l-2xl',
           side === 'left' &&
-            'data-[state=closed]:slide-out-to-left data-[state=open]:slide-in-from-left inset-y-0 left-0 h-full w-3/4 sm:max-w-sm',
+            'data-[state=closed]:slide-out-to-left data-[state=open]:slide-in-from-left top-2 bottom-2 left-0 w-3/4 sm:max-w-sm rounded-r-2xl',
           side === 'top' &&
             'data-[state=closed]:slide-out-to-top data-[state=open]:slide-in-from-top inset-x-0 top-0 h-auto border-b',
           side === 'bottom' &&

--- a/src/components/ui/sheet/SheetOverlay.vue
+++ b/src/components/ui/sheet/SheetOverlay.vue
@@ -17,7 +17,7 @@ const delegatedProps = reactiveOmit(props, "class");
     data-slot="sheet-overlay"
     :class="
       cn(
-        'data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-[100000] bg-black/70',
+        'data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed top-0 left-0 right-0 bottom-[60px] z-[100000] bg-black/70',
         props.class,
       )
     "

--- a/src/components/ui/sheet/SheetOverlay.vue
+++ b/src/components/ui/sheet/SheetOverlay.vue
@@ -17,7 +17,7 @@ const delegatedProps = reactiveOmit(props, "class");
     data-slot="sheet-overlay"
     :class="
       cn(
-        'data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-[100000] bg-black/80',
+        'data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-[100000] bg-black/70',
         props.class,
       )
     "

--- a/src/components/ui/sidebar/Sidebar.vue
+++ b/src/components/ui/sidebar/Sidebar.vue
@@ -54,7 +54,7 @@ const mobileSheetSide = computed<"left" | "right">(() => {
       data-slot="sidebar"
       data-mobile="true"
       :side="mobileSheetSide"
-      class="bg-sidebar text-sidebar-foreground w-(--sidebar-width) p-0 [&>button]:hidden"
+      class="sidebar-mobile-sheet bg-sidebar text-sidebar-foreground w-(--sidebar-width) p-0 [&>button]:hidden"
       :style="{
         '--sidebar-width': SIDEBAR_WIDTH_MOBILE,
       }"
@@ -116,3 +116,10 @@ const mobileSheetSide = computed<"left" | "right">(() => {
     </div>
   </div>
 </template>
+
+<style>
+/* Mobile sidebar: stop above bottom navigation */
+.sidebar-mobile-sheet {
+  bottom: 60px !important;
+}
+</style>

--- a/src/layouts/default/Footer.vue
+++ b/src/layouts/default/Footer.vue
@@ -32,9 +32,14 @@
         ? 'mediacontrols-player-float'
         : 'mediacontrols-player-default'
     }`"
-    :style="
-      store.isInPWAMode && !store.isIngressSession ? 'margin-bottom: 10px;' : ''
-    "
+    :style="[
+      store.mobileLayout && store.showPlayersMenu
+        ? 'z-index: 999 !important;'
+        : '',
+      store.isInPWAMode && !store.isIngressSession
+        ? 'margin-bottom: 10px;'
+        : '',
+    ]"
   >
     <Player :use-floating-player="store.mobileLayout" />
   </v-footer>

--- a/src/layouts/default/PlayerSelect.vue
+++ b/src/layouts/default/PlayerSelect.vue
@@ -362,13 +362,20 @@ const selectDefaultPlayer = function () {
  */
 .player-panel--overlay {
   z-index: 99999;
+  top: 8px;
+  bottom: 8px;
   border-left: none;
+  border-radius: 16px 0 0 16px;
+}
+
+.player-panel--overlay.player-panel--open {
+  box-shadow: -4px 0 24px rgba(0, 0, 0, 0.25);
 }
 
 @media (max-width: 769px) {
   .player-panel--overlay {
     width: 90vw;
-    height: calc(100% - 60px);
+    height: calc(100% - 68px);
   }
 }
 
@@ -378,14 +385,32 @@ const selectDefaultPlayer = function () {
   height: 100%;
   display: flex;
   flex-direction: column;
+  position: relative;
+}
+
+.player-panel-inner::after {
+  content: "";
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  height: 40px;
+  background: linear-gradient(
+    to bottom,
+    transparent,
+    rgb(var(--v-theme-surface)) 70%
+  );
+  pointer-events: none;
+  z-index: 1;
+  border-radius: 0 0 0 16px;
 }
 
 /* Mobile scrim/overlay */
 .player-panel-scrim {
   position: fixed;
   inset: 0;
-  z-index: 1100;
-  background: rgba(0, 0, 0, 0.5);
+  z-index: 1999;
+  background: rgba(0, 0, 0, 0.7);
 }
 
 .player-scrim-enter-active,


### PR DESCRIPTION
I personally found the overlayed menus (players on the right and the menu on the left) a bit clunky on mobile because the screen gets cutoff so I added a bit of a rounded styling so these panels look more like popouts from the side.

also adjusted the navigation menu on mobile to also hover above the footer menu.
This way the footer menu is simply always present on mobile and you can toggle these menus.

<img width="377" height="669" alt="image" src="https://github.com/user-attachments/assets/5f607754-dbf7-4f38-a73e-14d5b42b9b63" />

<img width="375" height="669" alt="image" src="https://github.com/user-attachments/assets/c6ebc37e-4ea4-45db-a5d2-075e6585a1c7" />
