### PR TITLE
Fix some members not showing up in Sync group creation.

### DIFF
--- a/src/views/settings/AddPlayerGroup.vue
+++ b/src/views/settings/AddPlayerGroup.vue
@@ -117,13 +117,13 @@ const syncPlayers = computed(() => {
     // for universal groups, show all available non-group players, regardless of provider
     return Object.values(api.players)
       .filter((x) => x.available && x.type != PlayerType.GROUP)
-      .sort((a, b) => (a.name.toUpperCase() > b.name?.toUpperCase() ? 1 : -1));
+      .sort((a, b) => (a.name ?? '').toUpperCase().localeCompare((b.name ?? '').toUpperCase()));
   }
   if (props.provider === "sync_group") {
     // for sync groups, show all available non-group players that are sync compatible
     return Object.values(api.players)
       .filter((x) => {
-        if (!x.available || x.type == PlayerType.GROUP) return false;
+        if (!x.available || x.type === PlayerType.GROUP) return false;
         if (!x.supported_features.includes(PlayerFeature.SET_MEMBERS))
           return false;
         // If a player is temporarily synced, can_group_with will be empty.
@@ -137,11 +137,11 @@ const syncPlayers = computed(() => {
           canGroupWith = api.players[x.synced_to].can_group_with;
         }
         if (canGroupWith.length === 0) return false;
-        if (members.value.length == 0) return true;
+        if (members.value.length === 0) return true;
         if (members.value.includes(x.player_id)) return true;
         return members.value.some((m) => canGroupWith.includes(m));
       })
-      .sort((a, b) => (a.name.toUpperCase() > b.name?.toUpperCase() ? 1 : -1));
+      .sort((a, b) => (a.name ?? '').toUpperCase().localeCompare((b.name ?? '').toUpperCase()));
   }
   return Object.values(api.players)
     .filter(
@@ -150,7 +150,7 @@ const syncPlayers = computed(() => {
         x.type != PlayerType.GROUP &&
         x.provider == providerDetails.value?.instance_id,
     )
-    .sort((a, b) => (a.name.toUpperCase() > b.name?.toUpperCase() ? 1 : -1));
+    .sort((a, b) => (a.name ?? '').toUpperCase().localeCompare((b.name ?? '').toUpperCase()));
 });
 
 // methods

--- a/src/views/settings/AddPlayerGroup.vue
+++ b/src/views/settings/AddPlayerGroup.vue
@@ -47,7 +47,7 @@
             clearable
             multiple
             :items="syncPlayers"
-            item-title="display_name"
+            item-title="name"
             item-value="player_id"
             :label="$t('settings.group_members')"
           />
@@ -115,29 +115,42 @@ const providerDetails = computed(() => {
 const syncPlayers = computed(() => {
   if (props.provider === "universal_group") {
     // for universal groups, show all available non-group players, regardless of provider
-    return Object.values(api.players).filter(
-      (x) => x.available && x.type != PlayerType.GROUP,
-    );
+    return Object.values(api.players)
+      .filter((x) => x.available && x.type != PlayerType.GROUP)
+      .sort((a, b) => (a.name.toUpperCase() > b.name?.toUpperCase() ? 1 : -1));
   }
   if (props.provider === "sync_group") {
-    // for sync groups, show all available non-group players that are sync compatible with the provider
-    return Object.values(api.players).filter(
+    // for sync groups, show all available non-group players that are sync compatible
+    return Object.values(api.players)
+      .filter((x) => {
+        if (!x.available || x.type == PlayerType.GROUP) return false;
+        if (!x.supported_features.includes(PlayerFeature.SET_MEMBERS))
+          return false;
+        // If a player is temporarily synced, can_group_with will be empty.
+        // In that case, use the sync leader's can_group_with as a proxy.
+        let canGroupWith = x.can_group_with;
+        if (
+          canGroupWith.length === 0 &&
+          x.synced_to &&
+          api.players[x.synced_to]
+        ) {
+          canGroupWith = api.players[x.synced_to].can_group_with;
+        }
+        if (canGroupWith.length === 0) return false;
+        if (members.value.length == 0) return true;
+        if (members.value.includes(x.player_id)) return true;
+        return members.value.some((m) => canGroupWith.includes(m));
+      })
+      .sort((a, b) => (a.name.toUpperCase() > b.name?.toUpperCase() ? 1 : -1));
+  }
+  return Object.values(api.players)
+    .filter(
       (x) =>
         x.available &&
         x.type != PlayerType.GROUP &&
-        x.supported_features.includes(PlayerFeature.SET_MEMBERS) &&
-        x.can_group_with.length > 0 &&
-        (members.value.length == 0 ||
-          members.value.includes(x.player_id) ||
-          members.value.some((m) => x.can_group_with.includes(m))),
-    );
-  }
-  return Object.values(api.players).filter(
-    (x) =>
-      x.available &&
-      x.type != PlayerType.GROUP &&
-      x.provider == providerDetails.value?.instance_id,
-  );
+        x.provider == providerDetails.value?.instance_id,
+    )
+    .sort((a, b) => (a.name.toUpperCase() > b.name?.toUpperCase() ? 1 : -1));
 });
 
 // methods


### PR DESCRIPTION
This PR fixes 2 issues with Sync groups:
- Some players were not shown during Sync group creation when they were grouped to another player
- The list of players is now sorted alphabetically, same as in the players view

Before
<img width="561" height="632" alt="image" src="https://github.com/user-attachments/assets/5c74562b-2d81-4b62-a4d4-3dea34231dd5" />

After
<img width="497" height="628" alt="image" src="https://github.com/user-attachments/assets/32e58bdc-85e7-421d-91ad-829e04179875" />