### PR TITLE
Restore the player settings entry in the player menu

### DIFF
--- a/src/helpers/player_menu_items.ts
+++ b/src/helpers/player_menu_items.ts
@@ -249,6 +249,20 @@ export const getPlayerMenuItems = (
       });
     }
 
+    // open player settings (player menu only)
+    if (isPlayer) {
+      menuItems.push({
+        label: "open_player_settings",
+        labelArgs: [],
+        action: () => {
+          store.showFullscreenPlayer = false;
+          store.showPlayersMenu = false;
+          router.push(`/settings/editplayer/${player.player_id}`);
+        },
+        icon: "mdi-cog-outline",
+      });
+    }
+
     // open dsp settings (player menu only)
     if (isPlayer && player.type !== PlayerType.GROUP) {
       menuItems.push({
@@ -263,7 +277,7 @@ export const getPlayerMenuItems = (
       });
     }
 
-    // open player settings (both menus)
+    // open player options (both menus)
     if (player.options.length > 0) {
       menuItems.push({
         label: "player_options.open",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -682,6 +682,7 @@
     "powered_off_players": "Unpowered players",
     "sync_player_with": "Synchronize with another player",
     "open_queue_settings": "Open queue settings",
+    "open_player_settings": "Open player settings",
     "select_repeat_mode": "Select repeat mode",
     "repeat_mode": {
         "all": "Repeat entire queue",


### PR DESCRIPTION
The player context menu (the 3-dots on a player entry in the player select) no longer had an entry to open that player's settings. The per-queue settings change (#1942) repurposed that menu slot into "Open queue settings" and dropped the player settings shortcut along with its translation key, leaving no way to reach the player settings page from the menu.

- Restore the "Open player settings" entry in the player context menu, linking to the player settings page
- Re-add the `open_player_settings` translation key