### PR TITLE
Fix self-sustaining WebRTC reconnect storm in remote transport

### DIFF
--- a/src/plugins/remote/webrtc-transport.ts
+++ b/src/plugins/remote/webrtc-transport.ts
@@ -481,6 +481,9 @@ export class WebRTCTransport extends BaseTransport {
   }
 
   private scheduleReconnect(): void {
+    // Connection is down; cancel any pending backoff reset before we bail or retry.
+    this.clearStableConnectionTimer();
+
     // One reconnect at a time: bail if a timer is pending or a connect is in flight.
     if (this.reconnectTimer || this.connectInFlight) {
       return;
@@ -494,8 +497,6 @@ export class WebRTCTransport extends BaseTransport {
       return;
     }
 
-    // Connection is down; cancel any pending backoff reset.
-    this.clearStableConnectionTimer();
     this.setState(TransportState.RECONNECTING);
     this.emit("close", "Connection lost, reconnecting...");
 

--- a/src/plugins/remote/webrtc-transport.ts
+++ b/src/plugins/remote/webrtc-transport.ts
@@ -156,7 +156,6 @@ export class WebRTCTransport extends BaseTransport {
   disconnect(): void {
     this.intentionalClose = true;
     this.clearReconnectTimer();
-    this.clearStableConnectionTimer();
     this.cleanup();
     this.setState(TransportState.DISCONNECTED);
     this.emit("close", "Disconnected by user");
@@ -553,6 +552,9 @@ export class WebRTCTransport extends BaseTransport {
   }
 
   private cleanup(): void {
+    // Cancel the pending backoff reset so it can't fire after teardown.
+    this.clearStableConnectionTimer();
+
     if (this.dataChannel) {
       // Detach first so our own close doesn't fire onclose -> scheduleReconnect (the loop).
       this.dataChannel.onopen = null;

--- a/src/plugins/remote/webrtc-transport.ts
+++ b/src/plugins/remote/webrtc-transport.ts
@@ -45,6 +45,10 @@ const FALLBACK_ICE_SERVERS: IceServerConfig[] = [
   { urls: "stun:stun.cloudflare.com:3478" },
 ];
 
+// A connection must hold this long before its success resets the backoff,
+// otherwise a flapping loop (which briefly connects) keeps backoff flat.
+const STABLE_CONNECTION_THRESHOLD_MS = 5000;
+
 export class WebRTCTransport extends BaseTransport {
   private options: Required<WebRTCTransportOptions>;
   private signaling: SignalingClient;
@@ -54,7 +58,10 @@ export class WebRTCTransport extends BaseTransport {
   private remoteDescriptionSet = false;
   private reconnectAttempts = 0;
   private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+  private stableConnectionTimer: ReturnType<typeof setTimeout> | null = null;
   private intentionalClose = false;
+  // Serialises connect(); concurrent negotiation corrupts the shared pc/SDP state.
+  private connectInFlight = false;
   private httpProxyCallbacks = new Map<
     string,
     {
@@ -91,6 +98,11 @@ export class WebRTCTransport extends BaseTransport {
   }
 
   async connect(): Promise<void> {
+    // Let the in-flight attempt finish; a concurrent negotiation corrupts pc/SDP state.
+    if (this.connectInFlight) {
+      return;
+    }
+    this.connectInFlight = true;
     this.intentionalClose = false;
     this.setState(TransportState.CONNECTING);
 
@@ -117,8 +129,8 @@ export class WebRTCTransport extends BaseTransport {
       // Wait for connection to be established
       await this.waitForConnection();
 
-      // Reset reconnect attempts on successful connection
-      this.reconnectAttempts = 0;
+      // Reset backoff only once the connection proves stable, not on every connect.
+      this.scheduleBackoffReset();
       this.setState(TransportState.CONNECTED);
     } catch (error) {
       console.error("[WebRTCTransport] Connection failed:", error);
@@ -136,12 +148,15 @@ export class WebRTCTransport extends BaseTransport {
       // else: keep RECONNECTING state for next retry
 
       throw error;
+    } finally {
+      this.connectInFlight = false;
     }
   }
 
   disconnect(): void {
     this.intentionalClose = true;
     this.clearReconnectTimer();
+    this.clearStableConnectionTimer();
     this.cleanup();
     this.setState(TransportState.DISCONNECTED);
     this.emit("close", "Disconnected by user");
@@ -187,7 +202,9 @@ export class WebRTCTransport extends BaseTransport {
 
     this.peerConnection.oniceconnectionstatechange = () => {
       const state = this.peerConnection?.iceConnectionState;
-      if (state === "failed" || state === "disconnected") {
+      // `disconnected` is transient and usually self-heals; only act on the
+      // terminal `failed` state (the browser escalates `disconnected` to it).
+      if (state === "failed") {
         this.handleConnectionFailure();
       }
     };
@@ -465,9 +482,8 @@ export class WebRTCTransport extends BaseTransport {
   }
 
   private scheduleReconnect(): void {
-    // Prevent duplicate reconnect schedules
-    if (this._state === TransportState.RECONNECTING && this.reconnectTimer) {
-      console.log("[WebRTCTransport] Reconnect already scheduled, ignoring");
+    // One reconnect at a time: bail if a timer is pending or a connect is in flight.
+    if (this.reconnectTimer || this.connectInFlight) {
       return;
     }
 
@@ -479,21 +495,25 @@ export class WebRTCTransport extends BaseTransport {
       return;
     }
 
-    this.clearReconnectTimer();
+    // Connection is down; cancel any pending backoff reset.
+    this.clearStableConnectionTimer();
     this.setState(TransportState.RECONNECTING);
     this.emit("close", "Connection lost, reconnecting...");
 
-    const delay = Math.min(
+    const backoff = Math.min(
       this.options.reconnectDelay *
         Math.pow(this.options.reconnectDelayGrowth, this.reconnectAttempts),
       this.options.maxReconnectDelay,
     );
+    // Jitter so reconnects don't line up at fixed intervals.
+    const delay = Math.round(backoff * (0.5 + Math.random() * 0.5));
 
     console.log(
       `[WebRTCTransport] Scheduling reconnect attempt ${this.reconnectAttempts + 1} in ${delay}ms`,
     );
 
     this.reconnectTimer = setTimeout(async () => {
+      this.reconnectTimer = null;
       this.reconnectAttempts++;
       // Clean up old connection first
       this.cleanup();
@@ -517,13 +537,37 @@ export class WebRTCTransport extends BaseTransport {
     }
   }
 
+  private scheduleBackoffReset(): void {
+    this.clearStableConnectionTimer();
+    this.stableConnectionTimer = setTimeout(() => {
+      this.reconnectAttempts = 0;
+      this.stableConnectionTimer = null;
+    }, STABLE_CONNECTION_THRESHOLD_MS);
+  }
+
+  private clearStableConnectionTimer(): void {
+    if (this.stableConnectionTimer) {
+      clearTimeout(this.stableConnectionTimer);
+      this.stableConnectionTimer = null;
+    }
+  }
+
   private cleanup(): void {
     if (this.dataChannel) {
+      // Detach first so our own close doesn't fire onclose -> scheduleReconnect (the loop).
+      this.dataChannel.onopen = null;
+      this.dataChannel.onclose = null;
+      this.dataChannel.onerror = null;
+      this.dataChannel.onmessage = null;
       this.dataChannel.close();
       this.dataChannel = null;
     }
 
     if (this.peerConnection) {
+      // Detach first so close doesn't re-enter handleConnectionFailure().
+      this.peerConnection.onicecandidate = null;
+      this.peerConnection.oniceconnectionstatechange = null;
+      this.peerConnection.onconnectionstatechange = null;
       this.peerConnection.close();
       this.peerConnection = null;
     }


### PR DESCRIPTION
## Problem

In remote (WebRTC) mode the transport could enter a perpetual reconnect loop: a **healthy** connection — data channel `open`, ICE `connected` — was torn down and rebuilt roughly every 2 seconds and never stabilised. On iOS PWAs this surfaced as an endless *connecting → connected → reconnecting* cycle after backgrounding the app, and server-side as a new WebRTC session created and destroyed every ~2s.

## Root cause

Three compounding issues in `WebRTCTransport` (`src/plugins/remote/webrtc-transport.ts`):

1. **`cleanup()` re-triggered recovery (the engine of the loop).** Each reconnect runs `cleanup()` then `connect()`. `cleanup()` closed the data channel while its `onclose` handler was still attached, and that handler calls `scheduleReconnect()`. So the act of tearing down to reconnect scheduled *another* reconnect — and since `connect()` re-creates a healthy channel, the next cleanup closed a healthy channel and re-armed the loop. Once entered it never stopped.
2. **`connect()` / `scheduleReconnect()` were not serialised.** Multiple recovery drivers (`dataChannel.onclose`, signaling `peer-disconnected`, ICE/connection `failed`) — all of which fire together on a real network drop or iOS resume — ran concurrently and corrupted the shared peer connection / SDP state (`InvalidModificationError: setLocalDescription ... SDP does not match`). The previous guard only blocked while `RECONNECTING` with a pending timer.
3. **Backoff never escalated.** `reconnectAttempts` reset to `0` on every successful connect; because each storm cycle briefly succeeds, the delay stayed flat (~1.5s) instead of backing off.

## Changes

- **Detach handlers before close** in `cleanup()` (data channel + peer connection) so teardown no longer re-enters the recovery path.
- **Serialise `connect()`** via an in-flight guard, and bail from `scheduleReconnect()` when a reconnect is already pending or a connect is in flight.
- **Defer the backoff reset** until the connection has been stable for 5s, and add **jitter** to the reconnect delay.
- **Only treat the terminal ICE `failed` state as a failure**; let the transient `disconnected` state self-heal (it usually recovers on its own; the browser escalates `disconnected → failed` if it does not). This aligns with WebRTC guidance.

## Verification

Reproduced deterministically against a local debug server (frontend dev build connected over real WebRTC/signaling), correlating client console + server logs:

| | Before | After |
|---|---|---|
| Concurrent `connect()` | `InvalidModificationError`, teardown | extra calls bail cleanly, single negotiation |
| Sustained flapping | stuck `reconnecting` 25s+ after triggers stop | recovers to `connected`, no pending timer, attempts reset |
| Server sessions | new session every ~2s, indefinitely | churn bounded to the trigger window, then quiet |

`vue-tsc --noEmit`, ESLint, and the vitest suite (176 tests) all pass.

## Follow-up (not in this PR)

**In-place ICE restart recovery (`restartIce()`).** The WebRTC-recommended way to recover from a connectivity drop is an in-place ICE restart, which preserves DTLS keys and data channels instead of tearing down and rebuilding the whole `RTCPeerConnection`. This PR makes the existing teardown-and-rebuild path correct and bounded; it does **not** adopt `restartIce()`.

Adopting it requires the **server** to support in-place renegotiation on an existing peer connection (today the gateway creates a fresh `RTCPeerConnection` per signaling session), so it is best done alongside the planned switch to a server-side WebRTC library with trickle-ICE support. At that point the natural companion change is to add a short grace timer on ICE `disconnected` that triggers `restartIce()` (cheap recovery) rather than waiting for `failed`. The serialised-negotiation guard added here is the foundation that work builds on.