### PR TITLE
Restore timeline progress bar spacing in the player bar

### DIFF
--- a/src/layouts/default/PlayerOSD/PlayerTimeline.vue
+++ b/src/layouts/default/PlayerOSD/PlayerTimeline.vue
@@ -4,7 +4,7 @@
       <SliderRoot
         v-model="wrappedCurTimeValue"
         data-slot="slider"
-        class="relative flex items-center select-none touch-none w-full h-5 mb-2"
+        class="relative flex items-center select-none touch-none w-full h-8"
         :disabled="!canSeek"
         :min="0"
         :max="store.activePlayer?.current_media?.duration ?? 0"


### PR DESCRIPTION
## Problem

The reka-ui slider migration (#1857) set the timeline `SliderRoot` to `h-5` (20px), centering the track ~10px from the top. The old Vuetify slider used a 32px control (~16px above the track), so the compact player bar lost ~6px of breathing room and the progress bar now hugs the play controls. It also added a stray `mb-2` the old slider never had.

## Changes

- Restore the slider height to 32px (`h-8`) so the track re-centers with the original spacing
- Drop the `mb-2` that didn't exist before the migration

## Before
<img width="1498" height="97" alt="image" src="https://github.com/user-attachments/assets/ea56d20c-f8e6-4cfc-988b-b5fe238a0d56" />


## After 
<img width="1498" height="95" alt="image" src="https://github.com/user-attachments/assets/b8918f31-ee95-48b7-9c76-3977994fe649" />
