### PR TITLE
Lower smart playlist dedup_hours max to 2160h (90 days)

### DIFF
--- a/src/components/smart_playlist/SmartPlaylistDedupField.vue
+++ b/src/components/smart_playlist/SmartPlaylistDedupField.vue
@@ -28,7 +28,7 @@
         id="sp-dedup"
         :model-value="modelValue ?? 0"
         :min="0"
-        :max="8760"
+        :max="2160"
         :format-options="{ useGrouping: false, maximumFractionDigits: 0 }"
         class="w-[120px]"
         @update:model-value="onChange"
@@ -82,6 +82,6 @@ function onChange(v: number) {
     emit("update:modelValue", undefined);
     return;
   }
-  emit("update:modelValue", Math.min(8760, Math.floor(v)));
+  emit("update:modelValue", Math.min(2160, Math.floor(v)));
 }
 </script>


### PR DESCRIPTION
## What does this implement/fix?

Lowers the maximum value of the smart playlist "do not repeat within X hours" (`dedup_hours`) field from **8760h to 2160h (90 days)** to match the server-side validation.

The server now bounds `dedup_hours` to the playlog retention window (90 days), since the dedup is computed from the playlog. Without this change the UI would accept values up to 8760h that the backend rejects.

Two spots in `SmartPlaylistDedupField.vue` are updated: the `NumberField` `:max` attribute and the clamp in `onChange()`.

## Companion PR

Server: music-assistant/server#4082