### PR TITLE
Improve default Sendspin sync delays

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
         "@mdi/font": "7.4.47",
         "@mdi/js": "7.4.47",
         "@scure/base": "^2.0.0",
-        "@sendspin/sendspin-js": "2.0.3",
+        "@sendspin/sendspin-js": "2.0.4",
         "@tabler/icons-vue": "^3.40.0",
         "@tailwindcss/vite": "^4.2.2",
         "@tanstack/vue-form": "^1.28.5",

--- a/src/components/SendspinPlayer.vue
+++ b/src/components/SendspinPlayer.vue
@@ -10,9 +10,12 @@
 
 <script setup lang="ts">
 import { useMediaBrowserMetaData } from "@/helpers/useMediaBrowserMetaData";
-import { getSendspinDefaultSyncDelay } from "@/helpers/utils";
 import { getDeviceName } from "@/plugins/api/helpers";
-import { SendspinPlayer, Codec } from "@sendspin/sendspin-js";
+import {
+  SendspinPlayer,
+  Codec,
+  getDefaultSyncDelay,
+} from "@sendspin/sendspin-js";
 
 import almostSilentMp3 from "@/assets/almost_silent.mp3";
 import api from "@/plugins/api";
@@ -209,7 +212,7 @@ onMounted(() => {
   if (audioRef.value) {
     const audioElement = isMobileOutput ? audioRef.value : undefined;
 
-    const defaultSyncDelay = getSendspinDefaultSyncDelay();
+    const defaultSyncDelay = getDefaultSyncDelay();
     const syncDelay = parseInt(
       localStorage.getItem("frontend.settings.sendspin_sync_delay") ||
         String(defaultSyncDelay),

--- a/src/helpers/utils.ts
+++ b/src/helpers/utils.ts
@@ -909,26 +909,6 @@ export const handleMenuBtnClick = function (
 };
 
 /**
- * Get platform-specific default sync delay for Sendspin player.
- * Based on testing across various platforms/browsers.
- */
-export const getSendspinDefaultSyncDelay = function (): number {
-  const ua = navigator.userAgent;
-  const isAndroid = /android/i.test(ua);
-  const isIOS = /iPad|iPhone|iPod/i.test(ua);
-  const isFirefox = /firefox/i.test(ua);
-
-  if (isIOS) {
-    return -250;
-  } else if (!isAndroid && !isFirefox) {
-    // Desktop Chrome/Chromium/Edge
-    return -300;
-  }
-  // Android, Firefox (desktop/mobile)
-  return -200;
-};
-
-/**
  * Check if a player config should be hidden from settings due to being a
  * Sendspin web player that is currently unavailable.
  *

--- a/src/views/settings/FrontendConfig.vue
+++ b/src/views/settings/FrontendConfig.vue
@@ -51,7 +51,7 @@ import {
 } from "@/components/ui/card";
 import { Spinner } from "@/components/ui/spinner";
 import { DEFAULT_MENU_ITEMS } from "@/constants";
-import { getSendspinDefaultSyncDelay } from "@/helpers/utils";
+import { getDefaultSyncDelay } from "@sendspin/sendspin-js";
 import {
   ConfigEntry,
   ConfigEntryType,
@@ -190,7 +190,7 @@ onMounted(() => {
     });
 
     // Sendspin sync delay option
-    const defaultSyncDelay = getSendspinDefaultSyncDelay();
+    const defaultSyncDelay = getDefaultSyncDelay();
     configEntries.push({
       key: "sendspin_sync_delay",
       type: ConfigEntryType.INTEGER,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2005,10 +2005,10 @@
   resolved "https://registry.yarnpkg.com/@scure/base/-/base-2.0.0.tgz#ba6371fddf92c2727e88ad6ab485db6e624f9a98"
   integrity sha512-3E1kpuZginKkek01ovG8krQ0Z44E3DHPjc5S2rjJw9lZn3KSQOs8S7wqikF/AH7iRanHypj85uGyxk0XAyC37w==
 
-"@sendspin/sendspin-js@2.0.3":
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/@sendspin/sendspin-js/-/sendspin-js-2.0.3.tgz#15c4b3feaaff30f1c1280cc5b0391001025e354c"
-  integrity sha512-UTNiqMQASqHvpmI9sGhCi+I369WgCQ1xX354ryqeBCC1CfQczHJUhgHhGnfdwLm0ctVYtQgKOyIzJLvM8onT5Q==
+"@sendspin/sendspin-js@2.0.4":
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/@sendspin/sendspin-js/-/sendspin-js-2.0.4.tgz#bc8e8054109c4f04670724ad322ea519429eae35"
+  integrity sha512-cP8vRTA7cx8Vi/hQ8/mspvUe1vcZrvRwGEYRWNwAyrBxT9r+EtPQr6t7E6n2mupFnwVyCqH2iTxCv23WQOxySA==
   dependencies:
     opus-encdec "^0.1.1"
 


### PR DESCRIPTION
Improves the defaults sync delay values based on more testing:

| OS | Browser | Before | After |
|---|---|---|---|
| iOS | All | -250 ms | -250 ms |
| Android | Chromium | -200 ms | -200 ms |
| Android | Firefox | -200 ms | -200 ms |
| Mac | Safari | -300 ms | -190 ms |
| Mac | Chromium/Edge | -300 ms | -150 ms |
| Windows | Chromium/Edge | -300 ms | -250 ms |
| Windows | Firefox | -200 ms | -250 ms |
| Linux | Chromium | -300 ms | -200 ms |
| Linux | Firefox | -200 ms | -200 ms |

Additionally, the delay defaults are now selected in the upstream `sendspin-js` library instead of just Music Assistant.