### PR TITLE
Fix/tapping sliders

### DIFF
--- a/src/composables/playActionInProgress.ts
+++ b/src/composables/playActionInProgress.ts
@@ -1,4 +1,4 @@
-import { onUnmounted, ref, watch, type Ref } from "vue";
+import { onScopeDispose, ref, watch, type Ref } from "vue";
 import type { PlayerQueue } from "@/plugins/api/interfaces";
 
 // `play_action_in_progress` blips true for ~50ms during a seek (the stream
@@ -28,7 +28,7 @@ export function usePlayActionInProgress(
     { immediate: true },
   );
 
-  onUnmounted(() => {
+  onScopeDispose(() => {
     if (timer) clearTimeout(timer);
   });
 

--- a/src/composables/playActionInProgress.ts
+++ b/src/composables/playActionInProgress.ts
@@ -1,0 +1,36 @@
+import { onUnmounted, ref, watch, type Ref } from "vue";
+import type { PlayerQueue } from "@/plugins/api/interfaces";
+
+// `play_action_in_progress` blips true for ~50ms during a seek (the stream
+// restarts at the new position). Debouncing it means the dependent UI — the
+// play-button spinner and the disabled state of the transport controls — only
+// reacts to genuinely slow actions instead of flickering on every seek.
+export function usePlayActionInProgress(
+  playerQueue: Ref<PlayerQueue | undefined>,
+  delay = 200,
+) {
+  const isLoading = ref(false);
+  let timer: ReturnType<typeof setTimeout> | null = null;
+
+  watch(
+    () => playerQueue.value?.extra_attributes?.play_action_in_progress === true,
+    (inProgress) => {
+      if (timer) {
+        clearTimeout(timer);
+        timer = null;
+      }
+      if (inProgress) {
+        timer = setTimeout(() => (isLoading.value = true), delay);
+      } else {
+        isLoading.value = false;
+      }
+    },
+    { immediate: true },
+  );
+
+  onUnmounted(() => {
+    if (timer) clearTimeout(timer);
+  });
+
+  return { isLoading };
+}

--- a/src/layouts/default/PlayerOSD/PlayerControlBtn/NextBtn.vue
+++ b/src/layouts/default/PlayerOSD/PlayerControlBtn/NextBtn.vue
@@ -18,6 +18,7 @@ import api from "@/plugins/api";
 import { Player, PlayerFeature, PlayerQueue } from "@/plugins/api/interfaces";
 import { useActiveAudioSource } from "@/composables/activeAudioSource";
 import { useActiveSource } from "@/composables/activeSource";
+import { usePlayActionInProgress } from "@/composables/playActionInProgress";
 import { computed, toRef } from "vue";
 import { SkipForward } from "lucide-vue-next";
 
@@ -74,10 +75,5 @@ const canNext = computed(() => {
   return queueHasNext.value || playerHasNext.value;
 });
 
-const isLoading = computed(() => {
-  if (!compProps.player) return false;
-  return (
-    compProps.playerQueue?.extra_attributes?.play_action_in_progress === true
-  );
-});
+const { isLoading } = usePlayActionInProgress(toRef(compProps, "playerQueue"));
 </script>

--- a/src/layouts/default/PlayerOSD/PlayerControlBtn/PlayBtn.vue
+++ b/src/layouts/default/PlayerOSD/PlayerControlBtn/PlayBtn.vue
@@ -36,6 +36,7 @@ defineOptions({ inheritAttrs: false });
 import Icon, { IconProps } from "@/components/Icon.vue";
 import { useActiveAudioSource } from "@/composables/activeAudioSource";
 import { useActiveSource } from "@/composables/activeSource";
+import { usePlayActionInProgress } from "@/composables/playActionInProgress";
 import api from "@/plugins/api";
 import {
   MediaType,
@@ -109,12 +110,7 @@ const isPlaying = computed(() => {
   return compProps.player?.playback_state == PlaybackState.PLAYING;
 });
 
-const isLoading = computed(() => {
-  if (!compProps.player) return false;
-  return (
-    compProps.playerQueue?.extra_attributes?.play_action_in_progress === true
-  );
-});
+const { isLoading } = usePlayActionInProgress(toRef(compProps, "playerQueue"));
 
 const isDisabled = computed(() => {
   if (isLoading.value) return true;

--- a/src/layouts/default/PlayerOSD/PlayerControlBtn/PreviousBtn.vue
+++ b/src/layouts/default/PlayerOSD/PlayerControlBtn/PreviousBtn.vue
@@ -18,6 +18,7 @@ import api from "@/plugins/api";
 import { Player, PlayerFeature, PlayerQueue } from "@/plugins/api/interfaces";
 import { useActiveAudioSource } from "@/composables/activeAudioSource";
 import { useActiveSource } from "@/composables/activeSource";
+import { usePlayActionInProgress } from "@/composables/playActionInProgress";
 import { computed, toRef } from "vue";
 import { SkipBack } from "lucide-vue-next";
 
@@ -74,10 +75,5 @@ const canPrevious = computed(() => {
   return queueHasPrevious.value || playerHasPrevious.value;
 });
 
-const isLoading = computed(() => {
-  if (!compProps.player) return false;
-  return (
-    compProps.playerQueue?.extra_attributes?.play_action_in_progress === true
-  );
-});
+const { isLoading } = usePlayActionInProgress(toRef(compProps, "playerQueue"));
 </script>

--- a/src/layouts/default/PlayerOSD/PlayerControlBtn/RepeatBtn.vue
+++ b/src/layouts/default/PlayerOSD/PlayerControlBtn/RepeatBtn.vue
@@ -51,7 +51,8 @@ import {
   isQueueDynamicPlaylist,
   isQueueInfiniteStream,
 } from "@/plugins/api/helpers";
-import { computed } from "vue";
+import { usePlayActionInProgress } from "@/composables/playActionInProgress";
+import { computed, toRef } from "vue";
 import { IconRepeat, IconRepeatOff, IconRepeatOnce } from "@tabler/icons-vue";
 
 // properties
@@ -67,11 +68,7 @@ const compProps = withDefaults(defineProps<Props>(), {
   size: 20,
 });
 
-const isLoading = computed(() => {
-  return (
-    compProps.playerQueue?.extra_attributes?.play_action_in_progress === true
-  );
-});
+const { isLoading } = usePlayActionInProgress(toRef(compProps, "playerQueue"));
 
 const isSingleDynamicPlaylist = computed(() =>
   isQueueDynamicPlaylist(compProps.playerQueue),

--- a/src/layouts/default/PlayerOSD/PlayerControlBtn/ShuffleBtn.vue
+++ b/src/layouts/default/PlayerOSD/PlayerControlBtn/ShuffleBtn.vue
@@ -38,9 +38,10 @@ import {
   isQueueDynamicPlaylist,
   isQueueInfiniteStream,
 } from "@/plugins/api/helpers";
+import { usePlayActionInProgress } from "@/composables/playActionInProgress";
 import { IconArrowsRight } from "@tabler/icons-vue";
 import { Shuffle } from "lucide-vue-next";
-import { computed } from "vue";
+import { computed, toRef } from "vue";
 
 // properties
 export interface Props {
@@ -55,11 +56,7 @@ const compProps = withDefaults(defineProps<Props>(), {
   size: 20,
 });
 
-const isLoading = computed(() => {
-  return (
-    compProps.playerQueue?.extra_attributes?.play_action_in_progress === true
-  );
-});
+const { isLoading } = usePlayActionInProgress(toRef(compProps, "playerQueue"));
 
 const isSingleDynamicPlaylist = computed(() =>
   isQueueDynamicPlaylist(compProps.playerQueue),

--- a/src/layouts/default/PlayerOSD/PlayerTimeline.vue
+++ b/src/layouts/default/PlayerOSD/PlayerTimeline.vue
@@ -88,7 +88,10 @@ const showRemainingTime = ref(false);
 const isThumbHidden = ref(true);
 const isDragging = ref(false);
 const curTimeValue = ref(0);
-const tempTime = ref(0);
+// After a seek, hold the slider at the target until the backend's elapsed time
+// catches up, so it doesn't briefly snap back to the pre-seek position.
+const pendingSeek = ref<number | null>(null);
+let pendingSeekTimer: ReturnType<typeof setTimeout> | null = null;
 // ticking ref to force recompute of elapsed time (Date.now() is non-reactive)
 // rAF drives smooth 60fps slider movement; a 1s interval keeps text
 // labels up-to-date when the tab is backgrounded (rAF pauses).
@@ -125,6 +128,7 @@ const stopTick = () => {
 
 onUnmounted(() => {
   stopTick();
+  if (pendingSeekTimer) clearTimeout(pendingSeekTimer);
 });
 
 // computed properties
@@ -180,25 +184,38 @@ const playerTotalTimeStr = computed(() => {
   return formatDuration(duration);
 });
 
-const computedElapsedTime = computed(() => {
-  // include nowTick.value so this computed re-evaluates periodically while mounted
-  // and updates UI for fallback player-level current_media that relies on Date.now()
-  void nowTick.value;
-
-  // Adaptive tick: only run the timer when we have a playing source that relies on time progression
+// Whether the elapsed-time ticker should run: only while a source is actively
+// playing and its position advances with wall-clock time (a live MA queue, or an
+// external source reporting current_media). Gating the rAF/interval loop from a
+// dedicated watch — rather than from inside computedElapsedTime — keeps that
+// getter pure: a computed must not start/stop timers as a side effect (it can be
+// re-evaluated any number of times, and Vue gives no ordering guarantees).
+const shouldTick = computed(() => {
   const isPlaying = store.activePlayer?.playback_state === "playing";
   const usingQueue = !!(
     store.activePlayerQueue && store.activePlayerQueue.active
   );
   const hasCurrentMedia =
     store.activePlayer?.current_media?.elapsed_time != null;
+  return isPlaying && (usingQueue || hasCurrentMedia);
+});
 
-  // Start ticking when playing and either using queue or external current_media
-  if (isPlaying && (usingQueue || hasCurrentMedia)) startTick();
-  else stopTick();
+watch(
+  shouldTick,
+  (active) => {
+    if (active) startTick();
+    else stopTick();
+  },
+  { immediate: true },
+);
+
+const computedElapsedTime = computed(() => {
+  // Read nowTick so this getter re-evaluates on each ticker frame, refreshing the
+  // wall-clock extrapolation below. The ticker is started/stopped by the
+  // shouldTick watch above — never here — so this computed stays side-effect-free.
+  void nowTick.value;
+
   if (isDragging.value) {
-    // eslint-disable-next-line vue/no-side-effects-in-computed-properties
-    tempTime.value = curTimeValue.value;
     return curTimeValue.value;
   }
 
@@ -265,9 +282,17 @@ const chapterTicks = computed(() => {
 
 //watch
 watch(computedElapsedTime, (newTime) => {
-  if (!isDragging.value) {
-    curTimeValue.value = newTime;
+  if (isDragging.value) return;
+  if (pendingSeek.value !== null) {
+    // Ignore stale pre-seek values; release once the backend confirms (±2s).
+    if (Math.abs(newTime - pendingSeek.value) > 2) return;
+    pendingSeek.value = null;
+    if (pendingSeekTimer) {
+      clearTimeout(pendingSeekTimer);
+      pendingSeekTimer = null;
+    }
   }
+  curTimeValue.value = newTime;
 });
 
 // methods
@@ -275,14 +300,20 @@ const startDragging = function () {
   isDragging.value = true;
 };
 
-const stopDragging = () => {
+const stopDragging = (value: number) => {
   isDragging.value = false;
-  if (!isDragging.value && store.activePlayer) {
-    api.playerCommandSeek(
-      store.activePlayer.player_id,
-      Math.round(tempTime.value),
-    );
-  }
+  if (!store.activePlayer) return;
+  const target = Math.round(value);
+  // Optimistic: show the target immediately and hold it until the backend
+  // reports a matching elapsed time (or the safety timeout fires).
+  curTimeValue.value = target;
+  pendingSeek.value = target;
+  if (pendingSeekTimer) clearTimeout(pendingSeekTimer);
+  pendingSeekTimer = setTimeout(() => {
+    pendingSeek.value = null;
+    pendingSeekTimer = null;
+  }, 3000);
+  api.playerCommandSeek(store.activePlayer.player_id, target);
 };
 
 const chapterClicked = function (chaperPos: number) {

--- a/src/layouts/default/PlayerOSD/PlayerVolume.vue
+++ b/src/layouts/default/PlayerOSD/PlayerVolume.vue
@@ -530,18 +530,13 @@ const onTouchEnd = (event: TouchEvent) => {
     if (hasGroupPopout.value) {
       toggleGroupPopout();
     } else {
-      // Single player: tap before/after handle for volume up/down
+      // Single player: jump to the tapped position (absolute), matching the
+      // desktop click behaviour instead of stepping volume up/down.
       const touch = event.changedTouches[0];
-      const thumb = sliderContainerRef.value?.querySelector("[role=slider]");
-      if (thumb) {
-        const thumbRect = thumb.getBoundingClientRect();
-        const thumbCenter = thumbRect.left + thumbRect.width / 2;
-        if (touch.clientX > thumbCenter) {
-          volumeUp();
-        } else {
-          volumeDown();
-        }
-      }
+      const finalValue = getPercentageFromX(touch.clientX);
+      displayValue.value = finalValue;
+      emit("update:local-value", finalValue);
+      setVolume(finalValue);
     }
   } else {
     // Drag end: send the final absolute value to the server

--- a/tests/composables/playActionInProgress.test.ts
+++ b/tests/composables/playActionInProgress.test.ts
@@ -1,0 +1,89 @@
+import { effectScope, ref } from "vue";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { usePlayActionInProgress } from "@/composables/playActionInProgress";
+import type { PlayerQueue } from "@/plugins/api/interfaces";
+
+// The composable only reads extra_attributes.play_action_in_progress.
+const makeQueue = (inProgress: boolean) =>
+  ({
+    extra_attributes: { play_action_in_progress: inProgress },
+  }) as unknown as PlayerQueue;
+
+describe("usePlayActionInProgress", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("stays false for a brief blip shorter than the debounce (the seek case)", async () => {
+    const queue = ref<PlayerQueue | undefined>(makeQueue(false));
+    const scope = effectScope();
+    let result!: ReturnType<typeof usePlayActionInProgress>;
+    scope.run(() => {
+      result = usePlayActionInProgress(queue, 200);
+    });
+
+    queue.value = makeQueue(true);
+    await Promise.resolve();
+    await vi.advanceTimersByTimeAsync(50);
+    queue.value = makeQueue(false); // blip ends well before 200ms
+    await Promise.resolve();
+    await vi.advanceTimersByTimeAsync(200);
+
+    expect(result.isLoading.value).toBe(false);
+    scope.stop();
+  });
+
+  it("becomes true after the debounce when sustained", async () => {
+    const queue = ref<PlayerQueue | undefined>(makeQueue(false));
+    const scope = effectScope();
+    let result!: ReturnType<typeof usePlayActionInProgress>;
+    scope.run(() => {
+      result = usePlayActionInProgress(queue, 200);
+    });
+
+    queue.value = makeQueue(true);
+    await Promise.resolve();
+    expect(result.isLoading.value).toBe(false); // not yet — still within the window
+
+    await vi.advanceTimersByTimeAsync(200);
+    expect(result.isLoading.value).toBe(true);
+    scope.stop();
+  });
+
+  it("clears immediately when the flag goes false", async () => {
+    const queue = ref<PlayerQueue | undefined>(makeQueue(true));
+    const scope = effectScope();
+    let result!: ReturnType<typeof usePlayActionInProgress>;
+    scope.run(() => {
+      result = usePlayActionInProgress(queue, 200);
+    });
+
+    await vi.advanceTimersByTimeAsync(200);
+    expect(result.isLoading.value).toBe(true);
+
+    queue.value = makeQueue(false);
+    await Promise.resolve();
+    expect(result.isLoading.value).toBe(false);
+    scope.stop();
+  });
+
+  it("cancels a pending timer when the scope is disposed", async () => {
+    const queue = ref<PlayerQueue | undefined>(makeQueue(false));
+    const scope = effectScope();
+    let result!: ReturnType<typeof usePlayActionInProgress>;
+    scope.run(() => {
+      result = usePlayActionInProgress(queue, 200);
+    });
+
+    queue.value = makeQueue(true);
+    await Promise.resolve();
+    scope.stop(); // onScopeDispose -> clearTimeout
+    await vi.advanceTimersByTimeAsync(200);
+
+    expect(result.isLoading.value).toBe(false);
+  });
+});


### PR DESCRIPTION
# Changelog
Makes the player sliders seek/jump to the tapped position on touch, and stops the transport controls flickering during a seek.
I made a few extra fews along the way that were related to the same part of the app to smoothen the UX a little bit. 🌟

This is how it looks with all of the bugs fixed from below, the videos are here to showcase the bugs in question so that we have full context on what was wrong

https://github.com/user-attachments/assets/7c949a6c-1c6e-4aa3-a662-7c56fe169cbf

- 🟢 **Progress slider — tap-to-seek**: tapping the progress bar jumps to the tapped position instead of nudging by a small step.
Tapping on mobile was overall not working at all if not dragging the seek along.

https://github.com/user-attachments/assets/92f732c1-b767-47f6-8b44-8cb4d58d1828
  
- 🟢 **Progress slider — no post-seek bounce**: it no longer briefly snaps back to the old position before settling on the seeked one.
I fixed the ugly behavior on desktop where it would take the stale value.

https://github.com/user-attachments/assets/6e7bad1f-9e97-42b6-8aa7-0ab3b0dd746f
  
- 🟢 **Volume slider — tap-to-position**: tapping the volume bar on touch jumps to the tapped position instead of stepping volume up/down.
I [wasn't sure about this one initially](https://github.com/music-assistant/backlog/issues/67#issuecomment-4614376039) but then decided to just match parity with the desktop behavior, kinda safe decision I think. 🤗

<img width="387" height="800" alt="CleanShot 2026-06-03 at 19 56 39" src="https://github.com/user-attachments/assets/d3db540f-4225-4054-9325-d40fd23a2ad0" />

- 🟢 **No control-bar flicker on seek**: the play / next / previous / shuffle / repeat buttons no longer flash their spinner / disabled state during a seek.
This one didn't look professional because of the flickering controls on both mobile + desktop.

<img width="800" height="417" alt="controls_desktop" src="https://github.com/user-attachments/assets/fea00837-833a-48c8-b7e6-0a61240c7947" />

---

<img width="419" height="800" alt="controls_mobile" src="https://github.com/user-attachments/assets/2339de17-0685-4998-ae7a-c79ca1e3896b" />

## Technical details
1. **Progress tap-to-seek:** `@end` seeked to a lazily-synced `tempTime` mirror that only refreshed during a continuous drag, so a quick tap sent a stale value.
Now it uses the value from Vuetify's `@end` event (the committed position).
 
2. **Post-seek bounce:** between the seek command and the backend's `queue_time_updated` confirmation, the elapsed-time watcher wrote the stale pre-seek value back.
The slider is now held optimistically at the target until the backend's elapsed catches up (±2s) or a 3s safety timeout.

3. **Volume tap:** on touch, `onTouchEnd` stepped volume up/down based on which side of the thumb was tapped, instead of jumping. Desktop already jumps via the reka-ui slider's `@update:model-value`. Touch taps now jump to the tapped position too (reusing the existing `getPercentageFromX` helper). Drag and the group-popout tap are unchanged.

4. **Control-bar flicker:** `play_action_in_progress` blips true for ~50ms during a seek (the stream restarts). Five buttons each read it directly to drive their spinner / disabled state. Extracted into a shared `usePlayActionInProgress` composable that debounces it (200ms), so the spinner only shows for genuinely slow actions.

## Refactor in [commit #3](https://github.com/music-assistant/frontend/commit/bc127a3bf29c72c2e6aa3bb9294e98f0df9d6464)

Removing `tempTime` let `computedElapsedTime` drop a mutation it performed inside the getter (`tempTime.value = curTimeValue.value`, previously suppressed with an `eslint-disable`).
Mostly wanted to [avoid doing the Vue anti-pattern](https://vuejs.org/guide/essentials/computed.html#avoid-mutating-computed-value) there.

## Commits details
I split my work across 3 commits so that any could be reverted if not considered atomic enough (or just outside of the scope of this PR).
We could argue that this PR is "doing too much", yet I wanted to leave it better than it initially was without making it too huge.

1. **Fix progress slider seek**: `PlayerTimeline.vue`: tap-to-seek + optimistic post-seek hold, plus the side-effect-free `computedElapsedTime` cleanup above.
2. **Fix volume slider tap on touch**: `PlayerVolume.vue` (jump to tapped position).
3. **Debounce play_action_in_progress across transport controls**: new composable + the five control buttons. Related polish; can be reverted independently.
4. **Unit test the new composable**: I somehow totally forgot to check the structure of the project more in depth and glanced over the UT. After double-checking [this part](https://github.com/music-assistant/frontend#helpers--utilities), it is now added! 🤦🏻‍♂️

## Verification
Linter + typecking + tests all pass (added coverage of my new composable). ✅

- Manually checked on **desktop and a real Android device (as shown in the GIFs/videos above)**, in both the
  **mini player and the fullscreen player**:
  - tapping the progress bar (touch + mouse) jumps to the tapped position
  - tapping the volume bar jumps to the tapped position
  - no post-seek bounce — progress no longer flicks back toward 0 before settling
  - no spinner / disabled flicker on the transport controls while seeking
  - drag and the group-volume popout behave as before
  - verified across several different tracks

Closes https://github.com/music-assistant/backlog/issues/67

---

PS: disclaimer regarding the [OHF AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md):
- Claude Code was used to scaffold the writing of this PR, I filled in the gaps + added some visuals to illustrate all the bugs/work done 🤗
- it was also used to speed up my dev workflow, I take full ownership and I'm 100% able to explain what was pushed 