### PR TITLE
Stop play button animation with external source

### DIFF
--- a/src/components/InfoHeader.vue
+++ b/src/components/InfoHeader.vue
@@ -288,11 +288,7 @@
               icon="mdi-play-circle-outline"
               :text="truncateString($t('play'), 14)"
               :disabled="!item"
-              :loading="
-                store.activePlayerQueue &&
-                store.activePlayerQueue.extra_attributes
-                  ?.play_action_in_progress === true
-              "
+              :loading="playActionInProgress"
               :open-menu-on-click="!store.activePlayer"
               style="margin-right: 8px; margin-bottom: 4px"
               @click="playButtonClick"
@@ -607,6 +603,20 @@ const backButtonClick = function () {
     name: "discover",
   });
 };
+
+// Resolve the queue playMedia targets directly, since activePlayerQueue is
+// undefined while an external source is active.
+const playActionInProgress = computed(() => {
+  const player = store.activePlayer;
+  if (!player) return false;
+  const queueId =
+    player.active_source && player.active_source in api.queues
+      ? player.active_source
+      : player.player_id;
+  return (
+    api.queues[queueId]?.extra_attributes?.play_action_in_progress === true
+  );
+});
 
 const playButtonClick = function (forceMenu = false) {
   const playButton = document.getElementById("playbutton") as HTMLElement;

--- a/src/components/MenuButton.vue
+++ b/src/components/MenuButton.vue
@@ -54,7 +54,7 @@ withDefaults(defineProps<Props>(), {
   text: undefined,
   disabled: false,
   width: 200,
-  loading: true,
+  loading: false,
 });
 
 // emitters


### PR DESCRIPTION
Fixes: https://github.com/music-assistant/support/issues/5699

With an external source playing the blue play button in the banner kept showing the loading animation because there's no active queue in that state, and the button defaulted to "loading" whenever it wasn't explicitly told otherwise.