### PR TITLE
Use toast notifications for config flow errors instead of browser alerts

### DIFF
--- a/src/views/settings/AddProviderDetails.vue
+++ b/src/views/settings/AddProviderDetails.vue
@@ -94,6 +94,7 @@ import ProviderIcon from "@/components/ProviderIcon.vue";
 import ProviderSaveErrorDialog from "@/components/ProviderSaveErrorDialog.vue";
 import { watch } from "vue";
 import { markdownToHtml } from "@/helpers/utils";
+import { toast } from "vue-sonner";
 import { useI18n } from "vue-i18n";
 
 // global refs
@@ -205,8 +206,7 @@ const onAction = async function (
       config_entries.value = entries;
     })
     .catch((err) => {
-      // TODO: make this a bit more fancy someday
-      alert(err);
+      toast.error(String(err));
     })
     .finally(() => {
       loading.value = false;

--- a/src/views/settings/EditPlayer.vue
+++ b/src/views/settings/EditPlayer.vue
@@ -230,6 +230,7 @@
 <script setup lang="ts">
 import { computed, onBeforeUnmount, ref } from "vue";
 import { useRouter } from "vue-router";
+import { toast } from "vue-sonner";
 import { api } from "@/plugins/api";
 import {
   ConfigEntryType,
@@ -469,8 +470,7 @@ const onAction = async function (
       }
     })
     .catch((err) => {
-      // TODO: make this a bit more fancy someday
-      alert(err);
+      toast.error(String(err));
     })
     .finally(() => {
       loading.value = false;

--- a/src/views/settings/EditProvider.vue
+++ b/src/views/settings/EditProvider.vue
@@ -393,8 +393,7 @@ const onAction = async function (
       }
     })
     .catch((err) => {
-      // TODO: make this a bit more fancy someday
-      alert(err);
+      toast.error(String(err));
     })
     .finally(() => {
       loading.value = false;

--- a/src/views/settings/Providers.vue
+++ b/src/views/settings/Providers.vue
@@ -286,6 +286,7 @@ import { Plus } from "lucide-vue-next";
 import { match } from "ts-pattern";
 import { computed, inject, onBeforeUnmount, onMounted, ref, watch } from "vue";
 import { useRoute, useRouter } from "vue-router";
+import { toast } from "vue-sonner";
 import AddProviderDialog from "./AddProviderDialog.vue";
 
 // global refs
@@ -387,7 +388,7 @@ const reloadProvider = function (providerInstanceId: string) {
     .sendCommand("config/providers/reload", {
       instance_id: providerInstanceId,
     })
-    .catch((err) => alert(err));
+    .catch((err) => toast.error(String(err)));
 };
 
 const onMenu = function (evt: Event, item: ProviderConfig) {


### PR DESCRIPTION
Provider and player config flows reported auth flow-step and reload errors with native browser `alert()` dialogs, which look out of place next to the rest of the UI. This routes them through the existing sonner toast (error variant) so failures surface consistently.

The save-failure alerts in the provider config flows are intentionally left as-is here — those are handled by the dedicated error dialog in #1927.

### Changes
- `AddProviderDetails.vue` — auth flow-step (`onAction`) error → toast
- `EditProvider.vue` — auth flow-step (`onAction`) error → toast
- `EditPlayer.vue` — auth flow-step (`onAction`) error → toast
- `Providers.vue` — provider reload error → toast