### PR TITLE
Fix browse sort/view settings not persisting per folder

### DIFF
--- a/src/components/ItemsListing.vue
+++ b/src/components/ItemsListing.vue
@@ -1437,10 +1437,13 @@ const loadData = async function (
   tempHide.value = false;
 };
 
-// Get preferences as a computed ref that updates automatically
-const savedPrefs = getItemsListingPreferences(
-  props.path || props.itemtype,
-  props.itemtype,
+// Re-derive from the current props.path: browse reuses one ItemsListing
+// instance across folders, so a ref bound to the mount-time path would read
+// and reset the wrong folder's saved sort/view settings.
+const savedPrefs = computed(
+  () =>
+    getItemsListingPreferences(props.path || props.itemtype, props.itemtype)
+      .value,
 );
 
 const restoreSettings = async function () {


### PR DESCRIPTION
`savedPrefs` captured `props.path` once at setup, but `BrowseView` reuses one `ItemsListing` instance across folder navigation while `props.path` changes. The read key drifted from the write key used by `changeSort`, so selecting a sort in a browse folder was immediately reset to the default by the `restoreSettings` watcher. Re-derive `savedPrefs` from the current `props.path` so each folder reads and writes its own settings.