### PR TITLE
Declutter the player queue list item layout

### DIFF
--- a/src/layouts/default/PlayerOSD/QueueListItem.vue
+++ b/src/layouts/default/PlayerOSD/QueueListItem.vue
@@ -86,11 +86,13 @@
       <!-- Fixed-width slot so the menu stays aligned whether or not a row has a
            grip (only up-next rows are reorderable). -->
       <div class="qitem__actions">
-        <!-- drag handle to reorder (up-next items only) -->
+        <!-- drag handle to reorder. Shown active on up-next items; shown
+             disabled/grayed on already-played items (can't be reordered). -->
         <button
-          v-if="state === 'upcoming'"
+          v-if="state === 'upcoming' || state === 'played'"
           type="button"
           class="qitem__grip"
+          :disabled="state !== 'upcoming'"
           :aria-label="$t('queue_reorder')"
           @pointerdown.stop.prevent="emit('dragstart', $event)"
           @click.stop
@@ -362,12 +364,18 @@ const isMobile = computed(() => store.mobileLayout);
   touch-action: none;
 }
 
-.qitem__grip:hover {
+.qitem__grip:not(:disabled):hover {
   background: color-mix(
     in srgb,
     var(--text-color, currentColor) 12%,
     transparent
   );
+}
+
+/* Already-played rows: the handle is present for alignment but can't reorder. */
+.qitem__grip:disabled {
+  opacity: 0.4;
+  cursor: default;
 }
 
 /* The source row stays in place but invisible while dragging — the floating

--- a/src/layouts/default/PlayerOSD/QueueListItem.vue
+++ b/src/layouts/default/PlayerOSD/QueueListItem.vue
@@ -37,25 +37,22 @@
     <!-- title + subtitle -->
     <div class="qitem__body">
       <MarqueeText :sync="marqueeSync" :disabled="!marqueeActive">
-        <span class="qitem__title">{{ item.name }}</span>
+        <span class="qitem__title">{{ title }}</span>
       </MarqueeText>
-      <div class="qitem__subtitle">
-        <span class="qitem__duration">{{ formatDuration(item.duration) }}</span>
-        <template v-if="albumName">
-          <span class="qitem__sep">·</span>
-          <MarqueeText
-            class="qitem__album"
-            :sync="marqueeSync"
-            :disabled="!marqueeActive"
-          >
-            <span>{{ albumName }}</span>
-          </MarqueeText>
-        </template>
+      <div v-if="artistName" class="qitem__subtitle">
+        <MarqueeText
+          class="qitem__artist"
+          :sync="marqueeSync"
+          :disabled="!marqueeActive"
+        >
+          <span>{{ artistName }}</span>
+        </MarqueeText>
       </div>
     </div>
 
     <!-- trailing badges + actions -->
     <div class="qitem__append">
+      <span class="qitem__duration">{{ formatDuration(item.duration) }}</span>
       <PartyPlayerBadge
         v-if="item.extra_attributes?.party_guest === true"
         :type="
@@ -178,10 +175,12 @@ const showEqualizer = computed(
   () => props.state === "playing" && props.isPlaying,
 );
 
-const albumName = computed(() => {
+const title = computed(() => props.item.media_item?.name || props.item.name);
+
+const artistName = computed(() => {
   const mediaItem = props.item.media_item;
-  if (mediaItem && "album" in mediaItem && mediaItem.album) {
-    return mediaItem.album.name;
+  if (mediaItem && "artists" in mediaItem && mediaItem.artists?.length) {
+    return mediaItem.artists.map((a) => a.name).join(", ");
   }
   return "";
 });
@@ -286,13 +285,13 @@ const albumName = computed(() => {
 
 .qitem__duration {
   white-space: nowrap;
+  margin-right: 6px;
+  font-size: var(--queue-subtitle-size, 0.78rem);
+  opacity: 0.7;
+  font-variant-numeric: tabular-nums;
 }
 
-.qitem__sep {
-  opacity: 0.6;
-}
-
-.qitem__album {
+.qitem__artist {
   min-width: 0;
   overflow: hidden;
 }

--- a/src/layouts/default/PlayerOSD/QueueListItem.vue
+++ b/src/layouts/default/PlayerOSD/QueueListItem.vue
@@ -87,7 +87,7 @@
       />
       <!-- Fixed-width slot the duration and the action buttons share: on desktop
            the duration shows by default and is swapped for the menu on hover;
-           on mobile there's no duration, just the grip. -->
+           on mobile there's no duration and the buttons stay visible. -->
       <div class="qitem__trailing">
         <span class="qitem__duration">{{ formatDuration(item.duration) }}</span>
         <div class="qitem__actions">
@@ -103,9 +103,8 @@
           >
             <GripVerticalIcon class="size-4" />
           </button>
-          <!-- context menu button (desktop only; touch uses a long press) -->
+          <!-- context menu button -->
           <Button
-            v-if="!isMobile"
             variant="ghost"
             size="icon-sm"
             class="qitem__menu"
@@ -144,7 +143,7 @@ import {
   InfoIcon,
   TriangleAlertIcon,
 } from "@lucide/vue";
-import { computed, onBeforeUnmount, ref } from "vue";
+import { computed, ref } from "vue";
 
 export type QueueItemState = "played" | "playing" | "buffered" | "upcoming";
 
@@ -203,74 +202,16 @@ const artistName = computed(() => {
 // Only up-next items can be reordered; the floating ghost is never a drag source.
 const draggable = computed(() => props.state === "upcoming" && !props.ghost);
 
-// Mobile layout drops the duration, shows only the grip, and reaches the
-// context menu via long-press. Width-based (store.mobileLayout) rather than a
-// hover media query, which isn't reliable in the PWA / device emulation.
+// Mobile layout drops the duration and shows the grip alongside the menu
+// button. Width-based (store.mobileLayout) rather than a hover media query,
+// which isn't reliable in the PWA / device emulation.
 const isMobile = computed(() => store.mobileLayout);
 
-const LONG_PRESS_MS = 450;
-// Pointer travel (px) that turns a long press into a scroll and cancels it.
-const LONG_PRESS_MOVE = 10;
-
-let longPressTimer: ReturnType<typeof setTimeout> | null = null;
-let longPressAbort: AbortController | null = null;
-
-const cancelLongPress = () => {
-  if (longPressTimer !== null) {
-    clearTimeout(longPressTimer);
-    longPressTimer = null;
-  }
-  longPressAbort?.abort();
-  longPressAbort = null;
-};
-
-// Touch: a long press (no scroll) opens the context menu, since the menu button
-// is hidden on touch. The native long-press menu is suppressed for the duration
-// of the press so it can't fire on top of ours.
-const startLongPress = (event: PointerEvent) => {
-  cancelLongPress();
-  const startX = event.clientX;
-  const startY = event.clientY;
-  longPressAbort = new AbortController();
-  const { signal } = longPressAbort;
-  window.addEventListener(
-    "pointermove",
-    (e: PointerEvent) => {
-      if (
-        Math.hypot(e.clientX - startX, e.clientY - startY) > LONG_PRESS_MOVE
-      ) {
-        cancelLongPress();
-      }
-    },
-    { passive: true, signal },
-  );
-  window.addEventListener("pointerup", cancelLongPress, { signal });
-  window.addEventListener("pointercancel", cancelLongPress, { signal });
-  window.addEventListener(
-    "contextmenu",
-    (e: Event) => {
-      e.preventDefault();
-      e.stopPropagation();
-    },
-    { capture: true, signal },
-  );
-  longPressTimer = setTimeout(() => {
-    longPressTimer = null;
-    emit("menu", event);
-  }, LONG_PRESS_MS);
-};
-
-// Desktop drives a whole-row drag with the mouse; touch arms a long press.
+// Desktop drives a whole-row drag with the mouse; touch reorders via the grip.
 const onRowPointerDown = (event: PointerEvent) => {
-  if (props.ghost) return;
-  if (event.pointerType === "mouse") {
-    if (draggable.value) emit("dragstart", event);
-    return;
-  }
-  startLongPress(event);
+  if (!draggable.value || event.pointerType !== "mouse") return;
+  emit("dragstart", event);
 };
-
-onBeforeUnmount(cancelLongPress);
 </script>
 
 <style scoped>
@@ -285,7 +226,6 @@ onBeforeUnmount(cancelLongPress);
     background-color 0.12s ease,
     opacity 0.12s ease;
   user-select: none;
-  -webkit-touch-callout: none;
 }
 
 .qitem:hover {

--- a/src/layouts/default/PlayerOSD/QueueListItem.vue
+++ b/src/layouts/default/PlayerOSD/QueueListItem.vue
@@ -86,14 +86,14 @@
         class="size-4 shrink-0 text-destructive"
       />
       <!-- Fixed-width slot the duration and the action buttons share: on desktop
-           the duration shows by default and is swapped for the buttons on hover;
-           on touch there's no duration and the buttons stay visible. -->
+           the duration shows by default and is swapped for the menu on hover;
+           on mobile there's no duration, just the grip. -->
       <div class="qitem__trailing">
         <span class="qitem__duration">{{ formatDuration(item.duration) }}</span>
         <div class="qitem__actions">
-          <!-- drag handle to reorder (up-next items only) -->
+          <!-- drag handle to reorder (touch only; desktop drags the whole row) -->
           <button
-            v-if="state === 'upcoming'"
+            v-if="isMobile && state === 'upcoming'"
             type="button"
             class="qitem__grip"
             :aria-label="$t('queue_reorder')"
@@ -103,7 +103,9 @@
           >
             <GripVerticalIcon class="size-4" />
           </button>
+          <!-- context menu button (desktop only; touch uses a long press) -->
           <Button
+            v-if="!isMobile"
             variant="ghost"
             size="icon-sm"
             class="qitem__menu"
@@ -437,9 +439,8 @@ onBeforeUnmount(cancelLongPress);
   opacity: 0.85;
 }
 
-/* Mobile layout: drop the duration entirely, show only the grip (the whole-row
-   drag is mouse-only), and reach the context menu via long-press rather than a
-   button. */
+/* Mobile layout: no duration, and the grip stays visible (the menu button isn't
+   rendered — the context menu opens on long-press). */
 .qitem--mobile .qitem__duration {
   display: none;
 }
@@ -449,19 +450,11 @@ onBeforeUnmount(cancelLongPress);
   pointer-events: auto;
 }
 
-.qitem--mobile .qitem__grip {
-  display: inline-flex;
-}
-
-.qitem--mobile .qitem__menu {
-  display: none;
-}
-
 /* Drag handle: a plain button (not a shadcn Button) so we fully control the
-   pointer gesture. Sized to match the icon-sm buttons beside it. Hidden on
-   desktop, where the whole row is draggable instead. */
+   pointer gesture. Sized to match the icon-sm buttons beside it. Rendered only
+   in the mobile layout — desktop drags the whole row instead. */
 .qitem__grip {
-  display: none;
+  display: inline-flex;
   align-items: center;
   justify-content: center;
   flex: 0 0 auto;

--- a/src/layouts/default/PlayerOSD/QueueListItem.vue
+++ b/src/layouts/default/PlayerOSD/QueueListItem.vue
@@ -9,20 +9,24 @@
 <template>
   <div
     class="qitem"
-    :class="{
-      'qitem--played': state === 'played',
-      'qitem--playing': state === 'playing',
-      'qitem--buffered': state === 'buffered',
-      'qitem--unavailable': !item.available,
-      'qitem--dragging': dragging,
-      'qitem--ghost': ghost,
-    }"
+    :class="[
+      draggable ? 'cursor-grab' : 'cursor-pointer',
+      {
+        'qitem--played': state === 'played',
+        'qitem--playing': state === 'playing',
+        'qitem--buffered': state === 'buffered',
+        'qitem--unavailable': !item.available,
+        'qitem--dragging': dragging,
+        'qitem--ghost': ghost,
+      },
+    ]"
     :data-queue-current="state === 'playing' ? 'true' : undefined"
     role="button"
     tabindex="0"
     @click="emit('click', $event)"
     @contextmenu.prevent="emit('menu', $event)"
     @keydown.enter.prevent="emit('click', $event)"
+    @pointerdown="onRowPointerDown"
     @mouseenter="hovered = true"
     @mouseleave="hovered = false"
   >
@@ -39,19 +43,14 @@
       <MarqueeText :sync="marqueeSync" :disabled="!marqueeActive">
         <span class="qitem__title">{{ title }}</span>
       </MarqueeText>
-      <div class="qitem__subtitle">
+      <div v-if="artistName" class="qitem__subtitle">
         <MarqueeText
-          v-if="artistName"
           class="qitem__artist"
           :sync="marqueeSync"
           :disabled="!marqueeActive"
         >
           <span>{{ artistName }}</span>
         </MarqueeText>
-        <span v-if="artistName" class="qitem__sep">·</span>
-        <span class="qitem__sub-duration">{{
-          formatDuration(item.duration)
-        }}</span>
       </div>
     </div>
 
@@ -87,7 +86,7 @@
       />
       <!-- Fixed-width slot the duration and the action buttons share: on desktop
            the duration shows by default and is swapped for the buttons on hover;
-           on touch the duration lives in the subtitle and the buttons stay. -->
+           on touch there's no duration and the buttons stay visible. -->
       <div class="qitem__trailing">
         <span class="qitem__duration">{{ formatDuration(item.duration) }}</span>
         <div class="qitem__actions">
@@ -196,6 +195,16 @@ const artistName = computed(() => {
   }
   return "";
 });
+
+// Only up-next items can be reordered; the floating ghost is never a drag source.
+const draggable = computed(() => props.state === "upcoming" && !props.ghost);
+
+// Desktop drags the whole row; touch keeps using the explicit grip handle so
+// list scrolling isn't hijacked.
+const onRowPointerDown = (event: PointerEvent) => {
+  if (!draggable.value || event.pointerType !== "mouse") return;
+  emit("dragstart", event);
+};
 </script>
 
 <style scoped>
@@ -205,7 +214,6 @@ const artistName = computed(() => {
   gap: 12px;
   padding: 6px 8px;
   border-radius: 8px;
-  cursor: pointer;
   color: var(--text-color, currentColor);
   transition:
     background-color 0.12s ease,
@@ -300,23 +308,6 @@ const artistName = computed(() => {
   overflow: hidden;
 }
 
-/* Subtitle duration is touch-only — hidden on hover-capable (desktop) devices,
-   where the duration lives in the trailing slot instead. */
-.qitem__sep,
-.qitem__sub-duration {
-  display: none;
-}
-
-.qitem__sep {
-  opacity: 0.6;
-}
-
-.qitem__sub-duration {
-  flex: 0 0 auto;
-  white-space: nowrap;
-  font-variant-numeric: tabular-nums;
-}
-
 .qitem__append {
   flex: 0 0 auto;
   display: flex;
@@ -381,8 +372,8 @@ const artistName = computed(() => {
   opacity: 0.85;
 }
 
-/* Touch devices have no hover: keep the buttons visible and move the duration
-   into the subtitle next to the artist. */
+/* Touch devices have no hover: drop the duration entirely, keep the buttons
+   visible, and bring back the grip handle (the whole-row drag is mouse-only). */
 @media (hover: none) {
   .qitem__duration {
     display: none;
@@ -393,16 +384,16 @@ const artistName = computed(() => {
     pointer-events: auto;
   }
 
-  .qitem__sep,
-  .qitem__sub-duration {
-    display: inline;
+  .qitem__grip {
+    display: inline-flex;
   }
 }
 
 /* Drag handle: a plain button (not a shadcn Button) so we fully control the
-   pointer gesture. Sized to match the icon-sm buttons beside it. */
+   pointer gesture. Sized to match the icon-sm buttons beside it. Hidden on
+   desktop, where the whole row is draggable instead. */
 .qitem__grip {
-  display: inline-flex;
+  display: none;
   align-items: center;
   justify-content: center;
   flex: 0 0 auto;
@@ -434,17 +425,11 @@ const artistName = computed(() => {
   cursor: grabbing;
 }
 
-/* The floating clone that tracks the pointer. Tinted with the same themed
-   color the rows use (no clashing gray) and lifted with a soft shadow so it
-   reads as picked-up, not detached. Its own action buttons are hidden. */
+/* The floating clone that tracks the pointer. Tinted MA blue (the now-playing
+   accent) so a drag-in-progress reads clearly, and lifted with a soft shadow so
+   it reads as picked-up, not detached. Its own action buttons are hidden. */
 .qitem--ghost {
-  background: color-mix(
-    in srgb,
-    var(--text-color, currentColor) 10%,
-    transparent
-  );
-  backdrop-filter: blur(14px);
-  -webkit-backdrop-filter: blur(14px);
+  background: var(--primary);
   box-shadow: 0 4px 14px rgba(0, 0, 0, 0.18);
   cursor: grabbing;
 }

--- a/src/layouts/default/PlayerOSD/QueueListItem.vue
+++ b/src/layouts/default/PlayerOSD/QueueListItem.vue
@@ -86,10 +86,9 @@
       <!-- Fixed-width slot so the menu stays aligned whether or not a row has a
            grip (only up-next rows are reorderable). -->
       <div class="qitem__actions">
-        <!-- drag handle to reorder. Shown active on up-next items; shown
-             disabled/grayed on already-played items (can't be reordered). -->
+        <!-- drag handle to reorder. Active on up-next items; disabled/grayed on
+             every other row (now playing, buffered, played can't be reordered). -->
         <button
-          v-if="state === 'upcoming' || state === 'played'"
           type="button"
           class="qitem__grip"
           :disabled="state !== 'upcoming'"
@@ -372,7 +371,7 @@ const isMobile = computed(() => store.mobileLayout);
   );
 }
 
-/* Already-played rows: the handle is present for alignment but can't reorder. */
+/* Non-upcoming rows: the handle is present for alignment but can't reorder. */
 .qitem__grip:disabled {
   opacity: 0.4;
   cursor: default;

--- a/src/layouts/default/PlayerOSD/QueueListItem.vue
+++ b/src/layouts/default/PlayerOSD/QueueListItem.vue
@@ -85,36 +85,34 @@
         v-if="!item.available"
         class="size-4 shrink-0 text-destructive"
       />
-      <!-- Fixed-width slot the duration and the action buttons share: on desktop
-           the duration shows by default and is swapped for the menu on hover;
-           on mobile there's no duration and the buttons stay visible. -->
-      <div class="qitem__trailing">
-        <span class="qitem__duration">{{ formatDuration(item.duration) }}</span>
-        <div class="qitem__actions">
-          <!-- drag handle to reorder (touch only; desktop drags the whole row) -->
-          <button
-            v-if="isMobile && state === 'upcoming'"
-            type="button"
-            class="qitem__grip"
-            :aria-label="$t('queue_reorder')"
-            @pointerdown.stop.prevent="emit('dragstart', $event)"
-            @click.stop
-            @contextmenu.prevent
-          >
-            <GripVerticalIcon class="size-4" />
-          </button>
-          <!-- context menu button -->
-          <Button
-            variant="ghost"
-            size="icon-sm"
-            class="qitem__menu"
-            :aria-label="$t('queue_options')"
-            @click.stop="emit('menu', $event)"
-            @pointerdown.stop
-          >
-            <EllipsisVerticalIcon class="size-4" />
-          </Button>
-        </div>
+      <!-- duration sits to the left of the always-visible action buttons -->
+      <span class="qitem__duration">{{ formatDuration(item.duration) }}</span>
+      <!-- Fixed-width slot so the menu stays aligned whether or not a row has a
+           grip (only up-next rows are reorderable). -->
+      <div class="qitem__actions">
+        <!-- drag handle to reorder (up-next items only) -->
+        <button
+          v-if="state === 'upcoming'"
+          type="button"
+          class="qitem__grip"
+          :aria-label="$t('queue_reorder')"
+          @pointerdown.stop.prevent="emit('dragstart', $event)"
+          @click.stop
+          @contextmenu.prevent
+        >
+          <GripVerticalIcon class="size-4" />
+        </button>
+        <!-- context menu button -->
+        <Button
+          variant="ghost"
+          size="icon-sm"
+          class="qitem__menu"
+          :aria-label="$t('queue_options')"
+          @click.stop="emit('menu', $event)"
+          @pointerdown.stop
+        >
+          <EllipsisVerticalIcon class="size-4" />
+        </Button>
       </div>
     </div>
   </div>
@@ -322,49 +320,24 @@ const onRowPointerDown = (event: PointerEvent) => {
   gap: 4px;
 }
 
-/* The duration and the action buttons share this fixed-width slot (2 × 2rem +
-   gap), both pinned to the right edge so nothing shifts when they swap. */
-.qitem__trailing {
-  position: relative;
-  flex: 0 0 auto;
-  width: calc(4rem + 4px);
-  height: 2rem;
-}
-
 .qitem__duration {
-  position: absolute;
-  inset: 0;
-  display: flex;
-  align-items: center;
-  justify-content: flex-end;
+  flex: 0 0 auto;
+  margin-right: 6px;
   white-space: nowrap;
   font-size: var(--queue-subtitle-size, 0.78rem);
   opacity: 0.7;
   font-variant-numeric: tabular-nums;
-  pointer-events: none;
 }
 
+/* Fixed-width (2 × 2rem + gap) and right-aligned, so the menu keeps the same
+   position whether or not a row has a grip. */
 .qitem__actions {
-  position: absolute;
-  inset: 0;
+  flex: 0 0 auto;
   display: flex;
   align-items: center;
   justify-content: flex-end;
   gap: 4px;
-  opacity: 0;
-  pointer-events: none;
-}
-
-/* Desktop: swap the duration out for the action buttons on hover/focus. */
-.qitem:hover .qitem__duration,
-.qitem:focus-within .qitem__duration {
-  opacity: 0;
-}
-
-.qitem:hover .qitem__actions,
-.qitem:focus-within .qitem__actions {
-  opacity: 1;
-  pointer-events: auto;
+  width: calc(4rem + 4px);
 }
 
 .qitem__info {
@@ -379,20 +352,14 @@ const onRowPointerDown = (event: PointerEvent) => {
   opacity: 0.85;
 }
 
-/* Mobile layout: no duration, and the grip stays visible (the menu button isn't
-   rendered — the context menu opens on long-press). */
+/* Mobile layout drops the duration; the grip + menu stay visible. */
 .qitem--mobile .qitem__duration {
   display: none;
 }
 
-.qitem--mobile .qitem__actions {
-  opacity: 1;
-  pointer-events: auto;
-}
-
 /* Drag handle: a plain button (not a shadcn Button) so we fully control the
-   pointer gesture. Sized to match the icon-sm buttons beside it. Rendered only
-   in the mobile layout — desktop drags the whole row instead. */
+   pointer gesture. Sized to match the icon-sm buttons beside it. Shown on
+   up-next rows; the whole row is also draggable on desktop. */
 .qitem__grip {
   display: inline-flex;
   align-items: center;

--- a/src/layouts/default/PlayerOSD/QueueListItem.vue
+++ b/src/layouts/default/PlayerOSD/QueueListItem.vue
@@ -239,8 +239,7 @@ const isMobile = computed(() => store.mobileLayout);
   background: color-mix(in srgb, var(--primary) 18%, transparent);
 }
 
-/* Buffered = already loaded into the stream and locked to play next. Sits in
-   the "up next" list but keeps a faint tint so it reads as already cued. */
+/* Buffered: locked into the stream to play next — faint tint reads as cued. */
 .qitem--buffered {
   background: color-mix(in srgb, var(--primary) 5%, transparent);
 }
@@ -317,8 +316,7 @@ const isMobile = computed(() => store.mobileLayout);
   font-variant-numeric: tabular-nums;
 }
 
-/* Fixed-width (2 × 2rem + gap) and right-aligned, so the menu keeps the same
-   position whether or not a row has a grip. */
+/* Fixed-width + right-aligned so the menu aligns with or without a grip. */
 .qitem__actions {
   flex: 0 0 auto;
   display: flex;
@@ -345,9 +343,7 @@ const isMobile = computed(() => store.mobileLayout);
   display: none;
 }
 
-/* Drag handle: a plain button (not a shadcn Button) so we fully control the
-   pointer gesture. Sized to match the icon-sm buttons beside it. Shown on
-   up-next rows and is the only way to start a reorder. */
+/* Drag handle: plain button for full pointer-gesture control, sized like icon-sm. */
 .qitem__grip {
   display: inline-flex;
   align-items: center;
@@ -358,7 +354,7 @@ const isMobile = computed(() => store.mobileLayout);
   border-radius: 6px;
   color: var(--text-color, currentColor);
   cursor: grab;
-  /* Stop the browser from hijacking the gesture as a scroll on touch. */
+  /* Don't let touch turn the drag into a scroll. */
   touch-action: none;
 }
 
@@ -370,16 +366,13 @@ const isMobile = computed(() => store.mobileLayout);
   );
 }
 
-/* Non-upcoming rows: the handle is present for alignment but can't reorder.
-   A solid muted color (not opacity) so it stays legible even on the already
-   dimmed played rows. */
+/* Non-reorderable rows: solid muted color (not opacity) stays legible when dimmed. */
 .qitem__grip:disabled {
   color: var(--muted-foreground);
   cursor: default;
 }
 
-/* The source row stays in place but invisible while dragging — the floating
-   ghost is its stand-in, and the other rows slide to open the landing gap. */
+/* Source row hides in place; the ghost stands in while dragging. */
 .qitem--dragging {
   opacity: 0;
   pointer-events: none;
@@ -389,9 +382,7 @@ const isMobile = computed(() => store.mobileLayout);
   cursor: grabbing;
 }
 
-/* The floating clone that tracks the pointer. Tinted MA blue (the now-playing
-   accent) so a drag-in-progress reads clearly, and lifted with a soft shadow so
-   it reads as picked-up, not detached. Its own action buttons are hidden. */
+/* Floating drag clone: accent-tinted + shadowed so it reads as picked-up. */
 .qitem--ghost {
   background: var(--primary);
   box-shadow: 0 4px 14px rgba(0, 0, 0, 0.18);

--- a/src/layouts/default/PlayerOSD/QueueListItem.vue
+++ b/src/layouts/default/PlayerOSD/QueueListItem.vue
@@ -311,7 +311,6 @@ const isMobile = computed(() => store.mobileLayout);
 
 .qitem__duration {
   flex: 0 0 auto;
-  margin-right: 6px;
   white-space: nowrap;
   font-size: var(--queue-subtitle-size, 0.78rem);
   opacity: 0.7;
@@ -371,9 +370,11 @@ const isMobile = computed(() => store.mobileLayout);
   );
 }
 
-/* Non-upcoming rows: the handle is present for alignment but can't reorder. */
+/* Non-upcoming rows: the handle is present for alignment but can't reorder.
+   A solid muted color (not opacity) so it stays legible even on the already
+   dimmed played rows. */
 .qitem__grip:disabled {
-  opacity: 0.4;
+  color: var(--muted-foreground);
   cursor: default;
 }
 

--- a/src/layouts/default/PlayerOSD/QueueListItem.vue
+++ b/src/layouts/default/PlayerOSD/QueueListItem.vue
@@ -18,6 +18,7 @@
         'qitem--unavailable': !item.available,
         'qitem--dragging': dragging,
         'qitem--ghost': ghost,
+        'qitem--mobile': isMobile,
       },
     ]"
     :data-queue-current="state === 'playing' ? 'true' : undefined"
@@ -134,6 +135,7 @@ import { MarqueeTextSync } from "@/helpers/marquee_text_sync";
 import { formatDuration } from "@/helpers/utils";
 import { QueueItem } from "@/plugins/api/interfaces";
 import { $t } from "@/plugins/i18n";
+import { store } from "@/plugins/store";
 import {
   EllipsisVerticalIcon,
   GripVerticalIcon,
@@ -198,6 +200,11 @@ const artistName = computed(() => {
 
 // Only up-next items can be reordered; the floating ghost is never a drag source.
 const draggable = computed(() => props.state === "upcoming" && !props.ghost);
+
+// Mobile layout drops the duration, shows only the grip, and reaches the
+// context menu via long-press. Width-based (store.mobileLayout) rather than a
+// hover media query, which isn't reliable in the PWA / device emulation.
+const isMobile = computed(() => store.mobileLayout);
 
 const LONG_PRESS_MS = 450;
 // Pointer travel (px) that turns a long press into a scroll and cancels it.
@@ -430,26 +437,24 @@ onBeforeUnmount(cancelLongPress);
   opacity: 0.85;
 }
 
-/* Touch devices have no hover: drop the duration entirely, show only the grip
-   (the whole-row drag is mouse-only), and reach the context menu via long-press
-   rather than a button. */
-@media (hover: none) {
-  .qitem__duration {
-    display: none;
-  }
+/* Mobile layout: drop the duration entirely, show only the grip (the whole-row
+   drag is mouse-only), and reach the context menu via long-press rather than a
+   button. */
+.qitem--mobile .qitem__duration {
+  display: none;
+}
 
-  .qitem__actions {
-    opacity: 1;
-    pointer-events: auto;
-  }
+.qitem--mobile .qitem__actions {
+  opacity: 1;
+  pointer-events: auto;
+}
 
-  .qitem__grip {
-    display: inline-flex;
-  }
+.qitem--mobile .qitem__grip {
+  display: inline-flex;
+}
 
-  .qitem__menu {
-    display: none;
-  }
+.qitem--mobile .qitem__menu {
+  display: none;
 }
 
 /* Drag handle: a plain button (not a shadcn Button) so we fully control the

--- a/src/layouts/default/PlayerOSD/QueueListItem.vue
+++ b/src/layouts/default/PlayerOSD/QueueListItem.vue
@@ -39,20 +39,24 @@
       <MarqueeText :sync="marqueeSync" :disabled="!marqueeActive">
         <span class="qitem__title">{{ title }}</span>
       </MarqueeText>
-      <div v-if="artistName" class="qitem__subtitle">
+      <div class="qitem__subtitle">
         <MarqueeText
+          v-if="artistName"
           class="qitem__artist"
           :sync="marqueeSync"
           :disabled="!marqueeActive"
         >
           <span>{{ artistName }}</span>
         </MarqueeText>
+        <span v-if="artistName" class="qitem__sep">·</span>
+        <span class="qitem__sub-duration">{{
+          formatDuration(item.duration)
+        }}</span>
       </div>
     </div>
 
     <!-- trailing badges + actions -->
     <div class="qitem__append">
-      <span class="qitem__duration">{{ formatDuration(item.duration) }}</span>
       <PartyPlayerBadge
         v-if="item.extra_attributes?.party_guest === true"
         :type="
@@ -81,32 +85,35 @@
         v-if="!item.available"
         class="size-4 shrink-0 text-destructive"
       />
-      <!-- Fixed-width slot so the duration keeps the same right edge whether or
-           not the drag handle is present (now-playing/played rows omit it) and
-           while a row is being dragged (its actions are hidden). -->
-      <div class="qitem__actions">
-        <!-- drag handle to reorder (up-next items only) -->
-        <button
-          v-if="state === 'upcoming'"
-          type="button"
-          class="qitem__action qitem__grip"
-          :aria-label="$t('queue_reorder')"
-          @pointerdown.stop.prevent="emit('dragstart', $event)"
-          @click.stop
-          @contextmenu.prevent
-        >
-          <GripVerticalIcon class="size-4" />
-        </button>
-        <Button
-          variant="ghost"
-          size="icon-sm"
-          class="qitem__action qitem__menu"
-          :aria-label="$t('queue_options')"
-          @click.stop="emit('menu', $event)"
-          @pointerdown.stop
-        >
-          <EllipsisVerticalIcon class="size-4" />
-        </Button>
+      <!-- Fixed-width slot the duration and the action buttons share: on desktop
+           the duration shows by default and is swapped for the buttons on hover;
+           on touch the duration lives in the subtitle and the buttons stay. -->
+      <div class="qitem__trailing">
+        <span class="qitem__duration">{{ formatDuration(item.duration) }}</span>
+        <div class="qitem__actions">
+          <!-- drag handle to reorder (up-next items only) -->
+          <button
+            v-if="state === 'upcoming'"
+            type="button"
+            class="qitem__grip"
+            :aria-label="$t('queue_reorder')"
+            @pointerdown.stop.prevent="emit('dragstart', $event)"
+            @click.stop
+            @contextmenu.prevent
+          >
+            <GripVerticalIcon class="size-4" />
+          </button>
+          <Button
+            variant="ghost"
+            size="icon-sm"
+            class="qitem__menu"
+            :aria-label="$t('queue_options')"
+            @click.stop="emit('menu', $event)"
+            @pointerdown.stop
+          >
+            <EllipsisVerticalIcon class="size-4" />
+          </Button>
+        </div>
       </div>
     </div>
   </div>
@@ -288,17 +295,26 @@ const artistName = computed(() => {
   opacity: 0.7;
 }
 
-.qitem__duration {
-  white-space: nowrap;
-  margin-right: 6px;
-  font-size: var(--queue-subtitle-size, 0.78rem);
-  opacity: 0.7;
-  font-variant-numeric: tabular-nums;
-}
-
 .qitem__artist {
   min-width: 0;
   overflow: hidden;
+}
+
+/* Subtitle duration is touch-only — hidden on hover-capable (desktop) devices,
+   where the duration lives in the trailing slot instead. */
+.qitem__sep,
+.qitem__sub-duration {
+  display: none;
+}
+
+.qitem__sep {
+  opacity: 0.6;
+}
+
+.qitem__sub-duration {
+  flex: 0 0 auto;
+  white-space: nowrap;
+  font-variant-numeric: tabular-nums;
 }
 
 .qitem__append {
@@ -308,15 +324,49 @@ const artistName = computed(() => {
   gap: 4px;
 }
 
-/* Reserve room for both trailing buttons (2 × 2rem + gap) and right-align them
-   so the duration's right edge is identical across every row state. */
-.qitem__actions {
+/* The duration and the action buttons share this fixed-width slot (2 × 2rem +
+   gap), both pinned to the right edge so nothing shifts when they swap. */
+.qitem__trailing {
+  position: relative;
   flex: 0 0 auto;
+  width: calc(4rem + 4px);
+  height: 2rem;
+}
+
+.qitem__duration {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  white-space: nowrap;
+  font-size: var(--queue-subtitle-size, 0.78rem);
+  opacity: 0.7;
+  font-variant-numeric: tabular-nums;
+  pointer-events: none;
+}
+
+.qitem__actions {
+  position: absolute;
+  inset: 0;
   display: flex;
   align-items: center;
   justify-content: flex-end;
   gap: 4px;
-  width: calc(4rem + 4px);
+  opacity: 0;
+  pointer-events: none;
+}
+
+/* Desktop: swap the duration out for the action buttons on hover/focus. */
+.qitem:hover .qitem__duration,
+.qitem:focus-within .qitem__duration {
+  opacity: 0;
+}
+
+.qitem:hover .qitem__actions,
+.qitem:focus-within .qitem__actions {
+  opacity: 1;
+  pointer-events: auto;
 }
 
 .qitem__info {
@@ -331,19 +381,21 @@ const artistName = computed(() => {
   opacity: 0.85;
 }
 
-.qitem__action {
-  opacity: 0;
-}
-
-.qitem:hover .qitem__action,
-.qitem:focus-within .qitem__action {
-  opacity: 1;
-}
-
-/* Touch devices have no hover — always reveal the action affordances. */
+/* Touch devices have no hover: keep the buttons visible and move the duration
+   into the subtitle next to the artist. */
 @media (hover: none) {
-  .qitem__action {
+  .qitem__duration {
+    display: none;
+  }
+
+  .qitem__actions {
     opacity: 1;
+    pointer-events: auto;
+  }
+
+  .qitem__sep,
+  .qitem__sub-duration {
+    display: inline;
   }
 }
 
@@ -397,7 +449,7 @@ const artistName = computed(() => {
   cursor: grabbing;
 }
 
-.qitem--ghost .qitem__action {
+.qitem--ghost .qitem__actions {
   display: none;
 }
 </style>

--- a/src/layouts/default/PlayerOSD/QueueListItem.vue
+++ b/src/layouts/default/PlayerOSD/QueueListItem.vue
@@ -140,7 +140,7 @@ import {
   InfoIcon,
   TriangleAlertIcon,
 } from "@lucide/vue";
-import { computed, ref } from "vue";
+import { computed, onBeforeUnmount, ref } from "vue";
 
 export type QueueItemState = "played" | "playing" | "buffered" | "upcoming";
 
@@ -199,12 +199,69 @@ const artistName = computed(() => {
 // Only up-next items can be reordered; the floating ghost is never a drag source.
 const draggable = computed(() => props.state === "upcoming" && !props.ghost);
 
-// Desktop drags the whole row; touch keeps using the explicit grip handle so
-// list scrolling isn't hijacked.
-const onRowPointerDown = (event: PointerEvent) => {
-  if (!draggable.value || event.pointerType !== "mouse") return;
-  emit("dragstart", event);
+const LONG_PRESS_MS = 450;
+// Pointer travel (px) that turns a long press into a scroll and cancels it.
+const LONG_PRESS_MOVE = 10;
+
+let longPressTimer: ReturnType<typeof setTimeout> | null = null;
+let longPressAbort: AbortController | null = null;
+
+const cancelLongPress = () => {
+  if (longPressTimer !== null) {
+    clearTimeout(longPressTimer);
+    longPressTimer = null;
+  }
+  longPressAbort?.abort();
+  longPressAbort = null;
 };
+
+// Touch: a long press (no scroll) opens the context menu, since the menu button
+// is hidden on touch. The native long-press menu is suppressed for the duration
+// of the press so it can't fire on top of ours.
+const startLongPress = (event: PointerEvent) => {
+  cancelLongPress();
+  const startX = event.clientX;
+  const startY = event.clientY;
+  longPressAbort = new AbortController();
+  const { signal } = longPressAbort;
+  window.addEventListener(
+    "pointermove",
+    (e: PointerEvent) => {
+      if (
+        Math.hypot(e.clientX - startX, e.clientY - startY) > LONG_PRESS_MOVE
+      ) {
+        cancelLongPress();
+      }
+    },
+    { passive: true, signal },
+  );
+  window.addEventListener("pointerup", cancelLongPress, { signal });
+  window.addEventListener("pointercancel", cancelLongPress, { signal });
+  window.addEventListener(
+    "contextmenu",
+    (e: Event) => {
+      e.preventDefault();
+      e.stopPropagation();
+    },
+    { capture: true, signal },
+  );
+  longPressTimer = setTimeout(() => {
+    longPressTimer = null;
+    emit("menu", event);
+  }, LONG_PRESS_MS);
+};
+
+// Desktop drives a whole-row drag with the mouse; touch arms a long press.
+const onRowPointerDown = (event: PointerEvent) => {
+  if (props.ghost) return;
+  if (event.pointerType === "mouse") {
+    if (draggable.value) emit("dragstart", event);
+    return;
+  }
+  startLongPress(event);
+};
+
+onBeforeUnmount(cancelLongPress);
 </script>
 
 <style scoped>
@@ -219,6 +276,7 @@ const onRowPointerDown = (event: PointerEvent) => {
     background-color 0.12s ease,
     opacity 0.12s ease;
   user-select: none;
+  -webkit-touch-callout: none;
 }
 
 .qitem:hover {
@@ -372,8 +430,9 @@ const onRowPointerDown = (event: PointerEvent) => {
   opacity: 0.85;
 }
 
-/* Touch devices have no hover: drop the duration entirely, keep the buttons
-   visible, and bring back the grip handle (the whole-row drag is mouse-only). */
+/* Touch devices have no hover: drop the duration entirely, show only the grip
+   (the whole-row drag is mouse-only), and reach the context menu via long-press
+   rather than a button. */
 @media (hover: none) {
   .qitem__duration {
     display: none;
@@ -386,6 +445,10 @@ const onRowPointerDown = (event: PointerEvent) => {
 
   .qitem__grip {
     display: inline-flex;
+  }
+
+  .qitem__menu {
+    display: none;
   }
 }
 

--- a/src/layouts/default/PlayerOSD/QueueListItem.vue
+++ b/src/layouts/default/PlayerOSD/QueueListItem.vue
@@ -9,25 +9,21 @@
 <template>
   <div
     class="qitem"
-    :class="[
-      draggable ? 'cursor-grab' : 'cursor-pointer',
-      {
-        'qitem--played': state === 'played',
-        'qitem--playing': state === 'playing',
-        'qitem--buffered': state === 'buffered',
-        'qitem--unavailable': !item.available,
-        'qitem--dragging': dragging,
-        'qitem--ghost': ghost,
-        'qitem--mobile': isMobile,
-      },
-    ]"
+    :class="{
+      'qitem--played': state === 'played',
+      'qitem--playing': state === 'playing',
+      'qitem--buffered': state === 'buffered',
+      'qitem--unavailable': !item.available,
+      'qitem--dragging': dragging,
+      'qitem--ghost': ghost,
+      'qitem--mobile': isMobile,
+    }"
     :data-queue-current="state === 'playing' ? 'true' : undefined"
     role="button"
     tabindex="0"
     @click="emit('click', $event)"
     @contextmenu.prevent="emit('menu', $event)"
     @keydown.enter.prevent="emit('click', $event)"
-    @pointerdown="onRowPointerDown"
     @mouseenter="hovered = true"
     @mouseleave="hovered = false"
   >
@@ -197,19 +193,10 @@ const artistName = computed(() => {
   return "";
 });
 
-// Only up-next items can be reordered; the floating ghost is never a drag source.
-const draggable = computed(() => props.state === "upcoming" && !props.ghost);
-
 // Mobile layout drops the duration and shows the grip alongside the menu
 // button. Width-based (store.mobileLayout) rather than a hover media query,
 // which isn't reliable in the PWA / device emulation.
 const isMobile = computed(() => store.mobileLayout);
-
-// Desktop drives a whole-row drag with the mouse; touch reorders via the grip.
-const onRowPointerDown = (event: PointerEvent) => {
-  if (!draggable.value || event.pointerType !== "mouse") return;
-  emit("dragstart", event);
-};
 </script>
 
 <style scoped>
@@ -219,6 +206,7 @@ const onRowPointerDown = (event: PointerEvent) => {
   gap: 12px;
   padding: 6px 8px;
   border-radius: 8px;
+  cursor: pointer;
   color: var(--text-color, currentColor);
   transition:
     background-color 0.12s ease,
@@ -359,7 +347,7 @@ const onRowPointerDown = (event: PointerEvent) => {
 
 /* Drag handle: a plain button (not a shadcn Button) so we fully control the
    pointer gesture. Sized to match the icon-sm buttons beside it. Shown on
-   up-next rows; the whole row is also draggable on desktop. */
+   up-next rows and is the only way to start a reorder. */
 .qitem__grip {
   display: inline-flex;
   align-items: center;

--- a/src/layouts/default/PlayerOSD/QueueListItem.vue
+++ b/src/layouts/default/PlayerOSD/QueueListItem.vue
@@ -81,28 +81,33 @@
         v-if="!item.available"
         class="size-4 shrink-0 text-destructive"
       />
-      <!-- drag handle to reorder (up-next items only) -->
-      <button
-        v-if="state === 'upcoming'"
-        type="button"
-        class="qitem__action qitem__grip"
-        :aria-label="$t('queue_reorder')"
-        @pointerdown.stop.prevent="emit('dragstart', $event)"
-        @click.stop
-        @contextmenu.prevent
-      >
-        <GripVerticalIcon class="size-4" />
-      </button>
-      <Button
-        variant="ghost"
-        size="icon-sm"
-        class="qitem__action qitem__menu"
-        :aria-label="$t('queue_options')"
-        @click.stop="emit('menu', $event)"
-        @pointerdown.stop
-      >
-        <EllipsisVerticalIcon class="size-4" />
-      </Button>
+      <!-- Fixed-width slot so the duration keeps the same right edge whether or
+           not the drag handle is present (now-playing/played rows omit it) and
+           while a row is being dragged (its actions are hidden). -->
+      <div class="qitem__actions">
+        <!-- drag handle to reorder (up-next items only) -->
+        <button
+          v-if="state === 'upcoming'"
+          type="button"
+          class="qitem__action qitem__grip"
+          :aria-label="$t('queue_reorder')"
+          @pointerdown.stop.prevent="emit('dragstart', $event)"
+          @click.stop
+          @contextmenu.prevent
+        >
+          <GripVerticalIcon class="size-4" />
+        </button>
+        <Button
+          variant="ghost"
+          size="icon-sm"
+          class="qitem__action qitem__menu"
+          :aria-label="$t('queue_options')"
+          @click.stop="emit('menu', $event)"
+          @pointerdown.stop
+        >
+          <EllipsisVerticalIcon class="size-4" />
+        </Button>
+      </div>
     </div>
   </div>
 </template>
@@ -301,6 +306,17 @@ const artistName = computed(() => {
   display: flex;
   align-items: center;
   gap: 4px;
+}
+
+/* Reserve room for both trailing buttons (2 × 2rem + gap) and right-align them
+   so the duration's right edge is identical across every row state. */
+.qitem__actions {
+  flex: 0 0 auto;
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 4px;
+  width: calc(4rem + 4px);
 }
 
 .qitem__info {

--- a/src/layouts/default/PlayerOSD/useQueueDragReorder.ts
+++ b/src/layouts/default/PlayerOSD/useQueueDragReorder.ts
@@ -23,10 +23,6 @@ interface QueueDragReorderOptions {
 export function useQueueDragReorder(options: QueueDragReorderOptions) {
   const { scrollEl, getVirtualItems, itemAt, onDragStart } = options;
 
-  // Pointer travel (px) before an armed press turns into a reorder drag, so a
-  // plain click/press on a row doesn't move anything.
-  const DRAG_THRESHOLD = 4;
-
   // Absolute index of the row being dragged (null when idle) and the index the
   // item would be inserted *before* on drop. While dragging, the source row
   // hides in place, a floating ghost follows the pointer, and the rows between
@@ -53,14 +49,6 @@ export function useQueueDragReorder(options: QueueDragReorderOptions) {
   let autoScrollRaf = 0;
   // Lets cleanup detach every drag listener at once (no per-handler bookkeeping).
   let dragAbort: AbortController | null = null;
-  // An armed-but-not-yet-engaged drag: captured on pointerdown, promoted to a
-  // real drag once the pointer passes DRAG_THRESHOLD.
-  let pendingDrag: {
-    index: number;
-    startX: number;
-    startY: number;
-    target: HTMLElement | null;
-  } | null = null;
 
   const totalItems = () => store.activePlayerQueue?.items ?? 0;
 
@@ -141,14 +129,7 @@ export function useQueueDragReorder(options: QueueDragReorderOptions) {
   }
 
   const onDragPointerMove = (evt: PointerEvent) => {
-    // Still armed: engage the drag only once the pointer passes the threshold.
-    if (dragSourceIndex.value == null) {
-      if (!pendingDrag) return;
-      const dx = evt.clientX - pendingDrag.startX;
-      const dy = evt.clientY - pendingDrag.startY;
-      if (Math.hypot(dx, dy) < DRAG_THRESHOLD) return;
-      beginActiveDrag(evt.clientY);
-    }
+    if (dragSourceIndex.value == null) return;
     evt.preventDefault();
     updateAutoScroll(evt.clientY);
     updateDragPositions(evt.clientY);
@@ -166,7 +147,6 @@ export function useQueueDragReorder(options: QueueDragReorderOptions) {
     dragRowHeight.value = 0;
     dragGrabOffset = 0;
     dragItemId = null;
-    pendingDrag = null;
   };
 
   const finishDrag = (commit: boolean) => {
@@ -185,78 +165,50 @@ export function useQueueDragReorder(options: QueueDragReorderOptions) {
     api.queueCommandMoveItem(queue.queue_id, itemId, shift);
   };
 
-  // Promote the armed press to a live drag once the threshold is crossed.
-  // Measures the grabbed item so the ghost lines up under the pointer and the
-  // gap the other rows open matches the item's height. Falls back to the
-  // virtualizer's measurement if the element can't be resolved.
-  const beginActiveDrag = (clientY: number) => {
-    const armed = pendingDrag;
-    if (!armed) return;
-    const item = itemAt(armed.index);
-    if (!item) {
-      cleanupDrag();
-      return;
-    }
-
-    const el = scrollEl.value;
-    const qitemEl = armed.target?.closest(".qitem");
-    if (el && qitemEl) {
-      const cRect = el.getBoundingClientRect();
-      const qRect = qitemEl.getBoundingClientRect();
-      const qTop = qRect.top - cRect.top + el.scrollTop;
-      dragRowHeight.value = qRect.height;
-      dragGrabOffset = armed.startY - cRect.top + el.scrollTop - qTop;
-      ghostY.value = qTop;
-    } else {
-      const vItem = getVirtualItems().find((v) => v.index === armed.index);
-      dragRowHeight.value = vItem?.size ?? 60;
-      dragGrabOffset = dragRowHeight.value / 2;
-      ghostY.value = (vItem?.start ?? 0) + dragRowHeight.value / 2;
-    }
-
-    dragSourceIndex.value = armed.index;
-    dragDropIndex.value = armed.index;
-    draggedItem.value = item;
-    dragItemId = item.queue_item_id;
-    dragPointerY = clientY;
-    autoScrollSpeed = 0;
-    onDragStart?.();
-    autoScrollRaf = requestAnimationFrame(autoScrollFrame);
-  };
-
-  const onDragPointerUp = () => {
-    // Released before crossing the threshold → it was a click, not a drag.
-    if (dragSourceIndex.value == null) {
-      cleanupDrag();
-      return;
-    }
-    finishDrag(true);
-  };
-
-  // Arm a drag from a row (whole-row on desktop) or the drag handle (touch).
-  // The reorder only engages once the pointer passes DRAG_THRESHOLD.
+  // Begin dragging an up-next row from its drag handle.
   const startItemDrag = (evt: PointerEvent, index: number) => {
     // Primary mouse button / touch / pen only.
     if (evt.pointerType === "mouse" && evt.button !== 0) return;
     const item = itemAt(index);
     if (!item || index < firstReorderableIndex()) return;
 
-    pendingDrag = {
-      index,
-      startX: evt.clientX,
-      startY: evt.clientY,
-      target: evt.target as HTMLElement | null,
-    };
+    // Measure the grabbed item so the ghost lines up under the finger and the
+    // gap the other rows open matches the item's height. Fall back to the
+    // virtualizer's measurement if the element can't be resolved.
+    const el = scrollEl.value;
+    const qitemEl = (evt.target as HTMLElement | null)?.closest(".qitem");
+    if (el && qitemEl) {
+      const cRect = el.getBoundingClientRect();
+      const qRect = qitemEl.getBoundingClientRect();
+      const qTop = qRect.top - cRect.top + el.scrollTop;
+      dragRowHeight.value = qRect.height;
+      dragGrabOffset = evt.clientY - cRect.top + el.scrollTop - qTop;
+      ghostY.value = qTop;
+    } else {
+      const vItem = getVirtualItems().find((v) => v.index === index);
+      dragRowHeight.value = vItem?.size ?? 60;
+      dragGrabOffset = dragRowHeight.value / 2;
+      ghostY.value = (vItem?.start ?? 0) + dragRowHeight.value / 2;
+    }
+
+    dragSourceIndex.value = index;
+    dragDropIndex.value = index;
+    draggedItem.value = item;
+    dragItemId = item.queue_item_id;
+    dragPointerY = evt.clientY;
+    autoScrollSpeed = 0;
+    onDragStart?.();
     dragAbort = new AbortController();
     const { signal } = dragAbort;
     window.addEventListener("pointermove", onDragPointerMove, {
       passive: false,
       signal,
     });
-    window.addEventListener("pointerup", onDragPointerUp, { signal });
+    window.addEventListener("pointerup", () => finishDrag(true), { signal });
     window.addEventListener("pointercancel", () => finishDrag(false), {
       signal,
     });
+    autoScrollRaf = requestAnimationFrame(autoScrollFrame);
   };
 
   // Index of the row currently being dragged (the hidden source row).

--- a/src/layouts/default/PlayerOSD/useQueueDragReorder.ts
+++ b/src/layouts/default/PlayerOSD/useQueueDragReorder.ts
@@ -23,6 +23,10 @@ interface QueueDragReorderOptions {
 export function useQueueDragReorder(options: QueueDragReorderOptions) {
   const { scrollEl, getVirtualItems, itemAt, onDragStart } = options;
 
+  // Pointer travel (px) before an armed press turns into a reorder drag, so a
+  // plain click/press on a row doesn't move anything.
+  const DRAG_THRESHOLD = 4;
+
   // Absolute index of the row being dragged (null when idle) and the index the
   // item would be inserted *before* on drop. While dragging, the source row
   // hides in place, a floating ghost follows the pointer, and the rows between
@@ -49,6 +53,14 @@ export function useQueueDragReorder(options: QueueDragReorderOptions) {
   let autoScrollRaf = 0;
   // Lets cleanup detach every drag listener at once (no per-handler bookkeeping).
   let dragAbort: AbortController | null = null;
+  // An armed-but-not-yet-engaged drag: captured on pointerdown, promoted to a
+  // real drag once the pointer passes DRAG_THRESHOLD.
+  let pendingDrag: {
+    index: number;
+    startX: number;
+    startY: number;
+    target: HTMLElement | null;
+  } | null = null;
 
   const totalItems = () => store.activePlayerQueue?.items ?? 0;
 
@@ -129,7 +141,14 @@ export function useQueueDragReorder(options: QueueDragReorderOptions) {
   }
 
   const onDragPointerMove = (evt: PointerEvent) => {
-    if (dragSourceIndex.value == null) return;
+    // Still armed: engage the drag only once the pointer passes the threshold.
+    if (dragSourceIndex.value == null) {
+      if (!pendingDrag) return;
+      const dx = evt.clientX - pendingDrag.startX;
+      const dy = evt.clientY - pendingDrag.startY;
+      if (Math.hypot(dx, dy) < DRAG_THRESHOLD) return;
+      beginActiveDrag(evt.clientY);
+    }
     evt.preventDefault();
     updateAutoScroll(evt.clientY);
     updateDragPositions(evt.clientY);
@@ -147,6 +166,7 @@ export function useQueueDragReorder(options: QueueDragReorderOptions) {
     dragRowHeight.value = 0;
     dragGrabOffset = 0;
     dragItemId = null;
+    pendingDrag = null;
   };
 
   const finishDrag = (commit: boolean) => {
@@ -165,50 +185,78 @@ export function useQueueDragReorder(options: QueueDragReorderOptions) {
     api.queueCommandMoveItem(queue.queue_id, itemId, shift);
   };
 
-  // Begin dragging an up-next row from its drag handle.
+  // Promote the armed press to a live drag once the threshold is crossed.
+  // Measures the grabbed item so the ghost lines up under the pointer and the
+  // gap the other rows open matches the item's height. Falls back to the
+  // virtualizer's measurement if the element can't be resolved.
+  const beginActiveDrag = (clientY: number) => {
+    const armed = pendingDrag;
+    if (!armed) return;
+    const item = itemAt(armed.index);
+    if (!item) {
+      cleanupDrag();
+      return;
+    }
+
+    const el = scrollEl.value;
+    const qitemEl = armed.target?.closest(".qitem");
+    if (el && qitemEl) {
+      const cRect = el.getBoundingClientRect();
+      const qRect = qitemEl.getBoundingClientRect();
+      const qTop = qRect.top - cRect.top + el.scrollTop;
+      dragRowHeight.value = qRect.height;
+      dragGrabOffset = armed.startY - cRect.top + el.scrollTop - qTop;
+      ghostY.value = qTop;
+    } else {
+      const vItem = getVirtualItems().find((v) => v.index === armed.index);
+      dragRowHeight.value = vItem?.size ?? 60;
+      dragGrabOffset = dragRowHeight.value / 2;
+      ghostY.value = (vItem?.start ?? 0) + dragRowHeight.value / 2;
+    }
+
+    dragSourceIndex.value = armed.index;
+    dragDropIndex.value = armed.index;
+    draggedItem.value = item;
+    dragItemId = item.queue_item_id;
+    dragPointerY = clientY;
+    autoScrollSpeed = 0;
+    onDragStart?.();
+    autoScrollRaf = requestAnimationFrame(autoScrollFrame);
+  };
+
+  const onDragPointerUp = () => {
+    // Released before crossing the threshold → it was a click, not a drag.
+    if (dragSourceIndex.value == null) {
+      cleanupDrag();
+      return;
+    }
+    finishDrag(true);
+  };
+
+  // Arm a drag from a row (whole-row on desktop) or the drag handle (touch).
+  // The reorder only engages once the pointer passes DRAG_THRESHOLD.
   const startItemDrag = (evt: PointerEvent, index: number) => {
     // Primary mouse button / touch / pen only.
     if (evt.pointerType === "mouse" && evt.button !== 0) return;
     const item = itemAt(index);
     if (!item || index < firstReorderableIndex()) return;
 
-    // Measure the grabbed item so the ghost lines up under the finger and the
-    // gap the other rows open matches the item's height. Fall back to the
-    // virtualizer's measurement if the element can't be resolved.
-    const el = scrollEl.value;
-    const qitemEl = (evt.target as HTMLElement | null)?.closest(".qitem");
-    if (el && qitemEl) {
-      const cRect = el.getBoundingClientRect();
-      const qRect = qitemEl.getBoundingClientRect();
-      const qTop = qRect.top - cRect.top + el.scrollTop;
-      dragRowHeight.value = qRect.height;
-      dragGrabOffset = evt.clientY - cRect.top + el.scrollTop - qTop;
-      ghostY.value = qTop;
-    } else {
-      const vItem = getVirtualItems().find((v) => v.index === index);
-      dragRowHeight.value = vItem?.size ?? 60;
-      dragGrabOffset = dragRowHeight.value / 2;
-      ghostY.value = (vItem?.start ?? 0) + dragRowHeight.value / 2;
-    }
-
-    dragSourceIndex.value = index;
-    dragDropIndex.value = index;
-    draggedItem.value = item;
-    dragItemId = item.queue_item_id;
-    dragPointerY = evt.clientY;
-    autoScrollSpeed = 0;
-    onDragStart?.();
+    pendingDrag = {
+      index,
+      startX: evt.clientX,
+      startY: evt.clientY,
+      target: evt.target as HTMLElement | null,
+    };
     dragAbort = new AbortController();
     const { signal } = dragAbort;
     window.addEventListener("pointermove", onDragPointerMove, {
       passive: false,
       signal,
     });
-    window.addEventListener("pointerup", () => finishDrag(true), { signal });
+    window.addEventListener("pointerup", onDragPointerUp, { signal });
     window.addEventListener("pointercancel", () => finishDrag(false), {
       signal,
     });
-    autoScrollRaf = requestAnimationFrame(autoScrollFrame);
   };
 
   // Index of the row currently being dragged (the hidden source row).


### PR DESCRIPTION
The queue list rows were crowded: the main line combined artist + title, and the subtitle stacked duration and album on top of the album already being visible in the now-playing view. The reorder/menu controls also only appeared on hover.

This simplifies each row so the relevant info is easier to scan and the controls are always reachable.

- Main line shows just the track title (was artist + title)
- Subtitle now shows the artist (album dropped — it's already visible in the now-playing view)
- Duration moved to the right of the row, with figures that line up across rows
- Drag handle and context-menu button are always visible (no longer hover-only)
- Reordering is initiated only from the drag handle; it's shown disabled/grayed on rows that can't be moved (now playing, buffered, played)
- Duration is hidden on mobile to save space
- The item being dragged is highlighted with the accent color

## Before
<img width="1512" height="1400" alt="image" src="https://github.com/user-attachments/assets/f316f7a7-29c1-45dc-9995-1a217ad0fd68" />

## After
<img width="1500" height="1400" alt="image" src="https://github.com/user-attachments/assets/9ff43cd8-c767-45f6-9832-8b6aafe5a022" />

Reordering:
<img width="1818" height="1522" alt="image" src="https://github.com/user-attachments/assets/b1509d20-bb7c-4d48-ac1e-339952c20399" />

