### PR TITLE
Fix genre display in smart playlist rule picker

### DIFF
--- a/src/composables/useSmartPlaylistGenres.ts
+++ b/src/composables/useSmartPlaylistGenres.ts
@@ -1,9 +1,12 @@
 import { computed, onMounted, ref } from "vue";
+import { useI18n } from "vue-i18n";
 import api from "@/plugins/api";
 import type { Genre } from "@/plugins/api/interfaces";
+import { getGenreDisplayName } from "@/helpers/utils";
 
 export function useSmartPlaylistGenres() {
   const genres = ref<Genre[]>([]);
+  const { t, te } = useI18n();
 
   onMounted(async () => {
     genres.value = await api.getLibraryGenres({ hide_empty: false });
@@ -12,17 +15,15 @@ export function useSmartPlaylistGenres() {
   const genreOptions = computed(() =>
     genres.value.map((g) => ({
       id: parseInt(g.item_id),
-      name: g.name,
+      name: getGenreDisplayName(g.name, g.translation_key, t, te),
       item: g,
     })),
   );
 
   function genreName(id: number, fallback?: string): string {
-    return (
-      genres.value.find((g) => parseInt(g.item_id) === id)?.name ??
-      fallback ??
-      String(id)
-    );
+    const genre = genres.value.find((g) => parseInt(g.item_id) === id);
+    if (!genre) return fallback ?? String(id);
+    return getGenreDisplayName(genre.name, genre.translation_key, t, te);
   }
 
   return { genres, genreOptions, genreName };

--- a/tests/composables/smart_playlist/useSmartPlaylistGenres.test.ts
+++ b/tests/composables/smart_playlist/useSmartPlaylistGenres.test.ts
@@ -8,6 +8,14 @@ vi.mock("vue", async () => {
   };
 });
 
+vi.mock("vue-i18n", () => ({
+  useI18n: () => ({ t: (k: string) => k, te: () => false }),
+}));
+
+vi.mock("@/helpers/utils", () => ({
+  getGenreDisplayName: (name: string) => name,
+}));
+
 vi.mock("@/plugins/api", () => ({
   default: {
     getLibraryGenres: vi.fn().mockResolvedValue([


### PR DESCRIPTION
## What does this implement/fix?

The Smart Playlist genre rule picker was showing raw lowercase genre names from the database (e.g. `rock`, `synthwave`) instead of the properly translated/capitalised display names shown everywhere else in the UI (e.g. `Rock`, `Synthwave`).

**Root cause:** `useSmartPlaylistGenres.ts` was using `g.name` directly (the raw DB value), while the rest of the frontend uses `getGenreDisplayName(name, translation_key, t, te)` which resolves the i18n translation key and falls back to the raw name when no translation exists.

**Fix:** `genreOptions` and `genreName()` in `useSmartPlaylistGenres.ts` now call `getGenreDisplayName()`, matching the pattern used by `ListviewItem.vue` and other components. No server-side changes required.

The test for `useSmartPlaylistGenres` was updated with mocks for `vue-i18n` and `@/helpers/utils` to avoid pulling in the router/auth import chain in the test environment.

**Related issue (if applicable):**

- related issue <link to issue>