### PR TITLE
Fix stale sidebar shortcuts causing 'not found in library' popups

### DIFF
--- a/src/composables/useShortcuts.ts
+++ b/src/composables/useShortcuts.ts
@@ -1,5 +1,6 @@
 import { computed, onMounted, onUnmounted, ref, watch } from "vue";
 import { api } from "@/plugins/api";
+import { isMediaNotFoundError } from "@/plugins/api/errors";
 import type {
   Album,
   Artist,
@@ -336,7 +337,7 @@ export function useShortcuts() {
     const prunedUris: string[] = [];
 
     const settled = await Promise.allSettled(
-      uris.map((uri) => api.getItemByUri(uri)),
+      uris.map((uri) => api.getItemByUri(uri, { suppressErrorToast: true })),
     );
     settled.forEach((result, i) => {
       const uri = uris[i];
@@ -348,8 +349,12 @@ export function useShortcuts() {
           // Item explicitly gone (null / unsupported type) — prune.
           prunedUris.push(uri);
         }
+      } else if (isMediaNotFoundError(result.reason)) {
+        // Item deleted server-side while no frontend was listening
+        // (e.g. provider removed) — prune.
+        prunedUris.push(uri);
       }
-      // rejected = network/transport error — keep URI pinned, don't prune.
+      // other rejections = network/transport error — keep URI pinned, don't prune.
     });
 
     resolvedItems.value = results;
@@ -409,9 +414,10 @@ export function useShortcuts() {
     );
     if (toAdd.length > 0) {
       const settled = await Promise.allSettled(
-        toAdd.map((uri) => api.getItemByUri(uri)),
+        toAdd.map((uri) => api.getItemByUri(uri, { suppressErrorToast: true })),
       );
-      settled.forEach((result) => {
+      const prunedUris: string[] = [];
+      settled.forEach((result, i) => {
         if (
           result.status === "fulfilled" &&
           result.value &&
@@ -421,9 +427,21 @@ export function useShortcuts() {
             ...resolvedItems.value,
             result.value as ShortcutItem,
           ];
+        } else if (
+          result.status === "rejected" &&
+          isMediaNotFoundError(result.reason)
+        ) {
+          // Item deleted server-side — prune so it doesn't linger forever.
+          prunedUris.push(toAdd[i]);
         }
-        // rejected = network/backend error — don't mutate pinned URIs here.
+        // other rejections = network/backend error — don't mutate pinned URIs here.
       });
+      if (prunedUris.length > 0) {
+        await setPreference(
+          PREF_KEY,
+          pinnedUris.value.filter((u) => !prunedUris.includes(u)),
+        );
+      }
     }
   });
 

--- a/src/plugins/api/errors.ts
+++ b/src/plugins/api/errors.ts
@@ -1,0 +1,22 @@
+// Error codes as defined in music_assistant_models/errors.py
+export enum ApiErrorCode {
+  UNKNOWN = 0,
+  PROVIDER_UNAVAILABLE = 1,
+  MEDIA_NOT_FOUND = 2,
+}
+
+export class ApiError extends Error {
+  constructor(
+    public readonly errorCode: number,
+    details?: string,
+  ) {
+    super(details || `Server error (code ${errorCode})`);
+    this.name = "ApiError";
+  }
+}
+
+export function isMediaNotFoundError(err: unknown): boolean {
+  return (
+    err instanceof ApiError && err.errorCode === ApiErrorCode.MEDIA_NOT_FOUND
+  );
+}

--- a/src/plugins/api/index.ts
+++ b/src/plugins/api/index.ts
@@ -5,6 +5,7 @@ import { toast } from "vue-sonner";
 import { $t } from "../i18n";
 import type { ITransport } from "../remote/transport";
 import { WebSocketTransport } from "../remote/websocket-transport";
+import { ApiError } from "./errors";
 import { getDeviceName } from "./helpers";
 import {
   type Album,
@@ -101,6 +102,7 @@ export class MusicAssistantApi {
     {
       resolve: (result: unknown) => void;
       reject: (err: unknown) => void;
+      suppressErrorToast?: boolean;
     }
   >;
 
@@ -1266,11 +1268,18 @@ export class MusicAssistantApi {
     });
   }
 
-  public getItemByUri(uri: string): Promise<MediaItemType> {
+  public getItemByUri(
+    uri: string,
+    options?: { suppressErrorToast?: boolean },
+  ): Promise<MediaItemType> {
     // Get single music item providing a mediaitem uri.
-    return this.sendCommand("music/item_by_uri", {
-      uri,
-    });
+    return this.sendCommand(
+      "music/item_by_uri",
+      {
+        uri,
+      },
+      options,
+    );
   }
 
   public refreshItem(
@@ -2345,7 +2354,7 @@ export class MusicAssistantApi {
         errorMsg.includes("Authentication required") ||
         errorMsg.toLowerCase().includes("unauthorized");
 
-      if (!isAuthError) {
+      if (!isAuthError && !resultPromise?.suppressErrorToast) {
         toast.error(msg.details || msg.error_code);
       }
     } else if (DEBUG) {
@@ -2372,7 +2381,7 @@ export class MusicAssistantApi {
 
     this.commands.delete(msg.message_id);
     if ("error_code" in msg) {
-      resultPromise.reject(msg.details || msg.error_code);
+      resultPromise.reject(new ApiError(Number(msg.error_code), msg.details));
     } else {
       msg = msg as SuccessResultMessage;
       resultPromise.resolve(msg.result);
@@ -2809,6 +2818,7 @@ export class MusicAssistantApi {
   public sendCommand<Result>(
     command: string,
     args?: Record<string, unknown>,
+    options?: { suppressErrorToast?: boolean },
   ): Promise<Result> {
     // send command to the server and return promise where the result can be returned
     const cmdId = this._genCmdId();
@@ -2816,6 +2826,7 @@ export class MusicAssistantApi {
       this.commands.set(cmdId, {
         resolve: resolve as (result: unknown) => void,
         reject,
+        suppressErrorToast: options?.suppressErrorToast,
       });
       this._sendCommand(command, args, cmdId);
     });

--- a/tests/composables/useShortcuts.test.ts
+++ b/tests/composables/useShortcuts.test.ts
@@ -1,20 +1,27 @@
 import { MediaType } from "@/plugins/api/interfaces";
+import { flushPromises, mount } from "@vue/test-utils";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { defineComponent, h } from "vue";
 
-const { mockUpdateUser, storeMock } = vi.hoisted(() => {
-  return {
-    mockUpdateUser: vi.fn(),
-    storeMock: {
-      currentUser: {
-        user_id: "user-1",
-        preferences: {} as Record<string, unknown>,
+const { mockGetItemByUri, mockSubscribe, mockUpdateUser, storeMock } =
+  vi.hoisted(() => {
+    return {
+      mockGetItemByUri: vi.fn(),
+      mockSubscribe: vi.fn(() => () => {}),
+      mockUpdateUser: vi.fn(),
+      storeMock: {
+        currentUser: {
+          user_id: "user-1",
+          preferences: {} as Record<string, unknown>,
+        },
       },
-    },
-  };
-});
+    };
+  });
 
 vi.mock("@/plugins/api", () => ({
   api: {
+    getItemByUri: mockGetItemByUri,
+    subscribe: mockSubscribe,
     updateUser: mockUpdateUser,
   },
 }));
@@ -31,7 +38,22 @@ import {
   pinShortcutStandalone,
   reorderShortcutStandalone,
   unpinShortcutStandaloneItem,
+  useShortcuts,
 } from "@/composables/useShortcuts";
+import { ApiError } from "@/plugins/api/errors";
+
+function mountShortcuts() {
+  let shortcuts!: ReturnType<typeof useShortcuts>;
+  const wrapper = mount(
+    defineComponent({
+      setup() {
+        shortcuts = useShortcuts();
+        return () => h("div");
+      },
+    }),
+  );
+  return { wrapper, shortcuts };
+}
 
 const PODCAST_FEED = "https://ronzheimer.podigee.io/feed/mp3";
 const ENCODED_PODCAST_URI = `itunes_podcasts://podcast/${encodeURIComponent(PODCAST_FEED)}`;
@@ -224,5 +246,83 @@ describe("useShortcuts standalone helpers", () => {
       ENCODED_PODCAST_URI,
       "builtin://radio/http%3A%2F%2Fexample.com%2Fstream",
     ]);
+  });
+});
+
+describe("useShortcuts stale shortcut pruning", () => {
+  const ALIVE_URI = "library://playlist/99";
+  const DELETED_URI = "library://playlist/123";
+  const alivePlaylist = {
+    provider: "library",
+    media_type: MediaType.PLAYLIST,
+    item_id: "99",
+    uri: ALIVE_URI,
+  };
+
+  beforeEach(() => {
+    mockUpdateUser.mockReset();
+    mockGetItemByUri.mockReset();
+    mockSubscribe.mockClear();
+    storeMock.currentUser = {
+      user_id: "user-1",
+      preferences: {},
+    };
+  });
+
+  it("resolves shortcuts with the global error toast suppressed", async () => {
+    storeMock.currentUser.preferences["sidebar.shortcuts"] = [ALIVE_URI];
+    mockGetItemByUri.mockResolvedValue(alivePlaylist);
+
+    const { wrapper } = mountShortcuts();
+    await flushPromises();
+    wrapper.unmount();
+
+    expect(mockGetItemByUri).toHaveBeenCalledWith(ALIVE_URI, {
+      suppressErrorToast: true,
+    });
+  });
+
+  it("prunes a pinned URI when the item no longer exists on the server", async () => {
+    storeMock.currentUser.preferences["sidebar.shortcuts"] = [
+      DELETED_URI,
+      ALIVE_URI,
+    ];
+    mockGetItemByUri.mockImplementation((uri: string) =>
+      uri === DELETED_URI
+        ? Promise.reject(new ApiError(2, "playlist not found in library: 123"))
+        : Promise.resolve(alivePlaylist),
+    );
+
+    const { wrapper, shortcuts } = mountShortcuts();
+    await flushPromises();
+
+    expect(storeMock.currentUser.preferences["sidebar.shortcuts"]).toEqual([
+      ALIVE_URI,
+    ]);
+    expect(mockUpdateUser).toHaveBeenCalledTimes(1);
+    expect(shortcuts.pinnedItems.value).toEqual([alivePlaylist]);
+    wrapper.unmount();
+  });
+
+  it("keeps a pinned URI on transient (network/transport) errors", async () => {
+    storeMock.currentUser.preferences["sidebar.shortcuts"] = [
+      DELETED_URI,
+      ALIVE_URI,
+    ];
+    mockGetItemByUri.mockImplementation((uri: string) =>
+      uri === DELETED_URI
+        ? Promise.reject(new Error("connection lost"))
+        : Promise.resolve(alivePlaylist),
+    );
+
+    const { wrapper } = mountShortcuts();
+    await flushPromises();
+
+    expect(mockUpdateUser).not.toHaveBeenCalled();
+    expect(storeMock.currentUser.preferences["sidebar.shortcuts"]).toEqual([
+      DELETED_URI,
+      ALIVE_URI,
+    ]);
+    wrapper.unmount();
   });
 });

--- a/tests/plugins/api/errorHandling.test.ts
+++ b/tests/plugins/api/errorHandling.test.ts
@@ -1,0 +1,81 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockToastError } = vi.hoisted(() => ({
+  mockToastError: vi.fn(),
+}));
+
+vi.mock("vue-sonner", () => ({
+  toast: {
+    error: mockToastError,
+    info: vi.fn(),
+    success: vi.fn(),
+  },
+}));
+vi.mock("@/plugins/i18n", () => ({ $t: (key: string) => key }));
+vi.mock("@/plugins/store", () => ({ store: {} }));
+
+import { api } from "@/plugins/api";
+import { ApiError, isMediaNotFoundError } from "@/plugins/api/errors";
+
+function seedCommand(suppressErrorToast?: boolean) {
+  const resolve = vi.fn();
+  const reject = vi.fn();
+  (api as any).commands.set("42", { resolve, reject, suppressErrorToast });
+  return { resolve, reject };
+}
+
+function sendErrorResult(details = "playlist not found in library: 123") {
+  (api as any).handleResultMessage({
+    message_id: "42",
+    error_code: 2,
+    details,
+  });
+}
+
+describe("api error result handling", () => {
+  beforeEach(() => {
+    mockToastError.mockReset();
+    (api as any).commands.clear();
+  });
+
+  it("rejects the pending command with an ApiError carrying the error code", () => {
+    const { reject } = seedCommand();
+
+    sendErrorResult();
+
+    expect(reject).toHaveBeenCalledTimes(1);
+    const err = reject.mock.calls[0][0];
+    expect(err).toBeInstanceOf(ApiError);
+    expect(isMediaNotFoundError(err)).toBe(true);
+    expect((err as ApiError).message).toBe(
+      "playlist not found in library: 123",
+    );
+  });
+
+  it("shows the global error toast by default", () => {
+    seedCommand();
+
+    sendErrorResult();
+
+    expect(mockToastError).toHaveBeenCalledTimes(1);
+  });
+
+  it("skips the global error toast when the command opted out", () => {
+    const { reject } = seedCommand(true);
+
+    sendErrorResult();
+
+    expect(mockToastError).not.toHaveBeenCalled();
+    expect(reject).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not match other error codes as media-not-found", () => {
+    expect(isMediaNotFoundError(new ApiError(1, "provider unavailable"))).toBe(
+      false,
+    );
+    expect(isMediaNotFoundError(new Error("connection lost"))).toBe(false);
+    expect(isMediaNotFoundError("playlist not found in library: 123")).toBe(
+      false,
+    );
+  });
+});


### PR DESCRIPTION
## Problem

When a media item pinned as a sidebar shortcut is deleted on the server while no frontend is connected (e.g. removing a music provider deletes its playlists from the library), the stored shortcut URI becomes stale. On every sidebar load the URI resolution fails with `MediaNotFoundError`, which surfaced as a recurring **"playlist not found in library: 123"** error toast — and the dead shortcut was never cleaned up from the user's preferences.

This happened because the api client rejected commands with a plain message string (losing the server's error code), so the shortcut loader could not distinguish "item is gone" (safe to prune) from a transient network error (must keep), and the client toasts every command error globally.

## Changes

- Add `ApiError` (with the server's numeric `error_code`) and reject pending commands with it instead of a bare string
- Add a `suppressErrorToast` option to `sendCommand`/`getItemByUri` so background operations can handle errors themselves without triggering the global error toast
- `useShortcuts`: resolve pinned URIs with the toast suppressed, and prune URIs that reject with `MediaNotFoundError` from the stored preference (both on initial load and when resolving newly pinned items); other rejections still keep the URI pinned
- Add regression tests for the prune/keep behavior and the api error handling