### PR TITLE
Include icon aliases in IconPicker search results

### DIFF
--- a/src/components/IconPicker.vue
+++ b/src/components/IconPicker.vue
@@ -49,15 +49,17 @@
 
 <script setup lang="ts">
 import {
+  getAllSearchableIconNames,
   getLucideIcon,
   getLucideIconNames,
-  MA_ICON_NAMES,
   SUGGESTED_ICON_NAMES,
 } from "@/helpers/icon";
 import { computed, onMounted, ref } from "vue";
 
+const searchableIconNames = ref<readonly string[]>([]);
 const lucideIconNames = ref<readonly string[]>([]);
 onMounted(() => {
+  searchableIconNames.value = getAllSearchableIconNames();
   getLucideIconNames().then((names) => {
     lucideIconNames.value = names;
   });
@@ -94,8 +96,8 @@ const filteredItems = computed(() => {
   const suggestedSet = new Set(SUGGESTED_ICON_NAMES);
   const ranked: { rank: number; name: string }[] = [];
 
-  // MA icons searched first so they appear at the top when matched
-  for (const name of [...MA_ICON_NAMES, ...lucideIconNames.value]) {
+  // Search across MA icons (including aliases) and Lucide icons
+  for (const name of [...searchableIconNames.value, ...lucideIconNames.value]) {
     const parts = name.split("-");
     let rank: number;
 

--- a/src/helpers/icon.ts
+++ b/src/helpers/icon.ts
@@ -44,6 +44,11 @@ export function isMdiIcon(name: string | null | undefined): boolean {
   return !!name?.startsWith("mdi-");
 }
 
+/** All searchable MA icon names including aliases, sorted alphabetically. */
+export function getAllSearchableIconNames(): readonly string[] {
+  return [...MA_ICON_NAMES, ...Object.keys(MaIcons.aliases)].sort();
+}
+
 /** All Lucide icon names in kebab-case, sorted alphabetically. Awaits the async module. */
 export async function getLucideIconNames(): Promise<readonly string[]> {
   return Object.keys(lucideModule)


### PR DESCRIPTION
# What does this implement/fix?

Fixes an issue reported in #1779 where icon aliases (like `speaker-loud` → `volume-2`) only appeared in the default suggestions list but not when typing a search query.

## Changes

- Added `getAllSearchableIconNames()` helper to export MA icon names + all aliases
- Updated IconPicker to search across both canonical names and aliases
- Aliases like `speaker-loud`, `bluetooth-speaker`, `laptop-2` are now findable via search

## Example

Before: Searching for "speaker" → only shows `speaker` (Lucide icon)
After: Searching for "speaker" → shows `speaker`, `speaker-loud`, `bluetooth-speaker`, `monitor-speaker`

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the code style of this project
- [x] All existing tests pass locally
- [ ] No new tests needed (search functionality has no dedicated test coverage)