### PR TITLE
Disable shuffle and repeat buttons for dynamic playlists

### DIFF
--- a/src/layouts/default/PlayerOSD/PlayerControlBtn/RepeatBtn.vue
+++ b/src/layouts/default/PlayerOSD/PlayerControlBtn/RepeatBtn.vue
@@ -4,7 +4,10 @@
     v-if="isVisible && playerQueue"
     v-bind="{ ...icon, ...$attrs }"
     :disabled="
-      !playerQueue.active || playerQueue.items == 0 || isLoading || isDynamic
+      !playerQueue.active ||
+      playerQueue.items == 0 ||
+      isLoading ||
+      isSingleDynamicPlaylist
     "
     :color="
       getValueFromSources(icon?.color, [
@@ -70,12 +73,12 @@ const isLoading = computed(() => {
   );
 });
 
-const isDynamic = computed(() => {
+const isSingleDynamicPlaylist = computed(() => {
+  const items = compProps.playerQueue?.enqueued_media_items;
   return (
-    compProps.playerQueue?.enqueued_media_items?.some(
-      (item) =>
-        item.media_type === MediaType.PLAYLIST && (item as Playlist).is_dynamic,
-    ) ?? false
+    items?.length === 1 &&
+    items[0].media_type === MediaType.PLAYLIST &&
+    (items[0] as Playlist).is_dynamic
   );
 });
 </script>

--- a/src/layouts/default/PlayerOSD/PlayerControlBtn/RepeatBtn.vue
+++ b/src/layouts/default/PlayerOSD/PlayerControlBtn/RepeatBtn.vue
@@ -3,7 +3,9 @@
   <Icon
     v-if="isVisible && playerQueue"
     v-bind="{ ...icon, ...$attrs }"
-    :disabled="!playerQueue.active || playerQueue.items == 0 || isLoading"
+    :disabled="
+      !playerQueue.active || playerQueue.items == 0 || isLoading || isDynamic
+    "
     :color="
       getValueFromSources(icon?.color, [
         [playerQueue.repeat_mode == RepeatMode.OFF, undefined],
@@ -40,7 +42,12 @@ defineOptions({ inheritAttrs: false });
 import Icon, { IconProps } from "@/components/Icon.vue";
 import { getValueFromSources } from "@/helpers/utils";
 import api from "@/plugins/api";
-import { PlayerQueue, RepeatMode } from "@/plugins/api/interfaces";
+import {
+  MediaType,
+  Playlist,
+  PlayerQueue,
+  RepeatMode,
+} from "@/plugins/api/interfaces";
 import { computed } from "vue";
 import { IconRepeat, IconRepeatOff, IconRepeatOnce } from "@tabler/icons-vue";
 
@@ -60,6 +67,15 @@ const compProps = withDefaults(defineProps<Props>(), {
 const isLoading = computed(() => {
   return (
     compProps.playerQueue?.extra_attributes?.play_action_in_progress === true
+  );
+});
+
+const isDynamic = computed(() => {
+  return (
+    compProps.playerQueue?.enqueued_media_items?.some(
+      (item) =>
+        item.media_type === MediaType.PLAYLIST && (item as Playlist).is_dynamic,
+    ) ?? false
   );
 });
 </script>

--- a/src/layouts/default/PlayerOSD/PlayerControlBtn/ShuffleBtn.vue
+++ b/src/layouts/default/PlayerOSD/PlayerControlBtn/ShuffleBtn.vue
@@ -53,12 +53,12 @@ const isLoading = computed(() => {
   );
 });
 
-const isDynamic = computed(() => {
+const isSingleDynamicPlaylist = computed(() => {
+  const items = compProps.playerQueue?.enqueued_media_items;
   return (
-    compProps.playerQueue?.enqueued_media_items?.some(
-      (item) =>
-        item.media_type === MediaType.PLAYLIST && (item as Playlist).is_dynamic,
-    ) ?? false
+    items?.length === 1 &&
+    items[0].media_type === MediaType.PLAYLIST &&
+    (items[0] as Playlist).is_dynamic
   );
 });
 </script>

--- a/src/layouts/default/PlayerOSD/PlayerControlBtn/ShuffleBtn.vue
+++ b/src/layouts/default/PlayerOSD/PlayerControlBtn/ShuffleBtn.vue
@@ -4,7 +4,10 @@
     v-if="isVisible && playerQueue"
     v-bind="{ ...icon, ...$attrs }"
     :disabled="
-      !playerQueue.active || playerQueue.items == 0 || isLoading || isDynamic
+      !playerQueue.active ||
+      playerQueue.items == 0 ||
+      isLoading ||
+      isSingleDynamicPlaylist
     "
     :color="
       getValueFromSources(icon?.color, [

--- a/src/layouts/default/PlayerOSD/PlayerControlBtn/ShuffleBtn.vue
+++ b/src/layouts/default/PlayerOSD/PlayerControlBtn/ShuffleBtn.vue
@@ -3,7 +3,9 @@
   <Icon
     v-if="isVisible && playerQueue"
     v-bind="{ ...icon, ...$attrs }"
-    :disabled="!playerQueue.active || playerQueue.items == 0 || isLoading"
+    :disabled="
+      !playerQueue.active || playerQueue.items == 0 || isLoading || isDynamic
+    "
     :color="
       getValueFromSources(icon?.color, [
         [playerQueue.shuffle_enabled, 'primary', ''],
@@ -27,7 +29,7 @@ defineOptions({ inheritAttrs: false });
 import Icon, { IconProps } from "@/components/Icon.vue";
 import { getValueFromSources } from "@/helpers/utils";
 import api from "@/plugins/api";
-import { PlayerQueue } from "@/plugins/api/interfaces";
+import { MediaType, Playlist, PlayerQueue } from "@/plugins/api/interfaces";
 import { IconArrowsRight } from "@tabler/icons-vue";
 import { Shuffle } from "lucide-vue-next";
 import { computed } from "vue";
@@ -48,6 +50,15 @@ const compProps = withDefaults(defineProps<Props>(), {
 const isLoading = computed(() => {
   return (
     compProps.playerQueue?.extra_attributes?.play_action_in_progress === true
+  );
+});
+
+const isDynamic = computed(() => {
+  return (
+    compProps.playerQueue?.enqueued_media_items?.some(
+      (item) =>
+        item.media_type === MediaType.PLAYLIST && (item as Playlist).is_dynamic,
+    ) ?? false
   );
 });
 </script>

--- a/src/plugins/api/interfaces.ts
+++ b/src/plugins/api/interfaces.ts
@@ -694,6 +694,7 @@ export interface Playlist extends MediaItem {
   owner: string;
   is_editable: boolean;
   supported_mediatypes: MediaType[];
+  is_dynamic: boolean;
 }
 
 export interface Radio extends MediaItem {}
@@ -859,6 +860,7 @@ export interface PlayerQueue {
   current_item?: QueueItem;
   next_item?: QueueItem;
   radio_source: MediaItemType[];
+  enqueued_media_items: MediaItemType[];
   // extra_attributes: additional attributes for this player_queue to store/forward
   // additional data that is not part of the standard model
   // must be serializable types only


### PR DESCRIPTION
## Summary

Shuffle and repeat have no meaningful effect on dynamic playlists — the provider controls track selection, not MA. The server already skips shuffle logic for dynamic playlists in [server#3527](https://github.com/music-assistant/server/pull/3527), but the buttons in the UI remained enabled regardless.

## Changes

- **\`interfaces.ts\`**: Added \`is_dynamic: boolean\` to the \`Playlist\` interface and \`enqueued_media_items: MediaItemType[]\` to the \`PlayerQueue\` interface — both fields exist in \`music-assistant-models v1.1.109\` but were missing from the frontend type definitions
- **\`ShuffleBtn.vue\`**: Disabled when \`enqueued_media_items\` contains a \`Playlist\` with \`is_dynamic=true\`
- **\`RepeatBtn.vue\`**: Same — disabled for dynamic playlists

## Related

- [server#3527](https://github.com/music-assistant/server/pull/3527) — queue controller: dynamic playlist auto-refill (server-side shuffle already skipped there)
- [server#3555](https://github.com/music-assistant/server/pull/3555) — Infinite Mix built-in playlists (use \`is_dynamic=True\`, benefit directly from this fix)
- [server#3433](https://github.com/music-assistant/server/pull/3433) — Apple Music provider: track-based stations mapped to \`Playlist(is_dynamic=True)\`
- [discussion#5129](https://github.com/orgs/music-assistant/discussions/5129) — original feature discussion