### PR TITLE
Gray out protocol badges when protocol is unavailable

### DIFF
--- a/src/components/SettingsPlayerCard.vue
+++ b/src/components/SettingsPlayerCard.vue
@@ -47,6 +47,7 @@
             size="x-small"
             variant="tonal"
             class="protocol-chip"
+            :class="{ 'protocol-chip--unavailable': !protocol.available }"
           >
             <template #prepend>
               <ProviderIcon
@@ -261,6 +262,10 @@ const handleMenu = (event: Event) => {
   text-transform: uppercase;
   font-size: 10px;
   letter-spacing: 0.3px;
+}
+
+.protocol-chip--unavailable {
+  opacity: 0.4;
 }
 
 .status-icons {

--- a/src/views/settings/EditPlayer.vue
+++ b/src/views/settings/EditPlayer.vue
@@ -91,6 +91,7 @@
                   'protocol-chip--clickable': api.getProviderManifest(
                     protocol.protocol_domain!,
                   )?.documentation,
+                  'protocol-chip--unavailable': !protocol.available,
                 }"
                 @click="
                   api.getProviderManifest(protocol.protocol_domain!)
@@ -547,6 +548,10 @@ const onAction = async function (
 
 .protocol-chip--clickable:hover {
   opacity: 0.85;
+}
+
+.protocol-chip--unavailable {
+  opacity: 0.4;
 }
 
 .chip-icon {

--- a/src/views/settings/Players.vue
+++ b/src/views/settings/Players.vue
@@ -88,6 +88,7 @@
                   size="x-small"
                   variant="tonal"
                   class="protocol-chip"
+                  :class="{ 'protocol-chip--unavailable': !protocol.available }"
                 >
                   <template #prepend>
                     <ProviderIcon
@@ -537,6 +538,10 @@ watch(
   text-transform: uppercase;
   font-size: 10px;
   letter-spacing: 0.3px;
+}
+
+.protocol-chip--unavailable {
+  opacity: 0.4;
 }
 
 .chip-icon {


### PR DESCRIPTION
Give some visual feedback when a protocol is unavailable by graying them out. Examples:

<img width="722" height="159" alt="image" src="https://github.com/user-attachments/assets/d187c2c0-6d9c-46f7-b292-6536b90c3de3" />

<img width="471" height="138" alt="image" src="https://github.com/user-attachments/assets/07848705-273a-4c12-94f4-74cc49aba2ae" />

When available, it changes to:
<img width="420" height="68" alt="image" src="https://github.com/user-attachments/assets/d3eb852a-68f5-47a3-ac0f-515a2d2dd4c4" />
