### PR TITLE
Move "refresh" button to the toolbar for playlists

### DIFF
--- a/src/components/ItemsListing.vue
+++ b/src/components/ItemsListing.vue
@@ -1224,6 +1224,7 @@ const menuItems = computed(() => {
       action: onRefreshClicked,
       active: newContentAvailable.value,
       disabled: loading.value,
+      overflowAllowed: !["playlisttracks"].includes(props.itemtype),
     });
   }
 


### PR DESCRIPTION
For the specific case of the builtin playlists which are auto generated e.g. "Random Album (from library)" it is (IMHO) useful to be able to quickly flick through proposals looking for something that appeals right now.

---

Ideally this would only happen for the kind of "auto generated" playlists like "Random Album (from library)" but this is not exposed from the backend, it's not the same thing as the existing "is_dynamic" (which AIUI is to do with infinite mix). If the necessary info is available and I've missed it I'd be happy to update, I'm also happy to make a backend PR to add a field if that is necessary and preferable.

