### PR TITLE
Isolate queue elapsed time from main reactive queue objects

### DIFF
--- a/src/components/SendspinPlayer.vue
+++ b/src/components/SendspinPlayer.vue
@@ -317,7 +317,9 @@ onMounted(() => {
       const targetId = getTargetPlayerId();
       if (!targetId) return;
       const offset = evt.seekOffset || 10;
-      const elapsed = lastSeekPos ?? store.activePlayerQueue?.elapsed_time ?? 0;
+      const queueId = store.activePlayerQueue?.queue_id;
+      const queueTime = queueId ? api.queueElapsedTime[queueId] : undefined;
+      const elapsed = lastSeekPos ?? queueTime?.elapsed_time ?? 0;
       const newPos = Math.round(elapsed + offset);
       lastSeekPos = newPos;
       resetLastSeekPos();
@@ -328,7 +330,9 @@ onMounted(() => {
       const targetId = getTargetPlayerId();
       if (!targetId) return;
       const offset = evt.seekOffset || 10;
-      const elapsed = lastSeekPos ?? store.activePlayerQueue?.elapsed_time ?? 0;
+      const queueId = store.activePlayerQueue?.queue_id;
+      const queueTime = queueId ? api.queueElapsedTime[queueId] : undefined;
+      const elapsed = lastSeekPos ?? queueTime?.elapsed_time ?? 0;
       const newPos = Math.round(Math.max(0, elapsed - offset));
       lastSeekPos = newPos;
       resetLastSeekPos();

--- a/src/components/party/PartyTrackCard.vue
+++ b/src/components/party/PartyTrackCard.vue
@@ -67,6 +67,7 @@ import type { QueueItem } from "@/plugins/api/interfaces";
 import { $t } from "@/plugins/i18n";
 import { Rocket, UserRound } from "lucide-vue-next";
 import { store } from "@/plugins/store";
+import api from "@/plugins/api";
 import computeElapsedTime from "@/helpers/elapsed";
 
 const { config: partyConfig } = usePartyConfig();
@@ -230,14 +231,19 @@ const progressPercentage = computed(() => {
     return 0;
   }
 
-  // Get elapsed time from the active player queue
+  // Get elapsed time from the isolated reactive map
   const queue = store.activePlayerQueue;
-  if (queue?.elapsed_time != null && queue?.elapsed_time_last_updated != null) {
+  const queueId = queue?.queue_id;
+  const queueTime = queueId ? api.queueElapsedTime[queueId] : undefined;
+  if (
+    queueTime?.elapsed_time != null &&
+    queueTime?.elapsed_time_last_updated != null
+  ) {
     const elapsed =
       computeElapsedTime(
-        queue.elapsed_time,
-        queue.elapsed_time_last_updated,
-        queue.state,
+        queueTime.elapsed_time,
+        queueTime.elapsed_time_last_updated,
+        queue!.state,
       ) ?? 0;
     return Math.min((elapsed / duration) * 100, 100);
   }

--- a/src/composables/useLyricsElapsedTime.ts
+++ b/src/composables/useLyricsElapsedTime.ts
@@ -10,6 +10,7 @@ import { ref, watchEffect, onScopeDispose, type Ref } from "vue";
 import { PlaybackState } from "@/plugins/api/interfaces";
 import { store } from "@/plugins/store";
 import { computeElapsedTime } from "@/helpers/elapsed";
+import api from "@/plugins/api";
 
 export function useLyricsElapsedTime(enabled?: Ref<boolean>) {
   const elapsedTime = ref(0);
@@ -17,14 +18,16 @@ export function useLyricsElapsedTime(enabled?: Ref<boolean>) {
 
   const update = () => {
     const queue = store.activePlayerQueue;
+    const queueId = queue?.queue_id;
+    const queueTime = queueId ? api.queueElapsedTime[queueId] : undefined;
     if (
-      queue?.elapsed_time != null &&
-      queue?.elapsed_time_last_updated != null
+      queueTime?.elapsed_time != null &&
+      queueTime?.elapsed_time_last_updated != null
     ) {
       elapsedTime.value =
         computeElapsedTime(
-          queue.elapsed_time,
-          queue.elapsed_time_last_updated,
+          queueTime.elapsed_time,
+          queueTime.elapsed_time_last_updated,
           store.activePlayer?.playback_state,
         ) ?? 0;
     }

--- a/src/helpers/useMediaBrowserMetaData.ts
+++ b/src/helpers/useMediaBrowserMetaData.ts
@@ -81,9 +81,13 @@ export function useMediaBrowserMetaData(player_id?: string) {
     },
     { immediate: true },
   );
+  const queueElapsed = computed(() => {
+    const queueId = playerQueue.value?.queue_id;
+    return queueId ? api.queueElapsedTime[queueId] : undefined;
+  });
   const unwatch_position = watch(
     () => [
-      playerQueue.value?.elapsed_time,
+      queueElapsed.value?.elapsed_time,
       playerQueue.value?.current_item?.duration,
     ],
     () => {
@@ -99,8 +103,8 @@ export function useMediaBrowserMetaData(player_id?: string) {
       const duration = playerQueue.value?.current_item?.duration || 1;
       const position = Math.min(
         duration,
-        playerQueue.value?.elapsed_time != null
-          ? playerQueue.value?.elapsed_time
+        queueElapsed.value?.elapsed_time != null
+          ? queueElapsed.value.elapsed_time
           : 0,
       );
       navigator.mediaSession.setPositionState({

--- a/src/layouts/default/PlayerOSD/PlayerBrowserMediaControls.vue
+++ b/src/layouts/default/PlayerOSD/PlayerBrowserMediaControls.vue
@@ -109,8 +109,10 @@ const seekHandler = function (
     to = evt.seekTime;
   } else if (evt.action === "seekforward" || evt.action === "seekbackward") {
     const offset = evt.seekOffset || 10;
+    const queueId = store.activePlayerQueue?.queue_id;
+    const queueTime = queueId ? api.queueElapsedTime[queueId] : undefined;
     const elapsed_time =
-      lastSeekPos != null ? lastSeekPos : store.activePlayerQueue?.elapsed_time;
+      lastSeekPos != null ? lastSeekPos : queueTime?.elapsed_time;
     if (elapsed_time == null) return;
     if (evt.action === "seekbackward") {
       to = elapsed_time - offset;

--- a/src/layouts/default/PlayerOSD/PlayerTimeline.vue
+++ b/src/layouts/default/PlayerOSD/PlayerTimeline.vue
@@ -194,13 +194,18 @@ const computedElapsedTime = computed(() => {
     return curTimeValue.value;
   }
 
-  // Prefer queue-level elapsed_time if available
+  // Prefer queue-level elapsed_time if available (from isolated reactive map)
   const queue = store.activePlayerQueue;
-  if (queue?.elapsed_time != null && queue?.elapsed_time_last_updated != null) {
+  const queueId = queue?.queue_id;
+  const queueTime = queueId ? api.queueElapsedTime[queueId] : undefined;
+  if (
+    queueTime?.elapsed_time != null &&
+    queueTime?.elapsed_time_last_updated != null
+  ) {
     const computed = computeElapsedTime(
-      queue.elapsed_time,
-      queue.elapsed_time_last_updated,
-      queue.state,
+      queueTime.elapsed_time,
+      queueTime.elapsed_time_last_updated,
+      queue!.state,
     );
     return computed ?? 0;
   }

--- a/src/plugins/api/index.ts
+++ b/src/plugins/api/index.ts
@@ -80,6 +80,12 @@ export class MusicAssistantApi {
   public serverInfo = ref<ServerInfoMessage>();
   public players = reactive<{ [player_id: string]: Player }>({});
   public queues = reactive<{ [queue_id: string]: PlayerQueue }>({});
+  public queueElapsedTime = reactive<{
+    [queue_id: string]: {
+      elapsed_time: number;
+      elapsed_time_last_updated: number;
+    };
+  }>({});
   public providers = reactive<{ [instance_id: string]: ProviderInstance }>({});
   public providerManifests = reactive<{ [domain: string]: ProviderManifest }>(
     {},
@@ -377,6 +383,9 @@ export class MusicAssistantApi {
     // Clear reactive state
     Object.keys(this.players).forEach((key) => delete this.players[key]);
     Object.keys(this.queues).forEach((key) => delete this.queues[key]);
+    Object.keys(this.queueElapsedTime).forEach(
+      (key) => delete this.queueElapsedTime[key],
+    );
     Object.keys(this.providers).forEach((key) => delete this.providers[key]);
     Object.keys(this.providerManifests).forEach(
       (key) => delete this.providerManifests[key],
@@ -2153,16 +2162,33 @@ export class MusicAssistantApi {
     if (msg.event == EventType.QUEUE_ADDED) {
       const queue = msg.data as PlayerQueue;
       this.queues[queue.queue_id] = queue;
+      this.queueElapsedTime[queue.queue_id] = {
+        elapsed_time: queue.elapsed_time,
+        elapsed_time_last_updated: queue.elapsed_time_last_updated,
+      };
     } else if (msg.event == EventType.QUEUE_UPDATED) {
       const queue = msg.data as PlayerQueue;
       if (queue.queue_id in this.queues)
         Object.assign(this.queues[queue.queue_id], queue);
       else this.queues[queue.queue_id] = queue;
+      this.queueElapsedTime[queue.queue_id] = {
+        elapsed_time: queue.elapsed_time,
+        elapsed_time_last_updated: queue.elapsed_time_last_updated,
+      };
     } else if (msg.event == EventType.QUEUE_TIME_UPDATED) {
       const queueId = msg.object_id as string;
       if (queueId in this.queues) {
-        this.queues[queueId].elapsed_time = msg.data as unknown as number;
-        this.queues[queueId].elapsed_time_last_updated = Date.now() / 1000;
+        const now = Date.now() / 1000;
+        const elapsed = msg.data as unknown as number;
+        if (queueId in this.queueElapsedTime) {
+          this.queueElapsedTime[queueId].elapsed_time = elapsed;
+          this.queueElapsedTime[queueId].elapsed_time_last_updated = now;
+        } else {
+          this.queueElapsedTime[queueId] = {
+            elapsed_time: elapsed,
+            elapsed_time_last_updated: now,
+          };
+        }
       }
     } else if (msg.event == EventType.PLAYER_ADDED) {
       const player = msg.data as Player;
@@ -2175,6 +2201,7 @@ export class MusicAssistantApi {
     } else if (msg.event == EventType.PLAYER_REMOVED) {
       delete this.players[msg.object_id!];
       delete this.queues[msg.object_id!];
+      delete this.queueElapsedTime[msg.object_id!];
     } else if (msg.event == EventType.CORE_STATE_UPDATED) {
       // Update serverInfo with the new server state
       this.serverInfo.value = msg.data as ServerInfoMessage;
@@ -2731,6 +2758,10 @@ export class MusicAssistantApi {
     }
     for (const queue of await this.getPlayerQueues()) {
       this.queues[queue.queue_id] = queue;
+      this.queueElapsedTime[queue.queue_id] = {
+        elapsed_time: queue.elapsed_time,
+        elapsed_time_last_updated: queue.elapsed_time_last_updated,
+      };
     }
 
     for (const prov of await this.sendCommand<ProviderManifest[]>(


### PR DESCRIPTION

QUEUE_TIME_UPDATED events were mutating elapsed_time directly on the reactive queue objects, triggering re-renders in every component reading activePlayerQueue (~158 references across 9 OSD files).

Introduce a separate api.queueElapsedTime reactive map that only subscribers to elapsed time will track. This prevents high-frequency time updates from dirtying the broad queue object and cascading unnecessary DOM commits and layerization.

Cuts down on CPU use by approximately half (combined with the other performance PR)
<img width="481" height="451" alt="Screenshot 2026-04-04 at 10 18 46 PM" src="https://github.com/user-attachments/assets/b5855dfc-ec47-4f7f-a8f6-d57f79ddec5a" />
<img width="481" height="451" alt="Screenshot 2026-04-04 at 10 22 37 PM" src="https://github.com/user-attachments/assets/4761cd7d-483e-4b69-82b8-76a6fd7adc8e" />
