### PR TITLE
Add smart shuffle indicator to the player

### DIFF
--- a/src/layouts/default/PlayerOSD/PlayerControlBtn/ShuffleBtn.vue
+++ b/src/layouts/default/PlayerOSD/PlayerControlBtn/ShuffleBtn.vue
@@ -5,11 +5,8 @@
     :disabled="
       !playerQueue || !playerQueue.active || isLoading || isInfiniteStream
     "
-    :color="
-      getValueFromSources(icon?.color, [
-        [playerQueue?.shuffle_enabled || false, 'primary', ''],
-      ])
-    "
+    :color="getValueFromSources(icon?.color, [[shuffleActive, 'primary', '']])"
+    :title="shuffleTitle"
     variant="button"
     @click="
       api.queueCommandShuffle(
@@ -18,7 +15,11 @@
       )
     "
   >
-    <Shuffle v-if="playerQueue?.shuffle_enabled" :size="size" />
+    <ShuffleIcon
+      v-if="shuffleActive"
+      :size="size"
+      :smart="smartShuffleActive"
+    />
     <IconArrowsRight v-else :size="size" />
   </Icon>
 </template>
@@ -26,11 +27,12 @@
 <script setup lang="ts">
 defineOptions({ inheritAttrs: false });
 import Icon, { IconProps } from "@/components/Icon.vue";
+import ShuffleIcon from "@/layouts/default/PlayerOSD/PlayerControlBtn/ShuffleIcon.vue";
 import { getValueFromSources } from "@/helpers/utils";
 import api from "@/plugins/api";
 import { isQueueInfiniteStream } from "@/plugins/api/helpers";
 import { PlayerQueue } from "@/plugins/api/interfaces";
-import { Shuffle } from "@lucide/vue";
+import { $t } from "@/plugins/i18n";
 import { IconArrowsRight } from "@tabler/icons-vue";
 import { computed } from "vue";
 
@@ -54,4 +56,26 @@ const isLoading = computed(() => {
 const isInfiniteStream = computed(() =>
   isQueueInfiniteStream(compProps.playerQueue),
 );
+
+// Server-derived: shuffle is on with the per-queue smart-shuffle setting, or
+// radio mode is active (the server sets this in both cases). Drives the
+// twinkling smart-shuffle indicator.
+const smartShuffleActive = computed(
+  () => compProps.playerQueue?.smart_shuffle_active === true,
+);
+
+// Whether shuffle is in effect at all (plain or smart) — drives the icon choice
+// and the primary highlight.
+const shuffleActive = computed(
+  () =>
+    compProps.playerQueue?.shuffle_enabled === true || smartShuffleActive.value,
+);
+
+// State-aware tooltip reflecting plain vs smart shuffle.
+const shuffleTitle = computed(() => {
+  if (smartShuffleActive.value) return $t("shuffle_smart_active");
+  return compProps.playerQueue?.shuffle_enabled
+    ? $t("shuffle_disable")
+    : $t("shuffle_enable");
+});
 </script>

--- a/src/layouts/default/PlayerOSD/PlayerControlBtn/ShuffleIcon.vue
+++ b/src/layouts/default/PlayerOSD/PlayerControlBtn/ShuffleIcon.vue
@@ -1,0 +1,88 @@
+<template>
+  <!--
+    Shuffle icon.
+    Inlined version of the lucide "shuffle" icon. When smart shuffle is active
+    the short upper-left stub is replaced by an "AI sparkle" (à la Spotify's
+    smart shuffle) that twinkles with a soft glow, setting the smart mode apart
+    from plain shuffle.
+  -->
+  <svg
+    class="shuffle-icon"
+    :width="size"
+    :height="size"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    stroke-width="2"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+    aria-hidden="true"
+  >
+    <path d="m18 14 4 4-4 4" />
+    <path d="m18 2 4 4-4 4" />
+    <path d="M2 18h1.973a4 4 0 0 0 3.3-1.7l5.454-8.6a4 4 0 0 1 3.3-1.7H22" />
+    <!-- upper-left stub: shown for plain shuffle, replaced by the sparkle when smart -->
+    <path v-if="!smart" d="M2 6h1.972a4 4 0 0 1 3.6 2.2" />
+    <path d="M22 18h-6.041a4 4 0 0 1-3.3-1.8l-.359-.45" />
+    <path
+      v-if="smart"
+      class="shuffle-sparkle"
+      stroke="none"
+      fill="currentColor"
+      d="M5 2.6Q6.1 5.9 9.4 7Q6.1 8.1 5 11.4Q3.9 8.1 0.6 7Q3.9 5.9 5 2.6Z"
+    />
+  </svg>
+</template>
+
+<script setup lang="ts">
+withDefaults(
+  defineProps<{
+    size?: number | string;
+    smart?: boolean;
+  }>(),
+  {
+    size: 24,
+    smart: false,
+  },
+);
+</script>
+
+<style scoped>
+.shuffle-icon {
+  display: inline-block;
+  vertical-align: middle;
+  /* let the sparkle glow extend slightly beyond the icon box */
+  overflow: visible;
+}
+
+/*
+  The "AI sparkle" that marks smart shuffle: a soft glow plus a gentle scale +
+  opacity pulse around its own centre, so the smart state reads at a glance.
+*/
+.shuffle-sparkle {
+  transform-box: fill-box;
+  transform-origin: center;
+  filter: drop-shadow(0 0 2px currentColor);
+  animation: shuffle-sparkle-twinkle 2.4s ease-in-out infinite;
+}
+
+@keyframes shuffle-sparkle-twinkle {
+  0%,
+  100% {
+    opacity: 0.6;
+    transform: scale(0.78);
+  }
+  50% {
+    opacity: 1;
+    transform: scale(1);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .shuffle-sparkle {
+    animation: none;
+    opacity: 1;
+    transform: none;
+  }
+}
+</style>

--- a/src/layouts/default/PlayerOSD/PlayerFullscreenHeaderControls.vue
+++ b/src/layouts/default/PlayerOSD/PlayerFullscreenHeaderControls.vue
@@ -204,7 +204,13 @@
                 : $t("crossfade_enable")
             }}
           </p>
-          <p v-if="!crossfadeEnabled" class="mt-1 opacity-80">
+          <p
+            v-if="crossfadeEnabled && smartFadesActive"
+            class="mt-1 opacity-80"
+          >
+            {{ $t("crossfade_smart_active") }}
+          </p>
+          <p v-else-if="!crossfadeEnabled" class="mt-1 opacity-80">
             {{ $t("crossfade_explanation") }}
           </p>
         </TooltipContent>

--- a/src/plugins/api/interfaces.ts
+++ b/src/plugins/api/interfaces.ts
@@ -883,6 +883,10 @@ export interface PlayerQueue {
   available: boolean;
   items: number;
   shuffle_enabled: boolean;
+  // smart_shuffle_active: whether shuffle is currently in "smart" mode (server-derived,
+  // read-only). True when shuffle is on with the per-queue smart-shuffle setting enabled,
+  // or while radio mode is active. Lets clients show a smart-shuffle indicator.
+  smart_shuffle_active: boolean;
   autoplay_enabled: boolean;
   repeat_mode: RepeatMode;
   crossfade_enabled: boolean;

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -708,6 +708,7 @@
     },
     "shuffle_disable": "Disable shuffle",
     "shuffle_enable": "Enable shuffle",
+    "shuffle_smart_active": "Smart shuffle is on. Click to turn it off.",
     "open_dsp_settings": "Open DSP settings",
     "audiobook": "Audiobook",
     "audiobooks": "Audiobooks",


### PR DESCRIPTION
The server added a "smart shuffle" queue mode (companion server PR: music-assistant/server#4475, shipped in music-assistant-models 1.1.145). This surfaces it in the player.

- Add the read-only `smart_shuffle_active` field to the `PlayerQueue` model
- Show a Spotify-style AI-sparkle indicator on the shuffle button when smart shuffle is active (the shuffle's upper-left stub becomes a glowing sparkle)
- Add a state-aware tooltip to the shuffle button (enable / disable / smart)
- Note smart fades in the crossfade tooltip when they're active
