### PR TITLE
Improve 'Now playing' screen for other resolutions as well

### DIFF
--- a/src/layouts/default/PlayerOSD/PlayerFullscreen.vue
+++ b/src/layouts/default/PlayerOSD/PlayerFullscreen.vue
@@ -176,7 +176,7 @@
                 store.activePlayer?.powered != false &&
                 store.curQueueItem?.streamdetails
               "
-              style="margin: auto; padding-top: min(20px, 2vh)"
+              style="padding-top: min(20px, 2vh)"
             >
               <QualityDetailsBtn />
             </div>
@@ -737,15 +737,15 @@ const titleFontSize = computed(() => {
     case "xs":
       return "1.2em";
     case "sm":
-      return "1.4em";
-    case "md":
       return "1.5em";
+    case "md":
+      return "1.7em";
     case "lg":
-      return store.showQueueItems ? "1.4em" : "1.8em";
-    case "xl":
       return store.showQueueItems ? "1.5em" : "2em";
-    case "xxl":
+    case "xl":
       return store.showQueueItems ? "1.6em" : "2.2em";
+    case "xxl":
+      return store.showQueueItems ? "1.7em" : "2.4em";
     default:
       return "1.0em";
   }
@@ -756,15 +756,15 @@ const subTitleFontSize = computed(() => {
     case "xs":
       return "1.05em";
     case "sm":
-      return "1.15em";
+      return "1.25em";
     case "md":
-      return "1.2em";
+      return "1.35em";
     case "lg":
-      return store.showQueueItems ? "1.0em" : "1.3em";
+      return store.showQueueItems ? "1.1em" : "1.45em";
     case "xl":
-      return store.showQueueItems ? "1.1em" : "1.5em";
-    case "xxl":
       return store.showQueueItems ? "1.2em" : "1.6em";
+    case "xxl":
+      return store.showQueueItems ? "1.3em" : "1.8em";
     default:
       return "1.0em";
   }
@@ -1478,6 +1478,9 @@ watchEffect(() => {
   flex: 50%;
   max-width: 100%;
   width: 50%;
+  height: 100%;
+  display: flex !important;
+  flex-direction: column;
 }
 
 .main-queue-items {

--- a/src/layouts/default/PlayerOSD/PlayerFullscreen.vue
+++ b/src/layouts/default/PlayerOSD/PlayerFullscreen.vue
@@ -69,7 +69,6 @@
                 store.activePlayer?.powered != false &&
                 store.activePlayer?.current_media?.image_url
               "
-              style="max-width: 100%; width: auto"
               :src="
                 getMediaImageUrl(store.activePlayer.current_media.image_url)
               "
@@ -379,7 +378,6 @@
           <div class="main-media-details-image main-media-details-image-alt">
             <v-img
               v-if="store.activePlayer?.current_media?.image_url"
-              style="max-width: 100%; width: auto"
               :src="
                 getMediaImageUrl(store.activePlayer.current_media.image_url)
               "
@@ -741,15 +739,15 @@ const titleFontSize = computed(() => {
     case "sm":
       return "1.4em";
     case "md":
-      return "2em";
+      return "1.5em";
     case "lg":
-      return store.showQueueItems ? "1.5em" : "2.5em";
+      return store.showQueueItems ? "1.4em" : "1.8em";
     case "xl":
-      return store.showQueueItems ? "1.6em" : "3em";
+      return store.showQueueItems ? "1.5em" : "2em";
     case "xxl":
-      return store.showQueueItems ? "1.7em" : "3.2em";
+      return store.showQueueItems ? "1.6em" : "2.2em";
     default:
-      return "1.0em.";
+      return "1.0em";
   }
 });
 
@@ -760,15 +758,15 @@ const subTitleFontSize = computed(() => {
     case "sm":
       return "1.15em";
     case "md":
-      return "1.7em";
+      return "1.2em";
     case "lg":
-      return store.showQueueItems ? "1.0em" : "1.6em";
+      return store.showQueueItems ? "1.0em" : "1.3em";
     case "xl":
-      return store.showQueueItems ? "1.2em" : "2em";
+      return store.showQueueItems ? "1.1em" : "1.5em";
     case "xxl":
-      return store.showQueueItems ? "1.2em" : "2em";
+      return store.showQueueItems ? "1.2em" : "1.6em";
     default:
-      return "1.0em.";
+      return "1.0em";
   }
 });
 
@@ -1503,21 +1501,26 @@ watchEffect(() => {
   min-height: 50%;
   max-height: 80%;
   height: 60%;
-  align-content: center;
+  display: flex;
+  justify-content: center;
+  align-items: center;
   padding-left: 20px;
   padding-right: 20px;
+  container-type: size;
 }
 .main-media-details-image .v-img {
-  width: auto;
+  width: min(100cqi, 100cqh);
+  height: min(100cqi, 100cqh);
+  flex: 0 0 auto;
   border-radius: 10px;
   box-shadow: 0 8px 24px rgba(0, 0, 0, 0.25);
+  overflow: hidden;
 }
 
 .main-media-details-image-alt {
   height: 100% !important;
   max-height: 100% !important;
-  align-content: center;
-  padding: 0px !important;
+  padding: 10px !important;
 }
 
 .main-media-details-track-info {
@@ -1538,6 +1541,7 @@ watchEffect(() => {
   bottom: 0;
   position: unset !important;
   padding-bottom: 5%;
+  width: 100%;
 }
 
 .track-info {
@@ -1686,6 +1690,13 @@ button {
   letter-spacing: 0.3px;
   color: var(--badge-color);
   margin-right: 0.5rem;
+}
+
+@media (min-width: 960px) {
+  .main-media-details:only-child {
+    max-width: 600px;
+    margin: 0 auto;
+  }
 }
 
 @media (max-width: 540px) {

--- a/src/layouts/default/PlayerOSD/PlayerFullscreen.vue
+++ b/src/layouts/default/PlayerOSD/PlayerFullscreen.vue
@@ -1695,13 +1695,6 @@ button {
   margin-right: 0.5rem;
 }
 
-@media (min-width: 960px) {
-  .main-media-details:only-child {
-    max-width: 600px;
-    margin: 0 auto;
-  }
-}
-
 @media (max-width: 540px) {
   .main:has(.main-media-details) {
     --main-height: 70%;

--- a/src/layouts/default/PlayerOSD/PlayerFullscreen.vue
+++ b/src/layouts/default/PlayerOSD/PlayerFullscreen.vue
@@ -1474,12 +1474,12 @@ watchEffect(() => {
   padding-bottom: 5px;
 }
 
-.main-media-details {
+.main .main-media-details {
   flex: 50%;
   max-width: 100%;
   width: 50%;
   height: 100%;
-  display: flex !important;
+  display: flex;
   flex-direction: column;
 }
 


### PR DESCRIPTION
Follow up to [this PR](https://github.com/music-assistant/frontend/pull/1543). Now also apply the same design changes to other resolutions as well.

Some old vs new for ipad air / desktop with queue opened:

<img width="1492" height="1356" alt="image" src="https://github.com/user-attachments/assets/6b8f24ad-6abb-43bf-897e-155424d38dfe" />
<img width="1488" height="1356" alt="image" src="https://github.com/user-attachments/assets/1e729c70-63d0-4e37-afee-9413944b1d96" />
<img width="819" height="1184" alt="image" src="https://github.com/user-attachments/assets/54b97d69-0673-40ae-85d6-eb907034daa2" />
<img width="824" height="1184" alt="image" src="https://github.com/user-attachments/assets/278542eb-c55c-4d6f-bc34-4a5fad005394" />


<img width="1485" height="1347" alt="image" src="https://github.com/user-attachments/assets/c66d2536-9560-4c1e-9497-7a79af1936b4" />
<img width="1484" height="1353" alt="image" src="https://github.com/user-attachments/assets/bbdac9c1-b8ab-455e-a694-3b11128055d0" />
<img width="817" height="1180" alt="image" src="https://github.com/user-attachments/assets/e40b8c14-4857-4049-b971-f60a6745dccf" />
<img width="824" height="1184" alt="image" src="https://github.com/user-attachments/assets/239c1886-8408-4e1c-94a0-f659c33f4aa7" />


<img width="1487" height="1348" alt="image" src="https://github.com/user-attachments/assets/474048a6-8e3f-460e-9815-2dd293d3cc72" />
<img width="1487" height="1352" alt="image" src="https://github.com/user-attachments/assets/72f9af5f-4631-4872-8c7c-8de5e7ebe262" />
<img width="822" height="1181" alt="image" src="https://github.com/user-attachments/assets/b86db224-020b-48e1-a8f5-4dfd3debbc22" />
<img width="823" height="1175" alt="image" src="https://github.com/user-attachments/assets/cee51d50-57dd-499d-846e-e138e45653df" />
