### PR TITLE
Add link to background analysis Concurrency Setting

### DIFF
--- a/src/components/AudioAnalysisConcurrency.vue
+++ b/src/components/AudioAnalysisConcurrency.vue
@@ -1,0 +1,32 @@
+<template>
+  <Card>
+    <CardHeader>
+      <CardTitle>{{
+        $t("settings.audio_analysis_concurrency.title")
+      }}</CardTitle>
+      <CardDescription>
+        {{ $t("settings.audio_analysis_concurrency.description") }}
+      </CardDescription>
+    </CardHeader>
+    <CardContent>
+      <Button as-child variant="outline">
+        <RouterLink to="/settings/editcore/streams">
+          {{ $t("settings.audio_analysis_concurrency.open_settings") }}
+        </RouterLink>
+      </Button>
+    </CardContent>
+  </Card>
+</template>
+
+<script setup lang="ts">
+import { $t } from "@/plugins/i18n";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { RouterLink } from "vue-router";
+</script>

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -771,6 +771,11 @@
             "unavailable": "unavailable",
             "none": "—"
         },
+        "audio_analysis_concurrency": {
+            "title": "Background analysis concurrency",
+            "description": "Control how many tracks are analyzed concurrently during the nightly background scan. This setting lives in the Streams core configuration.",
+            "open_settings": "Open Streams settings"
+        },
         "audio_analysis_description": "Track audio analysis coverage across your providers"
     },
     "similar_tracks": "Similar tracks",

--- a/src/views/settings/AudioAnalysis.vue
+++ b/src/views/settings/AudioAnalysis.vue
@@ -1,9 +1,11 @@
 <template>
   <div class="space-y-6 p-6">
+    <AudioAnalysisConcurrency />
     <AudioAnalysisCoverage />
   </div>
 </template>
 
 <script setup lang="ts">
+import AudioAnalysisConcurrency from "@/components/AudioAnalysisConcurrency.vue";
 import AudioAnalysisCoverage from "@/components/AudioAnalysisCoverage.vue";
 </script>


### PR DESCRIPTION
## What

Adds a card to **Settings → System → Audio Analysis**, positioned **above** the existing coverage frame (`<AudioAnalysisCoverage />`), that links to the **Streams** core configuration where the `background_scan_concurrency` value can be edited.

The setting stays in the generic core-config editor (it is *not* hidden on the backend), so this page simply points to it rather than duplicating the control.

## Changes

- **New component** `src/components/AudioAnalysisConcurrency.vue` — a `Card` (title + description) with a button that routes to `/settings/editcore/streams` via the existing `editcore/:domain` route, using the shadcn `Button as-child` + `RouterLink` pattern.
- **`src/views/settings/AudioAnalysis.vue`** — renders the card above `<AudioAnalysisCoverage />`.
- **`src/translations/en.json`** — adds the `audio_analysis_concurrency` block (title, description, and `open_settings` label).

## Testing

- `yarn lint` → 0 errors (3 pre-existing warnings in unrelated files).
- `vue-tsc --noEmit` → clean.
- Full test suite → 171/171 passing.

<img width="1494" height="209" alt="image" src="https://github.com/user-attachments/assets/b5e22e34-da46-4198-9a66-303850ac7161" />