### PR TITLE
Always expand players when clicking the player button from the 'now playing' screen (#60)

### DIFF
--- a/src/layouts/default/PlayerSelect.vue
+++ b/src/layouts/default/PlayerSelect.vue
@@ -189,7 +189,9 @@ const preferredPlayers = computed(() => {
 watch(
   () => store.showPlayersMenu,
   (newVal) => {
-    if (!newVal) {
+    if (newVal) {
+      showSubPlayers.value = true;
+    } else {
       // Save preferences and reset state when menu closes
       playerSearchQuery.value = "";
       if (store.activePlayerId) {


### PR DESCRIPTION
This PR addresses the issue reported in [_Always expand players when clicking the player button from the 'now playing' screen
 #60_](https://github.com/music-assistant/backlog/issues/60)
 
 ### Result:
 
https://github.com/user-attachments/assets/942a89dd-65a7-4ef5-a93f-951ffd6b93aa


### What changed
Minimal change in **PlayerSelect.vue** that enables the auto expand when clicking the player button. Manual collapse/expand via the expand toggle still works as before.