### PR TITLE
Fix for disabling the web player on party mode routes

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -260,7 +260,12 @@ const completeInitialization = async () => {
     localStorage.getItem("frontend.settings.enable_browser_controls") || "true";
 
   // Disable web player for party mode guests, companion mode, and party dashboard
-  const isPartyDashboard = router.currentRoute.value.path.startsWith("/party");
+  const routePath = router.currentRoute.value.path;
+  const hashPath = window.location.hash.replace(/^#/, "").split("?")[0];
+  const isPartyDashboard =
+    routePath.startsWith("/party") ||
+    hashPath.startsWith("/party") ||
+    window.location.pathname.startsWith("/party");
   if (isPartyModeGuest || companionMode.value || isPartyDashboard) {
     webPlayer.setMode(WebPlayerMode.DISABLED);
   } else if (

--- a/src/App.vue
+++ b/src/App.vue
@@ -46,10 +46,7 @@ import "vue-sonner/style.css";
 import { useTheme } from "vuetify";
 import SendspinPlayer from "./components/SendspinPlayer.vue";
 import PlayerBrowserMediaControls from "./layouts/default/PlayerOSD/PlayerBrowserMediaControls.vue";
-import {
-  companionMode,
-  initializeCompanionIntegration,
-} from "./plugins/companion";
+import { initializeCompanionIntegration } from "./plugins/companion";
 // import {
 //   subscribeToHAProperties,
 //   unsubscribeFromHAProperties,
@@ -59,7 +56,11 @@ import type { User } from "./plugins/api/interfaces";
 import { remoteConnectionManager } from "./plugins/remote";
 import { httpProxyBridge } from "./plugins/remote/http-proxy";
 import type { ITransport } from "./plugins/remote/transport";
-import { webPlayer, WebPlayerMode } from "./plugins/web_player";
+import {
+  initializeWebPlayerModeSync,
+  webPlayer,
+  WebPlayerMode,
+} from "./plugins/web_player";
 import Login from "./views/Login.vue";
 
 const theme = useTheme();
@@ -252,44 +253,6 @@ const completeInitialization = async () => {
     store.enabledPlugins.delete("party_mode");
   }
 
-  // Enable Sendspin if available and not explicitly disabled
-  // Sendspin works over WebRTC DataChannel which requires signaling via the API server
-  const webPlayerEnabledPref =
-    localStorage.getItem("frontend.settings.web_player_enabled") || "true";
-  const browserControlsEnabledPref =
-    localStorage.getItem("frontend.settings.enable_browser_controls") || "true";
-
-  // Disable web player for party mode guests, companion mode, and party dashboard
-  const routePath = router.currentRoute.value.path;
-  const hashPath = window.location.hash.replace(/^#/, "").split("?")[0];
-  const isPartyDashboard =
-    routePath.startsWith("/party") ||
-    hashPath.startsWith("/party") ||
-    window.location.pathname.startsWith("/party");
-  if (isPartyModeGuest || companionMode.value || isPartyDashboard) {
-    webPlayer.setMode(WebPlayerMode.DISABLED);
-  } else if (
-    webPlayerEnabledPref !== "false" &&
-    browserControlsEnabledPref !== "false"
-  ) {
-    // sendspin enabled, browser controls enabled
-    webPlayer.setMode(WebPlayerMode.SENDSPIN_WITH_CONTROLS);
-  } else if (
-    webPlayerEnabledPref !== "false" &&
-    browserControlsEnabledPref === "false"
-  ) {
-    // sendspin enabled but no browser controls
-    webPlayer.setMode(WebPlayerMode.SENDSPIN_ONLY);
-  } else if (
-    webPlayerEnabledPref === "false" &&
-    browserControlsEnabledPref !== "false"
-  ) {
-    // sendspin disabled but browser controls allowed
-    webPlayer.setMode(WebPlayerMode.CONTROLS_ONLY);
-  } else {
-    webPlayer.setMode(WebPlayerMode.DISABLED);
-  }
-
   const urlParams = new URLSearchParams(window.location.search);
   if (
     (urlParams.get("onboard") === "true" ||
@@ -306,6 +269,7 @@ const completeInitialization = async () => {
   // from the URL hash. The router config already redirects "/" to "/discover"
   api.state.value = ConnectionState.INITIALIZED;
   initializationCompleted = true;
+  await initializeWebPlayerModeSync();
 
   // Initialize companion app integration
   if (api.baseUrl) {

--- a/src/plugins/router.ts
+++ b/src/plugins/router.ts
@@ -11,6 +11,8 @@ const routes = [
   // which exchanges the short join code for a JWT before navigating here
   {
     path: "/guest",
+    // Guest users don't have access to the player.
+    meta: { disableWebPlayer: true },
     component: () => import("@/layouts/PartyModeGuestLayout.vue"),
     children: [
       {
@@ -27,6 +29,8 @@ const routes = [
   // Placed at top level so it renders without navigation/player controls
   {
     path: "/party",
+    // Party mode only displays the dashboard and doesn't need the player.
+    meta: { disableWebPlayer: true },
     component: () => import("@/layouts/PartyModeGuestLayout.vue"),
     children: [
       {

--- a/src/plugins/web_player.ts
+++ b/src/plugins/web_player.ts
@@ -43,6 +43,10 @@ self.crypto.getRandomValues(array);
 const uniqueId = array.join("");
 
 bc.onmessage = (event) => {
+  if (webPlayer.mode === WebPlayerMode.DISABLED) {
+    return;
+  }
+
   if (
     typeof event.data === "string" &&
     event.data.startsWith(BC_MSG.TAKING_CONTROL)
@@ -60,7 +64,11 @@ bc.onmessage = (event) => {
   }
   switch (event.data) {
     case BC_MSG.IS_ACTIVE:
-      if (isPlaybackMode(webPlayer.tabMode) && webPlayer.player_id) {
+      if (
+        isPlaybackMode(webPlayer.mode) &&
+        isPlaybackMode(webPlayer.tabMode) &&
+        webPlayer.player_id
+      ) {
         // Check if we timed out
         if (webPlayer.timedOutDueToThrottling()) {
           webPlayer.setTabMode(WebPlayerMode.CONTROLS_ONLY, true);

--- a/src/plugins/web_player.ts
+++ b/src/plugins/web_player.ts
@@ -1,6 +1,9 @@
-import { reactive } from "vue";
+import { reactive, watch } from "vue";
+import authManager from "./auth";
 import api from "./api";
 import { EventType } from "./api/interfaces";
+import { companionMode } from "./companion";
+import router from "./router";
 import { resetSendspinConnection } from "./sendspin-connection";
 
 export enum WebPlayerMode {
@@ -138,6 +141,95 @@ async function isAnotherTabActive(): Promise<boolean> {
 }
 
 let highestPriority: string | undefined;
+let modeSyncInitialized = false;
+let modeSyncInitializationPromise: Promise<void> | null = null;
+let pendingModeApplication = Promise.resolve();
+
+function resolvePreferredMode(): WebPlayerMode {
+  // This route explicitly disables the web player
+  const routeDisablesWebPlayer = router.currentRoute.value.matched.some(
+    (record) => record.meta.disableWebPlayer === true,
+  );
+
+  // Hard-disable conditions always win over user preferences.
+  if (
+    authManager.isPartyModeGuest() ||
+    companionMode.value ||
+    routeDisablesWebPlayer
+  ) {
+    return WebPlayerMode.DISABLED;
+  }
+
+  const webPlayerEnabledPref =
+    window.localStorage.getItem("frontend.settings.web_player_enabled") ||
+    "true";
+  const browserControlsEnabledPref =
+    window.localStorage.getItem("frontend.settings.enable_browser_controls") ||
+    "true";
+
+  if (
+    webPlayerEnabledPref !== "false" &&
+    browserControlsEnabledPref !== "false"
+  ) {
+    return WebPlayerMode.SENDSPIN_WITH_CONTROLS;
+  }
+  if (
+    webPlayerEnabledPref !== "false" &&
+    browserControlsEnabledPref === "false"
+  ) {
+    return WebPlayerMode.SENDSPIN_ONLY;
+  }
+  if (
+    webPlayerEnabledPref === "false" &&
+    browserControlsEnabledPref !== "false"
+  ) {
+    return WebPlayerMode.CONTROLS_ONLY;
+  }
+  return WebPlayerMode.DISABLED;
+}
+
+// Serializes mode updates so concurrent triggers (init/route/watchers) apply in order.
+function queueModeApplication(): Promise<void> {
+  pendingModeApplication = pendingModeApplication.then(async () => {
+    const mode = resolvePreferredMode();
+    if (mode !== webPlayer.mode || mode !== webPlayer.tabMode) {
+      await webPlayer.setMode(mode);
+    }
+  });
+  return pendingModeApplication;
+}
+
+// Automatically sets web player mode from route policy, guest/companion state, and user preferences.
+// Must be called once on page load to set up mode synchronization hooks.
+// Safe to call multiple times.
+export async function initializeWebPlayerModeSync(): Promise<void> {
+  if (modeSyncInitializationPromise) {
+    await modeSyncInitializationPromise;
+    return queueModeApplication();
+  }
+
+  if (modeSyncInitialized) {
+    return queueModeApplication();
+  }
+
+  modeSyncInitializationPromise = (async () => {
+    await router.isReady();
+    await queueModeApplication();
+
+    router.afterEach(() => {
+      void queueModeApplication();
+    });
+
+    watch(companionMode, () => {
+      void queueModeApplication();
+    });
+
+    modeSyncInitialized = true;
+    modeSyncInitializationPromise = null;
+  })();
+
+  return modeSyncInitializationPromise;
+}
 
 async function canTakeControl(): Promise<boolean> {
   // Generate a unique priority string with interaction as a prefix


### PR DESCRIPTION
Refactors web player mode selection into `web_player.ts` so `resolvePreferredMode()` decides from route policy, party guest state, companion mode, and user preferences in one place.

Adds a router level property `meta.disableWebPlayer` so future pages can also easily opt out of the web player.

Also fixes a bug where the internally used broadcast channel (for selecting the tab used for the web player) was active even when the web player was disabled.