### PR TITLE
Add translation key for now playing badge

### DIFF
--- a/src/components/NowPlayingBadge.vue
+++ b/src/components/NowPlayingBadge.vue
@@ -4,9 +4,9 @@
     v-if="showBadge"
     :style="badgeStyle"
     class="now-playing-badge"
-    aria-label="Now playing"
+    :aria-label="$t('now_playing')"
   >
-    Now playing
+    {{ $t("now_playing") }}
   </span>
   <!-- Now playing icon -->
   <div v-if="showIcon" :style="iconStyle" class="now-playing-icon">

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -70,6 +70,7 @@
     "no_content": "No items found.",
     "no_content_filter": "No items found for the current filter/search conditions.",
     "no_player": "No player selected",
+    "now_playing": "Now playing",
     "off": "Off",
     "on": "On",
     "other_versions": "Other versions",


### PR DESCRIPTION
## What

The "Now playing" badge in `NowPlayingBadge.vue` had its text and `aria-label` hardcoded in English. This replaces both with a new `now_playing` translation key so the badge is localizable.

## Changes

- `NowPlayingBadge.vue`: use `$t("now_playing")` for the visible text and the `aria-label` (same key for both).
- `translations/en.json`: add `now_playing` source key. Other locales will be populated via Lokalise.

## Testing

- `now_playing` badge renders on the now-playing list item (e.g. radio list) — confirm it shows "Now playing" in English and the localized string under a non-English locale.
- Lint + full unit test suite pass via pre-commit hooks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)