### PR TITLE
Genre media type filtering

### DIFF
--- a/src/components/ItemsListing.vue
+++ b/src/components/ItemsListing.vue
@@ -294,6 +294,7 @@ export interface LoadDataParams {
   refresh?: boolean;
   albumType?: string[];
   provider?: string[];
+  genreContentTypeFilter?: MediaType;
 }
 // properties
 export interface Props {
@@ -329,6 +330,7 @@ export interface Props {
   emptyMessage?: string;
   showLibraryOnlyFilter?: boolean;
   showGenreFilter?: boolean;
+  showGenreContentTypeFilter?: boolean;
   showHideEmptyFilter?: boolean;
   showHideFullyPlayedFilter?: boolean;
   allowCollapse?: boolean;
@@ -375,6 +377,7 @@ const props = withDefaults(defineProps<Props>(), {
   subtitle: undefined,
   showLibraryOnlyFilter: false,
   showGenreFilter: false,
+  showGenreContentTypeFilter: false,
   showHideEmptyFilter: false,
   showHideFullyPlayedFilter: false,
   extraMenuItems: undefined,
@@ -593,6 +596,19 @@ const toggleHideEmptyFilter = function () {
     props.itemtype,
     "hideEmptyFilter",
     params.value.hideEmptyFilter,
+  );
+  loadData(undefined, undefined, true);
+};
+
+const changeGenreContentTypeFilter = function (mediaType?: MediaType) {
+  // single-select: clicking the active type clears it back to "all"
+  params.value.genreContentTypeFilter =
+    params.value.genreContentTypeFilter === mediaType ? undefined : mediaType;
+  setItemsListingPreference(
+    props.path || props.itemtype,
+    props.itemtype,
+    "genreContentTypeFilter",
+    params.value.genreContentTypeFilter,
   );
   loadData(undefined, undefined, true);
 };
@@ -865,6 +881,7 @@ const hasActiveFilters = computed(() => {
     // a required selector always has a provider chosen — that is not a "filter"
     (!props.requireProviderSelection && p.provider && p.provider.length > 0) ||
     (p.albumType && p.albumType.length > 0) ||
+    Boolean(p.genreContentTypeFilter) ||
     genreActive ||
     // hide-empty genres filter: true (hide empty) and null (defaults only)
     // both narrow the result; false/undefined means "show all"
@@ -1167,6 +1184,31 @@ const menuItems = computed(() => {
     });
   }
 
+  // genre content-type filter (music / audiobooks / podcasts)
+  if (props.showGenreContentTypeFilter === true) {
+    const active = params.value.genreContentTypeFilter;
+    items.push({
+      label: "tooltip.genre_content_type",
+      icon: "mdi-bookshelf",
+      disabled: loading.value,
+      active: !!active,
+      closeOnContentClick: true,
+      overflowAllowed: true,
+      subItems: [
+        { label: "genre_content_type.audiobooks", value: MediaType.AUDIOBOOK },
+        { label: "genre_content_type.podcasts", value: MediaType.PODCAST },
+      ].map((entry) => {
+        return {
+          label: entry.label,
+          selected: active === entry.value,
+          action: () => {
+            changeGenreContentTypeFilter(entry.value);
+          },
+        };
+      }),
+    });
+  }
+
   // album type filter
   if (props.showAlbumTypeFilter) {
     items.push({
@@ -1466,6 +1508,14 @@ const restoreSettings = async function () {
   // get stored/default albumType filter for this itemtype
   if (props.showAlbumTypeFilter === true && prefs.albumType) {
     params.value.albumType = prefs.albumType;
+  }
+
+  // get stored genre content-type filter for this itemtype
+  if (
+    props.showGenreContentTypeFilter === true &&
+    prefs.genreContentTypeFilter
+  ) {
+    params.value.genreContentTypeFilter = prefs.genreContentTypeFilter;
   }
 
   // get stored/default provider filter for this itemtype

--- a/src/components/ItemsListing.vue
+++ b/src/components/ItemsListing.vue
@@ -1195,6 +1195,7 @@ const menuItems = computed(() => {
       closeOnContentClick: true,
       overflowAllowed: true,
       subItems: [
+        { label: "genre_content_type.all", value: undefined },
         { label: "genre_content_type.audiobooks", value: MediaType.AUDIOBOOK },
         { label: "genre_content_type.podcasts", value: MediaType.PODCAST },
       ].map((entry) => {

--- a/src/composables/userPreferences.ts
+++ b/src/composables/userPreferences.ts
@@ -1,5 +1,6 @@
 import { computed, ComputedRef } from "vue";
 import { api } from "@/plugins/api";
+import { MediaType } from "@/plugins/api/interfaces";
 import { store } from "@/plugins/store";
 
 export interface ItemsListingPreferences {
@@ -12,6 +13,7 @@ export interface ItemsListingPreferences {
   hideFullyPlayedFilter?: boolean;
   albumType?: string[];
   providerFilter?: string[];
+  genreContentTypeFilter?: MediaType;
   expand?: boolean;
   search?: string;
 }

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -18,6 +18,10 @@
         "soundtrack": "Soundtrack"
     },
     "albums": "Albums",
+    "genre_content_type": {
+        "audiobooks": "Audiobooks",
+        "podcasts": "Podcasts"
+    },
     "appears_on": "Appears on",
     "artist": "Artist",
     "artist_albums": "Albums",
@@ -624,7 +628,8 @@
         "filter_genre": "Filter by genre",
         "show_only_default_genres": "Show only default genres",
         "show_all_genres": "Show all genres",
-        "filter_hide_fully_played": "Hide fully-played episodes"
+        "filter_hide_fully_played": "Hide fully-played episodes",
+        "genre_content_type": "Media type"
     },
     "topresult": "Top result",
     "track": "Track",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -19,6 +19,7 @@
     },
     "albums": "Albums",
     "genre_content_type": {
+        "all": "All",
         "audiobooks": "Audiobooks",
         "podcasts": "Podcasts"
     },

--- a/src/views/LibraryGenres.vue
+++ b/src/views/LibraryGenres.vue
@@ -16,6 +16,7 @@
     :total="total"
     :show-provider-filter="true"
     :show-hide-empty-filter="true"
+    :show-genre-content-type-filter="true"
     :extra-menu-items="extraMenuItems"
   />
   <AddGenreDialog v-model="showAddGenreDialog" @success="handleGenreAdded" />
@@ -83,15 +84,23 @@ const loadItems = async function (params: LoadDataParams) {
         : undefined,
     genre: params.genreIds,
     hide_empty: params.hideEmptyFilter,
+    media_type: params.genreContentTypeFilter,
   });
 };
 
 const setTotals = async function (params: LoadDataParams) {
-  if (!params.favoritesOnly && !params.provider) {
+  if (
+    !params.favoritesOnly &&
+    !params.provider &&
+    !params.genreContentTypeFilter
+  ) {
     total.value = store.libraryGenresCount;
     return;
   }
-  if (params.provider && params.provider.length > 0) {
+  if (
+    (params.provider && params.provider.length > 0) ||
+    params.genreContentTypeFilter
+  ) {
     total.value = undefined;
     return;
   }

--- a/src/views/LibraryGenres.vue
+++ b/src/views/LibraryGenres.vue
@@ -84,6 +84,9 @@ const loadItems = async function (params: LoadDataParams) {
         : undefined,
     genre: params.genreIds,
     hide_empty: params.hideEmptyFilter,
+    // when media_type is set the backend ignores hide_empty (media_type implies
+    // non-empty and takes precedence), so the hide-empty toggle is a no-op while
+    // a content-type filter is active.
     media_type: params.genreContentTypeFilter,
   });
 };

--- a/tests/composables/userPreferences.test.ts
+++ b/tests/composables/userPreferences.test.ts
@@ -1,0 +1,120 @@
+import { MediaType } from "@/plugins/api/interfaces";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockUpdateUser, storeMock } = vi.hoisted(() => {
+  return {
+    mockUpdateUser: vi.fn(),
+    storeMock: {
+      currentUser: null as {
+        user_id: string;
+        preferences?: Record<string, unknown>;
+      } | null,
+    },
+  };
+});
+
+vi.mock("@/plugins/api", () => ({
+  api: {
+    updateUser: mockUpdateUser,
+  },
+}));
+
+vi.mock("@/plugins/store", () => ({
+  store: storeMock,
+}));
+
+import { useUserPreferences } from "@/composables/userPreferences";
+
+// `getItemsListingPreferences` returns a computed, so we read it through a fresh
+// call after each write to avoid relying on computed caching against the plain
+// (non-reactive) store mock.
+function readPrefs(path: string, itemtype: string) {
+  return useUserPreferences().getItemsListingPreferences(path, itemtype).value;
+}
+
+describe("userPreferences - genreContentTypeFilter", () => {
+  beforeEach(() => {
+    mockUpdateUser.mockReset();
+    mockUpdateUser.mockResolvedValue(undefined);
+    storeMock.currentUser = { user_id: "u1", preferences: {} };
+  });
+
+  it("persists the genre media-type filter under the namespaced key", async () => {
+    const { setItemsListingPreference } = useUserPreferences();
+
+    await setItemsListingPreference(
+      "librarygenres",
+      "genres",
+      "genreContentTypeFilter",
+      MediaType.AUDIOBOOK,
+    );
+
+    expect(readPrefs("librarygenres", "genres").genreContentTypeFilter).toBe(
+      MediaType.AUDIOBOOK,
+    );
+    expect(mockUpdateUser).toHaveBeenCalledWith("u1", {
+      preferences: {
+        "itemsListing.librarygenres.genres": {
+          genreContentTypeFilter: MediaType.AUDIOBOOK,
+        },
+      },
+    });
+  });
+
+  it("merges with sibling filter keys without clobbering them", async () => {
+    const { setItemsListingPreference } = useUserPreferences();
+
+    await setItemsListingPreference(
+      "librarygenres",
+      "genres",
+      "hideEmptyFilter",
+      true,
+    );
+    await setItemsListingPreference(
+      "librarygenres",
+      "genres",
+      "genreContentTypeFilter",
+      MediaType.PODCAST,
+    );
+
+    const prefs = readPrefs("librarygenres", "genres");
+    expect(prefs.hideEmptyFilter).toBe(true);
+    expect(prefs.genreContentTypeFilter).toBe(MediaType.PODCAST);
+  });
+
+  it("keeps the filter isolated per path/itemtype", async () => {
+    const { setItemsListingPreference } = useUserPreferences();
+
+    await setItemsListingPreference(
+      "librarygenres",
+      "genres",
+      "genreContentTypeFilter",
+      MediaType.PODCAST,
+    );
+
+    expect(
+      readPrefs("libraryalbums", "albums").genreContentTypeFilter,
+    ).toBeUndefined();
+  });
+
+  it("clears the filter when set back to undefined (toggle-off)", async () => {
+    const { setItemsListingPreference } = useUserPreferences();
+
+    await setItemsListingPreference(
+      "librarygenres",
+      "genres",
+      "genreContentTypeFilter",
+      MediaType.PODCAST,
+    );
+    await setItemsListingPreference(
+      "librarygenres",
+      "genres",
+      "genreContentTypeFilter",
+      undefined,
+    );
+
+    expect(
+      readPrefs("librarygenres", "genres").genreContentTypeFilter,
+    ).toBeUndefined();
+  });
+});


### PR DESCRIPTION
This PR adds a MediaType filter to the genre library view.
This uses existing backend features, but is the first part of a series of PRs aimed at adding 2 extra genre taxonomies to Music Assistant.