### PR TITLE
Hide the player menu subtitle when off or empty queue

### DIFF
--- a/src/components/PlayerCard.vue
+++ b/src/components/PlayerCard.vue
@@ -92,9 +92,8 @@
           style="font-size: 0.78rem; white-space: nowrap; line-height: 1.3"
         >
           <!-- player powered off -->
-          <div v-if="player.powered == false">
-            {{ $t("off") }}
-          </div>
+          <div v-if="player.powered == false"></div>
+
           <!-- artist + album -->
           <div
             v-else-if="
@@ -104,17 +103,15 @@
             {{ player.current_media.artist }} •
             {{ player.current_media.album }}
           </div>
+
           <!-- artist only -->
           <div v-else-if="player.current_media?.artist">
             {{ player.current_media.artist }}
           </div>
+
           <!-- album only -->
           <div v-else-if="player.current_media?.album">
             {{ player.current_media.album }}
-          </div>
-          <!-- queue empty message -->
-          <div v-else-if="playerQueue?.items == 0">
-            {{ $t("queue_empty") }}
           </div>
         </div>
       </template>


### PR DESCRIPTION
### Summary
When the player is off or the queue is empty, these additional subtitles add visual complexity to the players menu.

I don't believe this information is necessary when the player is not in use.

### Photos

Before:
<img width="914" height="1780" alt="before" src="https://github.com/user-attachments/assets/c947fcef-44ca-4f28-b3f7-b206a1e449b9" />

After:
<img width="914" height="1780" alt="after" src="https://github.com/user-attachments/assets/c1366a10-28c9-469a-a412-5daec8bc2198" />
 