### PR TITLE
Localize frontend-injected config entry categories

### DIFF
--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -150,6 +150,7 @@
             "web_player": "Web Player",
             "protocol_settings": "Output Protocol(s)",
             "options": "Player options",
+            "dsp": "DSP",
             "preferences": "Preferences",
             "display_settings": "Display"
         },

--- a/src/views/settings/EditPlayer.vue
+++ b/src/views/settings/EditPlayer.vue
@@ -247,7 +247,11 @@ import ProviderIcon from "@/components/ProviderIcon.vue";
 import { watch } from "vue";
 
 import { nanoid } from "nanoid";
-import { ConfigEntryUI, UI_ENTRY_TYPE } from "@/helpers/config_entry_ui";
+import {
+  ConfigEntryUI,
+  UI_ENTRY_TYPE,
+  isInjected,
+} from "@/helpers/config_entry_ui";
 import { openLinkInNewTab } from "@/helpers/utils";
 import { $t } from "@/plugins/i18n";
 // global refs
@@ -348,6 +352,16 @@ const config_entries = computed(() => {
       category: "options",
       injected: true,
     });
+  }
+  // Frontend-injected entries need their category heading translated here
+  // (server-provided entries get category_label resolved server-side).
+  for (const entry of entries) {
+    if (isInjected(entry) && entry.category) {
+      entry.category_label = $t(
+        `settings.category.${entry.category}`,
+        entry.category,
+      );
+    }
   }
   return entries;
 });


### PR DESCRIPTION
Config entry category headings come pre-translated from the server, but entries that the frontend injects on its own (the DSP shortcut, the multi-device DSP notes and the player options link) showed their raw category key (e.g. `dsp`, `options`) as the section heading. Only server-provided entries get their `category_label` resolved server-side, so the injected ones had no localized heading.

## Changes

- Resolve `category_label` for frontend-injected config entries from the `settings.category.*` translations in `EditPlayer.vue`, falling back to the raw category key when a translation is missing.
- Add the missing `settings.category.dsp` translation key.
