### PR TITLE
Fix unable to scroll on the add to playlist dialog

### DIFF
--- a/src/layouts/default/AddToPlaylistDialog.vue
+++ b/src/layouts/default/AddToPlaylistDialog.vue
@@ -14,8 +14,8 @@
         {{ $t("add_playlist") }}
       </SheetDescription>
 
-      <ScrollArea class="flex-1">
-        <div class="py-2">
+      <ScrollArea class="h-full max-h-full overflow-hidden flex-1">
+        <div class="pt-2 pb-8">
           <button
             v-for="playlist of playlists"
             :key="playlist.item_id"


### PR DESCRIPTION
Issue reported in discord: https://discordapp.com/channels/753947050995089438/1479667627906568265

The scroll functionality is missing on the "AddToPlaylistDialog" component.