### PR TITLE
Add additional padding to volume popup

### DIFF
--- a/src/layouts/default/PlayerOSD/PlayerVolume.vue
+++ b/src/layouts/default/PlayerOSD/PlayerVolume.vue
@@ -775,7 +775,7 @@ watch(
 .group-popout-divider {
   height: 1px;
   background: rgba(var(--v-border-color), 0.15);
-  margin: 6px 0;
+  margin: 14px 0 10px 0;
 }
 
 /* Drag handle for swipe-down-to-dismiss (touch only) */


### PR DESCRIPTION
Add some additional padding to the group volume popup to avoid confusion when changing volume for groups. [Discord ](https://discord.com/channels/753947050995089438/1424427701602750626/1481475241103593483)

**Before**
<img width="397" height="799" alt="image" src="https://github.com/user-attachments/assets/28ce0496-1804-4585-88f3-28f5703c5cb0" />


**After**
<img width="396" height="803" alt="image" src="https://github.com/user-attachments/assets/923c3264-53a9-4cae-9d46-8becee5d3d51" />
