### PR TITLE
Add right-click context menu to player cards on home screen

### DIFF
--- a/src/components/PlayerCard.vue
+++ b/src/components/PlayerCard.vue
@@ -10,6 +10,7 @@
     :ripple="false"
     :disabled="!player.available"
     @click="$emit('click', player)"
+    @contextmenu.prevent="openPlayerMenu"
   >
     <!-- now playing media -->
     <v-list-item class="panel-item-details" flat :ripple="false">


### PR DESCRIPTION
**Disclaimer: This PR was coded using Claude**

The player detail page already has a context menu with options like stop playback, shuffle, repeat, etc. This PR wires up the same context menu to the player cards on the home screen via right-click, making the behavior consistent across screens. 

The players on the Discovery page are also the only element without right-click/long-tap functionality. Maybe that's for good reason but offering up this PR for your consideration! 