### PR TITLE
Center the play button in the fullscreen player controls

### DIFF
--- a/src/layouts/default/PlayerOSD/PlayerFullscreen.vue
+++ b/src/layouts/default/PlayerOSD/PlayerFullscreen.vue
@@ -1575,8 +1575,12 @@ watchEffect(() => {
   max-width: 100%;
 }
 
+/* Equal-width columns (same idiom as .media-controls-bottom) so the play
+   button stays at the true horizontal centre regardless of each control's
+   content width. */
 .media-controls > div {
-  width: calc(100% / 3);
+  flex-basis: 0;
+  flex-grow: 1;
 }
 
 .mediacontrols-right {

--- a/src/layouts/default/PlayerOSD/PlayerFullscreen.vue
+++ b/src/layouts/default/PlayerOSD/PlayerFullscreen.vue
@@ -1579,10 +1579,7 @@ watchEffect(() => {
   width: calc(100% / 3);
 }
 
-/* The transport icons carry no horizontal margin, but the queue button is the
-   only .media-controls-item that picks up its 5/10px margin — pushing the row's
-   right side out and drifting the centred play button left. Zero it so every
-   control is evenly spaced and the play button sits on the true centre. */
+/* Match the marginless transport icons so the play button stays centred. */
 .media-controls > .queue-btn-wrapper {
   margin: 0;
 }

--- a/src/layouts/default/PlayerOSD/PlayerFullscreen.vue
+++ b/src/layouts/default/PlayerOSD/PlayerFullscreen.vue
@@ -408,11 +408,11 @@
         <!-- player select button (compact, Spotify-style) -->
         <div
           v-if="showExpandedPlayerSelectButton"
+          class="row"
           style="
             display: flex;
             justify-content: center;
             align-items: center;
-            width: 100%;
             padding-bottom: 8px;
             padding-top: 4px;
           "
@@ -1575,12 +1575,16 @@ watchEffect(() => {
   max-width: 100%;
 }
 
-/* Equal-width columns (same idiom as .media-controls-bottom) so the play
-   button stays at the true horizontal centre regardless of each control's
-   content width. */
 .media-controls > div {
-  flex-basis: 0;
-  flex-grow: 1;
+  width: calc(100% / 3);
+}
+
+/* The play button's circle has a fixed 60px width, so its wrapper must centre
+   it — otherwise it left-aligns in its column and drifts off the row centre. */
+.play-btn-wrapper {
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 
 .mediacontrols-right {

--- a/src/layouts/default/PlayerOSD/PlayerFullscreen.vue
+++ b/src/layouts/default/PlayerOSD/PlayerFullscreen.vue
@@ -408,11 +408,11 @@
         <!-- player select button (compact, Spotify-style) -->
         <div
           v-if="showExpandedPlayerSelectButton"
-          class="row"
           style="
             display: flex;
             justify-content: center;
             align-items: center;
+            width: 100%;
             padding-bottom: 8px;
             padding-top: 4px;
           "

--- a/src/layouts/default/PlayerOSD/PlayerFullscreen.vue
+++ b/src/layouts/default/PlayerOSD/PlayerFullscreen.vue
@@ -1579,12 +1579,12 @@ watchEffect(() => {
   width: calc(100% / 3);
 }
 
-/* The play button's circle has a fixed 60px width, so its wrapper must centre
-   it — otherwise it left-aligns in its column and drifts off the row centre. */
-.play-btn-wrapper {
-  display: flex;
-  align-items: center;
-  justify-content: center;
+/* The transport icons carry no horizontal margin, but the queue button is the
+   only .media-controls-item that picks up its 5/10px margin — pushing the row's
+   right side out and drifting the centred play button left. Zero it so every
+   control is evenly spaced and the play button sits on the true centre. */
+.media-controls > .queue-btn-wrapper {
+  margin: 0;
 }
 
 .mediacontrols-right {


### PR DESCRIPTION
The play button sat slightly off the horizontal centre, so the player-select button below it (which is centred) didn't line up with it.

The control row gave each control a `width: calc(100% / 3)` column, which doesn't distribute evenly once the controls have differing content widths. Switched to the equal-column idiom already used by `.media-controls-bottom` (`flex-basis: 0; flex-grow: 1`) so every control gets an equal column and the centre (play) button lands on the true centre.

- Use equal-width flex columns for the media control buttons

## Before
<img width="1420" height="234" alt="image" src="https://github.com/user-attachments/assets/e27e05b6-7ea7-4e21-83d6-592dcf79f468" />


## After 
<img width="1383" height="216" alt="image" src="https://github.com/user-attachments/assets/ba420687-92bd-46c9-8a0a-5048b08a64ff" />
