### PR TITLE
Drag to reorder up next items in the fullscreen queue

### DIFF
--- a/src/layouts/default/PlayerOSD/PlayerFullscreen.vue
+++ b/src/layouts/default/PlayerOSD/PlayerFullscreen.vue
@@ -193,6 +193,7 @@
             <div
               v-else
               class="queue-virt"
+              :class="{ 'queue-virt--dragging': isDragging }"
               :style="{ height: `${totalSize}px` }"
             >
               <div
@@ -201,7 +202,9 @@
                 :ref="measureRow"
                 :data-index="row.index"
                 class="queue-virt-row"
-                :style="{ transform: `translateY(${row.vItem.start}px)` }"
+                :style="{
+                  transform: `translateY(${row.vItem.start + rowOffset(row.index)}px)`,
+                }"
               >
                 <!-- section divider (Now playing / Up next) -->
                 <div v-if="row.divider" class="queue-divider">
@@ -222,6 +225,7 @@
                   :item="row.item"
                   :state="row.state"
                   :is-playing="playerActive"
+                  :dragging="draggingIndex === row.index"
                   :marquee-sync="
                     row.state === 'playing'
                       ? playerMarqueeSync
@@ -231,6 +235,7 @@
                   :boost-badge-color="boostBadgeColor"
                   @click="(e: Event) => openQueueItemMenu(e, row.index)"
                   @menu="(e: Event) => openQueueItemMenu(e, row.index)"
+                  @dragstart="(e: PointerEvent) => startItemDrag(e, row.index)"
                 />
                 <!-- placeholder while the page loads -->
                 <div v-else class="queue-skeleton">
@@ -263,6 +268,20 @@
                     </span>
                   </button>
                 </div>
+              </div>
+              <!-- floating ghost of the dragged item; tracks the pointer -->
+              <div
+                v-if="isDragging && draggedItem"
+                class="queue-ghost"
+                :style="{ transform: `translateY(${ghostY}px)` }"
+              >
+                <QueueListItem
+                  :item="draggedItem"
+                  state="upcoming"
+                  ghost
+                  :request-badge-color="requestBadgeColor"
+                  :boost-badge-color="boostBadgeColor"
+                />
               </div>
             </div>
           </div>
@@ -586,6 +605,12 @@ const {
   queueSubtitleFontSize,
   openQueueItemMenu,
   chapterClicked,
+  startItemDrag,
+  draggingIndex,
+  isDragging,
+  draggedItem,
+  ghostY,
+  rowOffset,
 } = useFullscreenQueue(showLyrics);
 
 // Protocols with accurate playback time reporting don't need a latency offset.
@@ -1273,6 +1298,22 @@ watchEffect(() => {
   top: 0;
   left: 0;
   width: 100%;
+}
+
+/* While dragging, the rows slide smoothly as the landing gap opens/moves. */
+.queue-virt--dragging .queue-virt-row {
+  transition: transform 0.18s cubic-bezier(0.2, 0, 0, 1);
+}
+
+/* Floating clone of the dragged row; sits above the list and tracks the
+   pointer. Positioned via an inline translateY in content space. */
+.queue-ghost {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  z-index: 3;
+  pointer-events: none;
 }
 
 /* Placeholder shown while a page of items is still loading. */

--- a/src/layouts/default/PlayerOSD/QueueListItem.vue
+++ b/src/layouts/default/PlayerOSD/QueueListItem.vue
@@ -14,6 +14,8 @@
       'qitem--playing': state === 'playing',
       'qitem--buffered': state === 'buffered',
       'qitem--unavailable': !item.available,
+      'qitem--dragging': dragging,
+      'qitem--ghost': ghost,
     }"
     :data-queue-current="state === 'playing' ? 'true' : undefined"
     role="button"
@@ -52,7 +54,7 @@
       </div>
     </div>
 
-    <!-- trailing badges + menu -->
+    <!-- trailing badges + actions -->
     <div class="qitem__append">
       <PartyPlayerBadge
         v-if="item.extra_attributes?.party_guest === true"
@@ -82,10 +84,22 @@
         v-if="!item.available"
         class="size-4 shrink-0 text-destructive"
       />
+      <!-- drag handle to reorder (up-next items only) -->
+      <button
+        v-if="state === 'upcoming'"
+        type="button"
+        class="qitem__action qitem__grip"
+        :aria-label="$t('queue_reorder')"
+        @pointerdown.stop.prevent="emit('dragstart', $event)"
+        @click.stop
+        @contextmenu.prevent
+      >
+        <GripVerticalIcon class="size-4" />
+      </button>
       <Button
         variant="ghost"
         size="icon-sm"
-        class="qitem__menu"
+        class="qitem__action qitem__menu"
         :aria-label="$t('queue_options')"
         @click.stop="emit('menu', $event)"
         @pointerdown.stop
@@ -112,7 +126,12 @@ import { MarqueeTextSync } from "@/helpers/marquee_text_sync";
 import { formatDuration } from "@/helpers/utils";
 import { QueueItem } from "@/plugins/api/interfaces";
 import { $t } from "@/plugins/i18n";
-import { EllipsisVerticalIcon, InfoIcon, TriangleAlertIcon } from "@lucide/vue";
+import {
+  EllipsisVerticalIcon,
+  GripVerticalIcon,
+  InfoIcon,
+  TriangleAlertIcon,
+} from "@lucide/vue";
 import { computed, ref } from "vue";
 
 export type QueueItemState = "played" | "playing" | "buffered" | "upcoming";
@@ -126,6 +145,10 @@ interface Props {
   marqueeSync?: MarqueeTextSync;
   requestBadgeColor?: string;
   boostBadgeColor?: string;
+  // Whether this row is the one currently being dragged to reorder.
+  dragging?: boolean;
+  // Whether this is the floating "ghost" clone that follows the pointer.
+  ghost?: boolean;
 }
 
 const props = withDefaults(defineProps<Props>(), {
@@ -133,11 +156,14 @@ const props = withDefaults(defineProps<Props>(), {
   marqueeSync: undefined,
   requestBadgeColor: "#2196f3",
   boostBadgeColor: "#ff5722",
+  dragging: false,
+  ghost: false,
 });
 
 const emit = defineEmits<{
   (e: "click", event: Event): void;
   (e: "menu", event: Event): void;
+  (e: "dragstart", event: PointerEvent): void;
 }>();
 
 const hovered = ref(false);
@@ -290,19 +316,73 @@ const albumName = computed(() => {
   opacity: 0.85;
 }
 
-.qitem__menu {
+.qitem__action {
   opacity: 0;
 }
 
-.qitem:hover .qitem__menu,
-.qitem:focus-within .qitem__menu {
+.qitem:hover .qitem__action,
+.qitem:focus-within .qitem__action {
   opacity: 1;
 }
 
-/* Touch devices have no hover — always reveal the menu affordance. */
+/* Touch devices have no hover — always reveal the action affordances. */
 @media (hover: none) {
-  .qitem__menu {
+  .qitem__action {
     opacity: 1;
   }
+}
+
+/* Drag handle: a plain button (not a shadcn Button) so we fully control the
+   pointer gesture. Sized to match the icon-sm buttons beside it. */
+.qitem__grip {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex: 0 0 auto;
+  width: 2rem;
+  height: 2rem;
+  border-radius: 6px;
+  color: var(--text-color, currentColor);
+  cursor: grab;
+  /* Stop the browser from hijacking the gesture as a scroll on touch. */
+  touch-action: none;
+}
+
+.qitem__grip:hover {
+  background: color-mix(
+    in srgb,
+    var(--text-color, currentColor) 12%,
+    transparent
+  );
+}
+
+/* The source row stays in place but invisible while dragging — the floating
+   ghost is its stand-in, and the other rows slide to open the landing gap. */
+.qitem--dragging {
+  opacity: 0;
+  pointer-events: none;
+}
+
+.qitem--dragging .qitem__grip {
+  cursor: grabbing;
+}
+
+/* The floating clone that tracks the pointer. Lifted off the list with a
+   shadow + subtle scale; its own action buttons are hidden. */
+.qitem--ghost {
+  background: color-mix(
+    in srgb,
+    var(--text-color, currentColor) 14%,
+    #80808055
+  );
+  backdrop-filter: blur(14px);
+  -webkit-backdrop-filter: blur(14px);
+  box-shadow: 0 10px 28px rgba(0, 0, 0, 0.4);
+  transform: scale(1.015);
+  cursor: grabbing;
+}
+
+.qitem--ghost .qitem__action {
+  display: none;
 }
 </style>

--- a/src/layouts/default/PlayerOSD/useFullscreenQueue.ts
+++ b/src/layouts/default/PlayerOSD/useFullscreenQueue.ts
@@ -392,6 +392,220 @@ export function useFullscreenQueue(showLyrics: Ref<boolean>) {
     );
   };
 
+  // ---- drag-to-reorder (up-next items only) --------------------------------
+
+  // While dragging, the source row hides in place, a floating "ghost" of it
+  // follows the pointer, and the rows between source and target slide aside to
+  // open a gap — so you can see where the item will land. dragDropIndex is the
+  // index the item would be inserted *before* on drop.
+  const dragSourceIndex = ref<number | null>(null);
+  const dragDropIndex = ref<number | null>(null);
+  // The item being dragged (drives the floating ghost). Captured at drag start.
+  const draggedItem = ref<QueueItem | null>(null);
+  // Y of the floating ghost's top within the virtual spacer (content space).
+  const ghostY = ref(0);
+  // Height (px) of the dragged row — the size of the gap the others open up.
+  const dragRowHeight = ref(0);
+  // Offset between the pointer and the top of the grabbed item, so the ghost
+  // keeps the same grip point under the finger instead of jumping.
+  let dragGrabOffset = 0;
+  // queue_item_id captured at drag start — the item data may be re-fetched
+  // mid-drag, so we don't hold on to the object itself.
+  let dragItemId: string | null = null;
+  // Last pointer Y (viewport px) so the auto-scroll loop can recompute the drop
+  // target as the list scrolls under a stationary finger.
+  let dragPointerY = 0;
+  // Auto-scroll velocity (px/frame) while the pointer sits near an edge.
+  let autoScrollSpeed = 0;
+  let autoScrollRaf = 0;
+  // Lets cleanup detach every drag listener at once (no per-handler bookkeeping).
+  let dragAbort: AbortController | null = null;
+
+  // First absolute index an up-next item may occupy. Everything up to and
+  // including the buffered items is locked (already cued in the stream).
+  const firstReorderableIndex = () => {
+    const queue = store.activePlayerQueue;
+    if (!queue) return 0;
+    const current = queue.current_index ?? 0;
+    const buffer = Math.max(queue.index_in_buffer ?? current, current);
+    return buffer + 1;
+  };
+
+  // Resolve the insertion index (drop *before* this absolute index) for a given
+  // pointer Y, clamped to the reorderable up-next region.
+  const computeDropIndex = (clientY: number): number => {
+    const el = queueScrollRef.value;
+    if (!el) return dragDropIndex.value ?? firstReorderableIndex();
+    const rect = el.getBoundingClientRect();
+    const y = clientY - rect.top + el.scrollTop;
+    const rows = virtualizer.value.getVirtualItems();
+    let dropIndex = totalItems.value;
+    let matched = false;
+    for (const row of rows) {
+      if (y < row.start + row.size / 2) {
+        dropIndex = row.index;
+        matched = true;
+        break;
+      }
+    }
+    if (!matched) {
+      const last = rows[rows.length - 1];
+      dropIndex = last ? last.index + 1 : totalItems.value;
+    }
+    const min = firstReorderableIndex();
+    return Math.min(Math.max(dropIndex, min), totalItems.value);
+  };
+
+  // Set the auto-scroll velocity from how close the pointer is to an edge.
+  const updateAutoScroll = (clientY: number) => {
+    const el = queueScrollRef.value;
+    if (!el) {
+      autoScrollSpeed = 0;
+      return;
+    }
+    const rect = el.getBoundingClientRect();
+    const EDGE = 56; // px from the edge where auto-scroll engages
+    const distTop = clientY - rect.top;
+    const distBottom = rect.bottom - clientY;
+    if (distTop < EDGE) {
+      autoScrollSpeed = -Math.ceil((EDGE - distTop) / 5);
+    } else if (distBottom < EDGE) {
+      autoScrollSpeed = Math.ceil((EDGE - distBottom) / 5);
+    } else {
+      autoScrollSpeed = 0;
+    }
+  };
+
+  // Recompute the ghost position and drop target from the current pointer Y.
+  const updateDragPositions = (clientY: number) => {
+    dragPointerY = clientY;
+    const el = queueScrollRef.value;
+    if (el) {
+      const rect = el.getBoundingClientRect();
+      ghostY.value = clientY - rect.top + el.scrollTop - dragGrabOffset;
+    }
+    dragDropIndex.value = computeDropIndex(clientY);
+  };
+
+  function autoScrollFrame() {
+    if (dragSourceIndex.value == null) return;
+    const el = queueScrollRef.value;
+    if (autoScrollSpeed !== 0 && el) {
+      el.scrollTop += autoScrollSpeed;
+      updateDragPositions(dragPointerY);
+    }
+    autoScrollRaf = requestAnimationFrame(autoScrollFrame);
+  }
+
+  const onDragPointerMove = (evt: PointerEvent) => {
+    if (dragSourceIndex.value == null) return;
+    evt.preventDefault();
+    updateAutoScroll(evt.clientY);
+    updateDragPositions(evt.clientY);
+  };
+
+  const cleanupDrag = () => {
+    dragAbort?.abort();
+    dragAbort = null;
+    if (autoScrollRaf) cancelAnimationFrame(autoScrollRaf);
+    autoScrollRaf = 0;
+    autoScrollSpeed = 0;
+    dragSourceIndex.value = null;
+    dragDropIndex.value = null;
+    draggedItem.value = null;
+    dragRowHeight.value = 0;
+    dragGrabOffset = 0;
+    dragItemId = null;
+  };
+
+  const finishDrag = (commit: boolean) => {
+    const source = dragSourceIndex.value;
+    const drop = dragDropIndex.value;
+    const itemId = dragItemId;
+    const queue = store.activePlayerQueue;
+    cleanupDrag();
+    if (!commit || source == null || drop == null || itemId == null || !queue)
+      return;
+    // Removing the source first shifts everything after it down by one, so the
+    // final resting index is one lower when dropping below the original spot.
+    const finalIndex = drop > source ? drop - 1 : drop;
+    const shift = finalIndex - source;
+    if (shift === 0) return;
+    api.queueCommandMoveItem(queue.queue_id, itemId, shift);
+  };
+
+  // Begin dragging an up-next row from its drag handle.
+  const startItemDrag = (evt: PointerEvent, index: number) => {
+    // Primary mouse button / touch / pen only.
+    if (evt.pointerType === "mouse" && evt.button !== 0) return;
+    const item = itemAt(index);
+    if (!item || itemState(index) !== "upcoming") return;
+
+    // Measure the grabbed item so the ghost lines up under the finger and the
+    // gap the other rows open matches the item's height. Fall back to the
+    // virtualizer's measurement if the element can't be resolved.
+    const el = queueScrollRef.value;
+    const qitemEl = (evt.target as HTMLElement | null)?.closest(".qitem");
+    if (el && qitemEl) {
+      const cRect = el.getBoundingClientRect();
+      const qRect = qitemEl.getBoundingClientRect();
+      const qTop = qRect.top - cRect.top + el.scrollTop;
+      dragRowHeight.value = qRect.height;
+      dragGrabOffset = evt.clientY - cRect.top + el.scrollTop - qTop;
+      ghostY.value = qTop;
+    } else {
+      const vItem = virtualizer.value
+        .getVirtualItems()
+        .find((v) => v.index === index);
+      dragRowHeight.value = vItem?.size ?? 60;
+      dragGrabOffset = dragRowHeight.value / 2;
+      ghostY.value = (vItem?.start ?? 0) + dragRowHeight.value / 2;
+    }
+
+    dragSourceIndex.value = index;
+    dragDropIndex.value = index;
+    draggedItem.value = item;
+    dragItemId = item.queue_item_id;
+    dragPointerY = evt.clientY;
+    autoScrollSpeed = 0;
+    // Don't let playback advance re-focus (yank) the list while dragging.
+    followCurrent.value = false;
+    dragAbort = new AbortController();
+    const { signal } = dragAbort;
+    window.addEventListener("pointermove", onDragPointerMove, {
+      passive: false,
+      signal,
+    });
+    window.addEventListener("pointerup", () => finishDrag(true), { signal });
+    window.addEventListener("pointercancel", () => finishDrag(false), {
+      signal,
+    });
+    autoScrollRaf = requestAnimationFrame(autoScrollFrame);
+  };
+
+  // Index of the row currently being dragged (the hidden source row).
+  const draggingIndex = computed(() => dragSourceIndex.value);
+
+  // Whether a reorder drag is in progress (drives the ghost + gap rendering).
+  const isDragging = computed(() => dragSourceIndex.value !== null);
+
+  // Extra Y offset for a visible row so the rows between the source and the
+  // drop target slide aside, opening a gap the size of the dragged row exactly
+  // where it will land. Returns 0 for everything else (incl. the source row).
+  const rowOffset = (index: number): number => {
+    const source = dragSourceIndex.value;
+    const drop = dragDropIndex.value;
+    if (source == null || drop == null || index === source) return 0;
+    const height = dragRowHeight.value;
+    // Dragging down: rows below the source and above the target shift up.
+    if (drop > source && index > source && index < drop) return -height;
+    // Dragging up: rows from the target down to the source shift down.
+    if (drop < source && index >= drop && index < source) return height;
+    return 0;
+  };
+
+  onBeforeUnmount(cleanupDrag);
+
   // ---- party badge colors --------------------------------------------------
 
   const { config: partyConfig, fetchConfig: fetchPartyConfig } =
@@ -490,5 +704,11 @@ export function useFullscreenQueue(showLyrics: Ref<boolean>) {
     queueSubtitleFontSize,
     openQueueItemMenu,
     chapterClicked,
+    startItemDrag,
+    draggingIndex,
+    isDragging,
+    draggedItem,
+    ghostY,
+    rowOffset,
   };
 }

--- a/src/layouts/default/PlayerOSD/useFullscreenQueue.ts
+++ b/src/layouts/default/PlayerOSD/useFullscreenQueue.ts
@@ -4,6 +4,7 @@
 // keep that component focused on layout.
 import { usePartyConfig } from "@/composables/usePartyConfig";
 import { MarqueeTextSync } from "@/helpers/marquee_text_sync";
+import { useQueueDragReorder } from "@/layouts/default/PlayerOSD/useQueueDragReorder";
 import api from "@/plugins/api";
 import {
   EventMessage,
@@ -394,217 +395,23 @@ export function useFullscreenQueue(showLyrics: Ref<boolean>) {
 
   // ---- drag-to-reorder (up-next items only) --------------------------------
 
-  // While dragging, the source row hides in place, a floating "ghost" of it
-  // follows the pointer, and the rows between source and target slide aside to
-  // open a gap — so you can see where the item will land. dragDropIndex is the
-  // index the item would be inserted *before* on drop.
-  const dragSourceIndex = ref<number | null>(null);
-  const dragDropIndex = ref<number | null>(null);
-  // The item being dragged (drives the floating ghost). Captured at drag start.
-  const draggedItem = ref<QueueItem | null>(null);
-  // Y of the floating ghost's top within the virtual spacer (content space).
-  const ghostY = ref(0);
-  // Height (px) of the dragged row — the size of the gap the others open up.
-  const dragRowHeight = ref(0);
-  // Offset between the pointer and the top of the grabbed item, so the ghost
-  // keeps the same grip point under the finger instead of jumping.
-  let dragGrabOffset = 0;
-  // queue_item_id captured at drag start — the item data may be re-fetched
-  // mid-drag, so we don't hold on to the object itself.
-  let dragItemId: string | null = null;
-  // Last pointer Y (viewport px) so the auto-scroll loop can recompute the drop
-  // target as the list scrolls under a stationary finger.
-  let dragPointerY = 0;
-  // Auto-scroll velocity (px/frame) while the pointer sits near an edge.
-  let autoScrollSpeed = 0;
-  let autoScrollRaf = 0;
-  // Lets cleanup detach every drag listener at once (no per-handler bookkeeping).
-  let dragAbort: AbortController | null = null;
-
-  // First absolute index an up-next item may occupy. Everything up to and
-  // including the buffered items is locked (already cued in the stream).
-  const firstReorderableIndex = () => {
-    const queue = store.activePlayerQueue;
-    if (!queue) return 0;
-    const current = queue.current_index ?? 0;
-    const buffer = Math.max(queue.index_in_buffer ?? current, current);
-    return buffer + 1;
-  };
-
-  // Resolve the insertion index (drop *before* this absolute index) for a given
-  // pointer Y, clamped to the reorderable up-next region.
-  const computeDropIndex = (clientY: number): number => {
-    const el = queueScrollRef.value;
-    if (!el) return dragDropIndex.value ?? firstReorderableIndex();
-    const rect = el.getBoundingClientRect();
-    const y = clientY - rect.top + el.scrollTop;
-    const rows = virtualizer.value.getVirtualItems();
-    let dropIndex = totalItems.value;
-    let matched = false;
-    for (const row of rows) {
-      if (y < row.start + row.size / 2) {
-        dropIndex = row.index;
-        matched = true;
-        break;
-      }
-    }
-    if (!matched) {
-      const last = rows[rows.length - 1];
-      dropIndex = last ? last.index + 1 : totalItems.value;
-    }
-    const min = firstReorderableIndex();
-    return Math.min(Math.max(dropIndex, min), totalItems.value);
-  };
-
-  // Set the auto-scroll velocity from how close the pointer is to an edge.
-  const updateAutoScroll = (clientY: number) => {
-    const el = queueScrollRef.value;
-    if (!el) {
-      autoScrollSpeed = 0;
-      return;
-    }
-    const rect = el.getBoundingClientRect();
-    const EDGE = 56; // px from the edge where auto-scroll engages
-    const distTop = clientY - rect.top;
-    const distBottom = rect.bottom - clientY;
-    if (distTop < EDGE) {
-      autoScrollSpeed = -Math.ceil((EDGE - distTop) / 5);
-    } else if (distBottom < EDGE) {
-      autoScrollSpeed = Math.ceil((EDGE - distBottom) / 5);
-    } else {
-      autoScrollSpeed = 0;
-    }
-  };
-
-  // Recompute the ghost position and drop target from the current pointer Y.
-  const updateDragPositions = (clientY: number) => {
-    dragPointerY = clientY;
-    const el = queueScrollRef.value;
-    if (el) {
-      const rect = el.getBoundingClientRect();
-      ghostY.value = clientY - rect.top + el.scrollTop - dragGrabOffset;
-    }
-    dragDropIndex.value = computeDropIndex(clientY);
-  };
-
-  function autoScrollFrame() {
-    if (dragSourceIndex.value == null) return;
-    const el = queueScrollRef.value;
-    if (autoScrollSpeed !== 0 && el) {
-      el.scrollTop += autoScrollSpeed;
-      updateDragPositions(dragPointerY);
-    }
-    autoScrollRaf = requestAnimationFrame(autoScrollFrame);
-  }
-
-  const onDragPointerMove = (evt: PointerEvent) => {
-    if (dragSourceIndex.value == null) return;
-    evt.preventDefault();
-    updateAutoScroll(evt.clientY);
-    updateDragPositions(evt.clientY);
-  };
-
-  const cleanupDrag = () => {
-    dragAbort?.abort();
-    dragAbort = null;
-    if (autoScrollRaf) cancelAnimationFrame(autoScrollRaf);
-    autoScrollRaf = 0;
-    autoScrollSpeed = 0;
-    dragSourceIndex.value = null;
-    dragDropIndex.value = null;
-    draggedItem.value = null;
-    dragRowHeight.value = 0;
-    dragGrabOffset = 0;
-    dragItemId = null;
-  };
-
-  const finishDrag = (commit: boolean) => {
-    const source = dragSourceIndex.value;
-    const drop = dragDropIndex.value;
-    const itemId = dragItemId;
-    const queue = store.activePlayerQueue;
-    cleanupDrag();
-    if (!commit || source == null || drop == null || itemId == null || !queue)
-      return;
-    // Removing the source first shifts everything after it down by one, so the
-    // final resting index is one lower when dropping below the original spot.
-    const finalIndex = drop > source ? drop - 1 : drop;
-    const shift = finalIndex - source;
-    if (shift === 0) return;
-    api.queueCommandMoveItem(queue.queue_id, itemId, shift);
-  };
-
-  // Begin dragging an up-next row from its drag handle.
-  const startItemDrag = (evt: PointerEvent, index: number) => {
-    // Primary mouse button / touch / pen only.
-    if (evt.pointerType === "mouse" && evt.button !== 0) return;
-    const item = itemAt(index);
-    if (!item || itemState(index) !== "upcoming") return;
-
-    // Measure the grabbed item so the ghost lines up under the finger and the
-    // gap the other rows open matches the item's height. Fall back to the
-    // virtualizer's measurement if the element can't be resolved.
-    const el = queueScrollRef.value;
-    const qitemEl = (evt.target as HTMLElement | null)?.closest(".qitem");
-    if (el && qitemEl) {
-      const cRect = el.getBoundingClientRect();
-      const qRect = qitemEl.getBoundingClientRect();
-      const qTop = qRect.top - cRect.top + el.scrollTop;
-      dragRowHeight.value = qRect.height;
-      dragGrabOffset = evt.clientY - cRect.top + el.scrollTop - qTop;
-      ghostY.value = qTop;
-    } else {
-      const vItem = virtualizer.value
-        .getVirtualItems()
-        .find((v) => v.index === index);
-      dragRowHeight.value = vItem?.size ?? 60;
-      dragGrabOffset = dragRowHeight.value / 2;
-      ghostY.value = (vItem?.start ?? 0) + dragRowHeight.value / 2;
-    }
-
-    dragSourceIndex.value = index;
-    dragDropIndex.value = index;
-    draggedItem.value = item;
-    dragItemId = item.queue_item_id;
-    dragPointerY = evt.clientY;
-    autoScrollSpeed = 0;
-    // Don't let playback advance re-focus (yank) the list while dragging.
-    followCurrent.value = false;
-    dragAbort = new AbortController();
-    const { signal } = dragAbort;
-    window.addEventListener("pointermove", onDragPointerMove, {
-      passive: false,
-      signal,
-    });
-    window.addEventListener("pointerup", () => finishDrag(true), { signal });
-    window.addEventListener("pointercancel", () => finishDrag(false), {
-      signal,
-    });
-    autoScrollRaf = requestAnimationFrame(autoScrollFrame);
-  };
-
-  // Index of the row currently being dragged (the hidden source row).
-  const draggingIndex = computed(() => dragSourceIndex.value);
-
-  // Whether a reorder drag is in progress (drives the ghost + gap rendering).
-  const isDragging = computed(() => dragSourceIndex.value !== null);
-
-  // Extra Y offset for a visible row so the rows between the source and the
-  // drop target slide aside, opening a gap the size of the dragged row exactly
-  // where it will land. Returns 0 for everything else (incl. the source row).
-  const rowOffset = (index: number): number => {
-    const source = dragSourceIndex.value;
-    const drop = dragDropIndex.value;
-    if (source == null || drop == null || index === source) return 0;
-    const height = dragRowHeight.value;
-    // Dragging down: rows below the source and above the target shift up.
-    if (drop > source && index > source && index < drop) return -height;
-    // Dragging up: rows from the target down to the source shift down.
-    if (drop < source && index >= drop && index < source) return height;
-    return 0;
-  };
-
-  onBeforeUnmount(cleanupDrag);
+  // Pointer-driven reorder of the up-next items, in its own composable. While
+  // dragging it stops the list from following playback (so it can't yank).
+  const {
+    startItemDrag,
+    draggingIndex,
+    isDragging,
+    draggedItem,
+    ghostY,
+    rowOffset,
+  } = useQueueDragReorder({
+    scrollEl: queueScrollRef,
+    getVirtualItems: () => virtualizer.value.getVirtualItems(),
+    itemAt,
+    onDragStart: () => {
+      followCurrent.value = false;
+    },
+  });
 
   // ---- party badge colors --------------------------------------------------
 

--- a/src/layouts/default/PlayerOSD/useQueueDragReorder.ts
+++ b/src/layouts/default/PlayerOSD/useQueueDragReorder.ts
@@ -1,0 +1,245 @@
+// Pointer-driven drag-to-reorder for the fullscreen player's up-next items.
+// Built to work with the virtualized list: the source row hides in place, a
+// floating "ghost" follows the pointer, and the rows between source and target
+// slide aside to reveal the drop position. Only transforms are touched, so the
+// virtualizer never re-measures.
+import api from "@/plugins/api";
+import { QueueItem } from "@/plugins/api/interfaces";
+import { store } from "@/plugins/store";
+import type { VirtualItem } from "@tanstack/vue-virtual";
+import { Ref, computed, onBeforeUnmount, ref } from "vue";
+
+interface QueueDragReorderOptions {
+  // Scroll viewport element (the virtualizer's scroll parent).
+  scrollEl: Ref<HTMLElement | null>;
+  // Reads the currently rendered virtual rows.
+  getVirtualItems: () => VirtualItem[];
+  // Resolves the (sparsely loaded) queue item at an absolute index.
+  itemAt: (index: number) => QueueItem | undefined;
+  // Called when a drag begins (e.g. to stop the list following playback).
+  onDragStart?: () => void;
+}
+
+export function useQueueDragReorder(options: QueueDragReorderOptions) {
+  const { scrollEl, getVirtualItems, itemAt, onDragStart } = options;
+
+  // Absolute index of the row being dragged (null when idle) and the index the
+  // item would be inserted *before* on drop. While dragging, the source row
+  // hides in place, a floating ghost follows the pointer, and the rows between
+  // source and target slide aside to reveal where the item will land.
+  const dragSourceIndex = ref<number | null>(null);
+  const dragDropIndex = ref<number | null>(null);
+  // The item being dragged (drives the floating ghost). Captured at drag start.
+  const draggedItem = ref<QueueItem | null>(null);
+  // Y of the floating ghost's top within the virtual spacer (content space).
+  const ghostY = ref(0);
+  // Height (px) of the dragged row — the size of the gap the others open up.
+  const dragRowHeight = ref(0);
+  // Offset between the pointer and the top of the grabbed item, so the ghost
+  // keeps the same grip point under the finger instead of jumping.
+  let dragGrabOffset = 0;
+  // queue_item_id captured at drag start — the item data may be re-fetched
+  // mid-drag, so we don't hold on to the object itself.
+  let dragItemId: string | null = null;
+  // Last pointer Y (viewport px) so the auto-scroll loop can recompute the drop
+  // target as the list scrolls under a stationary finger.
+  let dragPointerY = 0;
+  // Auto-scroll velocity (px/frame) while the pointer sits near an edge.
+  let autoScrollSpeed = 0;
+  let autoScrollRaf = 0;
+  // Lets cleanup detach every drag listener at once (no per-handler bookkeeping).
+  let dragAbort: AbortController | null = null;
+
+  const totalItems = () => store.activePlayerQueue?.items ?? 0;
+
+  // First absolute index an up-next item may occupy. Everything up to and
+  // including the buffered items is locked (already cued in the stream).
+  const firstReorderableIndex = () => {
+    const queue = store.activePlayerQueue;
+    if (!queue) return 0;
+    const current = queue.current_index ?? 0;
+    const buffer = Math.max(queue.index_in_buffer ?? current, current);
+    return buffer + 1;
+  };
+
+  // Resolve the insertion index (drop *before* this absolute index) for a given
+  // pointer Y, clamped to the reorderable up-next region.
+  const computeDropIndex = (clientY: number): number => {
+    const el = scrollEl.value;
+    if (!el) return dragDropIndex.value ?? firstReorderableIndex();
+    const rect = el.getBoundingClientRect();
+    const y = clientY - rect.top + el.scrollTop;
+    const rows = getVirtualItems();
+    let dropIndex = totalItems();
+    let matched = false;
+    for (const row of rows) {
+      if (y < row.start + row.size / 2) {
+        dropIndex = row.index;
+        matched = true;
+        break;
+      }
+    }
+    if (!matched) {
+      const last = rows[rows.length - 1];
+      dropIndex = last ? last.index + 1 : totalItems();
+    }
+    const min = firstReorderableIndex();
+    return Math.min(Math.max(dropIndex, min), totalItems());
+  };
+
+  // Set the auto-scroll velocity from how close the pointer is to an edge.
+  const updateAutoScroll = (clientY: number) => {
+    const el = scrollEl.value;
+    if (!el) {
+      autoScrollSpeed = 0;
+      return;
+    }
+    const rect = el.getBoundingClientRect();
+    const EDGE = 56; // px from the edge where auto-scroll engages
+    const distTop = clientY - rect.top;
+    const distBottom = rect.bottom - clientY;
+    if (distTop < EDGE) {
+      autoScrollSpeed = -Math.ceil((EDGE - distTop) / 5);
+    } else if (distBottom < EDGE) {
+      autoScrollSpeed = Math.ceil((EDGE - distBottom) / 5);
+    } else {
+      autoScrollSpeed = 0;
+    }
+  };
+
+  // Recompute the ghost position and drop target from the current pointer Y.
+  const updateDragPositions = (clientY: number) => {
+    dragPointerY = clientY;
+    const el = scrollEl.value;
+    if (el) {
+      const rect = el.getBoundingClientRect();
+      ghostY.value = clientY - rect.top + el.scrollTop - dragGrabOffset;
+    }
+    dragDropIndex.value = computeDropIndex(clientY);
+  };
+
+  function autoScrollFrame() {
+    if (dragSourceIndex.value == null) return;
+    const el = scrollEl.value;
+    if (autoScrollSpeed !== 0 && el) {
+      el.scrollTop += autoScrollSpeed;
+      updateDragPositions(dragPointerY);
+    }
+    autoScrollRaf = requestAnimationFrame(autoScrollFrame);
+  }
+
+  const onDragPointerMove = (evt: PointerEvent) => {
+    if (dragSourceIndex.value == null) return;
+    evt.preventDefault();
+    updateAutoScroll(evt.clientY);
+    updateDragPositions(evt.clientY);
+  };
+
+  const cleanupDrag = () => {
+    dragAbort?.abort();
+    dragAbort = null;
+    if (autoScrollRaf) cancelAnimationFrame(autoScrollRaf);
+    autoScrollRaf = 0;
+    autoScrollSpeed = 0;
+    dragSourceIndex.value = null;
+    dragDropIndex.value = null;
+    draggedItem.value = null;
+    dragRowHeight.value = 0;
+    dragGrabOffset = 0;
+    dragItemId = null;
+  };
+
+  const finishDrag = (commit: boolean) => {
+    const source = dragSourceIndex.value;
+    const drop = dragDropIndex.value;
+    const itemId = dragItemId;
+    const queue = store.activePlayerQueue;
+    cleanupDrag();
+    if (!commit || source == null || drop == null || itemId == null || !queue)
+      return;
+    // Removing the source first shifts everything after it down by one, so the
+    // final resting index is one lower when dropping below the original spot.
+    const finalIndex = drop > source ? drop - 1 : drop;
+    const shift = finalIndex - source;
+    if (shift === 0) return;
+    api.queueCommandMoveItem(queue.queue_id, itemId, shift);
+  };
+
+  // Begin dragging an up-next row from its drag handle.
+  const startItemDrag = (evt: PointerEvent, index: number) => {
+    // Primary mouse button / touch / pen only.
+    if (evt.pointerType === "mouse" && evt.button !== 0) return;
+    const item = itemAt(index);
+    if (!item || index < firstReorderableIndex()) return;
+
+    // Measure the grabbed item so the ghost lines up under the finger and the
+    // gap the other rows open matches the item's height. Fall back to the
+    // virtualizer's measurement if the element can't be resolved.
+    const el = scrollEl.value;
+    const qitemEl = (evt.target as HTMLElement | null)?.closest(".qitem");
+    if (el && qitemEl) {
+      const cRect = el.getBoundingClientRect();
+      const qRect = qitemEl.getBoundingClientRect();
+      const qTop = qRect.top - cRect.top + el.scrollTop;
+      dragRowHeight.value = qRect.height;
+      dragGrabOffset = evt.clientY - cRect.top + el.scrollTop - qTop;
+      ghostY.value = qTop;
+    } else {
+      const vItem = getVirtualItems().find((v) => v.index === index);
+      dragRowHeight.value = vItem?.size ?? 60;
+      dragGrabOffset = dragRowHeight.value / 2;
+      ghostY.value = (vItem?.start ?? 0) + dragRowHeight.value / 2;
+    }
+
+    dragSourceIndex.value = index;
+    dragDropIndex.value = index;
+    draggedItem.value = item;
+    dragItemId = item.queue_item_id;
+    dragPointerY = evt.clientY;
+    autoScrollSpeed = 0;
+    onDragStart?.();
+    dragAbort = new AbortController();
+    const { signal } = dragAbort;
+    window.addEventListener("pointermove", onDragPointerMove, {
+      passive: false,
+      signal,
+    });
+    window.addEventListener("pointerup", () => finishDrag(true), { signal });
+    window.addEventListener("pointercancel", () => finishDrag(false), {
+      signal,
+    });
+    autoScrollRaf = requestAnimationFrame(autoScrollFrame);
+  };
+
+  // Index of the row currently being dragged (the hidden source row).
+  const draggingIndex = computed(() => dragSourceIndex.value);
+
+  // Whether a reorder drag is in progress (drives the ghost + gap rendering).
+  const isDragging = computed(() => dragSourceIndex.value !== null);
+
+  // Extra Y offset for a visible row so the rows between the source and the
+  // drop target slide aside, opening a gap the size of the dragged row exactly
+  // where it will land. Returns 0 for everything else (incl. the source row).
+  const rowOffset = (index: number): number => {
+    const source = dragSourceIndex.value;
+    const drop = dragDropIndex.value;
+    if (source == null || drop == null || index === source) return 0;
+    const height = dragRowHeight.value;
+    // Dragging down: rows below the source and above the target shift up.
+    if (drop > source && index > source && index < drop) return -height;
+    // Dragging up: rows from the target down to the source shift down.
+    if (drop < source && index >= drop && index < source) return height;
+    return 0;
+  };
+
+  onBeforeUnmount(cleanupDrag);
+
+  return {
+    startItemDrag,
+    draggingIndex,
+    isDragging,
+    draggedItem,
+    ghostY,
+    rowOffset,
+  };
+}

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -82,6 +82,7 @@
     "queue_next_items": "Next items",
     "queue_options": "Queue options",
     "queue_previous_items": "Played items",
+    "queue_reorder": "Drag to reorder",
     "queue_radio_based_on": "The queue is dynamically filled with tracks based on:",
     "queue_radio_enabled": "Radio mode is enabled",
     "radios": "Radio",

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,5 +1,5 @@
 import { defineConfig, mergeConfig } from "vite";
-import "vitest/config";
+import { configDefaults } from "vitest/config";
 import viteConfig from "./vite.config";
 
 export default mergeConfig(
@@ -10,6 +10,9 @@ export default mergeConfig(
       globals: true,
       css: false,
       setupFiles: [],
+      // Ignore nested git worktrees so a sibling branch's tests under
+      // ./.worktrees aren't picked up by this repo's suite.
+      exclude: [...configDefaults.exclude, "**/.worktrees/**"],
     },
   }),
 );


### PR DESCRIPTION
Up next items in the fullscreen player queue could previously only be reordered through the context menu (move up / down / to next / to end). This adds direct drag-and-drop reordering, with a live preview of where the item will land.

## Changes
- Add a drag handle to up next items to reorder them by dragging.
- Lift the dragged row into a floating ghost that follows the pointer while the other rows slide apart to reveal the drop position.
- Auto-scroll the list when dragging near the top or bottom edge.
- Keep buffered and playing items locked; only up next items can be moved.
- Works with the existing virtualized list — no new dependencies.

_Also excludes the local `.worktrees/` folder from the vitest run, so a nested git worktree's tests aren't scanned by the suite._
