### PR TITLE
Add AudioSource media type for plugin sources

### DIFF
--- a/src/composables/activeAudioSource.ts
+++ b/src/composables/activeAudioSource.ts
@@ -6,11 +6,6 @@ import { store } from "@/plugins/store";
 /**
  * Composable that exposes the AudioSource currently playing on a player,
  * or undefined when the active queue item is not an AudioSource.
- *
- * Plugin sources (Spotify Connect, AirPlay receiver, Snapcast, etc.) are
- * no longer injected into player.source_list — they surface as queue items
- * of type AUDIO_SOURCE with their own capability flags. When present,
- * those flags take precedence over the player's source-list capabilities.
  */
 export function useActiveAudioSource(
   player:

--- a/src/composables/activeAudioSource.ts
+++ b/src/composables/activeAudioSource.ts
@@ -1,0 +1,31 @@
+import { computed, ComputedRef, Ref } from "vue";
+import { AudioSource, Player } from "@/plugins/api/interfaces";
+import { isAudioSource } from "@/plugins/api/helpers";
+import { store } from "@/plugins/store";
+
+/**
+ * Composable that exposes the AudioSource currently playing on a player,
+ * or undefined when the active queue item is not an AudioSource.
+ *
+ * Plugin sources (Spotify Connect, AirPlay receiver, Snapcast, etc.) are
+ * no longer injected into player.source_list — they surface as queue items
+ * of type AUDIO_SOURCE with their own capability flags. When present,
+ * those flags take precedence over the player's source-list capabilities.
+ */
+export function useActiveAudioSource(
+  player:
+    | ComputedRef<Player | undefined>
+    | Ref<Player | undefined>
+    | Player
+    | undefined,
+) {
+  const activeAudioSource = computed((): AudioSource | undefined => {
+    const playerObj =
+      typeof player === "object" && "value" in player ? player.value : player;
+    if (!playerObj) return undefined;
+    const item = store.curQueueItem?.media_item;
+    return isAudioSource(item) ? item : undefined;
+  });
+
+  return { activeAudioSource };
+}

--- a/src/helpers/genre.ts
+++ b/src/helpers/genre.ts
@@ -25,6 +25,7 @@ export const genreMediaTypeIconMap: Record<MediaType, string | Component> = {
   [MediaType.ARTIST]: "mdi-account-music",
   [MediaType.PLAYLIST]: "mdi-playlist-music",
   [MediaType.RADIO]: "mdi-radio",
+  [MediaType.AUDIO_SOURCE]: "mdi-audio-input-rca",
   [MediaType.AUDIOBOOK]: "mdi-book-music",
   [MediaType.PODCAST]: "mdi-podcast",
   [MediaType.GENRE]: GenreIcon,

--- a/src/layouts/default/PlayerOSD/Player.vue
+++ b/src/layouts/default/PlayerOSD/Player.vue
@@ -35,8 +35,10 @@
           :is-progress-bar="false"
           :disabled="
             !store.activePlayerQueue?.active ||
-            store.activePlayerQueue?.current_item?.media_item?.media_type !==
-              MediaType.TRACK
+            !timelineMediaTypes.includes(
+              store.activePlayerQueue?.current_item?.media_item
+                ?.media_type as MediaType,
+            )
           "
         />
       </div>
@@ -150,6 +152,10 @@ const themeColor = computed(() =>
 const playIconStyle = computed(() => ({
   "--play-icon-color": vuetify.theme.current.value.dark ? "#212121" : "#fff",
 }));
+
+// Media types that get a fully-featured timeline. AudioSource items decide
+// seekability via their own can_seek flag (read inside PlayerTimeline).
+const timelineMediaTypes = [MediaType.TRACK, MediaType.AUDIO_SOURCE];
 </script>
 
 <style scoped lang="scss">

--- a/src/layouts/default/PlayerOSD/PlayerControlBtn/NextBtn.vue
+++ b/src/layouts/default/PlayerOSD/PlayerControlBtn/NextBtn.vue
@@ -1,7 +1,7 @@
 <template>
   <!-- next button -->
   <Icon
-    v-if="isVisible && player"
+    v-if="isVisible && player && showNextPrev"
     v-bind="{ ...icon, ...$attrs }"
     :disabled="!canNext || isLoading"
     variant="button"
@@ -16,6 +16,7 @@ defineOptions({ inheritAttrs: false });
 import Icon, { IconProps } from "@/components/Icon.vue";
 import api from "@/plugins/api";
 import { Player, PlayerFeature, PlayerQueue } from "@/plugins/api/interfaces";
+import { useActiveAudioSource } from "@/composables/activeAudioSource";
 import { useActiveSource } from "@/composables/activeSource";
 import { computed, toRef } from "vue";
 import { SkipForward } from "lucide-vue-next";
@@ -36,6 +37,13 @@ const compProps = withDefaults(defineProps<Props>(), {
 });
 
 const { activeSource } = useActiveSource(toRef(compProps, "player"));
+const { activeAudioSource } = useActiveAudioSource(toRef(compProps, "player"));
+
+// Hide the button when the active queue item is an AudioSource without
+// next/previous support.
+const showNextPrev = computed(() =>
+  activeAudioSource.value ? activeAudioSource.value.can_next_previous : true,
+);
 
 const queueHasNext = computed(() => {
   if (!compProps.playerQueue?.active) return false;
@@ -54,6 +62,10 @@ const playerHasNext = computed(() => {
 });
 
 const canNext = computed(() => {
+  // AudioSource queue items carry their own capability flags
+  if (activeAudioSource.value) {
+    return activeAudioSource.value.can_next_previous;
+  }
   // Check if active source can next/previous
   if (activeSource.value) {
     return activeSource.value.can_next_previous;

--- a/src/layouts/default/PlayerOSD/PlayerControlBtn/PlayBtn.vue
+++ b/src/layouts/default/PlayerOSD/PlayerControlBtn/PlayBtn.vue
@@ -1,14 +1,20 @@
 <template>
-  <!-- play/pause button: disabled if no content -->
+  <!-- play/pause/stop button -->
   <Icon
-    v-if="isVisible && player && showPlayPause"
+    v-if="isVisible && player"
     v-bind="{ ...icon, ...$attrs }"
     class="play-btn-icon"
-    :disabled="!canPlayPause || isLoading"
+    :disabled="isDisabled"
     variant="button"
-    @click="api.playerCommandPlayPause(player.player_id)"
+    @click="onClick"
   >
-    <Pause v-if="isPlaying" :size="size" fill="currentColor" />
+    <Square
+      v-if="isPlaying && showStop"
+      :size="size"
+      fill="currentColor"
+      stroke-width="0"
+    />
+    <Pause v-else-if="isPlaying" :size="size" fill="currentColor" />
     <Play
       v-else
       :size="size"
@@ -17,7 +23,7 @@
     />
   </Icon>
   <v-progress-circular
-    v-if="isVisible && player && showPlayPause && isLoading"
+    v-if="isVisible && player && isLoading"
     class="play-btn-spinner"
     indeterminate
     :size="compProps.spinnerSize"
@@ -31,8 +37,13 @@ import Icon, { IconProps } from "@/components/Icon.vue";
 import { useActiveAudioSource } from "@/composables/activeAudioSource";
 import { useActiveSource } from "@/composables/activeSource";
 import api from "@/plugins/api";
-import { PlaybackState, Player, PlayerQueue } from "@/plugins/api/interfaces";
-import { Pause, Play } from "lucide-vue-next";
+import {
+  MediaType,
+  PlaybackState,
+  Player,
+  PlayerQueue,
+} from "@/plugins/api/interfaces";
+import { Pause, Play, Square } from "lucide-vue-next";
 import { computed, toRef } from "vue";
 
 // properties
@@ -57,12 +68,6 @@ const compProps = withDefaults(defineProps<Props>(), {
 
 const { activeSource } = useActiveSource(toRef(compProps, "player"));
 const { activeAudioSource } = useActiveAudioSource(toRef(compProps, "player"));
-
-// Hide the button entirely when the active queue item is an AudioSource
-// that does not advertise play/pause support.
-const showPlayPause = computed(() =>
-  activeAudioSource.value ? activeAudioSource.value.can_play_pause : true,
-);
 
 const queueCanPlay = computed(() => {
   if (!compProps.playerQueue) return false;
@@ -89,6 +94,17 @@ const canPlayPause = computed(() => {
   return queueCanPlay.value || playerCanPlay.value;
 });
 
+// When the current media can't be paused, surface Stop while playing so the
+// user always has a way to terminate playback. Covers AudioSources without
+// pause support, external sources that don't advertise it, and radio streams.
+const showStop = computed(() => {
+  if (activeAudioSource.value) return !activeAudioSource.value.can_play_pause;
+  if (compProps.player?.current_media?.media_type === MediaType.RADIO)
+    return true;
+  if (activeSource.value) return !activeSource.value.can_play_pause;
+  return false;
+});
+
 const isPlaying = computed(() => {
   return compProps.player?.playback_state == PlaybackState.PLAYING;
 });
@@ -99,6 +115,22 @@ const isLoading = computed(() => {
     compProps.playerQueue?.extra_attributes?.play_action_in_progress === true
   );
 });
+
+const isDisabled = computed(() => {
+  if (isLoading.value) return true;
+  // Stop is always available while playing, even when pause isn't supported
+  if (isPlaying.value && showStop.value) return false;
+  return !canPlayPause.value;
+});
+
+const onClick = () => {
+  if (!compProps.player) return;
+  if (isPlaying.value && showStop.value) {
+    api.playerCommandStop(compProps.player.player_id);
+  } else {
+    api.playerCommandPlayPause(compProps.player.player_id);
+  }
+};
 </script>
 
 <style>

--- a/src/layouts/default/PlayerOSD/PlayerControlBtn/PlayBtn.vue
+++ b/src/layouts/default/PlayerOSD/PlayerControlBtn/PlayBtn.vue
@@ -1,7 +1,7 @@
 <template>
   <!-- play/pause button: disabled if no content -->
   <Icon
-    v-if="isVisible && player"
+    v-if="isVisible && player && showPlayPause"
     v-bind="{ ...icon, ...$attrs }"
     class="play-btn-icon"
     :disabled="!canPlayPause || isLoading"
@@ -17,7 +17,7 @@
     />
   </Icon>
   <v-progress-circular
-    v-if="isVisible && player && isLoading"
+    v-if="isVisible && player && showPlayPause && isLoading"
     class="play-btn-spinner"
     indeterminate
     :size="compProps.spinnerSize"
@@ -28,6 +28,7 @@
 <script setup lang="ts">
 defineOptions({ inheritAttrs: false });
 import Icon, { IconProps } from "@/components/Icon.vue";
+import { useActiveAudioSource } from "@/composables/activeAudioSource";
 import { useActiveSource } from "@/composables/activeSource";
 import api from "@/plugins/api";
 import { PlaybackState, Player, PlayerQueue } from "@/plugins/api/interfaces";
@@ -55,6 +56,13 @@ const compProps = withDefaults(defineProps<Props>(), {
 });
 
 const { activeSource } = useActiveSource(toRef(compProps, "player"));
+const { activeAudioSource } = useActiveAudioSource(toRef(compProps, "player"));
+
+// Hide the button entirely when the active queue item is an AudioSource
+// that does not advertise play/pause support.
+const showPlayPause = computed(() =>
+  activeAudioSource.value ? activeAudioSource.value.can_play_pause : true,
+);
 
 const queueCanPlay = computed(() => {
   if (!compProps.playerQueue) return false;
@@ -69,6 +77,10 @@ const playerCanPlay = computed(() => {
 });
 
 const canPlayPause = computed(() => {
+  // AudioSource queue items carry their own capability flags
+  if (activeAudioSource.value) {
+    return activeAudioSource.value.can_play_pause;
+  }
   // Check if active source can play/pause
   if (activeSource.value) {
     return activeSource.value.can_play_pause;

--- a/src/layouts/default/PlayerOSD/PlayerControlBtn/PreviousBtn.vue
+++ b/src/layouts/default/PlayerOSD/PlayerControlBtn/PreviousBtn.vue
@@ -1,7 +1,7 @@
 <template>
   <!-- prev button -->
   <Icon
-    v-if="isVisible && player"
+    v-if="isVisible && player && showNextPrev"
     v-bind="{ ...icon, ...$attrs }"
     :disabled="!canPrevious || isLoading"
     variant="button"
@@ -16,6 +16,7 @@ defineOptions({ inheritAttrs: false });
 import Icon, { IconProps } from "@/components/Icon.vue";
 import api from "@/plugins/api";
 import { Player, PlayerFeature, PlayerQueue } from "@/plugins/api/interfaces";
+import { useActiveAudioSource } from "@/composables/activeAudioSource";
 import { useActiveSource } from "@/composables/activeSource";
 import { computed, toRef } from "vue";
 import { SkipBack } from "lucide-vue-next";
@@ -36,6 +37,13 @@ const compProps = withDefaults(defineProps<Props>(), {
 });
 
 const { activeSource } = useActiveSource(toRef(compProps, "player"));
+const { activeAudioSource } = useActiveAudioSource(toRef(compProps, "player"));
+
+// Hide the button when the active queue item is an AudioSource without
+// next/previous support.
+const showNextPrev = computed(() =>
+  activeAudioSource.value ? activeAudioSource.value.can_next_previous : true,
+);
 
 const queueHasPrevious = computed(() => {
   if (!compProps.playerQueue?.active) return false;
@@ -54,6 +62,10 @@ const playerHasPrevious = computed(() => {
 });
 
 const canPrevious = computed(() => {
+  // AudioSource queue items carry their own capability flags
+  if (activeAudioSource.value) {
+    return activeAudioSource.value.can_next_previous;
+  }
   // Check if active source can next/previous
   if (activeSource.value) {
     return activeSource.value.can_next_previous;

--- a/src/layouts/default/PlayerOSD/PlayerControlBtn/QueueBtn.vue
+++ b/src/layouts/default/PlayerOSD/PlayerControlBtn/QueueBtn.vue
@@ -1,6 +1,6 @@
 <template>
   <Button
-    v-if="isVisible"
+    v-if="isVisible && !activeAudioSource"
     variant="icon"
     :ripple="false"
     icon
@@ -21,6 +21,7 @@
 <script setup lang="ts">
 defineOptions({ inheritAttrs: false });
 import Button from "@/components/Button.vue";
+import { useActiveAudioSource } from "@/composables/activeAudioSource";
 import { store } from "@/plugins/store";
 import { ListVideo } from "lucide-vue-next";
 import { computed } from "vue";
@@ -34,6 +35,10 @@ withDefaults(defineProps<Props>(), {
   isVisible: true,
   size: 20,
 });
+
+const { activeAudioSource } = useActiveAudioSource(
+  computed(() => store.activePlayer),
+);
 
 const activeColor = computed(() =>
   store.showFullscreenPlayer && store.showQueueItems ? "primary" : undefined,

--- a/src/layouts/default/PlayerOSD/PlayerFullscreen.vue
+++ b/src/layouts/default/PlayerOSD/PlayerFullscreen.vue
@@ -64,7 +64,11 @@
       <div class="main">
         <!-- left column: media thumb + details-->
         <div
-          v-if="getBreakpointValue('bp7') || !store.showQueueItems"
+          v-if="
+            getBreakpointValue('bp7') ||
+            !store.showQueueItems ||
+            isCurAudioSource
+          "
           class="main-media-details"
         >
           <div
@@ -195,7 +199,9 @@
 
         <!-- right column: queue items-->
         <div
-          v-if="store.showQueueItems && store.activePlayerQueue"
+          v-if="
+            store.showQueueItems && store.activePlayerQueue && !isCurAudioSource
+          "
           class="main-queue-items"
         >
           <v-tabs
@@ -596,7 +602,7 @@ import RepeatBtn from "@/layouts/default/PlayerOSD/PlayerControlBtn/RepeatBtn.vu
 import ShuffleBtn from "@/layouts/default/PlayerOSD/PlayerControlBtn/ShuffleBtn.vue";
 import PlayerVolume from "@/layouts/default/PlayerOSD/PlayerVolume.vue";
 import api from "@/plugins/api";
-import { getSourceName } from "@/plugins/api/helpers";
+import { getSourceName, isAudioSource } from "@/plugins/api/helpers";
 import {
   EventMessage,
   EventType,
@@ -677,6 +683,10 @@ const boostBadgeColor = ref("#ff5722");
 const { elapsedTime: lyricsElapsedTime } = useLyricsElapsedTime();
 
 // Computed properties
+
+const isCurAudioSource = computed(() =>
+  isAudioSource(store.curQueueItem?.media_item),
+);
 
 const nextItems = computed(() => {
   if (store.activePlayerQueue) {

--- a/src/layouts/default/PlayerOSD/PlayerTimeline.vue
+++ b/src/layouts/default/PlayerOSD/PlayerTimeline.vue
@@ -61,6 +61,7 @@
 import api from "@/plugins/api";
 import { MediaType } from "@/plugins/api/interfaces";
 import { store } from "@/plugins/store";
+import { useActiveAudioSource } from "@/composables/activeAudioSource";
 import { useActiveSource } from "@/composables/activeSource";
 import { formatDuration } from "@/helpers/utils";
 import { ref, computed, watch, toRef, onUnmounted } from "vue";
@@ -78,6 +79,9 @@ withDefaults(defineProps<Props>(), {
 });
 
 const { activeSource } = useActiveSource(toRef(store, "activePlayer"));
+const { activeAudioSource } = useActiveAudioSource(
+  toRef(store, "activePlayer"),
+);
 
 // local refs
 const showRemainingTime = ref(false);
@@ -125,14 +129,18 @@ onUnmounted(() => {
 
 // computed properties
 const canSeek = computed(() => {
+  if (store.activePlayer?.powered === false) return false;
+  const currentMediaDuration = store.activePlayer?.current_media?.duration;
+  const currentMediaHasDuration = !!currentMediaDuration;
+
+  // AudioSource queue items carry their own capability flags; defer to them
+  // before falling back to the player's source-list source.
+  if (activeAudioSource.value) {
+    return activeAudioSource.value.can_seek && currentMediaHasDuration;
+  }
+
   // Check if active source allows seeking
   if (activeSource.value) {
-    // Only allow seeking if the source reports that it supports seeking
-    // (can_seek) AND the current media has a known duration.
-    if (store.activePlayer?.powered === false) return false;
-    const currentMediaDuration = store.activePlayer?.current_media?.duration;
-    const currentMediaHasDuration = !!currentMediaDuration;
-
     // Disallow seeking for radio streams (or other duration-less streams)
     const isRadio =
       store.activePlayer?.current_media?.media_type == MediaType.RADIO ||

--- a/src/plugins/api/helpers.ts
+++ b/src/plugins/api/helpers.ts
@@ -2,6 +2,7 @@
 
 import api from ".";
 import {
+  AudioSource,
   MediaItemType,
   ItemMapping,
   MediaType,
@@ -23,6 +24,18 @@ export const isQueueDynamicPlaylist = function (
     source[0].media_type === MediaType.PLAYLIST &&
     (source[0] as Playlist).is_dynamic
   );
+};
+
+/**
+ * Type guard for AudioSource media items.
+ * AudioSource is a first-class MediaItem representing a plugin source
+ * (Spotify Connect, AirPlay receiver, Snapcast, etc.) — its capability
+ * flags drive which transport controls are surfaced when active.
+ */
+export const isAudioSource = function (
+  item: MediaItemType | ItemMapping | undefined,
+): item is AudioSource {
+  return item?.media_type === MediaType.AUDIO_SOURCE;
 };
 
 /**

--- a/src/plugins/api/interfaces.ts
+++ b/src/plugins/api/interfaces.ts
@@ -297,12 +297,9 @@ export enum PlayerFeature {
 export enum SourceControl {
   PLAY = "play",
   PAUSE = "pause",
-  STOP = "stop",
   NEXT = "next",
   PREVIOUS = "previous",
   SEEK = "seek",
-  VOLUME = "volume",
-  SELECT = "select",
   UNKNOWN = "unknown",
 }
 

--- a/src/plugins/api/interfaces.ts
+++ b/src/plugins/api/interfaces.ts
@@ -103,6 +103,7 @@ export enum MediaType {
   PLAYLIST = "playlist",
   RADIO = "radio",
   AUDIOBOOK = "audiobook",
+  AUDIO_SOURCE = "audio_source",
   PODCAST = "podcast",
   PODCAST_EPISODE = "podcast_episode",
   GENRE = "genre",
@@ -291,6 +292,18 @@ export enum PlayerFeature {
   SELECT_SOURCE = "select_source",
   SELECT_SOUND_MODE = "select_sound_mode",
   OPTIONS = "options",
+}
+
+export enum SourceControl {
+  PLAY = "play",
+  PAUSE = "pause",
+  STOP = "stop",
+  NEXT = "next",
+  PREVIOUS = "previous",
+  SEEK = "seek",
+  VOLUME = "volume",
+  SELECT = "select",
+  UNKNOWN = "unknown",
 }
 
 export enum EventType {
@@ -701,6 +714,14 @@ export interface Playlist extends MediaItem {
 
 export interface Radio extends MediaItem {}
 
+export interface AudioSource extends MediaItem {
+  can_play_pause: boolean;
+  can_seek: boolean;
+  can_next_previous: boolean;
+  exclusive: boolean;
+  allow_external_trigger: boolean;
+}
+
 export interface Audiobook extends MediaItem {
   publisher: string;
   authors: string[];
@@ -741,6 +762,7 @@ export type MediaItemType =
   | Album
   | Track
   | Radio
+  | AudioSource
   | Playlist
   | Audiobook
   | Podcast
@@ -748,7 +770,12 @@ export type MediaItemType =
   | Genre
   | BrowseFolder;
 
-export type PlayableMediaItemType = Track | Radio | Audiobook | PodcastEpisode;
+export type PlayableMediaItemType =
+  | Track
+  | Radio
+  | AudioSource
+  | Audiobook
+  | PodcastEpisode;
 export type MediaItemTypeOrItemMapping = MediaItemType | ItemMapping;
 
 export interface SearchResults {

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -887,6 +887,7 @@
     "dont_stop_the_music_enable": "Enable 'Don't stop the music!'",
     "dont_stop_the_music_disable": "Disable 'Don't stop the music!'",
     "open_dsp_settings": "Open DSP settings",
+    "audio_source": "Audio source",
     "audiobook": "Audiobook",
     "audiobooks": "Audiobooks",
     "chapter": "Chapter",

--- a/tests/plugins/api/helpers.test.ts
+++ b/tests/plugins/api/helpers.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@/plugins/api", () => ({
+  default: {
+    serverInfo: { value: null },
+    providers: {},
+    queues: {},
+  },
+}));
+
+import { isAudioSource } from "@/plugins/api/helpers";
+import { MediaType } from "@/plugins/api/interfaces";
+import type { MediaItemType } from "@/plugins/api/interfaces";
+
+describe("isAudioSource", () => {
+  it("returns true for AUDIO_SOURCE media type", () => {
+    const item = { media_type: MediaType.AUDIO_SOURCE } as MediaItemType;
+    expect(isAudioSource(item)).toBe(true);
+  });
+
+  it("returns false for non-AudioSource media types", () => {
+    for (const type of [
+      MediaType.TRACK,
+      MediaType.RADIO,
+      MediaType.ALBUM,
+      MediaType.PLAYLIST,
+      MediaType.AUDIOBOOK,
+    ]) {
+      const item = { media_type: type } as MediaItemType;
+      expect(isAudioSource(item)).toBe(false);
+    }
+  });
+
+  it("returns false for undefined", () => {
+    expect(isAudioSource(undefined)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Mirrors the server's new `AudioSource` MediaItem so plugin sources (Spotify Connect, AirPlay receiver, Snapcast, VBAN, Yandex Ynison, …) surface as first-class browseable queue items instead of being injected into each player's `source_list`. The player OSD reads per-item capability flags (`can_play_pause`, `can_seek`, `can_next_previous`) so only the controls the source actually supports are rendered. Coordinates with the matching server PR; only fully functional once both ship.

## Changes

- `MediaType.AUDIO_SOURCE` enum value, new `AudioSource` interface (capability flags + `exclusive` / `allow_external_trigger`), `SourceControl` enum, added to `MediaItemType` and `PlayableMediaItemType` unions.
- `isAudioSource` type guard in `plugins/api/helpers.ts`.
- New `useActiveAudioSource` composable, mirroring `useActiveSource`.
- Player OSD transport buttons (`PlayBtn`, `NextBtn`, `PreviousBtn`) hide via `v-if` when the active AudioSource doesn't advertise the capability; existing disabled behaviour kept for non-AudioSource items.
- `PlayerTimeline.canSeek` defers to the active AudioSource's `can_seek` when present.
- `Player.vue` lets the timeline render for both `TRACK` and `AUDIO_SOURCE` (seekability still gated by `canSeek`).
- `PlayerFullscreen` hides the upcoming-tracks panel — and `QueueBtn` hides itself — when the active queue item is an AudioSource.
- Genre icon map covers the new media type so the typed `Record<MediaType, …>` stays exhaustive.
- `audio_source` translation key in `en.json`.
- Vitest unit test for `isAudioSource`.