### PR TITLE
Add "hide fully-played episodes" toggle to podcast details

### DIFF
--- a/src/components/ItemsListing.vue
+++ b/src/components/ItemsListing.vue
@@ -273,6 +273,7 @@ export interface LoadDataParams {
   albumArtistsFilter?: boolean;
   libraryOnly?: boolean;
   hideEmptyFilter?: boolean | null;
+  hideFullyPlayed?: boolean;
   refresh?: boolean;
   albumType?: string[];
   provider?: string[];
@@ -299,6 +300,7 @@ export interface Props {
   showLibraryOnlyFilter?: boolean;
   showGenreFilter?: boolean;
   showHideEmptyFilter?: boolean;
+  showHideFullyPlayedFilter?: boolean;
   allowCollapse?: boolean;
   allowKeyHooks?: boolean;
   extraMenuItems?: ToolBarMenuItem[];
@@ -339,6 +341,7 @@ const props = withDefaults(defineProps<Props>(), {
   showLibraryOnlyFilter: false,
   showGenreFilter: false,
   showHideEmptyFilter: false,
+  showHideFullyPlayedFilter: false,
   extraMenuItems: undefined,
   loadPagedData: undefined,
   loadItems: undefined,
@@ -469,6 +472,17 @@ const toggleFavoriteFilter = function () {
     props.itemtype,
     "favoriteFilter",
     params.value.favoritesOnly,
+  );
+  loadData(undefined, undefined, true);
+};
+
+const toggleHideFullyPlayedFilter = function () {
+  params.value.hideFullyPlayed = !params.value.hideFullyPlayed;
+  setItemsListingPreference(
+    props.path || props.itemtype,
+    props.itemtype,
+    "hideFullyPlayedFilter",
+    params.value.hideFullyPlayed,
   );
   loadData(undefined, undefined, true);
 };
@@ -908,6 +922,19 @@ const menuItems = computed(() => {
     });
   }
 
+  // hide fully played filter (e.g. podcast episodes)
+  if (props.showHideFullyPlayedFilter === true) {
+    items.push({
+      label: "tooltip.filter_hide_fully_played",
+      icon: params.value.hideFullyPlayed
+        ? "mdi-eye-off"
+        : "mdi-eye-off-outline",
+      action: toggleHideFullyPlayedFilter,
+      active: params.value.hideFullyPlayed,
+      overflowAllowed: true,
+    });
+  }
+
   // album artists only filter
   if (props.showAlbumArtistsOnlyFilter === true) {
     items.push({
@@ -1190,6 +1217,10 @@ const restoreSettings = async function () {
   // get stored/default favoriteOnlyFilter for this itemtype
   if (props.showFavoritesOnlyFilter !== false && prefs.favoriteFilter) {
     params.value.favoritesOnly = prefs.favoriteFilter;
+  }
+
+  if (props.showHideFullyPlayedFilter === true && prefs.hideFullyPlayedFilter) {
+    params.value.hideFullyPlayed = prefs.hideFullyPlayedFilter;
   }
 
   // get stored/default libraryOnlyFilter for this itemtype
@@ -1631,6 +1662,10 @@ const getFilteredItems = function (
 
   if (params.favoritesOnly) {
     result = result.filter((x) => x.favorite);
+  }
+
+  if (params.hideFullyPlayed) {
+    result = result.filter((x) => (x as PodcastEpisode).fully_played !== true);
   }
 
   if (params.albumType && params.albumType.length > 0) {

--- a/src/composables/userPreferences.ts
+++ b/src/composables/userPreferences.ts
@@ -9,6 +9,7 @@ export interface ItemsListingPreferences {
   libraryFilter?: boolean;
   albumArtistsFilter?: boolean;
   hideEmptyFilter?: boolean | null;
+  hideFullyPlayedFilter?: boolean;
   albumType?: string[];
   providerFilter?: string[];
   expand?: boolean;

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -804,6 +804,7 @@
         "sort_options": "Sort options",
         "toggle_view_mode": "Toggle view mode list\/thumbs",
         "filter_favorites": "Only show favorites",
+        "filter_hide_fully_played": "Hide fully-played episodes",
         "favorite": "Mark\/unmark as a favorite",
         "open_provider_link": "Open this item on the provider's website",
         "collapse_expand": "Collapse\/expand this listing",

--- a/src/views/PodcastDetails.vue
+++ b/src/views/PodcastDetails.vue
@@ -7,6 +7,7 @@
     :show-provider="false"
     :show-library="false"
     :show-favorites-only-filter="false"
+    :show-hide-fully-played-filter="true"
     :show-track-number="true"
     :show-refresh-button="true"
     :load-items="loadPodcastEpisodes"


### PR DESCRIPTION
I'm working on a new podcast provider and quickly ran into "I have a bunch of fully played podcasts but no way to not see them in the list".

Adds a generic showHideFullyPlayedFilter prop to ItemsListing, enabled on the PodcastDetails view. Mirrors the existing favorites-filter pattern: server-stored per-user preference via useUserPreferences, client-side filtering of already-loaded items in getFilteredItems on the fully_played flag.

No backend change required.