### PR TITLE
Fix auto-refresh toggle on server logs page

### DIFF
--- a/src/views/settings/ServerLogs.vue
+++ b/src/views/settings/ServerLogs.vue
@@ -4,7 +4,7 @@
       <CardHeader class="shrink-0 border-b px-6 py-4">
         <div class="flex flex-wrap items-center justify-between gap-2">
           <div class="flex items-center gap-2">
-            <Switch id="auto-refresh" v-model:checked="autoRefresh" />
+            <Switch id="auto-refresh" v-model="autoRefresh" />
             <Label class="cursor-pointer" for="auto-refresh">
               {{ $t("settings.auto_refresh_log") }}
             </Label>


### PR DESCRIPTION
Fixes: https://github.com/music-assistant/support/issues/5477

The reka-ui Switch component exposes its state as `modelValue`, not `checked`, so `v-model:checked` never bound to `autoRefresh`. The ref stayed `true` regardless of the toggle, so the 5s interval kept running and toggling did nothing.