### PR TITLE
Add translation keys for Recommendations plugin provider

### DIFF
--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -986,18 +986,13 @@
         "library": "Library",
         "trending_podcasts": "Trending podcasts",
         "trending_stations": "Trending stations",
-        "recommendation": {
-            "forgotten_tracks": "Forgotten Tracks",
-            "forgotten_albums": "Forgotten Albums",
-            "forgotten_artists": "Forgotten Artists",
-            "most_played_tracks": "Most Played Tracks",
-            "never_played_tracks": "Never / Rarely Played",
-            "recent_favorite_tracks": "Recently Favorited Tracks",
-            "recent_favorite_albums": "Recently Favorited Albums",
-            "recently_added_tracks": "Recently Added Tracks",
-            "random_artists": "Random Artists",
-            "random_albums": "Random Albums"
-        }
+        "forgotten_tracks": "Forgotten tracks",
+        "forgotten_albums": "Forgotten albums",
+        "forgotten_artists": "Forgotten artists",
+        "most_played_tracks": "Most played tracks",
+        "never_played_tracks": "Never / rarely played",
+        "recent_favorite_albums": "Recently favorited albums",
+        "recently_added_tracks": "Recently added tracks"
     },
     "homescreen_edit_enable": "Edit Home screen",
     "homescreen_edit_disable": "Leave Home screen edit mode",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -985,7 +985,19 @@
         "libraries": "Libraries",
         "library": "Library",
         "trending_podcasts": "Trending podcasts",
-        "trending_stations": "Trending stations"
+        "trending_stations": "Trending stations",
+        "recommendation": {
+            "forgotten_tracks": "Forgotten Tracks",
+            "forgotten_albums": "Forgotten Albums",
+            "forgotten_artists": "Forgotten Artists",
+            "most_played_tracks": "Most Played Tracks",
+            "never_played_tracks": "Never / Rarely Played",
+            "recent_favorite_tracks": "Recently Favorited Tracks",
+            "recent_favorite_albums": "Recently Favorited Albums",
+            "recently_added_tracks": "Recently Added Tracks",
+            "random_artists": "Random Artists",
+            "random_albums": "Random Albums"
+        }
     },
     "homescreen_edit_enable": "Edit Home screen",
     "homescreen_edit_disable": "Leave Home screen edit mode",


### PR DESCRIPTION
## Translation keys for Recommendations plugin provider

Adds English translation keys for the 10 recommendation folders introduced by the server-side Recommendations plugin provider (music-assistant/server#3890).

Keys are namespaced under `recommendations.recommendation.*` to avoid conflicts with existing built-in recommendation keys.

| Key | English |
|---|---|
| `recommendation.forgotten_tracks` | Forgotten Tracks |
| `recommendation.forgotten_albums` | Forgotten Albums |
| `recommendation.forgotten_artists` | Forgotten Artists |
| `recommendation.most_played_tracks` | Most Played Tracks |
| `recommendation.never_played_tracks` | Never / Rarely Played |
| `recommendation.recent_favorite_tracks` | Recently Favorited Tracks |
| `recommendation.recent_favorite_albums` | Recently Favorited Albums |
| `recommendation.recently_added_tracks` | Recently Added Tracks |
| `recommendation.random_artists` | Random Artists |
| `recommendation.random_albums` | Random Albums |

Other locales will be added by the translation team.
