### PR TITLE
Reload queue items after reset in fullscreen player

### DIFF
--- a/src/layouts/default/PlayerOSD/PlayerFullscreen.vue
+++ b/src/layouts/default/PlayerOSD/PlayerFullscreen.vue
@@ -1228,6 +1228,9 @@ const resetItems = async function () {
   allItemsLoaded.value = false;
   await sleep(100);
   tempHide.value = false;
+  if (store.showFullscreenPlayer && store.showQueueItems) {
+    loadNextPage();
+  }
 };
 
 const loadNextPage = async function () {


### PR DESCRIPTION
## Problem

When the queue is refilled (e.g. for a dynamic playlist/radio station), a `QUEUE_ITEMS_UPDATED` event triggers `resetItems()`, which clears `queueItems` to `[]`. After the 100ms hide animation, `tempHide` is set back to `false` but no reload is triggered — leaving the queue panel empty until the user scrolls or toggles the view.

## Fix

After clearing items in `resetItems()`, call `loadNextPage()` if the fullscreen player and queue panel are currently visible.