### PR TITLE
Use ExplicitIcon for explicit content field in smart playlist rules

### DIFF
--- a/src/components/smart_playlist/fieldIcon.ts
+++ b/src/components/smart_playlist/fieldIcon.ts
@@ -1,5 +1,6 @@
 import { Ban, CalendarRange, Disc3, Heart, Mic2, Tags } from "lucide-vue-next";
 import { match } from "ts-pattern";
+import ExplicitIcon from "@/components/icons/ExplicitIcon.vue";
 import type { Component } from "vue";
 import type { RuleField } from "@/composables/useSmartPlaylistRulesForm";
 
@@ -11,5 +12,6 @@ export function fieldIcon(field: RuleField): Component {
     .with("album_type", () => Disc3)
     .with("favorite", () => Heart)
     .with("year", () => CalendarRange)
+    .with("explicit", () => ExplicitIcon)
     .otherwise(() => Ban);
 }


### PR DESCRIPTION
Updates the smart playlist rule field icon mapping to use the dedicated `ExplicitIcon` component for the explicit content field instead of the generic `Ban` icon.

This provides better visual consistency with the explicit content markers shown elsewhere in the UI.

**Changes:**
- Import `ExplicitIcon` component in `fieldIcon.ts`
- Map "explicit" field to `ExplicitIcon` in the field icon matcher