### PR TITLE
A11Y - Support Escape back navigation

### DIFF
--- a/src/components/InfoHeader.vue
+++ b/src/components/InfoHeader.vue
@@ -441,7 +441,7 @@ import { eventbus } from "@/plugins/eventbus";
 import { store } from "@/plugins/store";
 import { IconHeart, IconHeartFilled } from "@tabler/icons-vue";
 import { ArrowLeft, Merge, Trash2 } from "lucide-vue-next";
-import { computed, ref, watch } from "vue";
+import { computed, onBeforeUnmount, onMounted, ref, watch } from "vue";
 import { useI18n } from "vue-i18n";
 import { useRouter } from "vue-router";
 import { useDisplay } from "vuetify";
@@ -587,6 +587,62 @@ const backButtonClick = function () {
     name: "discover",
   });
 };
+
+const isEditableEscapeTarget = function (target: EventTarget | null) {
+  if (!(target instanceof HTMLElement)) return false;
+  return Boolean(
+    target.closest(
+      [
+        "input",
+        "select",
+        "textarea",
+        "[contenteditable='true']",
+        "[role='combobox']",
+        "[role='searchbox']",
+        "[role='slider']",
+        "[role='spinbutton']",
+        "[role='textbox']",
+      ].join(","),
+    ),
+  );
+};
+
+const hasActiveOverlay = function () {
+  if (showFullInfo.value || store.dialogActive || store.showPlayersMenu) {
+    return true;
+  }
+  return Boolean(
+    document.querySelector(
+      [
+        ".v-overlay--active",
+        "[role='dialog']:not([aria-hidden='true'])",
+        "[role='menu']:not([aria-hidden='true'])",
+      ].join(","),
+    ),
+  );
+};
+
+const handleEscapeBack = function (event: KeyboardEvent) {
+  if (event.defaultPrevented || event.key !== "Escape") return;
+  if (
+    hasActiveOverlay() ||
+    isEditableEscapeTarget(event.target) ||
+    isEditableEscapeTarget(document.activeElement)
+  ) {
+    return;
+  }
+
+  event.preventDefault();
+  backButtonClick();
+};
+
+onMounted(() => {
+  document.addEventListener("keydown", handleEscapeBack);
+});
+
+onBeforeUnmount(() => {
+  document.removeEventListener("keydown", handleEscapeBack);
+});
 
 const playButtonClick = function (forceMenu = false) {
   const playButton = document.getElementById("playbutton") as HTMLElement;

--- a/src/views/settings/Settings.vue
+++ b/src/views/settings/Settings.vue
@@ -300,7 +300,7 @@ import { authManager } from "@/plugins/auth";
 import { store } from "@/plugins/store";
 import { Settings } from "lucide-vue-next";
 import { match } from "ts-pattern";
-import { computed, provide, ref, watch } from "vue";
+import { computed, onBeforeUnmount, onMounted, provide, ref, watch } from "vue";
 import { useI18n } from "vue-i18n";
 import { useRouter, type RouteLocationRaw } from "vue-router";
 import { useDisplay } from "vuetify";
@@ -638,6 +638,40 @@ const getIconBackgroundStyle = (color: string) => {
 // computed properties
 const isOverview = computed(() => {
   return router.currentRoute.value.name === "settings";
+});
+
+const hasActiveOverlay = function () {
+  return Boolean(
+    document.querySelector(
+      ".v-overlay--active, [role='dialog']:not([aria-hidden='true'])",
+    ),
+  );
+};
+
+const returnFromSettingsSubpage = function () {
+  if (isOverview.value) return;
+
+  if (window.history.state?.back) {
+    router.back();
+  } else {
+    router.push({ name: "settings" });
+  }
+};
+
+const handleSettingsEscape = function (event: KeyboardEvent) {
+  if (event.defaultPrevented || event.key !== "Escape") return;
+  if (isOverview.value || store.dialogActive || hasActiveOverlay()) return;
+
+  event.preventDefault();
+  returnFromSettingsSubpage();
+};
+
+onMounted(() => {
+  document.addEventListener("keydown", handleSettingsEscape);
+});
+
+onBeforeUnmount(() => {
+  document.removeEventListener("keydown", handleSettingsEscape);
 });
 
 const activeTab = computed(() => {


### PR DESCRIPTION

## Summary

Adds Escape-key handling for detail and settings pages so VoiceOver’s scrub/back gesture can navigate back from those views.  This is important for ease of navigation when using VoiceOver as without it the user needs to manualy locate the back button with their finger which is very inefficient.  

The handler avoids taking over Escape when a dialog, menu, overlay, player menu, or editable control is active, so existing modal/menu/input behavior should continue to take priority.

## Files changed

- `src/components/InfoHeader.vue`
- `src/views/settings/Settings.vue`

## Testing

- `git diff --check`
- `yarn build`
- `yarn lint`
- `yarn test:run`

I also tested this with VoiceOver on detail and settings pages.

## AI usage

I used OpenAI Codex as an assistive tool while preparing this PR. I reviewed and tested the final change and am responsible for the submitted code.
