### PR TITLE
Fix titles overlapping on the Now Playing screen on Ultrawide resolutions

### DIFF
--- a/src/layouts/default/PlayerOSD/PlayerFullscreen.vue
+++ b/src/layouts/default/PlayerOSD/PlayerFullscreen.vue
@@ -1593,7 +1593,7 @@ watchEffect(() => {
   justify-content: flex-start;
   align-items: center;
   text-align: center;
-  padding: 5% 0 10px;
+  padding: min(5%, 5vh) 0 10px;
   overflow: hidden;
 }
 
@@ -1604,7 +1604,7 @@ watchEffect(() => {
 .player-bottom {
   flex-shrink: 0;
   position: unset !important;
-  padding-bottom: max(env(safe-area-inset-bottom, 0px), 3%);
+  padding-bottom: max(env(safe-area-inset-bottom, 0px), min(3%, 3vh));
   width: 100%;
 }
 


### PR DESCRIPTION
**Before**
<img width="4906" height="1353" alt="image" src="https://github.com/user-attachments/assets/02a9ce01-4bfc-44bb-8cd5-37039928412f" />


**After**
<img width="4906" height="1352" alt="image" src="https://github.com/user-attachments/assets/73b190f4-8a9e-45dc-a391-f891dffa37d3" />
