### PR TITLE
Add field icons to smart playlist rules

### DIFF
--- a/src/components/smart_playlist/SmartPlaylistRuleRow.vue
+++ b/src/components/smart_playlist/SmartPlaylistRuleRow.vue
@@ -6,6 +6,10 @@
     ]"
   >
     <div class="flex min-w-0 items-center gap-2">
+      <component
+        :is="fieldIcon(rule.field)"
+        class="h-3.5 w-3.5 shrink-0 text-muted-foreground"
+      />
       <Select
         :model-value="rule.field"
         @update:model-value="(v) => emit('change-field', v as RuleField)"
@@ -182,6 +186,7 @@ import type {
 } from "@/composables/useSmartPlaylistRulesForm";
 import type { Genre } from "@/plugins/api/interfaces";
 import { $t } from "@/plugins/i18n";
+import { fieldIcon } from "./fieldIcon";
 import { X } from "lucide-vue-next";
 import { computed } from "vue";
 import SmartPlaylistRuleValuePicker from "./SmartPlaylistRuleValuePicker.vue";

--- a/src/components/smart_playlist/SmartPlaylistRulesList.vue
+++ b/src/components/smart_playlist/SmartPlaylistRulesList.vue
@@ -86,9 +86,13 @@
           <DropdownMenuItem
             v-for="field in availableFields"
             :key="field"
-            class="text-xs cursor-pointer"
+            class="text-xs cursor-pointer gap-2"
             @click="emit('add-rule', field)"
           >
+            <component
+              :is="fieldIcon(field)"
+              class="h-3.5 w-3.5 shrink-0 text-muted-foreground"
+            />
             {{ fieldLabel(field) }}
           </DropdownMenuItem>
         </DropdownMenuContent>
@@ -119,6 +123,7 @@ import type {
 } from "@/composables/useSmartPlaylistRulesForm";
 import type { Genre } from "@/plugins/api/interfaces";
 import { $t } from "@/plugins/i18n";
+import { fieldIcon } from "./fieldIcon";
 import { Info, Plus } from "lucide-vue-next";
 import { match } from "ts-pattern";
 import SmartPlaylistRuleRow from "./SmartPlaylistRuleRow.vue";

--- a/src/components/smart_playlist/SmartPlaylistRulesView.vue
+++ b/src/components/smart_playlist/SmartPlaylistRulesView.vue
@@ -107,17 +107,8 @@
 import { Badge } from "@/components/ui/badge";
 import type { SmartPlaylistRules } from "@/plugins/api/interfaces";
 import { $t } from "@/plugins/i18n";
-import {
-  Ban,
-  CalendarRange,
-  Disc3,
-  Heart,
-  Library,
-  Mic2,
-  Sparkles,
-  Tags,
-  Timer,
-} from "lucide-vue-next";
+import { fieldIcon } from "./fieldIcon";
+import { Ban, Library, Sparkles, Timer } from "lucide-vue-next";
 import { computed, type Component } from "vue";
 
 interface RuleViewRow {
@@ -173,7 +164,7 @@ const ruleRows = computed<RuleViewRow[]>(() => {
   if (genreNames.length) {
     rows.push({
       key: "genre-is",
-      icon: Tags,
+      icon: fieldIcon("genre"),
       label: $t("smart_playlist.field_genre_is"),
       exclude: false,
       tags: genreNames,
@@ -194,7 +185,7 @@ const ruleRows = computed<RuleViewRow[]>(() => {
   if (artistNames.length) {
     rows.push({
       key: "artist-is",
-      icon: Mic2,
+      icon: fieldIcon("artist"),
       label: $t("smart_playlist.field_artist_is"),
       exclude: false,
       tags: artistNames,
@@ -218,7 +209,7 @@ const ruleRows = computed<RuleViewRow[]>(() => {
   if (albumNames.length) {
     rows.push({
       key: "album-is",
-      icon: Disc3,
+      icon: fieldIcon("album"),
       label: $t("smart_playlist.field_album_is"),
       exclude: false,
       tags: albumNames,
@@ -238,7 +229,7 @@ const ruleRows = computed<RuleViewRow[]>(() => {
   if (r.favorites_only) {
     rows.push({
       key: "favorite",
-      icon: Heart,
+      icon: fieldIcon("favorite"),
       label: $t("smart_playlist.field_favorite"),
       exclude: false,
       value: $t("smart_playlist.favorites_yes"),
@@ -251,7 +242,7 @@ const ruleRows = computed<RuleViewRow[]>(() => {
   if (albumTypeNames.length) {
     rows.push({
       key: "album-type-is",
-      icon: Disc3,
+      icon: fieldIcon("album_type"),
       label: $t("smart_playlist.field_album_type_is"),
       exclude: false,
       tags: albumTypeNames,
@@ -282,7 +273,7 @@ const ruleRows = computed<RuleViewRow[]>(() => {
     else v = `≤ ${yt}`;
     rows.push({
       key: "year",
-      icon: CalendarRange,
+      icon: fieldIcon("year"),
       label: $t("smart_playlist.field_year"),
       exclude: false,
       value: v,

--- a/src/components/smart_playlist/fieldIcon.ts
+++ b/src/components/smart_playlist/fieldIcon.ts
@@ -1,0 +1,22 @@
+import { Ban, CalendarRange, Disc3, Heart, Mic2, Tags } from "lucide-vue-next";
+import type { Component } from "vue";
+import type { RuleField } from "@/composables/useSmartPlaylistRulesForm";
+
+export function fieldIcon(field: RuleField): Component {
+  switch (field) {
+    case "genre":
+      return Tags;
+    case "artist":
+      return Mic2;
+    case "album":
+      return Disc3;
+    case "album_type":
+      return Disc3;
+    case "favorite":
+      return Heart;
+    case "year":
+      return CalendarRange;
+    default:
+      return Ban;
+  }
+}

--- a/src/components/smart_playlist/fieldIcon.ts
+++ b/src/components/smart_playlist/fieldIcon.ts
@@ -1,22 +1,15 @@
 import { Ban, CalendarRange, Disc3, Heart, Mic2, Tags } from "lucide-vue-next";
+import { match } from "ts-pattern";
 import type { Component } from "vue";
 import type { RuleField } from "@/composables/useSmartPlaylistRulesForm";
 
 export function fieldIcon(field: RuleField): Component {
-  switch (field) {
-    case "genre":
-      return Tags;
-    case "artist":
-      return Mic2;
-    case "album":
-      return Disc3;
-    case "album_type":
-      return Disc3;
-    case "favorite":
-      return Heart;
-    case "year":
-      return CalendarRange;
-    default:
-      return Ban;
-  }
+  return match(field)
+    .with("genre", () => Tags)
+    .with("artist", () => Mic2)
+    .with("album", () => Disc3)
+    .with("album_type", () => Disc3)
+    .with("favorite", () => Heart)
+    .with("year", () => CalendarRange)
+    .otherwise(() => Ban);
 }


### PR DESCRIPTION
Adds a small contextual icon next to each field type throughout the smart playlist UI for better visual scanning.

## Changes

- **Rule editor rows** ([SmartPlaylistRuleRow.vue](src/components/smart_playlist/SmartPlaylistRuleRow.vue)): icon shown left of the field select
- **"Add filter" dropdown** ([SmartPlaylistRulesList.vue](src/components/smart_playlist/SmartPlaylistRulesList.vue)): icon shown left of each menu item
- **Read-only rules summary** ([SmartPlaylistRulesView.vue](src/components/smart_playlist/SmartPlaylistRulesView.vue)): already displayed icons, now uses shared helper
- **Shared helper** ([fieldIcon.ts](src/components/smart_playlist/fieldIcon.ts)): maps each `RuleField` to its lucide icon, co-located in the smart_playlist component folder

The `Ban` icon in the read-only summary for "is not" rows is intentional — it replaces the missing operator text in that view.