### PR TITLE
Add crossfade control to the player and a per-queue settings page

### DIFF
--- a/src/helpers/player_menu_items.ts
+++ b/src/helpers/player_menu_items.ts
@@ -269,7 +269,9 @@ export const getPlayerMenuItems = (
       action: () => {
         store.showFullscreenPlayer = false;
         store.showPlayersMenu = false;
-        router.push(`/settings/editqueue/${player.player_id}`);
+        router.push(
+          `/settings/editqueue/${playerQueue?.queue_id ?? player.player_id}`,
+        );
       },
       icon: "mdi-cog-outline",
     });

--- a/src/helpers/player_menu_items.ts
+++ b/src/helpers/player_menu_items.ts
@@ -261,15 +261,15 @@ export const getPlayerMenuItems = (
       icon: "mdi-all-inclusive",
     });
   }
-  // add player settings (admin only)
+  // add queue settings (admin only)
   if (authManager.isAdmin()) {
     menuItems.push({
-      label: "open_player_settings",
+      label: "open_queue_settings",
       labelArgs: [],
       action: () => {
         store.showFullscreenPlayer = false;
         store.showPlayersMenu = false;
-        router.push(`/settings/editplayer/${player.player_id}`);
+        router.push(`/settings/editqueue/${player.player_id}`);
       },
       icon: "mdi-cog-outline",
     });

--- a/src/layouts/default/PlayerOSD/PlayerControlBtn/CrossfadeBtn.vue
+++ b/src/layouts/default/PlayerOSD/PlayerControlBtn/CrossfadeBtn.vue
@@ -1,5 +1,5 @@
 <template>
-  <!-- crossfade button: cycles disabled -> standard -> smart (if available) -> disabled -->
+  <!-- crossfade on/off toggle (shows a "magic" icon when smart fades are active) -->
   <Icon
     v-if="isVisible && playerQueue"
     v-bind="{ ...icon, ...$attrs }"
@@ -10,14 +10,16 @@
       isSingleDynamicPlaylist ||
       isInfiniteStream
     "
-    :color="crossfadeMode != CrossfadeMode.DISABLED ? 'primary' : icon?.color"
+    :color="playerQueue.crossfade_enabled ? 'primary' : icon?.color"
     variant="button"
-    @click="cycleCrossfade"
+    @click="
+      api.queueCommandCrossfade(
+        playerQueue.queue_id,
+        !playerQueue.crossfade_enabled,
+      )
+    "
   >
-    <Sparkles
-      v-if="crossfadeMode == CrossfadeMode.SMART_CROSSFADE"
-      :size="size"
-    />
+    <Sparkles v-if="smartFadesActive" :size="size" />
     <Blend v-else :size="size" />
   </Icon>
 </template>
@@ -26,7 +28,7 @@
 defineOptions({ inheritAttrs: false });
 import Icon, { IconProps } from "@/components/Icon.vue";
 import api from "@/plugins/api";
-import { CrossfadeMode, PlayerQueue } from "@/plugins/api/interfaces";
+import { PlayerQueue } from "@/plugins/api/interfaces";
 import {
   isQueueDynamicPlaylist,
   isQueueInfiniteStream,
@@ -47,8 +49,11 @@ const compProps = withDefaults(defineProps<Props>(), {
   size: 20,
 });
 
-const crossfadeMode = computed(
-  () => compProps.playerQueue?.crossfade_mode ?? CrossfadeMode.DISABLED,
+// smart fades are "active" when crossfade is on and smart fades are available
+const smartFadesActive = computed(
+  () =>
+    !!compProps.playerQueue?.crossfade_enabled &&
+    !!compProps.playerQueue?.smart_fades_available,
 );
 
 const isLoading = computed(() => {
@@ -64,21 +69,4 @@ const isSingleDynamicPlaylist = computed(() =>
 const isInfiniteStream = computed(() =>
   isQueueInfiniteStream(compProps.playerQueue),
 );
-
-const cycleCrossfade = function () {
-  const queue = compProps.playerQueue;
-  if (!queue) return;
-  // cycle to the next mode, skipping smart crossfade when it is not available
-  let nextMode: CrossfadeMode;
-  if (crossfadeMode.value == CrossfadeMode.DISABLED) {
-    nextMode = CrossfadeMode.STANDARD_CROSSFADE;
-  } else if (crossfadeMode.value == CrossfadeMode.STANDARD_CROSSFADE) {
-    nextMode = queue.smart_fades_available
-      ? CrossfadeMode.SMART_CROSSFADE
-      : CrossfadeMode.DISABLED;
-  } else {
-    nextMode = CrossfadeMode.DISABLED;
-  }
-  api.queueCommandCrossfade(queue.queue_id, nextMode);
-};
 </script>

--- a/src/layouts/default/PlayerOSD/PlayerControlBtn/CrossfadeBtn.vue
+++ b/src/layouts/default/PlayerOSD/PlayerControlBtn/CrossfadeBtn.vue
@@ -28,7 +28,7 @@
 defineOptions({ inheritAttrs: false });
 import Icon, { IconProps } from "@/components/Icon.vue";
 import api from "@/plugins/api";
-import { PlayerQueue } from "@/plugins/api/interfaces";
+import { CrossfadeMode, PlayerQueue } from "@/plugins/api/interfaces";
 import {
   isQueueDynamicPlaylist,
   isQueueInfiniteStream,
@@ -49,11 +49,9 @@ const compProps = withDefaults(defineProps<Props>(), {
   size: 20,
 });
 
-// smart fades are "active" when crossfade is on and smart fades are available
+// smart fades are "active" when the effective crossfade mode is smart crossfade
 const smartFadesActive = computed(
-  () =>
-    !!compProps.playerQueue?.crossfade_enabled &&
-    !!compProps.playerQueue?.smart_fades_available,
+  () => compProps.playerQueue?.crossfade_mode === CrossfadeMode.SMART_CROSSFADE,
 );
 
 const isLoading = computed(() => {

--- a/src/layouts/default/PlayerOSD/PlayerControlBtn/CrossfadeBtn.vue
+++ b/src/layouts/default/PlayerOSD/PlayerControlBtn/CrossfadeBtn.vue
@@ -1,7 +1,9 @@
 <template>
   <!-- crossfade on/off toggle (shows a "magic" icon when smart fades are active) -->
   <Icon
-    v-if="isVisible && playerQueue"
+    v-if="
+      isVisible && playerQueue && playerQueue.crossfade_enabled !== undefined
+    "
     v-bind="{ ...icon, ...$attrs }"
     :disabled="
       !playerQueue.active ||

--- a/src/layouts/default/PlayerOSD/PlayerControlBtn/CrossfadeBtn.vue
+++ b/src/layouts/default/PlayerOSD/PlayerControlBtn/CrossfadeBtn.vue
@@ -1,9 +1,7 @@
 <template>
   <!-- crossfade on/off toggle (shows a "magic" icon when smart fades are active) -->
   <Icon
-    v-if="
-      isVisible && playerQueue && playerQueue.crossfade_enabled !== undefined
-    "
+    v-if="isVisible && playerQueue"
     v-bind="{ ...icon, ...$attrs }"
     :disabled="
       !playerQueue.active ||

--- a/src/layouts/default/PlayerOSD/PlayerControlBtn/CrossfadeBtn.vue
+++ b/src/layouts/default/PlayerOSD/PlayerControlBtn/CrossfadeBtn.vue
@@ -1,0 +1,84 @@
+<template>
+  <!-- crossfade button: cycles disabled -> standard -> smart (if available) -> disabled -->
+  <Icon
+    v-if="isVisible && playerQueue"
+    v-bind="{ ...icon, ...$attrs }"
+    :disabled="
+      !playerQueue.active ||
+      playerQueue.items == 0 ||
+      isLoading ||
+      isSingleDynamicPlaylist ||
+      isInfiniteStream
+    "
+    :color="crossfadeMode != CrossfadeMode.DISABLED ? 'primary' : icon?.color"
+    variant="button"
+    @click="cycleCrossfade"
+  >
+    <Sparkles
+      v-if="crossfadeMode == CrossfadeMode.SMART_CROSSFADE"
+      :size="size"
+    />
+    <Blend v-else :size="size" />
+  </Icon>
+</template>
+
+<script setup lang="ts">
+defineOptions({ inheritAttrs: false });
+import Icon, { IconProps } from "@/components/Icon.vue";
+import api from "@/plugins/api";
+import { CrossfadeMode, PlayerQueue } from "@/plugins/api/interfaces";
+import {
+  isQueueDynamicPlaylist,
+  isQueueInfiniteStream,
+} from "@/plugins/api/helpers";
+import { computed } from "vue";
+import { Blend, Sparkles } from "lucide-vue-next";
+
+// properties
+export interface Props {
+  playerQueue: PlayerQueue | undefined;
+  isVisible?: boolean;
+  icon?: IconProps;
+  size?: number;
+}
+const compProps = withDefaults(defineProps<Props>(), {
+  isVisible: true,
+  icon: undefined,
+  size: 20,
+});
+
+const crossfadeMode = computed(
+  () => compProps.playerQueue?.crossfade_mode ?? CrossfadeMode.DISABLED,
+);
+
+const isLoading = computed(() => {
+  return (
+    compProps.playerQueue?.extra_attributes?.play_action_in_progress === true
+  );
+});
+
+const isSingleDynamicPlaylist = computed(() =>
+  isQueueDynamicPlaylist(compProps.playerQueue),
+);
+
+const isInfiniteStream = computed(() =>
+  isQueueInfiniteStream(compProps.playerQueue),
+);
+
+const cycleCrossfade = function () {
+  const queue = compProps.playerQueue;
+  if (!queue) return;
+  // cycle to the next mode, skipping smart crossfade when it is not available
+  let nextMode: CrossfadeMode;
+  if (crossfadeMode.value == CrossfadeMode.DISABLED) {
+    nextMode = CrossfadeMode.STANDARD_CROSSFADE;
+  } else if (crossfadeMode.value == CrossfadeMode.STANDARD_CROSSFADE) {
+    nextMode = queue.smart_fades_available
+      ? CrossfadeMode.SMART_CROSSFADE
+      : CrossfadeMode.DISABLED;
+  } else {
+    nextMode = CrossfadeMode.DISABLED;
+  }
+  api.queueCommandCrossfade(queue.queue_id, nextMode);
+};
+</script>

--- a/src/layouts/default/PlayerOSD/PlayerControlBtn/CrossfadeBtn.vue
+++ b/src/layouts/default/PlayerOSD/PlayerControlBtn/CrossfadeBtn.vue
@@ -28,7 +28,7 @@
 defineOptions({ inheritAttrs: false });
 import Icon, { IconProps } from "@/components/Icon.vue";
 import api from "@/plugins/api";
-import { CrossfadeMode, PlayerQueue } from "@/plugins/api/interfaces";
+import { PlayerQueue } from "@/plugins/api/interfaces";
 import {
   isQueueDynamicPlaylist,
   isQueueInfiniteStream,
@@ -49,9 +49,9 @@ const compProps = withDefaults(defineProps<Props>(), {
   size: 20,
 });
 
-// smart fades are "active" when the effective crossfade mode is smart crossfade
+// smart fades are "active" when the server reports the effective crossfade is smart crossfade
 const smartFadesActive = computed(
-  () => compProps.playerQueue?.crossfade_mode === CrossfadeMode.SMART_CROSSFADE,
+  () => compProps.playerQueue?.smart_fades_active === true,
 );
 
 const isLoading = computed(() => {

--- a/src/layouts/default/PlayerOSD/PlayerFullscreen.vue
+++ b/src/layouts/default/PlayerOSD/PlayerFullscreen.vue
@@ -513,6 +513,12 @@
             class="media-controls-item"
             max-height="35px"
           />
+          <CrossfadeBtn
+            v-if="$vuetify.display.mdAndUp"
+            :player-queue="store.activePlayerQueue"
+            class="media-controls-item"
+            max-height="30px"
+          />
           <div class="media-controls-item queue-btn-wrapper">
             <QueueBtn
               v-if="store.activePlayerQueue"
@@ -593,6 +599,7 @@ import {
 import NextBtn from "@/layouts/default/PlayerOSD/PlayerControlBtn/NextBtn.vue";
 import PlayBtn from "@/layouts/default/PlayerOSD/PlayerControlBtn/PlayBtn.vue";
 import PreviousBtn from "@/layouts/default/PlayerOSD/PlayerControlBtn/PreviousBtn.vue";
+import CrossfadeBtn from "@/layouts/default/PlayerOSD/PlayerControlBtn/CrossfadeBtn.vue";
 import RepeatBtn from "@/layouts/default/PlayerOSD/PlayerControlBtn/RepeatBtn.vue";
 import ShuffleBtn from "@/layouts/default/PlayerOSD/PlayerControlBtn/ShuffleBtn.vue";
 import PlayerVolume from "@/layouts/default/PlayerOSD/PlayerVolume.vue";

--- a/src/plugins/api/index.ts
+++ b/src/plugins/api/index.ts
@@ -35,6 +35,7 @@ import {
   ConfigEntry,
   ConfigValueType,
   CoreConfig,
+  CrossfadeMode,
   DSPConfig,
   DSPConfigPreset,
   EventType,
@@ -43,6 +44,7 @@ import {
   MediaType,
   PlayableMediaItemType,
   PlayerConfig,
+  PlayerQueueConfig,
   Podcast,
   PodcastEpisode,
   ProviderConfig,
@@ -1555,6 +1557,10 @@ export class MusicAssistantApi {
       this.queueCommandRepeat(queueId, RepeatMode.OFF);
     }
   }
+  public queueCommandCrossfade(queueId: string, crossfade_mode: CrossfadeMode) {
+    // Configure crossfade setting on the queue.
+    this.playerQueueCommand(queueId, "crossfade", { crossfade_mode });
+  }
   public queueCommandDontStopTheMusic(
     queueId: string,
     dont_stop_the_music_enabled: boolean,
@@ -2014,6 +2020,39 @@ export class MusicAssistantApi {
     // remove the configuration of a player
     return this.sendCommand("config/players/remove", {
       player_id,
+    });
+  }
+
+  // PlayerQueue Config related functions
+
+  public async getPlayerQueueConfig(
+    queue_id: string,
+  ): Promise<PlayerQueueConfig> {
+    // Return configuration for a single queue.
+    return this.sendCommand("config/player_queues/get", { queue_id });
+  }
+
+  public async getPlayerQueueConfigEntries(
+    queue_id: string,
+    action?: string,
+    values?: Record<string, ConfigValueType>,
+  ): Promise<ConfigEntry[]> {
+    // Return Config entries to configure a queue.
+    return this.sendCommand("config/player_queues/get_entries", {
+      queue_id,
+      action,
+      values,
+    });
+  }
+
+  public async savePlayerQueueConfig(
+    queue_id: string,
+    values: Record<string, ConfigValueType>,
+  ): Promise<PlayerQueueConfig> {
+    // Save/update PlayerQueueConfig.
+    return this.sendCommand("config/player_queues/save", {
+      queue_id,
+      values,
     });
   }
 

--- a/src/plugins/api/index.ts
+++ b/src/plugins/api/index.ts
@@ -35,7 +35,6 @@ import {
   ConfigEntry,
   ConfigValueType,
   CoreConfig,
-  CrossfadeMode,
   DSPConfig,
   DSPConfigPreset,
   EventType,
@@ -1557,9 +1556,16 @@ export class MusicAssistantApi {
       this.queueCommandRepeat(queueId, RepeatMode.OFF);
     }
   }
-  public queueCommandCrossfade(queueId: string, crossfade_mode: CrossfadeMode) {
-    // Configure crossfade setting on the queue.
-    this.playerQueueCommand(queueId, "crossfade", { crossfade_mode });
+  public queueCommandCrossfade(queueId: string, crossfade_enabled: boolean) {
+    // Enable or disable crossfade on the queue.
+    this.playerQueueCommand(queueId, "crossfade", { crossfade_enabled });
+  }
+  public queueCommandCrossfadeToggle(queueId: string) {
+    // Toggle crossfade on/off for a queue
+    this.queueCommandCrossfade(
+      queueId,
+      !this.queues[queueId].crossfade_enabled,
+    );
   }
   public queueCommandDontStopTheMusic(
     queueId: string,

--- a/src/plugins/api/interfaces.ts
+++ b/src/plugins/api/interfaces.ts
@@ -257,12 +257,6 @@ export enum RepeatMode {
   ALL = "all", // repeat entire queue
 }
 
-export enum CrossfadeMode {
-  DISABLED = "disabled", // no crossfade
-  STANDARD_CROSSFADE = "standard_crossfade", // standard crossfade only
-  SMART_CROSSFADE = "smart_crossfade", // smart crossfade with beat matching and EQ filters
-}
-
 export enum PlaybackState {
   IDLE = "idle",
   PAUSED = "paused",
@@ -886,8 +880,9 @@ export interface PlayerQueue {
   shuffle_enabled: boolean;
   dont_stop_the_music_enabled: boolean;
   repeat_mode: RepeatMode;
-  crossfade_mode?: CrossfadeMode;
-  // smart_fades_available: whether the smart_crossfade option can be selected (server-derived)
+  crossfade_enabled?: boolean;
+  // smart_fades_available: whether smart crossfade is currently usable (server-derived); lets
+  // clients show a "smart fades" indicator when crossfade is on and smart fades are available
   smart_fades_available?: boolean;
   current_index?: number;
   index_in_buffer?: number;

--- a/src/plugins/api/interfaces.ts
+++ b/src/plugins/api/interfaces.ts
@@ -257,6 +257,12 @@ export enum RepeatMode {
   ALL = "all", // repeat entire queue
 }
 
+export enum CrossfadeMode {
+  DISABLED = "disabled", // no crossfade
+  STANDARD_CROSSFADE = "standard_crossfade", // standard crossfade
+  SMART_CROSSFADE = "smart_crossfade", // smart crossfade (beat-matched)
+}
+
 export enum PlaybackState {
   IDLE = "idle",
   PAUSED = "paused",
@@ -881,9 +887,9 @@ export interface PlayerQueue {
   dont_stop_the_music_enabled: boolean;
   repeat_mode: RepeatMode;
   crossfade_enabled?: boolean;
-  // smart_fades_available: whether smart crossfade is currently usable (server-derived); lets
-  // clients show a "smart fades" indicator when crossfade is on and smart fades are available
-  smart_fades_available?: boolean;
+  // crossfade_mode: effective crossfade state (disabled/standard/smart), server-derived and
+  // read-only. Use crossfade_enabled to toggle; use this to display the active state.
+  crossfade_mode?: CrossfadeMode;
   current_index?: number;
   index_in_buffer?: number;
   elapsed_time: number;

--- a/src/plugins/api/interfaces.ts
+++ b/src/plugins/api/interfaces.ts
@@ -257,12 +257,6 @@ export enum RepeatMode {
   ALL = "all", // repeat entire queue
 }
 
-export enum CrossfadeMode {
-  DISABLED = "disabled", // no crossfade
-  STANDARD_CROSSFADE = "standard_crossfade", // standard crossfade
-  SMART_CROSSFADE = "smart_crossfade", // smart crossfade (beat-matched)
-}
-
 export enum PlaybackState {
   IDLE = "idle",
   PAUSED = "paused",
@@ -887,9 +881,9 @@ export interface PlayerQueue {
   dont_stop_the_music_enabled: boolean;
   repeat_mode: RepeatMode;
   crossfade_enabled?: boolean;
-  // crossfade_mode: effective crossfade state (disabled/standard/smart), server-derived and
-  // read-only. Use crossfade_enabled to toggle; use this to display the active state.
-  crossfade_mode?: CrossfadeMode;
+  // smart_fades_active: whether the effective crossfade is currently smart crossfade (server-derived,
+  // read-only). Lets clients show a smart-fades indicator when crossfade is on and smart is active.
+  smart_fades_active?: boolean;
   current_index?: number;
   index_in_buffer?: number;
   elapsed_time: number;

--- a/src/plugins/api/interfaces.ts
+++ b/src/plugins/api/interfaces.ts
@@ -513,6 +513,8 @@ export interface ConfigValueOption {
   value: ConfigValueType;
   // disabled: when true the option is shown but not selectable (currently unavailable)
   disabled?: boolean;
+  // disabled_reason: optional explanation of why the option is disabled
+  disabled_reason?: string;
 }
 
 export interface ConfigEntry {

--- a/src/plugins/api/interfaces.ts
+++ b/src/plugins/api/interfaces.ts
@@ -511,6 +511,8 @@ export interface ConfigValueOption {
   // Model for a value with separated name/value.
   title: string;
   value: ConfigValueType;
+  // disabled: when true the option is shown but not selectable (currently unavailable)
+  disabled?: boolean;
 }
 
 export interface ConfigEntry {

--- a/src/plugins/api/interfaces.ts
+++ b/src/plugins/api/interfaces.ts
@@ -884,10 +884,10 @@ export interface PlayerQueue {
   shuffle_enabled: boolean;
   dont_stop_the_music_enabled: boolean;
   repeat_mode: RepeatMode;
-  crossfade_enabled?: boolean;
+  crossfade_enabled: boolean;
   // smart_fades_active: whether the effective crossfade is currently smart crossfade (server-derived,
   // read-only). Lets clients show a smart-fades indicator when crossfade is on and smart is active.
-  smart_fades_active?: boolean;
+  smart_fades_active: boolean;
   current_index?: number;
   index_in_buffer?: number;
   elapsed_time: number;

--- a/src/plugins/api/interfaces.ts
+++ b/src/plugins/api/interfaces.ts
@@ -257,6 +257,12 @@ export enum RepeatMode {
   ALL = "all", // repeat entire queue
 }
 
+export enum CrossfadeMode {
+  DISABLED = "disabled", // no crossfade
+  STANDARD_CROSSFADE = "standard_crossfade", // standard crossfade only
+  SMART_CROSSFADE = "smart_crossfade", // smart crossfade with beat matching and EQ filters
+}
+
 export enum PlaybackState {
   IDLE = "idle",
   PAUSED = "paused",
@@ -603,6 +609,11 @@ export interface CoreConfig extends Config {
   last_error?: string;
 }
 
+export interface PlayerQueueConfig extends Config {
+  // PlayerQueue Configuration.
+  queue_id: string;
+}
+
 //// media_items
 
 export interface ProviderMapping {
@@ -875,6 +886,9 @@ export interface PlayerQueue {
   shuffle_enabled: boolean;
   dont_stop_the_music_enabled: boolean;
   repeat_mode: RepeatMode;
+  crossfade_mode?: CrossfadeMode;
+  // smart_fades_available: whether the smart_crossfade option can be selected (server-derived)
+  smart_fades_available?: boolean;
   current_index?: number;
   index_in_buffer?: number;
   elapsed_time: number;

--- a/src/plugins/router.ts
+++ b/src/plugins/router.ts
@@ -478,6 +478,16 @@ const routes: RouteRecordRaw[] = [
             meta: { requiresAdmin: true },
           },
           {
+            path: "editqueue/:queueId",
+            name: "editqueue",
+            component: () =>
+              import(
+                /* webpackChunkName: "editqueue" */ "@/views/settings/EditPlayerQueue.vue"
+              ),
+            props: true,
+            meta: { requiresAdmin: true },
+          },
+          {
             path: "editcore/:domain",
             name: "editcore",
             component: () =>

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -121,6 +121,7 @@
         "provider_disabled": "This provider entry is disabled",
         "provider_name": "Custom name for this provider entry",
         "providers": "Providers",
+        "queue_settings": "Queue settings",
         "reload": "Reload",
         "save": "Save",
         "settings": "Settings",
@@ -671,7 +672,7 @@
     "power_off_player": "Power off",
     "powered_off_players": "Unpowered players",
     "sync_player_with": "Synchronize with another player",
-    "open_player_settings": "Open settings",
+    "open_queue_settings": "Open queue settings",
     "select_repeat_mode": "Select repeat mode",
     "repeat_mode": {
         "all": "Repeat entire queue",

--- a/src/views/settings/ConfigEntryField.vue
+++ b/src/views/settings/ConfigEntryField.vue
@@ -178,6 +178,7 @@
           title: item.title,
           value: item.value,
           disabled: item.disabled,
+          subtitle: item.disabled ? item.disabled_reason : undefined,
         })
       "
       :disabled="isFieldDisabled"
@@ -346,6 +347,7 @@ const displayOptions = computed(() => {
       title: orgOption.title?.toString() || orgOption.value?.toString() || "",
       value: orgOption.value,
       disabled: orgOption.disabled,
+      disabled_reason: orgOption.disabled_reason,
     };
     if (option.value == props.confEntry.default_value) {
       option.title += ` [${$t("settings.default")}]`;

--- a/src/views/settings/ConfigEntryField.vue
+++ b/src/views/settings/ConfigEntryField.vue
@@ -173,6 +173,13 @@
       :clearable="true"
       :multiple="confEntry.multi_value"
       :items="displayOptions"
+      :item-props="
+        (item) => ({
+          title: item.title,
+          value: item.value,
+          disabled: item.disabled,
+        })
+      "
       :disabled="isFieldDisabled"
       :label="displayLabel()"
       :required="confEntry.required"
@@ -338,6 +345,7 @@ const displayOptions = computed(() => {
     const option: ConfigValueOption = {
       title: orgOption.title?.toString() || orgOption.value?.toString() || "",
       value: orgOption.value,
+      disabled: orgOption.disabled,
     };
     if (option.value == props.confEntry.default_value) {
       option.title += ` [${$t("settings.default")}]`;

--- a/src/views/settings/EditPlayerQueue.vue
+++ b/src/views/settings/EditPlayerQueue.vue
@@ -1,0 +1,158 @@
+<template>
+  <section class="edit-queue-config">
+    <v-card class="header-card mb-4" elevation="0">
+      <div class="header-content">
+        <div class="header-icon">
+          <v-icon size="32" color="primary">mdi-tune</v-icon>
+        </div>
+        <div class="header-info">
+          <h2 class="header-title">{{ $t("settings.queue_settings") }}</h2>
+          <p class="header-description">{{ queueName }}</p>
+        </div>
+      </div>
+    </v-card>
+
+    <edit-config
+      v-if="config"
+      :config-entries="allConfigEntries"
+      :disabled="false"
+      @submit="onSubmit"
+      @immediate-apply="onImmediateApply"
+    />
+
+    <v-overlay
+      v-model="loading"
+      scrim="true"
+      persistent
+      class="loading-overlay"
+    >
+      <v-progress-circular indeterminate size="64" color="primary" />
+    </v-overlay>
+  </section>
+</template>
+
+<script setup lang="ts">
+import { api } from "@/plugins/api";
+import { ConfigValueType, PlayerQueueConfig } from "@/plugins/api/interfaces";
+import { computed, ref, watch } from "vue";
+import { useRouter } from "vue-router";
+import { toast } from "vue-sonner";
+import EditConfig from "./EditConfig.vue";
+
+// global refs
+const router = useRouter();
+const config = ref<PlayerQueueConfig>();
+const loading = ref(false);
+
+// props
+const props = defineProps<{
+  queueId?: string;
+}>();
+
+// computed properties
+const allConfigEntries = computed(() => {
+  if (!config.value) return [];
+  return Object.values(config.value.values);
+});
+
+const queueName = computed(
+  () => api.queues[props.queueId || ""]?.display_name || props.queueId,
+);
+
+// watchers
+watch(
+  () => props.queueId,
+  async (val) => {
+    if (val) {
+      config.value = await api.getPlayerQueueConfig(val);
+    }
+  },
+  { immediate: true },
+);
+
+// methods
+const onSubmit = async function (values: Record<string, ConfigValueType>) {
+  loading.value = true;
+  api
+    .savePlayerQueueConfig(props.queueId!, values)
+    .then(() => {
+      router.back();
+    })
+    .catch((err) => {
+      toast.error(err.message || err);
+    })
+    .finally(() => {
+      loading.value = false;
+    });
+};
+
+const onImmediateApply = async function (
+  values: Record<string, ConfigValueType>,
+) {
+  // immediately apply a config value change and refresh from the server response
+  const updatedConfig = await api.savePlayerQueueConfig(props.queueId!, values);
+  for (const [key, entry] of Object.entries(updatedConfig.values)) {
+    config.value!.values[key] = entry;
+  }
+};
+</script>
+
+<style scoped>
+.edit-queue-config {
+  padding: 16px;
+}
+
+.header-card {
+  border: 1px solid rgba(var(--v-theme-on-surface), 0.12);
+  border-radius: 12px;
+}
+
+.header-content {
+  display: flex;
+  gap: 20px;
+  padding: 24px;
+}
+
+.header-icon {
+  flex-shrink: 0;
+  width: 56px;
+  height: 56px;
+  border-radius: 12px;
+  background: rgba(var(--v-theme-primary), 0.1);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.header-info {
+  flex: 1;
+  min-width: 0;
+}
+
+.header-title {
+  font-size: 1.25rem;
+  font-weight: 600;
+  margin: 0 0 8px 0;
+  color: rgb(var(--v-theme-on-surface));
+}
+
+.header-description {
+  font-size: 0.875rem;
+  color: rgba(var(--v-theme-on-surface), 0.7);
+  margin: 0;
+  line-height: 1.5;
+}
+
+.loading-overlay {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+@media (max-width: 600px) {
+  .header-content {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+}
+</style>

--- a/src/views/settings/EditPlayerQueue.vue
+++ b/src/views/settings/EditPlayerQueue.vue
@@ -90,10 +90,16 @@ const onImmediateApply = async function (
   values: Record<string, ConfigValueType>,
 ) {
   // immediately apply a config value change and refresh from the server response
-  const updatedConfig = await api.savePlayerQueueConfig(props.queueId!, values);
-  for (const [key, entry] of Object.entries(updatedConfig.values)) {
-    config.value!.values[key] = entry;
-  }
+  await api
+    .savePlayerQueueConfig(props.queueId!, values)
+    .then((updatedConfig) => {
+      for (const [key, entry] of Object.entries(updatedConfig.values)) {
+        config.value!.values[key] = entry;
+      }
+    })
+    .catch((err) => {
+      toast.error(err.message || err);
+    });
 };
 </script>
 


### PR DESCRIPTION
Frontend for the queue-scoped crossfade work (companion to music-assistant/server#4373 and music-assistant/models#269). Crossfade is now a per-play on/off toggle on the queue, and the queue's "set and forget" settings get their own page.

- Adds a crossfade on/off button to the fullscreen player (like shuffle/repeat), with a "magic" sparkle icon when smart fades are active (driven by the server-derived `smart_fades_active`).
- The player context menu's settings entry now opens a new dedicated per-queue settings page (standard crossfade duration, prefer smart fades, volume normalization) instead of the player settings.
- Adds the `PlayerQueue.crossfade_enabled` / `smart_fades_active` fields, the `PlayerQueueConfig` type, and the `config/player_queues/*` + `player_queues/crossfade` API client methods.

Requires the server and models companion PRs.