### PR TITLE
Use server-derived color palette via `MediaItemPalette`

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "color": "5.0.3",
-        "colorthief": "3.3.1",
         "happy-dom": "^20.9.0",
         "lucide-vue-next": "^1.0.0",
         "marked": "^18.0.2",

--- a/src/components/PlayerCard.vue
+++ b/src/components/PlayerCard.vue
@@ -233,20 +233,17 @@
 </template>
 
 <script setup lang="ts">
-import {
-  imgCoverDark,
-  imgCoverLight,
-} from "@/components/QualityDetailsBtn.vue";
 import { Button } from "@/components/ui/button";
 import VolumeControl from "@/components/VolumeControl.vue";
 import { useActiveSource } from "@/composables/activeSource";
 import { getPlayerMenuItems } from "@/helpers/player_menu_items";
 import {
-  getColorPalette,
+  EMPTY_COLOR_PALETTE,
   getMediaImageUrl,
   getPlayerName,
   ImageColorPalette,
   isBuiltinPlayer,
+  paletteFromServer,
 } from "@/helpers/utils";
 import api from "@/plugins/api";
 import {
@@ -259,7 +256,6 @@ import {
 import { getBreakpointValue } from "@/plugins/breakpoint";
 import { eventbus } from "@/plugins/eventbus";
 import { store } from "@/plugins/store";
-import vuetify from "@/plugins/vuetify";
 import { webPlayer } from "@/plugins/web_player";
 import { MoreVertical, Pause, Play, Power, Speaker } from "lucide-vue-next";
 import { computed, ref, toRef, watch } from "vue";
@@ -318,29 +314,14 @@ const canPlayPause = computed(() => {
 
 // local refs
 const coverImageColorPalette = ref<ImageColorPalette>({
-  "0": "",
-  "1": "",
-  "2": "",
-  "3": "",
-  "4": "",
-  "5": "",
-  lightColor: "",
-  darkColor: "",
+  ...EMPTY_COLOR_PALETTE,
 });
 
-// utility feature to extract the dominant colors from the cover image
-// we use this color palette to colorize the playerbar/OSD
-const img = new Image();
-img.src = vuetify.theme.current.value.dark ? imgCoverDark : imgCoverLight;
-img.crossOrigin = "Anonymous";
-img.addEventListener("load", function () {
-  coverImageColorPalette.value = getColorPalette(img);
-});
-
+// Use the server-derived palette from the now-playing media.
 watch(
-  () => compProps.player.current_media?.image_url,
-  (newImageUrl) => {
-    img.src = getMediaImageUrl(newImageUrl) || "";
+  () => compProps.player.current_media?.palette,
+  (palette) => {
+    coverImageColorPalette.value = paletteFromServer(palette);
   },
   { immediate: true },
 );

--- a/src/components/PlayerCard.vue
+++ b/src/components/PlayerCard.vue
@@ -238,7 +238,6 @@ import VolumeControl from "@/components/VolumeControl.vue";
 import { useActiveSource } from "@/composables/activeSource";
 import { getPlayerMenuItems } from "@/helpers/player_menu_items";
 import {
-  EMPTY_COLOR_PALETTE,
   getMediaImageUrl,
   getPlayerName,
   ImageColorPalette,
@@ -258,7 +257,7 @@ import { eventbus } from "@/plugins/eventbus";
 import { store } from "@/plugins/store";
 import { webPlayer } from "@/plugins/web_player";
 import { MoreVertical, Pause, Play, Power, Speaker } from "lucide-vue-next";
-import { computed, ref, toRef, watch } from "vue";
+import { computed, toRef } from "vue";
 
 // properties
 export interface Props {
@@ -312,18 +311,9 @@ const canPlayPause = computed(() => {
   return false;
 });
 
-// local refs
-const coverImageColorPalette = ref<ImageColorPalette>({
-  ...EMPTY_COLOR_PALETTE,
-});
-
 // Use the server-derived palette from the now-playing media.
-watch(
-  () => compProps.player.current_media?.palette,
-  (palette) => {
-    coverImageColorPalette.value = paletteFromServer(palette);
-  },
-  { immediate: true },
+const coverImageColorPalette = computed<ImageColorPalette>(() =>
+  paletteFromServer(compProps.player.current_media?.palette),
 );
 </script>
 

--- a/src/helpers/utils.ts
+++ b/src/helpers/utils.ts
@@ -27,8 +27,8 @@ import router from "@/plugins/router";
 import { store } from "@/plugins/store";
 import { webPlayer } from "@/plugins/web_player";
 import Color from "color";
-import { getPaletteSync } from "colorthief";
 import { Volume, Volume1, Volume2, VolumeX } from "lucide-vue-next";
+import type { MediaItemPalette } from "@/plugins/api/interfaces";
 
 export const openLinkInNewTab = function (url: string) {
   if (!url) return url;
@@ -425,9 +425,28 @@ export const numberRange = function (start: number, end: number): number[] {
 type RGBColor = [number, number, number];
 
 export interface ImageColorPalette {
-  [key: number]: string;
   lightColor: string;
   darkColor: string;
+}
+
+const _rgbTupleToHex = (rgb: RGBColor | null | undefined): string => {
+  if (!rgb) return "";
+  return rgbToHex(rgb);
+};
+
+export const EMPTY_COLOR_PALETTE: ImageColorPalette = {
+  lightColor: "",
+  darkColor: "",
+};
+
+export function paletteFromServer(
+  palette: MediaItemPalette | null | undefined,
+): ImageColorPalette {
+  if (!palette) return { ...EMPTY_COLOR_PALETTE };
+  return {
+    lightColor: _rgbTupleToHex(palette.on_dark),
+    darkColor: _rgbTupleToHex(palette.on_light),
+  };
 }
 
 export function getContrastingTextColor(hexColor: string): string {
@@ -487,64 +506,6 @@ export function rgbToHex(rgb: RGBColor): string {
     .toString(16)
     .padStart(2, "0")}${blue.toString(16).padStart(2, "0")}`;
   return hex;
-}
-
-export function findLightColor(colors: RGBColor[]): string {
-  let mostPleasantColor = "";
-  let highestContrastRatio = 0;
-
-  colors.forEach((rgb) => {
-    const hexColor = rgbToHex(rgb);
-    const contrastRatio = getContrastRatio("#000000", hexColor);
-
-    if (
-      (contrastRatio > highestContrastRatio && contrastRatio >= 7) ||
-      (contrastRatio > highestContrastRatio &&
-        contrastRatio >= highestContrastRatio * 0.7)
-    ) {
-      highestContrastRatio = contrastRatio;
-      mostPleasantColor = hexColor;
-    }
-  });
-  return mostPleasantColor;
-}
-
-export function findDarkColor(colors: RGBColor[]): string {
-  let mostPleasantColor = "";
-  let highestContrastRatio = 0;
-  const maxContrastRatio = 17.35;
-
-  colors.forEach((rgb) => {
-    const hexColor = rgbToHex(rgb);
-    const contrastRatio = getContrastRatio("#fff", hexColor);
-    if (maxContrastRatio >= contrastRatio) {
-      if (
-        (contrastRatio > highestContrastRatio && contrastRatio >= 7) ||
-        (contrastRatio > highestContrastRatio &&
-          contrastRatio >= highestContrastRatio * 0.7)
-      ) {
-        highestContrastRatio = contrastRatio;
-        mostPleasantColor = hexColor;
-      }
-    }
-  });
-  return mostPleasantColor;
-}
-
-export function getColorPalette(img: HTMLImageElement): ImageColorPalette {
-  const palette = getPaletteSync(img, { colorCount: 5 }) ?? [];
-  const colorNumberPalette: RGBColor[] = palette.map((c) => c.array());
-  const colorHexPalette: string[] = palette.map((c) => c.hex());
-
-  return {
-    0: colorHexPalette[0],
-    1: colorHexPalette[1],
-    2: colorHexPalette[2],
-    3: colorHexPalette[3],
-    4: colorHexPalette[4],
-    lightColor: findLightColor(colorNumberPalette),
-    darkColor: findDarkColor(colorNumberPalette),
-  };
 }
 
 export function getValueFromSources<T>(

--- a/src/helpers/utils.ts
+++ b/src/helpers/utils.ts
@@ -26,7 +26,6 @@ import { itemIsAvailable } from "@/plugins/api/helpers";
 import router from "@/plugins/router";
 import { store } from "@/plugins/store";
 import { webPlayer } from "@/plugins/web_player";
-import Color from "color";
 import { Volume, Volume1, Volume2, VolumeX } from "lucide-vue-next";
 import type { MediaItemPalette } from "@/plugins/api/interfaces";
 
@@ -447,49 +446,6 @@ export function paletteFromServer(
     lightColor: _rgbTupleToHex(palette.on_dark),
     darkColor: _rgbTupleToHex(palette.on_light),
   };
-}
-
-export function getContrastingTextColor(hexColor: string): string {
-  hexColor = hexColor.replace("#", "");
-  if (hexColor.length === 3) {
-    hexColor = hexColor
-      .split("")
-      .map((hex) => hex + hex)
-      .join("");
-  }
-
-  const r = parseInt(hexColor.substr(0, 2), 16);
-  const g = parseInt(hexColor.substr(2, 2), 16);
-  const b = parseInt(hexColor.substr(4, 2), 16);
-
-  const luminance = (0.299 * r + 0.587 * g + 0.114 * b) / 255;
-  if (luminance > 0.7) {
-    return "#000000";
-  } else {
-    return "#FFFFFF";
-  }
-}
-
-export function getContrastRatio(color1: string, color2: string): number {
-  const c1 = Color(color1);
-  const c2 = Color(color2);
-  return c1.contrast(c2);
-}
-
-export function lightenColor(hexCode: string, factor: number): string {
-  if (factor <= 0 || factor > 1) {
-    throw new Error("Factor must be in the range of 0 (exclusive) to 1.");
-  }
-
-  const rgbColor: RGBColor = hexToRgb(hexCode);
-
-  const newRgbColor: RGBColor = [
-    Math.min(255, Math.round(rgbColor[0] + (255 - rgbColor[0]) * factor)),
-    Math.min(255, Math.round(rgbColor[1] + (255 - rgbColor[1]) * factor)),
-    Math.min(255, Math.round(rgbColor[2] + (255 - rgbColor[2]) * factor)),
-  ];
-
-  return rgbToHex(newRgbColor);
 }
 
 export function hexToRgb(hex: string): RGBColor {

--- a/src/layouts/default/PlayerOSD/Player.vue
+++ b/src/layouts/default/PlayerOSD/Player.vue
@@ -111,20 +111,12 @@
 </template>
 
 <script setup lang="ts">
-import {
-  imgCoverDark,
-  imgCoverLight,
-} from "@/components/QualityDetailsBtn.vue";
-import {
-  ImageColorPalette,
-  getColorPalette,
-  getMediaImageUrl,
-} from "@/helpers/utils";
+import { ImageColorPalette, paletteFromServer } from "@/helpers/utils";
 import { MediaType } from "@/plugins/api/interfaces";
 import { getBreakpointValue } from "@/plugins/breakpoint";
 import { store } from "@/plugins/store";
 import vuetify from "@/plugins/vuetify";
-import { computed, ref, watch } from "vue";
+import { computed } from "vue";
 import PlayerControls from "./PlayerControls.vue";
 import PlayerExtendedControls from "./PlayerExtendedControls.vue";
 import PlayerTimeline from "./PlayerTimeline.vue";
@@ -136,26 +128,9 @@ interface Props {
 }
 const props = defineProps<Props>();
 
-// local refs
-const coverImageColorPalette = ref<ImageColorPalette>({
-  "0": "",
-  "1": "",
-  "2": "",
-  "3": "",
-  "4": "",
-  "5": "",
-  lightColor: "",
-  darkColor: "",
-});
-
-// utility feature to extract the dominant colors from the cover image
-// we use this color palette to colorize the playerbar/OSD
-const img = new Image();
-img.src = vuetify.theme.current.value.dark ? imgCoverDark : imgCoverLight;
-img.crossOrigin = "Anonymous";
-img.addEventListener("load", function () {
-  coverImageColorPalette.value = getColorPalette(img);
-});
+const coverImageColorPalette = computed<ImageColorPalette>(() =>
+  paletteFromServer(store.activePlayer?.current_media?.palette),
+);
 
 const backgroundColor = computed(() => {
   if (vuetify.theme.current.value.dark) {
@@ -175,20 +150,6 @@ const themeColor = computed(() =>
 const playIconStyle = computed(() => ({
   "--play-icon-color": vuetify.theme.current.value.dark ? "#212121" : "#fff",
 }));
-
-// watchers
-watch(
-  () => store.activePlayer?.current_media?.image_url,
-  () => {
-    // load cover image for the (new) QueueItem
-    // make sure that the image selection is exactly the same as on the player OSD thumb
-    if (store.activePlayer?.current_media?.image_url) {
-      img.src = getMediaImageUrl(store.activePlayer.current_media.image_url);
-    } else {
-      img.src = "";
-    }
-  },
-);
 </script>
 
 <style scoped lang="scss">

--- a/src/layouts/default/PlayerOSD/PlayerFullscreen.vue
+++ b/src/layouts/default/PlayerOSD/PlayerFullscreen.vue
@@ -1461,55 +1461,22 @@ const sliderColor = ref<string | undefined>(undefined);
 const backgroundColor = ref<string | undefined>(undefined);
 
 watchEffect(() => {
-  const LIGHT_TEXT_COLOR = Color("white");
-  const DARK_TEXT_COLOR = Color("black");
-  // Minimum WCAG contrast ration between the background and the text
-  // W3C recommends at least 4.5
-  const MIN_CONTRAST = 5;
-  const ADJUSTMENT_INCREMENT = 0.05;
-
-  // Determine the base color from palette or fallback to theme default
-  const coverImageColorCode = vuetify.theme.current.value.dark
+  const isDarkTheme = vuetify.theme.current.value.dark;
+  const bgHex = isDarkTheme
     ? compProps.colorPalette.darkColor || "#000"
     : compProps.colorPalette.lightColor || "#fff";
 
-  // Start with the original cover color as background
-  let bgColor = Color(coverImageColorCode);
+  const textHex = isDarkTheme ? "#ffffff" : "#000000";
+  const inverseTextHex = isDarkTheme ? "#000000" : "#ffffff";
 
-  // Calculate contrast with white and black
-  const lightContrast = LIGHT_TEXT_COLOR.contrast(bgColor);
-  const darkContrast = DARK_TEXT_COLOR.contrast(bgColor);
-
-  // Choose the color with higher contrast as starting value
-  const isLight = lightContrast >= darkContrast;
-  let textColor = isLight ? LIGHT_TEXT_COLOR : DARK_TEXT_COLOR;
-  let contrast = Math.max(lightContrast, darkContrast);
-
-  // If the best contrast still doesn't meet requirements, adjust background
-  if (contrast < MIN_CONTRAST) {
-    // Darken light bg or lighten dark bg until contrast is good
-    let adjustment = ADJUSTMENT_INCREMENT;
-
-    while (contrast < MIN_CONTRAST && adjustment <= 0.5) {
-      if (isLight) {
-        bgColor = bgColor.darken(ADJUSTMENT_INCREMENT);
-      } else {
-        bgColor = bgColor.lighten(ADJUSTMENT_INCREMENT);
-      }
-
-      contrast = Color(textColor).contrast(bgColor);
-      adjustment += ADJUSTMENT_INCREMENT;
-    }
-  }
-
-  // Keep color between text and sliders consistent.
-  // Also, this text color has a better contrast than the automatically selected one
-  document.documentElement.style.setProperty("--text-color", textColor.hex());
+  document.documentElement.style.setProperty("--text-color", textHex);
   document.documentElement.style.setProperty(
     "--text-color-inverse",
-    isLight ? DARK_TEXT_COLOR.hex() : LIGHT_TEXT_COLOR.hex(),
+    inverseTextHex,
   );
-  sliderColor.value = textColor.hex();
+  sliderColor.value = textHex;
+
+  const bgColor = Color(bgHex);
   const topColor = bgColor.lighten(0.25);
   const bottomColor = bgColor.darken(0.25);
   backgroundColor.value = `linear-gradient(to bottom, ${topColor.hex()}, ${bottomColor.hex()})`;

--- a/src/plugins/api/interfaces.ts
+++ b/src/plugins/api/interfaces.ts
@@ -895,6 +895,15 @@ export interface DeviceInfo {
   identifiers: Record<IdentifierType, string>;
 }
 
+export interface MediaItemPalette {
+  background_dark?: [number, number, number] | null;
+  background_light?: [number, number, number] | null;
+  primary?: [number, number, number] | null;
+  accent?: [number, number, number] | null;
+  on_dark?: [number, number, number] | null;
+  on_light?: [number, number, number] | null;
+}
+
 export interface PlayerMedia {
   uri: string; // uri or other identifier of the loaded media
   media_type: MediaType;
@@ -902,6 +911,7 @@ export interface PlayerMedia {
   artist?: string; // optional
   album?: string; // optional
   image_url?: string; // optional
+  palette?: MediaItemPalette | null; // optional
   duration?: number; // optional
   source_id?: string; // optional
   elapsed_time?: number; // optional

--- a/src/views/PartyDashboardView.vue
+++ b/src/views/PartyDashboardView.vue
@@ -302,8 +302,8 @@ import { useLyricsElapsedTime } from "@/composables/useLyricsElapsedTime";
 import { usePartyConfig } from "@/composables/usePartyConfig";
 import {
   ImageColorPalette,
-  getColorPalette,
   getMediaItemImageUrl,
+  paletteFromServer,
 } from "@/helpers/utils";
 import api from "@/plugins/api";
 import {
@@ -513,16 +513,9 @@ const lyricsTextColor = computed(() =>
 const { elapsedTime: lyricsElapsedTime, stop: stopTick } =
   useLyricsElapsedTime(lyricsEnabled);
 
-// Color palette state
-const colorPalette = ref<ImageColorPalette>({
-  "0": "",
-  "1": "",
-  "2": "",
-  "3": "",
-  "4": "",
-  lightColor: "",
-  darkColor: "",
-});
+const colorPalette = computed<ImageColorPalette>(() =>
+  paletteFromServer(store.activePlayer?.current_media?.palette),
+);
 
 // Single list of visible items for the unified TransitionGroup
 const visibleItems = computed(() => {
@@ -634,43 +627,6 @@ const fetchQueueItems = async (force = false) => {
     lastFetchedOffset.value = 0;
   }
 };
-
-// Dynamic background
-const img = new Image();
-img.crossOrigin = "Anonymous";
-const handleImageLoad = () => {
-  colorPalette.value = getColorPalette(img);
-};
-img.addEventListener("load", handleImageLoad);
-
-onBeforeUnmount(() => {
-  img.removeEventListener("load", handleImageLoad);
-  img.src = "";
-});
-
-watch(
-  () => store.curQueueItem?.image,
-  (image) => {
-    if (image) {
-      const imageUrl = getMediaItemImageUrl(image);
-      if (imageUrl) {
-        img.src = imageUrl;
-      }
-    } else {
-      // Reset to empty so the gradient computed picks theme-aware fallbacks
-      colorPalette.value = {
-        "0": "",
-        "1": "",
-        "2": "",
-        "3": "",
-        "4": "",
-        lightColor: "",
-        darkColor: "",
-      };
-    }
-  },
-  { immediate: true },
-);
 
 // Album art URL for the blurred background element
 const albumArtUrl = computed(() => {

--- a/tests/helpers/utils.test.ts
+++ b/tests/helpers/utils.test.ts
@@ -2,16 +2,17 @@ import {
   formatAliasName,
   formatDuration,
   formatRelativeTime,
-  getContrastingTextColor,
   getGenreDisplayName,
   hexToRgb,
   kebabize,
   numberRange,
+  paletteFromServer,
   parseBool,
   rgbToHex,
   sleep,
   truncateString,
 } from "@/helpers/utils";
+import type { MediaItemPalette } from "@/plugins/api/interfaces";
 import { describe, expect, it, vi } from "vitest";
 
 vi.mock("@/plugins/api", () => ({
@@ -45,20 +46,6 @@ vi.mock("@/layouts/default/ItemContextMenu.vue", () => ({
 
 vi.mock("@/plugins/api/helpers", () => ({
   itemIsAvailable: vi.fn(),
-}));
-
-vi.mock("colorthief", () => ({
-  default: class {
-    getPalette() {
-      return [
-        [255, 0, 0],
-        [0, 255, 0],
-        [0, 0, 255],
-        [255, 255, 0],
-        [255, 0, 255],
-      ];
-    }
-  },
 }));
 
 describe("formatDuration", () => {
@@ -168,20 +155,57 @@ describe("color utilities", () => {
     });
   });
 
-  describe("getContrastingTextColor", () => {
-    it("returns black text for light backgrounds", () => {
-      expect(getContrastingTextColor("#ffffff")).toBe("#000000");
-      expect(getContrastingTextColor("#f0f0f0")).toBe("#000000");
+  describe("paletteFromServer", () => {
+    it("returns empty palette for null", () => {
+      expect(paletteFromServer(null)).toEqual({
+        lightColor: "",
+        darkColor: "",
+      });
     });
 
-    it("returns white text for dark backgrounds", () => {
-      expect(getContrastingTextColor("#000000")).toBe("#FFFFFF");
-      expect(getContrastingTextColor("#333333")).toBe("#FFFFFF");
+    it("returns empty palette for undefined", () => {
+      expect(paletteFromServer(undefined)).toEqual({
+        lightColor: "",
+        darkColor: "",
+      });
     });
 
-    it("handles 3-character hex codes", () => {
-      expect(getContrastingTextColor("#fff")).toBe("#000000");
-      expect(getContrastingTextColor("#000")).toBe("#FFFFFF");
+    it("returns empty strings when on_dark and on_light are missing", () => {
+      const palette: MediaItemPalette = {};
+      expect(paletteFromServer(palette)).toEqual({
+        lightColor: "",
+        darkColor: "",
+      });
+    });
+
+    it("returns empty strings when on_dark and on_light are null", () => {
+      const palette: MediaItemPalette = { on_dark: null, on_light: null };
+      expect(paletteFromServer(palette)).toEqual({
+        lightColor: "",
+        darkColor: "",
+      });
+    });
+
+    it("maps on_dark to lightColor and on_light to darkColor", () => {
+      const palette: MediaItemPalette = {
+        on_dark: [255, 200, 100],
+        on_light: [40, 20, 10],
+      };
+      expect(paletteFromServer(palette)).toEqual({
+        lightColor: "#ffc864",
+        darkColor: "#28140a",
+      });
+    });
+
+    it("handles only one of on_dark/on_light being set", () => {
+      expect(paletteFromServer({ on_dark: [255, 255, 255] })).toEqual({
+        lightColor: "#ffffff",
+        darkColor: "",
+      });
+      expect(paletteFromServer({ on_light: [0, 0, 0] })).toEqual({
+        lightColor: "",
+        darkColor: "#000000",
+      });
     });
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -3419,11 +3419,6 @@ color@5.0.3:
     color-convert "^3.1.3"
     color-string "^2.1.3"
 
-colorthief@3.3.1:
-  version "3.3.1"
-  resolved "https://registry.npmjs.org/colorthief/-/colorthief-3.3.1.tgz"
-  integrity sha512-a3qzYXy51h6p3725pV8rnJwUBGTtvYQge2pVhKJwL+vETUD5pCi6VKmQyu51pBHdUbu/BPEXbwFLS0GnxXNhGA==
-
 combined-stream@^1.0.8:
   version "1.0.8"
   resolved "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz"


### PR DESCRIPTION
Drop the `colorthief` dependency and the local palette extraction in `utils.ts`. PlayerCard, PartyDashboardView, PlayerOSD and the player fullscreen view now read `current_media.palette` from `PlayerMedia` and convert it to the existing `ImageColorPalette` shape through the new `paletteFromServer` helper.

Depends on:
- https://github.com/music-assistant/server/pull/3915