### PR TITLE
Add multi-instance party provider support

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -237,20 +237,27 @@ const completeInitialization = async () => {
     console.debug("[App] Party guest - skipping full state fetch");
   }
 
-  // Check if party plugin is enabled
+  // Check party plugin instances
   try {
     const partyProviders = await api.getProviderConfigs(
       ProviderType.PLUGIN,
       "party",
     );
-    if (partyProviders.length > 0 && partyProviders[0].enabled) {
+    const enabledParty = partyProviders.filter((p) => p.enabled);
+    if (enabledParty.length > 0) {
       store.enabledPlugins.add("party");
+      store.partyInstances = enabledParty.map((p) => ({
+        instance_id: p.instance_id,
+        name: p.name || p.default_name || "Party",
+      }));
     } else {
       store.enabledPlugins.delete("party");
+      store.partyInstances = [];
     }
   } catch (error) {
     console.error("[App] Failed to check party status:", error);
     store.enabledPlugins.delete("party");
+    store.partyInstances = [];
   }
 
   const urlParams = new URLSearchParams(window.location.search);
@@ -413,10 +420,16 @@ onMounted(async () => {
         ProviderType.PLUGIN,
         "party",
       );
-      if (partyProviders.length > 0 && partyProviders[0].enabled) {
+      const enabledParty = partyProviders.filter((p) => p.enabled);
+      if (enabledParty.length > 0) {
         store.enabledPlugins.add("party");
+        store.partyInstances = enabledParty.map((p) => ({
+          instance_id: p.instance_id,
+          name: p.name || p.default_name || "Party",
+        }));
       } else {
         store.enabledPlugins.delete("party");
+        store.partyInstances = [];
       }
     } catch (error) {
       console.error("[App] Failed to update party status:", error);

--- a/src/App.vue
+++ b/src/App.vue
@@ -189,6 +189,30 @@ const handleLocalConnect = async (serverAddress: string) => {
 
 let initializationCompleted = false;
 
+const syncPartyInstances = async () => {
+  try {
+    const partyProviders = await api.getProviderConfigs(
+      ProviderType.PLUGIN,
+      "party",
+    );
+    const enabledParty = partyProviders.filter((p) => p.enabled);
+    if (enabledParty.length > 0) {
+      store.enabledPlugins.add("party");
+      store.partyInstances = enabledParty.map((p) => ({
+        instance_id: p.instance_id,
+        name: p.name || p.default_name || "Party",
+      }));
+    } else {
+      store.enabledPlugins.delete("party");
+      store.partyInstances = [];
+    }
+  } catch (error) {
+    console.error("[App] Failed to sync party status:", error);
+    store.enabledPlugins.delete("party");
+    store.partyInstances = [];
+  }
+};
+
 const completeInitialization = async () => {
   // Guard against multiple initializations
   if (initializationCompleted) {
@@ -238,27 +262,7 @@ const completeInitialization = async () => {
   }
 
   // Check party plugin instances
-  try {
-    const partyProviders = await api.getProviderConfigs(
-      ProviderType.PLUGIN,
-      "party",
-    );
-    const enabledParty = partyProviders.filter((p) => p.enabled);
-    if (enabledParty.length > 0) {
-      store.enabledPlugins.add("party");
-      store.partyInstances = enabledParty.map((p) => ({
-        instance_id: p.instance_id,
-        name: p.name || p.default_name || "Party",
-      }));
-    } else {
-      store.enabledPlugins.delete("party");
-      store.partyInstances = [];
-    }
-  } catch (error) {
-    console.error("[App] Failed to check party status:", error);
-    store.enabledPlugins.delete("party");
-    store.partyInstances = [];
-  }
+  await syncPartyInstances();
 
   const urlParams = new URLSearchParams(window.location.search);
   if (
@@ -415,25 +419,7 @@ onMounted(async () => {
 
   // Subscribe to PROVIDERS_UPDATED to keep enabledPlugins in sync
   api.subscribe(EventType.PROVIDERS_UPDATED, async () => {
-    try {
-      const partyProviders = await api.getProviderConfigs(
-        ProviderType.PLUGIN,
-        "party",
-      );
-      const enabledParty = partyProviders.filter((p) => p.enabled);
-      if (enabledParty.length > 0) {
-        store.enabledPlugins.add("party");
-        store.partyInstances = enabledParty.map((p) => ({
-          instance_id: p.instance_id,
-          name: p.name || p.default_name || "Party",
-        }));
-      } else {
-        store.enabledPlugins.delete("party");
-        store.partyInstances = [];
-      }
-    } catch (error) {
-      console.error("[App] Failed to update party status:", error);
-    }
+    await syncPartyInstances();
   });
 });
 

--- a/src/components/navigation/AppSidebar.vue
+++ b/src/components/navigation/AppSidebar.vue
@@ -28,6 +28,11 @@ const navItems = computed(() => {
       icon: item.icon,
       disabled: item.disabled,
       openInNewTab: item.openInNewTab,
+      subItems: item.subItems?.map((sub) => ({
+        title: sub.label,
+        url: sub.path,
+        openInNewTab: sub.openInNewTab,
+      })),
     }));
 });
 

--- a/src/components/navigation/NavMain.vue
+++ b/src/components/navigation/NavMain.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { markRaw, type Component } from "vue";
+import { markRaw, ref, type Component } from "vue";
 import { RouterLink, useRoute, useRouter } from "vue-router";
 
 const RouterLinkComponent = markRaw(RouterLink);
@@ -13,12 +13,19 @@ import {
   useSidebar,
 } from "@/components/ui/sidebar";
 
+interface NavSubItem {
+  title: string;
+  url: string;
+  openInNewTab?: boolean;
+}
+
 interface NavItem {
   title: string;
   url: string;
   icon?: Component;
   disabled?: boolean;
   openInNewTab?: boolean;
+  subItems?: NavSubItem[];
 }
 
 const props = defineProps<{
@@ -29,15 +36,43 @@ const route = useRoute();
 const router = useRouter();
 const { isMobile, setOpenMobile } = useSidebar();
 
+const showMenu = ref(false);
+const menuPosX = ref(0);
+const menuPosY = ref(0);
+const activeSubItems = ref<NavSubItem[]>([]);
+
 const isActive = (url: string) =>
   route.path === url || route.path.startsWith(url + "/");
 
 const handleClick = (item: NavItem, event: Event) => {
+  if (item.subItems && item.subItems.length > 0) {
+    event.preventDefault();
+    const mouseEvent = event as MouseEvent;
+    menuPosX.value = mouseEvent.clientX;
+    menuPosY.value = mouseEvent.clientY;
+    activeSubItems.value = item.subItems;
+    showMenu.value = true;
+    return;
+  }
   if (item.openInNewTab) {
     event.preventDefault();
     const resolved = router.resolve(item.url).href;
     const fullUrl = new URL(resolved, window.location.href).href;
     window.open(fullUrl, "_blank");
+  }
+  if (isMobile.value) {
+    setOpenMobile(false);
+  }
+};
+
+const handleSubItemClick = (subItem: NavSubItem) => {
+  showMenu.value = false;
+  if (subItem.openInNewTab) {
+    const resolved = router.resolve(subItem.url).href;
+    const fullUrl = new URL(resolved, window.location.href).href;
+    window.open(fullUrl, "_blank");
+  } else {
+    router.push(subItem.url);
   }
   if (isMobile.value) {
     setOpenMobile(false);
@@ -52,11 +87,15 @@ const handleClick = (item: NavItem, event: Event) => {
         <SidebarMenuItem v-for="item in items" :key="item.title" class="mr-1.5">
           <SidebarMenuButton
             :as="
-              item.disabled || item.openInNewTab
+              item.disabled || item.openInNewTab || item.subItems?.length
                 ? 'button'
                 : RouterLinkComponent
             "
-            v-bind="item.disabled || item.openInNewTab ? {} : { to: item.url }"
+            v-bind="
+              item.disabled || item.openInNewTab || item.subItems?.length
+                ? {}
+                : { to: item.url }
+            "
             :is-active="isActive(item.url)"
             :tooltip="item.title"
             :disabled="item.disabled"
@@ -80,6 +119,27 @@ const handleClick = (item: NavItem, event: Event) => {
       </SidebarMenu>
     </SidebarGroupContent>
   </SidebarGroup>
+
+  <v-menu
+    v-model="showMenu"
+    :target="[menuPosX, menuPosY]"
+    scrim
+    style="z-index: 999999"
+    z-index="999999"
+  >
+    <v-card min-width="200" style="overflow-y: auto">
+      <v-list density="compact" slim tile>
+        <v-list-item
+          v-for="subItem in activeSubItems"
+          :key="subItem.url"
+          :title="subItem.title"
+          link
+          style="padding-left: 16px"
+          @click="handleSubItemClick(subItem)"
+        />
+      </v-list>
+    </v-card>
+  </v-menu>
 </template>
 
 <style scoped>

--- a/src/components/navigation/NavMain.vue
+++ b/src/components/navigation/NavMain.vue
@@ -124,7 +124,6 @@ const handleSubItemClick = (subItem: NavSubItem) => {
     v-model="showMenu"
     :target="[menuPosX, menuPosY]"
     scrim
-    style="z-index: 999999"
     z-index="999999"
   >
     <v-card min-width="200" style="overflow-y: auto">

--- a/src/components/navigation/utils/getMenuItems.ts
+++ b/src/components/navigation/utils/getMenuItems.ts
@@ -17,6 +17,12 @@ import {
 } from "lucide-vue-next";
 import { Component } from "vue";
 
+export interface MenuSubItem {
+  label: string;
+  path: string;
+  openInNewTab?: boolean;
+}
+
 export interface MenuItem {
   label: string;
   icon: Component;
@@ -25,6 +31,7 @@ export interface MenuItem {
   hidden?: boolean;
   disabled?: boolean;
   openInNewTab?: boolean;
+  subItems?: MenuSubItem[];
 }
 
 export const getMenuItems = function () {
@@ -55,14 +62,38 @@ export const getMenuItems = function () {
       });
     }
     if (enabledMenuItemStr === "party") {
-      items.push({
-        label: "Party",
-        icon: PartyPopper,
-        path: "/party",
-        isLibraryNode: false,
-        hidden: !store.enabledPlugins.has("party"),
-        openInNewTab: true,
-      });
+      const instances = store.partyInstances;
+      if (instances.length === 1) {
+        items.push({
+          label: instances[0].name,
+          icon: PartyPopper,
+          path: `/party/${instances[0].instance_id}`,
+          isLibraryNode: false,
+          hidden: !store.enabledPlugins.has("party"),
+          openInNewTab: true,
+        });
+      } else if (instances.length > 1) {
+        items.push({
+          label: "Party",
+          icon: PartyPopper,
+          path: "/party",
+          isLibraryNode: false,
+          hidden: !store.enabledPlugins.has("party"),
+          subItems: instances.map((inst) => ({
+            label: inst.name,
+            path: `/party/${inst.instance_id}`,
+            openInNewTab: true,
+          })),
+        });
+      } else {
+        items.push({
+          label: "Party",
+          icon: PartyPopper,
+          path: "/party",
+          isLibraryNode: false,
+          hidden: true,
+        });
+      }
     }
     if (enabledMenuItemStr === "artists") {
       items.push({

--- a/src/components/party/PartyQR.vue
+++ b/src/components/party/PartyQR.vue
@@ -37,6 +37,10 @@ import { AlertCircle, Check } from "lucide-vue-next";
 import QRCode from "qrcode";
 import { onBeforeUnmount, onMounted, ref, watch } from "vue";
 
+const props = defineProps<{
+  instanceId: string;
+}>();
+
 const emit = defineEmits<{ available: [value: boolean] }>();
 const logoSrc = new URL("@/assets/logo/logo.svg", import.meta.url).href;
 
@@ -91,7 +95,9 @@ watch(qrCanvas, (canvas) => {
 const generateQRCode = async () => {
   loading.value = true;
   try {
-    const url = (await api.sendCommand("party/url")) as string | null;
+    const url = (await api.sendCommand(`party/${props.instanceId}/url`)) as
+      | string
+      | null;
 
     guestAccessEnabled.value = !!url;
 

--- a/src/composables/usePartyConfig.ts
+++ b/src/composables/usePartyConfig.ts
@@ -1,67 +1,92 @@
 /**
  * Shared composable for party configuration.
- * Fetches party/config once and shares reactive state across components,
- * avoiding redundant API calls when multiple components need the same config.
+ * Fetches party/{instanceId}/config once per instance and shares reactive state
+ * across components, avoiding redundant API calls when multiple components need
+ * the same config.
  */
 
 import { ref } from "vue";
 import api from "@/plugins/api";
 import { EventType, type PartyConfig } from "@/plugins/api/interfaces";
 
-const config = ref<PartyConfig | null>(null);
-const loading = ref(false);
-const loaded = ref(false);
+// Per-instance cache
+const configs = ref<Record<string, PartyConfig | null>>({});
+const loadingMap = ref<Record<string, boolean>>({});
+const loadedMap = ref<Record<string, boolean>>({});
 
-let fetchPromise: Promise<PartyConfig | null> | null = null;
+const fetchPromises: Record<string, Promise<PartyConfig | null> | null> = {};
 
 /**
- * Fetch party config, deduplicating concurrent requests.
+ * Fetch party config for a specific instance, deduplicating concurrent requests.
  * Returns the cached config if already loaded, unless force is true.
  */
-async function fetchConfig(force = false): Promise<PartyConfig | null> {
-  if (loaded.value && !force) {
-    return config.value;
+async function fetchConfig(
+  instanceId: string,
+  force = false,
+): Promise<PartyConfig | null> {
+  if (loadedMap.value[instanceId] && !force) {
+    return configs.value[instanceId] ?? null;
   }
 
   // Deduplicate concurrent fetches
-  if (fetchPromise && !force) {
-    return fetchPromise;
+  if (fetchPromises[instanceId] && !force) {
+    return fetchPromises[instanceId]!;
   }
 
-  loading.value = true;
-  fetchPromise = (async () => {
+  loadingMap.value[instanceId] = true;
+  fetchPromises[instanceId] = (async () => {
     try {
-      const result = (await api.sendCommand("party/config")) as PartyConfig;
-      config.value = result;
-      loaded.value = true;
+      const result = (await api.sendCommand(
+        `party/${instanceId}/config`,
+      )) as PartyConfig;
+      configs.value[instanceId] = result;
+      loadedMap.value[instanceId] = true;
       return result;
     } catch {
-      config.value = null;
-      loaded.value = true;
+      configs.value[instanceId] = null;
+      loadedMap.value[instanceId] = true;
       return null;
     } finally {
-      loading.value = false;
-      fetchPromise = null;
+      loadingMap.value[instanceId] = false;
+      delete fetchPromises[instanceId];
     }
   })();
 
-  return fetchPromise;
+  return fetchPromises[instanceId]!;
 }
 
 /**
- * Reset cached config (e.g., when provider is reloaded).
+ * Reset cached config for a specific instance or all instances.
  */
-function invalidate() {
-  config.value = null;
-  loaded.value = false;
-  fetchPromise = null;
+function invalidate(instanceId?: string) {
+  if (instanceId) {
+    delete configs.value[instanceId];
+    delete loadedMap.value[instanceId];
+    delete fetchPromises[instanceId];
+  } else {
+    configs.value = {};
+    loadedMap.value = {};
+    for (const key of Object.keys(fetchPromises)) {
+      delete fetchPromises[key];
+    }
+  }
+}
+
+/**
+ * Re-fetch configs for all previously loaded instances.
+ * Unlike invalidate(), this updates the reactive state in-place so watchers
+ * see the new per-instance values rather than a blanket null.
+ */
+async function refetchAll() {
+  const instanceIds = Object.keys(loadedMap.value);
+  await Promise.all(instanceIds.map((id) => fetchConfig(id, true)));
 }
 
 let subscribed = false;
 
 /**
  * Subscribe to PROVIDERS_UPDATED and CORE_STATE_UPDATED so the shared
- * config ref auto-refreshes whenever the party provider is reloaded
+ * config ref auto-refreshes whenever any party provider is reloaded
  * or remote access is toggled.
  */
 function ensureSubscribed() {
@@ -73,11 +98,10 @@ function ensureSubscribed() {
       (p) => p.domain === "party",
     );
     if (hasParty) {
-      invalidate();
-      await fetchConfig(true);
+      await refetchAll();
     } else {
-      config.value = null;
-      loaded.value = true;
+      configs.value = {};
+      loadedMap.value = {};
     }
   });
 
@@ -88,19 +112,24 @@ function ensureSubscribed() {
       (p) => p.domain === "party",
     );
     if (hasParty) {
-      invalidate();
-      await fetchConfig(true);
+      await refetchAll();
     }
   });
 }
 
-export function usePartyConfig() {
+export function usePartyConfig(instanceId?: string) {
   ensureSubscribed();
   return {
-    config,
-    loading,
-    loaded,
-    fetchConfig,
+    config: configs,
+    loading: loadingMap,
+    loaded: loadedMap,
+    fetchConfig: (force = false) => {
+      if (instanceId) {
+        return fetchConfig(instanceId, force);
+      }
+      return Promise.resolve(null);
+    },
+    fetchConfigForInstance: fetchConfig,
     invalidate,
   };
 }

--- a/src/composables/usePartyConfig.ts
+++ b/src/composables/usePartyConfig.ts
@@ -5,7 +5,7 @@
  * the same config.
  */
 
-import { ref } from "vue";
+import { computed, ref } from "vue";
 import api from "@/plugins/api";
 import { EventType, type PartyConfig } from "@/plugins/api/interfaces";
 
@@ -119,8 +119,12 @@ function ensureSubscribed() {
 
 export function usePartyConfig(instanceId?: string) {
   ensureSubscribed();
+  const singleConfig = instanceId
+    ? computed(() => configs.value[instanceId] ?? null)
+    : computed(() => null);
   return {
-    config: configs,
+    config: singleConfig,
+    allConfigs: configs,
     loading: loadingMap,
     loaded: loadedMap,
     fetchConfig: (force = false) => {

--- a/src/layouts/default/PlayerOSD/PlayerFullscreen.vue
+++ b/src/layouts/default/PlayerOSD/PlayerFullscreen.vue
@@ -1239,23 +1239,21 @@ const loadNextPage = async function ({
 };
 
 // Fetch badge colors from the party instance associated with the active player
-const { config: partyConfigs, fetchConfigForInstance } = usePartyConfig();
+const { allConfigs: partyConfigs, fetchConfigForInstance } = usePartyConfig();
 const partyPlayerMap = ref<Record<string, string>>({});
 
 const fetchPartyPlayerMap = async () => {
   const map: Record<string, string> = {};
-  for (const instance of store.partyInstances) {
-    try {
+  await Promise.allSettled(
+    store.partyInstances.map(async (instance) => {
       const playerId = (await api.sendCommand(
         `party/${instance.instance_id}/player`,
       )) as string | null;
       if (playerId) {
         map[playerId] = instance.instance_id;
       }
-    } catch {
-      // instance may not be ready yet
-    }
-  }
+    }),
+  );
   partyPlayerMap.value = map;
 };
 
@@ -1267,16 +1265,16 @@ const activePartyInstanceId = computed(() => {
 
 // React to party config changes for the active player's party instance
 watch(
-  [activePartyInstanceId, partyConfigs],
-  ([instanceId]) => {
-    if (!instanceId) return;
-    const config = partyConfigs.value[instanceId];
+  () => {
+    const id = activePartyInstanceId.value;
+    return id ? partyConfigs.value[id] : null;
+  },
+  (config) => {
     if (config) {
       requestBadgeColor.value = config.request_badge_color ?? "#2196F3";
       boostBadgeColor.value = config.boost_badge_color ?? "#FF5722";
     }
   },
-  { deep: true },
 );
 
 // When active player changes and maps to a party instance, fetch its config
@@ -1289,11 +1287,17 @@ watch(activePartyInstanceId, async (instanceId) => {
 onMounted(async () => {
   if (store.partyInstances.length > 0) {
     await fetchPartyPlayerMap();
-    // Fetch config for the instance matching the active player
     const instanceId = activePartyInstanceId.value;
     if (instanceId) {
       await fetchConfigForInstance(instanceId);
     }
+
+    // Refresh player map when party providers change
+    api.subscribe(EventType.PROVIDERS_UPDATED, async () => {
+      if (store.partyInstances.length > 0) {
+        await fetchPartyPlayerMap();
+      }
+    });
   }
 });
 

--- a/src/layouts/default/PlayerOSD/PlayerFullscreen.vue
+++ b/src/layouts/default/PlayerOSD/PlayerFullscreen.vue
@@ -1293,11 +1293,15 @@ onMounted(async () => {
     }
 
     // Refresh player map when party providers change
-    api.subscribe(EventType.PROVIDERS_UPDATED, async () => {
-      if (store.partyInstances.length > 0) {
-        await fetchPartyPlayerMap();
-      }
-    });
+    const unsubProviders = api.subscribe(
+      EventType.PROVIDERS_UPDATED,
+      async () => {
+        if (store.partyInstances.length > 0) {
+          await fetchPartyPlayerMap();
+        }
+      },
+    );
+    onBeforeUnmount(unsubProviders);
   }
 });
 

--- a/src/layouts/default/PlayerOSD/PlayerFullscreen.vue
+++ b/src/layouts/default/PlayerOSD/PlayerFullscreen.vue
@@ -1238,21 +1238,62 @@ const loadNextPage = async function ({
   }
 };
 
-// Fetch badge colors from party config
-const { config: partyConfig, fetchConfig: fetchPartyConfig } = usePartyConfig();
+// Fetch badge colors from the party instance associated with the active player
+const { config: partyConfigs, fetchConfigForInstance } = usePartyConfig();
+const partyPlayerMap = ref<Record<string, string>>({});
 
-// React to party config changes (e.g., admin changes badge colors)
-watch(partyConfig, (newConfig) => {
-  if (newConfig) {
-    requestBadgeColor.value = newConfig.request_badge_color ?? "#2196F3";
-    boostBadgeColor.value = newConfig.boost_badge_color ?? "#FF5722";
+const fetchPartyPlayerMap = async () => {
+  const map: Record<string, string> = {};
+  for (const instance of store.partyInstances) {
+    try {
+      const playerId = (await api.sendCommand(
+        `party/${instance.instance_id}/player`,
+      )) as string | null;
+      if (playerId) {
+        map[playerId] = instance.instance_id;
+      }
+    } catch {
+      // instance may not be ready yet
+    }
+  }
+  partyPlayerMap.value = map;
+};
+
+const activePartyInstanceId = computed(() => {
+  const playerId = store.activePlayer?.player_id;
+  if (!playerId) return undefined;
+  return partyPlayerMap.value[playerId];
+});
+
+// React to party config changes for the active player's party instance
+watch(
+  [activePartyInstanceId, partyConfigs],
+  ([instanceId]) => {
+    if (!instanceId) return;
+    const config = partyConfigs.value[instanceId];
+    if (config) {
+      requestBadgeColor.value = config.request_badge_color ?? "#2196F3";
+      boostBadgeColor.value = config.boost_badge_color ?? "#FF5722";
+    }
+  },
+  { deep: true },
+);
+
+// When active player changes and maps to a party instance, fetch its config
+watch(activePartyInstanceId, async (instanceId) => {
+  if (instanceId) {
+    await fetchConfigForInstance(instanceId);
   }
 });
 
 onMounted(async () => {
-  // Only fetch badge colors if party provider is loaded
-  if (Object.values(api.providers).some((p) => p.domain === "party")) {
-    await fetchPartyConfig();
+  if (store.partyInstances.length > 0) {
+    await fetchPartyPlayerMap();
+    // Fetch config for the instance matching the active player
+    const instanceId = activePartyInstanceId.value;
+    if (instanceId) {
+      await fetchConfigForInstance(instanceId);
+    }
   }
 });
 

--- a/src/plugins/api/interfaces.ts
+++ b/src/plugins/api/interfaces.ts
@@ -1236,4 +1236,5 @@ export interface PartyConfig {
   request_badge_color?: string;
   boost_badge_color?: string;
   anti_burn_in: boolean;
+  instance_count: number;
 }

--- a/src/plugins/api/interfaces.ts
+++ b/src/plugins/api/interfaces.ts
@@ -1218,6 +1218,8 @@ export interface RemoteAccessInfo {
 // Party interfaces
 
 export interface PartyConfig {
+  instance_id: string;
+  name: string;
   enable_rate_limiting: boolean;
   enable_add_queue: boolean;
   add_queue_limit: number;

--- a/src/plugins/auth.ts
+++ b/src/plugins/auth.ts
@@ -23,6 +23,7 @@ interface JWTClaims {
   provider_filter: string[];
   token_name: string;
   is_long_lived: boolean;
+  extra_claims?: Record<string, unknown>;
 }
 
 export class AuthManager {
@@ -126,6 +127,18 @@ export class AuthManager {
    */
   isPartyGuest(): boolean {
     return this.claims?.username === "party_guest";
+  }
+
+  /**
+   * Get the party instance ID from the JWT extra_claims.
+   * Returns undefined if not a party guest or no instance claim present.
+   */
+  getPartyInstanceId(): string | undefined {
+    const instanceFromClaim = this.claims?.extra_claims?.party_instance;
+    if (typeof instanceFromClaim === "string") {
+      return instanceFromClaim;
+    }
+    return undefined;
   }
 
   /**

--- a/src/plugins/router.ts
+++ b/src/plugins/router.ts
@@ -31,7 +31,7 @@ const routes: RouteRecordRaw[] = [
   // Party display uses minimal layout (fullscreen for wall-mounted tablets)
   // Placed at top level so it renders without navigation/player controls
   {
-    path: "/party",
+    path: "/party/:instanceId",
     // Party only displays the dashboard and doesn't need the player.
     meta: { disableWebPlayer: true },
     component: () => import("@/layouts/PartyGuestLayout.vue"),
@@ -43,7 +43,11 @@ const routes: RouteRecordRaw[] = [
           import(
             /* webpackChunkName: "party" */ "@/views/PartyDashboardView.vue"
           ),
-        props: (route: { query: Record<string, string> }) => ({
+        props: (route: {
+          params: Record<string, string>;
+          query: Record<string, string>;
+        }) => ({
+          instanceId: route.params.instanceId,
           ...route.query,
         }),
         beforeEnter: async (
@@ -72,6 +76,17 @@ const routes: RouteRecordRaw[] = [
         },
       },
     ],
+  },
+  // Redirect /party to the first instance (backward compat)
+  {
+    path: "/party",
+    redirect: () => {
+      const first = store.partyInstances[0];
+      if (first) {
+        return `/party/${first.instance_id}`;
+      }
+      return "/discover";
+    },
   },
   // All other routes go through default layout with navigation/player controls
   {

--- a/src/plugins/router.ts
+++ b/src/plugins/router.ts
@@ -84,10 +84,15 @@ const routes: RouteRecordRaw[] = [
       // Wait for API initialization so store.partyInstances is populated
       if (api.state.value !== ConnectionState.INITIALIZED) {
         await new Promise<void>((resolve) => {
+          const timeout = setTimeout(() => {
+            unwatch();
+            resolve();
+          }, 10000);
           const unwatch = watch(
             () => api.state.value,
             (newState) => {
               if (newState === ConnectionState.INITIALIZED) {
+                clearTimeout(timeout);
                 unwatch();
                 resolve();
               }

--- a/src/plugins/router.ts
+++ b/src/plugins/router.ts
@@ -80,13 +80,30 @@ const routes: RouteRecordRaw[] = [
   // Redirect /party to the first instance (backward compat)
   {
     path: "/party",
-    redirect: () => {
+    beforeEnter: async () => {
+      // Wait for API initialization so store.partyInstances is populated
+      if (api.state.value !== ConnectionState.INITIALIZED) {
+        await new Promise<void>((resolve) => {
+          const unwatch = watch(
+            () => api.state.value,
+            (newState) => {
+              if (newState === ConnectionState.INITIALIZED) {
+                unwatch();
+                resolve();
+              }
+            },
+            { immediate: true },
+          );
+        });
+      }
       const first = store.partyInstances[0];
       if (first) {
         return `/party/${first.instance_id}`;
       }
       return "/discover";
     },
+    // Component is required but won't render due to the redirect in beforeEnter
+    component: () => import("@/layouts/PartyGuestLayout.vue"),
   },
   // All other routes go through default layout with navigation/player controls
   {

--- a/src/plugins/store.ts
+++ b/src/plugins/store.ts
@@ -59,6 +59,7 @@ interface Store {
   isIngressSession: boolean;
   isOnboarding: boolean;
   enabledPlugins: Set<string>;
+  partyInstances: { instance_id: string; name: string }[];
   isPartyGuest: boolean;
   companionPlayerId?: string;
 }
@@ -132,5 +133,6 @@ export const store: Store = reactive({
   isIngressSession: window.location.pathname.includes("/hassio_ingress/"),
   isOnboarding: false,
   enabledPlugins: new Set(),
+  partyInstances: [],
   isPartyGuest: false,
 });

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -328,6 +328,7 @@
     "remove_library": "Remove from library",
     "remove_playlist": "Remove from playlist",
     "search": "Search",
+    "select_party_instance": "Select a Party",
     "series_plural": "Series",
     "series_singular": "Series",
     "server_state": {

--- a/src/views/PartyDashboardView.vue
+++ b/src/views/PartyDashboardView.vue
@@ -36,7 +36,7 @@
           class="karaoke-qr"
           :style="swapped ? { left: 'auto', right: '2vw' } : undefined"
         >
-          <PartyQR @available="qrAvailable = $event" />
+          <PartyQR :instance-id="instanceId" @available="qrAvailable = $event" />
         </div>
 
         <div class="karaoke-lyrics">
@@ -93,7 +93,7 @@
             class="qr-wrapper"
             :style="swapped && displayLyrics ? { order: 1 } : undefined"
           >
-            <PartyQR @available="qrAvailable = $event" />
+            <PartyQR :instance-id="instanceId" @available="qrAvailable = $event" />
           </div>
           <div
             v-if="displayLyrics"
@@ -183,11 +183,23 @@ import { Music, Speaker } from "lucide-vue-next";
 import { computed, onBeforeUnmount, onMounted, ref, watch } from "vue";
 import { useTheme } from "vuetify";
 
+const props = defineProps<{
+  instanceId: string;
+}>();
+
 const theme = useTheme();
-const { config: partyConfig, fetchConfig } = usePartyConfig();
+const { config: partyConfigs, fetchConfigForInstance } = usePartyConfig(
+  props.instanceId,
+);
+const partyConfig = computed(
+  () => partyConfigs.value[props.instanceId] ?? null,
+);
+const fetchConfig = () => fetchConfigForInstance(props.instanceId);
 
 const refreshPartyPlayer = async () => {
-  const partyPlayerId = await api.sendCommand<string | null>("party/player");
+  const partyPlayerId = await api.sendCommand<string | null>(
+    `party/${props.instanceId}/player`,
+  );
   accessError.value = "";
   if (partyPlayerId) {
     store.activePlayerId = partyPlayerId;

--- a/src/views/PartyDashboardView.vue
+++ b/src/views/PartyDashboardView.vue
@@ -188,13 +188,7 @@ const props = defineProps<{
 }>();
 
 const theme = useTheme();
-const { config: partyConfigs, fetchConfigForInstance } = usePartyConfig(
-  props.instanceId,
-);
-const partyConfig = computed(
-  () => partyConfigs.value[props.instanceId] ?? null,
-);
-const fetchConfig = () => fetchConfigForInstance(props.instanceId);
+const { config: partyConfig, fetchConfig } = usePartyConfig(props.instanceId);
 
 const refreshPartyPlayer = async () => {
   const partyPlayerId = await api.sendCommand<string | null>(

--- a/src/views/PartyDashboardView.vue
+++ b/src/views/PartyDashboardView.vue
@@ -36,7 +36,10 @@
           class="karaoke-qr"
           :style="swapped ? { left: 'auto', right: '2vw' } : undefined"
         >
-          <PartyQR :instance-id="instanceId" @available="qrAvailable = $event" />
+          <PartyQR
+            :instance-id="instanceId"
+            @available="qrAvailable = $event"
+          />
         </div>
 
         <div class="karaoke-lyrics">
@@ -93,7 +96,10 @@
             class="qr-wrapper"
             :style="swapped && displayLyrics ? { order: 1 } : undefined"
           >
-            <PartyQR :instance-id="instanceId" @available="qrAvailable = $event" />
+            <PartyQR
+              :instance-id="instanceId"
+              @available="qrAvailable = $event"
+            />
           </div>
           <div
             v-if="displayLyrics"

--- a/src/views/PartyGuestView.vue
+++ b/src/views/PartyGuestView.vue
@@ -5,6 +5,14 @@
       <img :src="logoSrc" alt="Music Assistant" class="logo-img" />
     </div>
 
+    <!-- Instance name (shown when multiple party instances exist) -->
+    <div
+      v-if="partyConfig && partyConfig.instance_count > 1"
+      class="instance-name"
+    >
+      {{ partyConfig.name }}
+    </div>
+
     <!-- Search Section -->
     <PartySearchBar
       ref="searchBarRef"
@@ -608,6 +616,15 @@ onBeforeUnmount(() => {
   width: auto;
   opacity: 0.85;
   margin-bottom: 1rem;
+}
+
+.instance-name {
+  text-align: center;
+  font-size: 1rem;
+  font-weight: 600;
+  opacity: 0.7;
+  margin-top: -0.5rem;
+  margin-bottom: 0.75rem;
 }
 
 .guest-view {

--- a/src/views/PartyGuestView.vue
+++ b/src/views/PartyGuestView.vue
@@ -242,11 +242,14 @@ const logoSrc = computed(() =>
 const instanceId = ref("");
 
 // --- Composables ---
-const { config: partyConfigs, fetchConfigForInstance } = usePartyConfig();
+const { allConfigs: partyConfigs, fetchConfigForInstance } = usePartyConfig();
 const partyConfig = computed(
   () => partyConfigs.value[instanceId.value] ?? null,
 );
-const fetchConfig = () => fetchConfigForInstance(instanceId.value);
+const fetchConfig = () => {
+  if (!instanceId.value) return Promise.resolve(null);
+  return fetchConfigForInstance(instanceId.value);
+};
 const rateLimit = useRateLimiting();
 const {
   rateLimitingEnabled,
@@ -528,6 +531,7 @@ let cleanupQueueEvents: (() => void) | null = null;
 let cleanupProvidersSub: (() => void) | null = null;
 
 const refreshPartyPlayer = async () => {
+  if (!instanceId.value) return;
   try {
     const partyPlayerId = await api.sendCommand<string | null>(
       `party/${instanceId.value}/player`,

--- a/src/views/PartyGuestView.vue
+++ b/src/views/PartyGuestView.vue
@@ -238,8 +238,15 @@ const logoSrc = computed(() =>
     : new URL("@/assets/logo/logo-dark.svg", import.meta.url).href,
 );
 
+// Discover the party instance ID from the guest username
+const instanceId = ref("");
+
 // --- Composables ---
-const { config: partyConfig, fetchConfig } = usePartyConfig();
+const { config: partyConfigs, fetchConfigForInstance } = usePartyConfig();
+const partyConfig = computed(
+  () => partyConfigs.value[instanceId.value] ?? null,
+);
+const fetchConfig = () => fetchConfigForInstance(instanceId.value);
 const rateLimit = useRateLimiting();
 const {
   rateLimitingEnabled,
@@ -388,10 +395,13 @@ const addToQueue = async (item: Track | Artist, position: "next" | "end") => {
   addingItems.value.add(key);
 
   try {
-    const result = (await api.sendCommand("party/add_to_queue", {
-      uri: item.uri,
-      boost: position === "next",
-    })) as { success: boolean; boosted: boolean; started_playback: boolean };
+    const result = (await api.sendCommand(
+      `party/${instanceId.value}/add_to_queue`,
+      {
+        uri: item.uri,
+        boost: position === "next",
+      },
+    )) as { success: boolean; boosted: boolean; started_playback: boolean };
 
     if (!result.success) {
       throw new Error("Server rejected the request");
@@ -434,9 +444,12 @@ const boostQueueItem = async (item: QueueItem) => {
 
   boostingQueueItemId.value = item.queue_item_id;
   try {
-    const result = (await api.sendCommand("party/boost_queue_item", {
-      queue_item_id: item.queue_item_id,
-    })) as { success: boolean };
+    const result = (await api.sendCommand(
+      `party/${instanceId.value}/boost_queue_item`,
+      {
+        queue_item_id: item.queue_item_id,
+      },
+    )) as { success: boolean };
 
     if (!result.success) {
       throw new Error("Server rejected the request");
@@ -472,7 +485,9 @@ const skipCurrentSong = async () => {
 
   skippingSong.value = true;
   try {
-    const result = (await api.sendCommand("party/skip")) as {
+    const result = (await api.sendCommand(
+      `party/${instanceId.value}/skip`,
+    )) as {
       success: boolean;
     };
 
@@ -514,7 +529,9 @@ let cleanupProvidersSub: (() => void) | null = null;
 
 const refreshPartyPlayer = async () => {
   try {
-    const partyPlayerId = await api.sendCommand<string | null>("party/player");
+    const partyPlayerId = await api.sendCommand<string | null>(
+      `party/${instanceId.value}/player`,
+    );
     partyQueueId.value = partyPlayerId;
     if (partyPlayerId) {
       store.activePlayerId = partyPlayerId;
@@ -532,6 +549,16 @@ const fetchAndApplyConfig = async () => {
 };
 
 onMounted(async () => {
+  // Discover which party instance this guest belongs to from the username
+  const { authManager } = await import("@/plugins/auth");
+  const discoveredId = authManager.getPartyInstanceId();
+  if (discoveredId) {
+    instanceId.value = discoveredId;
+  } else {
+    console.error("Could not determine party instance ID from guest username");
+    return;
+  }
+
   await fetchAndApplyConfig();
 
   history.pushState(null, "", location.href);

--- a/tests/composables/useRateLimiting.test.ts
+++ b/tests/composables/useRateLimiting.test.ts
@@ -115,6 +115,7 @@ describe("useRateLimiting", () => {
       request_badge_color: "#000000",
       boost_badge_color: "#ffffff",
       anti_burn_in: false,
+      instance_count: 1,
     };
 
     rateLimiting.configure(config);

--- a/tests/composables/useRateLimiting.test.ts
+++ b/tests/composables/useRateLimiting.test.ts
@@ -97,6 +97,8 @@ describe("useRateLimiting", () => {
     const rateLimiting = useRateLimiting();
 
     const config: PartyConfig = {
+      instance_id: "party--test123",
+      name: "Test Party",
       enable_rate_limiting: false,
       enable_add_queue: false,
       enable_boost: false,


### PR DESCRIPTION
- Add instance_id and name to PartyConfig interface
- Route party dashboard by instanceId (/party/:instanceId)
- Update PartyDashboardView, PartyQR, PartyGuestView for per-instance APIs
- Rewrite usePartyConfig composable with per-instance caching and refetchAll
- Add extra_claims to JWTClaims, read party_instance from JWT
- Show context menu for instance selection when multiple party instances exist
- Update PlayerFullscreen to use badge colors from active player's party instance
- Update App.vue party detection for multiple instances
- Add select_party_instance translation key