### PR TITLE
Show similar tracks section on TrackDetails view

### DIFF
--- a/src/plugins/api/index.ts
+++ b/src/plugins/api/index.ts
@@ -498,6 +498,18 @@ export class MusicAssistantApi {
     });
   }
 
+  public getSimilarTracks(
+    item_id: string,
+    provider_instance_id_or_domain: string,
+    limit = 25,
+  ): Promise<Track[]> {
+    return this.sendCommand("music/tracks/similar_tracks", {
+      item_id,
+      provider_instance_id_or_domain,
+      limit,
+    });
+  }
+
   public getTrackPreviewUrl(
     provider_instance_id_or_domain: string,
     item_id: string,

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -57,6 +57,7 @@
     "on": "On",
     "other_versions": "Other versions",
     "party_mode": "Party",
+    "similar_tracks": "Similar tracks",
     "perform_action": "Perform action on {0} item(s)",
     "play": "Play",
     "play_album_from": "Play Album from here",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -57,7 +57,6 @@
     "on": "On",
     "other_versions": "Other versions",
     "party_mode": "Party",
-    "similar_tracks": "Similar tracks",
     "perform_action": "Perform action on {0} item(s)",
     "play": "Play",
     "play_album_from": "Play Album from here",
@@ -752,6 +751,7 @@
         "missing_players_hint": "Missing players? {0}",
         "add_player_providers": "Add more player providers"
     },
+    "similar_tracks": "Similar tracks",
     "show_info": "Show info",
     "show_select_boxes": "Show selection boxes",
     "shuffle": "Shuffle",

--- a/src/views/TrackDetails.vue
+++ b/src/views/TrackDetails.vue
@@ -39,7 +39,7 @@
     <!-- similar tracks -->
     <ItemsListing
       v-if="itemDetails && !loading && hasSimilarTracksProvider"
-      itemtype="tracks"
+      itemtype="similartracks"
       :parent-item="itemDetails"
       :show-provider="false"
       :show-favorites-only-filter="false"

--- a/src/views/TrackDetails.vue
+++ b/src/views/TrackDetails.vue
@@ -143,9 +143,7 @@ const loadTrackAlbums = async function (params: LoadDataParams) {
 
 const hasSimilarTracksProvider = computed(() =>
   Object.values(api.providers).some((p) =>
-    (p.supported_features as unknown as string[]).includes(
-      ProviderFeature.SIMILAR_TRACKS,
-    ),
+    p.supported_features.includes(ProviderFeature.SIMILAR_TRACKS),
   ),
 );
 

--- a/src/views/TrackDetails.vue
+++ b/src/views/TrackDetails.vue
@@ -36,6 +36,20 @@
       :refresh-on-parent-update="true"
     />
     <br />
+    <!-- similar tracks -->
+    <ItemsListing
+      v-if="itemDetails && !loading && hasSimilarTracksProvider"
+      itemtype="tracks"
+      :parent-item="itemDetails"
+      :show-provider="false"
+      :show-favorites-only-filter="false"
+      :show-library-only-filter="false"
+      :show-refresh-button="false"
+      :load-items="loadSimilarTracks"
+      :title="$t('similar_tracks')"
+      :allow-collapse="true"
+    />
+    <br />
     <!-- provider mapping details -->
     <ProviderDetails v-if="itemDetails" :item-details="itemDetails" />
     <br />
@@ -45,11 +59,12 @@
 <script setup lang="ts">
 import ItemsListing, { LoadDataParams } from "@/components/ItemsListing.vue";
 import InfoHeader from "@/components/InfoHeader.vue";
-import { onBeforeUnmount, onMounted, ref } from "vue";
+import { computed, onBeforeUnmount, onMounted, ref } from "vue";
 import {
   EventMessage,
   EventType,
   MediaItemType,
+  ProviderFeature,
   type Track,
 } from "@/plugins/api/interfaces";
 import { api } from "@/plugins/api";
@@ -63,13 +78,16 @@ export interface Props {
 }
 const props = defineProps<Props>();
 const itemDetails = ref<Track>();
+const loading = ref(true);
 
 const loadItemDetails = async function () {
+  loading.value = true;
   itemDetails.value = await api.getTrack(
     props.itemId,
     props.provider,
     props.album,
   );
+  loading.value = false;
 };
 
 watch(
@@ -120,6 +138,29 @@ const loadTrackAlbums = async function (params: LoadDataParams) {
     props.itemId,
     props.provider,
     params.libraryOnly,
+  );
+};
+
+const hasSimilarTracksProvider = computed(() =>
+  Object.values(api.providers).some((p) =>
+    (p.supported_features as unknown as string[]).includes(
+      ProviderFeature.SIMILAR_TRACKS,
+    ),
+  ),
+);
+
+const loadSimilarTracks = async function (_params: LoadDataParams) {
+  if (!itemDetails.value) return [];
+  const tracks = await api.getSimilarTracks(props.itemId, props.provider);
+  return tracks.filter(
+    (t) =>
+      !itemDetails.value!.provider_mappings.some((refPm) =>
+        t.provider_mappings.some(
+          (tpm) =>
+            tpm.item_id === refPm.item_id &&
+            tpm.provider_domain === refPm.provider_domain,
+        ),
+      ),
   );
 };
 </script>


### PR DESCRIPTION
Adds a 'Similar tracks' section to the TrackDetails view, following the same pattern as the similar artists section in ArtistDetails (#1760).

## Changes
- Added `getSimilarTracks()` API method in `api/index.ts` (calls existing `music/tracks/similar_tracks` server endpoint)
- Added `"similar_tracks"` translation key to `en.json`
- Added Similar Tracks `ItemsListing` section to `TrackDetails.vue`, only shown when at least one provider supports `SIMILAR_TRACKS`
- The original track is filtered out from the results by comparing `provider_mappings`

## Screenshot
<img width="2008" height="1087" alt="track view with similar tracks" src="https://github.com/user-attachments/assets/6e97818b-ae8d-4598-b10d-58c9c26d2e54" />
