### PR TITLE
Add shortcut ordering actions

### DIFF
--- a/src/components/navigation/NavShortcuts.vue
+++ b/src/components/navigation/NavShortcuts.vue
@@ -123,7 +123,7 @@ const { navEl } = useSidebarScrollbarGutter(pinnedItems);
           <SidebarMenuItem
             v-for="{ item, url } in pinnedItemsWithUrls"
             :key="item.uri"
-            class="mr-1.5"
+            class="mr-1.5 transition-colors"
           >
             <SidebarMenuButton
               :as="RouterLinkComponent"
@@ -136,7 +136,7 @@ const { navEl } = useSidebarScrollbarGutter(pinnedItems);
                   ? 'no-underline font-bold'
                   : 'no-underline font-medium',
               ]"
-              @click="handleClick"
+              @click="handleClick($event)"
               @contextmenu.prevent="openContextMenu($event, item)"
             >
               <img

--- a/src/components/navigation/NavShortcuts.vue
+++ b/src/components/navigation/NavShortcuts.vue
@@ -136,7 +136,7 @@ const { navEl } = useSidebarScrollbarGutter(pinnedItems);
                   ? 'no-underline font-bold'
                   : 'no-underline font-medium',
               ]"
-              @click="handleClick($event)"
+              @click="handleClick"
               @contextmenu.prevent="openContextMenu($event, item)"
             >
               <img

--- a/src/components/navigation/NavShortcuts.vue
+++ b/src/components/navigation/NavShortcuts.vue
@@ -100,6 +100,8 @@ const openContextMenu = async (event: MouseEvent, item: ShortcutItem) => {
     event.clientY,
     true,
     true,
+    undefined,
+    { shortcutContext: true },
   );
 };
 

--- a/src/components/navigation/NavShortcuts.vue
+++ b/src/components/navigation/NavShortcuts.vue
@@ -123,7 +123,7 @@ const { navEl } = useSidebarScrollbarGutter(pinnedItems);
           <SidebarMenuItem
             v-for="{ item, url } in pinnedItemsWithUrls"
             :key="item.uri"
-            class="mr-1.5 transition-colors"
+            class="mr-1.5"
           >
             <SidebarMenuButton
               :as="RouterLinkComponent"

--- a/src/composables/useShortcuts.ts
+++ b/src/composables/useShortcuts.ts
@@ -397,11 +397,13 @@ export function useShortcuts() {
     sourceItem: ShortcutItem,
     targetItem: ShortcutItem,
   ) {
-    const sourceUri = pinnedUris.value.find((uri) =>
-      isSameShortcutUri(uri, sourceItem),
+    const sourceUri = findPinnedUriByIdentities(
+      getShortcutIdentities(sourceItem),
+      pinnedUris.value,
     );
-    const targetUri = pinnedUris.value.find((uri) =>
-      isSameShortcutUri(uri, targetItem),
+    const targetUri = findPinnedUriByIdentities(
+      getShortcutIdentities(targetItem),
+      pinnedUris.value,
     );
     if (!sourceUri || !targetUri) return;
 

--- a/src/composables/useShortcuts.ts
+++ b/src/composables/useShortcuts.ts
@@ -72,6 +72,10 @@ function parseShortcutUri(uri: string): ParsedShortcutUri | null {
   };
 }
 
+export function getShortcutUri(item: ShortcutItem | ItemMapping): string {
+  return `${item.provider}://${item.media_type}/${item.item_id}`;
+}
+
 // When right is a ShortcutItem, also matches by constructed MA URI so items
 // whose uri is a non-MA URL (e.g. a podcast RSS <link> website) still match.
 function isSameShortcutUri(
@@ -81,10 +85,7 @@ function isSameShortcutUri(
   const candidates: string[] =
     typeof right === "string"
       ? [right]
-      : [
-          `${right.provider}://${right.media_type}/${right.item_id}`,
-          ...(right.uri ? [right.uri] : []),
-        ];
+      : [getShortcutUri(right), ...(right.uri ? [right.uri] : [])];
 
   const a = parseShortcutUri(left);
   for (const candidate of candidates) {
@@ -142,6 +143,32 @@ function getShortcutIdentities(
   return identities;
 }
 
+function hasShortcutIdentityMatch(
+  parsedUri: ParsedShortcutUri,
+  identities: ParsedShortcutUri[],
+): boolean {
+  return identities.some(
+    (identity) =>
+      parsedUri.mediaType === identity.mediaType &&
+      parsedUri.provider === identity.provider &&
+      parsedUri.itemId === identity.itemId,
+  );
+}
+
+function findPinnedUriByIdentities(
+  identities: ParsedShortcutUri[],
+  pinnedUris: string[],
+): string | null {
+  for (const pinnedUri of pinnedUris) {
+    const parsed = parseShortcutUri(pinnedUri);
+    if (!parsed) continue;
+    if (hasShortcutIdentityMatch(parsed, identities)) {
+      return pinnedUri;
+    }
+  }
+  return null;
+}
+
 export function isShortcutMediaType(mediaType: MediaType): boolean {
   return SUPPORTED_TYPES.has(mediaType);
 }
@@ -171,12 +198,7 @@ export function isShortcutPinnedItem(
   return _getPinnedUris().some((pinnedUri) => {
     const parsed = parseShortcutUri(pinnedUri);
     if (!parsed) return false;
-    return identities.some(
-      (identity) =>
-        parsed.mediaType === identity.mediaType &&
-        parsed.provider === identity.provider &&
-        parsed.itemId === identity.itemId,
-    );
+    return hasShortcutIdentityMatch(parsed, identities);
   });
 }
 
@@ -189,12 +211,7 @@ export async function unpinShortcutStandaloneItem(
     _getPinnedUris().filter((pinnedUri) => {
       const parsed = parseShortcutUri(pinnedUri);
       if (!parsed) return true;
-      return !identities.some(
-        (identity) =>
-          parsed.mediaType === identity.mediaType &&
-          parsed.provider === identity.provider &&
-          parsed.itemId === identity.itemId,
-      );
+      return !hasShortcutIdentityMatch(parsed, identities);
     }),
   );
 }
@@ -207,7 +224,7 @@ export async function pinShortcutStandalone(
   if (uris.length >= MAX_SHORTCUTS) return;
   // Always construct a proper MA URI from provider/media_type/item_id.
   // item.uri may be a non-MA URL (e.g. a podcast website link).
-  const maUri = `${item.provider}://${item.media_type}/${item.item_id}`;
+  const maUri = getShortcutUri(item);
   if (uris.some((pinnedUri) => isSameShortcutUri(pinnedUri, maUri))) return;
   await setUserPreference(PREF_KEY, [...uris, maUri]);
 }
@@ -230,6 +247,73 @@ export function initGlobalShortcutsSync(): void {
     // Keep sidebar preferences clean even when nav components are unmounted.
     void removePinnedUriIfPresent(evt.object_id as string);
   });
+}
+
+function reorderShortcutUris(
+  uris: string[],
+  sourceUri: string,
+  targetUri: string,
+): string[] | null {
+  const fromIndex = uris.findIndex((uri) => isSameShortcutUri(uri, sourceUri));
+  const toIndex = uris.findIndex((uri) => isSameShortcutUri(uri, targetUri));
+  if (fromIndex < 0 || toIndex < 0 || fromIndex === toIndex) {
+    return null;
+  }
+  const nextUris = [...uris];
+  const [movedUri] = nextUris.splice(fromIndex, 1);
+  nextUris.splice(toIndex, 0, movedUri);
+  return nextUris;
+}
+
+export async function reorderShortcutStandalone(
+  sourceUri: string,
+  targetUri: string,
+): Promise<void> {
+  const currentUris = _getPinnedUris();
+  const nextUris = reorderShortcutUris(currentUris, sourceUri, targetUri);
+  if (!nextUris) return;
+  await setUserPreference(PREF_KEY, nextUris);
+}
+
+function findPinnedUriForItem(item: ShortcutItem | ItemMapping): string | null {
+  const identities = getShortcutIdentities(item);
+  return findPinnedUriByIdentities(identities, _getPinnedUris());
+}
+
+export function getShortcutMoveAvailability(item: ShortcutItem | ItemMapping): {
+  canMoveUp: boolean;
+  canMoveDown: boolean;
+} {
+  const uris = _getPinnedUris();
+  const uri = findPinnedUriForItem(item);
+  if (!uri) return { canMoveUp: false, canMoveDown: false };
+  const index = uris.findIndex((pinnedUri) =>
+    isSameShortcutUri(pinnedUri, uri),
+  );
+  if (index < 0) return { canMoveUp: false, canMoveDown: false };
+  return {
+    canMoveUp: index > 0,
+    canMoveDown: index < uris.length - 1,
+  };
+}
+
+export async function moveShortcutStandaloneItem(
+  item: ShortcutItem | ItemMapping,
+  direction: "up" | "down",
+): Promise<void> {
+  const uris = _getPinnedUris();
+  const uri = findPinnedUriForItem(item);
+  if (!uri) return;
+
+  const index = uris.findIndex((pinnedUri) =>
+    isSameShortcutUri(pinnedUri, uri),
+  );
+  if (index < 0) return;
+
+  const targetIndex = direction === "up" ? index - 1 : index + 1;
+  if (targetIndex < 0 || targetIndex >= uris.length) return;
+
+  await reorderShortcutStandalone(uri, uris[targetIndex]);
 }
 
 export function useShortcuts() {
@@ -290,7 +374,7 @@ export function useShortcuts() {
   async function pinItem(item: ShortcutItem) {
     // Always construct a proper MA URI from provider/media_type/item_id.
     // item.uri may be a non-MA URL (e.g. a podcast website link).
-    const maUri = `${item.provider}://${item.media_type}/${item.item_id}`;
+    const maUri = getShortcutUri(item);
     if (isPinned(maUri)) return;
     if (pinnedUris.value.length >= MAX_SHORTCUTS) return;
     // Add immediately for instant sidebar feedback; watch won't re-add (already present)
@@ -307,6 +391,46 @@ export function useShortcuts() {
       PREF_KEY,
       pinnedUris.value.filter((u) => !isSameShortcutUri(u, uri)),
     );
+  }
+
+  async function reorderItems(
+    sourceItem: ShortcutItem,
+    targetItem: ShortcutItem,
+  ) {
+    const sourceUri = pinnedUris.value.find((uri) =>
+      isSameShortcutUri(uri, sourceItem),
+    );
+    const targetUri = pinnedUris.value.find((uri) =>
+      isSameShortcutUri(uri, targetItem),
+    );
+    if (!sourceUri || !targetUri) return;
+
+    const nextUris = reorderShortcutUris(
+      pinnedUris.value,
+      sourceUri,
+      targetUri,
+    );
+    if (!nextUris) return;
+
+    // Keep local UI in sync immediately while preference update propagates.
+    const fromItemIndex = resolvedItems.value.findIndex((item) =>
+      isSameShortcutUri(sourceUri, item),
+    );
+    const toItemIndex = resolvedItems.value.findIndex((item) =>
+      isSameShortcutUri(targetUri, item),
+    );
+    if (
+      fromItemIndex >= 0 &&
+      toItemIndex >= 0 &&
+      fromItemIndex !== toItemIndex
+    ) {
+      const nextItems = [...resolvedItems.value];
+      const [movedItem] = nextItems.splice(fromItemIndex, 1);
+      nextItems.splice(toItemIndex, 0, movedItem);
+      resolvedItems.value = nextItems;
+    }
+
+    await setPreference(PREF_KEY, nextUris);
   }
 
   // React to external changes (e.g. pinShortcutStandalone from the context menu)
@@ -386,5 +510,6 @@ export function useShortcuts() {
     isPinned,
     pinItem,
     unpinItem,
+    reorderItems,
   };
 }

--- a/src/composables/useShortcuts.ts
+++ b/src/composables/useShortcuts.ts
@@ -393,48 +393,6 @@ export function useShortcuts() {
     );
   }
 
-  async function reorderItems(
-    sourceItem: ShortcutItem,
-    targetItem: ShortcutItem,
-  ) {
-    const sourceUri = findPinnedUriByIdentities(
-      getShortcutIdentities(sourceItem),
-      pinnedUris.value,
-    );
-    const targetUri = findPinnedUriByIdentities(
-      getShortcutIdentities(targetItem),
-      pinnedUris.value,
-    );
-    if (!sourceUri || !targetUri) return;
-
-    const nextUris = reorderShortcutUris(
-      pinnedUris.value,
-      sourceUri,
-      targetUri,
-    );
-    if (!nextUris) return;
-
-    // Keep local UI in sync immediately while preference update propagates.
-    const fromItemIndex = resolvedItems.value.findIndex((item) =>
-      isSameShortcutUri(sourceUri, item),
-    );
-    const toItemIndex = resolvedItems.value.findIndex((item) =>
-      isSameShortcutUri(targetUri, item),
-    );
-    if (
-      fromItemIndex >= 0 &&
-      toItemIndex >= 0 &&
-      fromItemIndex !== toItemIndex
-    ) {
-      const nextItems = [...resolvedItems.value];
-      const [movedItem] = nextItems.splice(fromItemIndex, 1);
-      nextItems.splice(toItemIndex, 0, movedItem);
-      resolvedItems.value = nextItems;
-    }
-
-    await setPreference(PREF_KEY, nextUris);
-  }
-
   // React to external changes (e.g. pinShortcutStandalone from the context menu)
   watch(pinnedUris, async (newUris) => {
     const currentItems = resolvedItems.value;
@@ -512,6 +470,5 @@ export function useShortcuts() {
     isPinned,
     pinItem,
     unpinItem,
-    reorderItems,
   };
 }

--- a/src/layouts/default/ItemContextMenu.vue
+++ b/src/layouts/default/ItemContextMenu.vue
@@ -237,9 +237,11 @@ import {
 import { authManager } from "@/plugins/auth";
 import { $t } from "@/plugins/i18n";
 import {
+  getShortcutMoveAvailability,
   isShortcutMediaType,
   isShortcutPinnedItem,
   isShortcutCapReached,
+  moveShortcutStandaloneItem,
   pinShortcutStandalone,
   unpinShortcutStandaloneItem,
 } from "@/composables/useShortcuts";
@@ -863,6 +865,22 @@ export const getContextMenuItems = async function (
   ) {
     const shortcutItem = items[0];
     if (isShortcutPinnedItem(shortcutItem)) {
+      const { canMoveUp, canMoveDown } =
+        getShortcutMoveAvailability(shortcutItem);
+      contextMenuItems.push({
+        label: "queue_move_up",
+        labelArgs: [],
+        action: () => moveShortcutStandaloneItem(shortcutItem, "up"),
+        icon: "mdi-arrow-up",
+        disabled: !canMoveUp,
+      });
+      contextMenuItems.push({
+        label: "queue_move_down",
+        labelArgs: [],
+        action: () => moveShortcutStandaloneItem(shortcutItem, "down"),
+        icon: "mdi-arrow-down",
+        disabled: !canMoveDown,
+      });
       contextMenuItems.push({
         label: "shortcut.remove_from",
         labelArgs: [],

--- a/src/layouts/default/ItemContextMenu.vue
+++ b/src/layouts/default/ItemContextMenu.vue
@@ -270,6 +270,7 @@ export const showContextMenuForMediaItem = async function (
   includePlayMenuItems = false,
   showPlayMenuHeader = false,
   sortBy?: string,
+  options?: ContextMenuOptions,
 ) {
   // show ContextMenu for given MediaItem(s)
   const mediaItems: MediaItemTypeOrItemMapping[] = Array.isArray(item)
@@ -286,7 +287,11 @@ export const showContextMenuForMediaItem = async function (
     return;
   }
 
-  const contextMenuItems = await getContextMenuItems(mediaItems, parentItem);
+  const contextMenuItems = await getContextMenuItems(
+    mediaItems,
+    parentItem,
+    options,
+  );
 
   let menuItems: ContextMenuItem[] = [];
 
@@ -398,9 +403,16 @@ export const showPlayMenuForMediaItem = async function (
   });
 };
 
+export interface ContextMenuOptions {
+  // true when the menu is opened from the sidebar shortcuts list,
+  // enabling actions that only make sense there (e.g. move up/down).
+  shortcutContext?: boolean;
+}
+
 export const getContextMenuItems = async function (
   items: MediaItemTypeOrItemMapping[],
   parentItem?: MediaItemType,
+  options?: ContextMenuOptions,
 ) {
   const contextMenuItems: ContextMenuItem[] = [];
   if (items.length == 0) {
@@ -865,22 +877,26 @@ export const getContextMenuItems = async function (
   ) {
     const shortcutItem = items[0];
     if (isShortcutPinnedItem(shortcutItem)) {
-      const { canMoveUp, canMoveDown } =
-        getShortcutMoveAvailability(shortcutItem);
-      contextMenuItems.push({
-        label: "queue_move_up",
-        labelArgs: [],
-        action: () => moveShortcutStandaloneItem(shortcutItem, "up"),
-        icon: "mdi-arrow-up",
-        disabled: !canMoveUp,
-      });
-      contextMenuItems.push({
-        label: "queue_move_down",
-        labelArgs: [],
-        action: () => moveShortcutStandaloneItem(shortcutItem, "down"),
-        icon: "mdi-arrow-down",
-        disabled: !canMoveDown,
-      });
+      // move up/down only make sense when the menu is opened on the
+      // sidebar shortcuts list itself
+      if (options?.shortcutContext) {
+        const { canMoveUp, canMoveDown } =
+          getShortcutMoveAvailability(shortcutItem);
+        contextMenuItems.push({
+          label: "queue_move_up",
+          labelArgs: [],
+          action: () => moveShortcutStandaloneItem(shortcutItem, "up"),
+          icon: "mdi-arrow-up",
+          disabled: !canMoveUp,
+        });
+        contextMenuItems.push({
+          label: "queue_move_down",
+          labelArgs: [],
+          action: () => moveShortcutStandaloneItem(shortcutItem, "down"),
+          icon: "mdi-arrow-down",
+          disabled: !canMoveDown,
+        });
+      }
       contextMenuItems.push({
         label: "shortcut.remove_from",
         labelArgs: [],

--- a/tests/composables/useShortcuts.test.ts
+++ b/tests/composables/useShortcuts.test.ts
@@ -24,9 +24,12 @@ vi.mock("@/plugins/store", () => ({
 }));
 
 import {
+  getShortcutMoveAvailability,
   isShortcutPinned,
   isShortcutPinnedItem,
+  moveShortcutStandaloneItem,
   pinShortcutStandalone,
+  reorderShortcutStandalone,
   unpinShortcutStandaloneItem,
 } from "@/composables/useShortcuts";
 
@@ -119,6 +122,107 @@ describe("useShortcuts standalone helpers", () => {
     expect(mockUpdateUser).not.toHaveBeenCalled();
     expect(storeMock.currentUser.preferences["sidebar.shortcuts"]).toEqual([
       ENCODED_PODCAST_URI,
+    ]);
+  });
+
+  it("reorders shortcuts by URI match", async () => {
+    storeMock.currentUser.preferences["sidebar.shortcuts"] = [
+      ENCODED_PODCAST_URI,
+      "builtin://radio/http%3A%2F%2Fexample.com%2Fstream",
+      "library://playlist/99",
+    ];
+
+    await reorderShortcutStandalone("library://playlist/99", RAW_PODCAST_URI);
+
+    expect(mockUpdateUser).toHaveBeenCalledTimes(1);
+    expect(storeMock.currentUser.preferences["sidebar.shortcuts"]).toEqual([
+      "library://playlist/99",
+      ENCODED_PODCAST_URI,
+      "builtin://radio/http%3A%2F%2Fexample.com%2Fstream",
+    ]);
+  });
+
+  it("does not update when reorder source is missing", async () => {
+    storeMock.currentUser.preferences["sidebar.shortcuts"] = [
+      ENCODED_PODCAST_URI,
+      "builtin://radio/http%3A%2F%2Fexample.com%2Fstream",
+    ];
+
+    await reorderShortcutStandalone(
+      "library://playlist/does-not-exist",
+      "builtin://radio/http%3A%2F%2Fexample.com%2Fstream",
+    );
+
+    expect(mockUpdateUser).not.toHaveBeenCalled();
+    expect(storeMock.currentUser.preferences["sidebar.shortcuts"]).toEqual([
+      ENCODED_PODCAST_URI,
+      "builtin://radio/http%3A%2F%2Fexample.com%2Fstream",
+    ]);
+  });
+
+  it("returns move availability for pinned shortcut", () => {
+    storeMock.currentUser.preferences["sidebar.shortcuts"] = [
+      ENCODED_PODCAST_URI,
+      "builtin://radio/http%3A%2F%2Fexample.com%2Fstream",
+      "library://playlist/99",
+    ];
+
+    const podcastItem = {
+      provider: "itunes_podcasts",
+      media_type: MediaType.PODCAST,
+      item_id: PODCAST_FEED,
+      uri: RAW_PODCAST_URI,
+    };
+
+    expect(getShortcutMoveAvailability(podcastItem as any)).toEqual({
+      canMoveUp: false,
+      canMoveDown: true,
+    });
+  });
+
+  it("moves pinned shortcut down by one position", async () => {
+    storeMock.currentUser.preferences["sidebar.shortcuts"] = [
+      ENCODED_PODCAST_URI,
+      "builtin://radio/http%3A%2F%2Fexample.com%2Fstream",
+      "library://playlist/99",
+    ];
+
+    const podcastItem = {
+      provider: "itunes_podcasts",
+      media_type: MediaType.PODCAST,
+      item_id: PODCAST_FEED,
+      uri: RAW_PODCAST_URI,
+    };
+
+    await moveShortcutStandaloneItem(podcastItem as any, "down");
+
+    expect(mockUpdateUser).toHaveBeenCalledTimes(1);
+    expect(storeMock.currentUser.preferences["sidebar.shortcuts"]).toEqual([
+      "builtin://radio/http%3A%2F%2Fexample.com%2Fstream",
+      ENCODED_PODCAST_URI,
+      "library://playlist/99",
+    ]);
+  });
+
+  it("does not move when pinned shortcut is already at boundary", async () => {
+    storeMock.currentUser.preferences["sidebar.shortcuts"] = [
+      ENCODED_PODCAST_URI,
+      "builtin://radio/http%3A%2F%2Fexample.com%2Fstream",
+    ];
+
+    const podcastItem = {
+      provider: "itunes_podcasts",
+      media_type: MediaType.PODCAST,
+      item_id: PODCAST_FEED,
+      uri: RAW_PODCAST_URI,
+    };
+
+    await moveShortcutStandaloneItem(podcastItem as any, "up");
+
+    expect(mockUpdateUser).not.toHaveBeenCalled();
+    expect(storeMock.currentUser.preferences["sidebar.shortcuts"]).toEqual([
+      ENCODED_PODCAST_URI,
+      "builtin://radio/http%3A%2F%2Fexample.com%2Fstream",
     ]);
   });
 });


### PR DESCRIPTION
## Summary
This PR improves shortcut ordering while keeping interaction consistent with current UX direction.

### What changed
- Added standalone shortcut ordering helpers in `useShortcuts` for:
  - reordering by URI
  - move availability (`canMoveUp` / `canMoveDown`)
  - move item up/down
- Added context menu actions for pinned shortcuts:
  - Move up
  - Move down
