### PR TITLE
Add support for variable playback speed

### DIFF
--- a/src/helpers/elapsed.test.ts
+++ b/src/helpers/elapsed.test.ts
@@ -58,4 +58,36 @@ describe("computeElapsedTime", () => {
     expect(result).toBeGreaterThanOrEqual(31.0 - 0.001);
     expect(result).toBeLessThanOrEqual(31.0 + 0.001);
   });
+
+  it("scales the delta by playback_speed > 1", () => {
+    const t0 = 10;
+    const ts = 1_600_000_000;
+    vi.setSystemTime(ts * 1000 + 4000); // 4s wall-clock
+
+    const result = computeElapsedTime(t0, ts, PlaybackState.PLAYING, 1.5);
+    // 10 + 4 * 1.5 = 16
+    expect(result).toBeGreaterThanOrEqual(15.999);
+    expect(result).toBeLessThanOrEqual(16.001);
+  });
+
+  it("scales the delta by playback_speed < 1", () => {
+    const t0 = 10;
+    const ts = 1_600_000_000;
+    vi.setSystemTime(ts * 1000 + 4000); // 4s wall-clock
+
+    const result = computeElapsedTime(t0, ts, PlaybackState.PLAYING, 0.5);
+    // 10 + 4 * 0.5 = 12
+    expect(result).toBeGreaterThanOrEqual(11.999);
+    expect(result).toBeLessThanOrEqual(12.001);
+  });
+
+  it("defaults playback_speed to 1 when omitted", () => {
+    const t0 = 10;
+    const ts = 1_600_000_000;
+    vi.setSystemTime(ts * 1000 + 2000);
+
+    const result = computeElapsedTime(t0, ts, PlaybackState.PLAYING);
+    expect(result).toBeGreaterThanOrEqual(11.999);
+    expect(result).toBeLessThanOrEqual(12.001);
+  });
 });

--- a/src/helpers/elapsed.ts
+++ b/src/helpers/elapsed.ts
@@ -3,9 +3,10 @@
  *
  * Calculate the current elapsed playback time in seconds from a stored
  * `elapsed_time` value and the `elapsed_time_last_updated` UTC timestamp
- * (milliseconds since epoch). The function assumes:
+ * (seconds since epoch). The function assumes:
  *  - elapsed_time: seconds (may be fractional)
- *  - elapsed_time_last_updated: ms since epoch (UTC)
+ *  - elapsed_time_last_updated: seconds since epoch (UTC)
+ *  - playback_speed: multiplier applied to the wall-clock delta (default 1)
  *
  * If `playbackState` is not PLAYING, the function returns the provided
  * `elapsed_time` without applying the time-delta. This avoids advancing the
@@ -17,6 +18,7 @@ export function computeElapsedTime(
   elapsed_time: number | undefined,
   elapsed_time_last_updated: number | undefined,
   playbackState?: PlaybackState,
+  playback_speed: number = 1,
 ): number | undefined {
   if (elapsed_time === undefined || elapsed_time_last_updated === undefined) {
     return elapsed_time;
@@ -32,9 +34,8 @@ export function computeElapsedTime(
 
   const nowMs = Date.now();
   const deltaMs = Math.max(0, nowMs - lastUpdatedMs);
-  const deltaSeconds = deltaMs / 1000;
+  const deltaSeconds = (deltaMs / 1000) * playback_speed;
 
-  // elapsed_time is expected to be in seconds.
   return elapsed_time + deltaSeconds;
 }
 

--- a/src/layouts/default/PlayerOSD/PlayerControlBtn/PlayerTrackMenu.vue
+++ b/src/layouts/default/PlayerOSD/PlayerControlBtn/PlayerTrackMenu.vue
@@ -27,24 +27,69 @@
         <RadioTower class="size-4" />
         {{ $t("play_radio") }}
       </DropdownMenuItem>
+      <DropdownMenuItem
+        v-if="playbackSpeedSupported"
+        @click="onOpenPlaybackSpeed"
+      >
+        <Gauge class="size-4" />
+        {{ $t("change_playback_speed") }}
+      </DropdownMenuItem>
     </DropdownMenuContent>
   </DropdownMenu>
+
+  <Dialog v-model:open="playbackSpeedDialogOpen">
+    <DialogContent class="playback-speed-dialog">
+      <DialogHeader>
+        <DialogTitle>{{ $t("change_playback_speed") }}</DialogTitle>
+      </DialogHeader>
+      <div class="playback-speed-current">
+        {{ formatSpeed(currentPlaybackSpeed) }}
+      </div>
+      <Slider
+        :model-value="[sliderPlaybackSpeed]"
+        :min="PLAYBACK_SPEED_SLIDER_MIN"
+        :max="PLAYBACK_SPEED_SLIDER_MAX"
+        :step="0.05"
+        class="playback-speed-slider"
+        @update:model-value="onSliderPlaybackSpeed"
+      />
+      <div class="playback-speed-options">
+        <Button
+          v-for="option in PLAYBACK_SPEED_OPTIONS"
+          :key="option"
+          :variant="option === currentPlaybackSpeed ? 'default' : 'outline'"
+          @click="onSelectPlaybackSpeed(option)"
+        >
+          {{ formatSpeed(option) }}
+        </Button>
+      </div>
+    </DialogContent>
+  </Dialog>
 </template>
 
 <script setup lang="ts">
 import Button from "@/components/Button.vue";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
 import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
+import { Slider } from "@/components/ui/slider";
 import api from "@/plugins/api";
 import { isQueueDynamicPlaylist } from "@/plugins/api/helpers";
 import {
   MediaType,
   ProviderFeature,
   QueueOption,
+  type Audiobook,
+  type PodcastEpisode,
   type Radio,
   type Track,
 } from "@/plugins/api/interfaces";
@@ -53,12 +98,32 @@ import router from "@/plugins/router";
 import { store } from "@/plugins/store";
 import {
   EllipsisIcon,
+  Gauge,
   Heart,
   Info,
   PlusCircle,
   RadioTower,
 } from "lucide-vue-next";
-import { computed } from "vue";
+import { computed, onBeforeUnmount, ref, watch } from "vue";
+
+const PLAYBACK_SPEED_OPTIONS = [1, 1.25, 1.5, 2, 3] as const;
+const PLAYBACK_SPEED_SLIDER_MIN = 0.5;
+const PLAYBACK_SPEED_SLIDER_MAX = 2;
+
+const playbackSpeedDialogOpen = ref(false);
+const currentPlaybackSpeed = ref<number>(1);
+
+const formatSpeed = (value: number) =>
+  Number.isInteger(value) ? value.toFixed(1) : value.toString();
+
+// Slider only spans 0.5–2.0; values outside (e.g. the 3.0 preset) peg the
+// thumb at the corresponding end so the slider stays in sync visually.
+const sliderPlaybackSpeed = computed(() =>
+  Math.min(
+    PLAYBACK_SPEED_SLIDER_MAX,
+    Math.max(PLAYBACK_SPEED_SLIDER_MIN, currentPlaybackSpeed.value),
+  ),
+);
 
 const currentTrack = computed(() => {
   const item = store.curQueueItem?.media_item;
@@ -72,7 +137,39 @@ const currentRadio = computed(() => {
   return undefined;
 });
 
-const currentItem = computed(() => currentTrack.value ?? currentRadio.value);
+const currentAudiobook = computed(() => {
+  const item = store.curQueueItem?.media_item;
+  if (item?.media_type === MediaType.AUDIOBOOK) return item as Audiobook;
+  return undefined;
+});
+
+const currentPodcastEpisode = computed(() => {
+  const item = store.curQueueItem?.media_item;
+  if (item?.media_type === MediaType.PODCAST_EPISODE)
+    return item as PodcastEpisode;
+  return undefined;
+});
+
+const currentItem = computed(
+  () =>
+    currentTrack.value ??
+    currentRadio.value ??
+    currentAudiobook.value ??
+    currentPodcastEpisode.value,
+);
+
+const playbackSpeedSupported = computed(
+  () => !!(currentAudiobook.value || currentPodcastEpisode.value),
+);
+
+watch(
+  () => store.curQueueItem,
+  (queueItem) => {
+    currentPlaybackSpeed.value =
+      queueItem?.extra_attributes?.playback_speed ?? 1;
+  },
+  { immediate: true },
+);
 
 const radioModeSupported = computed(() => {
   const item = currentTrack.value;
@@ -127,4 +224,111 @@ const onStartRadio = () => {
   if (!currentTrack.value) return;
   api.playMedia([currentTrack.value.uri], QueueOption.REPLACE, true);
 };
+
+const onOpenPlaybackSpeed = () => {
+  // Sync from latest queue state before opening so the displayed value is
+  // current even if the queue item updated since the menu was last touched.
+  currentPlaybackSpeed.value =
+    store.curQueueItem?.extra_attributes?.playback_speed ?? 1;
+  playbackSpeedDialogOpen.value = true;
+};
+
+// Debounce backend updates so dragging the slider doesn't spam the API —
+// only the value held for >=1s gets sent. If the dialog is closed before
+// the timer fires, the pending change is flushed immediately.
+const PLAYBACK_SPEED_DEBOUNCE_MS = 1000;
+let speedDebounceTimer: ReturnType<typeof setTimeout> | null = null;
+let pendingSpeed: {
+  value: number;
+  queueId: string;
+  queueItemId: string;
+} | null = null;
+
+const flushPendingSpeed = () => {
+  if (speedDebounceTimer !== null) {
+    clearTimeout(speedDebounceTimer);
+    speedDebounceTimer = null;
+  }
+  if (!pendingSpeed) return;
+  const { value, queueId, queueItemId } = pendingSpeed;
+  pendingSpeed = null;
+  api.queueCommandSetPlaybackSpeed(queueId, value, queueItemId);
+};
+
+const applyPlaybackSpeed = (value: number) => {
+  currentPlaybackSpeed.value = value;
+  const queueItem = store.curQueueItem;
+  if (!queueItem) return;
+  pendingSpeed = {
+    value,
+    queueId: queueItem.queue_id,
+    queueItemId: queueItem.queue_item_id,
+  };
+  if (speedDebounceTimer !== null) clearTimeout(speedDebounceTimer);
+  speedDebounceTimer = setTimeout(
+    flushPendingSpeed,
+    PLAYBACK_SPEED_DEBOUNCE_MS,
+  );
+};
+
+const onSelectPlaybackSpeed = (value: number) => {
+  applyPlaybackSpeed(value);
+};
+
+const onSliderPlaybackSpeed = (value: number[] | undefined) => {
+  if (!value || value.length === 0) return;
+  applyPlaybackSpeed(Math.round(value[0] * 100) / 100);
+};
+
+// Flush any pending change as soon as the dialog closes, so the user's
+// final selection is sent even if they close before the 1s window elapses.
+watch(playbackSpeedDialogOpen, (open) => {
+  if (!open) flushPendingSpeed();
+});
+
+onBeforeUnmount(flushPendingSpeed);
 </script>
+
+<style scoped>
+/* Anchor the dialog near the player bar (bottom-right) instead of the
+   default screen-centre, so it appears close to the overflow menu that
+   opened it. */
+.playback-speed-dialog {
+  width: 360px;
+  max-width: calc(100vw - 2rem) !important;
+  top: auto !important;
+  left: auto !important;
+  right: 1rem !important;
+  bottom: calc(env(safe-area-inset-bottom, 0) + 6rem) !important;
+  transform: none !important;
+}
+
+.playback-speed-current {
+  text-align: center;
+  font-size: 1.5rem;
+  font-variant-numeric: tabular-nums;
+  padding: 4px 0 8px;
+  opacity: 0.85;
+}
+
+.playback-speed-slider {
+  width: 100%;
+  margin-bottom: 12px;
+}
+
+.playback-speed-options {
+  display: flex;
+  flex-wrap: nowrap;
+  gap: 6px;
+  justify-content: center;
+  padding: 4px 0 0;
+}
+
+.playback-speed-options > * {
+  flex: 1 1 0;
+  min-width: 0;
+  border: 1px solid var(--border, hsl(var(--border, 0 0% 80%)));
+  border-radius: 8px;
+  font-variant-numeric: tabular-nums;
+}
+</style>

--- a/src/layouts/default/PlayerOSD/PlayerControlBtn/PlayerTrackMenu.vue
+++ b/src/layouts/default/PlayerOSD/PlayerControlBtn/PlayerTrackMenu.vue
@@ -57,7 +57,7 @@
         <Button
           v-for="option in PLAYBACK_SPEED_OPTIONS"
           :key="option"
-          :variant="option === currentPlaybackSpeed ? 'default' : 'outline'"
+          :variant="option === currentPlaybackSpeed ? 'default' : 'plain'"
           @click="onSelectPlaybackSpeed(option)"
         >
           {{ formatSpeed(option) }}

--- a/src/layouts/default/PlayerOSD/PlayerTimeline.vue
+++ b/src/layouts/default/PlayerOSD/PlayerTimeline.vue
@@ -206,6 +206,7 @@ const computedElapsedTime = computed(() => {
       queueTime.elapsed_time,
       queueTime.elapsed_time_last_updated,
       queue!.state,
+      store.curQueueItem?.extra_attributes?.playback_speed ?? 1,
     );
     return computed ?? 0;
   }
@@ -222,6 +223,7 @@ const computedElapsedTime = computed(() => {
       store.activePlayer.current_media.elapsed_time,
       store.activePlayer.current_media.elapsed_time_last_updated,
       store.activePlayer?.playback_state,
+      store.curQueueItem?.extra_attributes?.playback_speed ?? 1,
     );
     return computed ?? 0;
   }
@@ -235,6 +237,7 @@ const computedElapsedTime = computed(() => {
       store.activePlayer.elapsed_time,
       store.activePlayer.elapsed_time_last_updated,
       store.activePlayer?.playback_state,
+      store.curQueueItem?.extra_attributes?.playback_speed ?? 1,
     );
     return computed ?? 0;
   }

--- a/src/plugins/api/index.ts
+++ b/src/plugins/api/index.ts
@@ -1471,6 +1471,16 @@ export class MusicAssistantApi {
       !this.queues[queueId].dont_stop_the_music_enabled,
     );
   }
+  public queueCommandSetPlaybackSpeed(
+    queue_id: string,
+    speed: number,
+    queue_item_id: string,
+  ) {
+    this.playerQueueCommand(queue_id, "set_playback_speed", {
+      speed,
+      queue_item_id,
+    });
+  }
   public playerQueueCommand(
     queue_id: string,
     command: string,

--- a/src/plugins/api/interfaces.ts
+++ b/src/plugins/api/interfaces.ts
@@ -827,6 +827,7 @@ export interface QueueItem {
   extra_attributes?: {
     party_guest?: boolean; // true if added by party guest
     party_boosted?: boolean; // true if added as "boost" (play next)
+    playback_speed?: number; // current playback speed multiplier (audiobook/podcast)
   };
 }
 

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -65,6 +65,7 @@
     "play_on": "Play on: {0}",
     "play_playlist_from": "Play Playlist from here",
     "play_radio": "Start Radio",
+    "change_playback_speed": "Change playback speed",
     "player_type": {
         "group": "Group",
         "player": "Player",


### PR DESCRIPTION
Requires server PR: https://github.com/music-assistant/server/pull/3939

Adds a playback-speed control for audiobooks and podcasts. A "Change playback speed" item appears in the player's overflow menu when the current item is an audiobook or podcast episode. Selecting it opens a dialog with a slider (0.5×–2×) and preset buttons (1×, 1.25×, 1.5×, 2×, 3×). (Shamelessly stole this from YouTube!) Speed changes are debounced by one second so dragging the slider doesn't spam the backend, and any pending change is flushed when the dialog closes.

The frontend extrapolates the playback position between server updates by adding wall-clock time to the last reported elapsed_time. That extrapolation multiplies the delta by the queue item's `playback_speed`, so the progress indicator stays in sync with the actual playback rate instead of drifting and snapping on every server update.

Changes

- New `playback_speed` field on `QueueItem.extra_attributes`.
- New `queueCommandSetPlaybackSpeed` API helper that issues the `set_playback_speed` queue command.
- New menu item and dialog in `PlayerTrackMenu.vue`, restricted to audiobooks and podcasts.
- `computeElapsedTime` takes an optional speed multiplier (defaults to 1); `PlayerTimeline.vue` passes the current item's speed
- Translation key `change_playback_speed`.
- Unit tests covering the speed multiplier (>1, <1, and default).

<img width="474" height="229" alt="image" src="https://github.com/user-attachments/assets/8c220359-6b29-44c9-ac8d-e729b21ca911" />

<img width="531" height="237" alt="image" src="https://github.com/user-attachments/assets/15d0f2c8-b982-4c04-8477-6be971c294a9" />
 