### PR TITLE
Fix Smart Playlist seed picker dropping all results when only plugin providers supply SIMILAR_TRACKS

### DIFF
--- a/src/composables/useSmartPlaylistSeedItems.ts
+++ b/src/composables/useSmartPlaylistSeedItems.ts
@@ -37,20 +37,16 @@ export function useSmartPlaylistSeedItems() {
       .map((p) => p.instance_id),
   );
 
+  // Don't filter results by provider_mappings: the server's similar_*
+  // dispatchers fall back to plugin-tier providers, which never appear there.
   setupDebouncedSearch({
     query: seedTrackSearch,
     results: seedTrackResults,
     isSearching: isSeedSearching,
     searchFn: async (q) => {
-      const providerIds = _similarTrackProviderIds.value;
-      if (providerIds.length === 0) return [];
-
+      if (_similarTrackProviderIds.value.length === 0) return [];
       const result = await api.search(q, [MediaType.TRACK], 20);
-      return result.tracks.filter((t) =>
-        t.provider_mappings?.some((m) =>
-          providerIds.includes(m.provider_instance),
-        ),
-      );
+      return result.tracks;
     },
   });
 
@@ -59,15 +55,9 @@ export function useSmartPlaylistSeedItems() {
     results: seedArtistResults,
     isSearching: isSeedArtistSearching,
     searchFn: async (q) => {
-      const providerIds = _similarArtistProviderIds.value;
-      if (providerIds.length === 0) return [];
-
+      if (_similarArtistProviderIds.value.length === 0) return [];
       const result = await api.search(q, [MediaType.ARTIST], 20);
-      return result.artists.filter((a) =>
-        a.provider_mappings?.some((m) =>
-          providerIds.includes(m.provider_instance),
-        ),
-      );
+      return result.artists;
     },
   });
 

--- a/tests/composables/smart_playlist/useSmartPlaylistSeedItems.test.ts
+++ b/tests/composables/smart_playlist/useSmartPlaylistSeedItems.test.ts
@@ -42,7 +42,12 @@ vi.mock("@/plugins/api", () => ({
   },
 }));
 
+import api from "@/plugins/api";
 import { useSmartPlaylistSeedItems } from "@/composables/useSmartPlaylistSeedItems";
+
+interface SearchFnArg {
+  searchFn: (q: string) => Promise<unknown[]>;
+}
 
 describe("useSmartPlaylistSeedItems", () => {
   beforeEach(() => {
@@ -105,5 +110,67 @@ describe("useSmartPlaylistSeedItems", () => {
     expect(seed.seedArtistUri.value).toBe("tidal://artist/tidal-artist-1");
     expect(seed.selectedSeedTrack.value).toBeNull();
     expect(seed.seedTrackUri.value).toBe("");
+  });
+
+  describe("seed-track search filter", () => {
+    const originalProviders = (api as unknown as { providers: unknown })
+      .providers;
+
+    beforeEach(() => {
+      vi.mocked(api.search).mockClear();
+      (api as unknown as { providers: unknown }).providers = originalProviders;
+    });
+
+    it("returns library/streaming results when only a plugin supplies SIMILAR_TRACKS", async () => {
+      useSmartPlaylistSeedItems();
+      const trackSearchFn = (
+        mockSetupDebouncedSearch.mock.calls[0][0] as SearchFnArg
+      ).searchFn;
+
+      vi.mocked(api.search).mockResolvedValueOnce({
+        tracks: [
+          {
+            item_id: "lib-1",
+            name: "Library Track",
+            provider_mappings: [
+              { provider_instance: "library", provider_domain: "library" },
+              {
+                provider_instance: "filesystem_local",
+                provider_domain: "filesystem_local",
+              },
+            ],
+          },
+        ],
+        artists: [],
+        albums: [],
+        playlists: [],
+        radio: [],
+        audiobooks: [],
+        podcasts: [],
+      } as never);
+
+      const results = await trackSearchFn("anything");
+
+      expect(results).toHaveLength(1);
+      expect(api.search).toHaveBeenCalledWith("anything", ["track"], 20);
+    });
+
+    it("returns [] without searching when no provider supplies SIMILAR_TRACKS", async () => {
+      (api as unknown as { providers: Record<string, unknown> }).providers = {
+        only_unrelated: {
+          instance_id: "only_unrelated",
+          supported_features: [],
+        },
+      };
+      useSmartPlaylistSeedItems();
+      const trackSearchFn = (
+        mockSetupDebouncedSearch.mock.calls.at(-1)?.[0] as SearchFnArg
+      ).searchFn;
+
+      const results = await trackSearchFn("anything");
+
+      expect(results).toEqual([]);
+      expect(api.search).not.toHaveBeenCalled();
+    });
   });
 });


### PR DESCRIPTION
## Summary

The seed-track / seed-artist pickers in the Smart Playlist dialog (added in #1693) filtered the global search results to tracks/artists whose `provider_mappings` included a provider declaring `SIMILAR_TRACKS` / `SIMILAR_ARTISTS`. Plugin-tier providers (e.g. `sonic_similarity`, `lastfm_recommendations`) never appear in a music track's `provider_mappings` — they're cross-provider engines, not music providers — so when a plugin was the only source of similar tracks the filter dropped every result and the picker appeared empty.

The server's [`mass.music.tracks.similar_tracks()`](https://github.com/music-assistant/server/blob/dev/music_assistant/controllers/media/tracks.py) already falls back to `METADATA` + `PLUGIN` providers that declare `SIMILAR_TRACKS` (and the same for similar_artists), so any track returned by `music/search` is a valid seed — the picker's per-result filter was encoding a stricter rule than the dispatcher actually enforces.

## Change

- `useSmartPlaylistSeedItems.ts`: drop the per-result `provider_mappings` filter on both the track and artist seed searches; keep the up-front "is any provider capable?" gate so the picker still returns `[]` when no provider supplies the feature at all.
- `selectSeedTrack` / `selectSeedArtist` are unchanged — they prefer a mapping owned by a SIMILAR_TRACKS-capable music provider (e.g. Spotify) and fall back via `buildItemUri` to a `library://` URI otherwise, which the server resolves correctly through the plugin fallback.

## Test plan

- [x] `useSmartPlaylistSeedItems.test.ts`: existing tests still pass (URI build, provider-id collection)
- [x] New regression test: search returns library/streaming tracks whose mappings only point at `library` / `filesystem_local` when a plugin provides `SIMILAR_TRACKS`
- [x] New gate test: search returns `[]` without calling `api.search` when no provider declares `SIMILAR_TRACKS`
- [x] Manual: with only `sonic_similarity` installed (no Spotify / Last.fm), open *Create Smart Playlist → Similar to track → Pick a track*, type a library track name → expect results
- [ ] Manual: with Spotify installed, same flow → expect Spotify + library results
- [ ] Manual: with no SIMILAR_TRACKS-capable provider at all, picker remains empty (existing behaviour)