### PR TITLE
Add alternate view options in genre overview

### DIFF
--- a/src/components/InfoHeader.vue
+++ b/src/components/InfoHeader.vue
@@ -30,7 +30,11 @@
         :menu-items="menuItems"
         :enforce-overflow-menu="true"
         :icon-action="backButtonClick"
-      />
+      >
+        <template v-if="$slots['toolbar-append']" #append>
+          <slot name="toolbar-append"></slot>
+        </template>
+      </Toolbar>
       <v-layout
         v-if="item"
         style="

--- a/src/components/ItemsListing.vue
+++ b/src/components/ItemsListing.vue
@@ -305,7 +305,7 @@ export interface Props {
   restoreState?: boolean;
   onTitleClick?: () => void;
   refreshOnParentUpdate?: boolean;
-  forcedViewMode?: string;
+  forcedViewMode?: "list" | "panel" | "panel_compact";
 }
 const props = withDefaults(defineProps<Props>(), {
   sortKeys: () => ["name", "sort_name"],

--- a/src/components/ItemsListing.vue
+++ b/src/components/ItemsListing.vue
@@ -305,6 +305,7 @@ export interface Props {
   restoreState?: boolean;
   onTitleClick?: () => void;
   refreshOnParentUpdate?: boolean;
+  forcedViewMode?: string;
 }
 const props = withDefaults(defineProps<Props>(), {
   sortKeys: () => ["name", "sort_name"],
@@ -337,6 +338,7 @@ const props = withDefaults(defineProps<Props>(), {
   restoreState: false,
   onTitleClick: undefined,
   refreshOnParentUpdate: false,
+  forcedViewMode: undefined,
 });
 
 // global refs
@@ -434,13 +436,22 @@ const toggleExpand = function () {
 
 const selectViewMode = function (newMode: string) {
   viewMode.value = newMode;
-  setItemsListingPreference(
-    props.path || props.itemtype,
-    props.itemtype,
-    "viewMode",
-    newMode,
-  );
+  if (!props.forcedViewMode) {
+    setItemsListingPreference(
+      props.path || props.itemtype,
+      props.itemtype,
+      "viewMode",
+      newMode,
+    );
+  }
 };
+
+watch(
+  () => props.forcedViewMode,
+  (newMode) => {
+    if (newMode) viewMode.value = newMode;
+  },
+);
 
 const toggleFavoriteFilter = function () {
   params.value.favoritesOnly = !params.value.favoritesOnly;
@@ -1007,38 +1018,39 @@ const menuItems = computed(() => {
     });
   }
 
-  // toggle view mode
-  items.push({
-    label: "tooltip.toggle_view_mode",
-    icon: viewMode.value == "list" ? "mdi-view-list" : "mdi-grid",
-    overflowAllowed: true,
-    subItems: [
-      {
-        label: "view.list",
-        icon: "mdi-view-list",
-        selected: viewMode.value == "list",
-        action: () => {
-          selectViewMode("list");
+  // toggle view mode (hidden when view mode is controlled externally)
+  if (!props.forcedViewMode)
+    items.push({
+      label: "tooltip.toggle_view_mode",
+      icon: viewMode.value == "list" ? "mdi-view-list" : "mdi-grid",
+      overflowAllowed: true,
+      subItems: [
+        {
+          label: "view.list",
+          icon: "mdi-view-list",
+          selected: viewMode.value == "list",
+          action: () => {
+            selectViewMode("list");
+          },
         },
-      },
-      {
-        label: "view.panel",
-        icon: "mdi-grid",
-        selected: viewMode.value == "panel",
-        action: () => {
-          selectViewMode("panel");
+        {
+          label: "view.panel",
+          icon: "mdi-grid",
+          selected: viewMode.value == "panel",
+          action: () => {
+            selectViewMode("panel");
+          },
         },
-      },
-      {
-        label: "view.panel_compact",
-        icon: "mdi-grid",
-        selected: viewMode.value == "panel_compact",
-        action: () => {
-          selectViewMode("panel_compact");
+        {
+          label: "view.panel_compact",
+          icon: "mdi-grid",
+          selected: viewMode.value == "panel_compact",
+          action: () => {
+            selectViewMode("panel_compact");
+          },
         },
-      },
-    ],
-  });
+      ],
+    });
 
   if (props.extraMenuItems?.length) {
     items.push(...props.extraMenuItems);
@@ -1135,7 +1147,9 @@ const restoreSettings = async function () {
   const prefs = savedPrefs.value;
 
   // get stored/default viewMode for this itemtype
-  if (prefs.viewMode) {
+  if (props.forcedViewMode) {
+    viewMode.value = props.forcedViewMode;
+  } else if (prefs.viewMode) {
     viewMode.value = prefs.viewMode;
   } else if (props.itemtype == "artists") {
     viewMode.value = "panel";

--- a/src/components/Toolbar.vue
+++ b/src/components/Toolbar.vue
@@ -23,12 +23,10 @@
       </slot>
     </template>
 
-    <template v-if="$slots.append" #append>
+    <template v-if="$slots.append || menuItems?.length" #append>
       <slot name="append"></slot>
-    </template>
-    <template v-else-if="menuItems?.length" #append>
       <v-btn
-        v-for="menuItem of menuItems.filter(
+        v-for="menuItem of menuItems?.filter(
           (x) =>
             !x.hide &&
             !enforceOverflowMenu &&
@@ -61,8 +59,9 @@
       <div
         v-if="
           (!getBreakpointValue('bp8') || enforceOverflowMenu) &&
-          menuItems.filter((x) => x.hide != true && x.overflowAllowed !== false)
-            .length
+          menuItems?.filter(
+            (x) => x.hide != true && x.overflowAllowed !== false,
+          ).length
         "
       >
         <v-menu
@@ -87,7 +86,7 @@
           </template>
           <v-list density="compact" slim tile>
             <v-list-item
-              v-for="(menuItem, index) in menuItems.filter(
+              v-for="(menuItem, index) in menuItems?.filter(
                 (x) => x.hide != true && x.overflowAllowed != false,
               )"
               :key="index"

--- a/src/composables/userPreferences.ts
+++ b/src/composables/userPreferences.ts
@@ -24,6 +24,8 @@ export function useUserPreferences() {
   /**
    * Get a preference value from user preferences as a computed ref
    */
+  function getPreference<T>(key: string, defaultValue: T): ComputedRef<T>;
+  function getPreference<T>(key: string): ComputedRef<T | undefined>;
   function getPreference<T>(
     key: string,
     defaultValue?: T,

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -323,6 +323,7 @@
     "remove_alias_failed": "Failed to remove alias",
     "exclude_genre": "Exclude genre",
     "genre_exclusions": "Genre Exclusions",
+    "genre_view_discovery": "Discovery",
     "remove_genre_exclusion": "Remove exclusion",
     "remove_library": "Remove from library",
     "remove_playlist": "Remove from playlist",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -323,7 +323,7 @@
     "remove_alias_failed": "Failed to remove alias",
     "exclude_genre": "Exclude genre",
     "genre_exclusions": "Genre Exclusions",
-    "genre_view_discovery": "Discovery",
+
     "remove_genre_exclusion": "Remove exclusion",
     "remove_library": "Remove from library",
     "remove_playlist": "Remove from playlist",
@@ -1083,7 +1083,8 @@
     "view": {
         "list": "List view",
         "panel": "Thumbs view",
-        "panel_compact": "Compact thumbs view"
+        "panel_compact": "Compact thumbs view",
+        "discovery": "Discovery"
     },
     "play_replace": "Play Now (clear queue)",
     "played": "Played",

--- a/src/views/GenreDetails.vue
+++ b/src/views/GenreDetails.vue
@@ -1,20 +1,147 @@
 <template>
   <section>
-    <InfoHeader :item="itemDetails" :active-provider="provider" />
+    <InfoHeader :item="itemDetails" :active-provider="provider">
+      <template #toolbar-append>
+        <Button
+          variant="ghost"
+          size="icon"
+          :title="$t('tooltip.toggle_view_mode')"
+          @click="(e: MouseEvent) => openViewModeMenu(e)"
+        >
+          <component :is="viewModeIcon" class="size-[22px]" />
+        </Button>
+      </template>
+    </InfoHeader>
 
-    <div v-if="loadingRows" class="rows-loading">
-      <v-progress-linear color="accent" height="4" indeterminate rounded />
-    </div>
-
-    <div class="overview-container">
-      <div v-for="row in displayRows" :key="row.title" class="overview-row">
-        <WidgetRow
-          :widget-row="row"
-          :show-provider-on-cover="true"
-          :show-action-icon="true"
-        />
+    <!-- Discovery view -->
+    <template v-if="viewMode === 'discovery'">
+      <div v-if="loadingRows" class="rows-loading">
+        <v-progress-linear color="accent" height="4" indeterminate rounded />
       </div>
-    </div>
+
+      <div class="overview-container">
+        <div v-for="row in displayRows" :key="row.title" class="overview-row">
+          <WidgetRow
+            :widget-row="row"
+            :show-provider-on-cover="true"
+            :show-action-icon="true"
+          />
+        </div>
+      </div>
+    </template>
+
+    <!-- Traditional view -->
+    <template v-else-if="itemDetails && !loading">
+      <ItemsListing
+        itemtype="artists"
+        :load-items="loadGenreArtists"
+        :allow-collapse="true"
+        :show-favorites-only-filter="true"
+        :hide-on-empty="true"
+        :forced-view-mode="viewMode"
+      >
+        <template #title>
+          <span>{{ $t("artists") }}</span>
+          <SquareArrowRightEnter
+            :size="18"
+            class="navigate-icon"
+            @click.stop="navigateTo('artists')"
+          />
+        </template>
+      </ItemsListing>
+      <br />
+      <ItemsListing
+        itemtype="albums"
+        :load-items="loadGenreAlbums"
+        :allow-collapse="true"
+        :show-favorites-only-filter="true"
+        :hide-on-empty="true"
+        :forced-view-mode="viewMode"
+      >
+        <template #title>
+          <span>{{ $t("albums") }}</span>
+          <SquareArrowRightEnter
+            :size="18"
+            class="navigate-icon"
+            @click.stop="navigateTo('albums')"
+          />
+        </template>
+      </ItemsListing>
+      <br />
+      <ItemsListing
+        itemtype="tracks"
+        :load-items="loadGenreTracks"
+        :allow-collapse="true"
+        :show-favorites-only-filter="true"
+        :show-track-number="false"
+        :hide-on-empty="true"
+        :forced-view-mode="viewMode"
+      >
+        <template #title>
+          <span>{{ $t("tracks") }}</span>
+          <SquareArrowRightEnter
+            :size="18"
+            class="navigate-icon"
+            @click.stop="navigateTo('tracks')"
+          />
+        </template>
+      </ItemsListing>
+      <br />
+      <ItemsListing
+        itemtype="playlists"
+        :load-items="loadGenrePlaylists"
+        :allow-collapse="true"
+        :show-favorites-only-filter="true"
+        :hide-on-empty="true"
+        :forced-view-mode="viewMode"
+      >
+        <template #title>
+          <span>{{ $t("playlists") }}</span>
+          <SquareArrowRightEnter
+            :size="18"
+            class="navigate-icon"
+            @click.stop="navigateTo('playlists')"
+          />
+        </template>
+      </ItemsListing>
+      <br />
+      <ItemsListing
+        itemtype="podcasts"
+        :load-items="loadGenrePodcasts"
+        :allow-collapse="true"
+        :show-favorites-only-filter="true"
+        :hide-on-empty="true"
+        :forced-view-mode="viewMode"
+      >
+        <template #title>
+          <span>{{ $t("podcasts") }}</span>
+          <SquareArrowRightEnter
+            :size="18"
+            class="navigate-icon"
+            @click.stop="navigateTo('podcasts')"
+          />
+        </template>
+      </ItemsListing>
+      <br />
+      <ItemsListing
+        itemtype="audiobooks"
+        :load-items="loadGenreAudiobooks"
+        :allow-collapse="true"
+        :show-favorites-only-filter="true"
+        :hide-on-empty="true"
+        :forced-view-mode="viewMode"
+      >
+        <template #title>
+          <span>{{ $t("audiobooks") }}</span>
+          <SquareArrowRightEnter
+            :size="18"
+            class="navigate-icon"
+            @click.stop="navigateTo('audiobooks')"
+          />
+        </template>
+      </ItemsListing>
+      <br />
+    </template>
 
     <GenreAliasManager
       v-if="itemDetails && isAdmin"
@@ -28,7 +155,9 @@
 <script setup lang="ts">
 import GenreAliasManager from "@/components/genre/GenreAliasManager.vue";
 import InfoHeader from "@/components/InfoHeader.vue";
+import ItemsListing, { LoadDataParams } from "@/components/ItemsListing.vue";
 import WidgetRow from "@/components/WidgetRow.vue";
+import { useUserPreferences } from "@/composables/userPreferences";
 import { genreMediaTypeIconMap, folderIdToRoute } from "@/helpers/genre";
 import { getGenreDisplayName } from "@/helpers/utils";
 import { api } from "@/plugins/api";
@@ -41,6 +170,15 @@ import {
   MediaItemType,
 } from "@/plugins/api/interfaces";
 import { authManager } from "@/plugins/auth";
+import { eventbus } from "@/plugins/eventbus";
+import { Button } from "@/components/ui/button";
+import {
+  AlignJustify,
+  LayoutDashboard,
+  LayoutGrid,
+  Grid2X2,
+  SquareArrowRightEnter,
+} from "lucide-vue-next";
 import {
   computed,
   onBeforeUnmount,
@@ -75,9 +213,73 @@ const router = useRouter();
 
 const isAdmin = computed(() => authManager.isAdmin());
 
+const { getPreference, setPreference } = useUserPreferences();
+const savedViewMode = getPreference<string>("genre_detail_view", "discovery");
+const viewMode = ref<string>(savedViewMode.value ?? "discovery");
+
+watch(viewMode, (newVal) => {
+  setPreference("genre_detail_view", newVal);
+});
+
 const displayRows = computed(() =>
   overviewRows.value.filter((row) => row.items?.length),
 );
+
+const viewModeIcon = computed(() => {
+  if (viewMode.value === "discovery") return LayoutDashboard;
+  if (viewMode.value === "panel") return LayoutGrid;
+  if (viewMode.value === "panel_compact") return Grid2X2;
+  return AlignJustify;
+});
+
+const openViewModeMenu = (e: MouseEvent) => {
+  eventbus.emit("contextmenu", {
+    items: [
+      {
+        label: "genre_view_discovery",
+        icon: "mdi-view-dashboard",
+        selected: viewMode.value === "discovery",
+        action: () => {
+          viewMode.value = "discovery";
+        },
+      },
+      {
+        label: "view.list",
+        icon: "mdi-view-list",
+        selected: viewMode.value === "list",
+        action: () => {
+          viewMode.value = "list";
+        },
+      },
+      {
+        label: "view.panel",
+        icon: "mdi-grid",
+        selected: viewMode.value === "panel",
+        action: () => {
+          viewMode.value = "panel";
+        },
+      },
+      {
+        label: "view.panel_compact",
+        icon: "mdi-view-comfy",
+        selected: viewMode.value === "panel_compact",
+        action: () => {
+          viewMode.value = "panel_compact";
+        },
+      },
+    ],
+    posX: e.clientX,
+    posY: e.clientY,
+  });
+};
+
+const navigateTo = (routeName: string) => {
+  if (!itemDetails.value) return;
+  router.push({
+    name: routeName,
+    query: { genre_ids: itemDetails.value.item_id },
+  });
+};
 
 const loadItemDetails = async () => {
   loading.value = true;
@@ -153,6 +355,88 @@ const loadOverviewRows = async () => {
   loadingRows.value = false;
 };
 
+const genreId = () => parseInt(itemDetails.value!.item_id);
+
+const loadGenreArtists = async (params: LoadDataParams) => {
+  if (!itemDetails.value) return [];
+  return await api.getLibraryArtists(
+    params.favoritesOnly || undefined,
+    params.search,
+    undefined,
+    undefined,
+    params.sortBy,
+    undefined,
+    params.provider?.length ? params.provider : undefined,
+    genreId(),
+  );
+};
+
+const loadGenreAlbums = async (params: LoadDataParams) => {
+  if (!itemDetails.value) return [];
+  return await api.getLibraryAlbums(
+    params.favoritesOnly || undefined,
+    params.search,
+    undefined,
+    undefined,
+    params.sortBy,
+    undefined,
+    params.provider?.length ? params.provider : undefined,
+    genreId(),
+  );
+};
+
+const loadGenreTracks = async (params: LoadDataParams) => {
+  if (!itemDetails.value) return [];
+  return await api.getLibraryTracks(
+    params.favoritesOnly || undefined,
+    params.search,
+    undefined,
+    undefined,
+    params.sortBy,
+    params.provider?.length ? params.provider : undefined,
+    genreId(),
+  );
+};
+
+const loadGenrePlaylists = async (params: LoadDataParams) => {
+  if (!itemDetails.value) return [];
+  return await api.getLibraryPlaylists(
+    params.favoritesOnly || undefined,
+    params.search,
+    undefined,
+    undefined,
+    params.sortBy,
+    params.provider?.length ? params.provider : undefined,
+    genreId(),
+  );
+};
+
+const loadGenrePodcasts = async (params: LoadDataParams) => {
+  if (!itemDetails.value) return [];
+  return await api.getLibraryPodcasts(
+    params.favoritesOnly || undefined,
+    params.search,
+    undefined,
+    undefined,
+    params.sortBy,
+    params.provider?.length ? params.provider : undefined,
+    genreId(),
+  );
+};
+
+const loadGenreAudiobooks = async (params: LoadDataParams) => {
+  if (!itemDetails.value) return [];
+  return await api.getLibraryAudiobooks(
+    params.favoritesOnly || undefined,
+    params.search,
+    undefined,
+    undefined,
+    params.sortBy,
+    params.provider?.length ? params.provider : undefined,
+    genreId(),
+  );
+};
+
 watch(
   () => props.itemId,
   (val) => {
@@ -193,5 +477,24 @@ onMounted(() => {
 
 .overview-container {
   padding: 0 16px 16px 16px;
+}
+
+.overview-container :deep(.header.v-toolbar) {
+  font-family: "JetBrains Mono Medium";
+}
+
+.overview-container :deep(.header.v-toolbar .v-toolbar-title) {
+  font-weight: normal;
+}
+
+.navigate-icon {
+  margin-left: 6px;
+  cursor: pointer;
+  opacity: 0.7;
+  vertical-align: middle;
+}
+
+.navigate-icon:hover {
+  opacity: 1;
 }
 </style>

--- a/src/views/GenreDetails.vue
+++ b/src/views/GenreDetails.vue
@@ -489,10 +489,6 @@ onMounted(() => {
   padding: 0 16px 16px 16px;
 }
 
-.overview-container :deep(.header.v-toolbar .v-toolbar-title) {
-  font-weight: normal;
-}
-
 .navigate-icon {
   margin-left: 6px;
   cursor: pointer;

--- a/src/views/GenreDetails.vue
+++ b/src/views/GenreDetails.vue
@@ -38,7 +38,7 @@
         :allow-collapse="true"
         :show-favorites-only-filter="true"
         :hide-on-empty="true"
-        :forced-view-mode="viewMode"
+        :forced-view-mode="itemsViewMode"
       >
         <template #title>
           <span>{{ $t("artists") }}</span>
@@ -56,7 +56,7 @@
         :allow-collapse="true"
         :show-favorites-only-filter="true"
         :hide-on-empty="true"
-        :forced-view-mode="viewMode"
+        :forced-view-mode="itemsViewMode"
       >
         <template #title>
           <span>{{ $t("albums") }}</span>
@@ -75,7 +75,7 @@
         :show-favorites-only-filter="true"
         :show-track-number="false"
         :hide-on-empty="true"
-        :forced-view-mode="viewMode"
+        :forced-view-mode="itemsViewMode"
       >
         <template #title>
           <span>{{ $t("tracks") }}</span>
@@ -93,7 +93,7 @@
         :allow-collapse="true"
         :show-favorites-only-filter="true"
         :hide-on-empty="true"
-        :forced-view-mode="viewMode"
+        :forced-view-mode="itemsViewMode"
       >
         <template #title>
           <span>{{ $t("playlists") }}</span>
@@ -111,7 +111,7 @@
         :allow-collapse="true"
         :show-favorites-only-filter="true"
         :hide-on-empty="true"
-        :forced-view-mode="viewMode"
+        :forced-view-mode="itemsViewMode"
       >
         <template #title>
           <span>{{ $t("podcasts") }}</span>
@@ -129,7 +129,7 @@
         :allow-collapse="true"
         :show-favorites-only-filter="true"
         :hide-on-empty="true"
-        :forced-view-mode="viewMode"
+        :forced-view-mode="itemsViewMode"
       >
         <template #title>
           <span>{{ $t("audiobooks") }}</span>
@@ -213,9 +213,19 @@ const router = useRouter();
 
 const isAdmin = computed(() => authManager.isAdmin());
 
+type GenreViewMode = "discovery" | "list" | "panel" | "panel_compact";
+
 const { getPreference, setPreference } = useUserPreferences();
-const savedViewMode = getPreference<string>("genre_detail_view", "discovery");
-const viewMode = ref<string>(savedViewMode.value);
+const savedViewMode = getPreference<GenreViewMode>(
+  "genre_detail_view",
+  "discovery",
+);
+const viewMode = ref<GenreViewMode>(savedViewMode.value);
+const itemsViewMode = computed(() =>
+  viewMode.value !== "discovery"
+    ? (viewMode.value as "list" | "panel" | "panel_compact")
+    : undefined,
+);
 
 watch(viewMode, (newVal) => {
   setPreference("genre_detail_view", newVal);

--- a/src/views/GenreDetails.vue
+++ b/src/views/GenreDetails.vue
@@ -215,7 +215,7 @@ const isAdmin = computed(() => authManager.isAdmin());
 
 const { getPreference, setPreference } = useUserPreferences();
 const savedViewMode = getPreference<string>("genre_detail_view", "discovery");
-const viewMode = ref<string>(savedViewMode.value ?? "discovery");
+const viewMode = ref<string>(savedViewMode.value);
 
 watch(viewMode, (newVal) => {
   setPreference("genre_detail_view", newVal);
@@ -236,7 +236,7 @@ const openViewModeMenu = (e: MouseEvent) => {
   eventbus.emit("contextmenu", {
     items: [
       {
-        label: "genre_view_discovery",
+        label: "view.discovery",
         icon: "mdi-view-dashboard",
         selected: viewMode.value === "discovery",
         action: () => {
@@ -477,10 +477,6 @@ onMounted(() => {
 
 .overview-container {
   padding: 0 16px 16px 16px;
-}
-
-.overview-container :deep(.header.v-toolbar) {
-  font-family: "JetBrains Mono Medium";
 }
 
 .overview-container :deep(.header.v-toolbar .v-toolbar-title) {


### PR DESCRIPTION
Adds the classic list, thumb and compact thumb views as extra options to the genre overview

Discovery
<img width="1085" height="549" alt="Screenshot 2026-03-11 at 15 33 28" src="https://github.com/user-attachments/assets/71905c3a-ba31-4873-b387-9bb24b68cd51" />

List
<img width="1110" height="598" alt="Screenshot 2026-03-11 at 15 33 36" src="https://github.com/user-attachments/assets/b285ce59-e147-46e9-94cc-daf9a128bdfa" />

Thumbs
<img width="1086" height="663" alt="Screenshot 2026-03-11 at 15 33 46" src="https://github.com/user-attachments/assets/b7003fbf-fc3a-40ed-8fe3-2281985065ea" />

Selector
<img width="477" height="253" alt="Screenshot 2026-03-11 at 15 33 54" src="https://github.com/user-attachments/assets/24218c72-7559-4e1e-8484-3a149855eb9e" />

