### PR TITLE
Toggle homescreen edit mode label in user menu

### DIFF
--- a/src/components/navigation/NavUser.vue
+++ b/src/components/navigation/NavUser.vue
@@ -17,11 +17,11 @@ import {
 import { authManager } from "@/plugins/auth";
 import { eventbus } from "@/plugins/eventbus";
 import { store } from "@/plugins/store";
+import { LogOut, MoreVertical, Pencil, Settings } from "lucide-vue-next";
 import { computed } from "vue";
+import { useRouter } from "vue-router";
 
 const isEditMode = computed(() => store.homescreenEditMode);
-import { LogOut, MoreVertical, Pencil, Settings } from "lucide-vue-next";
-import { useRouter } from "vue-router";
 
 const router = useRouter();
 const { isMobile, setOpenMobile } = useSidebar();

--- a/src/components/navigation/NavUser.vue
+++ b/src/components/navigation/NavUser.vue
@@ -82,7 +82,10 @@ const handleLogout = () => {
           </SidebarMenuButton>
         </DropdownMenuTrigger>
         <DropdownMenuContent
-          :class="['z-[100001] w-(--reka-dropdown-menu-trigger-width) rounded-lg', isEditMode ? 'min-w-64' : 'min-w-56']"
+          :class="[
+            'z-[100001] w-(--reka-dropdown-menu-trigger-width) rounded-lg',
+            isEditMode ? 'min-w-64' : 'min-w-56',
+          ]"
           :side="isMobile ? 'bottom' : 'right'"
           :side-offset="isMobile ? 4 : 15"
           align="end"
@@ -116,7 +119,13 @@ const handleLogout = () => {
           </DropdownMenuItem>
           <DropdownMenuItem @click="handleEditHomescreen">
             <Pencil class="size-4" />
-            {{ $t(isEditMode ? "homescreen_edit_disable" : "homescreen_edit_enable") }}
+            {{
+              $t(
+                isEditMode
+                  ? "homescreen_edit_disable"
+                  : "homescreen_edit_enable",
+              )
+            }}
           </DropdownMenuItem>
           <DropdownMenuItem
             v-if="!store.isIngressSession"

--- a/src/components/navigation/NavUser.vue
+++ b/src/components/navigation/NavUser.vue
@@ -82,7 +82,7 @@ const handleLogout = () => {
           </SidebarMenuButton>
         </DropdownMenuTrigger>
         <DropdownMenuContent
-          class="z-[100001] w-(--reka-dropdown-menu-trigger-width) min-w-56 rounded-lg"
+          :class="['z-[100001] w-(--reka-dropdown-menu-trigger-width) rounded-lg', isEditMode ? 'min-w-64' : 'min-w-56']"
           :side="isMobile ? 'bottom' : 'right'"
           :side-offset="isMobile ? 4 : 15"
           align="end"

--- a/src/components/navigation/NavUser.vue
+++ b/src/components/navigation/NavUser.vue
@@ -17,6 +17,9 @@ import {
 import { authManager } from "@/plugins/auth";
 import { eventbus } from "@/plugins/eventbus";
 import { store } from "@/plugins/store";
+import { computed } from "vue";
+
+const isEditMode = computed(() => store.homescreenEditMode);
 import { LogOut, MoreVertical, Pencil, Settings } from "lucide-vue-next";
 import { useRouter } from "vue-router";
 
@@ -113,7 +116,7 @@ const handleLogout = () => {
           </DropdownMenuItem>
           <DropdownMenuItem @click="handleEditHomescreen">
             <Pencil class="size-4" />
-            {{ $t("homescreen_edit_enable") }}
+            {{ $t(isEditMode ? "homescreen_edit_disable" : "homescreen_edit_enable") }}
           </DropdownMenuItem>
           <DropdownMenuItem
             v-if="!store.isIngressSession"

--- a/src/plugins/store.ts
+++ b/src/plugins/store.ts
@@ -61,6 +61,7 @@ interface Store {
   enabledPlugins: Set<string>;
   isPartyGuest: boolean;
   companionPlayerId?: string;
+  homescreenEditMode: boolean;
 }
 
 export const store: Store = reactive({
@@ -133,4 +134,5 @@ export const store: Store = reactive({
   isOnboarding: false,
   enabledPlugins: new Set(),
   isPartyGuest: false,
+  homescreenEditMode: false,
 });

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -49,6 +49,7 @@ import Toolbar from "@/components/Toolbar.vue";
 import { api } from "@/plugins/api";
 import { authManager } from "@/plugins/auth";
 import { eventbus } from "@/plugins/eventbus";
+import { store } from "@/plugins/store";
 import { Compass } from "lucide-vue-next";
 import { onMounted, onUnmounted, ref } from "vue";
 import { useRouter } from "vue-router";
@@ -72,6 +73,7 @@ const navigateToProviders = () => {
 
 const handleHomescreenEditToggle = () => {
   editMode.value = !editMode.value;
+  store.homescreenEditMode = editMode.value;
 };
 
 onMounted(async () => {


### PR DESCRIPTION
## Problem

The "Edit Home screen" menu item in the user dropdown always showed the same label regardless of whether the homescreen was currently in edit mode or not. The translation key `homescreen_edit_disable` ("Leave Home screen edit mode") already existed but was never used.

## Solution

Track the homescreen edit mode state in the global store (`homescreenEditMode: boolean`) so that `NavUser.vue` can reactively switch the menu item label between:
- `homescreen_edit_enable` → "Edit Home screen" (when not in edit mode)
- `homescreen_edit_disable` → "Leave Home screen edit mode" (when in edit mode)

Both translation keys were already present in all language files — no new translations needed.