### PR TITLE
Do not inline the PlayerMenu on desktop

### DIFF
--- a/src/components/PlayerCard.vue
+++ b/src/components/PlayerCard.vue
@@ -22,7 +22,7 @@
           >
             <v-img
               class="media-thumb"
-              size="40"
+              size="44"
               :src="getMediaImageUrl(player.current_media.image_url)"
             />
           </div>
@@ -46,7 +46,7 @@
         <!-- special builtin player (web player or companion native player) -->
         <div
           v-if="isBuiltinPlayer(player)"
-          style="font-size: 0.85rem; line-height: 1.2"
+          style="font-size: 0.88rem; line-height: 1.3"
         >
           <span>{{ getPlayerName(player, 12) }}</span>
           <!-- append small icon to the title -->
@@ -63,7 +63,7 @@
           </v-chip>
         </div>
         <!-- regular player -->
-        <div v-else style="font-size: 0.85rem; line-height: 1.2">
+        <div v-else style="font-size: 0.88rem; line-height: 1.3">
           {{ getPlayerName(player, 27) }}
         </div>
       </template>
@@ -73,10 +73,10 @@
         <div
           v-if="player.powered != false"
           style="
-            font-size: 0.75rem;
+            font-size: 0.8rem;
             font-weight: 500;
             white-space: nowrap;
-            line-height: 1.2;
+            line-height: 1.3;
           "
         >
           <div v-if="player.current_media?.title">
@@ -89,7 +89,7 @@
       <template #default>
         <div
           class="v-list-item-subtitle"
-          style="font-size: 0.72rem; white-space: nowrap; line-height: 1.2"
+          style="font-size: 0.78rem; white-space: nowrap; line-height: 1.3"
         >
           <!-- player powered off -->
           <div v-if="player.powered == false">
@@ -346,14 +346,14 @@ watch(
   width: 100%;
   margin: 0px !important;
   padding: 0px !important;
-  min-height: 48px;
+  min-height: 58px;
 }
 
 .panel-item-details :deep(.v-list-item__content) {
   display: flex;
   flex-direction: column;
   justify-content: center;
-  min-height: 42px;
+  min-height: 50px;
   gap: 0px;
 }
 
@@ -415,14 +415,14 @@ watch(
 }
 
 .media-thumb {
-  width: 40px;
-  height: 40px;
+  width: 44px;
+  height: 44px;
   border-radius: 4px;
   background-color: rgba(var(--v-theme-on-surface), 0.08);
 }
 .icon-thumb {
-  width: 40px;
-  height: 40px;
+  width: 44px;
+  height: 44px;
   margin-top: 4px;
   border-radius: 4px;
   background-color: rgba(var(--v-theme-on-surface), 0.08);
@@ -433,10 +433,10 @@ watch(
   border-style: ridge;
   border-width: thin;
   border-color: rgba(var(--v-theme-on-surface), 0.12);
-  padding-left: 6px;
-  padding-right: 6px;
-  padding-top: 3px;
-  padding-bottom: 3px;
+  padding-left: 8px;
+  padding-right: 8px;
+  padding-top: 4px;
+  padding-bottom: 4px;
   background-color: rgba(var(--v-theme-primary), 0.04);
   opacity: 1;
   transition: opacity 0.4s ease-in-out;

--- a/src/components/VolumeControl.vue
+++ b/src/components/VolumeControl.vue
@@ -294,13 +294,13 @@ const syncCheckBoxChange = async function (
   margin-top: 0px;
   padding-top: 0px;
   padding-bottom: 0px;
-  height: 32px;
-  min-height: 32px;
+  height: 36px;
+  min-height: 36px;
 }
 
 .volumesliderrow :deep(.v-list-item__content) {
-  height: 32px;
-  min-height: 32px;
+  height: 36px;
+  min-height: 36px;
   overflow: visible !important;
   align-content: center;
 }
@@ -315,7 +315,7 @@ const syncCheckBoxChange = async function (
   align-items: center;
   padding: 0 2px;
   margin-top: 0px;
-  min-height: 28px;
+  min-height: 32px;
 }
 
 .volume-row :deep(.player-volume-container) {

--- a/src/components/ui/sheet/SheetContent.vue
+++ b/src/components/ui/sheet/SheetContent.vue
@@ -41,9 +41,9 @@ const forwarded = useForwardPropsEmits(delegatedProps, emits);
         cn(
           'bg-background data-[state=open]:animate-in data-[state=closed]:animate-out fixed z-[100000] flex flex-col gap-4 shadow-lg transition ease-in-out data-[state=closed]:duration-300 data-[state=open]:duration-500',
           side === 'right' &&
-            'data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right top-2 bottom-2 right-0 w-3/4 sm:max-w-sm rounded-l-2xl',
+            'data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right top-0 bottom-0 right-0 w-3/4 sm:max-w-sm rounded-l-md',
           side === 'left' &&
-            'data-[state=closed]:slide-out-to-left data-[state=open]:slide-in-from-left top-2 bottom-2 left-0 w-3/4 sm:max-w-sm rounded-r-2xl',
+            'data-[state=closed]:slide-out-to-left data-[state=open]:slide-in-from-left top-0 bottom-0 left-0 w-3/4 sm:max-w-sm rounded-r-md',
           side === 'top' &&
             'data-[state=closed]:slide-out-to-top data-[state=open]:slide-in-from-top inset-x-0 top-0 h-auto border-b',
           side === 'bottom' &&

--- a/src/helpers/utils.ts
+++ b/src/helpers/utils.ts
@@ -665,7 +665,6 @@ export const panelViewItemResponsive = function (displaySize: number) {
       condition: "lt",
     })
   ) {
-    if (store.showPlayersMenu) return 5;
     return 8;
   } else if (
     getBreakpointValue({
@@ -677,7 +676,6 @@ export const panelViewItemResponsive = function (displaySize: number) {
       condition: "lt",
     })
   ) {
-    if (store.showPlayersMenu) return 6;
     return 9;
   } else if (
     getBreakpointValue({
@@ -685,7 +683,6 @@ export const panelViewItemResponsive = function (displaySize: number) {
       condition: "gt",
     })
   ) {
-    if (store.showPlayersMenu) return 7;
     return 10;
   } else {
     return 0;

--- a/src/layouts/default/Footer.vue
+++ b/src/layouts/default/Footer.vue
@@ -14,15 +14,7 @@
 
   <!-- bottom navigation for mobile layout -->
   <!-- add a tiny bit of bottom-padding to avoid overlap with (iOS) bottom bar -->
-  <BottomNavigation
-    v-if="store.mobileLayout"
-    app
-    :style="
-      store.isInPWAMode && !store.isIngressSession
-        ? 'padding-bottom: 10px;height: 70px;'
-        : 'height: 60px;'
-    "
-  />
+  <BottomNavigation v-if="store.mobileLayout" app style="height: 60px" />
 
   <v-footer
     app

--- a/src/layouts/default/PlayerSelect.vue
+++ b/src/layouts/default/PlayerSelect.vue
@@ -329,8 +329,8 @@ const selectDefaultPlayer = function () {
 /* Overlay: higher z-index, rounded edges, shadow */
 .player-panel--overlay {
   z-index: 99999;
-  top: 8px;
-  bottom: 8px;
+  top: 0px;
+  bottom: 0px;
   border-left: none;
   border-radius: 6px 0 0 6px;
 }
@@ -342,7 +342,8 @@ const selectDefaultPlayer = function () {
 @media (max-width: 769px) {
   .player-panel--overlay {
     width: 90vw;
-    height: calc(100% - 68px);
+    max-width: 400px;
+    bottom: 60px;
   }
 }
 
@@ -361,15 +362,15 @@ const selectDefaultPlayer = function () {
   bottom: 0;
   left: 0;
   right: 0;
-  height: 40px;
+  height: 20px;
   background: linear-gradient(
     to bottom,
     transparent,
-    rgb(var(--v-theme-surface)) 70%
+    rgb(var(--v-theme-surface)) 80%
   );
   pointer-events: none;
   z-index: 1;
-  border-radius: 0 0 0 16px;
+  border-radius: 0 0 0 6px;
 }
 
 /* Mobile scrim/overlay */

--- a/src/layouts/default/PlayerSelect.vue
+++ b/src/layouts/default/PlayerSelect.vue
@@ -1,26 +1,18 @@
 <template>
-  <!-- Overlay scrim (used when panel overlays content instead of being inline) -->
+  <!-- Overlay scrim -->
   <Transition name="player-scrim">
     <div
-      v-if="!useInlinePanel && store.showPlayersMenu"
+      v-if="store.showPlayersMenu"
       class="player-panel-scrim"
       @click="store.showPlayersMenu = false"
     ></div>
   </Transition>
 
-  <!-- Inline spacer: only on wide screens, transitions width to push main content -->
-  <div
-    v-if="useInlinePanel"
-    class="player-panel-spacer"
-    :class="{ 'player-panel-spacer--open': store.showPlayersMenu }"
-  ></div>
-
   <!-- Panel: fixed position, slides in via transform -->
   <div
-    class="player-panel"
+    class="player-panel player-panel--overlay"
     :class="{
       'player-panel--open': store.showPlayersMenu,
-      'player-panel--overlay': !useInlinePanel,
     }"
   >
     <div class="player-panel-inner">
@@ -118,18 +110,11 @@ import { useUserPreferences } from "@/composables/userPreferences";
 import { playerVisible } from "@/helpers/utils";
 import { api } from "@/plugins/api";
 import { Player, PlayerFeature } from "@/plugins/api/interfaces";
-import { getBreakpointValue } from "@/plugins/breakpoint";
 
 import { store } from "@/plugins/store";
 import { webPlayer } from "@/plugins/web_player";
 import { Search, Speaker } from "lucide-vue-next";
 import { computed, nextTick, onMounted, ref, watch } from "vue";
-
-// Wide screens (bp9 >=1500px): inline sidebar that pushes content.
-// Narrower screens & mobile: overlay panel with scrim.
-const useInlinePanel = computed(
-  () => !store.mobileLayout && getBreakpointValue("bp9"),
-);
 
 const showSubPlayers = ref(false);
 const recentlySelectedPlayerIds = ref<string[]>([]);
@@ -318,22 +303,7 @@ const selectDefaultPlayer = function () {
 
 <style scoped>
 /*
- * Desktop spacer: transparent div in the flex layout.
- * Smoothly transitions width to push main content, just like AppSidebar.
- */
-.player-panel-spacer {
-  width: 0;
-  flex-shrink: 0;
-  transition: width 0.2s ease-linear;
-}
-
-.player-panel-spacer--open {
-  width: 400px;
-}
-
-/*
  * Panel: fixed position, slides via GPU-accelerated transform.
- * Content is never clipped — the spacer handles the layout shift separately.
  */
 .player-panel {
   position: fixed;
@@ -356,16 +326,13 @@ const selectDefaultPlayer = function () {
   transform: translateX(0);
 }
 
-/*
- * Overlay mode: narrower screens & mobile. Higher z-index, covers content.
- * On mobile (mobileLayout) it's 85vw; on mid-width desktops it stays 400px.
- */
+/* Overlay: higher z-index, rounded edges, shadow */
 .player-panel--overlay {
   z-index: 99999;
   top: 8px;
   bottom: 8px;
   border-left: none;
-  border-radius: 16px 0 0 16px;
+  border-radius: 6px 0 0 6px;
 }
 
 .player-panel--overlay.player-panel--open {


### PR DESCRIPTION
Follow-up after yesterday's changes to the PlayerSelect at the side, as discussed with @stvncode .

- less rounded corners
- take more space to the top (remove gap)
- ensure we are 60px from bottom (=mobile footer menu) on mobile
- make the playercard slightly bigger