### PR TITLE
Add PlayerNameLabel component and redesign footer track info layout

### DIFF
--- a/src/components/MarqueeText.vue
+++ b/src/components/MarqueeText.vue
@@ -209,15 +209,15 @@ const setup = () => {
   });
   if (!containerRef.value || !scrollingRef.value) return;
   // Setup observers
-  scrollingObserver.observe(scrollingRef.value, {
+  scrollingObserver.observe(scrollingRef.value as unknown as Node, {
     childList: true,
     subtree: true,
     characterData: true,
     attributes: true,
     attributeFilter: ["style", "class"],
   });
-  containerObserver.observe(containerRef.value);
-  visibilityObserver.observe(containerRef.value);
+  containerObserver.observe(containerRef.value as unknown as Element);
+  visibilityObserver.observe(containerRef.value as unknown as Element);
 };
 
 // Cleanup observers and animation

--- a/src/components/PlayerCard.vue
+++ b/src/components/PlayerCard.vue
@@ -54,7 +54,6 @@
         >
           <PlayerNameLabel
             :player="player"
-            :icon-size="16"
             :truncate="isBuiltinPlayer(player) ? 12 : 27"
           />
           <!-- append small icon for builtin player -->

--- a/src/components/PlayerCard.vue
+++ b/src/components/PlayerCard.vue
@@ -43,14 +43,27 @@
 
       <!-- playername -->
       <template #title>
-        <!-- special builtin player (web player or companion native player) -->
         <div
-          v-if="isBuiltinPlayer(player)"
-          style="font-size: 0.88rem; line-height: 1.3"
+          style="
+            font-size: 0.88rem;
+            line-height: 1.3;
+            display: flex;
+            align-items: center;
+            gap: 6px;
+          "
         >
-          <span>{{ getPlayerName(player, 12) }}</span>
-          <!-- append small icon to the title -->
-          <v-chip density="compact" size="small" class="ml-2" outlined>
+          <PlayerNameLabel
+            :player="player"
+            :icon-size="16"
+            :truncate="isBuiltinPlayer(player) ? 12 : 27"
+          />
+          <!-- append small icon for builtin player -->
+          <v-chip
+            v-if="isBuiltinPlayer(player)"
+            density="compact"
+            size="small"
+            outlined
+          >
             <v-icon
               size="14"
               :icon="
@@ -61,10 +74,6 @@
               $t("this_device")
             }}</span>
           </v-chip>
-        </div>
-        <!-- regular player -->
-        <div v-else style="font-size: 0.88rem; line-height: 1.3">
-          {{ getPlayerName(player, 27) }}
         </div>
       </template>
 
@@ -156,20 +165,21 @@
           @click.stop="$emit('toggle-expand', player)"
         >
           <v-badge
+            v-if="groupMemberCount > 1"
             color="primary"
             :offset-x="-5"
             :offset-y="-5"
-            :content="
-              player.type == PlayerType.GROUP
-                ? player.group_members.length
-                : player.group_members.length || 1
-            "
+            :content="groupMemberCount"
             class="group-badge"
           >
-            <Speaker
-              :size="getBreakpointValue({ breakpoint: 'phone' }) ? 24 : 26"
+            <SpeakerGroupIcon
+              :size="getBreakpointValue({ breakpoint: 'phone' }) ? 24 : 28"
             />
           </v-badge>
+          <SpeakerGroupIcon
+            v-else
+            :size="getBreakpointValue({ breakpoint: 'phone' }) ? 24 : 28"
+          />
         </Button>
 
         <!-- play/pause button -->
@@ -243,7 +253,6 @@ import { getPlayerMenuItems } from "@/helpers/player_menu_items";
 import {
   getColorPalette,
   getMediaImageUrl,
-  getPlayerName,
   ImageColorPalette,
   isBuiltinPlayer,
 } from "@/helpers/utils";
@@ -260,7 +269,9 @@ import { eventbus } from "@/plugins/eventbus";
 import { store } from "@/plugins/store";
 import vuetify from "@/plugins/vuetify";
 import { webPlayer } from "@/plugins/web_player";
-import { MoreVertical, Pause, Play, Power, Speaker } from "lucide-vue-next";
+import SpeakerGroupIcon from "@/components/icons/SpeakerGroupIcon.vue";
+import PlayerNameLabel from "@/components/PlayerNameLabel.vue";
+import { MoreVertical, Pause, Play, Power } from "lucide-vue-next";
 import { computed, ref, toRef, watch } from "vue";
 
 // properties
@@ -281,6 +292,13 @@ defineEmits<{
   (e: "click", player: Player): void;
   (e: "toggle-expand", player: Player): void;
 }>();
+
+const groupMemberCount = computed(() => {
+  if (compProps.player.type === PlayerType.GROUP) {
+    return compProps.player.group_members.length;
+  }
+  return compProps.player.group_members.length || 1;
+});
 
 const playerQueue = computed(() => {
   if (

--- a/src/components/PlayerNameLabel.vue
+++ b/src/components/PlayerNameLabel.vue
@@ -33,7 +33,7 @@ interface Props {
 
 const props = withDefaults(defineProps<Props>(), {
   player: undefined,
-  iconSize: 24,
+  iconSize: 20,
   truncate: 26,
   clickable: false,
 });

--- a/src/components/PlayerNameLabel.vue
+++ b/src/components/PlayerNameLabel.vue
@@ -1,0 +1,76 @@
+<template>
+  <span
+    class="player-name inline-flex items-center gap-1.5 whitespace-nowrap text-sm font-medium"
+    :class="{
+      'player-name--playing': isPlaying,
+      'cursor-pointer': clickable,
+    }"
+    @click="handleClick"
+  >
+    <component :is="speakerIcon" :size="iconSize" :playing="isPlaying" />
+    {{ displayName }}
+  </span>
+</template>
+
+<script setup lang="ts">
+import { computed } from "vue";
+import SpeakerIcon from "@/components/icons/SpeakerIcon.vue";
+import SpeakerGroupIcon from "@/components/icons/SpeakerGroupIcon.vue";
+import { getPlayerName } from "@/helpers/utils";
+import { store } from "@/plugins/store";
+import {
+  PlaybackState,
+  PlayerType,
+  type Player,
+} from "@/plugins/api/interfaces";
+
+interface Props {
+  player?: Player;
+  iconSize?: number;
+  truncate?: number;
+  clickable?: boolean;
+}
+
+const props = withDefaults(defineProps<Props>(), {
+  player: undefined,
+  iconSize: 24,
+  truncate: 26,
+  clickable: false,
+});
+
+const speakerIcon = computed(() => {
+  const p = props.player ?? store.activePlayer;
+  if (!p) return SpeakerIcon;
+  if (
+    p.type === PlayerType.GROUP ||
+    (p.type === PlayerType.PLAYER && p.group_members.length > 0)
+  ) {
+    return SpeakerGroupIcon;
+  }
+  return SpeakerIcon;
+});
+
+const displayName = computed(() => {
+  const p = props.player ?? store.activePlayer;
+  if (!p) return "";
+  return getPlayerName(p, props.truncate);
+});
+
+const isPlaying = computed(() => {
+  const p = props.player ?? store.activePlayer;
+  if (!p) return false;
+  return p.playback_state === PlaybackState.PLAYING;
+});
+
+function handleClick() {
+  if (props.clickable) {
+    store.showPlayersMenu = true;
+  }
+}
+</script>
+
+<style scoped>
+.player-name--playing :deep(svg) {
+  color: rgb(var(--v-theme-primary));
+}
+</style>

--- a/src/components/dsp/DSPParametricEQ.vue
+++ b/src/components/dsp/DSPParametricEQ.vue
@@ -907,7 +907,7 @@ onMounted(() => {
   });
 
   if (graphContainer.value) {
-    resizeObserver.observe(graphContainer.value);
+    resizeObserver.observe(graphContainer.value as unknown as Element);
   }
 
   return () => {

--- a/src/components/icons/SpeakerGroupIcon.vue
+++ b/src/components/icons/SpeakerGroupIcon.vue
@@ -1,0 +1,96 @@
+<template>
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    :width="size"
+    :height="size"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    stroke-width="2"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+  >
+    <!-- mask to hide the back speaker where it overlaps the front -->
+    <defs>
+      <mask id="back-speaker-mask">
+        <rect width="24" height="24" fill="white" />
+        <rect width="15" height="19" x="1" y="5" rx="2" fill="black" />
+      </mask>
+    </defs>
+    <!-- back speaker (offset), masked to hide behind front -->
+    <rect
+      width="13"
+      height="17"
+      x="9"
+      y="1"
+      rx="2"
+      opacity="0.45"
+      mask="url(#back-speaker-mask)"
+    />
+    <!-- front speaker -->
+    <rect width="13" height="17" x="2" y="6" rx="2" />
+    <circle cx="8.5" cy="15" r="2.8" />
+    <line x1="8.5" y1="9" x2="8.51" y2="9" />
+    <!-- cone ripples -->
+    <template v-if="playing">
+      <circle cx="8.5" cy="15" r="2.8" class="ripple ripple--1" />
+      <circle cx="8.5" cy="15" r="2.8" class="ripple ripple--2" />
+      <!-- tweeter ripple -->
+      <circle cx="8.5" cy="9" r="1" class="ripple-sm ripple--1" />
+      <circle cx="8.5" cy="9" r="1" class="ripple-sm ripple--2" />
+    </template>
+  </svg>
+</template>
+
+<script setup lang="ts">
+interface Props {
+  size?: number;
+  playing?: boolean;
+}
+withDefaults(defineProps<Props>(), {
+  size: 24,
+  playing: false,
+});
+</script>
+
+<style scoped>
+.ripple {
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 2;
+  animation: ripple-wave 1s ease-out infinite;
+}
+
+.ripple-sm {
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 2;
+  animation: ripple-wave-sm 1s ease-out infinite;
+}
+
+.ripple--2 {
+  animation-delay: 0.5s;
+}
+
+@keyframes ripple-wave {
+  0% {
+    r: 2.8;
+    opacity: 0.7;
+  }
+  100% {
+    r: 6;
+    opacity: 0;
+  }
+}
+
+@keyframes ripple-wave-sm {
+  0% {
+    r: 1;
+    opacity: 0.7;
+  }
+  100% {
+    r: 3;
+    opacity: 0;
+  }
+}
+</style>

--- a/src/components/icons/SpeakerIcon.vue
+++ b/src/components/icons/SpeakerIcon.vue
@@ -1,0 +1,78 @@
+<template>
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    :width="size"
+    :height="size"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    stroke-width="2"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+  >
+    <rect width="16" height="20" x="4" y="2" rx="2" />
+    <circle cx="12" cy="14" r="4" />
+    <line x1="12" y1="6" x2="12.01" y2="6" />
+    <!-- cone ripples -->
+    <template v-if="playing">
+      <circle cx="12" cy="14" r="4" class="ripple ripple--1" />
+      <circle cx="12" cy="14" r="4" class="ripple ripple--2" />
+      <!-- tweeter ripple -->
+      <circle cx="12" cy="6" r="1" class="ripple-sm ripple--1" />
+      <circle cx="12" cy="6" r="1" class="ripple-sm ripple--2" />
+    </template>
+  </svg>
+</template>
+
+<script setup lang="ts">
+interface Props {
+  size?: number;
+  playing?: boolean;
+}
+withDefaults(defineProps<Props>(), {
+  size: 24,
+  playing: false,
+});
+</script>
+
+<style scoped>
+.ripple {
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 2;
+  animation: ripple-wave 1s ease-out infinite;
+}
+
+.ripple-sm {
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 2;
+  animation: ripple-wave-sm 1s ease-out infinite;
+}
+
+.ripple--2 {
+  animation-delay: 0.5s;
+}
+
+@keyframes ripple-wave {
+  0% {
+    r: 4;
+    opacity: 0.7;
+  }
+  100% {
+    r: 8;
+    opacity: 0;
+  }
+}
+
+@keyframes ripple-wave-sm {
+  0% {
+    r: 1;
+    opacity: 0.7;
+  }
+  100% {
+    r: 3.5;
+    opacity: 0;
+  }
+}
+</style>

--- a/src/components/party/PartyQR.vue
+++ b/src/components/party/PartyQR.vue
@@ -161,7 +161,7 @@ onMounted(async () => {
         }
       }
     });
-    resizeObserver.observe(qrContainer.value);
+    resizeObserver.observe(qrContainer.value as unknown as Element);
   }
 
   // Subscribe to PROVIDERS_UPDATED to detect when party provider is

--- a/src/layouts/default/PlayerOSD/Player.vue
+++ b/src/layouts/default/PlayerOSD/Player.vue
@@ -6,7 +6,6 @@
       <div class="mediacontrols-left">
         <PlayerTrackDetails
           :show-quality-details-btn="getBreakpointValue('bp9') ? true : false"
-          :show-only-artist="getBreakpointValue('bp7') ? false : true"
           :color-palette="coverImageColorPalette"
           :primary-color="$vuetify.theme.current.dark ? '#fff' : '#000'"
         />
@@ -271,6 +270,7 @@ watch(
   min-width: 0;
   display: flex;
   justify-content: flex-end;
+  align-items: flex-start;
   > div {
     display: inline-flex;
     align-items: center;

--- a/src/layouts/default/PlayerOSD/PlayerExtendedControls.vue
+++ b/src/layouts/default/PlayerOSD/PlayerExtendedControls.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="extended-controls">
     <div v-if="store.activePlayer" class="extended-controls__label">
-      <PlayerNameLabel clickable :icon-size="20" />
+      <PlayerNameLabel clickable />
     </div>
     <div class="extended-controls__buttons">
       <PlayerTrackMenu v-if="contextMenu && contextMenu.isVisible" />

--- a/src/layouts/default/PlayerOSD/PlayerExtendedControls.vue
+++ b/src/layouts/default/PlayerOSD/PlayerExtendedControls.vue
@@ -1,34 +1,31 @@
 <template>
-  <ActivePlayerPopover
-    v-if="!store.mobileLayout && player && player.isVisible"
-    auto-show
-    align="end"
-    child-element-id="extended-controls-speaker-button"
-  />
-  <PlayerTrackMenu v-if="contextMenu && contextMenu.isVisible" />
-
-  <SpeakerBtn id="extended-controls-speaker-button" :color="player.color" />
-
-  <QueueBtn
-    v-if="queue && queue.isVisible"
-    :color="queue.color"
-    style="padding-left: 15px; padding-right: 20px"
-  />
-  <PlayerVolume
-    v-if="volume && volume.isVisible && store.activePlayer"
-    :player="store.activePlayer"
-    :width="volume.volumeSize || '150px'"
-    :allow-wheel="true"
-    :prefer-group-volume="true"
-  />
+  <div class="extended-controls">
+    <div v-if="store.activePlayer" class="extended-controls__label">
+      <PlayerNameLabel clickable :icon-size="20" />
+    </div>
+    <div class="extended-controls__buttons">
+      <PlayerTrackMenu v-if="contextMenu && contextMenu.isVisible" />
+      <QueueBtn
+        v-if="queue && queue.isVisible"
+        :color="queue.color"
+        style="padding-left: 15px; padding-right: 20px"
+      />
+      <PlayerVolume
+        v-if="volume && volume.isVisible && store.activePlayer"
+        :player="store.activePlayer"
+        :width="volume.volumeSize || '150px'"
+        :allow-wheel="true"
+        :prefer-group-volume="true"
+      />
+    </div>
+  </div>
 </template>
 
 <script setup lang="ts">
-import ActivePlayerPopover from "@/components/ActivePlayerPopover.vue";
+import PlayerNameLabel from "@/components/PlayerNameLabel.vue";
 import { store } from "@/plugins/store";
 import PlayerTrackMenu from "./PlayerControlBtn/PlayerTrackMenu.vue";
 import QueueBtn from "./PlayerControlBtn/QueueBtn.vue";
-import SpeakerBtn from "./PlayerControlBtn/SpeakerBtn.vue";
 import PlayerVolume from "./PlayerVolume.vue";
 
 // properties
@@ -65,3 +62,24 @@ withDefaults(defineProps<Props>(), {
   contextMenu: () => ({ isVisible: true }),
 });
 </script>
+
+<style scoped>
+.extended-controls {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+}
+
+.extended-controls__label {
+  padding-bottom: 2px;
+  align-self: flex-end;
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.extended-controls__buttons {
+  display: flex;
+  align-items: center;
+}
+</style>

--- a/src/layouts/default/PlayerOSD/PlayerFullscreen.vue
+++ b/src/layouts/default/PlayerOSD/PlayerFullscreen.vue
@@ -498,7 +498,6 @@
           "
         >
           <PlayerNameLabel
-            :icon-size="18"
             @click.stop="
               () => {
                 store.showPlayersMenu = true;

--- a/src/layouts/default/PlayerOSD/PlayerFullscreen.vue
+++ b/src/layouts/default/PlayerOSD/PlayerFullscreen.vue
@@ -41,13 +41,10 @@
             </v-card>
           </v-menu>
 
-          <SpeakerBtn
+          <PlayerNameLabel
             v-if="!showExpandedPlayerSelectButton"
-            @click="
-              () => {
-                store.showFullscreenPlayer = false;
-              }
-            "
+            clickable
+            @click="store.showFullscreenPlayer = false"
           />
 
           <Button icon @click.stop="openQueueMenu">
@@ -500,19 +497,15 @@
             padding-top: 15px;
           "
         >
-          <v-btn
-            class="responsive-icon-holder-btn"
-            variant="outlined"
-            @click="
+          <PlayerNameLabel
+            :icon-size="18"
+            @click.stop="
               () => {
                 store.showPlayersMenu = true;
                 store.showFullscreenPlayer = false;
               }
             "
-          >
-            <v-icon :icon="store.activePlayer?.icon || 'mdi-speaker'" />
-            {{ store.activePlayer ? getPlayerName(store.activePlayer) : "" }}
-          </v-btn>
+          />
         </div>
       </div>
     </v-card>
@@ -527,6 +520,7 @@ import LyricsViewer from "@/components/LyricsViewer.vue";
 import MarqueeText from "@/components/MarqueeText.vue";
 import MediaItemThumb from "@/components/MediaItemThumb.vue";
 import NowPlayingBadge from "@/components/NowPlayingBadge.vue";
+import PlayerNameLabel from "@/components/PlayerNameLabel.vue";
 import PartyPlayerBadge from "@/components/party/PartyPlayerBadge.vue";
 import QualityDetailsBtn from "@/components/QualityDetailsBtn.vue";
 import { useLyricsElapsedTime } from "@/composables/useLyricsElapsedTime";
@@ -537,7 +531,6 @@ import {
   ImageColorPalette,
   formatDuration,
   getMediaImageUrl,
-  getPlayerName,
   sleep,
 } from "@/helpers/utils";
 import NextBtn from "@/layouts/default/PlayerOSD/PlayerControlBtn/NextBtn.vue";
@@ -580,7 +573,6 @@ import {
 import { useDisplay } from "vuetify";
 import { ContextMenuItem } from "../ItemContextMenu.vue";
 import QueueBtn from "./PlayerControlBtn/QueueBtn.vue";
-import SpeakerBtn from "./PlayerControlBtn/SpeakerBtn.vue";
 import PlayerTimeline from "./PlayerTimeline.vue";
 
 const { name } = useDisplay();
@@ -617,7 +609,10 @@ const tempHide = ref(false);
 const requestBadgeColor = ref("#2196f3");
 const boostBadgeColor = ref("#ff5722");
 
-const { elapsedTime: lyricsElapsedTime } = useLyricsElapsedTime();
+const lyricsEnabled = computed(
+  () => store.showFullscreenPlayer && activeQueuePanel.value === 2,
+);
+const { elapsedTime: lyricsElapsedTime } = useLyricsElapsedTime(lyricsEnabled);
 
 // Computed properties
 

--- a/src/layouts/default/PlayerOSD/PlayerTrackDetails.vue
+++ b/src/layouts/default/PlayerOSD/PlayerTrackDetails.vue
@@ -51,32 +51,25 @@
           cursor: 'pointer',
           color: primaryColor,
         }"
-        class="d-flex align-center"
+        @click="store.showFullscreenPlayer = true"
       >
-        <div v-if="store.activePlayer && store.activePlayer?.powered != false">
-          {{ getPlayerName(store.activePlayer) }}
-        </div>
-        <!-- player name as title if its powered off-->
+        <template v-if="store.activePlayer?.current_media?.title">
+          <div class="ma-line-clamp-1">
+            {{ store.activePlayer.current_media.title }}
+          </div>
+        </template>
         <div
           v-else-if="store.activePlayer?.powered == false"
-          @click="store.showPlayersMenu = true"
+          @click.stop="store.showPlayersMenu = true"
         >
-          {{ store.activePlayer?.name }}
+          {{ store.activePlayer?.name }} — {{ $t("off") }}
         </div>
-        <!-- no player selected message -->
-        <div v-else @click="store.showPlayersMenu = true">
+        <div
+          v-else-if="!store.activePlayer"
+          @click.stop="store.showPlayersMenu = true"
+        >
           {{ $t("no_player") }}
         </div>
-        <NowPlayingBadge
-          v-if="
-            store.activePlayer &&
-            store.activePlayer?.powered != false &&
-            store.activePlayer?.playback_state != PlaybackState.IDLE
-          "
-          :show-badge="false"
-          :show-icon="true"
-          icon-style="margin-left: 12px; margin-bottom: 4px;"
-        />
       </div>
     </template>
     <!-- append chip(s): quality -->
@@ -102,37 +95,21 @@
         }"
         @click="store.showFullscreenPlayer = true"
       >
-        <!-- player powered off -->
-        <div v-if="store.activePlayer?.powered == false">
-          {{ $t("off") }}
-        </div>
-        <template v-else-if="store.activePlayer?.current_media?.title">
-          <div class="ma-line-clamp-1">
+        <template v-if="store.activePlayer?.current_media?.title">
+          <div
+            v-if="store.activePlayer?.current_media?.artist"
+            class="ma-line-clamp-1"
+          >
             <MarqueeText :sync="marqueeSync">
-              {{ store.activePlayer.current_media.title }}
+              {{ store.activePlayer.current_media.artist }}
             </MarqueeText>
           </div>
-          <div class="ma-line-clamp-1">
+          <div
+            v-if="store.activePlayer?.current_media?.album"
+            class="ma-line-clamp-1"
+          >
             <MarqueeText :sync="marqueeSync">
-              <!-- artists(s) + album -->
-              <span
-                v-if="
-                  store.activePlayer?.current_media?.artist &&
-                  store.activePlayer?.current_media?.album &&
-                  !props.showOnlyArtist
-                "
-              >
-                {{ store.activePlayer?.current_media?.artist }} •
-                {{ store.activePlayer?.current_media?.album }}
-              </span>
-              <!-- artists(s) only -->
-              <span v-else-if="store.activePlayer?.current_media?.artist">
-                {{ store.activePlayer?.current_media?.artist }}
-              </span>
-              <!-- album only -->
-              <span v-else-if="store.activePlayer?.current_media?.album">
-                {{ store.activePlayer?.current_media?.album }}
-              </span>
+              {{ store.activePlayer.current_media.album }}
             </MarqueeText>
           </div>
         </template>
@@ -172,16 +149,11 @@
 
 <script setup lang="ts">
 import MarqueeText from "@/components/MarqueeText.vue";
-import NowPlayingBadge from "@/components/NowPlayingBadge.vue";
 import QualityDetailsBtn from "@/components/QualityDetailsBtn.vue";
 import { MarqueeTextSync } from "@/helpers/marquee_text_sync";
-import {
-  ImageColorPalette,
-  getMediaImageUrl,
-  getPlayerName,
-} from "@/helpers/utils";
+import { ImageColorPalette, getMediaImageUrl } from "@/helpers/utils";
 import { getSourceName } from "@/plugins/api/helpers";
-import { PlaybackState, PlayerType } from "@/plugins/api/interfaces";
+import { PlayerType } from "@/plugins/api/interfaces";
 import { getBreakpointValue } from "@/plugins/breakpoint";
 import { store } from "@/plugins/store";
 import { computed } from "vue";
@@ -191,14 +163,12 @@ const marqueeSync = new MarqueeTextSync();
 
 // properties
 interface Props {
-  showOnlyArtist?: boolean;
   showQualityDetailsBtn?: boolean;
   colorPalette: ImageColorPalette;
   primaryColor: string;
 }
 
-const props = withDefaults(defineProps<Props>(), {
-  showOnlyArtist: false,
+withDefaults(defineProps<Props>(), {
   showQualityDetailsBtn: true,
   primaryColor: "",
 });

--- a/src/layouts/default/PlayerOSD/PlayerTrackDetails.vue
+++ b/src/layouts/default/PlayerOSD/PlayerTrackDetails.vue
@@ -55,7 +55,9 @@
       >
         <template v-if="store.activePlayer?.current_media?.title">
           <div class="ma-line-clamp-1">
-            {{ store.activePlayer.current_media.title }}
+            <MarqueeText :sync="marqueeSync">
+              {{ store.activePlayer.current_media.title }}
+            </MarqueeText>
           </div>
         </template>
         <div


### PR DESCRIPTION
Preliminary PR for reworking the player label and icons.
<img width="1017" height="87" alt="Screenshot 2026-04-08 at 1 30 46 AM" src="https://github.com/user-attachments/assets/16d9c84a-ce56-417d-bdc5-6dcc99b9bc63" />
My concept here:
* Left side = track info (now with more space so album gets it's own line)
* Right side = Player related info and controls

* Removes the need for the separate player/speaker button
* Removes the need for EQ animation (speaker icon is animated)

* New custom icon for speaker groups communicates purpose more clearly in player dialog
* Shows group icon when current player is a group
<img width="399" height="556" alt="Screenshot 2026-04-08 at 2 14 43 AM" src="https://github.com/user-attachments/assets/75dc69ae-8d95-4583-832f-1a1dd589180c" />
<img width="399" height="556" alt="Screenshot 2026-04-08 at 2 14 25 AM" src="https://github.com/user-attachments/assets/21013756-47cf-4f96-8c9f-6082d4074ece" />
