### PR TITLE
Fix widget rows reloading when toggling the player bar

### DIFF
--- a/src/components/HomeWidgetRows.vue
+++ b/src/components/HomeWidgetRows.vue
@@ -111,13 +111,13 @@ onMounted(() => {
 });
 
 watch(
-  () => store.currentUser?.preferences,
-  (newPrefs) => {
-    if (newPrefs) {
+  savedSettings,
+  (newVal) => {
+    if (newVal) {
       loadData();
     }
   },
-  { immediate: false },
+  { immediate: false, deep: true },
 );
 
 const onUpdateSettings = function (uri: string, settings: WidgetRowSettings) {


### PR DESCRIPTION
[Related Issue](https://github.com/music-assistant/support/issues/5141)

The reason is that we watch on the entire preference object of the currentUser, which is mutated when you expand/collapse the player bar, causing the Random albums/artists carousels to reload their content.

This PR narrows down the scope of the watch to the WidgetSettings only.

@stvncode Question before merging this. Do we need this watch at all?