### PR TITLE
Fix erroneous underline on Audio Analysis concurrency link

### DIFF
--- a/src/components/AudioAnalysisConcurrency.vue
+++ b/src/components/AudioAnalysisConcurrency.vue
@@ -10,7 +10,7 @@
     </CardHeader>
     <CardContent>
       <Button as-child variant="outline">
-        <RouterLink to="/settings/editcore/streams">
+        <RouterLink to="/settings/editcore/streams" class="no-underline">
           {{ $t("settings.audio_analysis_concurrency.open_settings") }}
         </RouterLink>
       </Button>


### PR DESCRIPTION
Removes the erroneous underline on the "Open settings" button added in #1830 (Settings → System → Audio Analysis).

Adds the standard `no-underline` Tailwind utility to the `RouterLink` — the same approach used in `About.vue` and the navigation components (`NavMain.vue`, `NavShortcuts.vue`).

```vue
<RouterLink to="/settings/editcore/streams" class="no-underline">
```

<img width="1202" height="206" alt="image" src="https://github.com/user-attachments/assets/e5d9116b-aa9a-44ab-8c6f-cf160a6fc751" />
