### PR TITLE
Skip getSmartPlaylistRules call for non-smart playlists

### DIFF
--- a/src/views/PlaylistDetails.vue
+++ b/src/views/PlaylistDetails.vue
@@ -112,7 +112,10 @@ const listingRef = ref<InstanceType<typeof ItemsListing>>();
 
 const loadItemDetails = async function () {
   itemDetails.value = await api.getPlaylist(props.itemId, props.provider);
-  if (props.provider === "library") {
+  const isSmartPlaylist = itemDetails.value?.provider_mappings?.some(
+    (m) => m.provider_domain === "smart_playlist",
+  );
+  if (isSmartPlaylist) {
     try {
       smartRules.value = await api.getSmartPlaylistRules(props.itemId);
     } catch {


### PR DESCRIPTION
## What does this implement/fix?

`PlaylistDetails` previously called `getSmartPlaylistRules` unconditionally for every playlist, relying on a try/catch to discard the result for non-smart playlists. This caused an unnecessary API round-trip on every playlist detail view.

Fix: Check `provider_mappings` for `provider_domain === "smart_playlist"` before making the call. Only smart playlists get the rules fetched; all others skip the call entirely.

Additionally, the previous code only fetched `smartRules` when `provider === "library"`, which meant the edit button and rule overview were missing when navigating to a smart playlist from the Discover/Recommendations page. This is fixed by removing that guard (the rules API accepts both library DB IDs and provider UUIDs).

**Related issue (if applicable):**

- Companion server PR: https://github.com/music-assistant/server/pull/4025

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

- [x] The code change is tested and works locally.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.