### PR TITLE
Fix: Update overflow menu on shortcuts change and album tracks on navigation

### DIFF
--- a/src/components/InfoHeader.vue
+++ b/src/components/InfoHeader.vue
@@ -457,6 +457,7 @@ import { computed, ref, watch } from "vue";
 import { useI18n } from "vue-i18n";
 import { useRouter } from "vue-router";
 import { useDisplay } from "vuetify";
+import { useUserPreferences } from "@/composables/userPreferences";
 import MarqueeText from "./MarqueeText.vue";
 import MediaItemThumb from "./MediaItemThumb.vue";
 import MenuButton from "./MenuButton.vue";
@@ -488,6 +489,7 @@ const imgGradient = new URL("../assets/info_gradient.jpg", import.meta.url)
 const marqueeSync = new MarqueeTextSync();
 const router = useRouter();
 const { t, te } = useI18n();
+const { getPreference } = useUserPreferences();
 
 const headerTitle = computed(() => {
   if (!compProps.item) return "";
@@ -533,6 +535,17 @@ watch(
   },
   { immediate: true },
 );
+
+// Watch shortcuts preference to update overflow menu when shortcuts change
+const shortcutsPreference = getPreference<string[]>("sidebar.shortcuts", []);
+watch(shortcutsPreference, async () => {
+  if (compProps.item) {
+    menuItems.value = await getContextMenuItems(
+      [compProps.item],
+      compProps.item,
+    );
+  }
+});
 
 const showGenreChipContextMenu = (evt: MouseEvent, genre: Genre) => {
   if (

--- a/src/views/AlbumDetails.vue
+++ b/src/views/AlbumDetails.vue
@@ -22,6 +22,7 @@
         'duration_desc',
       ]"
       :title="$t('tracks')"
+      :refresh-on-parent-update="true"
     />
     <br />
     <ItemsListing


### PR DESCRIPTION
## Problem

Two UI refresh issues when working with shortcuts:

1. **InfoHeader overflow menu (3-dot menu) doesn't update** when shortcuts are added/removed. The menu shows stale "Add to shortcuts" / "Remove from shortcuts" state until the page is reloaded. The right-click context menu works correctly because it regenerates on every open.

2. **Album track listing doesn't refresh** when navigating between different album shortcuts. The track list from the previous album remains visible until manually refreshed.

## Solution

### InfoHeader.vue
- Import and use `useUserPreferences` composable
- Watch the `sidebar.shortcuts` preference
- Refresh `menuItems` when shortcuts change
- Reuses existing `getContextMenuItems` function

### AlbumDetails.vue
- Add `:refresh-on-parent-update="true"` prop to the albumtracks `ItemsListing`
- Enables automatic reload when `parentItem` (itemDetails) changes
- Follows existing pattern from `TrackDetails.vue` and `PlaylistDetails.vue`

Both fixes use existing mechanisms and are minimal:
- InfoHeader: 13 lines added (import + composable usage + watch)
- AlbumDetails: 1 line added (prop)

## Testing

✅ TypeScript check passed  
✅ ESLint passed  
✅ All 176 tests passed  

Manual testing:
1. Add/remove album from shortcuts → overflow menu updates immediately
2. Navigate between album shortcuts → tracks reload automatically