### PR TITLE
fix(theme): fix dark-mode rendering

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -91,22 +91,22 @@ const setTheme = function () {
 
   if (themePref == "dark") {
     // forced dark mode
-    theme.global.name.value = "dark";
+    theme.change("dark");
     themeValue = "dark";
   } else if (themePref == "light") {
     // forced light mode
-    theme.global.name.value = "light";
+    theme.change("light");
     themeValue = "light";
   } else if (
     window.matchMedia &&
     window.matchMedia("(prefers-color-scheme: dark)").matches
   ) {
     // dark mode is enabled in browser
-    theme.global.name.value = "dark";
+    theme.change("dark");
     themeValue = "dark";
   } else {
     // light mode is enabled in browser
-    theme.global.name.value = "light";
+    theme.change("light");
     themeValue = "light";
   }
 

--- a/src/plugins/vuetify.ts
+++ b/src/plugins/vuetify.ts
@@ -40,6 +40,11 @@ export default createVuetify(
       },
     },
     theme: {
+      // Use a private id rather than the well-known
+      // "vuetify-theme-stylesheet" default: anything injecting CSS into
+      // the page (extensions, userscripts, other libraries) can target
+      // the public id by name and overwrite the runtime CSS variables.
+      stylesheetId: "mass-vuetify-theme",
       defaultTheme: "dark",
       themes: {
         light: {

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -43,6 +43,7 @@
 }
 
 :root {
+  color-scheme: light;
   --radius: 0.625rem;
   /* Light theme - matching Vuetify light */
   --background: #f5f5f5;
@@ -68,17 +69,22 @@
   --chart-3: #ff9800;
   --chart-4: #9c27b0;
   --chart-5: #f44336;
-  --sidebar: rgb(var(--v-theme-panel));
-  --sidebar-foreground: rgb(var(--v-theme-on-surface));
-  --sidebar-primary: rgb(var(--v-theme-primary));
-  --sidebar-primary-foreground: rgb(var(--v-theme-on-primary));
-  --sidebar-accent: rgba(var(--v-theme-on-surface), 0.08);
-  --sidebar-accent-foreground: rgb(var(--v-theme-on-surface));
-  --sidebar-border: rgba(var(--v-theme-on-surface), 0.12);
-  --sidebar-ring: rgb(var(--v-theme-primary));
+  /* Sidebar tokens hardcoded (not indirected through --v-theme-*) because the
+     Vuetify theme vars are only defined on .v-application; declared at :root
+     they evaluate to the first-listed theme (light) and inherit downward,
+     defeating .dark. Keep these in lockstep with vuetify.ts panel colors. */
+  --sidebar: #ffffff;
+  --sidebar-foreground: #000000;
+  --sidebar-primary: #03a9f4;
+  --sidebar-primary-foreground: #ffffff;
+  --sidebar-accent: rgba(0, 0, 0, 0.08);
+  --sidebar-accent-foreground: #000000;
+  --sidebar-border: rgba(0, 0, 0, 0.12);
+  --sidebar-ring: #03a9f4;
 }
 
 .dark {
+  color-scheme: dark;
   /* Dark theme - matching Vuetify dark */
   --background: #181818;
   --foreground: #ffffff;
@@ -103,12 +109,12 @@
   --chart-3: #ff9800;
   --chart-4: #9c27b0;
   --chart-5: #f44336;
-  --sidebar: rgb(var(--v-theme-panel));
-  --sidebar-foreground: rgb(var(--v-theme-on-surface));
-  --sidebar-primary: rgb(var(--v-theme-primary));
-  --sidebar-primary-foreground: rgb(var(--v-theme-on-primary));
-  --sidebar-accent: rgba(var(--v-theme-on-surface), 0.12);
-  --sidebar-accent-foreground: rgb(var(--v-theme-on-surface));
-  --sidebar-border: rgba(var(--v-theme-on-surface), 0.2);
-  --sidebar-ring: rgb(var(--v-theme-primary));
+  --sidebar: #232323;
+  --sidebar-foreground: #ffffff;
+  --sidebar-primary: #03a9f4;
+  --sidebar-primary-foreground: #ffffff;
+  --sidebar-accent: rgba(255, 255, 255, 0.12);
+  --sidebar-accent-foreground: #ffffff;
+  --sidebar-border: rgba(255, 255, 255, 0.2);
+  --sidebar-ring: #03a9f4;
 }


### PR DESCRIPTION
Ran into an issue where the web UI wasn't properly rendering when in dark mode in Safari in macOS, but was able to reproduce in Chrome as well. Black text on a dark background, etc. No backend changes needed.

Three changes:

1. vuetify.ts: give Vuetify a private stylesheetId ("mass-vuetify-theme") instead of the well-known default. Anything injecting CSS into the page (browser extensions, userscripts, other libraries on the same page) can target the default "vuetify-theme-stylesheet" by name and overwrite the runtime CSS custom properties Vuetify generates. We discovered this via a Safari extension injecting Vuetify-2-era theme CSS under that id, but the vulnerability is generic across any browser with installable extensions.

2. style.css: hardcode shadcn sidebar tokens in :root and .dark instead of indirecting through rgb(var(--v-theme-panel)). The original was incorrect by CSS scope rules: --v-theme-panel is only declared inside .v-application; at :root the indirection resolves to whatever Vuetify put at the root level (the defaultTheme: "dark" value). That meant light-mode rendered the sidebar with dark colors. The hardcoded values mirror vuetify.ts's panel colors and are commented to that effect. Also adds color-scheme: light/dark at :root / .dark for correct native form-control and scrollbar defaults.

3. App.vue: switch setTheme from `theme.global.name.value = X` to `theme.change(X)` (4 call sites). The former goes through a Vuetify 3.x deprecation proxy that logs a console warning on assignment; theme.change is the recommended API. Functionally equivalent.