### PR TITLE
Only refetch recommendations on track end, not periodic progress

### DIFF
--- a/src/components/HomeWidgetRows.vue
+++ b/src/components/HomeWidgetRows.vue
@@ -182,6 +182,7 @@ import { panelViewItemResponsive, playerVisible } from "@/helpers/utils";
 import api from "@/plugins/api";
 import {
   EventType,
+  type EventMessage,
   type Genre,
   type ItemMapping,
   type MediaItemTypeOrItemMapping,
@@ -592,9 +593,16 @@ onMounted(async () => {
     resolveHeroPicks();
   }, 1500);
 
-  const unsub = api.subscribe(EventType.MEDIA_ITEM_PLAYED, () => {
-    refreshRecommendations();
-  });
+  const unsub = api.subscribe(
+    EventType.MEDIA_ITEM_PLAYED,
+    (evt: EventMessage) => {
+      // Only refetch when a track actually finished (is_playing = false),
+      // not on the periodic ~30s progress reports that also emit this event.
+      if (evt.data && !(evt.data as Record<string, unknown>).is_playing) {
+        refreshRecommendations();
+      }
+    },
+  );
   onBeforeUnmount(unsub);
 });
 


### PR DESCRIPTION
PR #1869 added a 1500ms debounce to the recommendation refresh (good), but in the process dropped the `is_playing` guard on the MEDIA_ITEM_PLAYED subscription. That event fires on two paths:

- track change → is_playing=false (every few minutes)
- periodic progress report → is_playing=true, every ~30s during playback

Without the guard, recommendations now refetch on every periodic progress report — one call per connected client every 30s — instead of only when a track actually ends. The debounce collapses each client's burst into one call but can't undo the higher frequency.

Re-add the is_playing guard (and the EventMessage import #1869 removed) so we only refetch on track end, keeping the debounce.