### PR TITLE
Reduce items-per-row at large screen widths

### DIFF
--- a/src/helpers/utils.ts
+++ b/src/helpers/utils.ts
@@ -583,17 +583,6 @@ export const panelViewItemResponsive = function (displaySize: number) {
       condition: "gt",
     }) &&
     getBreakpointValue({
-      breakpoint: "bp5",
-      condition: "lt",
-    })
-  ) {
-    return 3;
-  } else if (
-    getBreakpointValue({
-      breakpoint: "bp5",
-      condition: "gt",
-    }) &&
-    getBreakpointValue({
       breakpoint: "bp6",
       condition: "lt",
     })
@@ -605,62 +594,51 @@ export const panelViewItemResponsive = function (displaySize: number) {
       condition: "gt",
     }) &&
     getBreakpointValue({
-      breakpoint: "bp7",
+      breakpoint: "bp8",
       condition: "lt",
     })
   ) {
     return 4;
   } else if (
     getBreakpointValue({
-      breakpoint: "bp7",
+      breakpoint: "bp8",
       condition: "gt",
     }) &&
     getBreakpointValue({
-      breakpoint: "bp8",
+      breakpoint: "bp9",
       condition: "lt",
     })
   ) {
     return 5;
   } else if (
     getBreakpointValue({
-      breakpoint: "bp8",
+      breakpoint: "bp9",
       condition: "gt",
     }) &&
     getBreakpointValue({
-      breakpoint: "bp9",
+      breakpoint: "bp10",
       condition: "lt",
     })
   ) {
     return 6;
   } else if (
     getBreakpointValue({
-      breakpoint: "bp9",
+      breakpoint: "bp10",
       condition: "gt",
     }) &&
     getBreakpointValue({
-      breakpoint: "bp10",
+      breakpoint: "bp11",
       condition: "lt",
+    })
+  ) {
+    return 7;
+  } else if (
+    getBreakpointValue({
+      breakpoint: "bp11",
+      condition: "gt",
     })
   ) {
     return 8;
-  } else if (
-    getBreakpointValue({
-      breakpoint: "bp10",
-      condition: "gt",
-    }) &&
-    getBreakpointValue({
-      breakpoint: "bp11",
-      condition: "lt",
-    })
-  ) {
-    return 9;
-  } else if (
-    getBreakpointValue({
-      breakpoint: "bp11",
-      condition: "gt",
-    })
-  ) {
-    return 10;
   } else {
     return 0;
   }


### PR DESCRIPTION
## Summary

The responsive grid currently shows up to **10 tiles per row** on panel grids (Library Albums/Artists, Album details, Browse, Search, ...) and **10.5** in the Home/Discover carousels (the `.5` is Swiper's intentional peek-next-tile hint). At 1900 px each tile is ~190 px wide, and a row of 10 album covers is visually noisy and pushes cognitive load past comfortable scanning. Peer apps (Spotify, Apple Music) stop at 5–7 per row on desktop.

This PR lowers the cap to 8 at the widest breakpoint and pulls down the mid-range counts. The mobile/small-tablet end (<960 px) is unchanged.

A single function — `panelViewItemResponsive` in `src/helpers/utils.ts` — governs both the Swiper carousel (`src/components/Carousel.vue`) and the Vuetify panel grids (`src/components/ItemsListing.vue`), so this is a one-file change that propagates to every consuming view. No CSS changes were needed (`col-2` … `col-10` were already defined; the new range is `col-2` … `col-8`).

## New mapping

Carousels show `N + 0.5` (the peek behaviour is preserved).

| Viewport width | Old | New |
|---|---|---|
| < 500 px | 2 | 2 |
| 500 – 960 px | 3 | 3 |
| 960 – 1100 px | 4 | 4 |
| 1100 – 1300 px | 5 | **4** |
| 1300 – 1500 px | 6 | **5** |
| 1500 – 1700 px | 8 | **6** |
| 1700 – 1900 px | 9 | **7** |
| ≥ 1900 px | 10 | **8** |

## Test plan

- [ ] `yarn build` passes (vue-tsc + Vite) — confirmed locally
- [ ] `yarn test:run` passes (160/160) — confirmed locally
- [ ] `yarn lint` clean — confirmed locally
- [ ] Open Home / Discover, resize browser across all breakpoints, confirm each carousel shows `N + 0.5` tiles for the widths above
- [ ] Open Library → Albums (panel grid), confirm same `N` counts at the same widths and no horizontal overflow
- [ ] Open an album with multiple versions, toggle the "Other versions" listing to panel mode, confirm tiles follow the new density
- [ ] Confirm at ≥ 1900 px the home carousel shows 8.5 tiles (was 10.5) and library grids show 8 per row (was 10)

🤖 Generated with [Claude Code](https://claude.com/claude-code)