### PR TITLE
Fix queue items disappearing in fullscreen player

### DIFF
--- a/src/layouts/default/PlayerOSD/PlayerFullscreen.vue
+++ b/src/layouts/default/PlayerOSD/PlayerFullscreen.vue
@@ -1336,8 +1336,18 @@ const virtualScrollRef = ref<InstanceType<
 > | null>(null);
 const loadingMore = ref(false);
 const allItemsLoaded = ref(false);
+// Number of queue items fetched per page, and the distance we keep loaded past
+// the current index so the "queue" tab (sliced from current_index) never empties.
+const QUEUE_PAGE_SIZE = 50;
+// Bumped on every reset; an in-flight page load compares against it to detect it
+// belongs to an outdated queue state and must discard its result.
+let loadGeneration = 0;
 
 const resetItems = async function () {
+  // invalidate any in-flight load and release the loading guard, so a fetch that
+  // errored (e.g. on a dropped remote connection) cannot wedge later loads.
+  loadGeneration += 1;
+  loadingMore.value = false;
   tempHide.value = true;
   queueItems.value = [];
   allItemsLoaded.value = false;
@@ -1356,23 +1366,44 @@ const loadNextPage = async function () {
     return;
   }
   loadingMore.value = true;
-  const pageSize = 50;
+  const generation = loadGeneration;
   const offset = queueItems.value.length;
   // On first load, ensure we fetch enough items to cover past the current
   // index so that nextItems (which slices from current_index) has data.
-  const minNeeded = (store.activePlayerQueue.current_index || 0) + pageSize;
+  const minNeeded =
+    (store.activePlayerQueue.current_index || 0) + QUEUE_PAGE_SIZE;
   const limit =
-    offset === 0 ? Math.max(pageSize, minNeeded - offset) : pageSize;
-  const result = await api.getPlayerQueueItems(
-    store.activePlayerQueue.queue_id,
-    limit,
-    offset,
-  );
-  queueItems.value.push(...result);
-  if (result.length < limit) {
-    allItemsLoaded.value = true;
+    offset === 0
+      ? Math.max(QUEUE_PAGE_SIZE, minNeeded - offset)
+      : QUEUE_PAGE_SIZE;
+  try {
+    const result = await api.getPlayerQueueItems(
+      store.activePlayerQueue.queue_id,
+      limit,
+      offset,
+    );
+    // a reset happened while awaiting; this page is stale, so drop it
+    if (generation !== loadGeneration) return;
+    queueItems.value.push(...result);
+    if (result.length < limit) {
+      allItemsLoaded.value = true;
+    }
+  } finally {
+    // leave the guard untouched if a reset already started a newer load
+    if (generation === loadGeneration) {
+      loadingMore.value = false;
+    }
   }
-  loadingMore.value = false;
+};
+
+// fetch another page when the loaded window no longer extends a full page past
+// the current index, which it is sliced from to build the "queue" tab
+const ensureWindowAheadOfIndex = function () {
+  if (!store.showFullscreenPlayer || !store.showQueueItems) return;
+  const index = store.activePlayerQueue?.current_index ?? 0;
+  if (queueItems.value.length - index < QUEUE_PAGE_SIZE) {
+    loadNextPage();
+  }
 };
 
 const onQueueScroll = function (e: Event) {
@@ -1405,20 +1436,17 @@ onMounted(async () => {
   }
 });
 
-// load initial page when queue items become visible
+// load the initial page (or top up a window that went stale while hidden) when
+// the queue items become visible
 watch(
   [() => store.showFullscreenPlayer, () => store.showQueueItems],
-  () => {
-    if (
-      store.showFullscreenPlayer &&
-      store.showQueueItems &&
-      queueItems.value.length === 0
-    ) {
-      loadNextPage();
-    }
-  },
+  ensureWindowAheadOfIndex,
   { immediate: true },
 );
+
+// keep extending the window as playback advances so the "queue" tab, which
+// slices nextItems from current_index, keeps showing the upcoming items
+watch(() => store.activePlayerQueue?.current_index, ensureWindowAheadOfIndex);
 
 // listen for item updates to refresh items when that happens
 onMounted(() => {


### PR DESCRIPTION
## Problem

The fullscreen player's queue panel builds its visible list by slicing a partial, locally-paginated `queueItems` array at `current_index` (`nextItems = queueItems.slice(current_index)`). Nothing kept that window in sync, producing two reported bugs where the queue **count stays correct but the list goes empty**:

- **[support#5475](https://github.com/music-assistant/support/issues/5475)** — after 150–200 tracks of a long queue have played, the Queued tab shows nothing; switching player and back fixes it. As `current_index` advanced the loaded window was never extended, so the slice eventually returned `[]`.
- **[support#5487](https://github.com/music-assistant/support/issues/5487)** — deleting a queue item makes the list vanish until a page refresh. `loadNextPage` had no error handling, so a single rejected `getPlayerQueueItems` (easy to hit over remote access) left `loadingMore` stuck `true` forever, silently no-op'ing every later load — including the reload triggered after the delete.

Server-side logs confirmed the backend is healthy: `player_queues/items` is served instantly with no errors, and the client had simply stopped requesting items (a 47-minute gap between fetches) while playback continued.

## Changes (all in `PlayerFullscreen.vue`)

- **`current_index` watcher** tops up the loaded window via a shared `ensureWindowAheadOfIndex` helper, so the Queued tab keeps showing upcoming items as playback advances (5475). The same helper now backs the visibility watcher, so a window that went stale while the panel was hidden is refreshed on reopen.
- **`try/finally` in `loadNextPage`** always releases `loadingMore`, so a failed fetch can no longer wedge all future loads (5487).
- **Load-generation token**: `resetItems` bumps a counter and clears `loadingMore`; an in-flight load discards its result if a reset happened mid-flight, instead of pushing stale items onto a just-cleared list.
- Hoisted the page size to a named `QUEUE_PAGE_SIZE` constant shared by the fetch and the window check.

## Testing

- `vue-tsc --noEmit` clean, eslint clean, full vitest suite passes (176 tests).
- Draft for manual verification of both scenarios (long playback; delete an item) on a separate machine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)