### PR TITLE
i18n: add 'inspired_by_recently_played' recommendations key

### DIFF
--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -963,6 +963,7 @@
         "in_progress_items": "Continue listening...",
         "recommended_new_tracks": "Recommended new tracks",
         "recently_played": "Recently played",
+        "inspired_by_recently_played": "Inspired by recently played",
         "suggested_new_albums_for_you": "Suggested new albums for you",
         "random_artists": "Random artists",
         "random_albums": "Random albums",


### PR DESCRIPTION
Adds the missing English translation key `recommendations.inspired_by_recently_played` ("Inspired by recently played").

Plugin providers that declare `ProviderFeature.RECOMMENDATIONS` can yield a `RecommendationFolder` with `translation_key="inspired_by_recently_played"` and have its title localised correctly by `HomeWidgetRows.vue`'s existing i18n lookup (`$t(`recommendations.${translation_key}`, recommendation.name)`). Without this key the lookup falls back to the raw English `name` field, which renders correctly in English but doesn't localise.

This pairs with an upcoming server-side plugin (`sonic_similarity`) that yields exactly this folder when it has indexed enough recently-played tracks. The server side is the only producer of this key today; merging this first lets the plugin land without an English-only fallback.