### PR TITLE
Smart Playlist: search UX & dynamic playlist provider details

### DIFF
--- a/src/components/smart_playlist/SmartPlaylistRuleRow.vue
+++ b/src/components/smart_playlist/SmartPlaylistRuleRow.vue
@@ -158,6 +158,7 @@ import type {
   RuleOperator,
   RuleRow,
 } from "@/composables/useSmartPlaylistRulesForm";
+import type { Genre } from "@/plugins/api/interfaces";
 import { $t } from "@/plugins/i18n";
 import { X } from "lucide-vue-next";
 import { computed } from "vue";
@@ -166,7 +167,7 @@ import SmartPlaylistRuleValuePicker from "./SmartPlaylistRuleValuePicker.vue";
 const props = defineProps<{
   rule: RuleRow;
   availableFields: RuleField[];
-  genreOptions: { id: number; name: string }[];
+  genreOptions: { id: number; name: string; item?: Genre }[];
   invalid?: boolean;
 }>();
 

--- a/src/components/smart_playlist/SmartPlaylistRuleValuePicker.vue
+++ b/src/components/smart_playlist/SmartPlaylistRuleValuePicker.vue
@@ -91,6 +91,10 @@ const query = ref("");
 const remoteResults = ref<Option[]>([]);
 const isSearching = ref(false);
 
+// Genre options are preloaded and filtered client-side; artist/album are
+// fetched remotely as the user types.
+const isRemote = computed(() => props.source !== "genre");
+
 const filteredPreloaded = computed(() => {
   const base = props.preloadedOptions.filter(
     (o) => !props.selectedIds.includes(o.id),
@@ -102,7 +106,7 @@ const filteredPreloaded = computed(() => {
 });
 
 const displayedOptions = computed(() => {
-  if (props.source === "genre") return filteredPreloaded.value;
+  if (!isRemote.value) return filteredPreloaded.value;
   return remoteResults.value.filter((o) => !props.selectedIds.includes(o.id));
 });
 
@@ -140,7 +144,7 @@ const runSearch = useDebounceFn(async (q: string) => {
 }, 400);
 
 watch(query, (q) => {
-  if (props.source === "genre") return;
+  if (!isRemote.value) return;
   if (q.length < 2) {
     remoteResults.value = [];
     isSearching.value = false;
@@ -167,7 +171,7 @@ function onPick(opt: Option) {
 }
 
 const emptyStateText = computed(() => {
-  if (props.source !== "genre" && query.value.length < 2) {
+  if (isRemote.value && query.value.length < 2) {
     return $t("smart_playlist.picker_empty_search", {
       label: props.addLabel.toLowerCase(),
     });

--- a/src/components/smart_playlist/SmartPlaylistRuleValuePicker.vue
+++ b/src/components/smart_playlist/SmartPlaylistRuleValuePicker.vue
@@ -12,7 +12,6 @@
     </PopoverTrigger>
     <PopoverContent align="start" class="w-[340px] p-2">
       <Input
-        v-if="searchable"
         v-model="query"
         :placeholder="$t('search')"
         class="mb-2 h-8 text-sm"
@@ -62,7 +61,7 @@ import {
   PopoverTrigger,
 } from "@/components/ui/popover";
 import api from "@/plugins/api";
-import type { Album, Artist } from "@/plugins/api/interfaces";
+import type { Album, Artist, Genre } from "@/plugins/api/interfaces";
 import { $t } from "@/plugins/i18n";
 import { useDebounceFn } from "@vueuse/core";
 import { Loader2, Plus } from "lucide-vue-next";
@@ -71,7 +70,7 @@ import { computed, ref, watch } from "vue";
 interface Option {
   id: number;
   name: string;
-  item?: Artist | Album;
+  item?: Artist | Album | Genre;
 }
 
 type Source = "genre" | "artist" | "album";
@@ -91,10 +90,6 @@ const open = ref(false);
 const query = ref("");
 const remoteResults = ref<Option[]>([]);
 const isSearching = ref(false);
-
-const searchable = computed(
-  () => props.source === "artist" || props.source === "album",
-);
 
 const filteredPreloaded = computed(() => {
   const base = props.preloadedOptions.filter(
@@ -145,7 +140,7 @@ const runSearch = useDebounceFn(async (q: string) => {
 }, 400);
 
 watch(query, (q) => {
-  if (!searchable.value) return;
+  if (props.source === "genre") return;
   if (q.length < 2) {
     remoteResults.value = [];
     isSearching.value = false;
@@ -172,7 +167,7 @@ function onPick(opt: Option) {
 }
 
 const emptyStateText = computed(() => {
-  if (searchable.value && query.value.length < 2) {
+  if (props.source !== "genre" && query.value.length < 2) {
     return $t("smart_playlist.picker_empty_search", {
       label: props.addLabel.toLowerCase(),
     });

--- a/src/components/smart_playlist/SmartPlaylistRuleValuePicker.vue
+++ b/src/components/smart_playlist/SmartPlaylistRuleValuePicker.vue
@@ -10,7 +10,7 @@
         {{ addLabel }}
       </Button>
     </PopoverTrigger>
-    <PopoverContent align="start" class="w-[260px] p-2">
+    <PopoverContent align="start" class="w-[340px] p-2">
       <Input
         v-if="searchable"
         v-model="query"
@@ -27,9 +27,15 @@
             v-for="opt in displayedOptions"
             :key="opt.id"
             type="button"
-            class="flex items-center gap-2 py-1 px-1.5 text-sm rounded-sm hover:bg-accent text-left"
+            class="flex items-center gap-1.5 py-1 px-1.5 text-sm rounded-sm hover:bg-accent text-left"
             @click.stop="onPick(opt)"
           >
+            <div
+              v-if="opt.item"
+              class="h-8 w-8 flex-none overflow-hidden rounded"
+            >
+              <MediaItemThumb :item="opt.item" :size="32" />
+            </div>
             <span class="truncate">{{ opt.name }}</span>
           </button>
         </template>
@@ -47,6 +53,7 @@
 </template>
 
 <script setup lang="ts">
+import MediaItemThumb from "@/components/MediaItemThumb.vue";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import {
@@ -55,6 +62,7 @@ import {
   PopoverTrigger,
 } from "@/components/ui/popover";
 import api from "@/plugins/api";
+import type { Album, Artist } from "@/plugins/api/interfaces";
 import { $t } from "@/plugins/i18n";
 import { useDebounceFn } from "@vueuse/core";
 import { Loader2, Plus } from "lucide-vue-next";
@@ -63,6 +71,7 @@ import { computed, ref, watch } from "vue";
 interface Option {
   id: number;
   name: string;
+  item?: Artist | Album;
 }
 
 type Source = "genre" | "artist" | "album";
@@ -112,10 +121,18 @@ const runSearch = useDebounceFn(async (q: string) => {
     let results: Option[] = [];
     if (props.source === "artist") {
       const res = await api.getLibraryArtists(undefined, q, 20);
-      results = res.map((a) => ({ id: parseInt(a.item_id), name: a.name }));
+      results = res.map((a) => ({
+        id: parseInt(a.item_id),
+        name: a.name,
+        item: a,
+      }));
     } else if (props.source === "album") {
       const res = await api.getLibraryAlbums(undefined, q, 20);
-      results = res.map((a) => ({ id: parseInt(a.item_id), name: a.name }));
+      results = res.map((a) => ({
+        id: parseInt(a.item_id),
+        name: a.name,
+        item: a,
+      }));
     }
     if (query.value === q) {
       remoteResults.value = results;
@@ -148,7 +165,7 @@ watch(open, (isOpen) => {
 });
 
 function onPick(opt: Option) {
-  emit("add", opt);
+  emit("add", { id: opt.id, name: opt.name });
   query.value = "";
   remoteResults.value = [];
   open.value = false;

--- a/src/components/smart_playlist/SmartPlaylistRulesList.vue
+++ b/src/components/smart_playlist/SmartPlaylistRulesList.vue
@@ -116,6 +116,7 @@ import type {
   RuleOperator,
   RuleRow,
 } from "@/composables/useSmartPlaylistRulesForm";
+import type { Genre } from "@/plugins/api/interfaces";
 import { $t } from "@/plugins/i18n";
 import { Info, Plus } from "lucide-vue-next";
 import { match } from "ts-pattern";
@@ -126,7 +127,7 @@ defineProps<{
   rules: RuleRow[];
   logic: "AND" | "OR";
   availableFields: RuleField[];
-  genreOptions: { id: number; name: string }[];
+  genreOptions: { id: number; name: string; item?: Genre }[];
   invalidRuleUids: Set<string>;
 }>();
 

--- a/src/components/smart_playlist/SmartPlaylistSeedPicker.vue
+++ b/src/components/smart_playlist/SmartPlaylistSeedPicker.vue
@@ -42,49 +42,34 @@
           <Loader2 class="h-4 w-4 animate-spin text-muted-foreground" />
         </div>
         <template v-else-if="results.length > 0">
-          <template v-if="libraryResults.length > 0">
+          <template v-for="(group, index) in resultGroups" :key="group.key">
             <div
-              class="px-1.5 pt-1 pb-0.5 text-[10px] font-semibold uppercase tracking-wider text-muted-foreground"
+              v-if="group.items.length > 0"
+              role="group"
+              :aria-label="group.heading"
             >
-              {{ $t("smart_playlist.results_library") }}
+              <div
+                class="px-1.5 pb-0.5 text-[10px] font-semibold uppercase tracking-wider text-muted-foreground"
+                :class="index === 0 ? 'pt-1' : 'pt-2'"
+              >
+                {{ group.heading }}
+              </div>
+              <button
+                v-for="item in group.items"
+                :key="`${group.key}-${item.item_id}`"
+                type="button"
+                class="w-full flex items-center gap-1.5 py-1 px-1.5 text-sm rounded-sm hover:bg-accent text-left"
+                @click.stop="onPick(item)"
+              >
+                <div class="h-8 w-8 flex-none overflow-hidden rounded">
+                  <MediaItemThumb :item="item" :size="32" />
+                </div>
+                <div class="flex flex-col min-w-0 flex-1">
+                  <span class="truncate font-medium">{{ item.name }}</span>
+                  <slot name="item-sub" :item="item"></slot>
+                </div>
+              </button>
             </div>
-            <button
-              v-for="item in libraryResults"
-              :key="`lib-${item.item_id}`"
-              type="button"
-              class="flex items-center gap-1.5 py-1 px-1.5 text-sm rounded-sm hover:bg-accent text-left"
-              @click.stop="onPick(item)"
-            >
-              <div class="h-8 w-8 flex-none overflow-hidden rounded">
-                <MediaItemThumb :item="item" :size="32" />
-              </div>
-              <div class="flex flex-col min-w-0 flex-1">
-                <span class="truncate font-medium">{{ item.name }}</span>
-                <slot name="item-sub" :item="item"></slot>
-              </div>
-            </button>
-          </template>
-          <template v-if="otherResults.length > 0">
-            <div
-              class="px-1.5 pt-2 pb-0.5 text-[10px] font-semibold uppercase tracking-wider text-muted-foreground"
-            >
-              {{ $t("smart_playlist.results_other") }}
-            </div>
-            <button
-              v-for="item in otherResults"
-              :key="`oth-${item.item_id}`"
-              type="button"
-              class="flex items-center gap-1.5 py-1 px-1.5 text-sm rounded-sm hover:bg-accent text-left"
-              @click.stop="onPick(item)"
-            >
-              <div class="h-8 w-8 flex-none overflow-hidden rounded">
-                <MediaItemThumb :item="item" :size="32" />
-              </div>
-              <div class="flex flex-col min-w-0 flex-1">
-                <span class="truncate font-medium">{{ item.name }}</span>
-                <slot name="item-sub" :item="item"></slot>
-              </div>
-            </button>
           </template>
         </template>
         <div
@@ -137,12 +122,18 @@ const emit = defineEmits<{
 
 const popoverOpen = ref(false);
 
-const libraryResults = computed(() =>
-  props.results.filter((r) => r.provider === "library"),
-);
-const otherResults = computed(() =>
-  props.results.filter((r) => r.provider !== "library"),
-);
+const resultGroups = computed(() => [
+  {
+    key: "lib",
+    heading: $t("smart_playlist.results_library"),
+    items: props.results.filter((r) => r.provider === "library"),
+  },
+  {
+    key: "oth",
+    heading: $t("smart_playlist.results_other"),
+    items: props.results.filter((r) => r.provider !== "library"),
+  },
+]);
 
 function onPick(item: SearchItem) {
   emit("select", item);

--- a/src/components/smart_playlist/SmartPlaylistSeedPicker.vue
+++ b/src/components/smart_playlist/SmartPlaylistSeedPicker.vue
@@ -14,7 +14,7 @@
         {{ buttonLabel }}
       </Button>
     </PopoverTrigger>
-    <PopoverContent align="start" class="w-[280px] p-2">
+    <PopoverContent align="start" class="w-[340px] p-2">
       <Tabs
         :model-value="kind"
         @update:model-value="(v) => emit('update:kind', v as SeedKind)"
@@ -42,16 +42,50 @@
           <Loader2 class="h-4 w-4 animate-spin text-muted-foreground" />
         </div>
         <template v-else-if="results.length > 0">
-          <button
-            v-for="item in results"
-            :key="item.item_id"
-            type="button"
-            class="flex flex-col py-1 px-1.5 text-sm rounded-sm hover:bg-accent text-left"
-            @click.stop="onPick(item)"
-          >
-            <span class="truncate font-medium">{{ item.name }}</span>
-            <slot name="item-sub" :item="item"></slot>
-          </button>
+          <template v-if="libraryResults.length > 0">
+            <div
+              class="px-1.5 pt-1 pb-0.5 text-[10px] font-semibold uppercase tracking-wider text-muted-foreground"
+            >
+              {{ $t("smart_playlist.results_library") }}
+            </div>
+            <button
+              v-for="item in libraryResults"
+              :key="`lib-${item.item_id}`"
+              type="button"
+              class="flex items-center gap-1.5 py-1 px-1.5 text-sm rounded-sm hover:bg-accent text-left"
+              @click.stop="onPick(item)"
+            >
+              <div class="h-8 w-8 flex-none overflow-hidden rounded">
+                <MediaItemThumb :item="item" :size="32" />
+              </div>
+              <div class="flex flex-col min-w-0 flex-1">
+                <span class="truncate font-medium">{{ item.name }}</span>
+                <slot name="item-sub" :item="item"></slot>
+              </div>
+            </button>
+          </template>
+          <template v-if="otherResults.length > 0">
+            <div
+              class="px-1.5 pt-2 pb-0.5 text-[10px] font-semibold uppercase tracking-wider text-muted-foreground"
+            >
+              {{ $t("smart_playlist.results_other") }}
+            </div>
+            <button
+              v-for="item in otherResults"
+              :key="`oth-${item.item_id}`"
+              type="button"
+              class="flex items-center gap-1.5 py-1 px-1.5 text-sm rounded-sm hover:bg-accent text-left"
+              @click.stop="onPick(item)"
+            >
+              <div class="h-8 w-8 flex-none overflow-hidden rounded">
+                <MediaItemThumb :item="item" :size="32" />
+              </div>
+              <div class="flex flex-col min-w-0 flex-1">
+                <span class="truncate font-medium">{{ item.name }}</span>
+                <slot name="item-sub" :item="item"></slot>
+              </div>
+            </button>
+          </template>
         </template>
         <div
           v-else
@@ -67,6 +101,7 @@
 </template>
 
 <script setup lang="ts">
+import MediaItemThumb from "@/components/MediaItemThumb.vue";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import {
@@ -76,15 +111,13 @@ import {
 } from "@/components/ui/popover";
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import type { SeedKind } from "@/composables/useSmartPlaylistSeedItems";
+import type { Album, Artist, Playlist, Track } from "@/plugins/api/interfaces";
 import { $t } from "@/plugins/i18n";
 import { Loader2, Plus } from "lucide-vue-next";
 import { match } from "ts-pattern";
 import { computed, ref } from "vue";
 
-interface SearchItem {
-  item_id: string;
-  name: string;
-}
+type SearchItem = Track | Artist | Album | Playlist;
 
 const props = defineProps<{
   kind: SeedKind;
@@ -103,6 +136,13 @@ const emit = defineEmits<{
 }>();
 
 const popoverOpen = ref(false);
+
+const libraryResults = computed(() =>
+  props.results.filter((r) => r.provider === "library"),
+);
+const otherResults = computed(() =>
+  props.results.filter((r) => r.provider !== "library"),
+);
 
 function onPick(item: SearchItem) {
   emit("select", item);

--- a/src/composables/useSmartPlaylistGenres.ts
+++ b/src/composables/useSmartPlaylistGenres.ts
@@ -10,7 +10,11 @@ export function useSmartPlaylistGenres() {
   });
 
   const genreOptions = computed(() =>
-    genres.value.map((g) => ({ id: parseInt(g.item_id), name: g.name })),
+    genres.value.map((g) => ({
+      id: parseInt(g.item_id),
+      name: g.name,
+      item: g,
+    })),
   );
 
   function genreName(id: number, fallback?: string): string {

--- a/src/layouts/default/EditSmartPlaylistDialog.vue
+++ b/src/layouts/default/EditSmartPlaylistDialog.vue
@@ -8,9 +8,6 @@
         <DialogTitle class="mb-2">
           {{ $t("smart_playlist.edit_rules") }}
         </DialogTitle>
-        <DialogDescription>
-          {{ playlistName }}
-        </DialogDescription>
       </DialogHeader>
 
       <div
@@ -21,6 +18,13 @@
       </div>
 
       <div v-else class="flex flex-col gap-3 py-2">
+        <div class="flex flex-col gap-2">
+          <Label for="sp-edit-name">{{
+            $t("smart_playlist.name_label")
+          }}</Label>
+          <Input id="sp-edit-name" v-model="name" />
+        </div>
+
         <div class="max-h-[60vh] overflow-y-auto -mx-6 px-6">
           <SmartPlaylistRulesForm
             ref="rulesForm"
@@ -47,7 +51,9 @@
           {{ $t("close") }}
         </Button>
         <Button
-          :disabled="loading || isSaving || !rulesForm?.hasChanges"
+          :disabled="
+            loading || isSaving || (!rulesForm?.hasChanges && !nameDirty)
+          "
           @click="doSave"
         >
           <span v-if="isSaving">{{ $t("smart_playlist.saving") }}</span>
@@ -59,7 +65,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, watch } from "vue";
+import { computed, ref, watch } from "vue";
 import { toast } from "vue-sonner";
 
 import SmartPlaylistRulesForm from "@/components/smart_playlist/SmartPlaylistRulesForm.vue";
@@ -68,18 +74,19 @@ import { Button } from "@/components/ui/button";
 import {
   Dialog,
   DialogContent,
-  DialogDescription,
   DialogFooter,
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
 import api from "@/plugins/api";
-import type { SmartPlaylistRules } from "@/plugins/api/interfaces";
+import type { Playlist, SmartPlaylistRules } from "@/plugins/api/interfaces";
 import { $t } from "@/plugins/i18n";
 
 export interface Props {
   dbPlaylistId: string;
-  playlistName: string;
+  playlist: Playlist;
 }
 
 const props = defineProps<Props>();
@@ -89,6 +96,11 @@ const showDialog = defineModel<boolean>("open", { default: false });
 
 const loading = ref(false);
 const isSaving = ref(false);
+const name = ref("");
+
+const nameDirty = computed(
+  () => name.value.trim() !== "" && name.value.trim() !== props.playlist.name,
+);
 const matchingTrackCount = ref<number | null>(null);
 const matchingDuration = ref<number | null>(null);
 const isCountingTracks = ref(false);
@@ -103,6 +115,7 @@ const loadedExcludedAlbumItems = ref<{ id: number; name: string }[]>([]);
 function resetDialogState() {
   loading.value = false;
   isSaving.value = false;
+  name.value = "";
   matchingTrackCount.value = null;
   matchingDuration.value = null;
   isCountingTracks.value = false;
@@ -116,6 +129,7 @@ function resetDialogState() {
 watch(showDialog, async (open) => {
   if (open) {
     loading.value = true;
+    name.value = props.playlist.name;
     loadedRules.value = null;
     loadedArtistItems.value = [];
     loadedAlbumItems.value = [];
@@ -208,11 +222,25 @@ async function doSave() {
     toast.error(errors[0]);
     return;
   }
+  const trimmedName = name.value.trim();
+  if (!trimmedName) {
+    toast.error($t("smart_playlist.name_required"));
+    return;
+  }
   isSaving.value = true;
   try {
-    const finalRules = rulesForm.value!.getFinalRules();
-    await api.updateSmartPlaylistRules(props.dbPlaylistId, finalRules);
-    toast.success($t("smart_playlist.edited", { name: props.playlistName }));
+    if (nameDirty.value) {
+      await api.updatePlaylist(
+        props.dbPlaylistId,
+        { ...props.playlist, name: trimmedName },
+        true,
+      );
+    }
+    if (rulesForm.value!.hasChanges) {
+      const finalRules = rulesForm.value!.getFinalRules();
+      await api.updateSmartPlaylistRules(props.dbPlaylistId, finalRules);
+    }
+    toast.success($t("smart_playlist.edited", { name: trimmedName }));
     showDialog.value = false;
     emit("saved");
   } catch (e) {

--- a/src/plugins/api/index.ts
+++ b/src/plugins/api/index.ts
@@ -819,6 +819,18 @@ export class MusicAssistantApi {
     });
   }
 
+  public updatePlaylist(
+    item_id: string | number,
+    update: Playlist,
+    overwrite: boolean = false,
+  ): Promise<Playlist> {
+    return this.sendCommand("music/playlists/update", {
+      item_id,
+      update,
+      overwrite,
+    });
+  }
+
   public exportPlaylist(db_playlist_id: string | number): Promise<string> {
     return this.sendCommand("music/playlists/export_playlist", {
       db_playlist_id,

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1685,6 +1685,8 @@
         "dynamic_sample_note": "Songs change each play. These are examples of what to expect.",
         "edit_rules": "Edit rules",
         "edited": "“{name}” updated",
+        "name_label": "Name",
+        "name_required": "Please enter a name.",
         "empty_desc": "No tracks match your current rules. Loosen a filter or pick a different seed to get started.",
         "empty_title": "Nothing to play yet",
         "favorites_yes": "Yes",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1710,6 +1710,8 @@
         "picker_empty_no_match": "No {label} matches your search.",
         "picker_empty_remote": "Type to search for a {label}.",
         "picker_empty_search": "Type at least 2 characters to find a {label}.",
+        "results_library": "Library results",
+        "results_other": "Other results",
         "op_is": "is",
         "op_is_not": "is not",
         "saving": "Saving…",

--- a/src/views/PlaylistDetails.vue
+++ b/src/views/PlaylistDetails.vue
@@ -25,10 +25,10 @@
     </template>
   </InfoHeader>
   <EditSmartPlaylistDialog
-    v-if="smartRules"
+    v-if="smartRules && itemDetails"
     v-model:open="showEditDialog"
     :db-playlist-id="props.itemId"
-    :playlist-name="itemDetails?.name ?? ''"
+    :playlist="itemDetails"
     @saved="loadItemDetails"
   />
   <!-- dynamic playlist: content is generated on the fly, so show a sample instead of a fixed tracklist -->

--- a/src/views/PlaylistDetails.vue
+++ b/src/views/PlaylistDetails.vue
@@ -67,11 +67,7 @@
     :no-server-side-sorting="true"
   />
 
-  <!-- provider mapping details + genre exclusions: not relevant for dynamic playlists -->
-  <ProviderDetails
-    v-if="itemDetails && !itemDetails.is_dynamic"
-    :item-details="itemDetails"
-  />
+  <ProviderDetails v-if="itemDetails" :item-details="itemDetails" />
 </template>
 
 <script setup lang="ts">

--- a/tests/composables/smart_playlist/useSmartPlaylistGenres.test.ts
+++ b/tests/composables/smart_playlist/useSmartPlaylistGenres.test.ts
@@ -27,8 +27,12 @@ describe("useSmartPlaylistGenres", () => {
     await Promise.resolve();
     expect(genres.value.length).toBe(2);
     expect(genreOptions.value).toEqual([
-      { id: 9, name: "Synthwave" },
-      { id: 2, name: "Rock" },
+      {
+        id: 9,
+        name: "Synthwave",
+        item: { item_id: "9", name: "Synthwave" },
+      },
+      { id: 2, name: "Rock", item: { item_id: "2", name: "Rock" } },
     ]);
   });
 


### PR DESCRIPTION
## Summary

- Dynamic / smart playlist detail view now renders the **Mapped providers** (Provider details) section at the bottom — matches regular playlists, albums and artists.
- Smart playlist **seed picker** (discover type): results are split into **Library results** / **Other results** with section headings; each row shows a 32px thumbnail so same-named items from different providers are visually distinguishable.
- Smart playlist **library-type rule picker** for artist and album: each result row now shows a thumbnail.
- Smart playlist **genre rule picker**: replaced the dropdown with a searchable input that shows all genres by default and filters as you type. Each row shows the genre's thumb/avatar.

Persisted rule values still serialize as `{id, name}` only — no extra payload on the wire.

## Test plan

- [ ] Open any dynamic / smart playlist → "Mapped providers" section appears at the bottom.
- [ ] Open the edit-smart-playlist dialog in **Discover** mode → for each tab (Track / Artist / Album / Playlist) results are grouped into Library / Other with thumbs; empty groups don't render a heading.
- [ ] Same dialog in **Library** mode → artist and album rule pickers render results with thumbs; genre rule picker shows a search input with all genres listed by default, typing filters them.
- [ ] Pick a value in each picker and confirm the resulting badge / persisted rule is unchanged.
- [ ] Reload — saved smart playlists still display correctly.