### PR TITLE
Auto-Refresh the AA Status Page 

### DIFF
--- a/src/components/AudioAnalysisCoverage.vue
+++ b/src/components/AudioAnalysisCoverage.vue
@@ -81,14 +81,20 @@ import {
   ItemTitle,
 } from "@/components/ui/item";
 import { Progress } from "@/components/ui/progress";
-import { onMounted, watch } from "vue";
+import { onMounted, onUnmounted, watch } from "vue";
 
-const { rows, refresh } = useAudioAnalysisCoverage();
+const { rows, refresh, startAutoRefresh, stopAutoRefresh } =
+  useAudioAnalysisCoverage();
 
 const none = $t("settings.audio_analysis_coverage.none");
 
 onMounted(() => {
-  refresh();
+  // Loads coverage immediately, then polls while analysis is in progress.
+  startAutoRefresh();
+});
+
+onUnmounted(() => {
+  stopAutoRefresh();
 });
 
 watch(

--- a/src/components/AudioAnalysisCoverage.vue
+++ b/src/components/AudioAnalysisCoverage.vue
@@ -89,7 +89,6 @@ const { rows, refresh, startAutoRefresh, stopAutoRefresh } =
 const none = $t("settings.audio_analysis_coverage.none");
 
 onMounted(() => {
-  // Loads coverage immediately, then polls while analysis is in progress.
   void startAutoRefresh();
 });
 

--- a/src/components/AudioAnalysisCoverage.vue
+++ b/src/components/AudioAnalysisCoverage.vue
@@ -90,7 +90,7 @@ const none = $t("settings.audio_analysis_coverage.none");
 
 onMounted(() => {
   // Loads coverage immediately, then polls while analysis is in progress.
-  startAutoRefresh();
+  void startAutoRefresh();
 });
 
 onUnmounted(() => {

--- a/src/composables/useAudioAnalysisCoverage.ts
+++ b/src/composables/useAudioAnalysisCoverage.ts
@@ -158,7 +158,7 @@ export function useAudioAnalysisCoverage(options?: { intervalMs?: number }): {
     if (document.hidden) {
       clearPollTimer();
     } else if (pollTimer === null) {
-      // Becoming visible refreshes immediately, then resumes polling.
+      // Refresh now rather than waiting out a full interval after returning.
       void poll();
     }
   }

--- a/src/composables/useAudioAnalysisCoverage.ts
+++ b/src/composables/useAudioAnalysisCoverage.ts
@@ -26,11 +26,16 @@ export interface ProviderCoverageRow {
   hasData: boolean;
 }
 
-export function useAudioAnalysisCoverage(): {
+const DEFAULT_POLL_INTERVAL_MS = 5000;
+
+export function useAudioAnalysisCoverage(options?: { intervalMs?: number }): {
   rows: Ref<ProviderCoverageRow[]>;
   loading: Ref<boolean>;
   refresh: () => Promise<void>;
+  startAutoRefresh: () => Promise<void>;
+  stopAutoRefresh: () => void;
 } {
+  const intervalMs = options?.intervalMs ?? DEFAULT_POLL_INTERVAL_MS;
   const rows = ref<ProviderCoverageRow[]>([]);
   const loading = ref(false);
 
@@ -109,5 +114,64 @@ export function useAudioAnalysisCoverage(): {
     }
   }
 
-  return { rows, loading, refresh };
+  // --- Auto-refresh ---------------------------------------------------------
+  // Adaptive polling: re-query coverage every `intervalMs` only while some
+  // provider still has pending work, and pause while the tab is hidden. This
+  // lets the page tick down live as analysis runs without hammering a
+  // fully-analyzed library.
+  let pollTimer: ReturnType<typeof setTimeout> | null = null;
+  let autoRefreshEnabled = false;
+
+  function hasPendingWork(): boolean {
+    return rows.value.some((row) => row.pending > 0);
+  }
+
+  function clearPollTimer(): void {
+    if (pollTimer !== null) {
+      clearTimeout(pollTimer);
+      pollTimer = null;
+    }
+  }
+
+  function scheduleNextPoll(): void {
+    if (!autoRefreshEnabled || document.hidden || !hasPendingWork()) return;
+    if (pollTimer !== null) return;
+    pollTimer = setTimeout(() => {
+      pollTimer = null;
+      void poll();
+    }, intervalMs);
+  }
+
+  async function poll(): Promise<void> {
+    // Silent refresh: background polls must not toggle the visible loading
+    // state, only the initial/manual refresh() does.
+    await fetchCoverage();
+    scheduleNextPoll();
+  }
+
+  function handleVisibilityChange(): void {
+    if (!autoRefreshEnabled) return;
+    if (document.hidden) {
+      clearPollTimer();
+    } else if (pollTimer === null) {
+      // Becoming visible refreshes immediately, then resumes polling.
+      void poll();
+    }
+  }
+
+  async function startAutoRefresh(): Promise<void> {
+    if (autoRefreshEnabled) return;
+    autoRefreshEnabled = true;
+    document.addEventListener("visibilitychange", handleVisibilityChange);
+    await refresh();
+    scheduleNextPoll();
+  }
+
+  function stopAutoRefresh(): void {
+    autoRefreshEnabled = false;
+    clearPollTimer();
+    document.removeEventListener("visibilitychange", handleVisibilityChange);
+  }
+
+  return { rows, loading, refresh, startAutoRefresh, stopAutoRefresh };
 }

--- a/src/composables/useAudioAnalysisCoverage.ts
+++ b/src/composables/useAudioAnalysisCoverage.ts
@@ -105,15 +105,6 @@ export function useAudioAnalysisCoverage(options?: { intervalMs?: number }): {
     );
   }
 
-  async function refresh(): Promise<void> {
-    loading.value = true;
-    try {
-      await fetchCoverage();
-    } finally {
-      loading.value = false;
-    }
-  }
-
   // --- Auto-refresh ---------------------------------------------------------
   // Adaptive polling: re-query coverage every `intervalMs` only while some
   // provider still has pending work, and pause while the tab is hidden. This
@@ -121,6 +112,19 @@ export function useAudioAnalysisCoverage(options?: { intervalMs?: number }): {
   // fully-analyzed library.
   let pollTimer: ReturnType<typeof setTimeout> | null = null;
   let autoRefreshEnabled = false;
+
+  async function refresh(): Promise<void> {
+    loading.value = true;
+    try {
+      await fetchCoverage();
+    } finally {
+      loading.value = false;
+    }
+    // When auto-refresh is active, re-arm polling so a manual or
+    // providers-driven refresh that surfaces new pending work resumes the
+    // live tick-down even after the loop has gone dormant.
+    if (autoRefreshEnabled) scheduleNextPoll();
+  }
 
   function hasPendingWork(): boolean {
     return rows.value.some((row) => row.pending > 0);
@@ -163,8 +167,8 @@ export function useAudioAnalysisCoverage(options?: { intervalMs?: number }): {
     if (autoRefreshEnabled) return;
     autoRefreshEnabled = true;
     document.addEventListener("visibilitychange", handleVisibilityChange);
+    // refresh() re-arms polling when work remains.
     await refresh();
-    scheduleNextPoll();
   }
 
   function stopAutoRefresh(): void {

--- a/tests/composables/useAudioAnalysisCoverage.test.ts
+++ b/tests/composables/useAudioAnalysisCoverage.test.ts
@@ -1,5 +1,5 @@
 import { ProviderType } from "@/plugins/api/interfaces";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const { mockSendCommand, providersMock } = vi.hoisted(() => {
   return {
@@ -211,5 +211,149 @@ describe("useAudioAnalysisCoverage", () => {
     expect(bad.hasData).toBe(false);
     expect(good.hasData).toBe(true);
     expect(good.coveragePct).toBe(100);
+  });
+});
+
+/** Force `document.hidden` / `visibilityState` and fire the change event. */
+function setTabHidden(hidden: boolean) {
+  Object.defineProperty(document, "hidden", {
+    configurable: true,
+    get: () => hidden,
+  });
+  Object.defineProperty(document, "visibilityState", {
+    configurable: true,
+    get: () => (hidden ? "hidden" : "visible"),
+  });
+  document.dispatchEvent(new Event("visibilitychange"));
+}
+
+const AA_PROVIDER = {
+  type: ProviderType.AUDIO_ANALYSIS,
+  domain: "sonic_analysis",
+  name: "Sonic Analysis",
+  instance_id: "sa1",
+  available: true,
+} as const;
+
+const POLL_MS = 5000;
+
+describe("useAudioAnalysisCoverage auto-refresh", () => {
+  beforeEach(() => {
+    mockSendCommand.mockReset();
+    setProviders([]);
+    setTabHidden(false);
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("re-queries coverage every interval while pending > 0", async () => {
+    setProviders([AA_PROVIDER]);
+    mockAa({
+      sonic_analysis: {
+        analyzed: 50,
+        pending: 50,
+        stale_version: 0,
+        analysis_version: 1,
+      },
+    });
+
+    const c = useAudioAnalysisCoverage({ intervalMs: POLL_MS });
+    await c.startAutoRefresh();
+    expect(mockSendCommand).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(POLL_MS);
+    expect(mockSendCommand).toHaveBeenCalledTimes(2);
+
+    await vi.advanceTimersByTimeAsync(POLL_MS);
+    expect(mockSendCommand).toHaveBeenCalledTimes(3);
+
+    c.stopAutoRefresh();
+  });
+
+  it("stops polling once every provider reaches pending 0", async () => {
+    setProviders([AA_PROVIDER]);
+    // First poll still has pending work; second poll reports fully analyzed.
+    mockSendCommand
+      .mockResolvedValueOnce({
+        analyzed: 90,
+        pending: 10,
+        stale_version: 0,
+        analysis_version: 1,
+      })
+      .mockResolvedValue({
+        analyzed: 100,
+        pending: 0,
+        stale_version: 0,
+        analysis_version: 1,
+      });
+
+    const c = useAudioAnalysisCoverage({ intervalMs: POLL_MS });
+    await c.startAutoRefresh(); // call 1: pending 10 -> keep polling
+    expect(mockSendCommand).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(POLL_MS); // call 2: pending 0 -> go dormant
+    expect(mockSendCommand).toHaveBeenCalledTimes(2);
+
+    await vi.advanceTimersByTimeAsync(POLL_MS * 3); // no further polls
+    expect(mockSendCommand).toHaveBeenCalledTimes(2);
+
+    c.stopAutoRefresh();
+  });
+
+  it("pauses polling while the tab is hidden and resumes when visible", async () => {
+    setProviders([AA_PROVIDER]);
+    mockAa({
+      sonic_analysis: {
+        analyzed: 50,
+        pending: 50,
+        stale_version: 0,
+        analysis_version: 1,
+      },
+    });
+
+    const c = useAudioAnalysisCoverage({ intervalMs: POLL_MS });
+    await c.startAutoRefresh();
+    expect(mockSendCommand).toHaveBeenCalledTimes(1);
+
+    setTabHidden(true);
+    await vi.advanceTimersByTimeAsync(POLL_MS * 3);
+    expect(mockSendCommand).toHaveBeenCalledTimes(1); // no polling while hidden
+
+    setTabHidden(false); // becoming visible refreshes immediately
+    await Promise.resolve();
+    expect(mockSendCommand).toHaveBeenCalledTimes(2);
+
+    await vi.advanceTimersByTimeAsync(POLL_MS);
+    expect(mockSendCommand).toHaveBeenCalledTimes(3);
+
+    c.stopAutoRefresh();
+  });
+
+  it("stopAutoRefresh halts polling and detaches the visibility listener", async () => {
+    setProviders([AA_PROVIDER]);
+    mockAa({
+      sonic_analysis: {
+        analyzed: 50,
+        pending: 50,
+        stale_version: 0,
+        analysis_version: 1,
+      },
+    });
+
+    const c = useAudioAnalysisCoverage({ intervalMs: POLL_MS });
+    await c.startAutoRefresh();
+    expect(mockSendCommand).toHaveBeenCalledTimes(1);
+
+    c.stopAutoRefresh();
+
+    await vi.advanceTimersByTimeAsync(POLL_MS * 3);
+    expect(mockSendCommand).toHaveBeenCalledTimes(1); // timer cleared
+
+    setTabHidden(false); // listener detached -> no resume refresh
+    await Promise.resolve();
+    expect(mockSendCommand).toHaveBeenCalledTimes(1);
   });
 });

--- a/tests/composables/useAudioAnalysisCoverage.test.ts
+++ b/tests/composables/useAudioAnalysisCoverage.test.ts
@@ -332,6 +332,39 @@ describe("useAudioAnalysisCoverage auto-refresh", () => {
     c.stopAutoRefresh();
   });
 
+  it("resumes polling when a refresh surfaces new pending work after going dormant", async () => {
+    setProviders([AA_PROVIDER]);
+    // Starts fully analyzed -> the loop goes dormant after the first load.
+    mockSendCommand
+      .mockResolvedValueOnce({
+        analyzed: 100,
+        pending: 0,
+        stale_version: 0,
+        analysis_version: 1,
+      })
+      .mockResolvedValue({
+        analyzed: 100,
+        pending: 20,
+        stale_version: 0,
+        analysis_version: 1,
+      });
+
+    const c = useAudioAnalysisCoverage({ intervalMs: POLL_MS });
+    await c.startAutoRefresh(); // call 1: pending 0 -> dormant
+    expect(mockSendCommand).toHaveBeenCalledTimes(1);
+    await vi.advanceTimersByTimeAsync(POLL_MS * 2);
+    expect(mockSendCommand).toHaveBeenCalledTimes(1); // confirmed dormant
+
+    // New pending work appears; the component's providers watch calls refresh().
+    await c.refresh(); // call 2: pending 20 -> should re-arm polling
+    expect(mockSendCommand).toHaveBeenCalledTimes(2);
+
+    await vi.advanceTimersByTimeAsync(POLL_MS);
+    expect(mockSendCommand).toHaveBeenCalledTimes(3); // polling resumed
+
+    c.stopAutoRefresh();
+  });
+
   it("stopAutoRefresh halts polling and detaches the visibility listener", async () => {
     setProviders([AA_PROVIDER]);
     mockAa({


### PR DESCRIPTION
Automatically refresh the data for this page every 5 seconds (when there are pending candidates only) so people who are waiting to see numbers tick over as their library is scanned can see that it's working.  This does this and tests it.

I would prefer to base this on an event being emitted from the AA system but those don't exist- I plan to add them in a later version.  I did this based on what the Genre page does (polls the genre scanner status unconditionally ever 30s) 