### PR TITLE
Fix clipping of last player cards on the Players widget of the Discover view

### DIFF
--- a/src/components/PlayersWidgetRow.vue
+++ b/src/components/PlayersWidgetRow.vue
@@ -27,7 +27,7 @@
     <swiper
       :slides-per-view="'auto'"
       :space-between="15"
-      :free-mode="false"
+      :free-mode="true
       :navigation="false"
       :mousewheel="{
         forceToAxis: true,

--- a/src/components/PlayersWidgetRow.vue
+++ b/src/components/PlayersWidgetRow.vue
@@ -27,7 +27,7 @@
     <swiper
       :slides-per-view="'auto'"
       :space-between="15"
-      :free-mode="true
+      :free-mode="true"
       :navigation="false"
       :mousewheel="{
         forceToAxis: true,


### PR DESCRIPTION
The Players widget row on the Discover page uses Swiper with free-mode disabled, which causes the last player cards to be clipped with no visual indicator that more content exists. Users have no way to discover or reach the hidden players.

This changes :free-mode from false to true, matching the pattern used in Carousel.vue, so users can drag/swipe to scroll through all player cards.

Fixes music-assistant/support#5263