### PR TITLE
Hide incompatible controls for dynamic playlists

### DIFF
--- a/src/helpers/player_menu_items.ts
+++ b/src/helpers/player_menu_items.ts
@@ -10,6 +10,7 @@ import {
   RepeatMode,
   PLAYER_CONTROL_NONE,
 } from "@/plugins/api/interfaces";
+import { isQueueDynamicPlaylist } from "@/plugins/api/helpers";
 import { authManager } from "@/plugins/auth";
 import router from "@/plugins/router";
 import { eventbus } from "@/plugins/eventbus";
@@ -84,8 +85,10 @@ export const getPlayerMenuItems = (
         ),
     });
   }
+  const isSingleDynamicPlaylist = isQueueDynamicPlaylist(playerQueue);
+
   // add enable/disable shuffle menu item
-  if (playerQueue) {
+  if (playerQueue && !isSingleDynamicPlaylist) {
     menuItems.push({
       label: playerQueue.shuffle_enabled ? "shuffle_disable" : "shuffle_enable",
       labelArgs: [],
@@ -99,7 +102,7 @@ export const getPlayerMenuItems = (
   }
 
   // add repeat mode item
-  if (playerQueue) {
+  if (playerQueue && !isSingleDynamicPlaylist) {
     menuItems.push({
       label: "select_repeat_mode",
       labelArgs: [],
@@ -240,7 +243,11 @@ export const getPlayerMenuItems = (
   }
 
   // add 'don't stop the music' menu item
-  if (playerQueue && "dont_stop_the_music_enabled" in playerQueue) {
+  if (
+    playerQueue &&
+    !isSingleDynamicPlaylist &&
+    "dont_stop_the_music_enabled" in playerQueue
+  ) {
     menuItems.push({
       label: playerQueue.dont_stop_the_music_enabled
         ? "dont_stop_the_music_disable"

--- a/src/layouts/default/ItemContextMenu.vue
+++ b/src/layouts/default/ItemContextMenu.vue
@@ -1115,6 +1115,10 @@ const radioModeSupported = function (item: MediaItemTypeOrItemMapping) {
   ) {
     return;
   }
+  // Dynamic playlists own their own track feed — radio mode would conflict
+  if (item.media_type === MediaType.PLAYLIST && (item as Playlist).is_dynamic) {
+    return false;
+  }
   if ("provider_mappings" in item) {
     for (const provId of item.provider_mappings) {
       if (

--- a/src/layouts/default/PlayerOSD/PlayerControlBtn/PlayerTrackMenu.vue
+++ b/src/layouts/default/PlayerOSD/PlayerControlBtn/PlayerTrackMenu.vue
@@ -51,6 +51,7 @@ import {
   QueueOption,
   type Track,
 } from "@/plugins/api/interfaces";
+import { isQueueDynamicPlaylist } from "@/plugins/api/helpers";
 import { eventbus } from "@/plugins/eventbus";
 import router from "@/plugins/router";
 import { store } from "@/plugins/store";
@@ -65,6 +66,9 @@ const currentTrack = computed(() => {
 const radioModeSupported = computed(() => {
   const item = currentTrack.value;
   if (!item) return false;
+  // hide radio mode for dynamic playlists
+  const queue = store.activePlayer ? api.queues[store.activePlayer.player_id] : undefined;
+  if (isQueueDynamicPlaylist(queue)) return false;
   for (const provId of item.provider_mappings) {
     if (
       api.providers[provId.provider_instance]?.supported_features.includes(

--- a/src/layouts/default/PlayerOSD/PlayerControlBtn/RepeatBtn.vue
+++ b/src/layouts/default/PlayerOSD/PlayerControlBtn/RepeatBtn.vue
@@ -46,11 +46,10 @@ import Icon, { IconProps } from "@/components/Icon.vue";
 import { getValueFromSources } from "@/helpers/utils";
 import api from "@/plugins/api";
 import {
-  MediaType,
-  Playlist,
   PlayerQueue,
   RepeatMode,
 } from "@/plugins/api/interfaces";
+import { isQueueDynamicPlaylist } from "@/plugins/api/helpers";
 import { computed } from "vue";
 import { IconRepeat, IconRepeatOff, IconRepeatOnce } from "@tabler/icons-vue";
 
@@ -73,12 +72,5 @@ const isLoading = computed(() => {
   );
 });
 
-const isSingleDynamicPlaylist = computed(() => {
-  const items = compProps.playerQueue?.enqueued_media_items;
-  return (
-    items?.length === 1 &&
-    items[0].media_type === MediaType.PLAYLIST &&
-    (items[0] as Playlist).is_dynamic
-  );
-});
+const isSingleDynamicPlaylist = computed(() => isQueueDynamicPlaylist(compProps.playerQueue));
 </script>

--- a/src/layouts/default/PlayerOSD/PlayerControlBtn/ShuffleBtn.vue
+++ b/src/layouts/default/PlayerOSD/PlayerControlBtn/ShuffleBtn.vue
@@ -32,7 +32,8 @@ defineOptions({ inheritAttrs: false });
 import Icon, { IconProps } from "@/components/Icon.vue";
 import { getValueFromSources } from "@/helpers/utils";
 import api from "@/plugins/api";
-import { MediaType, Playlist, PlayerQueue } from "@/plugins/api/interfaces";
+import { PlayerQueue } from "@/plugins/api/interfaces";
+import { isQueueDynamicPlaylist } from "@/plugins/api/helpers";
 import { IconArrowsRight } from "@tabler/icons-vue";
 import { Shuffle } from "lucide-vue-next";
 import { computed } from "vue";
@@ -56,12 +57,5 @@ const isLoading = computed(() => {
   );
 });
 
-const isSingleDynamicPlaylist = computed(() => {
-  const items = compProps.playerQueue?.enqueued_media_items;
-  return (
-    items?.length === 1 &&
-    items[0].media_type === MediaType.PLAYLIST &&
-    (items[0] as Playlist).is_dynamic
-  );
-});
+const isSingleDynamicPlaylist = computed(() => isQueueDynamicPlaylist(compProps.playerQueue));
 </script>

--- a/src/plugins/api/helpers.ts
+++ b/src/plugins/api/helpers.ts
@@ -1,7 +1,20 @@
 // several helpers for dealing with the api and its (media) items
 
 import api from ".";
-import { MediaItemType, ItemMapping, MediaType, Player } from "./interfaces";
+import { MediaItemType, ItemMapping, MediaType, Player, PlayerQueue, Playlist } from "./interfaces";
+
+/**
+ * Returns true when the given queue is currently playing a single dynamic playlist.
+ * In that case, shuffle, repeat, radio mode, and don't-stop-the-music should be hidden.
+ */
+export const isQueueDynamicPlaylist = function (queue: PlayerQueue | undefined): boolean {
+  const source = queue?.radio_source;
+  return (
+    source?.length === 1 &&
+    source[0].media_type === MediaType.PLAYLIST &&
+    (source[0] as Playlist).is_dynamic
+  );
+};
 
 export const itemIsAvailable = function (
   item: MediaItemType | ItemMapping,


### PR DESCRIPTION
When a dynamic playlist is active in the queue, certain controls are not applicable:

- **Play Radio** — the queue already _is_ radio mode
- **Shuffle** — dynamic playlists manage their own order
- **Repeat** — has no effect on an infinite stream
- **Don't stop the music** — redundant, the playlist never stops

## Changes

- Hide the Play Radio item in `ItemContextMenu` when the target item itself is a dynamic playlist
- Hide Shuffle, Repeat and Don't stop the music in the player menu (`player_menu_items.ts`) when a dynamic playlist is active in the queue
- Disable Shuffle and Repeat buttons (`ShuffleBtn.vue`, `RepeatBtn.vue`) when a dynamic playlist is active
- Hide the Play Radio item in `PlayerTrackMenu.vue` (the `...` menu on the currently playing track) when a dynamic playlist is active

### Implementation note

The queue carries the active dynamic playlist in `PlayerQueue.radio_source`, not in `enqueued_media_items` (which is empty for dynamic playlists). Detection is centralised in a new `isQueueDynamicPlaylist(queue)` helper exported from `src/plugins/api/helpers.ts`.