### PR TITLE
add bitrate information to the QualityDetailsBtn.vue screen

### DIFF
--- a/src/components/QualityDetailsBtn.vue
+++ b/src/components/QualityDetailsBtn.vue
@@ -216,8 +216,9 @@
               {{ streamDetails.audio_format.bit_depth }} bits
               <template
                 v-if="
-                  inputQualityTier == QualityTier.GOOD ||
-                  inputQualityTier == QualityTier.LOW && streamDetails.audio_format.bit_rate
+                  (inputQualityTier == QualityTier.GOOD ||
+                    inputQualityTier == QualityTier.LOW) &&
+                  streamDetails.audio_format.bit_rate
                 "
               >
                 / {{ streamDetails.audio_format.bit_rate.toFixed(0) }} kbps

--- a/src/components/QualityDetailsBtn.vue
+++ b/src/components/QualityDetailsBtn.vue
@@ -213,10 +213,15 @@
                 :src="inputFileIcon"
               />
               {{ streamDetails.audio_format.sample_rate / 1000 }} kHz /
-              <template v-if="inputQualityTier == QualityTier.GOOD || inputQualityTier == QualityTier.LOW">
-                {{ streamDetails.audio_format.bit_rate.toFixed(0) }} kbps /
-              </template>
               {{ streamDetails.audio_format.bit_depth }} bits
+              <template
+                v-if="
+                  inputQualityTier == QualityTier.GOOD ||
+                  inputQualityTier == QualityTier.LOW && streamDetails.audio_format.bit_rate
+                "
+              >
+                / {{ streamDetails.audio_format.bit_rate.toFixed(0) }} kbps
+              </template>
               <v-tooltip location="top" :open-on-click="true" max-width="300">
                 <template #activator="{ props }">
                   <v-icon class="ml-2" size="small" v-bind="props"
@@ -730,7 +735,6 @@ const inputQualityTier = computed(() => {
     return QualityTier.LOW;
   }
 });
-
 
 const outputQualityTiers = computed(() => {
   const tiers: Record<string, QualityTier> = {};

--- a/src/components/QualityDetailsBtn.vue
+++ b/src/components/QualityDetailsBtn.vue
@@ -213,6 +213,9 @@
                 :src="inputFileIcon"
               />
               {{ streamDetails.audio_format.sample_rate / 1000 }} kHz /
+              <template v-if="inputQualityTier == QualityTier.GOOD || inputQualityTier == QualityTier.LOW">
+                {{ streamDetails.audio_format.bit_rate.toFixed(0) }} kbps /
+              </template>
               {{ streamDetails.audio_format.bit_depth }} bits
               <v-tooltip location="top" :open-on-click="true" max-width="300">
                 <template #activator="{ props }">
@@ -727,6 +730,7 @@ const inputQualityTier = computed(() => {
     return QualityTier.LOW;
   }
 });
+
 
 const outputQualityTiers = computed(() => {
   const tiers: Record<string, QualityTier> = {};


### PR DESCRIPTION
add bitrate information to the QualityDetailsBtn.vue screen, but only…when input is encoded with a lossy codec
information is inserted between samplerate and bitdepth.