### PR TITLE
Add track action menu to player bar

### DIFF
--- a/src/layouts/default/PlayerOSD/Player.vue
+++ b/src/layouts/default/PlayerOSD/Player.vue
@@ -254,7 +254,6 @@ watch(
 }
 
 .mediacontrols-left {
-  flex: 1 1 0;
   min-width: 0;
   display: flex;
   align-items: center;

--- a/src/layouts/default/PlayerOSD/Player.vue
+++ b/src/layouts/default/PlayerOSD/Player.vue
@@ -52,6 +52,7 @@
             }"
             :volume="{
               isVisible: store.activePlayer != undefined,
+              volumeSize: getBreakpointValue('bp8') ? '150px' : '100px',
             }"
           />
         </div>

--- a/src/layouts/default/PlayerOSD/Player.vue
+++ b/src/layouts/default/PlayerOSD/Player.vue
@@ -10,16 +10,6 @@
           :color-palette="coverImageColorPalette"
           :primary-color="$vuetify.theme.current.dark ? '#fff' : '#000'"
         />
-        <!-- favorite button for current track -->
-        <FavoriteButton
-          v-if="
-            store.curQueueItem?.media_item &&
-            getBreakpointValue('bp7') &&
-            store.activePlayer?.powered !== false
-          "
-          :item="store.curQueueItem.media_item"
-          class="mediacontrols-favorite"
-        />
       </div>
       <div class="mediacontrols-bottom-center">
         <!-- player control buttons -->
@@ -134,7 +124,6 @@ import { getBreakpointValue } from "@/plugins/breakpoint";
 import { store } from "@/plugins/store";
 import vuetify from "@/plugins/vuetify";
 import { computed, ref, watch } from "vue";
-import FavoriteButton from "@/components/FavoriteButton.vue";
 import PlayerControls from "./PlayerControls.vue";
 import PlayerExtendedControls from "./PlayerExtendedControls.vue";
 import PlayerTimeline from "./PlayerTimeline.vue";
@@ -270,14 +259,11 @@ watch(
   display: flex;
   align-items: center;
   gap: 4px;
+  margin-inline-end: auto;
   > div {
     padding: 0px !important;
     min-width: 0;
   }
-}
-
-.mediacontrols-favorite {
-  flex-shrink: 0;
 }
 
 .mediacontrols-bottom-right {

--- a/src/layouts/default/PlayerOSD/Player.vue
+++ b/src/layouts/default/PlayerOSD/Player.vue
@@ -267,10 +267,8 @@ watch(
 }
 
 .mediacontrols-bottom-right {
-  flex: 1 1 0;
+  margin-inline-start: auto;
   min-width: 0;
-  display: flex;
-  justify-content: flex-end;
   > div {
     display: inline-flex;
     align-items: center;

--- a/src/layouts/default/PlayerOSD/Player.vue
+++ b/src/layouts/default/PlayerOSD/Player.vue
@@ -254,11 +254,11 @@ watch(
 }
 
 .mediacontrols-left {
+  flex: 1 1 0;
   min-width: 0;
   display: flex;
   align-items: center;
   gap: 4px;
-  margin-inline-end: auto;
   > div {
     padding: 0px !important;
     min-width: 0;
@@ -266,8 +266,10 @@ watch(
 }
 
 .mediacontrols-bottom-right {
-  margin-inline-start: auto;
+  flex: 1 1 0;
   min-width: 0;
+  display: flex;
+  justify-content: flex-end;
   > div {
     display: inline-flex;
     align-items: center;

--- a/src/layouts/default/PlayerOSD/PlayerControlBtn/PlayerTrackMenu.vue
+++ b/src/layouts/default/PlayerOSD/PlayerControlBtn/PlayerTrackMenu.vue
@@ -7,7 +7,7 @@
         variant="button"
         icon="mdi-dots-horizontal"
         :title="$t('more_options')"
-        style="padding-left: 15px; padding-right: 20px"
+        style="padding-left: 15px; padding-right: 15px"
       />
     </template>
     <v-list>

--- a/src/layouts/default/PlayerOSD/PlayerControlBtn/PlayerTrackMenu.vue
+++ b/src/layouts/default/PlayerOSD/PlayerControlBtn/PlayerTrackMenu.vue
@@ -12,8 +12,14 @@
     </template>
     <v-list>
       <v-list-item
-        :prepend-icon="currentTrack?.favorite ? 'mdi-heart' : 'mdi-heart-outline'"
-        :title="currentTrack?.favorite ? $t('favorites_remove') : $t('tooltip.favorite')"
+        :prepend-icon="
+          currentTrack?.favorite ? 'mdi-heart' : 'mdi-heart-outline'
+        "
+        :title="
+          currentTrack?.favorite
+            ? $t('favorites_remove')
+            : $t('tooltip.favorite')
+        "
         @click="onToggleFavorite"
       />
       <v-list-item

--- a/src/layouts/default/PlayerOSD/PlayerControlBtn/PlayerTrackMenu.vue
+++ b/src/layouts/default/PlayerOSD/PlayerControlBtn/PlayerTrackMenu.vue
@@ -1,0 +1,93 @@
+<template>
+  <v-menu v-if="currentTrack">
+    <template #activator="{ props: menuProps }">
+      <Icon
+        v-bind="menuProps"
+        variant="button"
+        icon="mdi-dots-horizontal"
+        :title="$t('more_options')"
+        style="padding-left: 15px; padding-right: 20px"
+      />
+    </template>
+    <v-list>
+      <v-list-item
+        :title="$t('add_playlist')"
+        prepend-icon="mdi-plus-circle-outline"
+        @click="onAddToPlaylist"
+      />
+      <v-list-item
+        :title="$t('show_info')"
+        prepend-icon="mdi-information-outline"
+        @click="onShowInfo"
+      />
+      <v-list-item
+        v-if="radioModeSupported"
+        :title="$t('play_radio')"
+        prepend-icon="mdi-radio-tower"
+        @click="onStartRadio"
+      />
+    </v-list>
+  </v-menu>
+</template>
+
+<script setup lang="ts">
+import Icon from "@/components/Icon.vue";
+import api from "@/plugins/api";
+import {
+  MediaType,
+  ProviderFeature,
+  QueueOption,
+  type Track,
+} from "@/plugins/api/interfaces";
+import { eventbus } from "@/plugins/eventbus";
+import router from "@/plugins/router";
+import { store } from "@/plugins/store";
+import { computed } from "vue";
+
+const currentTrack = computed(() => {
+  const item = store.curQueueItem?.media_item;
+  if (item?.media_type === MediaType.TRACK) return item as Track;
+  return undefined;
+});
+
+const radioModeSupported = computed(() => {
+  const item = currentTrack.value;
+  if (!item) return false;
+  for (const provId of item.provider_mappings) {
+    if (
+      api.providers[provId.provider_instance]?.supported_features.includes(
+        ProviderFeature.SIMILAR_TRACKS,
+      )
+    )
+      return true;
+  }
+  // generic radio mode: any provider supports SIMILAR_TRACKS and track is in library
+  if (item.provider === "library") {
+    for (const prov of Object.values(api.providers)) {
+      if (prov.supported_features.includes(ProviderFeature.SIMILAR_TRACKS))
+        return true;
+    }
+  }
+  return false;
+});
+
+const onAddToPlaylist = () => {
+  if (!currentTrack.value) return;
+  eventbus.emit("playlistdialog", { items: [currentTrack.value] });
+};
+
+const onShowInfo = () => {
+  const item = currentTrack.value;
+  if (!item) return;
+  router.push({
+    name: item.media_type,
+    params: { itemId: item.item_id, provider: item.provider },
+    query: { album: item.album?.uri ?? "" },
+  });
+};
+
+const onStartRadio = () => {
+  if (!currentTrack.value) return;
+  api.playMedia([currentTrack.value.uri], QueueOption.REPLACE, true);
+};
+</script>

--- a/src/layouts/default/PlayerOSD/PlayerControlBtn/PlayerTrackMenu.vue
+++ b/src/layouts/default/PlayerOSD/PlayerControlBtn/PlayerTrackMenu.vue
@@ -2,6 +2,7 @@
   <v-menu v-if="currentTrack">
     <template #activator="{ props: menuProps }">
       <Icon
+        v-if="currentTrack"
         v-bind="menuProps"
         variant="button"
         icon="mdi-dots-horizontal"
@@ -10,6 +11,11 @@
       />
     </template>
     <v-list>
+      <v-list-item
+        :prepend-icon="currentTrack?.favorite ? 'mdi-heart' : 'mdi-heart-outline'"
+        :title="currentTrack?.favorite ? $t('favorites_remove') : $t('tooltip.favorite')"
+        @click="onToggleFavorite"
+      />
       <v-list-item
         :title="$t('add_playlist')"
         prepend-icon="mdi-plus-circle-outline"
@@ -84,6 +90,11 @@ const onShowInfo = () => {
     params: { itemId: item.item_id, provider: item.provider },
     query: { album: item.album?.uri ?? "" },
   });
+};
+
+const onToggleFavorite = () => {
+  if (!currentTrack.value) return;
+  api.toggleFavorite(currentTrack.value);
 };
 
 const onStartRadio = () => {

--- a/src/layouts/default/PlayerOSD/PlayerExtendedControls.vue
+++ b/src/layouts/default/PlayerOSD/PlayerExtendedControls.vue
@@ -11,8 +11,9 @@
   <QueueBtn
     v-if="queue && queue.isVisible"
     :color="queue.color"
-    style="padding-left: 15px; padding-right: 20px"
+    style="padding-left: 15px"
   />
+  <PlayerTrackMenu />
   <PlayerVolume
     v-if="volume && volume.isVisible && store.activePlayer"
     :player="store.activePlayer"
@@ -25,6 +26,7 @@
 <script setup lang="ts">
 import ActivePlayerPopover from "@/components/ActivePlayerPopover.vue";
 import { store } from "@/plugins/store";
+import PlayerTrackMenu from "./PlayerControlBtn/PlayerTrackMenu.vue";
 import QueueBtn from "./PlayerControlBtn/QueueBtn.vue";
 import SpeakerBtn from "./PlayerControlBtn/SpeakerBtn.vue";
 import PlayerVolume from "./PlayerVolume.vue";

--- a/src/layouts/default/PlayerOSD/PlayerExtendedControls.vue
+++ b/src/layouts/default/PlayerOSD/PlayerExtendedControls.vue
@@ -5,7 +5,7 @@
     align="end"
     child-element-id="extended-controls-speaker-button"
   />
-  <PlayerTrackMenu />
+  <PlayerTrackMenu v-if="contextMenu && contextMenu.isVisible" />
 
   <SpeakerBtn id="extended-controls-speaker-button" :color="player.color" />
 
@@ -49,6 +49,9 @@ export interface Props {
     responsiveVolumeSize?: boolean;
     color?: string;
   };
+  contextMenu?: {
+    isVisible?: boolean;
+  };
 }
 
 withDefaults(defineProps<Props>(), {
@@ -59,5 +62,6 @@ withDefaults(defineProps<Props>(), {
     volumeSize: "150px",
     responsiveVolumeSize: false,
   }),
+  contextMenu: () => ({ isVisible: true }),
 });
 </script>

--- a/src/layouts/default/PlayerOSD/PlayerExtendedControls.vue
+++ b/src/layouts/default/PlayerOSD/PlayerExtendedControls.vue
@@ -5,18 +5,15 @@
     align="end"
     child-element-id="extended-controls-speaker-button"
   />
+  <PlayerTrackMenu />
 
   <SpeakerBtn id="extended-controls-speaker-button" :color="player.color" />
 
   <QueueBtn
     v-if="queue && queue.isVisible"
     :color="queue.color"
-    :style="{
-      'padding-left': '15px',
-      'padding-right': isTrackMenuVisible ? '0px' : '20px',
-    }"
+    style="padding-left: 15px; padding-right: 20px"
   />
-  <PlayerTrackMenu />
   <PlayerVolume
     v-if="volume && volume.isVisible && store.activePlayer"
     :player="store.activePlayer"
@@ -28,17 +25,11 @@
 
 <script setup lang="ts">
 import ActivePlayerPopover from "@/components/ActivePlayerPopover.vue";
-import { MediaType } from "@/plugins/api/interfaces";
 import { store } from "@/plugins/store";
-import { computed } from "vue";
 import PlayerTrackMenu from "./PlayerControlBtn/PlayerTrackMenu.vue";
 import QueueBtn from "./PlayerControlBtn/QueueBtn.vue";
 import SpeakerBtn from "./PlayerControlBtn/SpeakerBtn.vue";
 import PlayerVolume from "./PlayerVolume.vue";
-
-const isTrackMenuVisible = computed(
-  () => store.curQueueItem?.media_item?.media_type === MediaType.TRACK,
-);
 
 // properties
 export interface Props {

--- a/src/layouts/default/PlayerOSD/PlayerExtendedControls.vue
+++ b/src/layouts/default/PlayerOSD/PlayerExtendedControls.vue
@@ -11,7 +11,10 @@
   <QueueBtn
     v-if="queue && queue.isVisible"
     :color="queue.color"
-    style="padding-left: 15px"
+    :style="{
+      'padding-left': '15px',
+      'padding-right': isTrackMenuVisible ? '0px' : '20px',
+    }"
   />
   <PlayerTrackMenu />
   <PlayerVolume
@@ -25,11 +28,17 @@
 
 <script setup lang="ts">
 import ActivePlayerPopover from "@/components/ActivePlayerPopover.vue";
+import { MediaType } from "@/plugins/api/interfaces";
 import { store } from "@/plugins/store";
+import { computed } from "vue";
 import PlayerTrackMenu from "./PlayerControlBtn/PlayerTrackMenu.vue";
 import QueueBtn from "./PlayerControlBtn/QueueBtn.vue";
 import SpeakerBtn from "./PlayerControlBtn/SpeakerBtn.vue";
 import PlayerVolume from "./PlayerVolume.vue";
+
+const isTrackMenuVisible = computed(
+  () => store.curQueueItem?.media_item?.media_type === MediaType.TRACK,
+);
 
 // properties
 export interface Props {


### PR DESCRIPTION
Adds a ⋯ menu button in the player bar (between queue button and volume slider) that appears when a Track is playing.

**Actions:**
- Add to Playlist
- Show info (navigates to track detail page)
- Start Radio (only shown when the provider supports `SIMILAR_TRACKS`)

Relates to https://github.com/orgs/music-assistant/discussions/3830