### PR TITLE
Fix copy to clipboard

### DIFF
--- a/src/components/users/ManageTokensDialog.vue
+++ b/src/components/users/ManageTokensDialog.vue
@@ -373,9 +373,12 @@ const handleCreateToken = async () => {
 };
 
 const copyToken = async () => {
-  if (createdToken.value) {
-    await copyToClipboard(createdToken.value);
+  if (!createdToken.value) return;
+  const success = await copyToClipboard(createdToken.value);
+  if (success) {
     toast.success(t("auth.token_copied"));
+  } else {
+    toast.error(t("auth.token_copy_failed"));
   }
 };
 

--- a/src/helpers/utils.ts
+++ b/src/helpers/utils.ts
@@ -751,7 +751,7 @@ export async function copyToClipboard(text: string): Promise<boolean> {
   // so a focus trap (e.g. Reka UI Dialog) does not steal focus and clear the
   // textarea's selection before execCommand("copy") runs.
   const host =
-    document.activeElement?.closest<HTMLElement>('[role="dialog"]') ??
+    document.activeElement?.closest<HTMLElement>("[role=dialog]") ??
     document.body;
   const textArea = document.createElement("textarea");
   textArea.value = text;

--- a/src/helpers/utils.ts
+++ b/src/helpers/utils.ts
@@ -734,8 +734,8 @@ export const markdownToHtml = function (text: string): string {
 export async function copyToClipboard(text: string): Promise<boolean> {
   if (!text) return false;
 
-  // Try modern Clipboard API first (requires HTTPS or localhost)
-  if (navigator.clipboard && navigator.clipboard.writeText) {
+  // Modern Clipboard API: only available in secure contexts (HTTPS / localhost).
+  if (window.isSecureContext && navigator.clipboard?.writeText) {
     try {
       await navigator.clipboard.writeText(text);
       return true;
@@ -747,29 +747,33 @@ export async function copyToClipboard(text: string): Promise<boolean> {
     }
   }
 
-  // Fallback for older browsers or non-secure contexts
+  // Fallback for non-secure contexts. Append inside the active dialog (if any)
+  // so a focus trap (e.g. Reka UI Dialog) does not steal focus and clear the
+  // textarea's selection before execCommand("copy") runs.
+  const host =
+    document.activeElement?.closest<HTMLElement>('[role="dialog"]') ??
+    document.body;
+  const textArea = document.createElement("textarea");
+  textArea.value = text;
+  textArea.setAttribute("readonly", "");
+  textArea.style.position = "fixed";
+  textArea.style.top = "0";
+  textArea.style.left = "0";
+  textArea.style.width = "1px";
+  textArea.style.height = "1px";
+  textArea.style.opacity = "0";
+  textArea.style.pointerEvents = "none";
+  host.appendChild(textArea);
   try {
-    const textArea = document.createElement("textarea");
-    textArea.value = text;
-    textArea.style.position = "fixed";
-    textArea.style.left = "-999999px";
-    textArea.style.top = "-999999px";
-    document.body.appendChild(textArea);
     textArea.focus();
     textArea.select();
-
-    const successful = document.execCommand("copy");
-    document.body.removeChild(textArea);
-
-    if (successful) {
-      return true;
-    } else {
-      console.error("Legacy copy method failed");
-      return false;
-    }
+    textArea.setSelectionRange(0, text.length);
+    return document.execCommand("copy");
   } catch (error) {
     console.error("Failed to copy to clipboard:", error);
     return false;
+  } finally {
+    host.removeChild(textArea);
   }
 }
 


### PR DESCRIPTION
Fixes https://github.com/music-assistant/support/issues/5400

When the app is opened over plain HTTP on the local network (not HTTPS), the "copy token" button was not working. Browsers block the modern clipboard API on insecure pages, so we fall back to what I discovered is an old trick (creating a hidden text box and copying from it). The hidden text box was being placed outside the popup dialog, and the dialog kept stealing focus back, which silently wiped the copy. This PR puts the hidden text box inside the dialog so the copy actually goes through, and also fixes a small thing where the token dialog showed "copied!" even when the copy failed. 