### PR TITLE
Hide sidebar navigation in frameless mode

### DIFF
--- a/src/layouts/default/View.vue
+++ b/src/layouts/default/View.vue
@@ -4,12 +4,13 @@
     :class="['main-layout', { 'main-layout--mobile': store.mobileLayout }]"
   >
     <SidebarProvider>
-      <AppSidebar />
+      <AppSidebar v-if="!store.frameless" />
       <SidebarInset>
         <div
           :class="[
             'content-section',
             { 'content-section--mobile': store.mobileLayout },
+            { 'content-section--frameless': store.frameless },
           ]"
         >
           <router-view v-slot="{ Component }">
@@ -61,5 +62,9 @@ import ItemContextMenu from "./ItemContextMenu.vue";
 
 .content-section--mobile {
   padding-bottom: 230px;
+}
+
+.content-section--frameless {
+  padding-bottom: 0;
 }
 </style>


### PR DESCRIPTION
The frameless URL parameter (?frameless=true) hides the footer/player bar but the sidebar menu was still visible after the navigation was reworked. This conditionally hides the AppSidebar and removes unnecessary bottom padding when in frameless mode.