### PR TITLE
Party duplicate prevention

### DIFF
--- a/src/components/party/PartyResultItem.vue
+++ b/src/components/party/PartyResultItem.vue
@@ -27,7 +27,17 @@
 
     <!-- Actions for tracks (shown when expanded) -->
     <template v-if="item.media_type === 'track' && isExpanded">
-      <div class="result-actions">
+      <div v-if="isAdded || isInQueue" class="result-actions">
+        <span class="added-label">
+          <CircleCheck :size="16" />
+          {{
+            isAdded
+              ? $t("providers.party.guest_page.added")
+              : $t("providers.party.guest_page.already_in_queue")
+          }}
+        </span>
+      </div>
+      <div v-else class="result-actions">
         <Button
           v-if="boostEnabled"
           size="sm"
@@ -84,7 +94,7 @@ import { getMediaItemImageUrl } from "@/helpers/utils";
 import type { Artist, Track } from "@/plugins/api/interfaces";
 import { MediaType } from "@/plugins/api/interfaces";
 import { $t } from "@/plugins/i18n";
-import { ListPlus, Music, Rocket } from "lucide-vue-next";
+import { CircleCheck, ListPlus, Music, Rocket } from "lucide-vue-next";
 import { computed } from "vue";
 
 const props = defineProps<{
@@ -97,6 +107,8 @@ const props = defineProps<{
   boostBadgeColor: string;
   requestBadgeColor: string;
   addingItems: Set<string>;
+  addedItems: Set<string>;
+  queuedUris: Set<string>;
   isExpanded: boolean;
 }>();
 
@@ -106,6 +118,12 @@ const emit = defineEmits<{
   toggleExpand: [itemId: string];
 }>();
 
+const isAdded = computed(() =>
+  "uri" in props.item ? props.addedItems.has(props.item.uri) : false,
+);
+const isInQueue = computed(() =>
+  "uri" in props.item ? props.queuedUris.has(props.item.uri) : false,
+);
 const isBoostLoading = computed(() =>
   props.addingItems.has(`${props.item.media_type}-${props.item.item_id}-next`),
 );
@@ -236,5 +254,15 @@ const artistName = computed(() => {
 
 .action-btn:disabled {
   opacity: 0.3;
+}
+
+.added-label {
+  display: flex;
+  align-items: center;
+  gap: 0.375rem;
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: rgb(var(--v-theme-primary));
+  opacity: 0.8;
 }
 </style>

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1442,6 +1442,8 @@
                 "boost_limit_reached": "Boost limit reached. Next use available in {0} minutes.",
                 "current_queue": "Current Queue",
                 "filter_songs": "Songs",
+                "added": "Added",
+                "already_in_queue": "Already in queue",
                 "item_added_to_queue": "\"{0}\" added to queue",
                 "item_boosted": "\"{0}\" boosted",
                 "load_artist_tracks_failed": "Failed to load artist tracks. Please try again.",

--- a/src/views/PartyDashboardView.vue
+++ b/src/views/PartyDashboardView.vue
@@ -850,6 +850,21 @@ onMounted(async () => {
     fetchQueueItems(true);
   });
   onBeforeUnmount(unsub3);
+
+  // Re-resolve party player when a different queue starts playing (auto mode)
+  const unsub4 = api.subscribe(
+    EventType.QUEUE_UPDATED,
+    async (evt: EventMessage) => {
+      if (evt.object_id !== store.activePlayerQueue?.queue_id) {
+        const updatedQueue = api.queues[evt.object_id as string];
+        if (updatedQueue?.state === PlaybackState.PLAYING) {
+          await refreshPartyPlayer();
+          fetchQueueItems(true);
+        }
+      }
+    },
+  );
+  onBeforeUnmount(unsub4);
 });
 
 // Cleanup when leaving the party view

--- a/src/views/PartyGuestView.vue
+++ b/src/views/PartyGuestView.vue
@@ -216,6 +216,7 @@ import { useRateLimiting } from "@/composables/useRateLimiting";
 import api from "@/plugins/api";
 import {
   type Artist,
+  type EventMessage,
   EventType,
   PlaybackState,
   type QueueItem,
@@ -528,6 +529,7 @@ watch(partyConfig, (newConfig) => {
 let cleanupCountdown: (() => void) | null = null;
 let cleanupQueueEvents: (() => void) | null = null;
 let cleanupProvidersSub: (() => void) | null = null;
+let cleanupQueueUpdatedSub: (() => void) | null = null;
 
 const refreshPartyPlayer = async () => {
   try {
@@ -570,6 +572,21 @@ onMounted(async () => {
     },
   );
   cleanupProvidersSub = unsubProviders;
+
+  // Re-resolve party player when a different queue starts playing (auto mode)
+  const unsubQueueUpdated = api.subscribe(
+    EventType.QUEUE_UPDATED,
+    async (evt: EventMessage) => {
+      if (evt.object_id !== partyQueueId.value) {
+        const updatedQueue = api.queues[evt.object_id as string];
+        if (updatedQueue?.state === PlaybackState.PLAYING) {
+          await refreshPartyPlayer();
+          fetchQueueItems(true);
+        }
+      }
+    },
+  );
+  cleanupQueueUpdatedSub = unsubQueueUpdated;
 });
 
 onBeforeUnmount(() => {
@@ -577,6 +594,7 @@ onBeforeUnmount(() => {
   cleanupQueueEvents?.();
   cleanupCountdown?.();
   cleanupProvidersSub?.();
+  cleanupQueueUpdatedSub?.();
   search.cleanup();
 });
 </script>

--- a/src/views/PartyGuestView.vue
+++ b/src/views/PartyGuestView.vue
@@ -78,6 +78,8 @@
           :boost-badge-color="boostBadgeColor"
           :request-badge-color="requestBadgeColor"
           :adding-items="addingItems"
+          :added-items="addedItems"
+          :queued-uris="queuedUris"
           :is-expanded="
             expandedResultItemId === `${track.media_type}-${track.item_id}`
           "
@@ -139,6 +141,8 @@
           :boost-badge-color="boostBadgeColor"
           :request-badge-color="requestBadgeColor"
           :adding-items="addingItems"
+          :added-items="addedItems"
+          :queued-uris="queuedUris"
           :is-expanded="
             expandedResultItemId === `${item.media_type}-${item.item_id}`
           "
@@ -298,8 +302,17 @@ const {
   handleScroll,
 } = search;
 
+const queuedUris = computed(() => {
+  const uris = new Set<string>();
+  for (const item of queueItems.value) {
+    if (item.media_item?.uri) uris.add(item.media_item.uri);
+  }
+  return uris;
+});
+
 // --- Template-specific state ---
 const addingItems = ref(new Set<string>());
+const addedItems = ref(new Set<string>());
 const skippingSong = ref(false);
 const boostingQueueItemId = ref("");
 const expandedResultItemId = ref("");
@@ -405,6 +418,8 @@ const addToQueue = async (item: Track | Artist, position: "next" | "end") => {
         consumeAddQueueToken();
       }
     }
+
+    addedItems.value.add(item.uri);
 
     const message =
       position === "next"

--- a/src/views/settings/ConfigEntryField.vue
+++ b/src/views/settings/ConfigEntryField.vue
@@ -339,11 +339,12 @@ const getTranslatedActionLabel = () => {
 };
 
 const onUpdateValue = (value: ConfigValueType) => {
-  // When value is cleared (null/undefined/empty string/empty array), emit the default value instead
+  // When value is cleared (null/undefined/empty array), emit the default value instead
+  // For non-required fields, allow empty strings as a valid value
   if (
     value === null ||
     value === undefined ||
-    value === "" ||
+    (value === "" && props.confEntry.required) ||
     (Array.isArray(value) && value.length === 0)
   ) {
     emit("update:value", props.confEntry.default_value);


### PR DESCRIPTION
Adds feature to prevent duplicate track submissions by guests.
Defaults optional text on dashboard page to blank, and fixes a problem where it could not be set blank.
Fix auto selected player not being updated for guest UI.