### PR TITLE
Always show lights and visualisers in the group list

### DIFF
--- a/src/components/VolumeControl.vue
+++ b/src/components/VolumeControl.vue
@@ -138,7 +138,11 @@
 
 <script setup lang="ts">
 import Button from "@/components/Button.vue";
-import { getPlayerName, truncateString } from "@/helpers/utils";
+import {
+  getPlayerName,
+  groupMemberPickerVisible,
+  truncateString,
+} from "@/helpers/utils";
 import PlayerVolume from "@/layouts/default/PlayerOSD/PlayerVolume.vue";
 import { api } from "@/plugins/api";
 import {
@@ -201,10 +205,9 @@ const getChildPlayers = function (player: Player) {
       // skip unavailable players
       if (!syncPlayer.available) continue;
 
-      // skip players hidden from the UI (only filters the add-candidate
-      // path; current group members above are always shown so they don't
-      // become invisible participants).
-      if (syncPlayer.hide_in_ui) continue;
+      // skip players hidden from the picker; current group members above
+      // are always shown so they don't become invisible participants
+      if (!groupMemberPickerVisible(syncPlayer)) continue;
 
       // skip for group players
       if (syncPlayer.type == PlayerType.GROUP) continue;

--- a/src/helpers/player_menu_items.ts
+++ b/src/helpers/player_menu_items.ts
@@ -10,6 +10,7 @@ import {
   RepeatMode,
   PLAYER_CONTROL_NONE,
 } from "@/plugins/api/interfaces";
+import { groupMemberPickerVisible } from "@/helpers/utils";
 import { isQueueDynamicPlaylist } from "@/plugins/api/helpers";
 import { authManager } from "@/plugins/auth";
 import router from "@/plugins/router";
@@ -54,7 +55,7 @@ export const getPlayerMenuItems = (
       p.player_id != player.player_id &&
       p.available &&
       p.enabled &&
-      !p.hide_in_ui &&
+      groupMemberPickerVisible(p) &&
       (p.can_group_with.includes(player.provider) ||
         p.can_group_with.includes(player.player_id)) &&
       p.supported_features.includes(PlayerFeature.SET_MEMBERS) &&

--- a/src/helpers/utils.ts
+++ b/src/helpers/utils.ts
@@ -782,6 +782,17 @@ export const playerVisible = function (
   return true;
 };
 
+// Whether a player can be offered in the group/sync member picker. Honours
+// hide_in_ui, except for light/visualizer players which are hidden from the
+// normal player view but exist to be grouped (e.g. Hue lights synced to audio).
+export const groupMemberPickerVisible = function (player: Player): boolean {
+  return (
+    !player.hide_in_ui ||
+    player.type === PlayerType.LIGHT ||
+    player.type === PlayerType.VISUALIZER
+  );
+};
+
 /* Handle play button click */
 export const handlePlayBtnClick = function (
   item: MediaItemTypeOrItemMapping,

--- a/src/plugins/api/interfaces.ts
+++ b/src/plugins/api/interfaces.ts
@@ -265,8 +265,13 @@ export enum PlaybackState {
 
 export enum PlayerType {
   PLAYER = "player", // A regular player.
-  GROUP = "group", // A (dedicated) group player or playergroup.
   STEREO_PAIR = "stereo_pair",
+  GROUP = "group", // A (dedicated) group player or playergroup.
+  PROTOCOL = "protocol",
+  DISPLAY = "display",
+  VISUALIZER = "visualizer",
+  LIGHT = "light",
+  UNKNOWN = "unknown",
 }
 
 export enum PlayerOptionType {

--- a/src/views/settings/AddPlayerGroup.vue
+++ b/src/views/settings/AddPlayerGroup.vue
@@ -91,7 +91,7 @@
 import { computed, ref } from "vue";
 import { useRouter } from "vue-router";
 import { api } from "@/plugins/api";
-import { markdownToHtml } from "@/helpers/utils";
+import { groupMemberPickerVisible, markdownToHtml } from "@/helpers/utils";
 import { PlayerFeature, PlayerType } from "@/plugins/api/interfaces";
 
 // global refs
@@ -116,7 +116,12 @@ const syncPlayers = computed(() => {
   if (props.provider === "universal_group") {
     // for universal groups, show all available non-group players, regardless of provider
     return Object.values(api.players)
-      .filter((x) => x.available && x.type != PlayerType.GROUP && !x.hide_in_ui)
+      .filter(
+        (x) =>
+          x.available &&
+          x.type != PlayerType.GROUP &&
+          groupMemberPickerVisible(x),
+      )
       .sort((a, b) =>
         (a.name ?? "")
           .toUpperCase()
@@ -127,7 +132,11 @@ const syncPlayers = computed(() => {
     // for sync groups, show all available non-group players that are sync compatible
     return Object.values(api.players)
       .filter((x) => {
-        if (!x.available || x.type === PlayerType.GROUP || x.hide_in_ui)
+        if (
+          !x.available ||
+          x.type === PlayerType.GROUP ||
+          !groupMemberPickerVisible(x)
+        )
           return false;
         if (!x.supported_features.includes(PlayerFeature.SET_MEMBERS))
           return false;
@@ -157,7 +166,7 @@ const syncPlayers = computed(() => {
       (x) =>
         x.available &&
         x.type != PlayerType.GROUP &&
-        !x.hide_in_ui &&
+        groupMemberPickerVisible(x) &&
         x.provider == providerDetails.value?.instance_id,
     )
     .sort((a, b) =>


### PR DESCRIPTION
A possible solution to the issue that visualisers are marked as HIDE IN UI when they are created. However, they need to appear in the group list so they can be joined to the actual music players. 

This idea is that this type of player (and light) will always be seen in the group list (assuming there is a compatible protocol to group via)

The PlayerType enum aligns with https://github.com/music-assistant/models/blob/eb1ac336d7b673622b084041ba9ea486f77dfb7d/music_assistant_models/enums.py#L403