### PR TITLE
Use frameless mode for party dashboard instead of new tab

### DIFF
--- a/src/components/navigation/AppSidebar.vue
+++ b/src/components/navigation/AppSidebar.vue
@@ -9,6 +9,7 @@ import {
   SidebarTrigger,
   useSidebar,
 } from "@/components/ui/sidebar";
+import { usePartyConfig } from "@/composables/usePartyConfig";
 import { eventbus } from "@/plugins/eventbus";
 import { computed, onMounted, onUnmounted } from "vue";
 import { useI18n } from "vue-i18n";
@@ -18,9 +19,12 @@ import { getMenuItems } from "./utils/getMenuItems";
 
 const router = useRouter();
 const { t } = useI18n();
+const { config: partyConfig, fetchConfig: fetchPartyConfig } = usePartyConfig();
+fetchPartyConfig();
 
 const navItems = computed(() => {
-  return getMenuItems()
+  const partyOpenInNewTab = partyConfig.value?.open_in_new_tab ?? false;
+  return getMenuItems(partyOpenInNewTab)
     .filter((item) => !item.hidden)
     .map((item) => ({
       title: t(item.label),

--- a/src/components/navigation/utils/getMenuItems.ts
+++ b/src/components/navigation/utils/getMenuItems.ts
@@ -27,7 +27,7 @@ export interface MenuItem {
   openInNewTab?: boolean;
 }
 
-export const getMenuItems = function () {
+export const getMenuItems = function (partyOpenInNewTab = false) {
   const items: MenuItem[] = [];
   // we loop through DEFAULT_MENU_ITEMS to respect default order;
   // new items added to DEFAULT_MENU_ITEMS automatically appear unless explicitly disabled
@@ -58,10 +58,10 @@ export const getMenuItems = function () {
       items.push({
         label: "Party",
         icon: PartyPopper,
-        path: "/party",
+        path: partyOpenInNewTab ? "/party" : "/party?frameless=true",
         isLibraryNode: false,
         hidden: !store.enabledPlugins.has("party"),
-        openInNewTab: true,
+        openInNewTab: partyOpenInNewTab,
       });
     }
     if (enabledMenuItemStr === "artists") {

--- a/src/plugins/api/interfaces.ts
+++ b/src/plugins/api/interfaces.ts
@@ -1234,4 +1234,5 @@ export interface PartyConfig {
   request_badge_color?: string;
   boost_badge_color?: string;
   anti_burn_in: boolean;
+  open_in_new_tab: boolean;
 }

--- a/tests/composables/useRateLimiting.test.ts
+++ b/tests/composables/useRateLimiting.test.ts
@@ -113,6 +113,7 @@ describe("useRateLimiting", () => {
       request_badge_color: "#000000",
       boost_badge_color: "#ffffff",
       anti_burn_in: false,
+      open_in_new_tab: false,
     };
 
     rateLimiting.configure(config);


### PR DESCRIPTION
Read the open_in_new_tab setting from party config to determine whether to open the dashboard in a new tab or navigate in-place with the frameless query param.