### PR TITLE
Match now-playing typography to new discover tiles

### DIFF
--- a/src/layouts/default/PlayerOSD/PlayerFullscreen.vue
+++ b/src/layouts/default/PlayerOSD/PlayerFullscreen.vue
@@ -98,14 +98,14 @@
             <!-- player name as title if its powered off-->
             <v-card-title
               v-if="store.activePlayer?.powered == false"
-              :style="`font-size: ${titleFontSize};`"
+              :style="`font-size: ${titleFontSize};font-weight:600;`"
             >
               {{ store.activePlayer?.name }}
             </v-card-title>
             <!-- current media title -->
             <v-card-title
               v-else-if="store.activePlayer?.current_media?.title"
-              :style="`font-size: ${titleFontSize};cursor:pointer;`"
+              :style="`font-size: ${titleFontSize};font-weight:600;cursor:pointer;`"
               @click="onTitleClick"
             >
               <MarqueeText :sync="playerMarqueeSync">
@@ -115,7 +115,7 @@
             <!-- no player selected message -->
             <v-card-title
               v-else
-              :style="`font-size: ${titleFontSize};cursor:pointer;`"
+              :style="`font-size: ${titleFontSize};font-weight:600;cursor:pointer;`"
               @click="store.showPlayersMenu = true"
             >
               <MarqueeText :sync="playerMarqueeSync">
@@ -856,22 +856,9 @@ const titleFontSize = computed(() => {
 });
 
 const subTitleFontSize = computed(() => {
-  switch (name.value) {
-    case "xs":
-      return "0.95em";
-    case "sm":
-      return "1.15em";
-    case "md":
-      return "1.3em";
-    case "lg":
-      return store.showQueueItems ? "1.2em" : "1.5em";
-    case "xl":
-      return store.showQueueItems ? "1.3em" : "1.65em";
-    case "xxl":
-      return store.showQueueItems ? "1.35em" : "1.8em";
-    default:
-      return "1.0em";
-  }
+  // Anchor album/artist size to the track title using the EditorialMediaCard
+  // tile ratio (subtitle 12px / title 14px).
+  return `${(parseFloat(titleFontSize.value) * (12 / 14)).toFixed(3)}em`;
 });
 
 const queueTitleFontSize = computed(() => {


### PR DESCRIPTION
## What

Brings the fullscreen now-playing screen's title / artist / album typography in line with the revamped discover page tiles (`EditorialMediaCard`).

- **Track title** `font-weight` 500 → 600, matching the tile title weight.
- **Album / artist size** now derives from the track title using the tile's title:subtitle ratio (12 / 14 ≈ 0.857), replacing the previous per-breakpoint values (≈0.72 ratio). The subtitle now sits closer in size to the title, mirroring the tiles.

The subtitle colour/opacity is intentionally left as-is (original `var(--text-color)` at medium-emphasis opacity).

## Why

The new discover tiles introduced a clear bold-title / lighter-subtitle hierarchy. The now-playing screen looked off against it — the title wasn't as bold and the subtitle size relationship differed. This matches the title weight and the title:subtitle size relationship to the tiles, anchored to the existing track-title size (size of the title itself is unchanged).

## Testing

- Verified live on the now-playing fullscreen: computed title weight 600, subtitle/title size ratio 0.857.
- `eslint` and `vue-tsc --noEmit` pass; full unit test suite passes via the pre-commit hook.