### PR TITLE
Add export playlist feature

### DIFF
--- a/src/layouts/default/ItemContextMenu.vue
+++ b/src/layouts/default/ItemContextMenu.vue
@@ -780,7 +780,7 @@ export const getContextMenuItems = async function (
         const url = URL.createObjectURL(blob);
         const link = document.createElement("a");
         link.href = url;
-        link.download = `${playlist.name}.m3u8`;
+        link.download = `${playlist.name.replace(/[\\/:*?"<>|]/g, "_")}.m3u8`;
         document.body.appendChild(link);
         link.click();
         document.body.removeChild(link);

--- a/src/layouts/default/ItemContextMenu.vue
+++ b/src/layouts/default/ItemContextMenu.vue
@@ -763,6 +763,32 @@ export const getContextMenuItems = async function (
       icon: "mdi-refresh",
     });
   }
+  // export playlist
+  if (
+    items.length === 1 &&
+    items[0] == parentItem &&
+    items[0].media_type === MediaType.PLAYLIST &&
+    items[0].provider === "library"
+  ) {
+    contextMenuItems.push({
+      label: "export_playlist",
+      labelArgs: [],
+      action: async () => {
+        const playlist = items[0] as Playlist;
+        const m3uData = await api.exportPlaylist(playlist.item_id);
+        const blob = new Blob([m3uData], { type: "audio/x-mpegurl" });
+        const url = URL.createObjectURL(blob);
+        const link = document.createElement("a");
+        link.href = url;
+        link.download = `${playlist.name}.m3u8`;
+        document.body.appendChild(link);
+        link.click();
+        document.body.removeChild(link);
+        URL.revokeObjectURL(url);
+      },
+      icon: "mdi-export",
+    });
+  }
   // map to main item (add provider mapping)
   if (
     items.length === 1 &&

--- a/src/plugins/api/index.ts
+++ b/src/plugins/api/index.ts
@@ -785,6 +785,14 @@ export class MusicAssistantApi {
     });
   }
 
+  public exportPlaylist(
+    db_playlist_id: string | number,
+  ): Promise<string> {
+    return this.sendCommand("music/playlists/export_playlist", {
+      db_playlist_id,
+    });
+  }
+
   /**
    * Get Radio stations listing from the server.
    * @param favorite - Filter by favorite status

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -81,6 +81,7 @@
     "radios": "Radio",
     "read_more": "read more",
     "refresh_item": "Refresh item",
+    "export_playlist": "Export playlist",
     "remove_library": "Remove from library",
     "remove_playlist": "Remove from playlist",
     "search": "Search",


### PR DESCRIPTION
Add a new menu option to "Export Playlist" - this relies upon and utilizes playlist export functionality added in https://github.com/music-assistant/server/pull/3387. Playlist is an m3u8 file and the _import_ function will be a seperate PR.