### PR TITLE
Add trending_stations translation key for TuneIn recommendations

### DIFF
--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -978,7 +978,8 @@
         "discover": "Discover",
         "libraries": "Libraries",
         "library": "Library",
-        "trending_podcasts": "Trending podcasts"
+        "trending_podcasts": "Trending podcasts",
+        "trending_stations": "Trending stations"
     },
     "homescreen_edit_enable": "Edit Home screen",
     "homescreen_edit_disable": "Leave Home screen edit mode",


### PR DESCRIPTION
Adds the `trending_stations` translation key under `recommendations` in `en.json`, required by the companion server PR (https://github.com/music-assistant/server/pull/3865) that adds `translation_key="trending_stations"` to the TuneIn recommendations folder.