### PR TITLE
Drop server-stripped translation fields from frontend types

### DIFF
--- a/src/components/ItemsListing.vue
+++ b/src/components/ItemsListing.vue
@@ -1757,9 +1757,8 @@ const getSortName = function (
   preferSortName = false,
 ) {
   if (!item) return "";
-  // names (incl. translated folder/media names) are resolved server-side; sort by item.name,
-  // falling back to sort_name when explicitly preferred for regular items.
-  if ("translation_key" in item && item.translation_key) return item.name;
+  // names (incl. translated folder/media names) are resolved server-side, so we sort
+  // by item.name, falling back to sort_name when explicitly preferred.
   if (preferSortName && "sort_name" in item && item.sort_name)
     return item.sort_name;
   return item.name;

--- a/src/plugins/api/interfaces.ts
+++ b/src/plugins/api/interfaces.ts
@@ -674,7 +674,6 @@ interface _MediaItemBase {
   uri: string;
   external_ids?: Array<[ExternalID, string]>;
   is_playable: boolean; // if the item is playable (can be used in play_media command)
-  translation_key?: string; // an optional translation key identifier
   media_type: MediaType;
 }
 
@@ -1096,11 +1095,11 @@ export enum ProviderStatus {
 }
 
 export interface ProviderError {
-  // Structured, localizable error describing why a provider failed to load.
+  // Structured error describing why a provider failed to load. The server
+  // localizes `message` (translation key/args are stripped server-side), so the
+  // client renders it directly.
   error_code: number;
   message: string;
-  translation_key?: string;
-  translation_args: (string | number)[];
 }
 
 export interface ProviderInstance {
@@ -1157,8 +1156,6 @@ export interface BackgroundTask {
   id: string;
   name: string;
   status: TaskStatus;
-  translation_key?: string;
-  translation_args: unknown[];
   logs: string[];
   schedule?: TaskSchedule;
   last_run?: string;


### PR DESCRIPTION
With server-owned i18n, the server resolves these fields and strips the translation key/args before they reach the client, so the frontend types still declaring them is dead surface — the fields are never present on the wire. This makes the types match how the values are already rendered.

- **`ProviderError`** — drop `translation_key`/`translation_args`; `message` arrives localized from the server.
- **`BackgroundTask`** — drop `translation_key`/`translation_args`; `name` arrives localized (the client-side translation itself was already removed in #1925).
- **Media items (`_MediaItemBase`)** — drop `translation_key` and the now-dead `getSortName` branch that read it (the field is stripped server-side, so the branch never fired).
