### PR TITLE
Fix artist tiles using fanart instead of thumb in square views

### DIFF
--- a/src/components/discover/EditorialHeroCard.vue
+++ b/src/components/discover/EditorialHeroCard.vue
@@ -66,7 +66,9 @@ interface Props {
 const props = defineProps<Props>();
 const { t } = useI18n();
 
-const art = computed(() => itemArtwork(props.item, props.large ? 640 : 320));
+const art = computed(() =>
+  itemArtwork(props.item, props.large ? 640 : 320, true),
+);
 const kind = computed(() => t(props.item.media_type));
 const tag = computed(() => props.tag || t("recently_played"));
 

--- a/src/components/discover/editorialArtwork.ts
+++ b/src/components/discover/editorialArtwork.ts
@@ -32,10 +32,14 @@ export function itemInitials(name: string): string {
 export function itemArtwork(
   item: AnyItem,
   size = 320,
+  preferFanart = false,
 ): { image: string | undefined; gradient: string; initials?: string } {
-  const image =
-    getImageThumbForItem(item, ImageType.FANART, size) ??
-    getImageThumbForItem(item, ImageType.THUMB, size);
+  // Square tiles use the thumb; only the wide hero card prefers fanart, falling
+  // back to the thumb when no fanart is available.
+  const image = preferFanart
+    ? (getImageThumbForItem(item, ImageType.FANART, size) ??
+      getImageThumbForItem(item, ImageType.THUMB, size))
+    : getImageThumbForItem(item, ImageType.THUMB, size);
   // For artists/albums with no artwork, surface the initials over the banner.
   const showInitials =
     !image &&


### PR DESCRIPTION
`itemArtwork()` became fanart-first globally in "Fanart for top picks", which leaked into every square `EditorialMediaCard `tile (artist/album grids, search, genre, home rows) once those views adopted the discover-style card. Wide fanart is correct only for the Top Picks hero row.

Make fanart preference opt-in (default thumb-only) and have only the wide `EditorialHeroCard` request it.