### PR TITLE
feat: show loading spinner in player bar while buffering

### DIFF
--- a/src/layouts/default/PlayerOSD/PlayerTrackDetails.vue
+++ b/src/layouts/default/PlayerOSD/PlayerTrackDetails.vue
@@ -67,8 +67,17 @@
         <div v-else @click="store.showPlayersMenu = true">
           {{ $t("no_player") }}
         </div>
+        <!-- loading spinner while buffering -->
+        <v-progress-circular
+          v-if="isLoading"
+          indeterminate
+          size="14"
+          width="2"
+          color="primary"
+          style="margin-left: 12px; margin-bottom: 4px;"
+        />
         <NowPlayingBadge
-          v-if="
+          v-else-if="
             store.activePlayer &&
             store.activePlayer?.powered != false &&
             store.activePlayer?.playback_state != PlaybackState.IDLE
@@ -184,7 +193,7 @@ import { getSourceName } from "@/plugins/api/helpers";
 import { PlaybackState, PlayerType } from "@/plugins/api/interfaces";
 import { getBreakpointValue } from "@/plugins/breakpoint";
 import { store } from "@/plugins/store";
-import { computed } from "vue";
+import { computed, onUnmounted, ref, watch } from "vue";
 import PlayerFullscreen from "./PlayerFullscreen.vue";
 
 const marqueeSync = new MarqueeTextSync();
@@ -201,6 +210,41 @@ const props = withDefaults(defineProps<Props>(), {
   showOnlyArtist: false,
   showQualityDetailsBtn: true,
   primaryColor: "",
+});
+
+// loading state: shown from when a new track starts loading until playback_state = PLAYING
+const isLoading = ref(false);
+let loadingTimeout: ReturnType<typeof setTimeout> | null = null;
+
+watch(
+  () => store.activePlayerQueue?.current_item?.queue_item_id,
+  (newUri, oldUri) => {
+    if (newUri && newUri !== oldUri) {
+      isLoading.value = true;
+      if (loadingTimeout) clearTimeout(loadingTimeout);
+      // safety fallback: clear after 15s in case state never changes
+      loadingTimeout = setTimeout(() => {
+        isLoading.value = false;
+      }, 15000);
+    }
+  },
+);
+
+watch(
+  () => store.activePlayer?.playback_state,
+  (newState) => {
+    if (newState === PlaybackState.PLAYING) {
+      isLoading.value = false;
+      if (loadingTimeout) {
+        clearTimeout(loadingTimeout);
+        loadingTimeout = null;
+      }
+    }
+  },
+);
+
+onUnmounted(() => {
+  if (loadingTimeout) clearTimeout(loadingTimeout);
 });
 
 // computed properties

--- a/src/layouts/default/PlayerOSD/PlayerTrackDetails.vue
+++ b/src/layouts/default/PlayerOSD/PlayerTrackDetails.vue
@@ -236,7 +236,7 @@ watch(
   (newId, oldId) => {
     if (newId && newId !== oldId) {
       const state = store.activePlayer?.playback_state;
-      if (state === PlaybackState.IDLE) {
+      if (state === PlaybackState.IDLE && store.activePlayer?.powered !== false) {
         isLoading.value = true;
         if (loadingTimeout) clearTimeout(loadingTimeout);
         loadingTimeout = setTimeout(() => {

--- a/src/layouts/default/PlayerOSD/PlayerTrackDetails.vue
+++ b/src/layouts/default/PlayerOSD/PlayerTrackDetails.vue
@@ -212,40 +212,55 @@ const props = withDefaults(defineProps<Props>(), {
   primaryColor: "",
 });
 
-// loading state: shown from when a new track starts loading until playback_state = PLAYING
+// loading state: shown from when a new track starts loading until playback is confirmed
 const isLoading = ref(false);
 let loadingTimeout: ReturnType<typeof setTimeout> | null = null;
 
+function clearLoading() {
+  isLoading.value = false;
+  if (loadingTimeout) {
+    clearTimeout(loadingTimeout);
+    loadingTimeout = null;
+  }
+}
+
+// clear loading immediately when the active player changes
 watch(
-  () => store.activePlayerQueue?.current_item?.queue_item_id,
-  (newUri, oldUri) => {
-    if (newUri && newUri !== oldUri) {
-      isLoading.value = true;
-      if (loadingTimeout) clearTimeout(loadingTimeout);
-      // safety fallback: clear after 15s in case state never changes
-      loadingTimeout = setTimeout(() => {
-        isLoading.value = false;
-      }, 15000);
-    }
-  },
+  () => store.activePlayer?.player_id,
+  () => clearLoading(),
 );
 
+// detect new track loading — only show spinner if player is currently idle
 watch(
-  () => store.activePlayer?.playback_state,
-  (newState) => {
-    if (newState === PlaybackState.PLAYING) {
-      isLoading.value = false;
-      if (loadingTimeout) {
-        clearTimeout(loadingTimeout);
-        loadingTimeout = null;
+  () => store.activePlayerQueue?.current_item?.queue_item_id,
+  (newId, oldId) => {
+    if (newId && newId !== oldId) {
+      const state = store.activePlayer?.playback_state;
+      if (state === PlaybackState.IDLE) {
+        isLoading.value = true;
+        if (loadingTimeout) clearTimeout(loadingTimeout);
+        loadingTimeout = setTimeout(() => {
+          isLoading.value = false;
+        }, 15000);
       }
     }
   },
 );
 
-onUnmounted(() => {
-  if (loadingTimeout) clearTimeout(loadingTimeout);
-});
+// clear loading once playback is confirmed (playing or paused means track is loaded)
+watch(
+  () => store.activePlayer?.playback_state,
+  (newState) => {
+    if (
+      newState === PlaybackState.PLAYING ||
+      newState === PlaybackState.PAUSED
+    ) {
+      clearLoading();
+    }
+  },
+);
+
+onUnmounted(() => clearLoading());
 
 // computed properties
 const streamDetails = computed(() => {


### PR DESCRIPTION
## Summary

- Pressing play gave no immediate visual feedback — the animated equalizer bars only appeared once playback was confirmed, leaving users uncertain whether their action had registered.
- A small spinner now appears next to the player/device name in the bottom bar as soon as a new track starts loading.
- The spinner disappears once `playback_state` transitions to `PLAYING`, at which point the animated equalizer bars take over as normal.
- A 15-second timeout clears the spinner as a safety fallback if the state never changes (e.g. on error).

## Implementation

- Watches `current_item.queue_item_id` in `PlayerTrackDetails.vue` to detect when a new track begins loading.
- Watches `playback_state` to clear the loading state when playback is confirmed.
- Uses `v-progress-circular` (Vuetify) sized and styled to match the existing equalizer bar indicator.
- The spinner and the equalizer bars are mutually exclusive — only one is shown at a time.

## Test plan

- [x] Press play on a track and verify spinner appears next to the device name immediately
- [x] Verify spinner disappears and equalizer bars appear once music starts playing
- [ ] Verify no spinner appears during normal pause/resume (same track, no queue_item_id change)
- [ ] Verify 15-second fallback clears spinner if playback fails to start

<img width="1206" height="510" alt="image" src="https://github.com/user-attachments/assets/abc99b2b-a351-44b1-9a78-3a1636fa84b0" />


🤖 Generated with [Claude Code](https://claude.com/claude-code)