### PR TITLE
fix(i18n): replace edit by save

### DIFF
--- a/src/components/users/EditUserDialog.vue
+++ b/src/components/users/EditUserDialog.vue
@@ -237,7 +237,7 @@
           :disabled="loading"
           :loading="loading"
         >
-          {{ $t("edit") }}
+          {{ $t("settings.save") }}
         </Button>
       </DialogFooter>
     </DialogContent>


### PR DESCRIPTION
# Changelog

Small i18n change, nothing ground breaking of a contribution 😂

<img width="2016" height="2506" alt="i18n_change" src="https://github.com/user-attachments/assets/0769ab65-52af-4db8-b248-dadb8d4f70e4" />

I saw this low-hanging fruit: https://github.com/orgs/music-assistant/projects/2/views/3?pane=issue&itemId=161731480

Turns out it was even easier than expected because the auto-closing is already fixed for quite a few months apparently (in [this commit](https://github.com/music-assistant/frontend/commit/a5b77a4a33822c0b16211e170feaf9e45fed5ee5)) haha. 👍🏻