### PR TITLE
Show catalog providers in library provider filter

### DIFF
--- a/src/components/ItemsListing.vue
+++ b/src/components/ItemsListing.vue
@@ -819,20 +819,39 @@ const isPlayActionInProgress = computed(() => {
 });
 
 const musicProviders = computed(() => {
-  // Map itemtype to required ProviderFeature(s)
-  const featureMap: Record<string, ProviderFeature | ProviderFeature[]> = {
-    artists: ProviderFeature.LIBRARY_ARTISTS,
-    albums: ProviderFeature.LIBRARY_ALBUMS,
-    tracks: ProviderFeature.LIBRARY_TRACKS,
+  // Map itemtype to the ProviderFeatures that mark a provider as a possible
+  // source of that mediatype. This is intentionally broader than the
+  // LIBRARY_* (sync) features: a provider without a syncable library can still
+  // contribute items to the library by being browsed/searched and favorited
+  // (e.g. catalog providers exposing an artist's albums/tracks).
+  const featureMap: Record<string, ProviderFeature[]> = {
+    artists: [
+      ProviderFeature.LIBRARY_ARTISTS,
+      ProviderFeature.ARTIST_ALBUMS,
+      ProviderFeature.ARTIST_TOPALBUMS,
+      ProviderFeature.ARTIST_TRACKS,
+      ProviderFeature.ARTIST_TOPTRACKS,
+    ],
+    albums: [
+      ProviderFeature.LIBRARY_ALBUMS,
+      ProviderFeature.ARTIST_ALBUMS,
+      ProviderFeature.ARTIST_TOPALBUMS,
+    ],
+    tracks: [
+      ProviderFeature.LIBRARY_TRACKS,
+      ProviderFeature.ARTIST_TRACKS,
+      ProviderFeature.ARTIST_TOPTRACKS,
+    ],
     artisttracks: [
+      ProviderFeature.ARTIST_TRACKS,
       ProviderFeature.ARTIST_TOPTRACKS,
       ProviderFeature.LIBRARY_TRACKS,
     ],
-    playlists: ProviderFeature.LIBRARY_PLAYLISTS,
-    radios: ProviderFeature.LIBRARY_RADIOS,
-    podcasts: ProviderFeature.LIBRARY_PODCASTS,
-    audiobooks: ProviderFeature.LIBRARY_AUDIOBOOKS,
-    genres: ProviderFeature.LIBRARY_GENRES,
+    playlists: [ProviderFeature.LIBRARY_PLAYLISTS],
+    radios: [ProviderFeature.LIBRARY_RADIOS],
+    podcasts: [ProviderFeature.LIBRARY_PODCASTS],
+    audiobooks: [ProviderFeature.LIBRARY_AUDIOBOOKS],
+    genres: [ProviderFeature.LIBRARY_GENRES],
   };
 
   const requiredFeatures = featureMap[props.itemtype];
@@ -851,10 +870,7 @@ const musicProviders = computed(() => {
       }
       // If we have required feature(s) for this itemtype, filter by them
       if (requiredFeatures) {
-        const features = Array.isArray(requiredFeatures)
-          ? requiredFeatures
-          : [requiredFeatures];
-        return features.some((feature) =>
+        return requiredFeatures.some((feature) =>
           provider.supported_features.includes(feature),
         );
       }

--- a/src/plugins/api/interfaces.ts
+++ b/src/plugins/api/interfaces.ts
@@ -348,7 +348,9 @@ export enum ProviderFeature {
   LIBRARY_GENRES = "library_genres",
   // additional library features
   ARTIST_ALBUMS = "artist_albums",
+  ARTIST_TRACKS = "artist_tracks",
   ARTIST_TOPTRACKS = "artist_toptracks",
+  ARTIST_TOPALBUMS = "artist_topalbums",
   // library edit (=add/remove) feature per mediatype
   LIBRARY_ARTISTS_EDIT = "library_artists_edit",
   LIBRARY_ALBUMS_EDIT = "library_albums_edit",


### PR DESCRIPTION
The provider filter on library views only listed providers that declared the LIBRARY_<type> (sync) feature for the current mediatype. Catalog providers without a syncable library (e.g. Phish.in) were hidden even though their items can be favorited into the library and the backend filters library items by provider mapping regardless of sync support.

Broaden the per-itemtype feature map to also include the ARTIST_ALBUMS / ARTIST_TOPALBUMS / ARTIST_TRACKS / ARTIST_TOPTRACKS catalog features so these providers appear in the filter where they can contribute items, while keeping mediatype-specific providers (e.g. radio-only) out of unrelated filters. Also add the missing ARTIST_TRACKS / ARTIST_TOPALBUMS members to the ProviderFeature enum.