### PR TITLE
Add sleep timer support

### DIFF
--- a/src/helpers/player_menu_items.ts
+++ b/src/helpers/player_menu_items.ts
@@ -10,6 +10,7 @@ import {
   PLAYER_CONTROL_NONE,
 } from "@/plugins/api/interfaces";
 import { isQueueDynamicPlaylist } from "@/plugins/api/helpers";
+import { getSleepTimerMenuItem, sleepTimerActive } from "@/helpers/sleep_timer";
 import { authManager } from "@/plugins/auth";
 import router from "@/plugins/router";
 import { eventbus } from "@/plugins/eventbus";
@@ -59,6 +60,15 @@ export const getPlayerMenuItems = (
       },
       icon: "mdi-stop",
     });
+  }
+
+  // sleep timer (both menus); available while playing/paused or already running
+  if (
+    player?.playback_state == "playing" ||
+    player?.playback_state == "paused" ||
+    sleepTimerActive(player)
+  ) {
+    menuItems.push(getSleepTimerMenuItem(player));
   }
 
   const isSingleDynamicPlaylist = isQueueDynamicPlaylist(playerQueue);

--- a/src/helpers/sleep_timer.ts
+++ b/src/helpers/sleep_timer.ts
@@ -1,0 +1,67 @@
+// shared logic for the player sleep timer
+// provides the quick-pick durations, helpers to read the remaining time and the
+// menu items shown in the player/queue menus and the sleep timer indicator.
+import { ContextMenuItem } from "@/layouts/default/ItemContextMenu.vue";
+import { formatDuration } from "@/helpers/utils";
+import api from "@/plugins/api";
+import { Player } from "@/plugins/api/interfaces";
+import { Moon, X } from "@lucide/vue";
+
+// quick-pick durations (in minutes) offered when setting a sleep timer
+const SLEEP_TIMER_PRESETS = [
+  { minutes: 15, label: "sleep_timer_preset.15" },
+  { minutes: 30, label: "sleep_timer_preset.30" },
+  { minutes: 45, label: "sleep_timer_preset.45" },
+  { minutes: 60, label: "sleep_timer_preset.60" },
+  { minutes: 120, label: "sleep_timer_preset.120" },
+];
+
+// Whether the player currently has a sleep timer that will still fire.
+export const sleepTimerActive = (player?: Player): boolean => {
+  const expiresAt = player?.sleep_timer_expires_at;
+  return expiresAt != null && expiresAt > Date.now() / 1000;
+};
+
+// Seconds remaining until the sleep timer stops playback (0 when inactive).
+export const sleepTimerRemaining = (player?: Player): number => {
+  const expiresAt = player?.sleep_timer_expires_at;
+  if (expiresAt == null) return 0;
+  return Math.max(0, expiresAt - Date.now() / 1000);
+};
+
+// Formatted countdown (mm:ss / h:mm:ss) for the remaining sleep timer time.
+export const formatSleepTimerRemaining = (player?: Player): string => {
+  return formatDuration(sleepTimerRemaining(player));
+};
+
+// Sleep timer menu items: a duration preset list, plus a cancel action when a
+// timer is already running. Shared by the player/queue menus and the indicator.
+export const getSleepTimerMenuItems = (player: Player): ContextMenuItem[] => {
+  const menuItems: ContextMenuItem[] = SLEEP_TIMER_PRESETS.map((preset) => ({
+    label: preset.label,
+    labelArgs: [],
+    action: () => api.setSleepTimer(player.player_id, preset.minutes * 60),
+  }));
+  if (sleepTimerActive(player)) {
+    menuItems.push({
+      label: "sleep_timer_cancel",
+      labelArgs: [],
+      action: () => api.clearSleepTimer(player.player_id),
+      icon: X,
+      color: "error",
+    });
+  }
+  return menuItems;
+};
+
+// Single submenu entry for the player/queue context menus. Surfaces the
+// remaining time alongside the label while a timer is active.
+export const getSleepTimerMenuItem = (player: Player): ContextMenuItem => {
+  const active = sleepTimerActive(player);
+  return {
+    label: active ? "sleep_timer_active" : "sleep_timer",
+    labelArgs: active ? [formatSleepTimerRemaining(player)] : [],
+    icon: Moon,
+    subItems: getSleepTimerMenuItems(player),
+  };
+};

--- a/src/layouts/default/PlayerOSD/PlayerControlBtn/SleepTimerBtn.vue
+++ b/src/layouts/default/PlayerOSD/PlayerControlBtn/SleepTimerBtn.vue
@@ -1,0 +1,107 @@
+<!--
+  Sleep timer indicator. Only rendered while the active player has a running
+  sleep timer; shows a live countdown and opens the sleep timer menu (presets +
+  cancel) on click.
+-->
+<template>
+  <TooltipProvider v-if="active" :delay-duration="200">
+    <Tooltip>
+      <TooltipTrigger as-child>
+        <Button
+          variant="outline"
+          size="xs"
+          :class="['gap-1 tabular-nums', pill ? pillClass : '']"
+          :aria-label="$t('sleep_timer')"
+          v-bind="$attrs"
+          @click.stop="openMenu"
+        >
+          <Moon :size="16" />
+          <span>{{ remaining }}</span>
+        </Button>
+      </TooltipTrigger>
+      <TooltipContent side="bottom" class="z-[10001] max-w-[240px]">
+        <p class="font-medium">{{ $t("sleep_timer") }}</p>
+        <p class="mt-1 opacity-80">
+          {{ $t("sleep_timer_remaining", [remaining]) }}
+        </p>
+      </TooltipContent>
+    </Tooltip>
+  </TooltipProvider>
+</template>
+
+<script setup lang="ts">
+import { Button } from "@/components/ui/button";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { getSleepTimerMenuItems } from "@/helpers/sleep_timer";
+import { formatDuration } from "@/helpers/utils";
+import { eventbus } from "@/plugins/eventbus";
+import { $t } from "@/plugins/i18n";
+import { store } from "@/plugins/store";
+import { Moon } from "@lucide/vue";
+import { computed, onBeforeUnmount, ref, watch } from "vue";
+
+// forward fallthrough attrs (e.g. spacing classes) to the button, not the
+// renderless TooltipProvider root.
+defineOptions({ inheritAttrs: false });
+
+withDefaults(
+  defineProps<{
+    // frosted-glass styling to blend with the fullscreen player cover gradient
+    pill?: boolean;
+  }>(),
+  { pill: false },
+);
+
+// Frosted pill styling, matching the other fullscreen header controls.
+const pillClass =
+  "relative bg-background/40 backdrop-blur-md hover:bg-background/60";
+
+// Reactive clock that ticks every second while a timer is active, driving the
+// countdown and the auto-hide when it reaches zero.
+const now = ref(Date.now() / 1000);
+
+const expiresAt = computed(
+  () => store.activePlayer?.sleep_timer_expires_at ?? null,
+);
+const active = computed(
+  () => expiresAt.value != null && expiresAt.value > now.value,
+);
+const remaining = computed(() =>
+  active.value ? formatDuration(expiresAt.value! - now.value) : "",
+);
+
+let ticker: ReturnType<typeof setInterval> | undefined;
+const stopTicking = () => {
+  if (ticker) {
+    clearInterval(ticker);
+    ticker = undefined;
+  }
+};
+watch(
+  active,
+  (isActive) => {
+    if (isActive && !ticker) {
+      ticker = setInterval(() => (now.value = Date.now() / 1000), 1000);
+    } else if (!isActive) {
+      stopTicking();
+    }
+  },
+  { immediate: true },
+);
+onBeforeUnmount(stopTicking);
+
+const openMenu = function (evt: MouseEvent) {
+  const player = store.activePlayer;
+  if (!player) return;
+  eventbus.emit("contextmenu", {
+    items: getSleepTimerMenuItems(player),
+    posX: evt.clientX,
+    posY: evt.clientY,
+  });
+};
+</script>

--- a/src/layouts/default/PlayerOSD/PlayerExtendedControls.vue
+++ b/src/layouts/default/PlayerOSD/PlayerExtendedControls.vue
@@ -9,6 +9,8 @@
   />
   <SpeakerBtn id="extended-controls-speaker-button" :color="player.color" />
 
+  <SleepTimerBtn class="mr-1" />
+
   <QueueBtn
     v-if="queue && queue.isVisible"
     :color="queue.color"
@@ -28,6 +30,7 @@ import ActivePlayerPopover from "@/components/ActivePlayerPopover.vue";
 import { store } from "@/plugins/store";
 import PlayerTrackMenu from "./PlayerControlBtn/PlayerTrackMenu.vue";
 import QueueBtn from "./PlayerControlBtn/QueueBtn.vue";
+import SleepTimerBtn from "./PlayerControlBtn/SleepTimerBtn.vue";
 import SpeakerBtn from "./PlayerControlBtn/SpeakerBtn.vue";
 import PlayerVolume from "./PlayerVolume.vue";
 

--- a/src/layouts/default/PlayerOSD/PlayerFullscreenHeaderControls.vue
+++ b/src/layouts/default/PlayerOSD/PlayerFullscreenHeaderControls.vue
@@ -1,5 +1,8 @@
 <template>
   <div class="fullscreen-header-controls">
+    <!-- sleep timer countdown (only while a timer is running) -->
+    <SleepTimerBtn pill />
+
     <!-- streaming quality details chip (moved up from under the track info) -->
     <QualityDetailsBtn v-if="store.curQueueItem?.streamdetails" pill />
 
@@ -221,6 +224,7 @@
 
 <script setup lang="ts">
 import QualityDetailsBtn from "@/components/QualityDetailsBtn.vue";
+import SleepTimerBtn from "@/layouts/default/PlayerOSD/PlayerControlBtn/SleepTimerBtn.vue";
 import { Button } from "@/components/ui/button";
 import {
   Popover,

--- a/src/plugins/api/index.ts
+++ b/src/plugins/api/index.ts
@@ -1805,6 +1805,37 @@ export class MusicAssistantApi {
     return this.sendCommand("players/remove", { player_id: playerId });
   }
 
+  // Sleep timer related functions/commands
+
+  public getSleepTimer(playerId: string): Promise<number | null> {
+    /*
+      Return the active sleep timer expiry (unix utc timestamp) or null.
+    */
+    return this.sendCommand("players/sleep_timer/get", {
+      player_id: playerId,
+    });
+  }
+
+  public setSleepTimer(playerId: string, seconds: number): Promise<number> {
+    /*
+      Set a sleep timer that stops playback after the given number of seconds.
+      Returns the expiry (unix utc timestamp).
+    */
+    return this.sendCommand("players/sleep_timer/set", {
+      player_id: playerId,
+      seconds,
+    });
+  }
+
+  public clearSleepTimer(playerId: string): Promise<void> {
+    /*
+      Clear the active sleep timer for the given player.
+    */
+    return this.sendCommand("players/sleep_timer/clear", {
+      player_id: playerId,
+    });
+  }
+
   // PlayerGroup related functions/commands
 
   public playerCommandGroupVolume(playerId: string, newVolume: number) {

--- a/src/plugins/api/interfaces.ts
+++ b/src/plugins/api/interfaces.ts
@@ -313,6 +313,7 @@ export enum EventType {
   PLAYER_UPDATED = "player_updated",
   PLAYER_REMOVED = "player_removed",
   PLAYER_SETTINGS_UPDATED = "player_settings_updated",
+  PLAYER_SLEEP_TIMER_UPDATED = "player_sleep_timer_updated",
   QUEUE_ADDED = "queue_added",
   QUEUE_UPDATED = "queue_updated",
   QUEUE_ITEMS_UPDATED = "queue_items_updated",
@@ -1053,6 +1054,10 @@ export interface Player {
   // Can be "native" or a protocol player_id
   // null means no playback in progress or native playback without explicit selection
   active_output_protocol: string | null;
+
+  // sleep_timer_expires_at: unix (utc) timestamp at which the active sleep timer
+  // will stop playback, or null when no sleep timer is set.
+  sleep_timer_expires_at?: number | null;
 }
 
 // provider

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -691,6 +691,17 @@
     },
     "shuffle_disable": "Disable shuffle",
     "shuffle_enable": "Enable shuffle",
+    "sleep_timer": "Sleep timer",
+    "sleep_timer_active": "Sleep timer · {0}",
+    "sleep_timer_remaining": "Stops in {0}",
+    "sleep_timer_cancel": "Cancel sleep timer",
+    "sleep_timer_preset": {
+        "15": "15 minutes",
+        "30": "30 minutes",
+        "45": "45 minutes",
+        "60": "1 hour",
+        "120": "2 hours"
+    },
     "autoplay_enable": "Enable Autoplay",
     "autoplay_disable": "Disable Autoplay",
     "crossfade_enable": "Enable crossfade",


### PR DESCRIPTION
Adds frontend support for the native player sleep timer introduced in music-assistant/server#4432, so playback can stop automatically after a set time.

## Changes
- Add a **Sleep timer** entry to both the player and queue menus to set, reset or cancel a timer (quick-pick durations: 15 / 30 / 45 min, 1 h, 2 h).
- Show a live countdown indicator in the now playing bar and the fullscreen player header while a timer is active; click it to reset or cancel.
- Wrap the new `players/sleep_timer/{get,set,clear}` commands and expose `sleep_timer_expires_at` on the player model.

Companion to music-assistant/server#4432 — depends on that backend PR being merged first.
