### PR TITLE
Add scroll to description dialog for long descriptions

### DIFF
--- a/src/components/InfoHeader.vue
+++ b/src/components/InfoHeader.vue
@@ -404,6 +404,7 @@
         <!-- eslint-disable vue/no-v-html -->
         <div
           class="prose prose-sm dark:prose-invert max-w-none text-sm leading-relaxed"
+          style="max-height: 60vh; overflow-y: auto"
           v-html="fullDescription"
         ></div>
         <!-- eslint-enable vue/no-v-html -->


### PR DESCRIPTION
The description dialog now has a max-height of 60vh with vertical scroll to handle very long item descriptions without expanding the dialog beyond screen height.

**Changes:**
- Added `max-height: 60vh` to description dialog content
- Added `overflow-y: auto` to enable scrolling for long descriptions

This prevents the dialog from becoming too large when displaying lengthy artist biographies, album descriptions, or other metadata.

#### Screenshots
<img width="641" height="500" alt="info_screen_amy_macdonald" src="https://github.com/user-attachments/assets/c1866794-3d5c-4fbe-86a9-cb26288b337a" />

<img width="641" height="500" alt="info_screen_acdc" src="https://github.com/user-attachments/assets/1a6a1f08-461d-461b-a257-ddce933e935b" />
