### PR TITLE
Hide group count badge on standalone players when not synced

### DIFF
--- a/src/components/PlayerCard.vue
+++ b/src/components/PlayerCard.vue
@@ -160,11 +160,11 @@
             color="primary"
             :offset-x="-5"
             :offset-y="-5"
-            :content="
-              player.type == PlayerType.GROUP
-                ? player.group_members.length
-                : player.group_members.length || 1
+            :model-value="
+              player.type == PlayerType.GROUP ||
+              player.group_members.length >= 2
             "
+            :content="player.group_members.length"
             class="group-badge"
           >
             <Speaker


### PR DESCRIPTION
## Summary

Fixes the "looks like a notification" UX problem on standalone players, per the rule [confirmed by @marcelveldt in music-assistant/backlog#52](https://github.com/music-assistant/backlog/issues/52#issuecomment-3746023639).

- Before: standalone players always rendered a "1" badge on the group/sync button, looking like an unread-notification indicator with nothing clickable behind it.
- After: standalone players only show the badge when actually synced to ≥1 other player. Dedicated group players always show the badge (matching Marcel's spec and the Sonos app pattern).

## Behaviour matrix

| Player type | Sync state | Badge before | Badge after |
| --- | --- | --- | --- |
| `PlayerType.PLAYER` | not synced | "1" | hidden |
| `PlayerType.PLAYER` | synced to 1 other (2 members) | "2" | "2" |
| `PlayerType.GROUP` | 0 children | "0" | "0" |
| `PlayerType.GROUP` | 3 children | "3" | "3" |
| `PlayerType.STEREO_PAIR` | (always 2 members) | "2" | "2" |

## Implementation notes

- Toggles via `v-badge`'s `:model-value` prop. Same pattern as `Toolbar.vue:42` and `Icon.vue:8`, so no new conventions.
- Single-file change, 4 lines diff in `src/components/PlayerCard.vue`.
- `STEREO_PAIR` is implicitly handled — group_members.length is always 2, so it falls under the ≥ 2 rule and keeps showing the "2" badge.

## Test plan

<img width="1364" height="1192" alt="CleanShot 2026-05-22 at 14 03 42@2x" src="https://github.com/user-attachments/assets/67384ba7-0834-48da-b253-8a773c4b50ca" />



- [x] Verified locally against synthetic players covering the 4 states in the matrix above.
- [x] `yarn build` (vue-tsc + vite) passes.
- [x] `yarn lint` passes (no new warnings).
- [ ] Maintainer visual check against a real running server.

Refs: music-assistant/backlog#52 (sub-item 6 – group circle / notification-style badge)