### PR TITLE
Rewrite LyricsViewer syncing and extract elapsed time composable

### DIFF
--- a/src/components/LyricsViewer.vue
+++ b/src/components/LyricsViewer.vue
@@ -90,6 +90,7 @@ const setLineRef = (el: HTMLElement | null, index: number) => {
   }
 };
 
+// True when playback is before the first lyric timestamp — shows intro screen
 const beforeFirstLyric = computed(() => {
   if (!hasTimestamps.value || !parsedLyrics.value.length) {
     return false;
@@ -137,21 +138,25 @@ const hasLyrics = computed(() => {
   );
 });
 
+// Check parsed lyrics first, then fall back to raw data for LRC format patterns
 const hasTimestamps = computed(() => {
   if (parsedLyrics.value.some((line) => line.time > 0)) {
     return true;
   }
   const syncedLyrics = getSyncedLyrics();
   const plainLyrics = getPlainLyrics();
+  // Check lrc_lyrics field
   if (syncedLyrics && syncedLyrics.includes("[")) {
     return true;
   }
+  // Check regular lyrics field for LRC patterns like [00:29.79]
   if (plainLyrics && /\[\d+:\d+[.:]?\d*\]/.test(plainLyrics)) {
     return true;
   }
   return false;
 });
 
+// Parse a single LRC line like "[00:29.79] Some lyric text" into {time, text}
 const parseLrcLine = (line: string) => {
   const match = line.match(/\[(\d+):(\d+)([.:]\d+)?\](.*)/);
   if (match) {
@@ -169,6 +174,8 @@ const parseLrcLine = (line: string) => {
   return { time: 0, text: line.trim() || " " };
 };
 
+// Determine which lyrics source to use and parse them.
+// Priority: lrc_lyrics > plain lyrics with LRC patterns > plain text lyrics
 const fetchLyrics = () => {
   loading.value = true;
   try {
@@ -182,6 +189,7 @@ const fetchLyrics = () => {
       lyricsToProcess = syncedLyrics;
       isLrcFormat = true;
     } else if (plainLyrics && /\[\d+:\d+[.:]?\d*\]/.test(plainLyrics)) {
+      // Plain lyrics field contains LRC format
       lyricsToProcess = plainLyrics;
       isLrcFormat = true;
     } else if (plainLyrics) {
@@ -243,7 +251,8 @@ const calculateLookAhead = (currentPosition: number): number => {
   return Math.min(1.0, Math.max(0.05, gap * 0.15));
 };
 
-// Find active lyric index based on current position
+// Find active lyric index based on current position.
+// Uses millisecond precision to avoid floating-point comparison issues.
 const findActiveLyricIndex = (position: number, lookAhead: number): number => {
   const adjustedPositionMs = Math.round((position + lookAhead) * 1000);
 
@@ -276,7 +285,9 @@ const scrollToActiveLyric = (index: number) => {
   }, 400);
 };
 
-// Setup scroll listener to detect manual scrolling
+// Detect manual scrolling so we don't fight the user with auto-scroll.
+// Uses isProgrammaticScroll to distinguish our scrollIntoView calls from
+// user-initiated scrolls. After user scrolls, auto-scroll is paused for 8s.
 const setupScrollListener = () => {
   const root = scrollAreaRef.value?.$el as HTMLElement | undefined;
   const scrollEl = root?.querySelector<HTMLElement>(
@@ -287,7 +298,6 @@ const setupScrollListener = () => {
   scrollEl.addEventListener(
     "scroll",
     () => {
-      // Ignore scroll events triggered by our own scrollIntoView
       if (isProgrammaticScroll.value) return;
 
       userManuallyScrolled.value = true;

--- a/src/components/LyricsViewer.vue
+++ b/src/components/LyricsViewer.vue
@@ -1,39 +1,103 @@
 <template>
   <div class="lyrics-container">
-    <div v-if="loading" class="lyrics-loading">
+    <div v-if="loading || externalLoading" class="lyrics-loading">
       <Spinner class="size-6" />
       <div>{{ $t("loading_lyrics") }}</div>
     </div>
     <div v-else-if="!parsedLyrics.length" class="lyrics-empty">
       {{ $t("no_lyrics_available") }}
     </div>
-    <div v-else-if="beforeFirstLyric && hasTimestamps" class="lyrics-intro">
-      <div class="song-title" :style="{ color: textColor }">
-        {{ props.mediaItem?.name }}
-      </div>
-      <div class="artist-name">{{ artistName }}</div>
-      <div class="lyrics-coming-soon">{{ $t("lyrics_will_appear_soon") }}</div>
-    </div>
-    <ScrollArea
-      v-else
-      ref="scrollAreaRef"
-      class="h-full w-full"
-      :class="{ 'static-lyrics': !hasTimestamps }"
+    <!-- Synced lyrics: always mounted when timestamps exist so DOM is ready for transition -->
+    <div
+      v-else-if="hasTimestamps"
+      ref="syncedContainerRef"
+      class="synced-container"
     >
+      <Transition name="intro-fade">
+        <div v-if="beforeFirstLyric" class="lyrics-intro">
+          <div class="song-title" :style="{ color: textColor }">
+            {{ props.mediaItem?.name }}
+          </div>
+          <div class="artist-name">{{ artistName }}</div>
+          <div class="lyrics-coming-soon">
+            {{ $t("lyrics_will_appear_soon") }}
+          </div>
+        </div>
+      </Transition>
       <div
-        ref="lyricsContentRef"
-        :class="['lyrics-content', { 'lyrics-content--synced': hasTimestamps }]"
+        ref="syncedContentRef"
+        class="synced-content"
+        :style="{
+          transform: `translateY(${contentTranslateY}px)`,
+          transition: contentTransitionEnabled ? undefined : 'none',
+        }"
       >
+        <template v-for="(line, index) in parsedLyrics" :key="index">
+          <div
+            :ref="(el) => setLineRef(el as HTMLElement | null, index)"
+            :class="[
+              'lyrics-line',
+              {
+                active: activeLyricIndex === index,
+                'lyrics-line--hidden':
+                  activeLyricIndex >= 0
+                    ? index < activeLyricIndex - 1 ||
+                      index > activeLyricIndex + 2
+                    : index > 2,
+              },
+            ]"
+          >
+            {{ line.text }}
+          </div>
+          <!-- Musical break notes inserted between lines, never replacing them -->
+          <div
+            v-if="musicalBreakLineIndex === index"
+            :class="[
+              'lyrics-line',
+              {
+                active: isInMusicalBreak,
+                'lyrics-line--hidden':
+                  activeLyricIndex >= 0 &&
+                  (index < activeLyricIndex - 2 ||
+                    index > activeLyricIndex + 1),
+              },
+            ]"
+          >
+            <span
+              v-for="n in NOTE_COUNT"
+              :key="n"
+              class="break-note"
+              :class="{
+                'break-note--filled': n <= filledNoteCount,
+                'break-note--filling': n === filledNoteCount + 1,
+              }"
+              :style="
+                n === filledNoteCount + 1
+                  ? {
+                      backgroundImage: `linear-gradient(to right, ${textColor} ${currentNoteFillPercent}%, color-mix(in srgb, ${textColor} 35%, transparent) ${currentNoteFillPercent}%)`,
+                      backgroundClip: 'text',
+                      '-webkit-background-clip': 'text',
+                      '-webkit-text-fill-color': 'transparent',
+                    }
+                  : undefined
+              "
+              >&#9835;</span
+            >
+          </div>
+        </template>
+      </div>
+    </div>
+    <!-- Non-synced lyrics: simple scrollable list (hidden in karaoke mode) -->
+    <ScrollArea
+      v-else-if="!props.anticipation"
+      ref="scrollAreaRef"
+      class="h-full w-full static-lyrics"
+    >
+      <div class="lyrics-content">
         <div
           v-for="(line, index) in parsedLyrics"
           :key="index"
-          :ref="(el) => setLineRef(el as HTMLElement | null, index)"
-          :class="[
-            'lyrics-line',
-            {
-              active: activeLyricIndex === index || !hasTimestamps,
-            },
-          ]"
+          class="lyrics-line active"
         >
           {{ line.text }}
         </div>
@@ -58,6 +122,8 @@ interface Props {
   debugMode?: boolean;
   lyrics?: string | null;
   lrcLyrics?: string | null;
+  anticipation?: number;
+  externalLoading?: boolean;
 }
 
 const props = withDefaults(defineProps<Props>(), {
@@ -69,6 +135,8 @@ const props = withDefaults(defineProps<Props>(), {
   debugMode: false,
   lyrics: undefined,
   lrcLyrics: undefined,
+  anticipation: 0,
+  externalLoading: false,
 });
 
 // Core lyrics state
@@ -76,22 +144,14 @@ const parsedLyrics = ref<Array<{ time: number; text: string }>>([]);
 const loading = ref(false);
 const activeLyricIndex = ref(-1);
 const scrollAreaRef = ref<InstanceType<typeof ScrollArea> | null>(null);
-const lyricsContentRef = ref<HTMLElement | null>(null);
+const syncedContainerRef = ref<HTMLElement | null>(null);
+const syncedContentRef = ref<HTMLElement | null>(null);
 const lineRefs = new Map<number, HTMLElement>();
-const isProgrammaticScroll = ref(false);
-const userManuallyScrolled = ref(false);
-let manualScrollTimer: ReturnType<typeof setTimeout> | null = null;
 
-// Continuous scroll state.
-// Instead of discrete scrollIntoView jumps, we linearly interpolate scrollTop
-// between the current and next lyric's centered positions. This creates a
-// constant smooth scroll rate that lands the next line at center exactly
-// when it highlights.
-let scrollViewport: HTMLElement | null = null;
-let scrollStartTop = 0;
-let scrollEndTop = 0;
-let scrollStartTime = 0;
-let scrollDuration = 0;
+// Transform-based positioning: translateY applied to the content div
+// so the active line always sits at the fixed anchor point.
+const contentTranslateY = ref(0);
+const contentTransitionEnabled = ref(false);
 
 const setLineRef = (el: HTMLElement | null, index: number) => {
   if (el) {
@@ -101,14 +161,19 @@ const setLineRef = (el: HTMLElement | null, index: number) => {
   }
 };
 
-// True when playback is before the first lyric timestamp — shows intro screen
+// True when playback is before the first lyric timestamp — shows intro screen.
+// When anticipation is set (karaoke mode), the intro screen is dismissed early
+// so the singer can see the upcoming first line before they need to sing it.
 const beforeFirstLyric = computed(() => {
   if (!hasTimestamps.value || !parsedLyrics.value.length) {
     return false;
   }
   const firstLyricTime = parsedLyrics.value[0].time;
   const currentPosition = props.position || 0;
-  return activeLyricIndex.value === -1 && currentPosition < firstLyricTime;
+  return (
+    activeLyricIndex.value === -1 &&
+    currentPosition < firstLyricTime - props.anticipation
+  );
 });
 
 const artistName = computed(() => {
@@ -239,8 +304,59 @@ const fetchLyrics = () => {
   }
 };
 
-// Find active lyric index based on current position — no look-ahead.
-// The highlight always matches the actual timestamp exactly.
+// Musical break detection: show countdown notes during long instrumental gaps
+const GAP_THRESHOLD = 10; // seconds — minimum gap to trigger break display
+const BREAK_DELAY = 2; // seconds after line before showing notes
+const NOTE_COUNT = 7;
+
+const musicalBreakMap = computed(() => {
+  const map = new Map<number, { gapStart: number; gapEnd: number }>();
+  const lyrics = parsedLyrics.value;
+  for (let i = 0; i < lyrics.length - 1; i++) {
+    const gap = lyrics[i + 1].time - lyrics[i].time;
+    if (gap > GAP_THRESHOLD) {
+      map.set(i, {
+        gapStart: lyrics[i].time + BREAK_DELAY,
+        gapEnd: lyrics[i + 1].time,
+      });
+    }
+  }
+  return map;
+});
+
+const isInMusicalBreak = ref(false);
+const musicalBreakLineIndex = ref(-1);
+
+// Derive fill state as computed properties so the template always sees
+// values consistent with the current break state — no stale refs possible.
+const noteProgressState = computed(() => {
+  if (!isInMusicalBreak.value || musicalBreakLineIndex.value < 0) {
+    return { filled: NOTE_COUNT, percent: 100 };
+  }
+  const breakInfo = musicalBreakMap.value.get(musicalBreakLineIndex.value);
+  if (!breakInfo) {
+    return { filled: NOTE_COUNT, percent: 100 };
+  }
+  const pos = props.position || 0;
+  const gapDuration = breakInfo.gapEnd - breakInfo.gapStart;
+  const elapsed = Math.max(0, pos - breakInfo.gapStart);
+  const noteProgress = (elapsed / gapDuration) * NOTE_COUNT;
+  return {
+    filled: Math.min(NOTE_COUNT, Math.floor(noteProgress)),
+    percent: Math.round((noteProgress - Math.floor(noteProgress)) * 100),
+  };
+});
+const filledNoteCount = computed(() => noteProgressState.value.filled);
+const currentNoteFillPercent = computed(() => noteProgressState.value.percent);
+
+// How far ahead (in seconds) the highlight activates before the lyric timestamp.
+// Matches the CSS transition duration so the transition is fully complete
+// exactly when the lyric timestamp is reached.
+const HIGHLIGHT_LEAD_SECONDS = 1.0;
+
+// Find active lyric index based on current position.
+// The highlight activates HIGHLIGHT_LEAD_SECONDS (= transition duration) early
+// so the CSS transition is fully complete when the lyric timestamp is reached.
 const findActiveLyricIndex = (positionMs: number): number => {
   let index = -1;
   for (let i = 0; i < parsedLyrics.value.length; i++) {
@@ -254,81 +370,19 @@ const findActiveLyricIndex = (positionMs: number): number => {
   return index;
 };
 
-// Calculate the scrollTop value that centers a given lyric line in the viewport.
-const getCenteredScrollTop = (index: number): number | null => {
+// Calculate the translateY needed to place a line at the anchor point
+// (40% from top of the container).
+const computeTranslateY = (index: number) => {
   const el = lineRefs.get(index);
-  if (!el || !scrollViewport) return null;
-  const elTop = el.offsetTop;
-  const elHeight = el.offsetHeight;
-  const viewportHeight = scrollViewport.clientHeight;
-  return elTop - viewportHeight / 2 + elHeight / 2;
-};
+  const container = syncedContainerRef.value;
+  if (!el || !container) return;
 
-// Begin a new scroll interpolation from the current position to center the
-// target lyric, completing over the given duration in seconds.
-const beginScrollTo = (targetIndex: number, durationSec: number) => {
-  if (!scrollViewport) return;
-  const targetTop = getCenteredScrollTop(targetIndex);
-  if (targetTop === null) return;
+  const containerHeight = container.clientHeight;
+  const anchorY = containerHeight * 0.35;
+  const lineTop = el.offsetTop;
+  const lineHeight = el.offsetHeight;
 
-  scrollStartTop = scrollViewport.scrollTop;
-  scrollEndTop = targetTop;
-  scrollStartTime = performance.now();
-  // Minimum 300ms so very fast lyrics don't cause jarring snaps
-  scrollDuration = Math.max(300, durationSec * 1000);
-};
-
-// Called on every position update (~60fps via rAF) to advance the scroll.
-// Uses ease-out interpolation for a natural feel.
-const tickScroll = () => {
-  if (!scrollViewport || scrollDuration === 0) return;
-
-  const elapsed = performance.now() - scrollStartTime;
-  const t = Math.min(1, elapsed / scrollDuration);
-
-  // Ease-out for a natural feel: fast start, gentle arrival at center
-  const eased = 1 - (1 - t) * (1 - t);
-
-  isProgrammaticScroll.value = true;
-  scrollViewport.scrollTop =
-    scrollStartTop + (scrollEndTop - scrollStartTop) * eased;
-
-  if (t >= 1) {
-    scrollDuration = 0;
-    isProgrammaticScroll.value = false;
-  }
-};
-
-// Detect manual scrolling so we don't fight the user with auto-scroll.
-// Uses isProgrammaticScroll to distinguish our scroll writes from
-// user-initiated scrolls. After user scrolls, auto-scroll is paused for 8s.
-const setupScrollListener = () => {
-  const root = scrollAreaRef.value?.$el as HTMLElement | undefined;
-  scrollViewport = root?.querySelector<HTMLElement>(
-    "[data-slot=scroll-area-viewport]",
-  ) ?? null;
-  if (!scrollViewport) return;
-
-  scrollViewport.addEventListener(
-    "scroll",
-    () => {
-      if (isProgrammaticScroll.value) return;
-
-      userManuallyScrolled.value = true;
-      // Stop any in-progress interpolation
-      scrollDuration = 0;
-
-      // Debounce: clear previous timer, start new 8s timer
-      if (manualScrollTimer) {
-        clearTimeout(manualScrollTimer);
-      }
-      manualScrollTimer = setTimeout(() => {
-        userManuallyScrolled.value = false;
-        manualScrollTimer = null;
-      }, 8000);
-    },
-    { passive: true },
-  );
+  contentTranslateY.value = anchorY - lineTop - lineHeight / 2;
 };
 
 // Watch for lyrics data changes
@@ -336,30 +390,33 @@ watch(
   [() => props.mediaItem?.item_id, () => props.lyrics, () => props.lrcLyrics],
   () => {
     activeLyricIndex.value = -1;
-    scrollDuration = 0;
+    musicalBreakLineIndex.value = -1;
+    isInMusicalBreak.value = false;
+    contentTranslateY.value = 99999;
+    contentTransitionEnabled.value = false;
     lineRefs.clear();
     fetchLyrics();
+    // After DOM renders with new lyrics, position first line at bottom of container
+    nextTick(() => {
+      const container = syncedContainerRef.value;
+      if (container && hasTimestamps.value) {
+        contentTranslateY.value = container.clientHeight;
+      }
+    });
   },
   { immediate: true },
 );
 
-// Watch for ScrollArea ref becoming available and attach scroll listener
-watch(scrollAreaRef, (newRef) => {
-  if (newRef) {
-    nextTick(() => setupScrollListener());
+// Slide lyrics into view when the intro dismisses (handles anticipation mode
+// where beforeFirstLyric goes false before activeLyricIndex becomes 0).
+watch(beforeFirstLyric, (isBefore, wasBefore) => {
+  if (wasBefore && !isBefore && !contentTransitionEnabled.value) {
+    contentTransitionEnabled.value = true;
+    nextTick(() => computeTranslateY(0));
   }
 });
 
-// Main sync: highlight follows timestamps exactly, scroll interpolates smoothly.
-//
-// On each ~60fps position update:
-//   1. Check if the active lyric changed — if so, start a new scroll
-//      interpolation toward the NEXT lyric's centered position, timed to
-//      arrive exactly when that lyric will activate.
-//   2. Advance the ongoing scroll interpolation by one frame (tickScroll).
-//
-// This creates a constant, smooth scroll that naturally lands each line
-// at the center of the viewport right when it highlights.
+// Main sync: update active index and reposition content.
 watch(
   () => props.position,
   (newPosition: number | undefined) => {
@@ -371,35 +428,44 @@ watch(
       return;
     }
 
-    const positionMs = Math.round(newPosition * 1000);
-    const newActiveIndex = findActiveLyricIndex(positionMs);
+    // Shift position forward by the highlight lead time so the CSS transition
+    // finishes exactly when the lyric timestamp is reached.
+    const highlightPositionMs = Math.round(
+      (newPosition + HIGHLIGHT_LEAD_SECONDS) * 1000,
+    );
+    const newActiveIndex = findActiveLyricIndex(highlightPositionMs);
 
-    // When the active lyric changes, begin scrolling toward the next one
     if (newActiveIndex !== activeLyricIndex.value && newActiveIndex >= 0) {
+      contentTransitionEnabled.value = true;
       activeLyricIndex.value = newActiveIndex;
-
-      if (!userManuallyScrolled.value) {
-        const nextIndex = newActiveIndex + 1;
-        if (nextIndex < parsedLyrics.value.length) {
-          // Time until the next lyric activates — scroll over this duration
-          const timeUntilNext =
-            parsedLyrics.value[nextIndex].time - newPosition;
-          nextTick(() => beginScrollTo(nextIndex, timeUntilNext));
-        }
-      }
+      nextTick(() => computeTranslateY(newActiveIndex));
     }
 
-    // Advance the scroll interpolation every frame
-    if (!userManuallyScrolled.value) {
-      tickScroll();
+    // Update musical break state using raw position (not highlight-shifted).
+    // musicalBreakLineIndex persists so notes remain as a "previous line"
+    // after the next lyric activates. Fill state is derived via computed props.
+    const breakInfo = musicalBreakMap.value.get(activeLyricIndex.value);
+    if (
+      breakInfo &&
+      newPosition >= breakInfo.gapStart &&
+      newPosition < breakInfo.gapEnd
+    ) {
+      isInMusicalBreak.value = true;
+      musicalBreakLineIndex.value = activeLyricIndex.value;
+    } else {
+      isInMusicalBreak.value = false;
+      // Clear the break line index only once it would be scrolled out of view
+      if (
+        musicalBreakLineIndex.value >= 0 &&
+        activeLyricIndex.value > musicalBreakLineIndex.value + 1
+      ) {
+        musicalBreakLineIndex.value = -1;
+      }
     }
   },
 );
 
 onBeforeUnmount(() => {
-  if (manualScrollTimer) {
-    clearTimeout(manualScrollTimer);
-  }
   lineRefs.clear();
 });
 </script>
@@ -424,7 +490,9 @@ onBeforeUnmount(() => {
 }
 
 .lyrics-intro {
-  height: 100%;
+  position: absolute;
+  inset: 0;
+  z-index: 1;
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -432,22 +500,51 @@ onBeforeUnmount(() => {
   text-align: center;
 }
 
+.intro-fade-leave-active {
+  transition: opacity 0.8s ease;
+}
+
+.intro-fade-leave-to {
+  opacity: 0;
+}
+
 .song-title {
-  font-size: 2em;
+  font-size: clamp(1.8rem, 3.5vw, 3.5rem);
   font-weight: bold;
   margin-bottom: 10px;
 }
 
 .artist-name {
-  font-size: 1.5em;
+  font-size: clamp(1.4rem, 2.5vw, 2.5rem);
   margin-bottom: 40px;
   opacity: 0.8;
 }
 
 .lyrics-coming-soon {
-  font-size: 1.2em;
+  font-size: clamp(1rem, 1.8vw, 1.8rem);
   opacity: 0.6;
   font-style: italic;
+}
+
+/* Synced lyrics: fixed anchor with transform-based positioning */
+.synced-container {
+  height: 100%;
+  width: 100%;
+  overflow: hidden;
+  position: relative;
+}
+
+.synced-content {
+  text-align: center;
+  will-change: transform;
+  transition: transform 1s ease;
+}
+
+/* Non-synced static lyrics */
+.static-lyrics {
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-start;
 }
 
 .lyrics-content {
@@ -455,31 +552,46 @@ onBeforeUnmount(() => {
   padding: 10px 0;
 }
 
-.lyrics-content--synced {
-  padding: 40vh 0;
-}
-
-.static-lyrics {
-  display: flex;
-  flex-direction: column;
-  justify-content: flex-start;
-}
-
 .lyrics-line {
   padding: 10px 4px;
-  font-size: 1.1em;
-  opacity: 0.5;
+  font-size: clamp(2rem, 4vw, 4rem);
+  font-weight: bold;
+  opacity: 0.35;
   margin: 8px 0;
-  filter: blur(1px);
-  text-shadow: 0 0 1px var(--text-color);
+  transform: scale(0.78);
+  transform-origin: center center;
+  will-change: transform, opacity;
+  transition:
+    opacity 1s ease,
+    transform 1s ease;
+}
+
+.lyrics-line.lyrics-line--hidden {
+  opacity: 0;
+  transform: scale(0.78);
 }
 
 .lyrics-line.active {
   opacity: 1;
-  font-size: 1.4em;
-  font-weight: bold;
   color: v-bind(textColor);
-  filter: blur(0);
-  text-shadow: none;
+  transform: scale(1);
+}
+
+.break-note {
+  display: inline-block;
+  font-size: clamp(2rem, 4vw, 4rem);
+  margin: 0 0.15em;
+  color: v-bind(textColor);
+  opacity: 0.35;
+  background-image: none;
+  -webkit-text-fill-color: initial;
+}
+
+.break-note--filled {
+  opacity: 1;
+}
+
+.break-note--filling {
+  opacity: 1;
 }
 </style>

--- a/src/components/LyricsViewer.vue
+++ b/src/components/LyricsViewer.vue
@@ -47,7 +47,16 @@
               },
             ]"
           >
-            {{ line.text }}
+            <template v-if="line.words && activeLyricIndex === index">
+              <span
+                v-for="(word, wi) in line.words"
+                :key="wi"
+                class="lyrics-word"
+                :class="{ 'lyrics-word--active': isWordActive(word.time) }"
+                >{{ word.text }}
+              </span>
+            </template>
+            <template v-else>{{ line.text }}</template>
           </div>
           <!-- Musical break notes inserted between lines, never replacing them -->
           <div
@@ -139,8 +148,20 @@ const props = withDefaults(defineProps<Props>(), {
   externalLoading: false,
 });
 
+// Word-level timing for Enhanced LRC (A2 format)
+interface LyricWord {
+  time: number; // start time in seconds
+  text: string;
+}
+
+interface ParsedLyric {
+  time: number;
+  text: string;
+  words?: LyricWord[];
+}
+
 // Core lyrics state
-const parsedLyrics = ref<Array<{ time: number; text: string }>>([]);
+const parsedLyrics = ref<ParsedLyric[]>([]);
 // Timestamps of empty LRC lines — these mark genuine instrumental breaks
 const breakMarkerTimes = ref<Set<number>>(new Set());
 const loading = ref(false);
@@ -234,20 +255,50 @@ const hasTimestamps = computed(() => {
   return false;
 });
 
+// Parse a timestamp string "mm:ss.xx" into seconds
+const parseTimestamp = (
+  minutes: string,
+  seconds: string,
+  fraction?: string,
+): number => {
+  const min = parseInt(minutes);
+  const sec = parseInt(seconds);
+  let ms = 0;
+  if (fraction) {
+    const decimalPart = fraction.replace(/[.:]/, ".");
+    ms = Math.round(parseFloat(decimalPart) * 1000);
+  }
+  return (min * 60 * 1000 + sec * 1000 + ms) / 1000;
+};
+
+// Parse Enhanced LRC word timestamps from line text.
+// Format: "<mm:ss.xx> word <mm:ss.xx> word ..."
+const parseWordTimestamps = (text: string): LyricWord[] | undefined => {
+  const wordPattern = /<(\d+):(\d+)([.:]\d+)?>\s*([^<]*)/g;
+  const words: LyricWord[] = [];
+  let match;
+  while ((match = wordPattern.exec(text)) !== null) {
+    const time = parseTimestamp(match[1], match[2], match[3]);
+    const word = match[4].trim();
+    if (word) {
+      words.push({ time, text: word });
+    }
+  }
+  return words.length > 0 ? words : undefined;
+};
+
 // Parse a single LRC line like "[00:29.79] Some lyric text" into {time, text}
-const parseLrcLine = (line: string) => {
+// Also detects Enhanced LRC (A2) word-level timestamps like <00:00.04>
+const parseLrcLine = (line: string): ParsedLyric => {
   const match = line.match(/\[(\d+):(\d+)([.:]\d+)?\](.*)/);
   if (match) {
-    const minutes = parseInt(match[1]);
-    const seconds = parseInt(match[2]);
-    let milliseconds = 0;
-    if (match[3]) {
-      const decimalPart = match[3].replace(/[.:]/, ".");
-      milliseconds = Math.round(parseFloat(decimalPart) * 1000);
-    }
-    const timeMs = minutes * 60 * 1000 + seconds * 1000 + milliseconds;
-    const time = timeMs / 1000;
-    return { time, text: match[4].trim() || " " };
+    const time = parseTimestamp(match[1], match[2], match[3]);
+    const rawText = match[4];
+    const words = parseWordTimestamps(rawText);
+    const text = words
+      ? words.map((w) => w.text).join(" ")
+      : rawText.trim() || " ";
+    return { time, text, words };
   }
   return { time: 0, text: line.trim() || " " };
 };
@@ -371,6 +422,12 @@ const noteProgressState = computed(() => {
 });
 const filledNoteCount = computed(() => noteProgressState.value.filled);
 const currentNoteFillPercent = computed(() => noteProgressState.value.percent);
+
+// Check if a word-level timestamp has been reached (for Enhanced LRC highlighting)
+const isWordActive = (wordTime: number): boolean => {
+  const pos = props.position || 0;
+  return pos >= wordTime;
+};
 
 // How far ahead (in seconds) the highlight activates before the lyric timestamp.
 // Matches the CSS transition duration so the transition is fully complete
@@ -598,6 +655,16 @@ onBeforeUnmount(() => {
   opacity: 1;
   color: v-bind(textColor);
   transform: scale(1);
+}
+
+/* Enhanced LRC word-level highlighting */
+.lyrics-word {
+  opacity: 0.35;
+  transition: opacity 0.3s ease;
+}
+
+.lyrics-word--active {
+  opacity: 1;
 }
 
 .break-note {

--- a/src/components/LyricsViewer.vue
+++ b/src/components/LyricsViewer.vue
@@ -1,56 +1,53 @@
 <template>
   <div class="lyrics-container">
     <div v-if="loading" class="lyrics-loading">
-      <v-progress-circular indeterminate :color="textColor" />
+      <Spinner class="size-6" />
       <div>{{ $t("loading_lyrics") }}</div>
     </div>
     <div v-else-if="!parsedLyrics.length" class="lyrics-empty">
       {{ $t("no_lyrics_available") }}
     </div>
     <div v-else-if="beforeFirstLyric && hasTimestamps" class="lyrics-intro">
-      <div class="song-title">{{ props.mediaItem?.name }}</div>
+      <div class="song-title" :style="{ color: textColor }">
+        {{ props.mediaItem?.name }}
+      </div>
       <div class="artist-name">{{ artistName }}</div>
       <div class="lyrics-coming-soon">{{ $t("lyrics_will_appear_soon") }}</div>
     </div>
-    <div
+    <ScrollArea
       v-else
-      ref="lyricsContainer"
-      class="lyrics-scroll-container"
+      ref="scrollAreaRef"
+      class="h-full w-full"
       :class="{ 'static-lyrics': !hasTimestamps }"
     >
       <div
-        v-for="(line, index) in parsedLyrics"
-        :key="index"
-        :class="[
-          'lyrics-line',
-          {
-            active: activeLyricIndex === index || !hasTimestamps,
-          },
-        ]"
+        ref="lyricsContentRef"
+        :class="['lyrics-content', { 'lyrics-content--synced': hasTimestamps }]"
       >
-        {{ line.text }}
+        <div
+          v-for="(line, index) in parsedLyrics"
+          :key="index"
+          :ref="(el) => setLineRef(el as HTMLElement | null, index)"
+          :class="[
+            'lyrics-line',
+            {
+              active: activeLyricIndex === index || !hasTimestamps,
+            },
+          ]"
+        >
+          {{ line.text }}
+        </div>
       </div>
-    </div>
+    </ScrollArea>
   </div>
 </template>
 
 <script setup lang="ts">
-import {
-  ref,
-  computed,
-  watch,
-  nextTick,
-  onMounted,
-  onBeforeUnmount,
-} from "vue";
-import {
-  Track,
-  MediaItemType,
-  ContentType,
-  Artist,
-  StreamDetails,
-} from "@/plugins/api/interfaces";
+import { ref, computed, watch, nextTick, onBeforeUnmount } from "vue";
+import { Track, MediaItemType, StreamDetails } from "@/plugins/api/interfaces";
 import { $t } from "@/plugins/i18n";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import { Spinner } from "@/components/ui/spinner";
 
 interface Props {
   mediaItem?: MediaItemType;
@@ -74,63 +71,51 @@ const props = withDefaults(defineProps<Props>(), {
   lrcLyrics: undefined,
 });
 
-// Logger helper that respects debug mode
-const logSync = (message: string, isVerbose = true) => {
-  if (isVerbose && !props.debugMode) {
-    return; // Skip verbose logs in non-debug mode
-  }
-  // Always use console.debug for verbose logs, console.log for important ones
-  const logger = isVerbose ? console.debug : console.log;
-  logger(`[lyricSynch] ${message}`);
-};
-
 // Core lyrics state
 const parsedLyrics = ref<Array<{ time: number; text: string }>>([]);
 const loading = ref(false);
 const activeLyricIndex = ref(-1);
-const lyricsContainer = ref<HTMLElement | null>(null);
+const scrollAreaRef = ref<InstanceType<typeof ScrollArea> | null>(null);
+const lyricsContentRef = ref<HTMLElement | null>(null);
+const lineRefs = new Map<number, HTMLElement>();
+const isProgrammaticScroll = ref(false);
 const userManuallyScrolled = ref(false);
-const lyricsLookAhead = ref(0); // Dynamic look-ahead
-const previousLyricTransitionTime = ref(0);
+let manualScrollTimer: ReturnType<typeof setTimeout> | null = null;
 
-// Add this computed property to check if we're before the first lyric
+const setLineRef = (el: HTMLElement | null, index: number) => {
+  if (el) {
+    lineRefs.set(index, el);
+  } else {
+    lineRefs.delete(index);
+  }
+};
+
 const beforeFirstLyric = computed(() => {
   if (!hasTimestamps.value || !parsedLyrics.value.length) {
     return false;
   }
-
-  // Check if we're before the first lyric timestamp or if no lyric is active yet
   const firstLyricTime = parsedLyrics.value[0].time;
   const currentPosition = props.position || 0;
-
   return activeLyricIndex.value === -1 && currentPosition < firstLyricTime;
 });
 
-// Replace the artistName computed property
 const artistName = computed(() => {
   if (!props.mediaItem) return "";
-
-  // Handle Track which has artists array
   if (
     "media_type" in props.mediaItem &&
     props.mediaItem.media_type === "track"
   ) {
     const track = props.mediaItem as Track;
     if (track.artists?.length) {
-      // Use a more generic type approach - both ItemMapping and Artist have name property
       return track.artists.map((a) => a.name).join(", ");
     }
   }
-
-  // If it's an artist, return its own name
   if (
     "media_type" in props.mediaItem &&
     props.mediaItem.media_type === "artist"
   ) {
     return props.mediaItem.name;
   }
-
-  // Fall back to empty string if no artist found
   return "";
 });
 
@@ -143,7 +128,6 @@ const getSyncedLyrics = () => {
   return props.lrcLyrics ?? props.mediaItem?.metadata?.lrc_lyrics ?? null;
 };
 
-// Computed properties
 const hasLyrics = computed(() => {
   const plainLyrics = getPlainLyrics();
   const syncedLyrics = getSyncedLyrics();
@@ -154,48 +138,32 @@ const hasLyrics = computed(() => {
 });
 
 const hasTimestamps = computed(() => {
-  // First check if we have parsed lyrics with timestamps
   if (parsedLyrics.value.some((line) => line.time > 0)) {
     return true;
   }
-
-  // If no parsed lyrics yet, check the raw data for LRC format patterns
   const syncedLyrics = getSyncedLyrics();
   const plainLyrics = getPlainLyrics();
-
-  // Check lrc_lyrics field
   if (syncedLyrics && syncedLyrics.includes("[")) {
     return true;
   }
-
-  // Check regular lyrics field for LRC patterns like [00:29.79]
   if (plainLyrics && /\[\d+:\d+[.:]?\d*\]/.test(plainLyrics)) {
     return true;
   }
-
   return false;
 });
 
-// Methods for lyrics handling
 const parseLrcLine = (line: string) => {
   const match = line.match(/\[(\d+):(\d+)([.:]\d+)?\](.*)/);
   if (match) {
     const minutes = parseInt(match[1]);
-    let seconds = parseInt(match[2]);
+    const seconds = parseInt(match[2]);
     let milliseconds = 0;
-
-    // Handle milliseconds/hundredths part with more precision
     if (match[3]) {
       const decimalPart = match[3].replace(/[.:]/, ".");
       milliseconds = Math.round(parseFloat(decimalPart) * 1000);
     }
-
-    // Calculate total time in milliseconds for precision
     const timeMs = minutes * 60 * 1000 + seconds * 1000 + milliseconds;
-
-    // Store as seconds but with precise decimal
     const time = timeMs / 1000;
-
     return { time, text: match[4].trim() || " " };
   }
   return { time: 0, text: line.trim() || " " };
@@ -207,7 +175,6 @@ const fetchLyrics = () => {
     const syncedLyrics = getSyncedLyrics() || "";
     const plainLyrics = getPlainLyrics() || "";
 
-    // Determine which lyrics to use - prefer lrc_lyrics but check both for LRC format
     let lyricsToProcess = "";
     let isLrcFormat = false;
 
@@ -215,32 +182,23 @@ const fetchLyrics = () => {
       lyricsToProcess = syncedLyrics;
       isLrcFormat = true;
     } else if (plainLyrics && /\[\d+:\d+[.:]?\d*\]/.test(plainLyrics)) {
-      // Plain lyrics field contains LRC format
       lyricsToProcess = plainLyrics;
       isLrcFormat = true;
     } else if (plainLyrics) {
-      // Plain text lyrics without timestamps
       lyricsToProcess = plainLyrics;
       isLrcFormat = false;
     }
 
     if (isLrcFormat) {
-      // Process LRC formatted lyrics
       const lyricsLines = lyricsToProcess
         .split("\n")
         .filter((line) => line.trim());
 
       parsedLyrics.value = lyricsLines
         .map((line) => parseLrcLine(line))
-        .filter((line) => line.text.trim()) // Filter out empty text
+        .filter((line) => line.text.trim())
         .sort((a, b) => a.time - b.time);
-
-      logSync(
-        `Loaded ${parsedLyrics.value.length} synchronized lyrics lines`,
-        false,
-      );
     } else if (lyricsToProcess) {
-      // For plain text lyrics without timestamps
       const lyricsLines = lyricsToProcess
         .split("\n")
         .filter((line) => line.trim());
@@ -251,36 +209,24 @@ const fetchLyrics = () => {
           text: line.trim(),
         }))
         .filter((line) => line.text);
-
-      logSync(
-        `Loaded ${parsedLyrics.value.length} plain text lyrics lines`,
-        false,
-      );
     } else {
       parsedLyrics.value = [];
     }
   } catch (error) {
-    logSync(`Error processing lyrics: ${error}`, false);
+    console.error(`[LyricsViewer] Error processing lyrics: ${error}`);
     parsedLyrics.value = [];
   } finally {
     loading.value = false;
   }
 };
 
-// Function to calculate dynamic look-ahead based on upcoming lyrics pattern
-const calculateDynamicLookAhead = (currentPosition: number) => {
-  // Find current position in lyrics timeline
-  const adjustedTime = currentPosition;
-
-  // Basic state logging (verbose)
-  logSync(`Calculating look-ahead at ${currentPosition.toFixed(3)}s`);
-
-  // Find current and next lyric indices
+// Simple linear look-ahead: 15% of gap to next lyric, clamped to [0.05, 1.0]s
+const calculateLookAhead = (currentPosition: number): number => {
   let currentIndex = -1;
   let nextIndex = -1;
 
   for (let i = 0; i < parsedLyrics.value.length; i++) {
-    if (parsedLyrics.value[i].time <= adjustedTime) {
+    if (parsedLyrics.value[i].time <= currentPosition) {
       currentIndex = i;
     } else {
       nextIndex = i;
@@ -288,134 +234,19 @@ const calculateDynamicLookAhead = (currentPosition: number) => {
     }
   }
 
-  // Log the found indices (verbose)
-  logSync(
-    `Current lyric index: ${currentIndex}, Next lyric index: ${nextIndex}`,
-  );
-
-  // Handle special cases with more concise logging
-  if (nextIndex === 0) {
-    const firstLyricTime = parsedLyrics.value[0].time;
-    const timeUntilFirstLyric = firstLyricTime - adjustedTime;
-
-    logSync(
-      `Pre-lyrics intro: ${timeUntilFirstLyric.toFixed(2)}s until first lyric`,
-    );
-
-    if (timeUntilFirstLyric > 5) {
-      logSync("Long intro - using fixed look-ahead: 0.3s");
-      lyricsLookAhead.value = 0.3;
-      return;
-    } else if (timeUntilFirstLyric > 2) {
-      const newLookAhead = Math.min(1.0, timeUntilFirstLyric * 0.15);
-      logSync(
-        `Medium intro - calculated look-ahead: ${newLookAhead.toFixed(2)}s`,
-      );
-      lyricsLookAhead.value = newLookAhead;
-      return;
-    }
-    logSync("Short intro - using standard calculation");
-  }
-
-  // If we couldn't find next lyric, use a default look-ahead
   if (nextIndex === -1 || currentIndex === -1) {
-    logSync("Cannot determine appropriate look-ahead, using default: 0.3s");
-    lyricsLookAhead.value = 0.3;
-    return;
+    return 0.15;
   }
 
-  // Calculate time until next lyric
-  const currentLyricTime = parsedLyrics.value[currentIndex].time;
-  const nextLyricTime = parsedLyrics.value[nextIndex].time;
-  const gapToNextLyric = nextLyricTime - currentLyricTime;
-
-  // Get previous look-ahead for smoother transitions
-  const previousLookAhead = lyricsLookAhead.value;
-
-  // Gap analysis (verbose)
-  logSync(`Gap analysis:
-    - Current lyric time: ${currentLyricTime.toFixed(3)}s
-    - Next lyric time: ${nextLyricTime.toFixed(3)}s
-    - Gap between lyrics: ${gapToNextLyric.toFixed(3)}s
-    - Previous look-ahead: ${previousLookAhead.toFixed(3)}s`);
-
-  // Calculate look-ahead percentage based on gap size
-  let lookAheadPercentage;
-  if (gapToNextLyric < 0.5) {
-    lookAheadPercentage = 0.3; // Very rapid lyrics - 30%
-    logSync(
-      `Very rapid lyrics detected (${gapToNextLyric.toFixed(2)}s gap) - using 30% look-ahead`,
-    );
-  } else if (gapToNextLyric < 0.8) {
-    lookAheadPercentage = 0.1;
-    logSync(
-      `Fast lyrics detected (${gapToNextLyric.toFixed(2)}s gap) - using 10% look-ahead`,
-    );
-  } else if (gapToNextLyric < 1.5) {
-    lookAheadPercentage = 0.2;
-    logSync(
-      `Medium lyrics detected (${gapToNextLyric.toFixed(2)}s gap) - using 20% look-ahead`,
-    );
-  } else if (gapToNextLyric < 3) {
-    lookAheadPercentage = 0.3;
-    logSync(
-      `Slower lyrics detected (${gapToNextLyric.toFixed(2)}s gap) - using 30% look-ahead`,
-    );
-  } else if (gapToNextLyric > 10) {
-    lookAheadPercentage = 0.02; // Extremely slow - just 2%
-    logSync(
-      `Very slow lyrics detected (${gapToNextLyric.toFixed(2)}s gap) - using 2% look-ahead`,
-    );
-  } else {
-    lookAheadPercentage = 0.4;
-    logSync(
-      `Slow lyrics detected (${gapToNextLyric.toFixed(2)}s gap) - using 40% look-ahead`,
-    );
-  }
-
-  // Calculate target look-ahead
-  const targetLookAhead = Math.min(1.5, gapToNextLyric * lookAheadPercentage);
-  logSync(`Target look-ahead: ${targetLookAhead.toFixed(3)}s`);
-
-  // Smooth transition to new look-ahead
-  const difference = Math.abs(targetLookAhead - previousLookAhead);
-  const adaptationRate = Math.min(0.8, 0.3 + difference * 0.5); // More difference = faster adaptation
-  const newLookAhead =
-    previousLookAhead * (1 - adaptationRate) + targetLookAhead * adaptationRate;
-  logSync(
-    `Smoothed look-ahead: ${newLookAhead.toFixed(3)}s (adaptation rate: ${(adaptationRate * 100).toFixed(0)}%)`,
-  );
-
-  // Only log significant look-ahead changes (non-verbose)
-  if (Math.abs(newLookAhead - previousLookAhead) > 0.3) {
-    logSync(
-      `Look-ahead adjusted: ${previousLookAhead.toFixed(2)}s → ${newLookAhead.toFixed(2)}s`,
-      false,
-    );
-  }
-
-  // Update the look-ahead value
-  lyricsLookAhead.value = newLookAhead;
+  const gap =
+    parsedLyrics.value[nextIndex].time - parsedLyrics.value[currentIndex].time;
+  return Math.min(1.0, Math.max(0.05, gap * 0.15));
 };
 
-// Function to check if synchronization should be skipped
-const shouldSkipSync = (position?: number): boolean => {
-  return (
-    position === undefined ||
-    !parsedLyrics.value.length ||
-    !hasTimestamps.value ||
-    userManuallyScrolled.value
-  );
-};
+// Find active lyric index based on current position
+const findActiveLyricIndex = (position: number, lookAhead: number): number => {
+  const adjustedPositionMs = Math.round((position + lookAhead) * 1000);
 
-// Function to find active lyric index based on current position
-const findActiveLyricIndex = (position: number): number => {
-  // Calculate the adjusted position with look-ahead
-  const adjustedPositionMs = Math.round(
-    (position + lyricsLookAhead.value) * 1000,
-  );
-
-  // Find the active lyric using millisecond precision
   let index = -1;
   for (let i = 0; i < parsedLyrics.value.length; i++) {
     const lineTimeMs = Math.round(parsedLyrics.value[i].time * 1000);
@@ -425,115 +256,103 @@ const findActiveLyricIndex = (position: number): number => {
       break;
     }
   }
-
   return index;
 };
 
-// Function to handle active lyric change
-const handleActiveLyricChange = (newIndex: number, position: number) => {
-  if (newIndex < 0 || newIndex === activeLyricIndex.value) return;
+// Scroll to active lyric using scoped ref instead of document.querySelector
+const scrollToActiveLyric = (index: number) => {
+  const activeElement = lineRefs.get(index);
+  if (!activeElement) return;
 
-  // Log lyric activation
-  logSync(`Lyric activated: "${parsedLyrics.value[newIndex].text}"`);
+  isProgrammaticScroll.value = true;
+  activeElement.scrollIntoView({
+    behavior: "smooth",
+    block: "center",
+  });
 
-  // Debug logging
-  logSync(`Activating lyric at ${position.toFixed(2)}s (adjusted: ${(position + lyricsLookAhead.value).toFixed(2)}s):
-    - Index: ${newIndex}
-    - Lyric time: ${parsedLyrics.value[newIndex].time.toFixed(2)}s`);
-
-  logSync(`Transition details:
-    - Raw position: ${position.toFixed(3)}s
-    - Dynamic look-ahead: ${lyricsLookAhead.value.toFixed(3)}s
-    - Adjusted position: ${(position + lyricsLookAhead.value).toFixed(3)}s`);
-
-  // Timing analysis
-  if (newIndex > 0) {
-    logTimingAnalysis(newIndex, position);
-  }
-
-  // Store transition time for future analysis
-  previousLyricTransitionTime.value = position;
-
-  // Update state
-  activeLyricIndex.value = newIndex;
-
-  // Scroll to active lyric
-  nextTick(() => scrollToActiveLyric());
+  // Reset programmatic scroll flag after animation completes
+  setTimeout(() => {
+    isProgrammaticScroll.value = false;
+  }, 400);
 };
 
-// Function to analyze timing
-const logTimingAnalysis = (index: number, position: number) => {
-  const actualGap = position - previousLyricTransitionTime.value;
-  const expectedGap =
-    parsedLyrics.value[index].time - parsedLyrics.value[index - 1].time;
+// Setup scroll listener to detect manual scrolling
+const setupScrollListener = () => {
+  const root = scrollAreaRef.value?.$el as HTMLElement | undefined;
+  const scrollEl = root?.querySelector<HTMLElement>(
+    "[data-slot=scroll-area-viewport]",
+  );
+  if (!scrollEl) return;
 
-  logSync(`Timing analysis:
-    - Expected gap: ${expectedGap.toFixed(3)}s
-    - Actual gap: ${actualGap.toFixed(3)}s
-    - Difference: ${(actualGap - expectedGap).toFixed(3)}s`);
+  scrollEl.addEventListener(
+    "scroll",
+    () => {
+      // Ignore scroll events triggered by our own scrollIntoView
+      if (isProgrammaticScroll.value) return;
+
+      userManuallyScrolled.value = true;
+
+      // Debounce: clear previous timer, start new 8s timer
+      if (manualScrollTimer) {
+        clearTimeout(manualScrollTimer);
+      }
+      manualScrollTimer = setTimeout(() => {
+        userManuallyScrolled.value = false;
+        manualScrollTimer = null;
+      }, 8000);
+    },
+    { passive: true },
+  );
 };
 
-// Function to scroll to active lyric
-const scrollToActiveLyric = () => {
-  const activeElement = document.querySelector(".lyrics-line.active");
-  const container = lyricsContainer.value;
-
-  if (activeElement && container) {
-    activeElement.scrollIntoView({
-      behavior: "smooth",
-      block: "center",
-    });
-  }
-};
-
-// Setup watchers
+// Watch for lyrics data changes
 watch(
   [() => props.mediaItem?.item_id, () => props.lyrics, () => props.lrcLyrics],
   () => {
+    activeLyricIndex.value = -1;
+    lineRefs.clear();
     fetchLyrics();
   },
   { immediate: true },
 );
 
+// Watch for ScrollArea ref becoming available and attach scroll listener
+watch(scrollAreaRef, (newRef) => {
+  if (newRef) {
+    nextTick(() => setupScrollListener());
+  }
+});
+
+// Main sync watcher
 watch(
   () => props.position,
   (newPosition: number | undefined) => {
-    // Skip synchronization if needed
-    if (shouldSkipSync(newPosition)) return;
+    if (
+      newPosition === undefined ||
+      !parsedLyrics.value.length ||
+      !hasTimestamps.value
+    ) {
+      return;
+    }
 
-    // Safely handle the position with a default or unwrapped value
-    const position = newPosition ?? 0;
+    const lookAhead = calculateLookAhead(newPosition);
+    const newIndex = findActiveLyricIndex(newPosition, lookAhead);
 
-    // Calculate dynamic look-ahead based on upcoming lyrics
-    calculateDynamicLookAhead(position);
+    if (newIndex !== activeLyricIndex.value && newIndex >= 0) {
+      activeLyricIndex.value = newIndex;
 
-    // Find the active lyric index
-    const newIndex = findActiveLyricIndex(position);
-
-    // Handle lyric change if needed
-    if (newIndex !== activeLyricIndex.value) {
-      handleActiveLyricChange(newIndex, position);
+      if (!userManuallyScrolled.value) {
+        nextTick(() => scrollToActiveLyric(newIndex));
+      }
     }
   },
 );
 
-// Setup scroll listener to detect manual scrolling
-onMounted(() => {
-  const container = lyricsContainer.value;
-  if (container) {
-    container.addEventListener(
-      "scroll",
-      () => {
-        userManuallyScrolled.value = true;
-
-        // Reset the flag after 8 seconds of no scrolling
-        setTimeout(() => {
-          userManuallyScrolled.value = false;
-        }, 8000);
-      },
-      { passive: true },
-    );
+onBeforeUnmount(() => {
+  if (manualScrollTimer) {
+    clearTimeout(manualScrollTimer);
   }
+  lineRefs.clear();
 });
 </script>
 
@@ -569,7 +388,6 @@ onMounted(() => {
   font-size: 2em;
   font-weight: bold;
   margin-bottom: 10px;
-  color: v-bind(textColor);
 }
 
 .artist-name {
@@ -584,16 +402,16 @@ onMounted(() => {
   font-style: italic;
 }
 
-.lyrics-scroll-container {
-  height: 100%;
-  width: 100%;
-  overflow-y: auto;
-  padding: 40vh 0; /* This padding is for timestamped lyrics only */
+.lyrics-content {
   text-align: center;
+  padding: 10px 0;
+}
+
+.lyrics-content--synced {
+  padding: 40vh 0;
 }
 
 .static-lyrics {
-  padding: 10px 0 !important; /* Much less padding for static lyrics */
   display: flex;
   flex-direction: column;
   justify-content: flex-start;
@@ -603,14 +421,8 @@ onMounted(() => {
   padding: 10px 4px;
   font-size: 1.1em;
   opacity: 0.5;
-  transition:
-    opacity 0.3s ease,
-    font-size 0.3s ease,
-    filter 0.3s ease,
-    text-shadow 0.3s ease,
-    color 0.3s ease;
   margin: 8px 0;
-  filter: blur(1px); /* Blur effect for inactive lyrics */
+  filter: blur(1px);
   text-shadow: 0 0 1px var(--text-color);
 }
 
@@ -619,7 +431,7 @@ onMounted(() => {
   font-size: 1.4em;
   font-weight: bold;
   color: v-bind(textColor);
-  filter: blur(0); /* No blur effect for active lyric */
+  filter: blur(0);
   text-shadow: none;
 }
 </style>

--- a/src/components/LyricsViewer.vue
+++ b/src/components/LyricsViewer.vue
@@ -141,6 +141,8 @@ const props = withDefaults(defineProps<Props>(), {
 
 // Core lyrics state
 const parsedLyrics = ref<Array<{ time: number; text: string }>>([]);
+// Timestamps of empty LRC lines — these mark genuine instrumental breaks
+const breakMarkerTimes = ref<Set<number>>(new Set());
 const loading = ref(false);
 const activeLyricIndex = ref(-1);
 const scrollAreaRef = ref<InstanceType<typeof ScrollArea> | null>(null);
@@ -278,10 +280,20 @@ const fetchLyrics = () => {
         .split("\n")
         .filter((line) => line.trim());
 
-      parsedLyrics.value = lyricsLines
+      const allParsed = lyricsLines
         .map((line) => parseLrcLine(line))
-        .filter((line) => line.text.trim())
         .sort((a, b) => a.time - b.time);
+
+      // Empty timestamped lines mark genuine instrumental breaks
+      const markers = new Set<number>();
+      for (const line of allParsed) {
+        if (!line.text.trim() && line.time > 0) {
+          markers.add(line.time);
+        }
+      }
+      breakMarkerTimes.value = markers;
+
+      parsedLyrics.value = allParsed.filter((line) => line.text.trim());
     } else if (lyricsToProcess) {
       const lyricsLines = lyricsToProcess
         .split("\n")
@@ -304,20 +316,31 @@ const fetchLyrics = () => {
   }
 };
 
-// Musical break detection: show countdown notes during long instrumental gaps
-const GAP_THRESHOLD = 10; // seconds — minimum gap to trigger break display
+// Musical break detection: only trigger when the LRC contains an empty
+// timestamped line between two content lines (a genuine break marker).
 const BREAK_DELAY = 2; // seconds after line before showing notes
 const NOTE_COUNT = 7;
 
 const musicalBreakMap = computed(() => {
   const map = new Map<number, { gapStart: number; gapEnd: number }>();
   const lyrics = parsedLyrics.value;
+  const markers = breakMarkerTimes.value;
+  if (!markers.size) return map;
   for (let i = 0; i < lyrics.length - 1; i++) {
-    const gap = lyrics[i + 1].time - lyrics[i].time;
-    if (gap > GAP_THRESHOLD) {
+    const gapStart = lyrics[i].time;
+    const gapEnd = lyrics[i + 1].time;
+    // Check if any break marker timestamp falls within this gap
+    let hasMarker = false;
+    for (const t of markers) {
+      if (t > gapStart && t < gapEnd) {
+        hasMarker = true;
+        break;
+      }
+    }
+    if (hasMarker) {
       map.set(i, {
-        gapStart: lyrics[i].time + BREAK_DELAY,
-        gapEnd: lyrics[i + 1].time,
+        gapStart: gapStart + BREAK_DELAY,
+        gapEnd,
       });
     }
   }

--- a/src/components/LyricsViewer.vue
+++ b/src/components/LyricsViewer.vue
@@ -32,7 +32,6 @@
             'lyrics-line',
             {
               active: activeLyricIndex === index || !hasTimestamps,
-              upcoming: upcomingLyricIndex === index,
             },
           ]"
         >
@@ -76,7 +75,6 @@ const props = withDefaults(defineProps<Props>(), {
 const parsedLyrics = ref<Array<{ time: number; text: string }>>([]);
 const loading = ref(false);
 const activeLyricIndex = ref(-1);
-const upcomingLyricIndex = ref(-1);
 const scrollAreaRef = ref<InstanceType<typeof ScrollArea> | null>(null);
 const lyricsContentRef = ref<HTMLElement | null>(null);
 const lineRefs = new Map<number, HTMLElement>();
@@ -84,11 +82,16 @@ const isProgrammaticScroll = ref(false);
 const userManuallyScrolled = ref(false);
 let manualScrollTimer: ReturnType<typeof setTimeout> | null = null;
 
-// Rolling window of recent inter-lyric gaps for scroll anticipation timing.
-// Tracks the last N actual gap durations to derive a median "current tempo",
-// which determines how far ahead to pre-scroll the next line into view.
-const TEMPO_WINDOW_SIZE = 6;
-const recentGaps = ref<number[]>([]);
+// Continuous scroll state.
+// Instead of discrete scrollIntoView jumps, we linearly interpolate scrollTop
+// between the current and next lyric's centered positions. This creates a
+// constant smooth scroll rate that lands the next line at center exactly
+// when it highlights.
+let scrollViewport: HTMLElement | null = null;
+let scrollStartTop = 0;
+let scrollEndTop = 0;
+let scrollStartTime = 0;
+let scrollDuration = 0;
 
 const setLineRef = (el: HTMLElement | null, index: number) => {
   if (el) {
@@ -236,31 +239,6 @@ const fetchLyrics = () => {
   }
 };
 
-// Record the gap between the last two lyrics into the rolling tempo window.
-// Used to estimate current pacing for scroll anticipation.
-const recordGap = (index: number) => {
-  if (index <= 0) return;
-  const gap =
-    parsedLyrics.value[index].time - parsedLyrics.value[index - 1].time;
-  // Ignore outlier gaps (instrumental breaks) — they'd skew the tempo estimate
-  if (gap > 8) return;
-  recentGaps.value.push(gap);
-  if (recentGaps.value.length > TEMPO_WINDOW_SIZE) {
-    recentGaps.value.shift();
-  }
-};
-
-// Estimate scroll anticipation from rolling tempo.
-// Returns seconds ahead to pre-scroll the next line into view.
-// Uses the median of recent gaps so outliers don't cause jumps.
-const getScrollAnticipation = (): number => {
-  if (recentGaps.value.length < 2) return 0.4;
-  const sorted = [...recentGaps.value].sort((a, b) => a - b);
-  const median = sorted[Math.floor(sorted.length / 2)];
-  // Pre-scroll at 30% of the median gap, clamped to [0.15, 1.2]s
-  return Math.min(1.2, Math.max(0.15, median * 0.3));
-};
-
 // Find active lyric index based on current position — no look-ahead.
 // The highlight always matches the actual timestamp exactly.
 const findActiveLyricIndex = (positionMs: number): number => {
@@ -276,57 +254,69 @@ const findActiveLyricIndex = (positionMs: number): number => {
   return index;
 };
 
-// Find the upcoming lyric that should be pre-scrolled into view.
-// Uses rolling tempo anticipation so the next line is visible before it activates.
-const findUpcomingLyricIndex = (positionMs: number): number => {
-  const anticipation = getScrollAnticipation();
-  const anticipatedMs = positionMs + Math.round(anticipation * 1000);
-
-  let index = -1;
-  for (let i = 0; i < parsedLyrics.value.length; i++) {
-    const lineTimeMs = Math.round(parsedLyrics.value[i].time * 1000);
-    if (lineTimeMs <= anticipatedMs) {
-      index = i;
-    } else {
-      break;
-    }
-  }
-  return index;
+// Calculate the scrollTop value that centers a given lyric line in the viewport.
+const getCenteredScrollTop = (index: number): number | null => {
+  const el = lineRefs.get(index);
+  if (!el || !scrollViewport) return null;
+  const elTop = el.offsetTop;
+  const elHeight = el.offsetHeight;
+  const viewportHeight = scrollViewport.clientHeight;
+  return elTop - viewportHeight / 2 + elHeight / 2;
 };
 
-// Scroll to a lyric line using scoped ref instead of document.querySelector
-const scrollToLyric = (index: number) => {
-  const element = lineRefs.get(index);
-  if (!element) return;
+// Begin a new scroll interpolation from the current position to center the
+// target lyric, completing over the given duration in seconds.
+const beginScrollTo = (targetIndex: number, durationSec: number) => {
+  if (!scrollViewport) return;
+  const targetTop = getCenteredScrollTop(targetIndex);
+  if (targetTop === null) return;
+
+  scrollStartTop = scrollViewport.scrollTop;
+  scrollEndTop = targetTop;
+  scrollStartTime = performance.now();
+  // Minimum 300ms so very fast lyrics don't cause jarring snaps
+  scrollDuration = Math.max(300, durationSec * 1000);
+};
+
+// Called on every position update (~60fps via rAF) to advance the scroll.
+// Uses ease-out interpolation for a natural feel.
+const tickScroll = () => {
+  if (!scrollViewport || scrollDuration === 0) return;
+
+  const elapsed = performance.now() - scrollStartTime;
+  const t = Math.min(1, elapsed / scrollDuration);
+
+  // Ease-out for a natural feel: fast start, gentle arrival at center
+  const eased = 1 - (1 - t) * (1 - t);
 
   isProgrammaticScroll.value = true;
-  element.scrollIntoView({
-    behavior: "smooth",
-    block: "center",
-  });
+  scrollViewport.scrollTop =
+    scrollStartTop + (scrollEndTop - scrollStartTop) * eased;
 
-  // Reset programmatic scroll flag after animation completes
-  setTimeout(() => {
+  if (t >= 1) {
+    scrollDuration = 0;
     isProgrammaticScroll.value = false;
-  }, 400);
+  }
 };
 
 // Detect manual scrolling so we don't fight the user with auto-scroll.
-// Uses isProgrammaticScroll to distinguish our scrollIntoView calls from
+// Uses isProgrammaticScroll to distinguish our scroll writes from
 // user-initiated scrolls. After user scrolls, auto-scroll is paused for 8s.
 const setupScrollListener = () => {
   const root = scrollAreaRef.value?.$el as HTMLElement | undefined;
-  const scrollEl = root?.querySelector<HTMLElement>(
+  scrollViewport = root?.querySelector<HTMLElement>(
     "[data-slot=scroll-area-viewport]",
-  );
-  if (!scrollEl) return;
+  ) ?? null;
+  if (!scrollViewport) return;
 
-  scrollEl.addEventListener(
+  scrollViewport.addEventListener(
     "scroll",
     () => {
       if (isProgrammaticScroll.value) return;
 
       userManuallyScrolled.value = true;
+      // Stop any in-progress interpolation
+      scrollDuration = 0;
 
       // Debounce: clear previous timer, start new 8s timer
       if (manualScrollTimer) {
@@ -346,8 +336,7 @@ watch(
   [() => props.mediaItem?.item_id, () => props.lyrics, () => props.lrcLyrics],
   () => {
     activeLyricIndex.value = -1;
-    upcomingLyricIndex.value = -1;
-    recentGaps.value = [];
+    scrollDuration = 0;
     lineRefs.clear();
     fetchLyrics();
   },
@@ -361,11 +350,16 @@ watch(scrollAreaRef, (newRef) => {
   }
 });
 
-// Two-phase sync: highlight follows timestamps exactly, scroll anticipates.
-// The active highlight only changes when the playback position crosses a
-// lyric's exact timestamp (no look-ahead). Separately, we pre-scroll the
-// upcoming line into view using a rolling tempo estimate so the reader
-// sees the next line before it activates — like karaoke apps do.
+// Main sync: highlight follows timestamps exactly, scroll interpolates smoothly.
+//
+// On each ~60fps position update:
+//   1. Check if the active lyric changed — if so, start a new scroll
+//      interpolation toward the NEXT lyric's centered position, timed to
+//      arrive exactly when that lyric will activate.
+//   2. Advance the ongoing scroll interpolation by one frame (tickScroll).
+//
+// This creates a constant, smooth scroll that naturally lands each line
+// at the center of the viewport right when it highlights.
 watch(
   () => props.position,
   (newPosition: number | undefined) => {
@@ -378,25 +372,26 @@ watch(
     }
 
     const positionMs = Math.round(newPosition * 1000);
-
-    // Phase 1: Update highlight at exact timestamp (no look-ahead)
     const newActiveIndex = findActiveLyricIndex(positionMs);
-    if (newActiveIndex !== activeLyricIndex.value && newActiveIndex >= 0) {
-      recordGap(newActiveIndex);
-      activeLyricIndex.value = newActiveIndex;
-    }
 
-    // Phase 2: Pre-scroll upcoming line into view using tempo-based anticipation
-    const newUpcomingIndex = findUpcomingLyricIndex(positionMs);
-    if (
-      newUpcomingIndex !== upcomingLyricIndex.value &&
-      newUpcomingIndex >= 0
-    ) {
-      upcomingLyricIndex.value = newUpcomingIndex;
+    // When the active lyric changes, begin scrolling toward the next one
+    if (newActiveIndex !== activeLyricIndex.value && newActiveIndex >= 0) {
+      activeLyricIndex.value = newActiveIndex;
 
       if (!userManuallyScrolled.value) {
-        nextTick(() => scrollToLyric(newUpcomingIndex));
+        const nextIndex = newActiveIndex + 1;
+        if (nextIndex < parsedLyrics.value.length) {
+          // Time until the next lyric activates — scroll over this duration
+          const timeUntilNext =
+            parsedLyrics.value[nextIndex].time - newPosition;
+          nextTick(() => beginScrollTo(nextIndex, timeUntilNext));
+        }
       }
+    }
+
+    // Advance the scroll interpolation every frame
+    if (!userManuallyScrolled.value) {
+      tickScroll();
     }
   },
 );
@@ -477,11 +472,6 @@ onBeforeUnmount(() => {
   margin: 8px 0;
   filter: blur(1px);
   text-shadow: 0 0 1px var(--text-color);
-}
-
-.lyrics-line.upcoming {
-  opacity: 0.7;
-  filter: blur(0);
 }
 
 .lyrics-line.active {

--- a/src/components/LyricsViewer.vue
+++ b/src/components/LyricsViewer.vue
@@ -32,6 +32,7 @@
             'lyrics-line',
             {
               active: activeLyricIndex === index || !hasTimestamps,
+              upcoming: upcomingLyricIndex === index,
             },
           ]"
         >
@@ -75,12 +76,19 @@ const props = withDefaults(defineProps<Props>(), {
 const parsedLyrics = ref<Array<{ time: number; text: string }>>([]);
 const loading = ref(false);
 const activeLyricIndex = ref(-1);
+const upcomingLyricIndex = ref(-1);
 const scrollAreaRef = ref<InstanceType<typeof ScrollArea> | null>(null);
 const lyricsContentRef = ref<HTMLElement | null>(null);
 const lineRefs = new Map<number, HTMLElement>();
 const isProgrammaticScroll = ref(false);
 const userManuallyScrolled = ref(false);
 let manualScrollTimer: ReturnType<typeof setTimeout> | null = null;
+
+// Rolling window of recent inter-lyric gaps for scroll anticipation timing.
+// Tracks the last N actual gap durations to derive a median "current tempo",
+// which determines how far ahead to pre-scroll the next line into view.
+const TEMPO_WINDOW_SIZE = 6;
+const recentGaps = ref<number[]>([]);
 
 const setLineRef = (el: HTMLElement | null, index: number) => {
   if (el) {
@@ -228,38 +236,38 @@ const fetchLyrics = () => {
   }
 };
 
-// Simple linear look-ahead: 15% of gap to next lyric, clamped to [0.05, 1.0]s
-const calculateLookAhead = (currentPosition: number): number => {
-  let currentIndex = -1;
-  let nextIndex = -1;
-
-  for (let i = 0; i < parsedLyrics.value.length; i++) {
-    if (parsedLyrics.value[i].time <= currentPosition) {
-      currentIndex = i;
-    } else {
-      nextIndex = i;
-      break;
-    }
-  }
-
-  if (nextIndex === -1 || currentIndex === -1) {
-    return 0.15;
-  }
-
+// Record the gap between the last two lyrics into the rolling tempo window.
+// Used to estimate current pacing for scroll anticipation.
+const recordGap = (index: number) => {
+  if (index <= 0) return;
   const gap =
-    parsedLyrics.value[nextIndex].time - parsedLyrics.value[currentIndex].time;
-  return Math.min(1.0, Math.max(0.05, gap * 0.15));
+    parsedLyrics.value[index].time - parsedLyrics.value[index - 1].time;
+  // Ignore outlier gaps (instrumental breaks) — they'd skew the tempo estimate
+  if (gap > 8) return;
+  recentGaps.value.push(gap);
+  if (recentGaps.value.length > TEMPO_WINDOW_SIZE) {
+    recentGaps.value.shift();
+  }
 };
 
-// Find active lyric index based on current position.
-// Uses millisecond precision to avoid floating-point comparison issues.
-const findActiveLyricIndex = (position: number, lookAhead: number): number => {
-  const adjustedPositionMs = Math.round((position + lookAhead) * 1000);
+// Estimate scroll anticipation from rolling tempo.
+// Returns seconds ahead to pre-scroll the next line into view.
+// Uses the median of recent gaps so outliers don't cause jumps.
+const getScrollAnticipation = (): number => {
+  if (recentGaps.value.length < 2) return 0.4;
+  const sorted = [...recentGaps.value].sort((a, b) => a - b);
+  const median = sorted[Math.floor(sorted.length / 2)];
+  // Pre-scroll at 30% of the median gap, clamped to [0.15, 1.2]s
+  return Math.min(1.2, Math.max(0.15, median * 0.3));
+};
 
+// Find active lyric index based on current position — no look-ahead.
+// The highlight always matches the actual timestamp exactly.
+const findActiveLyricIndex = (positionMs: number): number => {
   let index = -1;
   for (let i = 0; i < parsedLyrics.value.length; i++) {
     const lineTimeMs = Math.round(parsedLyrics.value[i].time * 1000);
-    if (lineTimeMs <= adjustedPositionMs) {
+    if (lineTimeMs <= positionMs) {
       index = i;
     } else {
       break;
@@ -268,13 +276,31 @@ const findActiveLyricIndex = (position: number, lookAhead: number): number => {
   return index;
 };
 
-// Scroll to active lyric using scoped ref instead of document.querySelector
-const scrollToActiveLyric = (index: number) => {
-  const activeElement = lineRefs.get(index);
-  if (!activeElement) return;
+// Find the upcoming lyric that should be pre-scrolled into view.
+// Uses rolling tempo anticipation so the next line is visible before it activates.
+const findUpcomingLyricIndex = (positionMs: number): number => {
+  const anticipation = getScrollAnticipation();
+  const anticipatedMs = positionMs + Math.round(anticipation * 1000);
+
+  let index = -1;
+  for (let i = 0; i < parsedLyrics.value.length; i++) {
+    const lineTimeMs = Math.round(parsedLyrics.value[i].time * 1000);
+    if (lineTimeMs <= anticipatedMs) {
+      index = i;
+    } else {
+      break;
+    }
+  }
+  return index;
+};
+
+// Scroll to a lyric line using scoped ref instead of document.querySelector
+const scrollToLyric = (index: number) => {
+  const element = lineRefs.get(index);
+  if (!element) return;
 
   isProgrammaticScroll.value = true;
-  activeElement.scrollIntoView({
+  element.scrollIntoView({
     behavior: "smooth",
     block: "center",
   });
@@ -320,6 +346,8 @@ watch(
   [() => props.mediaItem?.item_id, () => props.lyrics, () => props.lrcLyrics],
   () => {
     activeLyricIndex.value = -1;
+    upcomingLyricIndex.value = -1;
+    recentGaps.value = [];
     lineRefs.clear();
     fetchLyrics();
   },
@@ -333,7 +361,11 @@ watch(scrollAreaRef, (newRef) => {
   }
 });
 
-// Main sync watcher
+// Two-phase sync: highlight follows timestamps exactly, scroll anticipates.
+// The active highlight only changes when the playback position crosses a
+// lyric's exact timestamp (no look-ahead). Separately, we pre-scroll the
+// upcoming line into view using a rolling tempo estimate so the reader
+// sees the next line before it activates — like karaoke apps do.
 watch(
   () => props.position,
   (newPosition: number | undefined) => {
@@ -345,14 +377,25 @@ watch(
       return;
     }
 
-    const lookAhead = calculateLookAhead(newPosition);
-    const newIndex = findActiveLyricIndex(newPosition, lookAhead);
+    const positionMs = Math.round(newPosition * 1000);
 
-    if (newIndex !== activeLyricIndex.value && newIndex >= 0) {
-      activeLyricIndex.value = newIndex;
+    // Phase 1: Update highlight at exact timestamp (no look-ahead)
+    const newActiveIndex = findActiveLyricIndex(positionMs);
+    if (newActiveIndex !== activeLyricIndex.value && newActiveIndex >= 0) {
+      recordGap(newActiveIndex);
+      activeLyricIndex.value = newActiveIndex;
+    }
+
+    // Phase 2: Pre-scroll upcoming line into view using tempo-based anticipation
+    const newUpcomingIndex = findUpcomingLyricIndex(positionMs);
+    if (
+      newUpcomingIndex !== upcomingLyricIndex.value &&
+      newUpcomingIndex >= 0
+    ) {
+      upcomingLyricIndex.value = newUpcomingIndex;
 
       if (!userManuallyScrolled.value) {
-        nextTick(() => scrollToActiveLyric(newIndex));
+        nextTick(() => scrollToLyric(newUpcomingIndex));
       }
     }
   },
@@ -434,6 +477,11 @@ onBeforeUnmount(() => {
   margin: 8px 0;
   filter: blur(1px);
   text-shadow: 0 0 1px var(--text-color);
+}
+
+.lyrics-line.upcoming {
+  opacity: 0.7;
+  filter: blur(0);
 }
 
 .lyrics-line.active {

--- a/src/composables/useLyricsElapsedTime.ts
+++ b/src/composables/useLyricsElapsedTime.ts
@@ -1,0 +1,63 @@
+/**
+ * Composable for computing lyrics elapsed time using requestAnimationFrame.
+ *
+ * Provides a reactive `elapsedTime` ref that updates at ~60fps while playing,
+ * suitable for smooth lyrics synchronization. Automatically starts/stops the
+ * rAF loop based on playback state and an optional `enabled` guard.
+ */
+
+import { ref, watchEffect, onScopeDispose, type Ref } from "vue";
+import { PlaybackState } from "@/plugins/api/interfaces";
+import { store } from "@/plugins/store";
+import { computeElapsedTime } from "@/helpers/elapsed";
+
+export function useLyricsElapsedTime(enabled?: Ref<boolean>) {
+  const elapsedTime = ref(0);
+  let rafId: number | null = null;
+
+  const update = () => {
+    const queue = store.activePlayerQueue;
+    if (
+      queue?.elapsed_time != null &&
+      queue?.elapsed_time_last_updated != null
+    ) {
+      elapsedTime.value =
+        computeElapsedTime(
+          queue.elapsed_time,
+          queue.elapsed_time_last_updated,
+          store.activePlayer?.playback_state,
+        ) ?? 0;
+    }
+    rafId = requestAnimationFrame(update);
+  };
+
+  const start = () => {
+    if (!rafId) {
+      rafId = requestAnimationFrame(update);
+    }
+  };
+
+  const stop = () => {
+    if (rafId) {
+      cancelAnimationFrame(rafId);
+      rafId = null;
+    }
+  };
+
+  watchEffect(() => {
+    const playing =
+      store.activePlayer?.playback_state === PlaybackState.PLAYING;
+    const queue = store.activePlayerQueue;
+    const isEnabled = enabled ? enabled.value : true;
+
+    if (playing && queue?.active && isEnabled) {
+      start();
+    } else {
+      stop();
+    }
+  });
+
+  onScopeDispose(stop);
+
+  return { elapsedTime, start, stop };
+}

--- a/src/layouts/default/PlayerOSD/PlayerFullscreen.vue
+++ b/src/layouts/default/PlayerOSD/PlayerFullscreen.vue
@@ -577,7 +577,7 @@ import QueueBtn from "./PlayerControlBtn/QueueBtn.vue";
 import SpeakerBtn from "./PlayerControlBtn/SpeakerBtn.vue";
 import PlayerTimeline from "./PlayerTimeline.vue";
 import { getSourceName } from "@/plugins/api/helpers";
-import computeElapsedTime from "@/helpers/elapsed";
+import { useLyricsElapsedTime } from "@/composables/useLyricsElapsedTime";
 
 const { name } = useDisplay();
 
@@ -604,51 +604,7 @@ const tempHide = ref(false);
 const requestBadgeColor = ref("#2196f3");
 const boostBadgeColor = ref("#ff5722");
 
-// Lyrics elapsed time computation (similar to PlayerTimeline)
-const nowTick = ref(0);
-let tickTimer: ReturnType<typeof setInterval> | null = null;
-
-const startTick = (interval = 250) => {
-  if (!tickTimer) {
-    tickTimer = setInterval(() => (nowTick.value = Date.now()), interval);
-  }
-};
-
-const stopTick = () => {
-  if (tickTimer) {
-    clearInterval(tickTimer);
-    tickTimer = null;
-  }
-};
-
-const lyricsElapsedTime = computed(() => {
-  // Include nowTick.value so this computed re-evaluates periodically
-  void nowTick.value;
-
-  const isPlaying =
-    store.activePlayer?.playback_state === PlaybackState.PLAYING;
-  const queue = store.activePlayerQueue;
-
-  // Start/stop tick based on playback state
-  if (isPlaying && queue?.active) {
-    startTick();
-  } else {
-    stopTick();
-  }
-
-  // Compute elapsed time from queue
-  if (queue?.elapsed_time != null && queue?.elapsed_time_last_updated != null) {
-    return (
-      computeElapsedTime(
-        queue.elapsed_time,
-        queue.elapsed_time_last_updated,
-        store.activePlayer?.playback_state,
-      ) ?? 0
-    );
-  }
-
-  return 0;
-});
+const { elapsedTime: lyricsElapsedTime } = useLyricsElapsedTime();
 
 // Computed properties
 
@@ -1324,7 +1280,6 @@ onMounted(() => {
   window.addEventListener("keydown", onKeydown);
   onBeforeUnmount(() => {
     window.removeEventListener("keydown", onKeydown);
-    stopTick();
   });
 });
 


### PR DESCRIPTION
- Replace setInterval(250ms) with requestAnimationFrame for ~16ms sync resolution
- Simplify look-ahead to a single linear formula instead of non-monotonic branches
- Fix scroll detection: debounce properly, distinguish programmatic vs user scroll
- Scope active lyric lookup to component refs instead of document.querySelector
- Replace Vuetify v-progress-circular with shadcn Spinner, use shadcn ScrollArea
- Extract useLyricsElapsedTime composable from duplicated rAF logic
- Make lyric highlighting instant (no CSS transition), keep smooth scroll