### PR TITLE
Format ArtistDetails similar artists API call

### DIFF
--- a/src/views/ArtistDetails.vue
+++ b/src/views/ArtistDetails.vue
@@ -170,10 +170,7 @@ const hasSimilarArtistsProvider = computed(() =>
 
 const loadSimilarArtists = async function (_params: LoadDataParams) {
   if (!itemDetails.value) return [];
-  return await api.getSimilarArtists(
-    props.itemId,
-    props.provider,
-  );
+  return await api.getSimilarArtists(props.itemId, props.provider);
 };
 
 const loadArtistTracks = async function (params: LoadDataParams) {


### PR DESCRIPTION
Small formatting-only change in `ArtistDetails.vue` to keep the `api.getSimilarArtists` call on one line.

This isolates the recurring local format diff into a dedicated PR so it no longer keeps reappearing in unrelated branches.