### PR TITLE
Improve listing empty states and declutter the action toolbar

### DIFF
--- a/src/components/ItemsListing.vue
+++ b/src/components/ItemsListing.vue
@@ -1,6 +1,6 @@
 <!-- eslint-disable vue/no-v-for-template-key-on-child -->
 <template>
-  <section v-if="!(hideOnEmpty && pagedItems.length == 0)">
+  <section v-if="!(hideOnEmpty && pagedItems.length == 0 && !hasActiveFilters)">
     <!-- eslint-disable vue/no-template-shadow -->
     <Toolbar
       :icon="icon"
@@ -9,6 +9,8 @@
       :count="params.search ? pagedItems.length : total || allItems.length"
       color="transparent"
       :menu-items="menuItems"
+      :enforce-overflow-menu="true"
+      :menu-active="hasActiveFilters"
       @title-clicked="toggleExpand"
     >
       <template #title>
@@ -164,28 +166,28 @@
         </v-virtual-scroll>
       </v-infinite-scroll>
 
-      <!-- show alert if no item found -->
-      <div v-if="!loading && pagedItems.length == 0">
-        <v-alert
-          v-if="
-            !loading &&
-            pagedItems.length == 0 &&
-            (params.search || params.favoritesOnly)
-          "
-          :title="$t('no_content_filter')"
-        >
-          <v-btn
-            v-if="params.search"
-            style="margin-top: 15px"
-            @click="redirectSearch"
-          >
+      <!-- subtle message shown when there are no items to display -->
+      <Empty
+        v-if="!loading && pagedItems.length == 0"
+        class="border-none gap-3 py-8"
+      >
+        <EmptyMedia variant="icon">
+          <FilterX v-if="hasActiveFilters" class="h-5 w-5" />
+          <ListMusic v-else class="h-5 w-5" />
+        </EmptyMedia>
+        <EmptyDescription>
+          {{
+            hasActiveFilters
+              ? $t("no_content_filter")
+              : emptyMessage || $t("no_content")
+          }}
+        </EmptyDescription>
+        <EmptyContent v-if="hasActiveFilters && params.search">
+          <Button variant="outline" size="sm" @click="redirectSearch">
             {{ $t("try_global_search") }}
-          </v-btn>
-        </v-alert>
-        <v-alert v-else-if="!loading && pagedItems.length == 0">
-          {{ $t("no_content") }}
-        </v-alert>
-      </div>
+          </Button>
+        </EmptyContent>
+      </Empty>
 
       <!-- box shown when item(s) selected -->
       <v-snackbar
@@ -224,7 +226,14 @@ import type { Component } from "vue";
 
 import Container from "@/components/Container.vue";
 import GenreIcon from "@/components/icons/GenreIcon.vue";
-import { Eye, EyeClosed, Layers } from "lucide-vue-next";
+import { Button } from "@/components/ui/button";
+import {
+  Empty,
+  EmptyContent,
+  EmptyDescription,
+  EmptyMedia,
+} from "@/components/ui/empty";
+import { Eye, EyeClosed, FilterX, Layers, ListMusic } from "lucide-vue-next";
 import ListViewSkeleton from "@/components/skeletons/ListViewSkeleton.vue";
 import PanelViewSkeleton from "@/components/skeletons/PanelViewSkeleton.vue";
 import Toolbar, { ToolBarMenuItem } from "@/components/Toolbar.vue";
@@ -313,6 +322,8 @@ export interface Props {
   title?: string;
   subtitle?: string;
   hideOnEmpty?: boolean;
+  // custom message shown when the listing has no items and no active filters
+  emptyMessage?: string;
   showLibraryOnlyFilter?: boolean;
   showGenreFilter?: boolean;
   showHideEmptyFilter?: boolean;
@@ -343,6 +354,7 @@ const props = withDefaults(defineProps<Props>(), {
   showDuration: true,
   parentItem: undefined,
   hideOnEmpty: false,
+  emptyMessage: undefined,
   showSearchButton: undefined,
   showRefreshButton: undefined,
   showSelectButton: undefined,
@@ -402,6 +414,10 @@ const allItemsReceived = ref(false);
 const initialDataReceived = ref(false);
 const tempHide = ref(false);
 const genreOptions = ref<{ label: string; value: number }[]>([]);
+
+// below this item count, the per-listing search option is hidden to reduce
+// clutter (consumers can force it on/off via the showSearchButton prop).
+const SEARCH_ITEM_THRESHOLD = 25;
 
 interface DiscHeader {
   isDiscHeader: true;
@@ -812,8 +828,56 @@ const isSearchActive = computed(() => {
   return searchActive;
 });
 
+// true when the listing has been narrowed by any user-controllable filter
+// (search, favorites, provider, genre, album-type, ...). Used to keep an
+// otherwise hidden-on-empty listing visible — and to explain an empty result —
+// whenever the emptiness might be caused by filtering rather than missing data.
+const hasActiveFilters = computed(() => {
+  const p = params.value;
+  const genreActive = Array.isArray(p.genreIds)
+    ? p.genreIds.length > 0
+    : p.genreIds !== undefined;
+  return Boolean(
+    (p.search && p.search.length > 0) ||
+    p.favoritesOnly ||
+    p.libraryOnly ||
+    p.albumArtistsFilter ||
+    p.hideFullyPlayed ||
+    (p.provider && p.provider.length > 0) ||
+    (p.albumType && p.albumType.length > 0) ||
+    genreActive ||
+    // hide-empty genres filter: true (hide empty) and null (defaults only)
+    // both narrow the result; false/undefined means "show all"
+    p.hideEmptyFilter === true ||
+    p.hideEmptyFilter === null,
+  );
+});
+
+// total number of items this listing represents. For flat (loadItems)
+// listings every item is loaded up front, so allItems holds the true total.
+// Server-paged listings only know their total when the parent passes it.
+const totalItemCount = computed(() => {
+  if (props.total !== undefined) return props.total;
+  if (props.loadItems != null) return allItems.value.length;
+  // server-paged without a known total: assume large enough to warrant search
+  return Number.POSITIVE_INFINITY;
+});
+
+// whether the search option is offered. An explicit showSearchButton wins;
+// otherwise search is auto-hidden for small listings to reduce clutter, but
+// kept available while a search is actually in progress.
+const searchAvailable = computed(() => {
+  if (props.showSearchButton === true) return true;
+  if (props.showSearchButton === false) return false;
+  return (
+    isSearchActive.value ||
+    showSearch.value ||
+    totalItemCount.value >= SEARCH_ITEM_THRESHOLD
+  );
+});
+
 const showSearchInput = computed(() => {
-  return showSearch.value && expanded.value;
+  return searchAvailable.value && showSearch.value && expanded.value;
 });
 
 const isLibraryItem = computed(() => {
@@ -1152,8 +1216,8 @@ const menuItems = computed(() => {
     });
   }
 
-  // toggle search
-  if (props.showSearchButton !== false) {
+  // toggle search (auto-hidden for small listings; always lives in the menu)
+  if (searchAvailable.value) {
     items.push({
       label: isSearchActive.value
         ? "tooltip.search_filter_active"
@@ -1162,7 +1226,6 @@ const menuItems = computed(() => {
       action: toggleSearch,
       active: isSearchActive.value,
       disabled: loading.value,
-      overflowAllowed: false,
     });
   }
 
@@ -1204,12 +1267,13 @@ const menuItems = computed(() => {
     items.push(...props.extraMenuItems);
   }
 
-  // toggle expand
+  // toggle collapse/expand — kept as a dedicated button next to the menu
   if (props.allowCollapse === true) {
     items.push({
       label: "tooltip.collapse_expand",
       icon: "mdi-chevron-up",
       action: toggleExpand,
+      overflowAllowed: false,
     });
   }
 

--- a/src/components/Toolbar.vue
+++ b/src/components/Toolbar.vue
@@ -32,8 +32,8 @@
         v-for="menuItem of menuItems?.filter(
           (x) =>
             !x.hide &&
-            !enforceOverflowMenu &&
-            (getBreakpointValue('bp8') || x.overflowAllowed === false),
+            (x.overflowAllowed === false ||
+              (!enforceOverflowMenu && getBreakpointValue('bp8'))),
         )"
         :key="menuItem.label"
         variant="text"
@@ -79,12 +79,14 @@
               style="width: 15px; margin-left: -10px"
               v-bind="props"
             >
-              <v-icon
-                icon="mdi-dots-vertical"
-                :color="$vuetify.theme.current.dark ? '#fff' : '#000'"
-                size="22"
-                style="margin-right: -5px; width: 15px"
-              />
+              <v-badge :model-value="menuActive == true" color="primary" dot>
+                <v-icon
+                  icon="mdi-dots-vertical"
+                  :color="$vuetify.theme.current.dark ? '#fff' : '#000'"
+                  size="22"
+                  style="margin-right: -5px; width: 15px"
+                />
+              </v-badge>
             </v-btn>
           </template>
           <v-list density="compact" slim tile>
@@ -180,6 +182,8 @@ interface Props {
   subtitle?: string;
   menuItems?: ToolBarMenuItem[];
   enforceOverflowMenu?: boolean;
+  // shows an "active" dot on the overflow (3-dots) button, e.g. when filters apply
+  menuActive?: boolean;
   isDiscoverPage?: boolean;
   iconAction?: () => void;
 }
@@ -191,6 +195,7 @@ withDefaults(defineProps<Props>(), {
   count: undefined,
   menuItems: undefined,
   enforceOverflowMenu: false,
+  menuActive: false,
   iconAction: undefined,
 });
 

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -24,6 +24,8 @@
     "appears_on": "Appears on",
     "artist": "Artist",
     "artist_albums": "Albums",
+    "artist_no_library_albums": "You don't have any albums in your library for this artist.",
+    "artist_no_library_tracks": "You don't have any tracks in your library for this artist.",
     "artist_topalbums": "Top albums",
     "artist_toptracks": "Top tracks",
     "artists": "Artists",
@@ -823,7 +825,7 @@
         "infinite_mix_favorites": {
             "label": "Infinite Mix (favorites)",
             "description": "Like Infinite Mix, but limited to your favorited tracks. 25 fresh random favorites are added whenever the queue is nearly empty."
-        }       
+        }
     },
     "similar_tracks": "Similar tracks",
     "show_info": "Show info",

--- a/src/views/ArtistDetails.vue
+++ b/src/views/ArtistDetails.vue
@@ -25,6 +25,7 @@
       ]"
       :title="$t('albums')"
       :subtitle="$t('in_library')"
+      :empty-message="$t('artist_no_library_albums')"
       :allow-collapse="true"
     />
     <!-- tracks in library (library artists only) -->
@@ -53,6 +54,7 @@
       ]"
       :title="$t('tracks')"
       :subtitle="$t('in_library')"
+      :empty-message="$t('artist_no_library_tracks')"
       :allow-collapse="true"
     />
     <!-- top albums -->


### PR DESCRIPTION
The `ItemsListing` toolbar had grown crowded — a row of action buttons that only collapsed on small screens — and the per-listing search cluttered even tiny listings. Worse, `hide-on-empty` could make an entire row vanish when a filter returned no results, leaving no way to clear that filter. The empty-state message was also minimal and never explained *why* a listing was empty.

### Changes
- `hide-on-empty` now only hides a listing when it is genuinely empty **and** no filters are active, so a filtered-empty result stays visible instead of disappearing.
- Reworked the empty state with a subtle shadcn `Empty` component: a filter-aware message when filters are active, plus an optional per-listing custom message via a new `emptyMessage` prop.
- Auto-hide the search option for small listings (< 25 items) to reduce clutter; consumers can still force it on/off with `showSearchButton`.
- Always route listing actions into the overflow (3-dots) menu and keep only the collapse/expand button beside it; the menu button shows a dot when any filter is active.
- `ArtistDetails`: friendly custom empty messages for the in-library albums and tracks listings.
- Added the required translation keys.