### PR TITLE
Add Audio Analysis failures table to settings page

### DIFF
--- a/src/components/AudioAnalysisFailures.vue
+++ b/src/components/AudioAnalysisFailures.vue
@@ -1,0 +1,245 @@
+<template>
+  <Card data-test="aa-failures">
+    <CardHeader>
+      <CardTitle>{{ $t("settings.audio_analysis_failures.title") }}</CardTitle>
+      <CardDescription>
+        {{ $t("settings.audio_analysis_failures.description") }}
+      </CardDescription>
+      <CardAction v-if="total > 0">
+        <AlertDialog>
+          <AlertDialogTrigger as-child>
+            <Button variant="outline" size="sm" :disabled="clearingAll">
+              {{ $t("settings.audio_analysis_failures.clear_all") }}
+            </Button>
+          </AlertDialogTrigger>
+          <AlertDialogContent>
+            <AlertDialogHeader>
+              <AlertDialogTitle>
+                {{ $t("settings.audio_analysis_failures.clear_all_confirm") }}
+              </AlertDialogTitle>
+              <AlertDialogDescription>
+                {{
+                  $t("settings.audio_analysis_failures.clear_all_description", [
+                    total,
+                  ])
+                }}
+              </AlertDialogDescription>
+            </AlertDialogHeader>
+            <AlertDialogFooter>
+              <AlertDialogCancel>{{ $t("cancel") }}</AlertDialogCancel>
+              <AlertDialogAction @click="onClearAll">
+                {{ $t("settings.audio_analysis_failures.clear_all") }}
+              </AlertDialogAction>
+            </AlertDialogFooter>
+          </AlertDialogContent>
+        </AlertDialog>
+      </CardAction>
+    </CardHeader>
+
+    <CardContent>
+      <div
+        v-if="loading && total === 0"
+        class="flex justify-center py-6"
+        data-test="aa-failures-loading"
+      >
+        <Spinner class="size-5" />
+      </div>
+
+      <p
+        v-else-if="total === 0"
+        class="text-muted-foreground text-sm"
+        data-test="aa-failures-empty"
+      >
+        {{ $t("settings.audio_analysis_failures.none") }}
+      </p>
+
+      <div v-else class="overflow-hidden rounded-lg border">
+        <Table>
+          <TableHeader class="bg-muted">
+            <TableRow>
+              <TableHead>
+                {{ $t("settings.audio_analysis_failures.col_item") }}
+              </TableHead>
+              <TableHead>
+                {{ $t("settings.audio_analysis_failures.col_reason") }}
+              </TableHead>
+              <TableHead>
+                {{ $t("settings.audio_analysis_failures.col_retry") }}
+              </TableHead>
+              <TableHead class="w-0 text-right">
+                <span class="sr-only">
+                  {{ $t("settings.audio_analysis_failures.col_actions") }}
+                </span>
+              </TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            <TableRow
+              v-for="row in pageRows"
+              :key="rowKey(row)"
+              data-test="aa-failure-row"
+            >
+              <TableCell>
+                <div class="font-medium">{{ row.name }}</div>
+                <div class="text-muted-foreground font-mono text-xs">
+                  <span v-if="row.artist">{{ row.artist }} · </span>
+                  {{ row.provider }} · {{ row.itemId }}
+                </div>
+              </TableCell>
+              <TableCell class="text-muted-foreground">{{
+                row.reason
+              }}</TableCell>
+              <TableCell>
+                <Badge :variant="retryVariant(row)" class="tabular-nums">
+                  {{ retryLabel(row) }}
+                </Badge>
+              </TableCell>
+              <TableCell class="text-right">
+                <Button
+                  variant="ghost"
+                  size="icon-sm"
+                  :disabled="pendingKey === rowKey(row)"
+                  :aria-label="$t('settings.audio_analysis_failures.delete')"
+                  :title="$t('settings.audio_analysis_failures.delete')"
+                  @click="onClearOne(row)"
+                >
+                  <Spinner v-if="pendingKey === rowKey(row)" class="size-3.5" />
+                  <Trash2 v-else class="size-3.5" />
+                </Button>
+              </TableCell>
+            </TableRow>
+          </TableBody>
+        </Table>
+
+        <TablePagination
+          v-if="pageCount > 1"
+          :info="$t('settings.audio_analysis_failures.count', [total])"
+          :page="page"
+          :total-pages="pageCount"
+          :has-next-page="hasNextPage"
+          @prev="prev"
+          @next="next"
+        />
+      </div>
+    </CardContent>
+  </Card>
+</template>
+
+<script setup lang="ts">
+import {
+  classifyRetry,
+  useAudioAnalysisFailures,
+  type FailureRow,
+} from "@/composables/useAudioAnalysisFailures";
+import { formatRelativeTime } from "@/helpers/utils";
+import { $t } from "@/plugins/i18n";
+import { api } from "@/plugins/api";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardAction,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Spinner } from "@/components/ui/spinner";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { TablePagination } from "@/components/ui/table-pagination";
+import { Trash2 } from "lucide-vue-next";
+import { onMounted, ref, watch } from "vue";
+import { toast } from "vue-sonner";
+
+const {
+  pageRows,
+  total,
+  page,
+  pageCount,
+  hasNextPage,
+  loading,
+  refresh,
+  next,
+  prev,
+  clearOne,
+  clearAll,
+} = useAudioAnalysisFailures();
+
+const pendingKey = ref<string | null>(null);
+const clearingAll = ref(false);
+
+function rowKey(row: FailureRow): string {
+  return `${row.provider}::${row.itemId}`;
+}
+
+function retryVariant(row: FailureRow): "warning" | "secondary" | "outline" {
+  const status = classifyRetry(row.nextRetry, Math.floor(Date.now() / 1000));
+  if (status.kind === "blocked") return "warning";
+  if (status.kind === "eligible") return "secondary";
+  return "outline";
+}
+
+function retryLabel(row: FailureRow): string {
+  const status = classifyRetry(row.nextRetry, Math.floor(Date.now() / 1000));
+  if (status.kind === "blocked")
+    return $t("settings.audio_analysis_failures.retry_blocked");
+  if (status.kind === "eligible")
+    return $t("settings.audio_analysis_failures.retry_eligible");
+  return $t("settings.audio_analysis_failures.retry_in", [
+    formatRelativeTime(status.seconds),
+  ]);
+}
+
+async function onClearOne(row: FailureRow): Promise<void> {
+  pendingKey.value = rowKey(row);
+  try {
+    await clearOne(row);
+    toast.success($t("settings.audio_analysis_failures.cleared_one"));
+  } catch {
+    toast.error($t("settings.audio_analysis_failures.clear_error"));
+  } finally {
+    pendingKey.value = null;
+  }
+}
+
+async function onClearAll(): Promise<void> {
+  clearingAll.value = true;
+  try {
+    const count = await clearAll();
+    toast.success($t("settings.audio_analysis_failures.cleared_many", [count]));
+  } catch {
+    toast.error($t("settings.audio_analysis_failures.clear_error"));
+  } finally {
+    clearingAll.value = false;
+  }
+}
+
+onMounted(() => {
+  refresh();
+});
+
+watch(
+  () => api.providers,
+  () => {
+    refresh();
+  },
+);
+</script>

--- a/src/composables/useAudioAnalysisFailures.ts
+++ b/src/composables/useAudioAnalysisFailures.ts
@@ -1,0 +1,223 @@
+import { api } from "@/plugins/api";
+import { computed, ref, type Ref } from "vue";
+
+/**
+ * Join artist names the same way `helpers/utils.getArtistsString` does, inlined
+ * to keep this data composable free of that module's heavy SFC import chain.
+ */
+function artistString(
+  artists: ReadonlyArray<{ name: string }> | undefined,
+): string | null {
+  if (!artists || artists.length === 0) return null;
+  return artists.map((a) => a.name).join(" | ");
+}
+
+/**
+ * Mirrors a row of the server's `audio_analysis/failures` command, mapped from
+ * the wire snake_case into camelCase. Timestamps are epoch seconds; `nextRetry`
+ * is null when the failure never auto-retries (permanently blocked).
+ */
+export interface RawFailure {
+  itemId: string;
+  provider: string;
+  aaDomain: string;
+  reason: string;
+  nextRetry: number | null;
+  timestampCreated: number;
+}
+
+/** A failure row enriched with the resolved track name/artist for display. */
+export interface FailureRow extends RawFailure {
+  /** Resolved track name, or the raw item_id when the lookup failed. */
+  name: string;
+  /** Resolved artist string, or null when unknown. */
+  artist: string | null;
+}
+
+/** Classification of a failure's retry state, derived from `nextRetry`. */
+export type RetryStatus =
+  | { kind: "blocked" }
+  | { kind: "eligible" }
+  | { kind: "scheduled"; seconds: number };
+
+/**
+ * Classify a failure's `nextRetry` (epoch seconds) against the current time.
+ * null -> blocked (never auto-retries); past/now -> eligible; future -> scheduled.
+ */
+export function classifyRetry(
+  nextRetry: number | null,
+  nowSeconds: number,
+): RetryStatus {
+  if (nextRetry === null) return { kind: "blocked" };
+  const seconds = nextRetry - nowSeconds;
+  if (seconds <= 0) return { kind: "eligible" };
+  return { kind: "scheduled", seconds };
+}
+
+interface ServerFailure {
+  item_id: string;
+  provider: string;
+  aa_provider_domain: string;
+  reason: string;
+  next_retry: number | null;
+  timestamp_created: number;
+}
+
+const DEFAULT_PAGE_SIZE = 25;
+
+function cacheKey(f: RawFailure): string {
+  return `${f.provider}::${f.itemId}`;
+}
+
+export function useAudioAnalysisFailures(options?: { pageSize?: number }): {
+  pageRows: Ref<FailureRow[]>;
+  total: Ref<number>;
+  page: Ref<number>;
+  pageCount: Ref<number>;
+  hasNextPage: Ref<boolean>;
+  loading: Ref<boolean>;
+  refresh: () => Promise<void>;
+  next: () => Promise<void>;
+  prev: () => Promise<void>;
+  clearOne: (row: RawFailure) => Promise<number>;
+  clearAll: () => Promise<number>;
+} {
+  const pageSize = options?.pageSize ?? DEFAULT_PAGE_SIZE;
+
+  const failures = ref<RawFailure[]>([]);
+  const pageRows = ref<FailureRow[]>([]);
+  const page = ref(1);
+  const loading = ref(false);
+
+  // Resolved-name cache keyed by provider+item_id. A null value means the
+  // lookup was attempted and failed, so we don't retry it on re-paging.
+  const nameCache = new Map<
+    string,
+    { name: string; artist: string | null } | null
+  >();
+
+  const total = computed(() => failures.value.length);
+  const pageCount = computed(() =>
+    Math.max(1, Math.ceil(failures.value.length / pageSize)),
+  );
+  const hasNextPage = computed(() => page.value < pageCount.value);
+
+  function toRow(f: RawFailure): FailureRow {
+    const resolved = nameCache.get(cacheKey(f));
+    return {
+      ...f,
+      name: resolved?.name ?? f.itemId,
+      artist: resolved?.artist ?? null,
+    };
+  }
+
+  function currentSlice(): RawFailure[] {
+    const start = (page.value - 1) * pageSize;
+    return failures.value.slice(start, start + pageSize);
+  }
+
+  async function resolveCurrentPage(): Promise<void> {
+    const slice = currentSlice();
+    // Render immediately with whatever is cached (raw item_id as fallback)...
+    pageRows.value = slice.map(toRow);
+    // ...then resolve the names we haven't tried yet, one lookup per row.
+    const pending = slice.filter((f) => !nameCache.has(cacheKey(f)));
+    await Promise.allSettled(
+      pending.map(async (f) => {
+        try {
+          const track = await api.getTrack(f.itemId, f.provider);
+          nameCache.set(cacheKey(f), {
+            name: track.name,
+            artist: artistString(track.artists),
+          });
+        } catch {
+          nameCache.set(cacheKey(f), null);
+        }
+      }),
+    );
+    pageRows.value = slice.map(toRow);
+  }
+
+  async function refresh(): Promise<void> {
+    loading.value = true;
+    try {
+      const rows = await api.sendCommand<ServerFailure[]>(
+        "audio_analysis/failures",
+      );
+      failures.value = rows.map((r) => ({
+        itemId: r.item_id,
+        provider: r.provider,
+        aaDomain: r.aa_provider_domain,
+        reason: r.reason,
+        nextRetry: r.next_retry,
+        timestampCreated: r.timestamp_created,
+      }));
+      page.value = 1;
+      await resolveCurrentPage();
+    } catch {
+      // The command is unavailable on servers without failure tracking (or the
+      // bus is briefly down). Degrade to an empty list rather than throwing,
+      // matching how the coverage card handles an unavailable provider.
+      failures.value = [];
+      pageRows.value = [];
+      page.value = 1;
+    } finally {
+      loading.value = false;
+    }
+  }
+
+  async function next(): Promise<void> {
+    if (!hasNextPage.value) return;
+    page.value += 1;
+    await resolveCurrentPage();
+  }
+
+  async function prev(): Promise<void> {
+    if (page.value <= 1) return;
+    page.value -= 1;
+    await resolveCurrentPage();
+  }
+
+  async function clearOne(row: RawFailure): Promise<number> {
+    const count = await api.sendCommand<number>(
+      "audio_analysis/failures/clear",
+      {
+        item_id: row.itemId,
+        provider: row.provider,
+        aa_domain: row.aaDomain,
+      },
+    );
+    failures.value = failures.value.filter(
+      (f) => cacheKey(f) !== cacheKey(row),
+    );
+    if (page.value > pageCount.value) page.value = pageCount.value;
+    await resolveCurrentPage();
+    return count;
+  }
+
+  async function clearAll(): Promise<number> {
+    const domains = [...new Set(failures.value.map((f) => f.aaDomain))];
+    const counts = await Promise.all(
+      domains.map((aa_domain) =>
+        api.sendCommand<number>("audio_analysis/failures/clear", { aa_domain }),
+      ),
+    );
+    const total = counts.reduce((sum, c) => sum + c, 0);
+    await refresh();
+    return total;
+  }
+
+  return {
+    pageRows,
+    total,
+    page,
+    pageCount,
+    hasNextPage,
+    loading,
+    refresh,
+    next,
+    prev,
+    clearOne,
+    clearAll,
+  };
+}

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -778,6 +778,26 @@
             "description": "Control how many tracks are analyzed concurrently during the nightly background scan. This setting lives in the Streams core configuration.",
             "open_settings": "Open Streams settings"
         },
+        "audio_analysis_failures": {
+            "title": "Audio Analysis Failures",
+            "description": "Tracks that failed analysis are skipped on future scans. Delete an entry to clear the failure and let it be analyzed again.",
+            "col_item": "Item",
+            "col_reason": "Reason",
+            "col_retry": "Next retry",
+            "col_actions": "Actions",
+            "retry_blocked": "Blocked",
+            "retry_eligible": "Eligible now",
+            "retry_in": "Retries in {0}",
+            "none": "No recorded analysis failures.",
+            "count": "{0} failures",
+            "delete": "Delete failure (force re-run)",
+            "clear_all": "Clear all",
+            "clear_all_confirm": "Clear all failures?",
+            "clear_all_description": "This removes all {0} recorded failures so the tracks will be analyzed again on the next scan.",
+            "cleared_one": "Failure cleared — the track will be analyzed again.",
+            "cleared_many": "Cleared {0} failures.",
+            "clear_error": "Couldn't clear failures. Please try again."
+        },
         "audio_analysis_description": "Track audio analysis coverage across your providers"
     },
     "similar_tracks": "Similar tracks",

--- a/src/views/settings/AudioAnalysis.vue
+++ b/src/views/settings/AudioAnalysis.vue
@@ -2,10 +2,12 @@
   <div class="space-y-6 p-6">
     <AudioAnalysisConcurrency />
     <AudioAnalysisCoverage />
+    <AudioAnalysisFailures />
   </div>
 </template>
 
 <script setup lang="ts">
 import AudioAnalysisConcurrency from "@/components/AudioAnalysisConcurrency.vue";
 import AudioAnalysisCoverage from "@/components/AudioAnalysisCoverage.vue";
+import AudioAnalysisFailures from "@/components/AudioAnalysisFailures.vue";
 </script>

--- a/tests/composables/useAudioAnalysisFailures.test.ts
+++ b/tests/composables/useAudioAnalysisFailures.test.ts
@@ -1,0 +1,291 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockSendCommand, mockGetTrack } = vi.hoisted(() => {
+  return {
+    mockSendCommand: vi.fn(),
+    mockGetTrack: vi.fn(),
+  };
+});
+
+vi.mock("@/plugins/api", () => {
+  return {
+    api: {
+      sendCommand: mockSendCommand,
+      getTrack: mockGetTrack,
+    },
+  };
+});
+
+import {
+  classifyRetry,
+  useAudioAnalysisFailures,
+  type RawFailure,
+} from "@/composables/useAudioAnalysisFailures";
+
+/** Server `audio_analysis/failures` row shape (snake_case, epoch seconds). */
+interface ServerFailure {
+  item_id: string;
+  provider: string;
+  aa_provider_domain: string;
+  reason: string;
+  next_retry: number | null;
+  timestamp_created: number;
+}
+
+function serverFailure(over: Partial<ServerFailure> = {}): ServerFailure {
+  return {
+    item_id: "1",
+    provider: "tidal",
+    aa_provider_domain: "sonic_analysis",
+    reason: "decode error",
+    next_retry: null,
+    timestamp_created: 1000,
+    ...over,
+  };
+}
+
+/** Mock the failures list + clear command bus. */
+function mockFailures(rows: ServerFailure[]) {
+  mockSendCommand.mockImplementation((cmd: string) => {
+    if (cmd === "audio_analysis/failures") return Promise.resolve(rows);
+    if (cmd === "audio_analysis/failures/clear") return Promise.resolve(1);
+    return Promise.resolve(undefined);
+  });
+}
+
+beforeEach(() => {
+  mockSendCommand.mockReset();
+  mockGetTrack.mockReset();
+  mockGetTrack.mockImplementation((itemId: string) =>
+    Promise.resolve({ name: `Track ${itemId}`, artists: [{ name: "Artist" }] }),
+  );
+});
+
+describe("classifyRetry", () => {
+  it("returns blocked when next_retry is null (never auto-retries)", () => {
+    expect(classifyRetry(null, 1000)).toEqual({ kind: "blocked" });
+  });
+
+  it("returns eligible when next_retry is in the past", () => {
+    expect(classifyRetry(500, 1000)).toEqual({ kind: "eligible" });
+  });
+
+  it("treats next_retry equal to now as eligible", () => {
+    expect(classifyRetry(1000, 1000)).toEqual({ kind: "eligible" });
+  });
+
+  it("returns scheduled with seconds remaining when next_retry is in the future", () => {
+    expect(classifyRetry(4600, 1000)).toEqual({
+      kind: "scheduled",
+      seconds: 3600,
+    });
+  });
+});
+
+describe("useAudioAnalysisFailures", () => {
+  it("fetches all failures (no domain filter) and exposes the total", async () => {
+    mockFailures([
+      serverFailure({ item_id: "1" }),
+      serverFailure({ item_id: "2" }),
+    ]);
+
+    const f = useAudioAnalysisFailures();
+    expect(f.loading.value).toBe(false);
+    const p = f.refresh();
+    expect(f.loading.value).toBe(true);
+    await p;
+
+    expect(f.loading.value).toBe(false);
+    expect(f.total.value).toBe(2);
+    expect(mockSendCommand).toHaveBeenCalledWith("audio_analysis/failures");
+  });
+
+  it("degrades to an empty list when the failures command is unsupported", async () => {
+    mockSendCommand.mockImplementation((cmd: string) => {
+      if (cmd === "audio_analysis/failures")
+        return Promise.reject(new Error("command not found"));
+      return Promise.resolve(undefined);
+    });
+
+    const f = useAudioAnalysisFailures();
+    await f.refresh();
+
+    expect(f.loading.value).toBe(false);
+    expect(f.total.value).toBe(0);
+    expect(f.pageRows.value).toEqual([]);
+  });
+
+  it("maps server snake_case rows into camelCase fields", async () => {
+    mockFailures([
+      serverFailure({
+        item_id: "42",
+        provider: "tidal",
+        aa_provider_domain: "sonic_analysis",
+        reason: "timeout",
+        next_retry: 5000,
+        timestamp_created: 1234,
+      }),
+    ]);
+
+    const f = useAudioAnalysisFailures();
+    await f.refresh();
+
+    const row = f.pageRows.value[0];
+    expect(row.itemId).toBe("42");
+    expect(row.provider).toBe("tidal");
+    expect(row.aaDomain).toBe("sonic_analysis");
+    expect(row.reason).toBe("timeout");
+    expect(row.nextRetry).toBe(5000);
+    expect(row.timestampCreated).toBe(1234);
+  });
+
+  it("resolves the track name + artist for the current page", async () => {
+    mockFailures([serverFailure({ item_id: "1", provider: "tidal" })]);
+    mockGetTrack.mockResolvedValueOnce({
+      name: "Creep",
+      artists: [{ name: "Radiohead" }],
+    });
+
+    const f = useAudioAnalysisFailures();
+    await f.refresh();
+
+    expect(mockGetTrack).toHaveBeenCalledWith("1", "tidal");
+    expect(f.pageRows.value[0].name).toBe("Creep");
+    expect(f.pageRows.value[0].artist).toBe("Radiohead");
+  });
+
+  it("falls back to the raw item_id when the track lookup fails", async () => {
+    mockFailures([
+      serverFailure({ item_id: "gone" }),
+      serverFailure({ item_id: "ok" }),
+    ]);
+    mockGetTrack.mockImplementation((itemId: string) => {
+      if (itemId === "gone") return Promise.reject(new Error("not found"));
+      return Promise.resolve({ name: "Fine", artists: [{ name: "Band" }] });
+    });
+
+    const f = useAudioAnalysisFailures();
+    await f.refresh();
+
+    const gone = f.pageRows.value.find((r) => r.itemId === "gone")!;
+    const ok = f.pageRows.value.find((r) => r.itemId === "ok")!;
+    expect(gone.name).toBe("gone");
+    expect(gone.artist).toBeNull();
+    expect(ok.name).toBe("Fine");
+  });
+
+  it("only resolves names for the visible page, not the whole list", async () => {
+    mockFailures([
+      serverFailure({ item_id: "1" }),
+      serverFailure({ item_id: "2" }),
+      serverFailure({ item_id: "3" }),
+    ]);
+
+    const f = useAudioAnalysisFailures({ pageSize: 2 });
+    await f.refresh();
+
+    // page 1 has 2 rows -> only 2 lookups so far
+    expect(mockGetTrack).toHaveBeenCalledTimes(2);
+    expect(f.pageRows.value).toHaveLength(2);
+
+    await f.next();
+    // page 2 has the 3rd row -> one more lookup
+    expect(mockGetTrack).toHaveBeenCalledTimes(3);
+    expect(f.pageRows.value).toHaveLength(1);
+    expect(f.pageRows.value[0].itemId).toBe("3");
+  });
+
+  it("computes pagination state and clamps next/prev to bounds", async () => {
+    mockFailures([
+      serverFailure({ item_id: "1" }),
+      serverFailure({ item_id: "2" }),
+      serverFailure({ item_id: "3" }),
+    ]);
+
+    const f = useAudioAnalysisFailures({ pageSize: 2 });
+    await f.refresh();
+
+    expect(f.page.value).toBe(1);
+    expect(f.pageCount.value).toBe(2);
+    expect(f.hasNextPage.value).toBe(true);
+
+    await f.next();
+    expect(f.page.value).toBe(2);
+    expect(f.hasNextPage.value).toBe(false);
+
+    await f.next(); // clamp at last page
+    expect(f.page.value).toBe(2);
+
+    await f.prev();
+    expect(f.page.value).toBe(1);
+    await f.prev(); // clamp at first page
+    expect(f.page.value).toBe(1);
+  });
+
+  it("clearOne deletes the exact row and removes it optimistically", async () => {
+    mockFailures([
+      serverFailure({ item_id: "1", provider: "tidal" }),
+      serverFailure({ item_id: "2", provider: "tidal" }),
+    ]);
+
+    const f = useAudioAnalysisFailures();
+    await f.refresh();
+
+    const target = f.pageRows.value.find((r) => r.itemId === "1")!;
+    const count = await f.clearOne(target);
+
+    expect(count).toBe(1);
+    expect(mockSendCommand).toHaveBeenCalledWith(
+      "audio_analysis/failures/clear",
+      {
+        item_id: "1",
+        provider: "tidal",
+        aa_domain: "sonic_analysis",
+      },
+    );
+    expect(f.total.value).toBe(1);
+    expect(f.pageRows.value.map((r) => r.itemId)).toEqual(["2"]);
+  });
+
+  it("clearAll deletes once per distinct AA domain and re-syncs from the server", async () => {
+    const rows = [
+      serverFailure({ item_id: "1", aa_provider_domain: "sonic_analysis" }),
+      serverFailure({ item_id: "2", aa_provider_domain: "sonic_analysis" }),
+      serverFailure({ item_id: "3", aa_provider_domain: "loudness" }),
+    ];
+    mockSendCommand.mockImplementation((cmd: string) => {
+      if (cmd === "audio_analysis/failures") {
+        // After clearAll the server returns an empty list on re-fetch.
+        return Promise.resolve(cleared ? [] : rows);
+      }
+      if (cmd === "audio_analysis/failures/clear") {
+        cleared = true;
+        return Promise.resolve(1);
+      }
+      return Promise.resolve(undefined);
+    });
+    let cleared = false;
+
+    const f = useAudioAnalysisFailures();
+    await f.refresh();
+
+    const total = await f.clearAll();
+
+    const clearCalls = mockSendCommand.mock.calls.filter(
+      (c) => c[0] === "audio_analysis/failures/clear",
+    );
+    expect(clearCalls).toHaveLength(2); // two distinct domains
+    expect(clearCalls.map((c) => c[1])).toEqual(
+      expect.arrayContaining([
+        { aa_domain: "sonic_analysis" },
+        { aa_domain: "loudness" },
+      ]),
+    );
+    expect(total).toBe(2);
+    expect(f.total.value).toBe(0);
+  });
+});
+
+// Keep the RawFailure import meaningful so the public type is part of the contract.
+const _typecheck: RawFailure | undefined = undefined;
+void _typecheck;


### PR DESCRIPTION
## What

Adds a card to **Settings → System → Audio Analysis**, below the existing coverage frame, that lists tracks which **failed audio analysis** and lets you delete entries to clear the failure (forcing a re-run on the next scan).

Pairs with the server branch `feat/aa-failure-tracking`, which adds the `audio_analysis/failures` (list) and `audio_analysis/failures/clear` (delete) commands.

## Behaviour

- **Lists failures** with the resolved track name + artist, the failure **reason**, and the **next-retry** state:
  - `Blocked` — never auto-retries (`next_retry` is null)
  - `Eligible now` — retry time has passed
  - `Retries in …` — scheduled in the future
- **Per-row delete** clears that exact failure immediately (item + provider + AA domain).
- **Clear all** (confirmed via `AlertDialog`) clears every failure, one call per distinct AA provider domain.
- Toast feedback on every action; the card always renders with a friendly empty state when there are no failures.
- Degrades to an empty list if the server doesn't expose the command (frontend/server version skew), mirroring how the coverage card handles an unavailable provider.

## Design notes

- The failures API returns only `item_id` + `provider` (no name), so names are resolved on demand via `api.getTrack`. Resolution is **lazy per visible page** — only the ~25 rows currently shown are looked up — so a large failure list doesn't fan out hundreds of calls on mount. Unresolvable items fall back to their raw `item_id`.
- Reuses the shared `ui/table/*` primitives and the (previously unused) `ui/table-pagination` component rather than pulling in the heavier TanStack setup used by the genre table.

## Files

- **New** `src/composables/useAudioAnalysisFailures.ts` — data + pagination + lazy name resolution + clear actions.
- **New** `src/components/AudioAnalysisFailures.vue` — the card/table UI.
- **New** `tests/composables/useAudioAnalysisFailures.test.ts` — 13 unit tests (retry classification, mapping, lazy resolution, pagination bounds, clear-one/clear-all, graceful degradation).
- `src/views/settings/AudioAnalysis.vue` — renders the card.
- `src/translations/en.json` — adds the `audio_analysis_failures` block.

## Testing

- `vue-tsc --noEmit` → clean
- `yarn lint` → 0 errors (3 pre-existing warnings in unrelated files)
- Full test suite → 189/189 passing (13 new)
- `yarn build` → success