### PR TITLE
Accept frameless query param without requiring a value

### DIFF
--- a/src/layouts/default/Default.vue
+++ b/src/layouts/default/Default.vue
@@ -49,7 +49,7 @@ watch(
 watch(
   () => route.query.frameless,
   (frameless) => {
-    if (frameless) {
+    if (frameless !== undefined) {
       store.frameless = true;
     }
   },


### PR DESCRIPTION
Check for presence of the frameless query parameter (undefined check) rather than truthiness, so ?frameless works without needing =true.