### PR TITLE
fixed cut off logomark

### DIFF
--- a/src/components/navigation/AppSidebar.vue
+++ b/src/components/navigation/AppSidebar.vue
@@ -87,7 +87,6 @@ onUnmounted(() => {
 .sidebar-header-logo {
   width: 30px;
   height: 30px;
-  border-radius: 6px;
   flex-shrink: 0;
 }
 


### PR DESCRIPTION
the logomark in the sidebar was cut off at the bottom because of the border-radius