### PR TITLE
Fix smart playlist operator label after field switch

### DIFF
--- a/src/components/smart_playlist/SmartPlaylistRuleRow.vue
+++ b/src/components/smart_playlist/SmartPlaylistRuleRow.vue
@@ -28,6 +28,7 @@
 
     <Select
       v-if="rule.field !== 'favorite'"
+      :key="`operator-${rule.field}`"
       :model-value="rule.operator"
       :disabled="rule.field === 'year'"
       @update:model-value="(v) => emit('change-operator', v as RuleOperator)"


### PR DESCRIPTION
## Summary
Fixes an operator label mismatch in the smart playlist rule editor when switching rule fields.

## Repro
- Change a rule field from `Year` to `Album` (or another non-year field).
- The operator label could remain `between` instead of switching back to `is`.
- The same could happen when switching back and forth between `Album` and `Year`.

## Fix
- Remount the operator select when the rule field changes by adding a field-based key.
- This ensures the displayed operator label always matches the currently selected field.

## Screenshot
Before and after the change from album to year

<img width="1020" height="284" alt="issue_switch from genre" src="https://github.com/user-attachments/assets/77c91091-dc72-46b5-a3e1-bdcce6d3d6ca" />

<img width="1020" height="284" alt="issue_switch_to_year" src="https://github.com/user-attachments/assets/064b6a2a-7858-4891-bedd-f7522c0f5dfb" />
You can see that the `is` is not set correctly – this PR fixes that.