### PR TITLE
Fix buffered icon spacing in the player queue list

### DIFF
--- a/src/layouts/default/PlayerOSD/QueueListItem.vue
+++ b/src/layouts/default/PlayerOSD/QueueListItem.vue
@@ -329,6 +329,9 @@ const isMobile = computed(() => store.mobileLayout);
 .qitem__info {
   display: inline-flex;
   align-items: center;
+  /* Match the optical gap on the duration's right (action buttons' icon inset)
+     so the icon isn't tighter to the duration than the grip is. */
+  margin-right: 8px;
   color: var(--text-color, currentColor);
   cursor: help;
   opacity: 0.5;

--- a/src/layouts/default/PlayerOSD/QueueListItem.vue
+++ b/src/layouts/default/PlayerOSD/QueueListItem.vue
@@ -329,7 +329,6 @@ const isMobile = computed(() => store.mobileLayout);
 .qitem__info {
   display: inline-flex;
   align-items: center;
-  /* Match the duration's optical gap to the action buttons. */
   margin-right: 8px;
   color: var(--text-color, currentColor);
   cursor: help;

--- a/src/layouts/default/PlayerOSD/QueueListItem.vue
+++ b/src/layouts/default/PlayerOSD/QueueListItem.vue
@@ -329,8 +329,7 @@ const isMobile = computed(() => store.mobileLayout);
 .qitem__info {
   display: inline-flex;
   align-items: center;
-  /* Match the optical gap on the duration's right (action buttons' icon inset)
-     so the icon isn't tighter to the duration than the grip is. */
+  /* Match the duration's optical gap to the action buttons. */
   margin-right: 8px;
   color: var(--text-color, currentColor);
   cursor: help;


### PR DESCRIPTION
The buffered indicator icon sat tighter to the duration than the duration sits to the action buttons (which have built-in icon padding), so the spacing looked uneven on buffered rows.

- Add a right margin to the buffered icon so its gap to the duration matches the duration's optical gap to the grip/menu buttons