### PR TITLE
Restore progress bar fill thickness and time-label spacing

### DIFF
--- a/src/layouts/default/PlayerOSD/PlayerTimeline.vue
+++ b/src/layouts/default/PlayerOSD/PlayerTimeline.vue
@@ -23,7 +23,7 @@
         >
           <SliderRange
             data-slot="slider-range"
-            class="absolute rounded-full h-1.5 top-1/2 -translate-y-1/2"
+            class="absolute rounded-full h-1 top-1/2 -translate-y-1/2"
             :style="{ 'background-color': color }"
           />
           <!-- pointerdown.stop prevents reka's slider track tap action -->

--- a/src/layouts/default/PlayerOSD/PlayerTimeline.vue
+++ b/src/layouts/default/PlayerOSD/PlayerTimeline.vue
@@ -362,7 +362,7 @@ const chapterClicked = function (chapter: MediaItemChapter) {
   opacity: 0.6;
   display: flex;
   flex: 1 1 auto;
-  margin-top: -10px;
+  margin-top: -6px;
   margin-bottom: 5px;
 }
 .time-text-row > div {


### PR DESCRIPTION
## Problem

Follow-up to #1994. The reka-ui slider migration (#1857) left two spacing regressions in the player timeline compared to the old Vuetify slider:

- The played portion (`SliderRange`) renders 6px thick on a 4px track, so the fill bulges beyond the rest of the bar.
- The time labels sit only 4px below the track (was 8px). reka's slider is a 32px box vs Vuetify's 36px, so the existing `margin-top: -10px` pull-up now crowds the labels against the bar.

## Changes

- Set the range height to 4px (`h-1`) so the fill matches the track — uniform bar again.
- Reduce the time-label pull-up (`margin-top` `-10px` → `-6px`) to restore the original 8px gap.