### PR TITLE
Redesign the fullscreen player queue as a single scrollable list

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
         "@tanstack/form-core": "1.33.0",
         "@tanstack/vue-form": "^1.33.0",
         "@tanstack/vue-table": "^8.21.3",
+        "@tanstack/vue-virtual": "3.13.29",
         "@types/qrcode": "^1.5.6",
         "@vueuse/core": "^14.3.0",
         "class-variance-authority": "^0.7.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,6 +47,9 @@ importers:
       '@tanstack/vue-table':
         specifier: ^8.21.3
         version: 8.21.3(vue@3.5.35(typescript@6.0.3))
+      '@tanstack/vue-virtual':
+        specifier: 3.13.29
+        version: 3.13.29(vue@3.5.35(typescript@6.0.3))
       '@types/qrcode':
         specifier: ^1.5.6
         version: 1.5.6

--- a/src/layouts/default/PlayerOSD/PlayerFullscreen.vue
+++ b/src/layouts/default/PlayerOSD/PlayerFullscreen.vue
@@ -166,179 +166,104 @@
           v-if="showRightColumn && store.activePlayerQueue"
           class="main-queue-items"
         >
-          <v-tabs
-            v-if="!showLyrics"
-            v-model="activeQueuePanel"
-            hide-slider
-            density="compact"
-            @click="activeQueuePanelClick"
-          >
-            <v-tab :value="0">
-              {{ $t("queue") }}
-              <v-badge
-                color="grey"
-                :content="
-                  (store.activePlayerQueue?.items || 0) -
-                  (store.activePlayerQueue?.current_index || 0)
-                "
-                inline
-              />
-            </v-tab>
-            <v-tab :value="1">
-              {{ $t("played") }}
-              <v-badge
-                color="grey"
-                :content="store.activePlayerQueue?.current_index"
-                inline
-              />
-            </v-tab>
-          </v-tabs>
+          <!-- Lyrics view -->
+          <div v-if="showLyrics" class="lyrics-wrapper">
+            <LyricsViewer
+              :media-item="store.curQueueItem?.media_item"
+              :position="lyricsElapsedTime"
+              :stream-details="store.curQueueItem?.streamdetails"
+              :text-color="sliderColor"
+              :lyrics="currentLyrics.plain"
+              :lrc-lyrics="currentLyrics.synced"
+              :offset="lyricsOffset"
+            />
+          </div>
+          <!-- Unified queue list: played → now playing → up next (virtualized) -->
           <div
+            v-else
+            ref="queueScrollRef"
             class="queue-items-scroll-box"
             :style="`--queue-title-size: ${queueTitleFontSize}; --queue-subtitle-size: ${queueSubtitleFontSize};`"
           >
-            <v-virtual-scroll
-              v-if="!tempHide && !showLyrics"
-              ref="virtualScrollRef"
-              :item-height="70"
-              height="100%"
-              :items="activeQueuePanel == 0 ? nextItems : previousItems"
-              @scroll="onQueueScroll"
+            <!-- empty state -->
+            <div v-if="!totalItems" class="queue-empty">
+              {{ $t("queue_empty") }}
+            </div>
+            <!-- virtual spacer sized to the whole queue; only visible rows render -->
+            <div
+              v-else
+              class="queue-virt"
+              :style="{ height: `${totalSize}px` }"
             >
-              <template #default="{ item, index }">
-                <ListItem
-                  link
-                  :show-menu-btn="true"
-                  :disabled="!item.available"
-                  @click.stop="(e: Event) => openQueueItemMenu(e, item)"
-                  @menu.stop="(e: Event) => openQueueItemMenu(e, item)"
-                  @mouseenter="hoveredQueueIndex = index"
-                  @mouseleave="hoveredQueueIndex = -1"
-                >
-                  <template #prepend>
-                    <div class="media-thumb listitem-media-thumb">
-                      <MediaItemThumb size="50" :item="item" />
-                    </div>
-                  </template>
-                  <template #title>
-                    <div class="title-row">
-                      <!-- only scroll the currently playing track, or when hovered with a separate sync group -->
-                      <MarqueeText
-                        :sync="
-                          index == 0 && activeQueuePanel == 0
-                            ? playerMarqueeSync
-                            : hoveredMarqueeSync
-                        "
-                        :disabled="
-                          !(
-                            (index == 0 && activeQueuePanel == 0) ||
-                            hoveredQueueIndex == index
-                          )
-                        "
-                      >
-                        <span
-                          :class="{
-                            'is-playing':
-                              item.queue_item_id ===
-                              store.curQueueItem?.queue_item_id,
-                          }"
-                        >
-                          {{ item.name }}
-                        </span>
-                      </MarqueeText>
-                    </div>
-                  </template>
-                  <template #subtitle>
-                    <div class="d-flex">
-                      <span style="white-space: nowrap" class="pr-1">
-                        {{ formatDuration(item.duration) }} |
-                      </span>
-                      <MarqueeText
-                        :sync="
-                          index == 0 && activeQueuePanel == 0
-                            ? playerMarqueeSync
-                            : hoveredMarqueeSync
-                        "
-                        :disabled="
-                          !(
-                            (index == 0 && activeQueuePanel == 0) ||
-                            hoveredQueueIndex == index
-                          )
-                        "
-                      >
-                        <span
-                          v-if="
-                            item.media_item &&
-                            'album' in item.media_item &&
-                            item.media_item.album
-                          "
-                        >
-                          {{ item.media_item.album.name }}
-                        </span>
-                      </MarqueeText>
-                    </div>
-                  </template>
-                  <template #append>
-                    <PartyPlayerBadge
-                      v-if="item.extra_attributes?.party_guest === true"
-                      :type="
-                        item.extra_attributes?.party_boosted === true
-                          ? 'boost'
-                          : 'request'
-                      "
-                      :badge-color="
-                        item.extra_attributes?.party_boosted === true
-                          ? boostBadgeColor
-                          : requestBadgeColor
-                      "
-                    />
-                    <NowPlayingBadge
-                      v-if="
-                        item.queue_item_id ===
-                          store.curQueueItem?.queue_item_id &&
-                        store.activePlayer?.playback_state != PlaybackState.IDLE
-                      "
-                      :show-badge="getBreakpointValue('bp4')"
-                    />
-                    <v-icon v-if="!item.available">mdi-alert</v-icon>
-                  </template>
-                </ListItem>
-                <!-- Show chapters -->
+              <div
+                v-for="row in virtualRows"
+                :key="row.index"
+                :ref="measureRow"
+                :data-index="row.index"
+                class="queue-virt-row"
+                :style="{ transform: `translateY(${row.vItem.start}px)` }"
+              >
+                <!-- section divider (Now playing / Up next) -->
+                <div v-if="row.divider" class="queue-divider">
+                  <span class="queue-divider__label">{{
+                    $t(row.divider)
+                  }}</span>
+                  <span
+                    v-if="row.divider === 'up_next' && upNextCount"
+                    class="queue-divider__count"
+                  >
+                    {{ upNextCount }}
+                  </span>
+                  <span class="queue-divider__line"></span>
+                </div>
+                <!-- loaded item -->
+                <QueueListItem
+                  v-if="row.item"
+                  :item="row.item"
+                  :state="row.state"
+                  :is-playing="playerActive"
+                  :marquee-sync="
+                    row.state === 'playing'
+                      ? playerMarqueeSync
+                      : hoveredMarqueeSync
+                  "
+                  :request-badge-color="requestBadgeColor"
+                  :boost-badge-color="boostBadgeColor"
+                  @click="(e: Event) => openQueueItemMenu(e, row.index)"
+                  @menu="(e: Event) => openQueueItemMenu(e, row.index)"
+                />
+                <!-- placeholder while the page loads -->
+                <div v-else class="queue-skeleton">
+                  <div class="queue-skeleton__thumb"></div>
+                  <div class="queue-skeleton__lines">
+                    <div class="queue-skeleton__line"></div>
+                    <div
+                      class="queue-skeleton__line queue-skeleton__line--sub"
+                    ></div>
+                  </div>
+                </div>
+                <!-- chapters for the current audiobook item -->
                 <div
                   v-if="
-                    item.queue_item_id == store.curQueueItem?.queue_item_id &&
-                    item.media_item?.metadata?.chapters?.length
+                    row.state === 'playing' &&
+                    row.item?.media_item?.metadata?.chapters?.length
                   "
-                  style="margin-left: 50px"
+                  class="queue-chapters"
                 >
-                  <v-list-item
-                    v-for="chapter in item.media_item.metadata?.chapters"
+                  <button
+                    v-for="chapter in row.item.media_item.metadata.chapters"
                     :key="chapter.position"
-                    @click.stop="chapterClicked(item.media_item, chapter)"
+                    type="button"
+                    class="queue-chapter"
+                    @click.stop="chapterClicked(row.item.media_item, chapter)"
                   >
-                    <template #title>
-                      <div>{{ chapter.name }}</div>
-                    </template>
-                    <template #append>
-                      <span v-if="chapter.end" class="text-caption"
-                        >{{ formatDuration(chapter.end - chapter.start) }}
-                      </span>
-                    </template>
-                  </v-list-item>
+                    <span class="queue-chapter__name">{{ chapter.name }}</span>
+                    <span v-if="chapter.end" class="queue-chapter__time">
+                      {{ formatDuration(chapter.end - chapter.start) }}
+                    </span>
+                  </button>
                 </div>
-              </template>
-            </v-virtual-scroll>
-            <!-- Lyrics view -->
-            <div v-if="showLyrics" class="lyrics-wrapper">
-              <LyricsViewer
-                :media-item="store.curQueueItem?.media_item"
-                :position="lyricsElapsedTime"
-                :stream-details="store.curQueueItem?.streamdetails"
-                :text-color="sliderColor"
-                :lyrics="currentLyrics.plain"
-                :lrc-lyrics="currentLyrics.synced"
-                :offset="lyricsOffset"
-              />
+              </div>
             </div>
           </div>
         </div>
@@ -490,15 +415,10 @@
 
 <script setup lang="ts">
 import Icon from "@/components/Icon.vue";
-import ListItem from "@/components/ListItem.vue";
 import LyricsViewer from "@/components/LyricsViewer.vue";
 import MarqueeText from "@/components/MarqueeText.vue";
-import MediaItemThumb from "@/components/MediaItemThumb.vue";
-import NowPlayingBadge from "@/components/NowPlayingBadge.vue";
-import PartyPlayerBadge from "@/components/party/PartyPlayerBadge.vue";
 import { Button } from "@/components/ui/button";
 import { useLyricsElapsedTime } from "@/composables/useLyricsElapsedTime";
-import { usePartyConfig } from "@/composables/usePartyConfig";
 import { MarqueeTextSync } from "@/helpers/marquee_text_sync";
 import { getPlayerMenuItems } from "@/helpers/player_menu_items";
 import {
@@ -506,7 +426,6 @@ import {
   formatDuration,
   getMediaImageUrl,
   getPlayerName,
-  sleep,
 } from "@/helpers/utils";
 import NextBtn from "@/layouts/default/PlayerOSD/PlayerControlBtn/NextBtn.vue";
 import PlayBtn from "@/layouts/default/PlayerOSD/PlayerControlBtn/PlayBtn.vue";
@@ -515,19 +434,16 @@ import RepeatBtn from "@/layouts/default/PlayerOSD/PlayerControlBtn/RepeatBtn.vu
 import ShuffleBtn from "@/layouts/default/PlayerOSD/PlayerControlBtn/ShuffleBtn.vue";
 import PlayerFullscreenHeaderControls from "@/layouts/default/PlayerOSD/PlayerFullscreenHeaderControls.vue";
 import PlayerVolume from "@/layouts/default/PlayerOSD/PlayerVolume.vue";
+import QueueListItem from "@/layouts/default/PlayerOSD/QueueListItem.vue";
+import { useFullscreenQueue } from "@/layouts/default/PlayerOSD/useFullscreenQueue";
 import api from "@/plugins/api";
 import { getSourceName } from "@/plugins/api/helpers";
 import {
   EventMessage,
   EventType,
-  MediaItemChapter,
   MediaItemType,
   MediaType,
-  PlaybackState,
-  PlayerQueue,
   PlayerType,
-  QueueItem,
-  QueueOption,
   Track,
 } from "@/plugins/api/interfaces";
 import { getBreakpointValue } from "@/plugins/breakpoint";
@@ -577,13 +493,6 @@ const playBtnStyle = computed(() => {
 });
 
 const playerMarqueeSync = new MarqueeTextSync();
-const hoveredQueueIndex = ref(-1);
-const hoveredMarqueeSync = new MarqueeTextSync();
-
-// Local refs
-const queueItems = ref<QueueItem[]>([]);
-const activeQueuePanel = ref(0);
-const tempHide = ref(false);
 
 // Track the favorite state of the current queue item independently from
 // media_item.favorite so optimistic updates survive server-side queue refreshes
@@ -598,26 +507,8 @@ watch(
   { immediate: true },
 );
 
-// Badge colors for guest request badges (loaded from party/config)
-const requestBadgeColor = ref("#2196f3");
-const boostBadgeColor = ref("#ff5722");
-
 const { elapsedTime: lyricsElapsedTime } = useLyricsElapsedTime();
 
-// Computed properties
-
-const nextItems = computed(() => {
-  if (store.activePlayerQueue) {
-    return queueItems.value.slice(store.activePlayerQueue.current_index);
-  } else return [];
-});
-const previousItems = computed(() => {
-  if (store.activePlayerQueue) {
-    return queueItems.value
-      .slice(0, store.activePlayerQueue.current_index)
-      .reverse();
-  } else return [];
-});
 // Local reactive state for lyrics
 const currentLyrics = ref<{ plain: string | null; synced: string | null }>({
   plain: null,
@@ -677,6 +568,25 @@ watch(lyricsState, (state) => {
 const showRightColumn = computed(
   () => store.showQueueItems || showLyrics.value,
 );
+
+// The unified queue list (virtualized rows, paging, now-playing focus, per-item
+// menu and chapters) lives in its own composable to keep this component lean.
+const {
+  queueScrollRef,
+  virtualRows,
+  totalItems,
+  upNextCount,
+  totalSize,
+  measureRow,
+  playerActive,
+  hoveredMarqueeSync,
+  requestBadgeColor,
+  boostBadgeColor,
+  queueTitleFontSize,
+  queueSubtitleFontSize,
+  openQueueItemMenu,
+  chapterClicked,
+} = useFullscreenQueue(showLyrics);
 
 // Protocols with accurate playback time reporting don't need a latency offset.
 const ACCURATE_TIME_PROTOCOLS = ["airplay"];
@@ -842,44 +752,6 @@ const subTitleFontSize = computed(() => {
   return `${(parseFloat(titleFontSize.value) * (12 / 14)).toFixed(3)}em`;
 });
 
-const queueTitleFontSize = computed(() => {
-  switch (name.value) {
-    case "xs":
-      return "0.875rem";
-    case "sm":
-      return "0.875rem";
-    case "md":
-      return "0.925rem";
-    case "lg":
-      return "0.9rem";
-    case "xl":
-      return "0.925rem";
-    case "xxl":
-      return "0.975rem";
-    default:
-      return "0.875rem";
-  }
-});
-
-const queueSubtitleFontSize = computed(() => {
-  switch (name.value) {
-    case "xs":
-      return "0.775rem";
-    case "sm":
-      return "0.775rem";
-    case "md":
-      return "0.8rem";
-    case "lg":
-      return "0.8rem";
-    case "xl":
-      return "0.8rem";
-    case "xxl":
-      return "0.85rem";
-    default:
-      return "0.775rem";
-  }
-});
-
 const showExpandedPlayerSelectButton = computed(() => {
   // Always show the player select button at the bottom; only hide it on very
   // short screens (never relocate it to the header).
@@ -887,18 +759,6 @@ const showExpandedPlayerSelectButton = computed(() => {
 });
 
 // methods
-
-const itemClick = function (item: MediaItemType) {
-  // mediaItem in the list is clicked
-  store.showFullscreenPlayer = false;
-  router.push({
-    name: item.media_type,
-    params: {
-      itemId: item.item_id,
-      provider: item.provider,
-    },
-  });
-};
 
 // Helper to parse a Music Assistant URI
 // Supports both formats:
@@ -1191,84 +1051,6 @@ const onArtistClick = async function () {
   }
 };
 
-const openQueueItemMenu = function (evt: Event, item: QueueItem) {
-  const itemIndex = queueItems.value.indexOf(item);
-  const menuItems = [
-    {
-      label: "play_now",
-      labelArgs: [],
-      action: () => {
-        queueCommand(item, "play_now");
-      },
-      icon: "mdi-play-circle-outline",
-      disabled:
-        itemIndex === store.activePlayerQueue?.current_index ||
-        itemIndex === store.activePlayerQueue?.index_in_buffer,
-    },
-    {
-      label: "play_next",
-      labelArgs: [],
-      action: () => {
-        queueCommand(item, "move_next");
-      },
-      icon: "mdi-skip-next-circle-outline",
-      disabled: itemIndex <= (store.activePlayerQueue?.index_in_buffer || 0),
-    },
-    {
-      label: "queue_move_up",
-      labelArgs: [],
-      action: () => {
-        queueCommand(item, "up");
-      },
-      icon: "mdi-arrow-up",
-      disabled: itemIndex <= (store.activePlayerQueue?.index_in_buffer || 0),
-    },
-    {
-      label: "queue_move_down",
-      labelArgs: [],
-      action: () => {
-        queueCommand(item, "down");
-      },
-      icon: "mdi-arrow-down",
-      disabled: itemIndex <= (store.activePlayerQueue?.index_in_buffer || 0),
-    },
-    {
-      label: "queue_move_end",
-      labelArgs: [],
-      action: () => {
-        queueCommand(item, "end");
-      },
-      icon: "mdi-arrow-collapse-down",
-      disabled: itemIndex <= (store.activePlayerQueue?.index_in_buffer || 0),
-    },
-    {
-      label: "queue_delete",
-      labelArgs: [],
-      action: () => {
-        queueCommand(item, "delete");
-      },
-      icon: "mdi-delete",
-      disabled: itemIndex <= (store.activePlayerQueue?.index_in_buffer || 0),
-    },
-  ];
-  if (item?.media_item?.media_type == MediaType.TRACK) {
-    menuItems.push({
-      label: "show_info",
-      labelArgs: [],
-      action: () => {
-        itemClick(item.media_item as Track);
-      },
-      icon: "mdi-information-outline",
-      disabled: false,
-    });
-  }
-  eventbus.emit("contextmenu", {
-    items: menuItems,
-    posX: (evt as PointerEvent).clientX,
-    posY: (evt as PointerEvent).clientY,
-  });
-};
-
 const openQueueMenu = function (evt: Event) {
   if (!store.activePlayer) return;
   eventbus.emit("contextmenu", {
@@ -1280,171 +1062,6 @@ const openQueueMenu = function (evt: Event) {
     posY: (evt as PointerEvent).clientY,
   });
 };
-
-const queueCommand = function (item: QueueItem | undefined, command: string) {
-  if (!item || !store.activePlayerQueue) return;
-  if (command == "play_now") {
-    api.queueCommandPlayIndex(
-      store.activePlayerQueue?.queue_id,
-      item.queue_item_id,
-    );
-  } else if (command == "move_next") {
-    api.queueCommandMoveNext(
-      store.activePlayerQueue?.queue_id,
-      item.queue_item_id,
-    );
-  } else if (command == "up") {
-    api.queueCommandMoveUp(
-      store.activePlayerQueue?.queue_id,
-      item.queue_item_id,
-    );
-  } else if (command == "down") {
-    api.queueCommandMoveDown(
-      store.activePlayerQueue?.queue_id,
-      item.queue_item_id,
-    );
-  } else if (command == "end") {
-    api.queueCommandMoveItemEnd(
-      store.activePlayerQueue?.queue_id,
-      item.queue_item_id,
-    );
-  } else if (command == "delete") {
-    api.queueCommandDelete(
-      store.activePlayerQueue?.queue_id,
-      item.queue_item_id,
-    );
-  }
-};
-
-const virtualScrollRef = ref<InstanceType<
-  typeof import("vuetify/components").VVirtualScroll
-> | null>(null);
-const loadingMore = ref(false);
-const allItemsLoaded = ref(false);
-// Number of queue items fetched per page, and the distance we keep loaded past
-// the current index so the "queue" tab (sliced from current_index) never empties.
-const QUEUE_PAGE_SIZE = 50;
-// Bumped on every reset; an in-flight page load compares against it to detect it
-// belongs to an outdated queue state and must discard its result.
-let loadGeneration = 0;
-
-const resetItems = async function () {
-  // invalidate any in-flight load and release the loading guard, so a fetch that
-  // errored (e.g. on a dropped remote connection) cannot wedge later loads.
-  loadGeneration += 1;
-  loadingMore.value = false;
-  tempHide.value = true;
-  queueItems.value = [];
-  allItemsLoaded.value = false;
-  await sleep(100);
-  tempHide.value = false;
-  if (store.showFullscreenPlayer && store.showQueueItems) {
-    loadNextPage();
-  }
-};
-
-const loadNextPage = async function () {
-  if (loadingMore.value || allItemsLoaded.value) return;
-  if (!store.activePlayerQueue || store.activePlayerQueue.items == 0) return;
-  if (queueItems.value.length >= store.activePlayerQueue.items) {
-    allItemsLoaded.value = true;
-    return;
-  }
-  loadingMore.value = true;
-  const generation = loadGeneration;
-  const offset = queueItems.value.length;
-  // On first load, ensure we fetch enough items to cover past the current
-  // index so that nextItems (which slices from current_index) has data.
-  const minNeeded =
-    (store.activePlayerQueue.current_index || 0) + QUEUE_PAGE_SIZE;
-  const limit =
-    offset === 0
-      ? Math.max(QUEUE_PAGE_SIZE, minNeeded - offset)
-      : QUEUE_PAGE_SIZE;
-  try {
-    const result = await api.getPlayerQueueItems(
-      store.activePlayerQueue.queue_id,
-      limit,
-      offset,
-    );
-    // a reset happened while awaiting; this page is stale, so drop it
-    if (generation !== loadGeneration) return;
-    queueItems.value.push(...result);
-    if (result.length < limit) {
-      allItemsLoaded.value = true;
-    }
-  } finally {
-    // leave the guard untouched if a reset already started a newer load
-    if (generation === loadGeneration) {
-      loadingMore.value = false;
-    }
-  }
-};
-
-// fetch another page when the loaded window no longer extends a full page past
-// the current index, which it is sliced from to build the "queue" tab
-const ensureWindowAheadOfIndex = function () {
-  if (!store.showFullscreenPlayer || !store.showQueueItems) return;
-  const index = store.activePlayerQueue?.current_index ?? 0;
-  if (queueItems.value.length - index < QUEUE_PAGE_SIZE) {
-    loadNextPage();
-  }
-};
-
-const onQueueScroll = function (e: Event) {
-  const target = e.target as HTMLElement;
-  if (!target) return;
-  const threshold = 500;
-  if (
-    target.scrollTop + target.clientHeight >=
-    target.scrollHeight - threshold
-  ) {
-    loadNextPage();
-  }
-};
-
-// Fetch badge colors from party config
-const { config: partyConfig, fetchConfig: fetchPartyConfig } = usePartyConfig();
-
-// React to party config changes (e.g., admin changes badge colors)
-watch(partyConfig, (newConfig) => {
-  if (newConfig) {
-    requestBadgeColor.value = newConfig.request_badge_color ?? "#2196F3";
-    boostBadgeColor.value = newConfig.boost_badge_color ?? "#FF5722";
-  }
-});
-
-onMounted(async () => {
-  // Only fetch badge colors if party provider is loaded
-  if (Object.values(api.providers).some((p) => p.domain === "party")) {
-    await fetchPartyConfig();
-  }
-});
-
-// load the initial page (or top up a window that went stale while hidden) when
-// the queue items become visible
-watch(
-  [() => store.showFullscreenPlayer, () => store.showQueueItems],
-  ensureWindowAheadOfIndex,
-  { immediate: true },
-);
-
-// keep extending the window as playback advances so the "queue" tab, which
-// slices nextItems from current_index, keeps showing the upcoming items
-watch(() => store.activePlayerQueue?.current_index, ensureWindowAheadOfIndex);
-
-// listen for item updates to refresh items when that happens
-onMounted(() => {
-  const unsub = api.subscribe(
-    EventType.QUEUE_ITEMS_UPDATED,
-    (evt: EventMessage) => {
-      if (evt.object_id != store.activePlayerQueue?.queue_id) return;
-      const queue = evt.data as PlayerQueue;
-      resetItems();
-    },
-  );
-  onBeforeUnmount(unsub);
-});
 
 // sync currentItemFavorite when the server confirms a favorite change
 onMounted(() => {
@@ -1574,36 +1191,6 @@ const onHeartBtnClick = async function (evt: PointerEvent | MouseEvent) {
   });
 };
 
-const activeQueuePanelClick = function () {
-  // this hack is needed in order to force refresh the infinite scroller
-  // otherwise it will not attempt to load more items if the end was reached
-  // and then we load new items with a different size
-  tempHide.value = true;
-  sleep(100).then(() => {
-    tempHide.value = false;
-  });
-};
-
-const chapterClicked = function (
-  item: MediaItemType,
-  chapter: MediaItemChapter,
-) {
-  api.playMedia(
-    item.uri,
-    QueueOption.PLAY,
-    undefined,
-    chapter.position.toString(),
-  );
-};
-
-// watchers
-watch(
-  () => store.activePlayerId,
-  (val) => {
-    resetItems();
-  },
-  { immediate: true },
-);
 const sliderColor = ref<string | undefined>(undefined);
 const backgroundColor = ref<string | undefined>(undefined);
 
@@ -1667,19 +1254,159 @@ watchEffect(() => {
 .queue-items-scroll-box {
   flex: 1;
   min-height: 0;
-  overflow-y: scroll;
+  overflow-y: auto;
+  padding-bottom: 12px;
+  /* Keep the list clear of the progress bar / controls below. */
+  margin-bottom: 24px;
+  scroll-behavior: auto;
 }
 
-.queue-items-scroll-box :deep(.v-list-item-title) {
-  font-size: var(--queue-title-size, 1rem);
+/* Virtual list: a spacer sized to the whole queue, with only the visible rows
+   rendered and absolutely positioned via an inline translateY. */
+.queue-virt {
+  position: relative;
+  width: 100%;
 }
 
-.queue-items-scroll-box :deep(.v-list-item-subtitle) {
-  font-size: var(--queue-subtitle-size, 0.875rem);
+.queue-virt-row {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
 }
 
-.v-infinite-scroll--vertical {
-  overflow-y: unset;
+/* Placeholder shown while a page of items is still loading. */
+.queue-skeleton {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  height: 60px;
+  padding: 6px 8px;
+}
+
+.queue-skeleton__thumb {
+  flex: 0 0 auto;
+  width: 48px;
+  height: 48px;
+  border-radius: 6px;
+  background: color-mix(
+    in srgb,
+    var(--text-color, currentColor) 10%,
+    transparent
+  );
+}
+
+.queue-skeleton__lines {
+  flex: 1 1 auto;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.queue-skeleton__line {
+  width: 55%;
+  height: 12px;
+  border-radius: 4px;
+  background: color-mix(
+    in srgb,
+    var(--text-color, currentColor) 10%,
+    transparent
+  );
+}
+
+.queue-skeleton__line--sub {
+  width: 38%;
+  height: 10px;
+}
+
+/* Section divider between played / now playing / up next. */
+.queue-divider {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 14px 8px 6px;
+}
+
+.queue-divider__label {
+  flex: 0 0 auto;
+  font-size: 0.7rem;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--text-color, currentColor);
+  opacity: 0.65;
+}
+
+.queue-divider__count {
+  flex: 0 0 auto;
+  font-size: 0.7rem;
+  font-weight: 600;
+  color: var(--text-color, currentColor);
+  opacity: 0.4;
+}
+
+.queue-divider__line {
+  flex: 1 1 auto;
+  height: 1px;
+  background: color-mix(
+    in srgb,
+    var(--text-color, currentColor) 18%,
+    transparent
+  );
+}
+
+/* Audiobook chapters under the current item. */
+.queue-chapters {
+  display: flex;
+  flex-direction: column;
+  margin: 2px 0 6px 60px;
+}
+
+.queue-chapter {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  width: 100%;
+  padding: 6px 8px;
+  border-radius: 6px;
+  text-align: left;
+  color: var(--text-color, currentColor);
+  background: transparent;
+  cursor: pointer;
+  transition: background-color 0.12s ease;
+}
+
+.queue-chapter:hover {
+  background: color-mix(
+    in srgb,
+    var(--text-color, currentColor) 8%,
+    transparent
+  );
+}
+
+.queue-chapter__name {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: var(--queue-subtitle-size, 0.8rem);
+}
+
+.queue-chapter__time {
+  flex: 0 0 auto;
+  font-size: 0.72rem;
+  opacity: 0.6;
+}
+
+.queue-empty {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+  padding: 24px;
+  text-align: center;
+  opacity: 0.6;
 }
 
 .main-media-details-image {
@@ -1741,13 +1468,6 @@ watchEffect(() => {
 
 .track-info-subtitle {
   opacity: 0.5;
-}
-
-.v-tab {
-  opacity: 0.5;
-}
-.v-tab-item--selected {
-  opacity: 1;
 }
 
 .media-controls {
@@ -1884,12 +1604,6 @@ button {
   .lyrics-wrapper :deep(.break-note) {
     font-size: clamp(1.4rem, 2vw, 2.2rem);
   }
-}
-
-.title-row {
-  display: flex;
-  align-items: center;
-  gap: 6px;
 }
 
 .icon-thumb-large {

--- a/src/layouts/default/PlayerOSD/QueueListItem.vue
+++ b/src/layouts/default/PlayerOSD/QueueListItem.vue
@@ -1,0 +1,308 @@
+<!--
+  A single row in the fullscreen player's unified queue list.
+
+  Dedicated, shadcn/Tailwind-based replacement for the generic (Vuetify)
+  ListItem when rendering PlayerQueue items. It is state-aware so the list can
+  visually distinguish already played tracks, the currently playing track, the
+  items locked in the stream buffer and the freely reorderable up-next items.
+-->
+<template>
+  <div
+    class="qitem"
+    :class="{
+      'qitem--played': state === 'played',
+      'qitem--playing': state === 'playing',
+      'qitem--buffered': state === 'buffered',
+      'qitem--unavailable': !item.available,
+    }"
+    :data-queue-current="state === 'playing' ? 'true' : undefined"
+    role="button"
+    tabindex="0"
+    @click="emit('click', $event)"
+    @contextmenu.prevent="emit('menu', $event)"
+    @keydown.enter.prevent="emit('click', $event)"
+    @mouseenter="hovered = true"
+    @mouseleave="hovered = false"
+  >
+    <!-- thumbnail (with now-playing equalizer overlay) -->
+    <div class="qitem__thumb">
+      <MediaItemThumb size="48" :item="item" />
+      <div v-if="showEqualizer" class="qitem__eq" aria-hidden="true">
+        <NowPlayingBadge :show-badge="false" :show-icon="true" />
+      </div>
+    </div>
+
+    <!-- title + subtitle -->
+    <div class="qitem__body">
+      <MarqueeText :sync="marqueeSync" :disabled="!marqueeActive">
+        <span class="qitem__title">{{ item.name }}</span>
+      </MarqueeText>
+      <div class="qitem__subtitle">
+        <span class="qitem__duration">{{ formatDuration(item.duration) }}</span>
+        <template v-if="albumName">
+          <span class="qitem__sep">·</span>
+          <MarqueeText
+            class="qitem__album"
+            :sync="marqueeSync"
+            :disabled="!marqueeActive"
+          >
+            <span>{{ albumName }}</span>
+          </MarqueeText>
+        </template>
+      </div>
+    </div>
+
+    <!-- trailing badges + menu -->
+    <div class="qitem__append">
+      <PartyPlayerBadge
+        v-if="item.extra_attributes?.party_guest === true"
+        :type="
+          item.extra_attributes?.party_boosted === true ? 'boost' : 'request'
+        "
+        :badge-color="
+          item.extra_attributes?.party_boosted === true
+            ? boostBadgeColor
+            : requestBadgeColor
+        "
+      />
+      <!-- buffered indicator: already loaded into the stream to play next -->
+      <TooltipProvider v-if="state === 'buffered'" :delay-duration="200">
+        <Tooltip>
+          <TooltipTrigger as-child>
+            <span class="qitem__info" @click.stop>
+              <InfoIcon class="size-3.5" />
+            </span>
+          </TooltipTrigger>
+          <TooltipContent side="top" class="z-[10001] max-w-[240px]">
+            {{ $t("queue_buffered_explanation") }}
+          </TooltipContent>
+        </Tooltip>
+      </TooltipProvider>
+      <TriangleAlertIcon
+        v-if="!item.available"
+        class="size-4 shrink-0 text-destructive"
+      />
+      <Button
+        variant="ghost"
+        size="icon-sm"
+        class="qitem__menu"
+        :aria-label="$t('queue_options')"
+        @click.stop="emit('menu', $event)"
+        @pointerdown.stop
+      >
+        <EllipsisVerticalIcon class="size-4" />
+      </Button>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import MarqueeText from "@/components/MarqueeText.vue";
+import MediaItemThumb from "@/components/MediaItemThumb.vue";
+import NowPlayingBadge from "@/components/NowPlayingBadge.vue";
+import PartyPlayerBadge from "@/components/party/PartyPlayerBadge.vue";
+import { Button } from "@/components/ui/button";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { MarqueeTextSync } from "@/helpers/marquee_text_sync";
+import { formatDuration } from "@/helpers/utils";
+import { QueueItem } from "@/plugins/api/interfaces";
+import { $t } from "@/plugins/i18n";
+import { EllipsisVerticalIcon, InfoIcon, TriangleAlertIcon } from "@lucide/vue";
+import { computed, ref } from "vue";
+
+export type QueueItemState = "played" | "playing" | "buffered" | "upcoming";
+
+interface Props {
+  item: QueueItem;
+  state: QueueItemState;
+  // Whether the player is actually rendering audio (drives the equalizer).
+  isPlaying?: boolean;
+  // Shared marquee sync group so the visible scrolling title(s) stay in sync.
+  marqueeSync?: MarqueeTextSync;
+  requestBadgeColor?: string;
+  boostBadgeColor?: string;
+}
+
+const props = withDefaults(defineProps<Props>(), {
+  isPlaying: false,
+  marqueeSync: undefined,
+  requestBadgeColor: "#2196f3",
+  boostBadgeColor: "#ff5722",
+});
+
+const emit = defineEmits<{
+  (e: "click", event: Event): void;
+  (e: "menu", event: Event): void;
+}>();
+
+const hovered = ref(false);
+
+// Only animate the title/album marquee for the now-playing track, or while a
+// row is hovered — keeps the list calm and avoids dozens of scrolling rows.
+const marqueeActive = computed(
+  () => props.state === "playing" || hovered.value,
+);
+
+const showEqualizer = computed(
+  () => props.state === "playing" && props.isPlaying,
+);
+
+const albumName = computed(() => {
+  const mediaItem = props.item.media_item;
+  if (mediaItem && "album" in mediaItem && mediaItem.album) {
+    return mediaItem.album.name;
+  }
+  return "";
+});
+</script>
+
+<style scoped>
+.qitem {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 6px 8px;
+  border-radius: 8px;
+  cursor: pointer;
+  color: var(--text-color, currentColor);
+  transition:
+    background-color 0.12s ease,
+    opacity 0.12s ease;
+  user-select: none;
+}
+
+.qitem:hover {
+  background: color-mix(
+    in srgb,
+    var(--text-color, currentColor) 8%,
+    transparent
+  );
+}
+
+.qitem--played {
+  opacity: 0.5;
+}
+
+.qitem--played:hover {
+  opacity: 0.72;
+}
+
+.qitem--playing {
+  background: color-mix(in srgb, var(--primary) 12%, transparent);
+}
+
+.qitem--playing:hover {
+  background: color-mix(in srgb, var(--primary) 18%, transparent);
+}
+
+/* Buffered = already loaded into the stream and locked to play next. Sits in
+   the "up next" list but keeps a faint tint so it reads as already cued. */
+.qitem--buffered {
+  background: color-mix(in srgb, var(--primary) 5%, transparent);
+}
+
+.qitem--buffered:hover {
+  background: color-mix(in srgb, var(--primary) 10%, transparent);
+}
+
+.qitem--unavailable {
+  opacity: 0.5;
+}
+
+.qitem__thumb {
+  position: relative;
+  flex: 0 0 auto;
+  width: 48px;
+  height: 48px;
+  border-radius: 6px;
+  overflow: hidden;
+}
+
+.qitem__eq {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(0, 0, 0, 0.45);
+}
+
+.qitem__body {
+  flex: 1 1 auto;
+  min-width: 0;
+  overflow: hidden;
+}
+
+.qitem__title {
+  font-size: var(--queue-title-size, 0.9rem);
+  font-weight: 500;
+  line-height: 1.3;
+}
+
+.qitem--playing .qitem__title {
+  color: var(--primary);
+  font-weight: 600;
+}
+
+.qitem__subtitle {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  margin-top: 1px;
+  font-size: var(--queue-subtitle-size, 0.78rem);
+  opacity: 0.7;
+}
+
+.qitem__duration {
+  white-space: nowrap;
+}
+
+.qitem__sep {
+  opacity: 0.6;
+}
+
+.qitem__album {
+  min-width: 0;
+  overflow: hidden;
+}
+
+.qitem__append {
+  flex: 0 0 auto;
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.qitem__info {
+  display: inline-flex;
+  align-items: center;
+  color: var(--text-color, currentColor);
+  cursor: help;
+  opacity: 0.5;
+}
+
+.qitem__info:hover {
+  opacity: 0.85;
+}
+
+.qitem__menu {
+  opacity: 0;
+}
+
+.qitem:hover .qitem__menu,
+.qitem:focus-within .qitem__menu {
+  opacity: 1;
+}
+
+/* Touch devices have no hover — always reveal the menu affordance. */
+@media (hover: none) {
+  .qitem__menu {
+    opacity: 1;
+  }
+}
+</style>

--- a/src/layouts/default/PlayerOSD/useFullscreenQueue.ts
+++ b/src/layouts/default/PlayerOSD/useFullscreenQueue.ts
@@ -1,0 +1,494 @@
+// Encapsulates the fullscreen player's unified queue list: the loaded window of
+// items, bidirectional paging, now-playing focus handling, the per-item context
+// menu and audiobook chapter playback. Extracted from PlayerFullscreen.vue to
+// keep that component focused on layout.
+import { usePartyConfig } from "@/composables/usePartyConfig";
+import { MarqueeTextSync } from "@/helpers/marquee_text_sync";
+import api from "@/plugins/api";
+import {
+  EventMessage,
+  EventType,
+  MediaItemChapter,
+  MediaItemType,
+  MediaType,
+  PlaybackState,
+  QueueItem,
+  QueueOption,
+  Track,
+} from "@/plugins/api/interfaces";
+import { eventbus } from "@/plugins/eventbus";
+import router from "@/plugins/router";
+import { store } from "@/plugins/store";
+import { useVirtualizer } from "@tanstack/vue-virtual";
+import {
+  Ref,
+  computed,
+  nextTick,
+  onBeforeUnmount,
+  onMounted,
+  ref,
+  watch,
+} from "vue";
+import { useDisplay } from "vuetify";
+
+export type QueueItemState = "played" | "playing" | "buffered" | "upcoming";
+
+export function useFullscreenQueue(showLyrics: Ref<boolean>) {
+  const { name } = useDisplay();
+
+  // Marquee sync group shared by the (non-playing) hovered rows.
+  const hoveredMarqueeSync = new MarqueeTextSync();
+
+  // Scroll viewport element (the virtualizer's scroll parent).
+  const queueScrollRef = ref<HTMLElement | null>(null);
+  // Keep the now-playing track scrolled into focus while true. Disabled when the
+  // user scrolls it out of view, re-enabled when they bring it back.
+  const followCurrent = ref(true);
+
+  // Total number of items in the queue (drives the virtualizer's row count).
+  const totalItems = computed(() => store.activePlayerQueue?.items ?? 0);
+
+  // Sparsely loaded item data, keyed by absolute queue index. Only the pages
+  // around the viewport are ever fetched, so a queue with thousands of tracks
+  // stays cheap in both memory and DOM (rows are virtualized).
+  const loadedItems = ref(new Map<number, QueueItem>());
+  const itemAt = (index: number) => loadedItems.value.get(index);
+
+  // Badge colors for guest request badges (loaded from party/config).
+  const requestBadgeColor = ref("#2196f3");
+  const boostBadgeColor = ref("#ff5722");
+
+  // ---- section state -------------------------------------------------------
+
+  // Section state for the queue item at the given absolute queue index.
+  const itemState = (absIndex: number): QueueItemState => {
+    const queue = store.activePlayerQueue;
+    const current = queue?.current_index ?? 0;
+    const buffer = Math.max(queue?.index_in_buffer ?? current, current);
+    if (absIndex < current) return "played";
+    if (absIndex === current) return "playing";
+    if (absIndex <= buffer) return "buffered";
+    return "upcoming";
+  };
+
+  // Translation key for the divider rendered *before* the item at the given
+  // absolute index (or null for none). "Now playing" labels just the current
+  // track; "Up next" introduces everything after it (buffered items included —
+  // they keep a subtle "buffered" tint so it's clear they're already cued).
+  const dividerBefore = (absIndex: number): string | null => {
+    const queue = store.activePlayerQueue;
+    if (!queue) return null;
+    const current = queue.current_index ?? 0;
+    if (absIndex === current) return "now_playing";
+    if (absIndex === current + 1) return "up_next";
+    return null;
+  };
+
+  // Number of items after the current track — the "Up next" section, which now
+  // includes any already-buffered items.
+  const upNextCount = computed(() => {
+    const queue = store.activePlayerQueue;
+    if (!queue) return 0;
+    const current = queue.current_index ?? 0;
+    return Math.max(0, (queue.items ?? 0) - current - 1);
+  });
+
+  // Whether the player is actually rendering audio (drives the equalizer icon).
+  const playerActive = computed(
+    () => store.activePlayer?.playback_state !== PlaybackState.IDLE,
+  );
+
+  // ---- virtualization ------------------------------------------------------
+
+  // Estimated row height (px), used before a row is measured. Real heights are
+  // measured per row (divider / audiobook-chapter rows are taller).
+  const ROW_ESTIMATE = 60;
+
+  const virtualizer = useVirtualizer(
+    computed(() => ({
+      count: totalItems.value,
+      getScrollElement: () => queueScrollRef.value,
+      estimateSize: () => ROW_ESTIMATE,
+      overscan: 8,
+      // Leave some history peeking above the now-playing track when we focus it.
+      scrollPaddingStart: queueScrollRef.value
+        ? queueScrollRef.value.clientHeight * 0.2
+        : 80,
+    })),
+  );
+
+  // Ref callback so the virtualizer can measure each rendered row's real height.
+  const measureRow = (el: unknown) => {
+    virtualizer.value.measureElement(el as HTMLElement | null);
+  };
+
+  const totalSize = computed(() => virtualizer.value.getTotalSize());
+
+  // Visible (+ overscan) rows with their data, section state and any divider.
+  const virtualRows = computed(() =>
+    virtualizer.value.getVirtualItems().map((vItem) => ({
+      vItem,
+      index: vItem.index,
+      item: itemAt(vItem.index),
+      state: itemState(vItem.index),
+      divider: dividerBefore(vItem.index),
+    })),
+  );
+
+  // ---- responsive font sizes ----------------------------------------------
+
+  const queueTitleFontSize = computed(() => {
+    switch (name.value) {
+      case "xs":
+        return "0.875rem";
+      case "sm":
+        return "0.875rem";
+      case "md":
+        return "0.925rem";
+      case "lg":
+        return "0.9rem";
+      case "xl":
+        return "0.925rem";
+      case "xxl":
+        return "0.975rem";
+      default:
+        return "0.875rem";
+    }
+  });
+
+  const queueSubtitleFontSize = computed(() => {
+    switch (name.value) {
+      case "xs":
+        return "0.775rem";
+      case "sm":
+        return "0.775rem";
+      case "md":
+        return "0.8rem";
+      case "lg":
+        return "0.8rem";
+      case "xl":
+        return "0.8rem";
+      case "xxl":
+        return "0.85rem";
+      default:
+        return "0.775rem";
+    }
+  });
+
+  // ---- data loading (per-page, around the viewport) ------------------------
+
+  // Items are fetched a page at a time and cached by absolute index. Only pages
+  // that intersect the visible range are ever requested, so a huge queue costs
+  // little memory and the DOM stays tiny (rows are virtualized).
+  const PAGE_SIZE = 50;
+  const loadedPages = new Set<number>();
+  const pendingPages = new Set<number>();
+  // Bumped whenever the cache is invalidated (queue changed / player switched);
+  // in-flight fetches compare against it and drop stale results.
+  let loadGeneration = 0;
+
+  const ensurePageLoaded = (page: number) => {
+    const queue = store.activePlayerQueue;
+    if (!queue || page < 0) return;
+    const offset = page * PAGE_SIZE;
+    if (offset >= queue.items) return;
+    if (loadedPages.has(page) || pendingPages.has(page)) return;
+    pendingPages.add(page);
+    const generation = loadGeneration;
+    api
+      .getPlayerQueueItems(queue.queue_id, PAGE_SIZE, offset)
+      .then((result) => {
+        if (generation !== loadGeneration) return;
+        const map = loadedItems.value;
+        result.forEach((item, i) => map.set(offset + i, item));
+        loadedPages.add(page);
+      })
+      .finally(() => {
+        if (generation === loadGeneration) pendingPages.delete(page);
+      });
+  };
+
+  const ensureRangeLoaded = (firstIndex: number, lastIndex: number) => {
+    if (lastIndex < firstIndex) return;
+    const firstPage = Math.floor(Math.max(0, firstIndex) / PAGE_SIZE);
+    const lastPage = Math.floor(lastIndex / PAGE_SIZE);
+    for (let page = firstPage; page <= lastPage; page++) ensurePageLoaded(page);
+  };
+
+  // First / last absolute index currently rendered by the virtualizer.
+  const visibleRange = computed<[number, number]>(() => {
+    const items = virtualizer.value.getVirtualItems();
+    if (!items.length) return [0, -1];
+    return [items[0].index, items[items.length - 1].index];
+  });
+
+  // Drop all cached data (e.g. after a reorder) and refetch what's visible.
+  const invalidate = () => {
+    loadGeneration += 1;
+    loadedItems.value = new Map();
+    loadedPages.clear();
+    pendingPages.clear();
+    const [first, last] = visibleRange.value;
+    ensureRangeLoaded(first, last);
+  };
+
+  // Scroll the now-playing track into focus (scrollPaddingStart leaves a little
+  // already-played history peeking above it).
+  const focusCurrent = (behavior: ScrollBehavior = "auto") => {
+    const current = store.activePlayerQueue?.current_index;
+    if (current == null || current < 0) return;
+    virtualizer.value.scrollToIndex(current, { align: "start", behavior });
+  };
+
+  // Load the pages the viewport needs, and track whether the now-playing track
+  // is on screen (so playback advances only re-focus while the user follows).
+  watch(
+    visibleRange,
+    ([first, last]) => {
+      ensureRangeLoaded(first, last);
+      const current = store.activePlayerQueue?.current_index;
+      if (current != null && last >= first) {
+        followCurrent.value = current >= first && current <= last;
+      }
+    },
+    { immediate: true },
+  );
+
+  // ---- per-item context menu / actions ------------------------------------
+
+  const itemClick = (item: MediaItemType) => {
+    // a media item in the list was clicked
+    store.showFullscreenPlayer = false;
+    router.push({
+      name: item.media_type,
+      params: {
+        itemId: item.item_id,
+        provider: item.provider,
+      },
+    });
+  };
+
+  const queueCommand = (item: QueueItem | undefined, command: string) => {
+    if (!item || !store.activePlayerQueue) return;
+    if (command == "play_now") {
+      api.queueCommandPlayIndex(
+        store.activePlayerQueue.queue_id,
+        item.queue_item_id,
+      );
+    } else if (command == "move_next") {
+      api.queueCommandMoveNext(
+        store.activePlayerQueue.queue_id,
+        item.queue_item_id,
+      );
+    } else if (command == "up") {
+      api.queueCommandMoveUp(
+        store.activePlayerQueue.queue_id,
+        item.queue_item_id,
+      );
+    } else if (command == "down") {
+      api.queueCommandMoveDown(
+        store.activePlayerQueue.queue_id,
+        item.queue_item_id,
+      );
+    } else if (command == "end") {
+      api.queueCommandMoveItemEnd(
+        store.activePlayerQueue.queue_id,
+        item.queue_item_id,
+      );
+    } else if (command == "delete") {
+      api.queueCommandDelete(
+        store.activePlayerQueue.queue_id,
+        item.queue_item_id,
+      );
+    }
+  };
+
+  const openQueueItemMenu = (evt: Event, index: number) => {
+    const item = itemAt(index);
+    if (!item) return;
+    const itemIndex = index;
+    const menuItems = [
+      {
+        label: "play_now",
+        labelArgs: [],
+        action: () => {
+          queueCommand(item, "play_now");
+        },
+        icon: "mdi-play-circle-outline",
+        disabled:
+          itemIndex === store.activePlayerQueue?.current_index ||
+          itemIndex === store.activePlayerQueue?.index_in_buffer,
+      },
+      {
+        label: "play_next",
+        labelArgs: [],
+        action: () => {
+          queueCommand(item, "move_next");
+        },
+        icon: "mdi-skip-next-circle-outline",
+        disabled: itemIndex <= (store.activePlayerQueue?.index_in_buffer || 0),
+      },
+      {
+        label: "queue_move_up",
+        labelArgs: [],
+        action: () => {
+          queueCommand(item, "up");
+        },
+        icon: "mdi-arrow-up",
+        disabled: itemIndex <= (store.activePlayerQueue?.index_in_buffer || 0),
+      },
+      {
+        label: "queue_move_down",
+        labelArgs: [],
+        action: () => {
+          queueCommand(item, "down");
+        },
+        icon: "mdi-arrow-down",
+        disabled: itemIndex <= (store.activePlayerQueue?.index_in_buffer || 0),
+      },
+      {
+        label: "queue_move_end",
+        labelArgs: [],
+        action: () => {
+          queueCommand(item, "end");
+        },
+        icon: "mdi-arrow-collapse-down",
+        disabled: itemIndex <= (store.activePlayerQueue?.index_in_buffer || 0),
+      },
+      {
+        label: "queue_delete",
+        labelArgs: [],
+        action: () => {
+          queueCommand(item, "delete");
+        },
+        icon: "mdi-delete",
+        disabled: itemIndex <= (store.activePlayerQueue?.index_in_buffer || 0),
+      },
+    ];
+    if (item?.media_item?.media_type == MediaType.TRACK) {
+      menuItems.push({
+        label: "show_info",
+        labelArgs: [],
+        action: () => {
+          itemClick(item.media_item as Track);
+        },
+        icon: "mdi-information-outline",
+        disabled: false,
+      });
+    }
+    eventbus.emit("contextmenu", {
+      items: menuItems,
+      posX: (evt as PointerEvent).clientX,
+      posY: (evt as PointerEvent).clientY,
+    });
+  };
+
+  const chapterClicked = (item: MediaItemType, chapter: MediaItemChapter) => {
+    api.playMedia(
+      item.uri,
+      QueueOption.PLAY,
+      undefined,
+      chapter.position.toString(),
+    );
+  };
+
+  // ---- party badge colors --------------------------------------------------
+
+  const { config: partyConfig, fetchConfig: fetchPartyConfig } =
+    usePartyConfig();
+
+  // React to party config changes (e.g., admin changes badge colors).
+  watch(partyConfig, (newConfig) => {
+    if (newConfig) {
+      requestBadgeColor.value = newConfig.request_badge_color ?? "#2196F3";
+      boostBadgeColor.value = newConfig.boost_badge_color ?? "#FF5722";
+    }
+  });
+
+  onMounted(async () => {
+    // Only fetch badge colors if party provider is loaded.
+    if (Object.values(api.providers).some((p) => p.domain === "party")) {
+      await fetchPartyConfig();
+    }
+  });
+
+  // ---- lifecycle / playback follow ----------------------------------------
+
+  // Focus the now-playing track when the queue list becomes visible.
+  watch(
+    () =>
+      store.showFullscreenPlayer && store.showQueueItems && !showLyrics.value,
+    (visible) => {
+      if (!visible) return;
+      followCurrent.value = true;
+      nextTick(() => requestAnimationFrame(() => focusCurrent("auto")));
+    },
+    { immediate: true },
+  );
+
+  // Re-focus the now-playing track as playback advances, while the user is
+  // following along (dividers/sections recompute reactively from current_index).
+  watch(
+    () => store.activePlayerQueue?.current_index,
+    (index) => {
+      if (
+        index == null ||
+        !store.showFullscreenPlayer ||
+        !store.showQueueItems ||
+        showLyrics.value
+      )
+        return;
+      if (followCurrent.value) nextTick(() => focusCurrent("smooth"));
+    },
+  );
+
+  // Reload data when the server reports the queue changed (reorder/add/remove).
+  onMounted(() => {
+    const unsub = api.subscribe(
+      EventType.QUEUE_ITEMS_UPDATED,
+      (evt: EventMessage) => {
+        if (evt.object_id != store.activePlayerQueue?.queue_id) return;
+        if (!store.showFullscreenPlayer || !store.showQueueItems) return;
+        invalidate();
+        if (followCurrent.value) {
+          nextTick(() => requestAnimationFrame(() => focusCurrent("auto")));
+        }
+      },
+    );
+    onBeforeUnmount(unsub);
+  });
+
+  // Reset when the active player changes.
+  watch(
+    () => store.activePlayerId,
+    () => {
+      invalidate();
+      if (
+        store.showFullscreenPlayer &&
+        store.showQueueItems &&
+        !showLyrics.value
+      ) {
+        followCurrent.value = true;
+        nextTick(() => requestAnimationFrame(() => focusCurrent("auto")));
+      }
+    },
+    { immediate: true },
+  );
+
+  return {
+    queueScrollRef,
+    virtualRows,
+    totalItems,
+    upNextCount,
+    totalSize,
+    measureRow,
+    playerActive,
+    hoveredMarqueeSync,
+    requestBadgeColor,
+    boostBadgeColor,
+    queueTitleFontSize,
+    queueSubtitleFontSize,
+    openQueueItemMenu,
+    chapterClicked,
+  };
+}

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1319,6 +1319,8 @@
     "disc": "Disc {number}",
     "album_type_label": "Album type",
     "now_playing": "Now playing",
+    "up_next": "Up next",
+    "queue_buffered_explanation": "This track is already buffered by the player to play next.",
     "artist_topalbums": "Top albums",
     "in_library": "In your library",
     "artist_no_library_albums": "You don't have any albums in your library for this artist.",


### PR DESCRIPTION
The fullscreen player split the queue into separate "Queue" and "Played" tabs, which made it awkward to see where you are and to browse around the current track. It also rendered every loaded row, so very large queues became heavy.

This replaces it with a single, continuous queue list — scroll up for history, down for what's next — with the now-playing track kept in focus, and virtualizes it so it stays smooth even with thousands of tracks.

## Changes
- Replace the Queue/Played tabs with one unified list (played → "Now playing" → "Up next") with clear section dividers and the current track auto-focused.
- Add a dedicated shadcn/Tailwind `QueueListItem` component (replacing the Vuetify `ListItem`), with played / now-playing / buffered / unavailable states.
- Virtualize the list with `@tanstack/vue-virtual`, loading queue items per page only around the viewport — keeping large queues light on memory and DOM.
- Extract all queue logic into a `useFullscreenQueue` composable to slim down `PlayerFullscreen.vue`.
- Show an "Up next" count and a small info indicator for tracks already buffered to play next.