### PR TITLE
Keep shortcuts in sync after delete and update events

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -32,6 +32,7 @@
 
 <script setup lang="ts">
 import { Toaster } from "@/components/ui/sonner";
+import { initGlobalShortcutsSync } from "@/composables/useShortcuts";
 import { api, ConnectionState } from "@/plugins/api";
 import { CoreState, EventType, ProviderType } from "@/plugins/api/interfaces";
 import { toast } from "vue-sonner";
@@ -318,6 +319,8 @@ const completeInitialization = async () => {
 };
 
 onMounted(async () => {
+  initGlobalShortcutsSync();
+
   // Detect if running as installed PWA (works across iOS, Android, and desktop)
   const nav = window.navigator as Navigator & { standalone?: boolean };
   store.isInPWAMode =

--- a/src/composables/useShortcuts.ts
+++ b/src/composables/useShortcuts.ts
@@ -212,6 +212,31 @@ export async function pinShortcutStandalone(
   await setUserPreference(PREF_KEY, [...uris, maUri]);
 }
 
+let _globalShortcutsSyncInitialized = false;
+
+async function removePinnedUriIfPresent(uri: string): Promise<void> {
+  const currentUris = _getPinnedUris();
+  const nextUris = currentUris.filter((u) => !isSameShortcutUri(u, uri));
+  if (nextUris.length !== currentUris.length) {
+    await setUserPreference(PREF_KEY, nextUris);
+  }
+}
+
+export function initGlobalShortcutsSync(): void {
+  if (_globalShortcutsSyncInitialized) return;
+  _globalShortcutsSyncInitialized = true;
+
+  api.subscribe_multi(
+    [EventType.MEDIA_ITEM_DELETED, EventType.MEDIA_ITEM_UPDATED],
+    (evt: EventMessage) => {
+      if (evt.event === EventType.MEDIA_ITEM_DELETED) {
+        // Keep sidebar preferences clean even when nav components are unmounted.
+        void removePinnedUriIfPresent(evt.object_id as string);
+      }
+    },
+  );
+}
+
 export function useShortcuts() {
   const { getPreference, setPreference } = useUserPreferences();
 
@@ -318,37 +343,37 @@ export function useShortcuts() {
             result.value as ShortcutItem,
           ];
         }
-        // rejected = network error — don't prune, the URI stays pinned
+        // rejected = network/backend error — don't mutate pinned URIs here.
       });
     }
   });
 
-  let _unsubscribe: (() => void) | undefined;
+  let _unsubscribeUpdated: (() => void) | undefined;
 
   onMounted(async () => {
     await loadShortcuts();
 
-    _unsubscribe = api.subscribe_multi(
-      [EventType.MEDIA_ITEM_DELETED, EventType.MEDIA_ITEM_UPDATED],
+    _unsubscribeUpdated = api.subscribe_multi(
+      [EventType.MEDIA_ITEM_UPDATED],
       (evt: EventMessage) => {
-        if (evt.event === EventType.MEDIA_ITEM_DELETED) {
-          if (isPinned(evt.object_id as string)) {
-            unpinItem(evt.object_id as string);
-          }
-        } else if (evt.event === EventType.MEDIA_ITEM_UPDATED) {
-          const idx = resolvedItems.value.findIndex((p) =>
-            isSameShortcutUri(evt.object_id as string, p),
-          );
-          if (idx >= 0) {
-            resolvedItems.value[idx] = evt.data as ShortcutItem;
-          }
+        const objectId = evt.object_id as string | undefined;
+        if (!objectId) return;
+        const idx = resolvedItems.value.findIndex((item) =>
+          isSameShortcutUri(objectId, item),
+        );
+        if (
+          idx >= 0 &&
+          evt.data &&
+          SUPPORTED_TYPES.has((evt.data as ShortcutItem).media_type)
+        ) {
+          resolvedItems.value[idx] = evt.data as ShortcutItem;
         }
       },
     );
   });
 
   onUnmounted(() => {
-    _unsubscribe?.();
+    _unsubscribeUpdated?.();
   });
 
   return {

--- a/src/composables/useShortcuts.ts
+++ b/src/composables/useShortcuts.ts
@@ -226,15 +226,10 @@ export function initGlobalShortcutsSync(): void {
   if (_globalShortcutsSyncInitialized) return;
   _globalShortcutsSyncInitialized = true;
 
-  api.subscribe_multi(
-    [EventType.MEDIA_ITEM_DELETED, EventType.MEDIA_ITEM_UPDATED],
-    (evt: EventMessage) => {
-      if (evt.event === EventType.MEDIA_ITEM_DELETED) {
-        // Keep sidebar preferences clean even when nav components are unmounted.
-        void removePinnedUriIfPresent(evt.object_id as string);
-      }
-    },
-  );
+  api.subscribe(EventType.MEDIA_ITEM_DELETED, (evt: EventMessage) => {
+    // Keep sidebar preferences clean even when nav components are unmounted.
+    void removePinnedUriIfPresent(evt.object_id as string);
+  });
 }
 
 export function useShortcuts() {
@@ -353,8 +348,8 @@ export function useShortcuts() {
   onMounted(async () => {
     await loadShortcuts();
 
-    _unsubscribeUpdated = api.subscribe_multi(
-      [EventType.MEDIA_ITEM_UPDATED],
+    _unsubscribeUpdated = api.subscribe(
+      EventType.MEDIA_ITEM_UPDATED,
       (evt: EventMessage) => {
         const objectId = evt.object_id as string | undefined;
         if (!objectId) return;


### PR DESCRIPTION
## Summary
- move shortcut delete cleanup to a global app-level subscription so stale pins are removed even when sidebar components are unmounted (mobile case)
- keep media item updates in `useShortcuts` so visible shortcut metadata (name/image) stays live

## Validation
- `yarn lint` (passes, existing repo warnings only)
- `yarn test:run` (all tests pass)


## Mobile view context
- On mobile, the sidebar/nav subtree can be unmounted while the app continues running.
- If a media item is deleted during that time, a listener that lives inside the sidebar composable can miss the MEDIA_ITEM_DELETED event.
- The stale shortcut URI then remains in user preferences and later triggers repeated "item not found" behavior when shortcuts are resolved.

## Why move delete listener to App.vue
- App.vue is always mounted for the active frontend session, so the delete cleanup listener is always active.
- This guarantees stale shortcut cleanup regardless of whether the sidebar is currently rendered.
- We keep MEDIA_ITEM_UPDATED handling in useShortcuts for local/live UI refresh (name/image) when shortcuts are visible.
- This split keeps correctness for deletion and preserves efficient UI updates for metadata changes.
