### PR TITLE
A11Y - Improve spoken search clear button label

### DIFF
--- a/src/views/Search.vue
+++ b/src/views/Search.vue
@@ -6,12 +6,14 @@
         v-model="store.globalSearchTerm"
         clearable
         prepend-inner-icon="mdi-magnify"
-        :label="$t('type_to_search')"
+        :label="$t('search')"
         hide-details
         variant="outlined"
         @focus="searchHasFocus = true"
         @blur="searchHasFocus = false"
-      />
+      >
+        <template #label>{{ $t("type_to_search") }}</template>
+      </v-text-field>
 
       <v-chip-group
         v-model="selectedSearchType"


### PR DESCRIPTION
## Summary

Improves the accessible name for the search field clear button.

Previously, VoiceOver announced the clear button as something like “Clear type here to search”. This changes the field’s programmatic label so the generated clear button is announced as “Clear search”, while keeping the visible label as “Type to search”.

## Files changed

- `src/views/Search.vue`

## Testing

- `git diff --check`
- `yarn build`
- `yarn lint`
- `yarn test:run`

I also tested this with VoiceOver.

## AI usage

I used OpenAI Codex as an assistive tool while preparing this PR. I reviewed and tested the final change and am responsible for the submitted code.