### PR TITLE
Allow unjoining the sync group leader to hand off playback

### DIFF
--- a/src/components/VolumeControl.vue
+++ b/src/components/VolumeControl.vue
@@ -95,9 +95,8 @@
               v-if="showSyncControls"
               :ripple="false"
               :disabled="
-                childPlayer.player_id == player.player_id ||
-                (player.static_group_members.includes(childPlayer.player_id) &&
-                  player.group_members.includes(childPlayer.player_id))
+                player.static_group_members.includes(childPlayer.player_id) &&
+                player.group_members.includes(childPlayer.player_id)
               "
               :model-value="
                 player.group_members.includes(childPlayer.player_id) ||


### PR DESCRIPTION
Unjoining the **leader** of a sync group used to stop the whole group. The server side (music-assistant/server#4412, merged) now hands playback off to a remaining member when the leader is unjoined — this enables that gesture in the UI.

- The sync leader's checkbox in the group/volume panel was always disabled; now it's enabled like any other member, so you can unjoin the leader. The server then transfers the queue to a remaining member (or dissolves the group if it was the last one).
