### PR TITLE
Add favorite button to player bar

### DIFF
--- a/src/layouts/default/PlayerOSD/Player.vue
+++ b/src/layouts/default/PlayerOSD/Player.vue
@@ -12,23 +12,30 @@
         />
       </div>
       <div class="mediacontrols-bottom-center">
-        <!-- player control buttons -->
-        <PlayerControls
-          :style="playIconStyle"
-          :visible-components="{
-            repeat: { isVisible: getBreakpointValue('bp3') },
-            shuffle: { isVisible: getBreakpointValue('bp3') },
-            play: {
-              isVisible: true,
-              icon: {
-                staticWidth: '48px',
-                staticHeight: '48px',
+        <div class="mediacontrols-center-controls">
+          <!-- favorite button for current track -->
+          <FavoriteButton
+            v-if="store.curQueueItem?.media_item && getBreakpointValue('bp3')"
+            :item="store.curQueueItem.media_item"
+          />
+          <!-- player control buttons -->
+          <PlayerControls
+            :style="playIconStyle"
+            :visible-components="{
+              repeat: { isVisible: getBreakpointValue('bp3') },
+              shuffle: { isVisible: getBreakpointValue('bp3') },
+              play: {
+                isVisible: true,
+                icon: {
+                  staticWidth: '48px',
+                  staticHeight: '48px',
+                },
               },
-            },
-            previous: { isVisible: getBreakpointValue('bp3') },
-            next: { isVisible: getBreakpointValue('bp3') },
-          }"
-        />
+              previous: { isVisible: getBreakpointValue('bp3') },
+              next: { isVisible: getBreakpointValue('bp3') },
+            }"
+          />
+        </div>
         <!-- progress bar -->
         <PlayerTimeline
           v-if="getBreakpointValue('bp6')"
@@ -42,11 +49,6 @@
       </div>
       <div class="mediacontrols-bottom-right">
         <div>
-          <!-- favorite button for current track -->
-          <FavoriteButton
-            v-if="store.curQueueItem?.media_item && getBreakpointValue('bp3')"
-            :item="store.curQueueItem.media_item"
-          />
           <!-- player extended control buttons -->
           <PlayerExtendedControls
             :queue="{
@@ -219,6 +221,12 @@ watch(
   background-color: rgb(var(--v-theme-overlay));
   .mediacontrols-bottom-center {
     width: 40%;
+  }
+
+  .mediacontrols-center-controls {
+    display: flex;
+    align-items: center;
+    justify-content: center;
   }
 
   &[data-mobile="true"] {

--- a/src/layouts/default/PlayerOSD/Player.vue
+++ b/src/layouts/default/PlayerOSD/Player.vue
@@ -11,31 +11,31 @@
           :primary-color="$vuetify.theme.current.dark ? '#fff' : '#000'"
         />
       </div>
+      <!-- favorite button for current track -->
+      <div class="mediacontrols-favorite">
+        <FavoriteButton
+          v-if="store.curQueueItem?.media_item && getBreakpointValue('bp3')"
+          :item="store.curQueueItem.media_item"
+        />
+      </div>
       <div class="mediacontrols-bottom-center">
-        <div class="mediacontrols-center-controls">
-          <!-- favorite button for current track -->
-          <FavoriteButton
-            v-if="store.curQueueItem?.media_item && getBreakpointValue('bp3')"
-            :item="store.curQueueItem.media_item"
-          />
-          <!-- player control buttons -->
-          <PlayerControls
-            :style="playIconStyle"
-            :visible-components="{
-              repeat: { isVisible: getBreakpointValue('bp3') },
-              shuffle: { isVisible: getBreakpointValue('bp3') },
-              play: {
-                isVisible: true,
-                icon: {
-                  staticWidth: '48px',
-                  staticHeight: '48px',
-                },
+        <!-- player control buttons -->
+        <PlayerControls
+          :style="playIconStyle"
+          :visible-components="{
+            repeat: { isVisible: getBreakpointValue('bp3') },
+            shuffle: { isVisible: getBreakpointValue('bp3') },
+            play: {
+              isVisible: true,
+              icon: {
+                staticWidth: '48px',
+                staticHeight: '48px',
               },
-              previous: { isVisible: getBreakpointValue('bp3') },
-              next: { isVisible: getBreakpointValue('bp3') },
-            }"
-          />
-        </div>
+            },
+            previous: { isVisible: getBreakpointValue('bp3') },
+            next: { isVisible: getBreakpointValue('bp3') },
+          }"
+        />
         <!-- progress bar -->
         <PlayerTimeline
           v-if="getBreakpointValue('bp6')"
@@ -223,10 +223,12 @@ watch(
     width: 40%;
   }
 
-  .mediacontrols-center-controls {
+  .mediacontrols-favorite {
     display: flex;
     align-items: center;
     justify-content: center;
+    margin-inline-start: auto;
+    margin-inline-end: auto;
   }
 
   &[data-mobile="true"] {

--- a/src/layouts/default/PlayerOSD/Player.vue
+++ b/src/layouts/default/PlayerOSD/Player.vue
@@ -223,14 +223,6 @@ watch(
     width: 40%;
   }
 
-  .mediacontrols-favorite {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    margin-inline-start: auto;
-    margin-inline-end: auto;
-  }
-
   &[data-mobile="true"] {
     background-color: transparent;
     padding: 8px 10px;
@@ -268,11 +260,17 @@ watch(
 }
 
 .mediacontrols-left {
-  margin-inline-end: auto;
   width: 20%;
   > div {
     padding: 0px !important;
   }
+}
+
+.mediacontrols-favorite {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  margin-inline-end: auto;
 }
 
 .mediacontrols-bottom-right {

--- a/src/layouts/default/PlayerOSD/Player.vue
+++ b/src/layouts/default/PlayerOSD/Player.vue
@@ -42,6 +42,11 @@
       </div>
       <div class="mediacontrols-bottom-right">
         <div>
+          <!-- favorite button for current track -->
+          <FavoriteButton
+            v-if="store.curQueueItem?.media_item && getBreakpointValue('bp3')"
+            :item="store.curQueueItem.media_item"
+          />
           <!-- player extended control buttons -->
           <PlayerExtendedControls
             :queue="{
@@ -124,6 +129,7 @@ import { getBreakpointValue } from "@/plugins/breakpoint";
 import { store } from "@/plugins/store";
 import vuetify from "@/plugins/vuetify";
 import { computed, ref, watch } from "vue";
+import FavoriteButton from "@/components/FavoriteButton.vue";
 import PlayerControls from "./PlayerControls.vue";
 import PlayerExtendedControls from "./PlayerExtendedControls.vue";
 import PlayerTimeline from "./PlayerTimeline.vue";


### PR DESCRIPTION
Closes https://github.com/orgs/music-assistant/discussions/3830

## What

Adds a favorite (heart) button to the mini player bar at the bottom, using the existing `FavoriteButton` component.

The button:
- Appears on breakpoints `bp3` and larger (same as shuffle/repeat controls)
- Is only shown when a media item is currently in the queue
- Reuses `api.toggleFavorite()` — same behavior as the fullscreen player and list items
- Does not appear on mobile (floating player), where screen space is limited