### PR TITLE
More improvements to the now playing screen

### DIFF
--- a/src/layouts/default/PlayerOSD/PlayerFullscreen.vue
+++ b/src/layouts/default/PlayerOSD/PlayerFullscreen.vue
@@ -1537,10 +1537,11 @@ watchEffect(() => {
   flex: 1;
   display: flex;
   flex-direction: column;
-  justify-content: center;
+  justify-content: flex-start;
   align-items: center;
   text-align: center;
   padding: 20px;
+  padding-top: 5%;
 }
 
 .player-bottom {

--- a/src/layouts/default/PlayerOSD/PlayerFullscreen.vue
+++ b/src/layouts/default/PlayerOSD/PlayerFullscreen.vue
@@ -217,7 +217,10 @@
               {{ $t("lyrics") }}
             </v-tab>
           </v-tabs>
-          <div class="queue-items-scroll-box">
+          <div
+            class="queue-items-scroll-box"
+            :style="`--queue-title-size: ${queueTitleFontSize}; --queue-subtitle-size: ${queueSubtitleFontSize};`"
+          >
             <v-infinite-scroll
               v-if="!tempHide && activeQueuePanel !== 2"
               :onLoad="loadNextPage"
@@ -735,17 +738,17 @@ watch(
 const titleFontSize = computed(() => {
   switch (name.value) {
     case "xs":
-      return "1.2em";
+      return "1.3em";
     case "sm":
-      return "1.5em";
+      return "1.6em";
     case "md":
-      return "1.7em";
+      return "1.8em";
     case "lg":
-      return store.showQueueItems ? "1.5em" : "2em";
+      return store.showQueueItems ? "1.7em" : "2.1em";
     case "xl":
-      return store.showQueueItems ? "1.6em" : "2.2em";
+      return store.showQueueItems ? "1.8em" : "2.3em";
     case "xxl":
-      return store.showQueueItems ? "1.7em" : "2.4em";
+      return store.showQueueItems ? "1.9em" : "2.5em";
     default:
       return "1.0em";
   }
@@ -754,19 +757,57 @@ const titleFontSize = computed(() => {
 const subTitleFontSize = computed(() => {
   switch (name.value) {
     case "xs":
-      return "1.05em";
+      return "0.95em";
     case "sm":
-      return "1.25em";
+      return "1.15em";
     case "md":
-      return "1.35em";
+      return "1.3em";
     case "lg":
-      return store.showQueueItems ? "1.1em" : "1.45em";
+      return store.showQueueItems ? "1.2em" : "1.5em";
     case "xl":
-      return store.showQueueItems ? "1.2em" : "1.6em";
+      return store.showQueueItems ? "1.3em" : "1.65em";
     case "xxl":
-      return store.showQueueItems ? "1.3em" : "1.8em";
+      return store.showQueueItems ? "1.35em" : "1.8em";
     default:
       return "1.0em";
+  }
+});
+
+const queueTitleFontSize = computed(() => {
+  switch (name.value) {
+    case "xs":
+      return "0.875rem";
+    case "sm":
+      return "0.875rem";
+    case "md":
+      return "0.925rem";
+    case "lg":
+      return "0.9rem";
+    case "xl":
+      return "0.925rem";
+    case "xxl":
+      return "0.975rem";
+    default:
+      return "0.875rem";
+  }
+});
+
+const queueSubtitleFontSize = computed(() => {
+  switch (name.value) {
+    case "xs":
+      return "0.775rem";
+    case "sm":
+      return "0.775rem";
+    case "md":
+      return "0.8rem";
+    case "lg":
+      return "0.8rem";
+    case "xl":
+      return "0.8rem";
+    case "xxl":
+      return "0.85rem";
+    default:
+      return "0.775rem";
   }
 });
 
@@ -1501,6 +1542,14 @@ watchEffect(() => {
   flex: 1;
   min-height: 0;
   overflow-y: scroll;
+}
+
+.queue-items-scroll-box :deep(.v-list-item-title) {
+  font-size: var(--queue-title-size, 1rem);
+}
+
+.queue-items-scroll-box :deep(.v-list-item-subtitle) {
+  font-size: var(--queue-subtitle-size, 0.875rem);
 }
 
 .v-infinite-scroll--vertical {

--- a/src/layouts/default/PlayerOSD/PlayerFullscreen.vue
+++ b/src/layouts/default/PlayerOSD/PlayerFullscreen.vue
@@ -176,7 +176,7 @@
                 store.activePlayer?.powered != false &&
                 store.curQueueItem?.streamdetails
               "
-              style="padding-top: min(20px, 2vh)"
+              style="padding-top: min(10px, 1vh)"
             >
               <QualityDetailsBtn />
             </div>
@@ -1591,6 +1591,7 @@ watchEffect(() => {
   text-align: center;
   padding: 20px;
   padding-top: 5%;
+  padding-bottom: 10px;
 }
 
 .player-bottom {

--- a/src/layouts/default/PlayerOSD/PlayerFullscreen.vue
+++ b/src/layouts/default/PlayerOSD/PlayerFullscreen.vue
@@ -227,7 +227,7 @@
               <!-- list view -->
               <v-virtual-scroll
                 :item-height="70"
-                max-height="90%"
+                max-height="100%"
                 :items="activeQueuePanel == 0 ? nextItems : previousItems"
               >
                 <template #default="{ item, index }">
@@ -1464,14 +1464,17 @@ watchEffect(() => {
 
 <style scoped>
 
-.main {
-  --main-height: 57%;
-  --main-max-height: 65%;
+.v-card {
+  overflow: hidden;
+  height: 100%;
   display: flex;
-  min-height: 50% !important;
-  height: var(--main-height) !important;
-  max-height: var(--main-max-height) !important;
-  padding-bottom: 5px;
+  flex-direction: column;
+}
+
+.main {
+  display: flex;
+  flex: 1;
+  min-height: 0;
 }
 
 .main .main-media-details {
@@ -1489,10 +1492,14 @@ watchEffect(() => {
   max-width: 100%;
   padding-right: 10px;
   padding-left: 15px;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
 }
 
 .queue-items-scroll-box {
-  max-height: 100%;
+  flex: 1;
+  min-height: 0;
   overflow-y: scroll;
 }
 
@@ -1537,13 +1544,9 @@ watchEffect(() => {
 }
 
 .player-bottom {
-  max-height: 35% !important;
-  min-height: 25% !important;
-  height: 30% !important;
-  margin-top: auto;
-  bottom: 0;
+  flex-shrink: 0;
   position: unset !important;
-  padding-bottom: 5%;
+  padding-bottom: max(env(safe-area-inset-bottom, 0px), 3%);
   width: 100%;
 }
 
@@ -1696,14 +1699,9 @@ button {
 }
 
 @media (max-width: 540px) {
-  .main:has(.main-media-details) {
-    --main-height: 70%;
-    --main-max-height: 75%;
-  }
-
   .main-media-details-image {
-    height: 75%;
-    max-height: 85%;
+    height: 70%;
+    max-height: 80%;
     padding-left: 16px;
     padding-right: 16px;
   }

--- a/src/layouts/default/PlayerOSD/PlayerFullscreen.vue
+++ b/src/layouts/default/PlayerOSD/PlayerFullscreen.vue
@@ -1589,9 +1589,12 @@ watchEffect(() => {
   justify-content: flex-start;
   align-items: center;
   text-align: center;
-  padding: 20px;
-  padding-top: 5%;
-  padding-bottom: 10px;
+  padding: 5% 0 10px;
+  overflow: hidden;
+}
+
+.main-media-details-track-info > * {
+  max-width: 100%;
 }
 
 .player-bottom {
@@ -1758,7 +1761,7 @@ button {
   }
 
   .main-media-details-track-info {
-    padding: 8px;
+    padding: 8px 0;
     height: 25%;
   }
 }

--- a/src/layouts/default/PlayerOSD/PlayerFullscreen.vue
+++ b/src/layouts/default/PlayerOSD/PlayerFullscreen.vue
@@ -1597,6 +1597,8 @@ watchEffect(() => {
   max-width: 100%;
 }
 
+
+
 .player-bottom {
   flex-shrink: 0;
   position: unset !important;
@@ -1754,15 +1756,14 @@ button {
 
 @media (max-width: 540px) {
   .main-media-details-image {
-    height: 70%;
-    max-height: 80%;
+    height: 65%;
+    max-height: 75%;
     padding-left: 16px;
     padding-right: 16px;
   }
 
   .main-media-details-track-info {
     padding: 8px 0;
-    height: 25%;
   }
 }
 

--- a/src/layouts/default/PlayerOSD/PlayerFullscreen.vue
+++ b/src/layouts/default/PlayerOSD/PlayerFullscreen.vue
@@ -7,7 +7,7 @@
     z-index="9999"
     persistent
   >
-    <v-card :style="{ background: backgroundColor }">
+    <v-card class="fullscreen-player-card" :style="{ background: backgroundColor }">
       <v-toolbar class="v-toolbar-default" color="transparent">
         <template #prepend>
           <Button icon @click="store.showFullscreenPlayer = false">
@@ -1505,7 +1505,7 @@ watchEffect(() => {
 
 <style scoped>
 
-.v-card {
+.fullscreen-player-card {
   overflow: hidden;
   height: 100%;
   display: flex;
@@ -1596,8 +1596,6 @@ watchEffect(() => {
 .main-media-details-track-info > * {
   max-width: 100%;
 }
-
-
 
 .player-bottom {
   flex-shrink: 0;


### PR DESCRIPTION
This PR:
- Fixes scrollbars on mobile in PWA mode
- Scrolls the title text horizontally when it is too large to fit
- Fixes the progress bar jumping when selecting the queue
- Now uses flex layouts so it properly sizes across all screens without overlapping elements, player controls now nicely float at the bottom
- Album art now scales to whatever room is left, making sure we always render titles/quality icon without overlap
- Make the artist and track title float more towards the image art

Examples at different ratios:
**Desktop with queue**
<img width="1486" height="1354" alt="image" src="https://github.com/user-attachments/assets/e875e330-b1c1-402c-a93f-dc33a5ae710a" />

**Desktop without queue**
<img width="1486" height="1354" alt="image" src="https://github.com/user-attachments/assets/154c8b41-c0a9-47e9-b5ab-aa05ae56cc88" />

**Ipad Air**
<img width="823" height="1184" alt="image" src="https://github.com/user-attachments/assets/fe106f18-f520-4468-a9c5-b40ff4f1a98c" />

**Iphone 15 pro in PWA mode**
<img width="393" height="799" alt="image" src="https://github.com/user-attachments/assets/ba8861cf-881c-477d-a6fb-6340dbe9823c" />

**Iphone SE**
<img width="378" height="671" alt="image" src="https://github.com/user-attachments/assets/c6d7f704-76d9-49ea-be6d-1c437d8c1072" />

**Teeny tiny square screen (yes the title scrolls)**
<img width="431" height="418" alt="image" src="https://github.com/user-attachments/assets/ebd353b5-88fb-4e1e-880d-c2133ac3834d" />

