### PR TITLE
Add playlist_art context menu for regenerating playlist artwork

### DIFF
--- a/src/components/Toolbar.vue
+++ b/src/components/Toolbar.vue
@@ -85,41 +85,75 @@
             </v-btn>
           </template>
           <v-list density="compact" slim tile>
-            <v-list-item
+            <template
               v-for="(menuItem, index) in menuItems?.filter(
                 (x) => x.hide != true && x.overflowAllowed != false,
               )"
               :key="index"
-              :title="$t(menuItem.label, menuItem.labelArgs || [])"
-              :disabled="menuItem.disabled == true"
-              :append-icon="
-                menuItem.subItems?.length ? 'mdi-chevron-right' : undefined
-              "
-              @click.prevent.stop="
-                (e: MouseEvent | KeyboardEvent) => onMenuItemClick(e, menuItem)
-              "
             >
-              <template v-if="menuItem.icon" #prepend>
-                <v-badge
-                  :model-value="menuItem.active == true"
-                  color="primary"
-                  dot
-                >
-                  <v-icon
-                    v-if="typeof menuItem.icon === 'string'"
-                    :icon="menuItem.icon"
-                    :color="$vuetify.theme.current.dark ? '#fff' : '#000'"
-                    size="22px"
-                  />
-                  <component
-                    :is="menuItem.icon"
-                    v-else
-                    class="w-[22px] h-[22px]"
-                    :color="$vuetify.theme.current.dark ? '#fff' : '#000'"
-                  />
-                </v-badge>
-              </template>
-            </v-list-item>
+              <!-- Item with sub-items: emit contextmenu event at cursor position (same as ItemContextMenu) -->
+              <v-list-item
+                v-if="menuItem.subItems?.length"
+                :title="$t(menuItem.label, menuItem.labelArgs || [])"
+                :disabled="menuItem.disabled == true"
+                append-icon="mdi-chevron-right"
+                @click.prevent.stop="
+                  (e: MouseEvent | KeyboardEvent) => onMenuItemClick(e, menuItem)
+                "
+              >
+                <template v-if="menuItem.icon" #prepend>
+                  <v-badge
+                    :model-value="menuItem.active == true"
+                    color="primary"
+                    dot
+                  >
+                    <v-icon
+                      v-if="typeof menuItem.icon === 'string'"
+                      :icon="menuItem.icon"
+                      :color="$vuetify.theme.current.dark ? '#fff' : '#000'"
+                      size="22px"
+                    />
+                    <component
+                      :is="menuItem.icon"
+                      v-else
+                      class="w-[22px] h-[22px]"
+                      :color="$vuetify.theme.current.dark ? '#fff' : '#000'"
+                    />
+                  </v-badge>
+                </template>
+              </v-list-item>
+
+              <!-- Regular item without sub-items -->
+              <v-list-item
+                v-else
+                :title="$t(menuItem.label, menuItem.labelArgs || [])"
+                :disabled="menuItem.disabled == true"
+                @click.prevent.stop="
+                  (e: MouseEvent | KeyboardEvent) => onMenuItemClick(e, menuItem)
+                "
+              >
+                <template v-if="menuItem.icon" #prepend>
+                  <v-badge
+                    :model-value="menuItem.active == true"
+                    color="primary"
+                    dot
+                  >
+                    <v-icon
+                      v-if="typeof menuItem.icon === 'string'"
+                      :icon="menuItem.icon"
+                      :color="$vuetify.theme.current.dark ? '#fff' : '#000'"
+                      size="22px"
+                    />
+                    <component
+                      :is="menuItem.icon"
+                      v-else
+                      class="w-[22px] h-[22px]"
+                      :color="$vuetify.theme.current.dark ? '#fff' : '#000'"
+                    />
+                  </v-badge>
+                </template>
+              </v-list-item>
+            </template>
           </v-list>
         </v-menu>
       </div>
@@ -145,19 +179,22 @@ const onMenuItemClick = (
 ) => {
   event.preventDefault();
   if (menuItem.subItems?.length) {
-    // Open submenu via global context menu
-    // Map closeOnContentClick to close_on_click on subItems if needed
-    const items =
-      menuItem.closeOnContentClick === false
-        ? menuItem.subItems.map((item) => ({
-            ...item,
-            close_on_click: item.close_on_click ?? false,
-          }))
-        : menuItem.subItems;
+    // Open submenu via global context menu at cursor position.
+    // Wrap each sub-item action so the overflow menu also closes when one is picked.
+    const wrappedItems = menuItem.subItems.map((item) => ({
+      ...item,
+      close_on_click: menuItem.closeOnContentClick === false ? (item.close_on_click ?? false) : item.close_on_click,
+      action: item.action
+        ? () => {
+            overflowMenuOpen.value = false;
+            item.action!();
+          }
+        : undefined,
+    }));
     const posX = "clientX" in event ? event.clientX : 0;
     const posY = "clientY" in event ? event.clientY : 0;
     eventbus.emit("contextmenu", {
-      items,
+      items: wrappedItems,
       posX,
       posY,
     });

--- a/src/components/Toolbar.vue
+++ b/src/components/Toolbar.vue
@@ -98,7 +98,8 @@
                 :disabled="menuItem.disabled == true"
                 append-icon="mdi-chevron-right"
                 @click.prevent.stop="
-                  (e: MouseEvent | KeyboardEvent) => onMenuItemClick(e, menuItem)
+                  (e: MouseEvent | KeyboardEvent) =>
+                    onMenuItemClick(e, menuItem)
                 "
               >
                 <template v-if="menuItem.icon" #prepend>
@@ -129,7 +130,8 @@
                 :title="$t(menuItem.label, menuItem.labelArgs || [])"
                 :disabled="menuItem.disabled == true"
                 @click.prevent.stop="
-                  (e: MouseEvent | KeyboardEvent) => onMenuItemClick(e, menuItem)
+                  (e: MouseEvent | KeyboardEvent) =>
+                    onMenuItemClick(e, menuItem)
                 "
               >
                 <template v-if="menuItem.icon" #prepend>
@@ -183,7 +185,10 @@ const onMenuItemClick = (
     // Wrap each sub-item action so the overflow menu also closes when one is picked.
     const wrappedItems = menuItem.subItems.map((item) => ({
       ...item,
-      close_on_click: menuItem.closeOnContentClick === false ? (item.close_on_click ?? false) : item.close_on_click,
+      close_on_click:
+        menuItem.closeOnContentClick === false
+          ? (item.close_on_click ?? false)
+          : item.close_on_click,
       action: item.action
         ? () => {
             overflowMenuOpen.value = false;

--- a/src/layouts/default/ItemContextMenu.vue
+++ b/src/layouts/default/ItemContextMenu.vue
@@ -768,58 +768,36 @@ export const getContextMenuItems = async function (
     items.length === 1 &&
     items[0].provider === "library" &&
     items[0].media_type === MediaType.PLAYLIST &&
+    (items[0] as Playlist).is_editable === true &&
     api.getProvider("playlist_art")
   ) {
+    const artworkSubItems: ContextMenuItem[] = [];
+    for (const [template, icon] of [
+      ["artist_mosaic", "mdi-view-dashboard"],
+      ["artist_grid", "mdi-view-grid"],
+      ["album_grid", "mdi-grid"],
+      ["artist_radio", "mdi-circle-slice-8"],
+      ["artist_banner", "mdi-image-text"],
+      ["album_fan", "mdi-cards"],
+      ["album_grid_tilted", "mdi-view-grid-outline"],
+    ] as [string, string][]) {
+      artworkSubItems.push({
+        label: `playlist_art.template.${template}`,
+        labelArgs: [],
+        action: async () => {
+          await api.sendCommand("playlist_art/regenerate", {
+            playlist_id: items[0].item_id,
+            template,
+          });
+        },
+        icon,
+      });
+    }
     contextMenuItems.push({
       label: "playlist_art.regenerate",
       labelArgs: [],
       icon: "mdi-image-refresh",
-      subItems: [
-        {
-          label: "playlist_art.template.artist_mosaic",
-          labelArgs: [],
-          action: async () => {
-            await api.sendCommand("playlist_art/regenerate", {
-              playlist_id: items[0].item_id,
-              template: "artist_mosaic",
-            });
-          },
-          icon: "mdi-view-dashboard",
-        },
-        {
-          label: "playlist_art.template.artist_grid",
-          labelArgs: [],
-          action: async () => {
-            await api.sendCommand("playlist_art/regenerate", {
-              playlist_id: items[0].item_id,
-              template: "artist_grid",
-            });
-          },
-          icon: "mdi-view-grid",
-        },
-        {
-          label: "playlist_art.template.album_grid",
-          labelArgs: [],
-          action: async () => {
-            await api.sendCommand("playlist_art/regenerate", {
-              playlist_id: items[0].item_id,
-              template: "album_grid",
-            });
-          },
-          icon: "mdi-grid",
-        },
-        {
-          label: "playlist_art.template.artist_radio",
-          labelArgs: [],
-          action: async () => {
-            await api.sendCommand("playlist_art/regenerate", {
-              playlist_id: items[0].item_id,
-              template: "artist_radio",
-            });
-          },
-          icon: "mdi-circle-slice-8",
-        },
-      ],
+      subItems: artworkSubItems,
     });
   }
   // export playlist

--- a/src/layouts/default/ItemContextMenu.vue
+++ b/src/layouts/default/ItemContextMenu.vue
@@ -771,7 +771,9 @@ export const getContextMenuItems = async function (
     items[0].provider === "library" &&
     items[0].media_type === MediaType.PLAYLIST &&
     (items[0] as Playlist).is_editable === true &&
-    (items[0] as Playlist).provider_mappings?.some((pm) => pm.provider_domain === "builtin") &&
+    (items[0] as Playlist).provider_mappings?.some(
+      (pm) => pm.provider_domain === "builtin",
+    ) &&
     api.getProvider("playlist_art")
   ) {
     const artworkSubItems: ContextMenuItem[] = [];

--- a/src/layouts/default/ItemContextMenu.vue
+++ b/src/layouts/default/ItemContextMenu.vue
@@ -764,22 +764,25 @@ export const getContextMenuItems = async function (
     });
   }
   // regenerate playlist artwork via playlist_art plugin
+  // Only for user-created library playlists (has builtin provider mapping + is_editable).
+  // Apple Music / Spotify playlists are excluded even if is_editable is true.
   if (
     items.length === 1 &&
     items[0].provider === "library" &&
     items[0].media_type === MediaType.PLAYLIST &&
     (items[0] as Playlist).is_editable === true &&
+    (items[0] as Playlist).provider_mappings?.some((pm) => pm.provider_domain === "builtin") &&
     api.getProvider("playlist_art")
   ) {
     const artworkSubItems: ContextMenuItem[] = [];
     for (const [template, icon] of [
-      ["artist_mosaic", "mdi-view-dashboard"],
-      ["artist_grid", "mdi-view-grid"],
       ["album_grid", "mdi-grid"],
-      ["artist_radio", "mdi-circle-slice-8"],
-      ["artist_banner", "mdi-image-text"],
       ["album_fan", "mdi-cards"],
       ["album_grid_tilted", "mdi-view-grid-outline"],
+      ["artist_mosaic", "mdi-view-dashboard"],
+      ["artist_grid", "mdi-view-grid"],
+      ["artist_radio", "mdi-circle-slice-8"],
+      ["artist_banner", "mdi-image-text"],
     ] as [string, string][]) {
       artworkSubItems.push({
         label: `playlist_art.template.${template}`,

--- a/src/layouts/default/ItemContextMenu.vue
+++ b/src/layouts/default/ItemContextMenu.vue
@@ -763,6 +763,65 @@ export const getContextMenuItems = async function (
       icon: "mdi-refresh",
     });
   }
+  // regenerate playlist artwork via playlist_art plugin
+  if (
+    items.length === 1 &&
+    items[0].provider === "library" &&
+    items[0].media_type === MediaType.PLAYLIST &&
+    api.getProvider("playlist_art")
+  ) {
+    contextMenuItems.push({
+      label: "playlist_art.regenerate",
+      labelArgs: [],
+      icon: "mdi-image-refresh",
+      subItems: [
+        {
+          label: "playlist_art.template.artist_mosaic",
+          labelArgs: [],
+          action: async () => {
+            await api.sendCommand("playlist_art/regenerate", {
+              playlist_id: items[0].item_id,
+              template: "artist_mosaic",
+            });
+          },
+          icon: "mdi-view-dashboard",
+        },
+        {
+          label: "playlist_art.template.artist_grid",
+          labelArgs: [],
+          action: async () => {
+            await api.sendCommand("playlist_art/regenerate", {
+              playlist_id: items[0].item_id,
+              template: "artist_grid",
+            });
+          },
+          icon: "mdi-view-grid",
+        },
+        {
+          label: "playlist_art.template.album_grid",
+          labelArgs: [],
+          action: async () => {
+            await api.sendCommand("playlist_art/regenerate", {
+              playlist_id: items[0].item_id,
+              template: "album_grid",
+            });
+          },
+          icon: "mdi-grid",
+        },
+        {
+          label: "playlist_art.template.artist_radio",
+          labelArgs: [],
+          action: async () => {
+            await api.sendCommand("playlist_art/regenerate", {
+              playlist_id: items[0].item_id,
+              template: "artist_radio",
+            });
+          },
+          icon: "mdi-circle-slice-8",
+        },
+      ],
+    });
+  }
   // export playlist
   if (
     items.length === 1 &&

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -85,6 +85,15 @@
     "radios": "Radio",
     "read_more": "read more",
     "refresh_item": "Refresh item",
+    "playlist_art": {
+        "regenerate": "Regenerate artwork",
+        "template": {
+            "artist_mosaic": "Artist Mosaic",
+            "artist_grid": "Artist Grid",
+            "album_grid": "Album Grid",
+            "artist_radio": "Artist Radio"
+        }
+    },
     "export_playlist": "Export playlist",
     "remove_library": "Remove from library",
     "remove_playlist": "Remove from playlist",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -91,7 +91,10 @@
             "artist_mosaic": "Artist Mosaic",
             "artist_grid": "Artist Grid",
             "album_grid": "Album Grid",
-            "artist_radio": "Artist Radio"
+            "artist_radio": "Artist Radio",
+            "artist_banner": "Artist Banner",
+            "album_fan": "Album Fan",
+            "album_grid_tilted": "Album Grid Tilted"
         }
     },
     "export_playlist": "Export playlist",


### PR DESCRIPTION
## What's new

Adds a **Regenerate Artwork** context menu entry for user-created library playlists, powered by the `playlist_art` server plugin.

### Context menu

A new **Regenerate artwork** entry appears in the context menu for playlists that:
- belong to the library (`provider === "library"`)
- are user-created (`is_editable === true` **and** have a `builtin` provider mapping)
- have the `playlist_art` plugin installed on the server

The entry expands into a submenu with all seven available templates (Album Grid, Album Fan, Album Grid Tilted, Artist Mosaic, Artist Grid, Artist Radio, Artist Banner), each with a distinct icon. Selecting a template immediately regenerates the artwork server-side.

Provider playlists (Apple Music, Spotify, etc.) are excluded from this menu even if they are editable.

### Toolbar overflow menu: subItems support

The overflow menu in `Toolbar.vue` now supports nested `subItems` on any menu item. Items with sub-items render with a chevron and open the global context menu at the cursor position on click. This is the same mechanism already used by the main context menu.

### Screenshots

#### Config
<img width="1360" height="705" alt="PluginConfig" src="https://github.com/user-attachments/assets/6beb13f6-3bb1-4964-b73d-7da5df0c659d" />

#### MenuItem / SubMenuItems
<img width="481" height="531" alt="Menu-Entries 2" src="https://github.com/user-attachments/assets/6e4ccc0b-ff84-48aa-84a8-c30404911c92" />

#### Without this Plugin
<img width="778" height="243" alt="No Plugin - before" src="https://github.com/user-attachments/assets/cca3c088-99b2-4f82-8b77-217f4be3e349" />

#### Album Grid (like the image without this plugin)
<img width="603" height="257" alt="Album Grid 2" src="https://github.com/user-attachments/assets/0125954d-39eb-4006-aba9-7976c065137e" />

#### Album Fan
<img width="603" height="257" alt="Album Fan" src="https://github.com/user-attachments/assets/30db83b4-7937-4f44-a144-555c6ac0a00b" />

#### Album Grid Tilted
<img width="603" height="257" alt="Album Grid Tilted" src="https://github.com/user-attachments/assets/c93cee7d-61c7-43e2-8638-a0ac62de3847" />

#### Artist Mosaik
<img width="603" height="257" alt="Artist Mosaik 2" src="https://github.com/user-attachments/assets/a41fcb87-e0ce-4ef1-8b43-1b14e7ce60c8" />

#### Artist Grid
<img width="603" height="257" alt="Artist Grid 2" src="https://github.com/user-attachments/assets/4a2b1e34-234e-4656-bb90-bb919a18ff47" />

#### Artist Radio
<img width="603" height="257" alt="Artist Radio 2" src="https://github.com/user-attachments/assets/bb130389-dc3e-431d-9ab7-18ab5867f5b1" />

#### Artist Banner
<img width="603" height="257" alt="Artist Banner" src="https://github.com/user-attachments/assets/21bcc255-265b-4086-9a43-0c889e8fe525" />

