### PR TITLE
AudioSource follow-up: treat as in-queue infinite stream

### DIFF
--- a/src/layouts/default/PlayerOSD/PlayerControlBtn/QueueBtn.vue
+++ b/src/layouts/default/PlayerOSD/PlayerControlBtn/QueueBtn.vue
@@ -1,6 +1,6 @@
 <template>
   <Button
-    v-if="isVisible && !activeAudioSource"
+    v-if="isVisible && store.activePlayerQueue"
     variant="icon"
     :ripple="false"
     icon
@@ -21,7 +21,6 @@
 <script setup lang="ts">
 defineOptions({ inheritAttrs: false });
 import Button from "@/components/Button.vue";
-import { useActiveAudioSource } from "@/composables/activeAudioSource";
 import { store } from "@/plugins/store";
 import { ListVideo } from "lucide-vue-next";
 import { computed } from "vue";
@@ -35,10 +34,6 @@ withDefaults(defineProps<Props>(), {
   isVisible: true,
   size: 20,
 });
-
-const { activeAudioSource } = useActiveAudioSource(
-  computed(() => store.activePlayer),
-);
 
 const activeColor = computed(() =>
   store.showFullscreenPlayer && store.showQueueItems ? "primary" : undefined,

--- a/src/layouts/default/PlayerOSD/PlayerControlBtn/RepeatBtn.vue
+++ b/src/layouts/default/PlayerOSD/PlayerControlBtn/RepeatBtn.vue
@@ -7,7 +7,8 @@
       !playerQueue.active ||
       playerQueue.items == 0 ||
       isLoading ||
-      isSingleDynamicPlaylist
+      isSingleDynamicPlaylist ||
+      isInfiniteStream
     "
     :color="
       getValueFromSources(icon?.color, [
@@ -46,7 +47,10 @@ import Icon, { IconProps } from "@/components/Icon.vue";
 import { getValueFromSources } from "@/helpers/utils";
 import api from "@/plugins/api";
 import { PlayerQueue, RepeatMode } from "@/plugins/api/interfaces";
-import { isQueueDynamicPlaylist } from "@/plugins/api/helpers";
+import {
+  isQueueDynamicPlaylist,
+  isQueueInfiniteStream,
+} from "@/plugins/api/helpers";
 import { computed } from "vue";
 import { IconRepeat, IconRepeatOff, IconRepeatOnce } from "@tabler/icons-vue";
 
@@ -71,5 +75,9 @@ const isLoading = computed(() => {
 
 const isSingleDynamicPlaylist = computed(() =>
   isQueueDynamicPlaylist(compProps.playerQueue),
+);
+
+const isInfiniteStream = computed(() =>
+  isQueueInfiniteStream(compProps.playerQueue),
 );
 </script>

--- a/src/layouts/default/PlayerOSD/PlayerControlBtn/ShuffleBtn.vue
+++ b/src/layouts/default/PlayerOSD/PlayerControlBtn/ShuffleBtn.vue
@@ -7,7 +7,8 @@
       !playerQueue.active ||
       playerQueue.items == 0 ||
       isLoading ||
-      isSingleDynamicPlaylist
+      isSingleDynamicPlaylist ||
+      isInfiniteStream
     "
     :color="
       getValueFromSources(icon?.color, [
@@ -33,7 +34,10 @@ import Icon, { IconProps } from "@/components/Icon.vue";
 import { getValueFromSources } from "@/helpers/utils";
 import api from "@/plugins/api";
 import { PlayerQueue } from "@/plugins/api/interfaces";
-import { isQueueDynamicPlaylist } from "@/plugins/api/helpers";
+import {
+  isQueueDynamicPlaylist,
+  isQueueInfiniteStream,
+} from "@/plugins/api/helpers";
 import { IconArrowsRight } from "@tabler/icons-vue";
 import { Shuffle } from "lucide-vue-next";
 import { computed } from "vue";
@@ -59,5 +63,9 @@ const isLoading = computed(() => {
 
 const isSingleDynamicPlaylist = computed(() =>
   isQueueDynamicPlaylist(compProps.playerQueue),
+);
+
+const isInfiniteStream = computed(() =>
+  isQueueInfiniteStream(compProps.playerQueue),
 );
 </script>

--- a/src/layouts/default/PlayerOSD/PlayerFullscreen.vue
+++ b/src/layouts/default/PlayerOSD/PlayerFullscreen.vue
@@ -64,11 +64,7 @@
       <div class="main">
         <!-- left column: media thumb + details-->
         <div
-          v-if="
-            getBreakpointValue('bp7') ||
-            !store.showQueueItems ||
-            isCurAudioSource
-          "
+          v-if="getBreakpointValue('bp7') || !store.showQueueItems"
           class="main-media-details"
         >
           <div
@@ -199,9 +195,7 @@
 
         <!-- right column: queue items-->
         <div
-          v-if="
-            store.showQueueItems && store.activePlayerQueue && !isCurAudioSource
-          "
+          v-if="store.showQueueItems && store.activePlayerQueue"
           class="main-queue-items"
         >
           <v-tabs
@@ -602,7 +596,7 @@ import RepeatBtn from "@/layouts/default/PlayerOSD/PlayerControlBtn/RepeatBtn.vu
 import ShuffleBtn from "@/layouts/default/PlayerOSD/PlayerControlBtn/ShuffleBtn.vue";
 import PlayerVolume from "@/layouts/default/PlayerOSD/PlayerVolume.vue";
 import api from "@/plugins/api";
-import { getSourceName, isAudioSource } from "@/plugins/api/helpers";
+import { getSourceName } from "@/plugins/api/helpers";
 import {
   EventMessage,
   EventType,
@@ -683,10 +677,6 @@ const boostBadgeColor = ref("#ff5722");
 const { elapsedTime: lyricsElapsedTime } = useLyricsElapsedTime();
 
 // Computed properties
-
-const isCurAudioSource = computed(() =>
-  isAudioSource(store.curQueueItem?.media_item),
-);
 
 const nextItems = computed(() => {
   if (store.activePlayerQueue) {

--- a/src/plugins/api/helpers.ts
+++ b/src/plugins/api/helpers.ts
@@ -27,6 +27,17 @@ export const isQueueDynamicPlaylist = function (
 };
 
 /**
+ * Returns true when the queue's current item is an infinite stream
+ * (radio station or AudioSource). Shuffle and repeat don't apply in that case.
+ */
+export const isQueueInfiniteStream = function (
+  queue: PlayerQueue | undefined,
+): boolean {
+  const mediaType = queue?.current_item?.media_item?.media_type;
+  return mediaType === MediaType.RADIO || mediaType === MediaType.AUDIO_SOURCE;
+};
+
+/**
  * Type guard for AudioSource media items.
  * AudioSource is a first-class MediaItem representing a plugin source
  * (Spotify Connect, AirPlay receiver, Snapcast, etc.) — its capability

--- a/tests/plugins/api/helpers.test.ts
+++ b/tests/plugins/api/helpers.test.ts
@@ -8,9 +8,9 @@ vi.mock("@/plugins/api", () => ({
   },
 }));
 
-import { isAudioSource } from "@/plugins/api/helpers";
+import { isAudioSource, isQueueInfiniteStream } from "@/plugins/api/helpers";
 import { MediaType } from "@/plugins/api/interfaces";
-import type { MediaItemType } from "@/plugins/api/interfaces";
+import type { MediaItemType, PlayerQueue } from "@/plugins/api/interfaces";
 
 describe("isAudioSource", () => {
   it("returns true for AUDIO_SOURCE media type", () => {
@@ -33,5 +33,37 @@ describe("isAudioSource", () => {
 
   it("returns false for undefined", () => {
     expect(isAudioSource(undefined)).toBe(false);
+  });
+});
+
+describe("isQueueInfiniteStream", () => {
+  const makeQueue = (mediaType: MediaType | undefined) =>
+    ({
+      current_item: mediaType
+        ? { media_item: { media_type: mediaType } }
+        : undefined,
+    }) as unknown as PlayerQueue;
+
+  it("returns true when the current item is a radio", () => {
+    expect(isQueueInfiniteStream(makeQueue(MediaType.RADIO))).toBe(true);
+  });
+
+  it("returns true when the current item is an AudioSource", () => {
+    expect(isQueueInfiniteStream(makeQueue(MediaType.AUDIO_SOURCE))).toBe(true);
+  });
+
+  it("returns false for finite media types", () => {
+    for (const type of [
+      MediaType.TRACK,
+      MediaType.AUDIOBOOK,
+      MediaType.PODCAST_EPISODE,
+    ]) {
+      expect(isQueueInfiniteStream(makeQueue(type))).toBe(false);
+    }
+  });
+
+  it("returns false when the queue or current item is missing", () => {
+    expect(isQueueInfiniteStream(undefined)).toBe(false);
+    expect(isQueueInfiniteStream(makeQueue(undefined))).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

Follow-up to #1786 / [server #3938](https://github.com/music-assistant/server/pull/3938). Now that AudioSource is a real queue item, the queue should remain accessible while one is playing and the transport controls should match how we already treat radio.

## Changes

- `QueueBtn` and the fullscreen queue-items panel are no longer hidden when the current queue item is an AudioSource. They only disappear when there's no MA queue at all (true external source).
- Shuffle and repeat are now disabled whenever the current queue item is an infinite stream — applies to both radio and AudioSource — via a new `isQueueInfiniteStream` helper.
- AudioSources now surface as a queue entry in the fullscreen queue list, giving the same visual "now playing X" indicator that radio stations have.