### PR TITLE
Update icons for player controls and player fullscreen

### DIFF
--- a/src/layouts/default/PlayerOSD/PlayerControlBtn/NextBtn.vue
+++ b/src/layouts/default/PlayerOSD/PlayerControlBtn/NextBtn.vue
@@ -4,10 +4,11 @@
     v-if="isVisible && player"
     v-bind="{ ...icon, ...$attrs }"
     :disabled="!canNext || isLoading"
-    icon="mdi-skip-next-outline"
     variant="button"
     @click="api.playerCommandNext(player.player_id)"
-  />
+  >
+    <SkipForward :size="size" />
+  </Icon>
 </template>
 
 <script setup lang="ts">
@@ -17,6 +18,7 @@ import api from "@/plugins/api";
 import { Player, PlayerFeature, PlayerQueue } from "@/plugins/api/interfaces";
 import { useActiveSource } from "@/composables/activeSource";
 import { computed, toRef } from "vue";
+import { SkipForward } from "lucide-vue-next";
 
 // properties
 export interface Props {
@@ -24,11 +26,13 @@ export interface Props {
   playerQueue?: PlayerQueue;
   isVisible?: boolean;
   icon?: IconProps;
+  size?: number;
 }
 const compProps = withDefaults(defineProps<Props>(), {
   playerQueue: undefined,
   isVisible: true,
   icon: undefined,
+  size: 20,
 });
 
 const { activeSource } = useActiveSource(toRef(compProps, "player"));

--- a/src/layouts/default/PlayerOSD/PlayerControlBtn/PlayBtn.vue
+++ b/src/layouts/default/PlayerOSD/PlayerControlBtn/PlayBtn.vue
@@ -5,10 +5,17 @@
     v-bind="{ ...icon, ...$attrs }"
     class="play-btn-icon"
     :disabled="!canPlayPause || isLoading"
-    :icon="iconStyle ? `${baseIcon}-${iconStyle}` : baseIcon"
     variant="button"
     @click="api.playerCommandPlayPause(player.player_id)"
-  />
+  >
+    <Pause v-if="isPlaying" :size="size" fill="currentColor" />
+    <Play
+      v-else
+      :size="size"
+      fill="currentColor"
+      :style="{ marginLeft: `${compProps.playOffset}px` }"
+    />
+  </Icon>
   <v-progress-circular
     v-if="isVisible && player && isLoading"
     class="play-btn-spinner"
@@ -21,9 +28,10 @@
 <script setup lang="ts">
 defineOptions({ inheritAttrs: false });
 import Icon, { IconProps } from "@/components/Icon.vue";
+import { useActiveSource } from "@/composables/activeSource";
 import api from "@/plugins/api";
 import { PlaybackState, Player, PlayerQueue } from "@/plugins/api/interfaces";
-import { useActiveSource } from "@/composables/activeSource";
+import { Pause, Play } from "lucide-vue-next";
 import { computed, toRef } from "vue";
 
 // properties
@@ -31,18 +39,18 @@ export interface Props {
   player: Player | undefined;
   playerQueue?: PlayerQueue;
   isVisible?: boolean;
-  withCircle?: boolean;
   icon?: IconProps;
-  iconStyle?: string;
   spinnerSize?: number;
+  size?: number;
+  playOffset?: number;
 }
 const compProps = withDefaults(defineProps<Props>(), {
   playerQueue: undefined,
   isVisible: true,
-  withCircle: true,
   icon: undefined,
-  iconStyle: "circle",
   spinnerSize: 46,
+  size: 24,
+  playOffset: 1,
 });
 
 const { activeSource } = useActiveSource(toRef(compProps, "player"));
@@ -68,11 +76,8 @@ const canPlayPause = computed(() => {
   return queueCanPlay.value || playerCanPlay.value;
 });
 
-const baseIcon = computed(() => {
-  if (compProps.player?.playback_state == PlaybackState.PLAYING) {
-    return "mdi-pause";
-  }
-  return "mdi-play";
+const isPlaying = computed(() => {
+  return compProps.player?.playback_state == PlaybackState.PLAYING;
 });
 
 const isLoading = computed(() => {
@@ -86,6 +91,14 @@ const isLoading = computed(() => {
 <style>
 .play-btn-icon {
   position: relative;
+  border-radius: 50%;
+  background-color: #212121;
+  color: #fff;
+}
+
+.v-theme--dark .play-btn-icon {
+  background-color: #fff;
+  color: #212121;
 }
 
 .play-btn-spinner {

--- a/src/layouts/default/PlayerOSD/PlayerControlBtn/PreviousBtn.vue
+++ b/src/layouts/default/PlayerOSD/PlayerControlBtn/PreviousBtn.vue
@@ -4,10 +4,11 @@
     v-if="isVisible && player"
     v-bind="{ ...icon, ...$attrs }"
     :disabled="!canPrevious || isLoading"
-    icon="mdi-skip-previous-outline"
     variant="button"
     @click="api.playerCommandPrevious(player.player_id)"
-  />
+  >
+    <SkipBack :size="size" />
+  </Icon>
 </template>
 
 <script setup lang="ts">
@@ -17,6 +18,7 @@ import api from "@/plugins/api";
 import { Player, PlayerFeature, PlayerQueue } from "@/plugins/api/interfaces";
 import { useActiveSource } from "@/composables/activeSource";
 import { computed, toRef } from "vue";
+import { SkipBack } from "lucide-vue-next";
 
 // properties
 export interface Props {
@@ -24,11 +26,13 @@ export interface Props {
   playerQueue?: PlayerQueue;
   isVisible?: boolean;
   icon?: IconProps;
+  size?: number;
 }
 const compProps = withDefaults(defineProps<Props>(), {
   playerQueue: undefined,
   isVisible: true,
   icon: undefined,
+  size: 20,
 });
 
 const { activeSource } = useActiveSource(toRef(compProps, "player"));

--- a/src/layouts/default/PlayerOSD/PlayerControlBtn/QueueBtn.vue
+++ b/src/layouts/default/PlayerOSD/PlayerControlBtn/QueueBtn.vue
@@ -8,7 +8,6 @@
         !store.curQueueItem &&
         !store.showQueueItems)
     "
-    icon="mdi-playlist-play"
     :color="
       getValueFromSources(icon?.color, [
         [store.showFullscreenPlayer && store.showQueueItems, 'primary', ''],
@@ -16,7 +15,9 @@
     "
     variant="button"
     @click="onClick"
-  />
+  >
+    <ListVideo :size="size" />
+  </Icon>
 </template>
 
 <script setup lang="ts">
@@ -24,16 +25,19 @@ defineOptions({ inheritAttrs: false });
 import Icon, { IconProps } from "@/components/Icon.vue";
 import { getValueFromSources } from "@/helpers/utils";
 import { store } from "@/plugins/store";
+import { ListVideo } from "lucide-vue-next";
 
 // properties
 export interface Props {
   isVisible?: boolean;
   icon?: IconProps;
+  size?: number;
 }
 
 withDefaults(defineProps<Props>(), {
   isVisible: true,
   icon: undefined,
+  size: 20,
 });
 
 const onClick = function () {

--- a/src/layouts/default/PlayerOSD/PlayerControlBtn/RepeatBtn.vue
+++ b/src/layouts/default/PlayerOSD/PlayerControlBtn/RepeatBtn.vue
@@ -11,14 +11,6 @@
         [playerQueue.repeat_mode == RepeatMode.ONE, 'primary'],
       ])
     "
-    :icon="
-      getValueFromSources(icon?.icon, [
-        [playerQueue.repeat_mode == RepeatMode.OFF, 'mdi-repeat-off'],
-        [playerQueue.repeat_mode == RepeatMode.ALL, 'mdi-repeat'],
-        [playerQueue.repeat_mode == RepeatMode.ONE, 'mdi-repeat-once'],
-        [true, 'mdi-repeat-off'],
-      ])
-    "
     variant="button"
     @click="
       api.queueCommandRepeat(
@@ -30,7 +22,11 @@
         ]) ?? RepeatMode.OFF,
       )
     "
-  />
+  >
+    <IconRepeatOff v-if="playerQueue.repeat_mode == RepeatMode.OFF" :size="size" />
+    <IconRepeat v-else-if="playerQueue.repeat_mode == RepeatMode.ALL" :size="size" />
+    <IconRepeatOnce v-else :size="size" />
+  </Icon>
 </template>
 
 <script setup lang="ts">
@@ -40,16 +36,19 @@ import { getValueFromSources } from "@/helpers/utils";
 import api from "@/plugins/api";
 import { PlayerQueue, RepeatMode } from "@/plugins/api/interfaces";
 import { computed } from "vue";
+import { IconRepeat, IconRepeatOff, IconRepeatOnce } from "@tabler/icons-vue";
 
 // properties
 export interface Props {
   playerQueue: PlayerQueue | undefined;
   isVisible?: boolean;
   icon?: IconProps;
+  size?: number;
 }
 const compProps = withDefaults(defineProps<Props>(), {
   isVisible: true,
   icon: undefined,
+  size: 20,
 });
 
 const isLoading = computed(() => {

--- a/src/layouts/default/PlayerOSD/PlayerControlBtn/ShuffleBtn.vue
+++ b/src/layouts/default/PlayerOSD/PlayerControlBtn/ShuffleBtn.vue
@@ -9,13 +9,6 @@
         [playerQueue.shuffle_enabled, 'primary', ''],
       ])
     "
-    :icon="
-      getValueFromSources(icon?.icon, [
-        [playerQueue.shuffle_enabled, 'mdi-shuffle'],
-        [playerQueue.shuffle_enabled == false, 'mdi-shuffle-disabled'],
-        [true, 'mdi-shuffle'],
-      ])
-    "
     variant="button"
     @click="
       api.queueCommandShuffle(
@@ -23,7 +16,10 @@
         playerQueue.shuffle_enabled ? false : true,
       )
     "
-  />
+  >
+    <Shuffle v-if="playerQueue.shuffle_enabled" :size="size" />
+    <IconArrowsRight v-else :size="size" />
+  </Icon>
 </template>
 
 <script setup lang="ts">
@@ -32,6 +28,8 @@ import Icon, { IconProps } from "@/components/Icon.vue";
 import { getValueFromSources } from "@/helpers/utils";
 import api from "@/plugins/api";
 import { PlayerQueue } from "@/plugins/api/interfaces";
+import { IconArrowsRight } from "@tabler/icons-vue";
+import { Shuffle } from "lucide-vue-next";
 import { computed } from "vue";
 
 // properties
@@ -39,10 +37,12 @@ export interface Props {
   playerQueue: PlayerQueue | undefined;
   isVisible?: boolean;
   icon?: IconProps;
+  size?: number;
 }
 const compProps = withDefaults(defineProps<Props>(), {
   isVisible: true,
   icon: undefined,
+  size: 20,
 });
 
 const isLoading = computed(() => {

--- a/src/layouts/default/PlayerOSD/PlayerControls.vue
+++ b/src/layouts/default/PlayerOSD/PlayerControls.vue
@@ -32,7 +32,6 @@
         :player="store.activePlayer"
         :player-queue="store.activePlayerQueue"
         class="media-controls-item"
-        icon-style="circle"
         :icon="visibleComponents.play.icon"
       />
     </div>

--- a/src/layouts/default/PlayerOSD/PlayerFullscreen.vue
+++ b/src/layouts/default/PlayerOSD/PlayerFullscreen.vue
@@ -418,17 +418,21 @@
           <Icon
             v-if="store.activePlayerQueue"
             :disabled="!store.curQueueItem?.media_item"
-            :icon="
-              store.curQueueItem?.media_item?.favorite
-                ? 'mdi-heart'
-                : 'mdi-heart-outline'
-            "
             :title="$t('tooltip.favorite')"
             variant="button"
             class="media-controls-item"
             max-height="30px"
             @click="onHeartBtnClick"
-          />
+          >
+            <Heart
+              :size="18"
+              :fill="
+                store.curQueueItem?.media_item?.favorite
+                  ? 'currentColor'
+                  : 'none'
+              "
+            />
+          </Icon>
           <ShuffleBtn
             v-if="$vuetify.display.mdAndUp"
             :player-queue="store.activePlayerQueue"
@@ -440,14 +444,17 @@
             :player-queue="store.activePlayerQueue"
             class="media-controls-item"
             max-height="45px"
+            :size="28"
           />
           <div class="play-btn-wrapper">
             <PlayBtn
               :player="store.activePlayer"
               :player-queue="store.activePlayerQueue"
               class="media-controls-item"
-              :icon="{ staticWidth: '70px', staticHeight: '70px' }"
+              :icon="{ staticWidth: '60px', staticHeight: '60px' }"
               :spinner-size="73"
+              :size="30"
+              :play-offset="2"
             />
           </div>
           <NextBtn
@@ -455,6 +462,7 @@
             :player-queue="store.activePlayerQueue"
             class="media-controls-item"
             max-height="45px"
+            :size="28"
           />
           <RepeatBtn
             v-if="$vuetify.display.mdAndUp"
@@ -466,6 +474,7 @@
             v-if="store.activePlayerQueue"
             class="media-controls-item"
             max-height="30px"
+            :size="18"
           />
         </div>
 
@@ -526,6 +535,8 @@ import MediaItemThumb from "@/components/MediaItemThumb.vue";
 import NowPlayingBadge from "@/components/NowPlayingBadge.vue";
 import PartyPlayerBadge from "@/components/party/PartyPlayerBadge.vue";
 import QualityDetailsBtn from "@/components/QualityDetailsBtn.vue";
+import { useLyricsElapsedTime } from "@/composables/useLyricsElapsedTime";
+import { usePartyConfig } from "@/composables/usePartyConfig";
 import { MarqueeTextSync } from "@/helpers/marquee_text_sync";
 import { getPlayerMenuItems } from "@/helpers/player_menu_items";
 import {
@@ -541,8 +552,8 @@ import PreviousBtn from "@/layouts/default/PlayerOSD/PlayerControlBtn/PreviousBt
 import RepeatBtn from "@/layouts/default/PlayerOSD/PlayerControlBtn/RepeatBtn.vue";
 import ShuffleBtn from "@/layouts/default/PlayerOSD/PlayerControlBtn/ShuffleBtn.vue";
 import PlayerVolume from "@/layouts/default/PlayerOSD/PlayerVolume.vue";
-import { usePartyConfig } from "@/composables/usePartyConfig";
 import api from "@/plugins/api";
+import { getSourceName } from "@/plugins/api/helpers";
 import {
   EventMessage,
   EventType,
@@ -563,6 +574,7 @@ import router from "@/plugins/router";
 import { store } from "@/plugins/store";
 import vuetify from "@/plugins/vuetify";
 import Color from "color";
+import { Heart } from "lucide-vue-next";
 import {
   computed,
   onBeforeUnmount,
@@ -576,8 +588,6 @@ import { ContextMenuItem } from "../ItemContextMenu.vue";
 import QueueBtn from "./PlayerControlBtn/QueueBtn.vue";
 import SpeakerBtn from "./PlayerControlBtn/SpeakerBtn.vue";
 import PlayerTimeline from "./PlayerTimeline.vue";
-import { getSourceName } from "@/plugins/api/helpers";
-import { useLyricsElapsedTime } from "@/composables/useLyricsElapsedTime";
 
 const { name } = useDisplay();
 

--- a/src/views/NotFound.vue
+++ b/src/views/NotFound.vue
@@ -6,15 +6,20 @@
           <!-- Vinyl + needle -->
           <div class="vinyl-scene">
             <div class="vinyl">
-              <div class="groove" v-for="i in 6" :key="i" :style="`--i: ${i}`" />
+              <div
+                v-for="i in 6"
+                :key="i"
+                class="groove"
+                :style="`--i: ${i}`"
+              ></div>
               <div class="label">
                 <div class="label-text">MA</div>
-                <div class="label-hole" />
+                <div class="label-hole"></div>
               </div>
             </div>
             <div class="needle-arm">
-              <div class="needle-rod" />
-              <div class="needle-head" />
+              <div class="needle-rod"></div>
+              <div class="needle-head"></div>
             </div>
           </div>
 
@@ -28,7 +33,12 @@
 
           <!-- Equalizer -->
           <div class="equalizer" aria-hidden="true">
-            <div v-for="i in 12" :key="i" class="eq-bar" :style="`--i: ${i}`" />
+            <div
+              v-for="i in 12"
+              :key="i"
+              class="eq-bar"
+              :style="`--i: ${i}`"
+            ></div>
           </div>
 
           <!-- Buttons -->
@@ -98,7 +108,7 @@ const router = useRouter();
   box-shadow:
     0 0 0 1px #333,
     0 12px 40px rgba(0, 0, 0, 0.6),
-    inset 0 0 20px rgba(255,255,255,0.03);
+    inset 0 0 20px rgba(255, 255, 255, 0.03);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -109,7 +119,7 @@ const router = useRouter();
 .groove {
   position: absolute;
   border-radius: 50%;
-  border: 1px solid rgba(255,255,255,0.04);
+  border: 1px solid rgba(255, 255, 255, 0.04);
   --size: calc(40px + var(--i) * 20px);
   width: var(--size);
   height: var(--size);
@@ -119,13 +129,17 @@ const router = useRouter();
   width: 60px;
   height: 60px;
   border-radius: 50%;
-  background: radial-gradient(circle at 35% 35%, hsl(var(--primary) / 0.9), hsl(var(--primary) / 0.6));
+  background: radial-gradient(
+    circle at 35% 35%,
+    hsl(var(--primary) / 0.9),
+    hsl(var(--primary) / 0.6)
+  );
   display: flex;
   flex-direction: column;
   align-items: center;
   justify-content: center;
   gap: 3px;
-  box-shadow: inset 0 1px 3px rgba(0,0,0,0.4);
+  box-shadow: inset 0 1px 3px rgba(0, 0, 0, 0.4);
   position: relative;
   z-index: 1;
 }
@@ -157,7 +171,11 @@ const router = useRouter();
 .needle-rod {
   width: 3px;
   height: 80px;
-  background: linear-gradient(to bottom, hsl(var(--muted-foreground) / 0.6), hsl(var(--muted-foreground) / 0.3));
+  background: linear-gradient(
+    to bottom,
+    hsl(var(--muted-foreground) / 0.6),
+    hsl(var(--muted-foreground) / 0.3)
+  );
   border-radius: 2px;
   transform: rotate(28deg);
   transform-origin: top center;
@@ -176,12 +194,19 @@ const router = useRouter();
 }
 
 @keyframes vinyl-spin {
-  to { transform: rotate(360deg); }
+  to {
+    transform: rotate(360deg);
+  }
 }
 
 @keyframes needle-sway {
-  0%, 100% { transform: rotate(-2deg); }
-  50%       { transform: rotate(2deg); }
+  0%,
+  100% {
+    transform: rotate(-2deg);
+  }
+  50% {
+    transform: rotate(2deg);
+  }
 }
 
 /* ─── 404 ─── */
@@ -209,8 +234,15 @@ const router = useRouter();
 }
 
 @keyframes digit-pulse {
-  0%, 100% { opacity: 1;    transform: translateY(0); }
-  50%       { opacity: 0.6; transform: translateY(-4px); }
+  0%,
+  100% {
+    opacity: 1;
+    transform: translateY(0);
+  }
+  50% {
+    opacity: 0.6;
+    transform: translateY(-4px);
+  }
 }
 
 /* ─── Text ─── */
@@ -238,13 +270,20 @@ const router = useRouter();
   width: 6px;
   border-radius: 3px 3px 0 0;
   background: hsl(var(--primary) / 0.7);
-  animation: eq-bounce calc(0.5s + var(--i) * 0.07s) ease-in-out infinite alternate;
+  animation: eq-bounce calc(0.5s + var(--i) * 0.07s) ease-in-out infinite
+    alternate;
   animation-delay: calc(var(--i) * 0.06s);
 }
 
 @keyframes eq-bounce {
-  from { height: 4px;  opacity: 0.4; }
-  to   { height: 28px; opacity: 1;   }
+  from {
+    height: 4px;
+    opacity: 0.4;
+  }
+  to {
+    height: 28px;
+    opacity: 1;
+  }
 }
 
 /* ─── Buttons ─── */


### PR DESCRIPTION
Before: 
<img width="1512" height="93" alt="Screenshot 2026-03-23 at 11 39 38" src="https://github.com/user-attachments/assets/3d915ffc-45ba-43bb-933e-e7a488a5f84f" />
<img width="1420" height="135" alt="Screenshot 2026-03-23 at 11 39 47" src="https://github.com/user-attachments/assets/f4e59237-841e-4dbb-ab0e-d9a3878dd5ff" />

After: 
<img width="1494" height="848" alt="Screenshot 2026-03-23 at 11 46 34" src="https://github.com/user-attachments/assets/e554711f-fa31-4498-85c1-ceebc70cf842" />
<img width="1500" height="182" alt="Screenshot 2026-03-23 at 11 46 42" src="https://github.com/user-attachments/assets/626383a6-a9eb-4d26-80e0-d4e134198a67" />
<img width="1503" height="168" alt="Screenshot 2026-03-23 at 11 48 31" src="https://github.com/user-attachments/assets/a90bea3e-6001-435b-bbe9-af26f926b882" />
<img width="1500" height="847" alt="Screenshot 2026-03-23 at 11 48 45" src="https://github.com/user-attachments/assets/990646fa-a4d2-431e-943e-4f9fb88202f7" />
