### PR TITLE
Check for lossless codec

### DIFF
--- a/src/components/FacetedFilter.vue
+++ b/src/components/FacetedFilter.vue
@@ -6,7 +6,10 @@
         {{ title }}
         <template v-if="selectedCount > 0">
           <Separator orientation="vertical" class="mx-2 h-4" />
-          <Badge class="lg:hidden font-medium rounded-[6px]" :aria-label="`${selectedCount} selected`">
+          <Badge
+            class="lg:hidden font-medium rounded-[6px]"
+            :aria-label="`${selectedCount} selected`"
+          >
             {{ selectedCount }}
           </Badge>
           <div class="hidden space-x-1 lg:flex">
@@ -44,7 +47,12 @@
     </PopoverTrigger>
     <PopoverContent class="w-[220px] p-0" align="start">
       <div class="faceted-filter-content">
-        <Input v-model="search" :placeholder="title" :aria-label="`Search ${title}`" class="mb-2 h-8" />
+        <Input
+          v-model="search"
+          :placeholder="title"
+          :aria-label="`Search ${title}`"
+          class="mb-2 h-8"
+        />
         <div class="faceted-filter-list">
           <div
             v-for="option in filteredOptions"

--- a/src/components/QualityDetailsBtn.vue
+++ b/src/components/QualityDetailsBtn.vue
@@ -697,7 +697,11 @@ const isContentTypeLossless = function (contentType: ContentType) {
 };
 
 const isHiResFormat = function (audioFormat: AudioFormat) {
-  if (!isContentTypeLossless(audioFormat.content_type)) return false;
+  if (
+    !isContentTypeLossless(audioFormat.content_type) &&
+    !isContentTypeLossless(audioFormat.codec_type)
+  )
+    return false;
   return audioFormat.bit_depth > 16 || audioFormat.sample_rate > 48000;
 };
 
@@ -708,10 +712,14 @@ const inputQualityTier = computed(() => {
 
   // Prefer making this decision based on codec type
   let content_type = sd.audio_format.content_type;
+  let codec_type = sd.audio_format.codec_type;
 
   if (isHiResFormat(sd.audio_format)) {
     return QualityTier.HIRES;
-  } else if (isContentTypeLossless(content_type)) {
+  } else if (
+    isContentTypeLossless(content_type) ||
+    isContentTypeLossless(codec_type)
+  ) {
     return QualityTier.LOSSLESS;
   } else if (sd.audio_format.bit_rate >= 256) {
     return QualityTier.GOOD;
@@ -735,7 +743,10 @@ const outputQualityTiers = computed(() => {
     let player_tier = QualityTier.UNKNOWN;
     if (isHiResFormat(dsp.output_format)) {
       player_tier = QualityTier.HIRES;
-    } else if (isContentTypeLossless(dsp.output_format.content_type)) {
+    } else if (
+      isContentTypeLossless(dsp.output_format.content_type) ||
+      isContentTypeLossless(dsp.output_format.codec_type)
+    ) {
       player_tier = QualityTier.LOSSLESS;
     } else if (dsp.output_format.bit_rate >= 256) {
       player_tier = QualityTier.GOOD;


### PR DESCRIPTION
Fixes https://github.com/music-assistant/support/issues/5269

ALAC tracks in MP4 containers were incorrectly showing as LQ (Low Quality) instead of HQ/HR                                                                                      

The quality tier logic only checked content_type (e.g. m4a) but not codec_type. Since m4a isn't in the lossless list, ALAC tracks were falling through to the bitrate check and being classified as low quality.                                                                                              

Fixed by also checking codec_type against the lossless codec list in all three quality tier checks (input, output, and hi-res detection) 