### PR TITLE
Keep shuffle/repeat player buttons enabled with most queues

### DIFF
--- a/src/helpers/player_menu_items.ts
+++ b/src/helpers/player_menu_items.ts
@@ -11,7 +11,10 @@ import {
   PLAYER_CONTROL_NONE,
 } from "@/plugins/api/interfaces";
 import { groupMemberPickerVisible } from "@/helpers/utils";
-import { isQueueDynamicPlaylist } from "@/plugins/api/helpers";
+import {
+  isQueueDynamicPlaylist,
+  isQueueInfiniteStream,
+} from "@/plugins/api/helpers";
 import { authManager } from "@/plugins/auth";
 import router from "@/plugins/router";
 import { eventbus } from "@/plugins/eventbus";
@@ -87,9 +90,10 @@ export const getPlayerMenuItems = (
     });
   }
   const isSingleDynamicPlaylist = isQueueDynamicPlaylist(playerQueue);
+  const isInfiniteStream = isQueueInfiniteStream(playerQueue);
 
   // add enable/disable shuffle menu item
-  if (playerQueue && !isSingleDynamicPlaylist) {
+  if (playerQueue && !isSingleDynamicPlaylist && !isInfiniteStream) {
     menuItems.push({
       label: playerQueue.shuffle_enabled ? "shuffle_disable" : "shuffle_enable",
       labelArgs: [],
@@ -103,7 +107,7 @@ export const getPlayerMenuItems = (
   }
 
   // add repeat mode item
-  if (playerQueue && !isSingleDynamicPlaylist) {
+  if (playerQueue && !isSingleDynamicPlaylist && !isInfiniteStream) {
     menuItems.push({
       label: "select_repeat_mode",
       labelArgs: [],

--- a/src/layouts/default/PlayerOSD/PlayerControlBtn/RepeatBtn.vue
+++ b/src/layouts/default/PlayerOSD/PlayerControlBtn/RepeatBtn.vue
@@ -3,13 +3,7 @@
   <Icon
     v-if="isVisible && playerQueue"
     v-bind="{ ...icon, ...$attrs }"
-    :disabled="
-      !playerQueue.active ||
-      playerQueue.items == 0 ||
-      isLoading ||
-      isSingleDynamicPlaylist ||
-      isInfiniteStream
-    "
+    :disabled="isSingleDynamicPlaylist || isInfiniteStream"
     :color="
       getValueFromSources(icon?.color, [
         [playerQueue.repeat_mode == RepeatMode.OFF, undefined],
@@ -65,12 +59,6 @@ const compProps = withDefaults(defineProps<Props>(), {
   isVisible: true,
   icon: undefined,
   size: 20,
-});
-
-const isLoading = computed(() => {
-  return (
-    compProps.playerQueue?.extra_attributes?.play_action_in_progress === true
-  );
 });
 
 const isSingleDynamicPlaylist = computed(() =>

--- a/src/layouts/default/PlayerOSD/PlayerControlBtn/ShuffleBtn.vue
+++ b/src/layouts/default/PlayerOSD/PlayerControlBtn/ShuffleBtn.vue
@@ -3,13 +3,7 @@
   <Icon
     v-if="isVisible && playerQueue"
     v-bind="{ ...icon, ...$attrs }"
-    :disabled="
-      !playerQueue.active ||
-      playerQueue.items == 0 ||
-      isLoading ||
-      isSingleDynamicPlaylist ||
-      isInfiniteStream
-    "
+    :disabled="isSingleDynamicPlaylist || isInfiniteStream"
     :color="
       getValueFromSources(icon?.color, [
         [playerQueue.shuffle_enabled, 'primary', ''],
@@ -53,12 +47,6 @@ const compProps = withDefaults(defineProps<Props>(), {
   isVisible: true,
   icon: undefined,
   size: 20,
-});
-
-const isLoading = computed(() => {
-  return (
-    compProps.playerQueue?.extra_attributes?.play_action_in_progress === true
-  );
 });
 
 const isSingleDynamicPlaylist = computed(() =>


### PR DESCRIPTION
Satisfies: https://github.com/orgs/music-assistant/discussions/5691

The player-bar shuffle and repeat buttons greyed out whenever the queue was empty, inactive or mid play-action, while the now-playing menu kept the equivalent options available. Drop those conditions so the buttons sre the same as the menu, leaving only the queue-type guards (single dynamic playlist, infinite stream) that genuinely make the controls meaningless.