### PR TITLE
Add Start Radio to the queue item menu and drop redundant move up/down

### DIFF
--- a/src/helpers/queue_item_menu_items.ts
+++ b/src/helpers/queue_item_menu_items.ts
@@ -1,7 +1,8 @@
 // shared logic to build the per-item context menu for the fullscreen queue list
+import { radioModeSupported } from "@/helpers/radio";
 import { ContextMenuItem } from "@/layouts/default/ItemContextMenu.vue";
 import api from "@/plugins/api";
-import { MediaType, QueueItem } from "@/plugins/api/interfaces";
+import { MediaType, QueueItem, QueueOption } from "@/plugins/api/interfaces";
 import router from "@/plugins/router";
 import { store } from "@/plugins/store";
 
@@ -33,20 +34,22 @@ export const getQueueItemMenuItems = (
       icon: "mdi-skip-next-circle-outline",
       disabled: locked,
     },
-    {
-      label: "queue_move_up",
+  ];
+
+  // start a radio (endless similar-tracks mix) based on this item
+  const mediaItem = item.media_item;
+  if (mediaItem && radioModeSupported(mediaItem)) {
+    menuItems.push({
+      label: "play_radio",
       labelArgs: [],
-      action: () => api.queueCommandMoveUp(queueId, item.queue_item_id),
-      icon: "mdi-arrow-up",
-      disabled: locked,
-    },
-    {
-      label: "queue_move_down",
-      labelArgs: [],
-      action: () => api.queueCommandMoveDown(queueId, item.queue_item_id),
-      icon: "mdi-arrow-down",
-      disabled: locked,
-    },
+      action: () => api.playMedia([mediaItem.uri], QueueOption.REPLACE, true),
+      icon: "mdi-radio-tower",
+      disabled: false,
+    });
+  }
+
+  // quick reorder / remove (drag the handle for fine-grained moves)
+  menuItems.push(
     {
       label: "queue_move_end",
       labelArgs: [],
@@ -61,10 +64,9 @@ export const getQueueItemMenuItems = (
       icon: "mdi-delete",
       disabled: locked,
     },
-  ];
+  );
 
   // tracks can be opened in their detail page (closes the fullscreen player)
-  const mediaItem = item.media_item;
   if (mediaItem?.media_type === MediaType.TRACK) {
     menuItems.push({
       label: "show_info",

--- a/src/helpers/radio.ts
+++ b/src/helpers/radio.ts
@@ -1,0 +1,53 @@
+// shared logic to decide whether "radio mode" (an endless similar-tracks mix)
+// can be started from a given media item
+import api from "@/plugins/api";
+import {
+  MediaItemTypeOrItemMapping,
+  MediaType,
+  Playlist,
+  ProviderFeature,
+} from "@/plugins/api/interfaces";
+
+export const radioModeSupported = (
+  item: MediaItemTypeOrItemMapping,
+): boolean => {
+  if (
+    ![
+      MediaType.TRACK,
+      MediaType.ARTIST,
+      MediaType.ALBUM,
+      MediaType.PLAYLIST,
+    ].includes(item.media_type)
+  ) {
+    return false;
+  }
+  // dynamic playlists own their own track feed — radio mode would conflict
+  if (item.media_type === MediaType.PLAYLIST && (item as Playlist).is_dynamic) {
+    return false;
+  }
+  if ("provider_mappings" in item) {
+    for (const provId of item.provider_mappings) {
+      if (
+        api.providers[provId.provider_instance]?.supported_features.includes(
+          ProviderFeature.SIMILAR_TRACKS,
+        )
+      )
+        return true;
+    }
+  } else if (
+    api.providers[item.provider]?.supported_features.includes(
+      ProviderFeature.SIMILAR_TRACKS,
+    )
+  ) {
+    return true;
+  }
+  // generic radio mode: any provider supports similar tracks and the item is
+  // (matched) in the library
+  if (item.provider === "library") {
+    for (const prov of Object.values(api.providers)) {
+      if (prov.supported_features.includes(ProviderFeature.SIMILAR_TRACKS))
+        return true;
+    }
+  }
+  return false;
+};

--- a/src/layouts/default/ItemContextMenu.vue
+++ b/src/layouts/default/ItemContextMenu.vue
@@ -217,6 +217,7 @@ const playMenuHeaderClicked = function (evt: MouseEvent | KeyboardEvent) {
 
 import router from "@/plugins/router";
 
+import { radioModeSupported } from "@/helpers/radio";
 import { playerVisible } from "@/helpers/utils";
 import { isItemInLibrary, itemIsAvailable } from "@/plugins/api/helpers";
 import {
@@ -1251,49 +1252,6 @@ export const getPlaybackContextMenuItems = async function (
     }
   }
   return playMenuItems;
-};
-
-const radioModeSupported = function (item: MediaItemTypeOrItemMapping) {
-  if (
-    ![
-      MediaType.TRACK,
-      MediaType.ARTIST,
-      MediaType.ALBUM,
-      MediaType.PLAYLIST,
-    ].includes(item.media_type)
-  ) {
-    return;
-  }
-  // Dynamic playlists own their own track feed — radio mode would conflict
-  if (item.media_type === MediaType.PLAYLIST && (item as Playlist).is_dynamic) {
-    return false;
-  }
-  if ("provider_mappings" in item) {
-    for (const provId of item.provider_mappings) {
-      if (
-        api.providers[provId.provider_instance]?.supported_features.includes(
-          ProviderFeature.SIMILAR_TRACKS,
-        )
-      )
-        return true;
-    }
-  } else if (
-    api.providers[item.provider]?.supported_features.includes(
-      ProviderFeature.SIMILAR_TRACKS,
-    )
-  ) {
-    return true;
-  }
-  // we also support a generic radio mode if we have ANY provider with similar track feature
-  // and the track is (matched) in the library
-  if (item.provider == "library") {
-    for (const prov of Object.values(api.providers)) {
-      if (prov.supported_features.includes(ProviderFeature.SIMILAR_TRACKS))
-        return true;
-    }
-  }
-
-  return false;
 };
 </script>
 


### PR DESCRIPTION
Follow-up to #1961 and #1962. Two tweaks to the per-item context menu in the fullscreen queue list.

## Changes
- **Add a "Start Radio" entry** for items whose provider supports similar tracks, mirroring the regular item menu.
- **Remove "move up" / "move down"** — up-next items can be dragged to reorder now (#1961), so they're redundant (the quick "play next" / "move to end" jumps stay).
- Extract the shared `radioModeSupported` check into `helpers/radio.ts`, reused by `ItemContextMenu`.

_No new translations needed (`play_radio` already exists)._
