### PR TITLE
Fix main listing search stealing focus from other inputs

### DIFF
--- a/src/components/ItemsListing.vue
+++ b/src/components/ItemsListing.vue
@@ -1554,6 +1554,18 @@ const keyListener = function (e: KeyboardEvent) {
   // Let searchInput handle this.
   if (searchHasFocus.value) return;
 
+  // ignore keystrokes typed into another editable element (e.g. the search box
+  // in the player drawer) so we don't steal focus to our own search input.
+  const target = e.target as HTMLElement | null;
+  if (
+    target &&
+    (target.tagName === "INPUT" ||
+      target.tagName === "TEXTAREA" ||
+      target.isContentEditable)
+  ) {
+    return;
+  }
+
   if (e.key === "a" && (e.ctrlKey || e.metaKey)) {
     e.preventDefault();
     selectAll();


### PR DESCRIPTION
The global keydown listener in `ItemsListing` opened and focused its own search box on any keypress, even while typing in another input such as the player drawer's search field. Ignore keystrokes that originate from an editable element so they no longer leak into the main listing search.