### PR TITLE
Use PlayerQueue.is_dynamic directly

### DIFF
--- a/src/plugins/api/helpers.ts
+++ b/src/plugins/api/helpers.ts
@@ -7,7 +7,6 @@ import {
   MediaType,
   Player,
   PlayerQueue,
-  Playlist,
 } from "./interfaces";
 
 /**
@@ -17,12 +16,7 @@ import {
 export const isQueueDynamicPlaylist = function (
   queue: PlayerQueue | undefined,
 ): boolean {
-  const source = queue?.radio_source;
-  return (
-    source?.length === 1 &&
-    source[0].media_type === MediaType.PLAYLIST &&
-    (source[0] as Playlist).is_dynamic
-  );
+  return queue?.is_dynamic ?? false;
 };
 
 /**

--- a/src/plugins/api/interfaces.ts
+++ b/src/plugins/api/interfaces.ts
@@ -862,6 +862,7 @@ export interface PlayerQueue {
   next_item?: QueueItem;
   radio_source: MediaItemType[];
   enqueued_media_items: MediaItemType[];
+  is_dynamic: boolean;
   // extra_attributes: additional attributes for this player_queue to store/forward
   // additional data that is not part of the standard model
   // must be serializable types only


### PR DESCRIPTION
## Summary

Uses the new `is_dynamic` field on `PlayerQueue` (music-assistant/models#224) directly, replacing the inline `radio_source` inspection in `RepeatBtn` and `ShuffleBtn`.

## Changes

- `interfaces.ts`: added `is_dynamic: boolean` to `PlayerQueue` interface
- `helpers.ts`: simplified `isQueueDynamicPlaylist` to use `queue.is_dynamic` directly; removed now-unused `Playlist` import

## Dependencies

Requires the following PRs to be merged and released first:
- music-assistant/models#224 — adds `PlayerQueue.is_dynamic` field ✅ merged
- music-assistant/server#3886 — sets `is_dynamic` when `radio_source` changes ✅ merged
- music-assistant/server#3948 — restores `is_dynamic` correctly after server restart (from cache) ✅ merged

## Related

- Models PR: music-assistant/models#224
- Server PR: music-assistant/server#3886
- Server fix PR: music-assistant/server#3948
- Mobile app issue: music-assistant/mobile-app#370