### PR TITLE
Extract the fullscreen queue item context menu into a helper

### DIFF
--- a/src/helpers/queue_item_menu_items.ts
+++ b/src/helpers/queue_item_menu_items.ts
@@ -1,0 +1,85 @@
+// shared logic to build the per-item context menu for the fullscreen queue list
+import { ContextMenuItem } from "@/layouts/default/ItemContextMenu.vue";
+import api from "@/plugins/api";
+import { MediaType, QueueItem } from "@/plugins/api/interfaces";
+import router from "@/plugins/router";
+import { store } from "@/plugins/store";
+
+// Builds the context-menu entries for a single queue item. Items up to and
+// including the buffered region are locked (already cued in the stream), so
+// they can't be moved or removed.
+export const getQueueItemMenuItems = (
+  item: QueueItem,
+  index: number,
+): ContextMenuItem[] => {
+  const queue = store.activePlayerQueue;
+  if (!queue) return [];
+  const queueId = queue.queue_id;
+  const locked = index <= (queue.index_in_buffer ?? 0);
+
+  const menuItems: ContextMenuItem[] = [
+    {
+      label: "play_now",
+      labelArgs: [],
+      action: () => api.queueCommandPlayIndex(queueId, item.queue_item_id),
+      icon: "mdi-play-circle-outline",
+      disabled:
+        index === queue.current_index || index === queue.index_in_buffer,
+    },
+    {
+      label: "play_next",
+      labelArgs: [],
+      action: () => api.queueCommandMoveNext(queueId, item.queue_item_id),
+      icon: "mdi-skip-next-circle-outline",
+      disabled: locked,
+    },
+    {
+      label: "queue_move_up",
+      labelArgs: [],
+      action: () => api.queueCommandMoveUp(queueId, item.queue_item_id),
+      icon: "mdi-arrow-up",
+      disabled: locked,
+    },
+    {
+      label: "queue_move_down",
+      labelArgs: [],
+      action: () => api.queueCommandMoveDown(queueId, item.queue_item_id),
+      icon: "mdi-arrow-down",
+      disabled: locked,
+    },
+    {
+      label: "queue_move_end",
+      labelArgs: [],
+      action: () => api.queueCommandMoveItemEnd(queueId, item.queue_item_id),
+      icon: "mdi-arrow-collapse-down",
+      disabled: locked,
+    },
+    {
+      label: "queue_delete",
+      labelArgs: [],
+      action: () => api.queueCommandDelete(queueId, item.queue_item_id),
+      icon: "mdi-delete",
+      disabled: locked,
+    },
+  ];
+
+  // tracks can be opened in their detail page (closes the fullscreen player)
+  const mediaItem = item.media_item;
+  if (mediaItem?.media_type === MediaType.TRACK) {
+    menuItems.push({
+      label: "show_info",
+      labelArgs: [],
+      action: () => {
+        store.showFullscreenPlayer = false;
+        router.push({
+          name: mediaItem.media_type,
+          params: { itemId: mediaItem.item_id, provider: mediaItem.provider },
+        });
+      },
+      icon: "mdi-information-outline",
+      disabled: false,
+    });
+  }
+
+  return menuItems;
+};

--- a/src/layouts/default/PlayerOSD/useFullscreenQueue.ts
+++ b/src/layouts/default/PlayerOSD/useFullscreenQueue.ts
@@ -4,6 +4,7 @@
 // keep that component focused on layout.
 import { usePartyConfig } from "@/composables/usePartyConfig";
 import { MarqueeTextSync } from "@/helpers/marquee_text_sync";
+import { getQueueItemMenuItems } from "@/helpers/queue_item_menu_items";
 import { useQueueDragReorder } from "@/layouts/default/PlayerOSD/useQueueDragReorder";
 import api from "@/plugins/api";
 import {
@@ -11,14 +12,11 @@ import {
   EventType,
   MediaItemChapter,
   MediaItemType,
-  MediaType,
   PlaybackState,
   QueueItem,
   QueueOption,
-  Track,
 } from "@/plugins/api/interfaces";
 import { eventbus } from "@/plugins/eventbus";
-import router from "@/plugins/router";
 import { store } from "@/plugins/store";
 import { useVirtualizer } from "@tanstack/vue-virtual";
 import {
@@ -257,128 +255,11 @@ export function useFullscreenQueue(showLyrics: Ref<boolean>) {
 
   // ---- per-item context menu / actions ------------------------------------
 
-  const itemClick = (item: MediaItemType) => {
-    // a media item in the list was clicked
-    store.showFullscreenPlayer = false;
-    router.push({
-      name: item.media_type,
-      params: {
-        itemId: item.item_id,
-        provider: item.provider,
-      },
-    });
-  };
-
-  const queueCommand = (item: QueueItem | undefined, command: string) => {
-    if (!item || !store.activePlayerQueue) return;
-    if (command == "play_now") {
-      api.queueCommandPlayIndex(
-        store.activePlayerQueue.queue_id,
-        item.queue_item_id,
-      );
-    } else if (command == "move_next") {
-      api.queueCommandMoveNext(
-        store.activePlayerQueue.queue_id,
-        item.queue_item_id,
-      );
-    } else if (command == "up") {
-      api.queueCommandMoveUp(
-        store.activePlayerQueue.queue_id,
-        item.queue_item_id,
-      );
-    } else if (command == "down") {
-      api.queueCommandMoveDown(
-        store.activePlayerQueue.queue_id,
-        item.queue_item_id,
-      );
-    } else if (command == "end") {
-      api.queueCommandMoveItemEnd(
-        store.activePlayerQueue.queue_id,
-        item.queue_item_id,
-      );
-    } else if (command == "delete") {
-      api.queueCommandDelete(
-        store.activePlayerQueue.queue_id,
-        item.queue_item_id,
-      );
-    }
-  };
-
   const openQueueItemMenu = (evt: Event, index: number) => {
     const item = itemAt(index);
     if (!item) return;
-    const itemIndex = index;
-    const menuItems = [
-      {
-        label: "play_now",
-        labelArgs: [],
-        action: () => {
-          queueCommand(item, "play_now");
-        },
-        icon: "mdi-play-circle-outline",
-        disabled:
-          itemIndex === store.activePlayerQueue?.current_index ||
-          itemIndex === store.activePlayerQueue?.index_in_buffer,
-      },
-      {
-        label: "play_next",
-        labelArgs: [],
-        action: () => {
-          queueCommand(item, "move_next");
-        },
-        icon: "mdi-skip-next-circle-outline",
-        disabled: itemIndex <= (store.activePlayerQueue?.index_in_buffer || 0),
-      },
-      {
-        label: "queue_move_up",
-        labelArgs: [],
-        action: () => {
-          queueCommand(item, "up");
-        },
-        icon: "mdi-arrow-up",
-        disabled: itemIndex <= (store.activePlayerQueue?.index_in_buffer || 0),
-      },
-      {
-        label: "queue_move_down",
-        labelArgs: [],
-        action: () => {
-          queueCommand(item, "down");
-        },
-        icon: "mdi-arrow-down",
-        disabled: itemIndex <= (store.activePlayerQueue?.index_in_buffer || 0),
-      },
-      {
-        label: "queue_move_end",
-        labelArgs: [],
-        action: () => {
-          queueCommand(item, "end");
-        },
-        icon: "mdi-arrow-collapse-down",
-        disabled: itemIndex <= (store.activePlayerQueue?.index_in_buffer || 0),
-      },
-      {
-        label: "queue_delete",
-        labelArgs: [],
-        action: () => {
-          queueCommand(item, "delete");
-        },
-        icon: "mdi-delete",
-        disabled: itemIndex <= (store.activePlayerQueue?.index_in_buffer || 0),
-      },
-    ];
-    if (item?.media_item?.media_type == MediaType.TRACK) {
-      menuItems.push({
-        label: "show_info",
-        labelArgs: [],
-        action: () => {
-          itemClick(item.media_item as Track);
-        },
-        icon: "mdi-information-outline",
-        disabled: false,
-      });
-    }
     eventbus.emit("contextmenu", {
-      items: menuItems,
+      items: getQueueItemMenuItems(item, index),
       posX: (evt as PointerEvent).clientX,
       posY: (evt as PointerEvent).clientY,
     });


### PR DESCRIPTION
Follow-up to #1961. The per-item context menu for the fullscreen queue list was built inline in `useFullscreenQueue`. This moves it into a dedicated helper, matching the existing `player_menu_items.ts` pattern, so the composable stays focused on the list itself.

## Changes
- Add `helpers/queue_item_menu_items.ts` with `getQueueItemMenuItems(item, index)`.
- Remove the inline menu building (plus the now-unused `queueCommand` / `itemClick` and their imports) from `useFullscreenQueue`.

_Pure refactor — no behaviour change._
