### PR TITLE
Fix album/playlist track order when played directly from a list

### DIFF
--- a/src/helpers/utils.ts
+++ b/src/helpers/utils.ts
@@ -813,7 +813,7 @@ export const handlePlayBtnClick = function (
     }
     // else: play the item directly
     api
-      .playMedia(item, undefined, undefined, undefined, undefined, sortBy)
+      .playMedia(item, undefined, undefined, undefined, undefined)
       .then(() => {});
     return;
   }


### PR DESCRIPTION
When playing an album or playlist directly, playMedia was forwarding the containing list's sortBy key (e.g. "name" from a track's "Appears On" section) to the server, which then applied it to the item's own tracks thus sorting album/show order alphabetically instead of the original order.

Drop sortBy from the "play item directly" branch so a directly-played item uses its original track order. The track-from-parent case still passes sortBy, since playing a track from a list should honour the displayed order.