### PR TITLE
Show Smart Playlist provider in playlists provider filter

### DIFF
--- a/src/components/ItemsListing.vue
+++ b/src/components/ItemsListing.vue
@@ -250,6 +250,7 @@ import {
   type MediaItemType,
   type Track,
 } from "@/plugins/api/interfaces";
+import { SMART_PLAYLIST_PROVIDER_DOMAIN } from "@/components/smart_playlist/constants";
 import { eventbus } from "@/plugins/eventbus";
 import { store } from "@/plugins/store";
 import {
@@ -839,6 +840,13 @@ const musicProviders = computed(() => {
 
   return Object.values(api.providers)
     .filter((provider) => {
+      // include Smart Playlist plugin provider in the playlists filter
+      if (
+        props.itemtype === "playlists" &&
+        provider.domain === SMART_PLAYLIST_PROVIDER_DOMAIN
+      ) {
+        return provider.available;
+      }
       if (provider.type !== ProviderType.MUSIC) return false;
       if (
         store.currentUser &&


### PR DESCRIPTION
## Problem

The provider filter dropdown in the Playlists library view (`ItemsListing.vue`) was restricted to `ProviderType.MUSIC` providers only. The Smart Playlist provider is a `PluginProvider` (`type = PLUGIN`) and was therefore never shown in the filter, even though it creates playlists that appear in the same view.

## Solution

Special-case the Smart Playlist provider domain in the `musicProviders` computed property so it is included when `itemtype === "playlists"`.

## Why not use `ProviderFeature.LIBRARY_PLAYLISTS`?

The clean solution would be to add `ProviderFeature.LIBRARY_PLAYLISTS` to the Smart Playlist provider's `SUPPORTED_FEATURES` and remove the `ProviderType.MUSIC` restriction for that feature. However, `LIBRARY_PLAYLISTS` currently implies library sync behaviour on the server side — adding it to a Plugin provider would trigger unwanted sync logic.

A more generic solution should be considered in v2.10.0, since Smart Playlist may not be the only Plugin provider that manages playlists.

## Screenshot

<img width="1360" height="364" alt="provider filter smart_playlist" src="https://github.com/user-attachments/assets/6f6982bb-d5dc-49dc-8735-ab8dacec8bc2" />