### PR TITLE
Update `sendspin-js` to improve playback stability of radio streams for web players

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
         "@mdi/font": "7.4.47",
         "@mdi/js": "7.4.47",
         "@scure/base": "^2.2.0",
-        "@sendspin/sendspin-js": "3.1.0",
+        "@sendspin/sendspin-js": "3.2.0",
         "@tabler/icons-vue": "^3.44.0",
         "@tailwindcss/vite": "^4.3.0",
         "@tanstack/vue-form": "^1.33.0",

--- a/src/components/SendspinPlayer.vue
+++ b/src/components/SendspinPlayer.vue
@@ -234,6 +234,10 @@ onMounted(() => {
           clientName: getDeviceName(),
           codecs,
           syncDelay,
+          requiredLeadTimeMs: 250,
+          // Ask for a larger buffer when we are being routed through WebRTC.
+          // This increases latency for live streams, but improves stability
+          minBufferMs: isDirectConnection() ? 2500 : 6000,
           onStateChange: (state) => {
             // Update reactive state when player state changes
             isPlaying.value = state.isPlaying;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2141,10 +2141,10 @@
   resolved "https://registry.yarnpkg.com/@scure/base/-/base-2.2.0.tgz#1311378ed247df6d58f8eb8941921965e97e5747"
   integrity sha512-b8XEupJibegiXV+tDUseI8oLQc8ei3d/4Jkb2RpbHh3MfE054ov3uIz2dhFkB3FI8iwYkEh0gGCApkrYggkPNg==
 
-"@sendspin/sendspin-js@3.1.0":
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/@sendspin/sendspin-js/-/sendspin-js-3.1.0.tgz#b62b6447dcb4740bf3c61aafc20097b21f9de63e"
-  integrity sha512-tljpoE7JwGIvAMk9M+UBGKkur4ME1RyZRxIV/FFJ0trp6fJOC5bWjewaO8bgm9ybEKO64su5PMbn/u63YzlaMQ==
+"@sendspin/sendspin-js@3.2.0":
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/@sendspin/sendspin-js/-/sendspin-js-3.2.0.tgz#504b8cc10c61722ea02541b4dc98ce1005e82ed7"
+  integrity sha512-sxMibcr9eiue5yT0viXxCruq8LTRSEzaz9epmhSp3Qe4gHcksE+JwFOTEJfgkY5kJBmPq22CkYlyvJXcHacK2g==
   dependencies:
     opus-encdec "^0.1.1"
 


### PR DESCRIPTION
This PR updates `sendspin-js` to 3.2.0 with a bunch of small bug fixes to the Sendspin web player.

## Increased stability when playing radio
The minimum buffer size is now increased from 250ms to 2.5s, or even 6s when accessed remotely.
This should make the web player more reliable for radio streams and other live sources.

## Improved volume curve
The volume curve is now perceptual, so quiet steps are more even.

## Other bug fixes
There are also a lot of other fixes for smaller edge cases. Notably some minor syncing bugs, but mostly spec conformance gaps not specifically applicable to the web player.
The full list of changes can be found [here](https://github.com/Sendspin/sendspin-js/releases/tag/3.2.0).