### PR TITLE
Fix single provider stale filter bug

### DIFF
--- a/src/components/ItemsListing.vue
+++ b/src/components/ItemsListing.vue
@@ -1217,7 +1217,13 @@ const restoreSettings = async function () {
   }
 
   // get stored/default provider filter for this itemtype
-  if (props.showProviderFilter === true && prefs.providerFilter) {
+  // only apply stored filter if there are multiple providers available
+  // with a single provider, any stored filter is either redundant or stale
+  if (
+    props.showProviderFilter === true &&
+    prefs.providerFilter &&
+    musicProviders.value.length > 1
+  ) {
     params.value.provider = prefs.providerFilter;
   }
 


### PR DESCRIPTION
Discovered a bug when testing something else. Its an edge case but this is repeatable sequence that shows it

1. User has two music providers that both support a media type (e.g., LIBRARY_ARTISTS)                                                   
2. User opens the artists view — the provider filter icon appears (2 providers available) and they select just one provider. This preference is saved server-side                 
3. For whatever reason the provider that was in view is removed          
4. User opens the artists view again — now only 1 provider supports the feature, so the filter icon is hidden
5. But `restoreSettings()` still loads the stale providerFilter preference from step 2 and applies it                                                   
6. The API call filters by a provider that no longer has items for that media type which results in empty results with no visible filter to clear                                                 
                                                                                                                                                                                   
The fix adds a `musicProviders.value.length > 1` guard to the preference loading, so (maybe stale) filters are ignored when only one provider remains. 

Not sure but this might fix https://github.com/music-assistant/support/issues/5128