### PR TITLE
Few UI scale fixes + fix 1 thumb shown on large screens

### DIFF
--- a/src/components/ItemsListing.vue
+++ b/src/components/ItemsListing.vue
@@ -1637,4 +1637,10 @@ const selectAll = async function () {
   flex-basis: 11.1%;
   padding: 8px;
 }
+.col-10 {
+  width: 10%;
+  max-width: 10%;
+  flex-basis: 10%;
+  padding: 8px;
+}
 </style>

--- a/src/components/MediaItemImages.vue
+++ b/src/components/MediaItemImages.vue
@@ -215,6 +215,12 @@ const toolbarMenuItems = computed(() => {
   flex-basis: 11.1%;
   padding: 8px;
 }
+.col-10 {
+  width: 10%;
+  max-width: 10%;
+  flex-basis: 10%;
+  padding: 8px;
+}
 
 .v-list-item--density-compact {
   padding: 5px !important;

--- a/src/helpers/utils.ts
+++ b/src/helpers/utils.ts
@@ -602,7 +602,7 @@ export const panelViewItemResponsive = function (displaySize: number) {
       condition: "lt",
     })
   ) {
-    return 3;
+    return 2;
   } else if (
     getBreakpointValue({
       breakpoint: "bp1",
@@ -624,7 +624,7 @@ export const panelViewItemResponsive = function (displaySize: number) {
       condition: "lt",
     })
   ) {
-    return 4;
+    return 3;
   } else if (
     getBreakpointValue({
       breakpoint: "bp6",


### PR DESCRIPTION
We had some issues with titles being cut off most of the time on smaller screens. Also fixed a bug where we would show 1 big art when >=1900px

## BEFORE
<img width="398" height="851" alt="image" src="https://github.com/user-attachments/assets/7f12cb8d-8609-42d1-91a2-dfa214a94c4a" />
<img width="822" height="1184" alt="image" src="https://github.com/user-attachments/assets/289dd456-1bc6-49fc-8e1f-c5745c541581" />

## AFTER
<img width="392" height="845" alt="image" src="https://github.com/user-attachments/assets/a173c8a1-56ec-4858-ae12-03c141f60173" />
<img width="828" height="1185" alt="image" src="https://github.com/user-attachments/assets/83ff4a9a-692a-4517-881a-9a92ae7c467b" />
