### PR TITLE
Bump PWA precache limit to 5 MiB for larger translation bundle

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -31,7 +31,7 @@ export default defineConfig({
       srcDir: "public",
       filename: "sw.js",
       injectManifest: {
-        maximumFileSizeToCacheInBytes: 3 * 1024 * 1024, // 3 MiB
+        maximumFileSizeToCacheInBytes: 5 * 1024 * 1024, // 5 MiB
       },
       includeAssets: [
         "favicon.svg",


### PR DESCRIPTION
Necessary as the many months of no downlading the translations has resulted in one very large one!