### PR TITLE
Fix heart icon spacing in list view and keep listing search visible

### DIFF
--- a/src/components/ItemsListing.vue
+++ b/src/components/ItemsListing.vue
@@ -1216,7 +1216,7 @@ const menuItems = computed(() => {
     });
   }
 
-  // toggle search (auto-hidden for small listings; always lives in the menu)
+  // toggle search (auto-hidden for small listings)
   if (searchAvailable.value) {
     items.push({
       label: isSearchActive.value
@@ -1226,6 +1226,7 @@ const menuItems = computed(() => {
       action: toggleSearch,
       active: isSearchActive.value,
       disabled: loading.value,
+      overflowAllowed: false,
     });
   }
 

--- a/src/components/ListviewItem.vue
+++ b/src/components/ListviewItem.vue
@@ -216,6 +216,7 @@
           showFavorite &&
           !$vuetify.display.mobile
         "
+        class="favorite-button-wrapper"
       >
         <FavouriteButton :item="item" />
       </div>
@@ -434,6 +435,10 @@ const onPlayClick = function (evt: PointerEvent) {
 
 .album-track-row :deep(.v-list-item__content) {
   margin-bottom: 1px;
+}
+
+.favorite-button-wrapper {
+  margin-inline: 10px;
 }
 
 .track-duration {


### PR DESCRIPTION
Two small UI fixes following the recent listing changes:

The new favorite (heart) icon in list view is a bare icon without the built-in whitespace its neighbours have, making the action icons look cramped. And since #1897 routed all listing actions into the overflow menu, the search option was no longer directly accessible.

### Changes
- Give the heart icon the same 10px side margins as `ProviderIcon`, so all list item action icons are spaced evenly.
- Mark the listing search action as `overflowAllowed: false` so it renders as a dedicated toolbar button again instead of hiding in the 3-dots menu (the auto-hide for listings with fewer than 25 items remains).