### PR TITLE
Fix albums not being able to be added to playlists anymore.

### DIFF
--- a/src/layouts/default/AddToPlaylistDialog.vue
+++ b/src/layouts/default/AddToPlaylistDialog.vue
@@ -159,7 +159,11 @@ const fetchPlaylists = async function () {
       playlist.item_id === parentItem.value.item_id
     )
       continue;
-    if (!playlist.supported_mediatypes.includes(refItem.media_type)) {
+    if (
+      !playlist.supported_mediatypes.includes(refItem.media_type) ||
+      (refItem.media_type === MediaType.ALBUM &&
+        !playlist.supported_mediatypes.includes(MediaType.TRACK))
+    ) {
       // target playlist doesn't support media type
       continue;
     }
@@ -183,7 +187,9 @@ const fetchPlaylists = async function () {
   for (const provider of Object.values(api.providers)) {
     // filter suitable create provider base on media_type
     if (
-      refItem.media_type == MediaType.TRACK &&
+      // album is unwrapped to individual tracks by backend
+      (refItem.media_type == MediaType.TRACK ||
+        refItem.media_type == MediaType.ALBUM) &&
       !provider.supported_features.includes(ProviderFeature.PLAYLIST_CREATE) &&
       !provider.supported_features.includes(
         ProviderFeature.PLAYLIST_CREATE_TRACKS,

--- a/src/layouts/default/AddToPlaylistDialog.vue
+++ b/src/layouts/default/AddToPlaylistDialog.vue
@@ -159,11 +159,11 @@ const fetchPlaylists = async function () {
       playlist.item_id === parentItem.value.item_id
     )
       continue;
-    if (
-      !playlist.supported_mediatypes.includes(refItem.media_type) ||
-      (refItem.media_type === MediaType.ALBUM &&
-        !playlist.supported_mediatypes.includes(MediaType.TRACK))
-    ) {
+    let _supported_mediatypes = playlist.supported_mediatypes;
+    if (_supported_mediatypes.includes(MediaType.TRACK))
+      // backend unwraps albums to individual tracks
+      _supported_mediatypes.push(MediaType.ALBUM);
+    if (!_supported_mediatypes.includes(refItem.media_type)) {
       // target playlist doesn't support media type
       continue;
     }


### PR DESCRIPTION
Bug was introduced in https://github.com/music-assistant/frontend/pull/1504 . This allows to add albums to playlists again, as before. The backend unwraps albums anyways.

Backend PR: https://github.com/music-assistant/server/pull/3385