### PR TITLE
Improve fullscreen player controls and lyrics/queue behavior

### DIFF
--- a/src/composables/useLyricsOffset.ts
+++ b/src/composables/useLyricsOffset.ts
@@ -1,0 +1,33 @@
+/**
+ * Shared lyrics latency offset (in seconds).
+ *
+ * Adjusted from the fullscreen player's overflow menu while lyrics are open and
+ * fed to the lyrics viewer. Module-level state so the value persists across
+ * track changes (and fullscreen open/close) within the session.
+ */
+
+import { computed, ref } from "vue";
+
+const MIN_OFFSET = -9.9;
+const MAX_OFFSET = 9.9;
+
+const offset = ref(0);
+
+export function useLyricsOffset() {
+  const adjust = (delta: number) => {
+    const next = Math.round((offset.value + delta) * 10) / 10;
+    offset.value = Math.max(MIN_OFFSET, Math.min(MAX_OFFSET, next));
+  };
+
+  const reset = () => {
+    offset.value = 0;
+  };
+
+  // Signed, one-decimal display (e.g. "+0.5", "0.0", "-1.2").
+  const display = computed(() => {
+    const sign = offset.value > 0 ? "+" : "";
+    return `${sign}${offset.value.toFixed(1)}`;
+  });
+
+  return { offset, adjust, reset, display };
+}

--- a/src/layouts/default/ItemContextMenu.vue
+++ b/src/layouts/default/ItemContextMenu.vue
@@ -48,8 +48,13 @@
       </template>
 
       <template v-for="menuItem of visibleItems" :key="menuItem.label">
+        <!-- custom inline control (e.g. a stepper); renders its own row and
+             manages its own interaction without closing the menu -->
+        <component :is="menuItem.component" v-if="menuItem.component" />
         <!-- item with submenu -->
-        <DropdownMenuSub v-if="menuItem.subItems && menuItem.subItems.length">
+        <DropdownMenuSub
+          v-else-if="menuItem.subItems && menuItem.subItems.length"
+        >
           <DropdownMenuSubTrigger
             :class="[
               'gap-3',
@@ -274,6 +279,10 @@ export interface ContextMenuItem {
   subItems?: ContextMenuItem[];
   close_on_click?: boolean;
   color?: string;
+  // Renders a custom control in place of the standard row (label/icon/action
+  // are ignored except for the list key). Used for inline controls like the
+  // lyrics-offset stepper.
+  component?: Component;
 }
 
 export const showContextMenuForMediaItem = async function (

--- a/src/layouts/default/PlayerOSD/LyricsOffsetMenuControl.vue
+++ b/src/layouts/default/PlayerOSD/LyricsOffsetMenuControl.vue
@@ -1,0 +1,121 @@
+<!--
+  Inline lyrics sync-offset stepper for the fullscreen player's overflow menu.
+
+  Rendered as a non-selectable row so the −/+ buttons adjust the offset in place
+  without closing the menu; press-and-hold accelerates after a short delay.
+-->
+<template>
+  <div class="lyrics-offset-row" @pointerdown.stop @click.stop>
+    <ChevronsLeftRight :size="20" class="lyrics-offset-row__icon" />
+    <span class="lyrics-offset-row__label">{{ $t("lyrics_offset") }}</span>
+    <div class="lyrics-offset-row__stepper">
+      <button
+        type="button"
+        class="lyrics-offset-row__btn"
+        :aria-label="$t('tooltip.decrease_offset')"
+        @click.stop
+        @mousedown.stop="startRepeating(-0.1)"
+        @touchstart.stop.prevent="startRepeating(-0.1)"
+      >
+        <Minus :size="16" />
+      </button>
+      <span class="lyrics-offset-row__value">{{ display }}s</span>
+      <button
+        type="button"
+        class="lyrics-offset-row__btn"
+        :aria-label="$t('tooltip.increase_offset')"
+        @click.stop
+        @mousedown.stop="startRepeating(0.1)"
+        @touchstart.stop.prevent="startRepeating(0.1)"
+      >
+        <Plus :size="16" />
+      </button>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { useLyricsOffset } from "@/composables/useLyricsOffset";
+import { $t } from "@/plugins/i18n";
+import { ChevronsLeftRight, Minus, Plus } from "@lucide/vue";
+import { onBeforeUnmount } from "vue";
+
+const { adjust, display } = useLyricsOffset();
+
+// Press-and-hold: first step on press, then accelerate after a short delay.
+let holdDelay: number | null = null;
+let holdInterval: number | null = null;
+
+const stopRepeating = () => {
+  if (holdDelay !== null) {
+    clearTimeout(holdDelay);
+    holdDelay = null;
+  }
+  if (holdInterval !== null) {
+    clearInterval(holdInterval);
+    holdInterval = null;
+  }
+  window.removeEventListener("mouseup", stopRepeating);
+  window.removeEventListener("touchend", stopRepeating);
+  window.removeEventListener("touchcancel", stopRepeating);
+};
+
+const startRepeating = (delta: number) => {
+  stopRepeating();
+  adjust(delta);
+  holdDelay = window.setTimeout(() => {
+    holdInterval = window.setInterval(() => adjust(delta), 80);
+  }, 400);
+  window.addEventListener("mouseup", stopRepeating);
+  window.addEventListener("touchend", stopRepeating);
+  window.addEventListener("touchcancel", stopRepeating);
+};
+
+onBeforeUnmount(stopRepeating);
+</script>
+
+<style scoped>
+.lyrics-offset-row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 6px 8px;
+  font-size: 0.875rem;
+}
+
+.lyrics-offset-row__icon {
+  flex: 0 0 auto;
+}
+
+.lyrics-offset-row__label {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+.lyrics-offset-row__stepper {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.lyrics-offset-row__btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.75rem;
+  height: 1.75rem;
+  border-radius: 6px;
+  color: inherit;
+  transition: background-color 0.12s ease;
+}
+
+.lyrics-offset-row__btn:hover {
+  background: var(--accent);
+}
+
+.lyrics-offset-row__value {
+  min-width: 3.5ch;
+  text-align: center;
+  font-variant-numeric: tabular-nums;
+}
+</style>

--- a/src/layouts/default/PlayerOSD/PlayerControlBtn/RepeatBtn.vue
+++ b/src/layouts/default/PlayerOSD/PlayerControlBtn/RepeatBtn.vue
@@ -16,6 +16,8 @@
         [playerQueue?.repeat_mode == RepeatMode.ONE, 'primary'],
       ])
     "
+    :title="repeatTitle"
+    :data-dynamic="isDynamic || undefined"
     variant="button"
     @click="api.queueCommandRepeat(playerQueue?.queue_id || '', nextRepeatMode)"
   >
@@ -38,6 +40,7 @@ import { getValueFromSources } from "@/helpers/utils";
 import api from "@/plugins/api";
 import { PlayerQueue, RepeatMode } from "@/plugins/api/interfaces";
 import { isQueueInfiniteStream } from "@/plugins/api/helpers";
+import { $t } from "@/plugins/i18n";
 import { computed } from "vue";
 import { IconRepeat, IconRepeatOff, IconRepeatOnce } from "@tabler/icons-vue";
 
@@ -72,4 +75,18 @@ const nextRepeatMode = computed<RepeatMode>(() => {
   if (current === RepeatMode.ALL) return RepeatMode.ONE;
   return RepeatMode.OFF;
 });
+
+// In dynamic mode the button is disabled; the tooltip explains why.
+const repeatTitle = computed<string | undefined>(() =>
+  isDynamic.value ? $t("repeat_dynamic_unavailable") : undefined,
+);
 </script>
+
+<style scoped>
+/* Disabled icons drop pointer events (so no tooltip), but in dynamic mode we
+   want the title to explain why repeat is unavailable. Re-enable hover just for
+   that case; the Icon still guards the click itself. */
+.icon-container--disabled[data-dynamic] {
+  pointer-events: auto;
+}
+</style>

--- a/src/layouts/default/PlayerOSD/PlayerControlBtn/ShuffleBtn.vue
+++ b/src/layouts/default/PlayerOSD/PlayerControlBtn/ShuffleBtn.vue
@@ -11,6 +11,7 @@
     "
     :color="getValueFromSources(icon?.color, [[shuffleActive, 'primary', '']])"
     :title="shuffleTitle"
+    :data-dynamic="isDynamic || undefined"
     variant="button"
     @click="
       api.queueCommandShuffle(
@@ -79,11 +80,22 @@ const shuffleActive = computed(
   () => compProps.playerQueue?.shuffle_enabled === true,
 );
 
-// State-aware tooltip reflecting plain vs smart shuffle.
+// State-aware tooltip. In dynamic mode the button is disabled and shuffle is
+// managed by the queue, so explain that rather than offering a toggle.
 const shuffleTitle = computed(() => {
+  if (isDynamic.value) return $t("shuffle_dynamic_active");
   if (smartShuffleActive.value) return $t("shuffle_smart_active");
   return compProps.playerQueue?.shuffle_enabled
     ? $t("shuffle_disable")
     : $t("shuffle_enable");
 });
 </script>
+
+<style scoped>
+/* Disabled icons drop pointer events (so no tooltip), but in dynamic mode we
+   want the title to explain why shuffle is unavailable. Re-enable hover just for
+   that case; the Icon still guards the click itself. */
+.icon-container--disabled[data-dynamic] {
+  pointer-events: auto;
+}
+</style>

--- a/src/layouts/default/PlayerOSD/PlayerFullscreen.vue
+++ b/src/layouts/default/PlayerOSD/PlayerFullscreen.vue
@@ -28,10 +28,7 @@
           <PlayerFullscreenHeaderControls
             :lyrics-state="lyricsState"
             :lyrics-active="lyricsActive"
-            :show-lyrics-offset="showLyricsOffset"
-            :lyrics-offset-display="lyricsOffsetDisplay"
             @toggle-lyrics="toggleLyrics"
-            @offset-press="startRepeatingOffset"
           />
 
           <Button
@@ -447,6 +444,7 @@ import LyricsViewer from "@/components/LyricsViewer.vue";
 import MarqueeText from "@/components/MarqueeText.vue";
 import { Button } from "@/components/ui/button";
 import { useLyricsElapsedTime } from "@/composables/useLyricsElapsedTime";
+import { useLyricsOffset } from "@/composables/useLyricsOffset";
 import { MarqueeTextSync } from "@/helpers/marquee_text_sync";
 import PlayerIcon from "@/components/PlayerIcon.vue";
 import { getPlayerMenuItems } from "@/helpers/player_menu_items";
@@ -461,6 +459,7 @@ import PlayBtn from "@/layouts/default/PlayerOSD/PlayerControlBtn/PlayBtn.vue";
 import PreviousBtn from "@/layouts/default/PlayerOSD/PlayerControlBtn/PreviousBtn.vue";
 import RepeatBtn from "@/layouts/default/PlayerOSD/PlayerControlBtn/RepeatBtn.vue";
 import ShuffleBtn from "@/layouts/default/PlayerOSD/PlayerControlBtn/ShuffleBtn.vue";
+import LyricsOffsetMenuControl from "@/layouts/default/PlayerOSD/LyricsOffsetMenuControl.vue";
 import PlayerFullscreenHeaderControls from "@/layouts/default/PlayerOSD/PlayerFullscreenHeaderControls.vue";
 import PlayerVolume from "@/layouts/default/PlayerOSD/PlayerVolume.vue";
 import QueueListItem from "@/layouts/default/PlayerOSD/QueueListItem.vue";
@@ -486,6 +485,7 @@ import { ChevronDownIcon, EllipsisVerticalIcon, Heart } from "@lucide/vue";
 import Color from "color";
 import {
   computed,
+  markRaw,
   onBeforeUnmount,
   onMounted,
   ref,
@@ -589,6 +589,28 @@ watch(lyricsState, (state) => {
   }
 });
 
+// The right column shows either the queue or the lyrics, never both (lyrics
+// render on top of the queue's slot). Keep the two toggles mutually exclusive
+// so each button visibly swaps the panel instead of silently flipping a hidden
+// state. Opening lyrics remembers whether the queue was showing so closing them
+// returns there rather than to the bare artwork.
+let queueVisibleBeforeLyrics = false;
+watch(showLyrics, (active) => {
+  if (active) {
+    queueVisibleBeforeLyrics = store.showQueueItems;
+    store.showQueueItems = false;
+  } else if (queueVisibleBeforeLyrics) {
+    store.showQueueItems = true;
+    queueVisibleBeforeLyrics = false;
+  }
+});
+watch(
+  () => store.showQueueItems,
+  (active) => {
+    if (active) showLyrics.value = false;
+  },
+);
+
 // Whether the right-hand column (queue list or lyrics) is visible. Used to
 // collapse the media details column on small/narrow screens.
 const showRightColumn = computed(
@@ -642,52 +664,9 @@ const showLyricsOffset = computed(() => {
   return !ACCURATE_TIME_PROTOCOLS.includes(domain);
 });
 
-// Lyrics latency offset, in seconds. Adjustable via the lyrics sync pill in
-// the header; persists across tracks within the session.
-const lyricsOffset = ref(0);
-
-const lyricsOffsetDisplay = computed(() => {
-  const val = lyricsOffset.value;
-  const sign = val > 0 ? "+" : "";
-  return `${sign}${val.toFixed(1)}`;
-});
-
-const adjustLyricsOffset = (delta: number) => {
-  const next = Math.round((lyricsOffset.value + delta) * 10) / 10;
-  lyricsOffset.value = Math.max(-9.9, Math.min(9.9, next));
-};
-
-// Press-and-hold: first step on press, then accelerate after a short delay.
-let offsetHoldDelay: number | null = null;
-let offsetHoldInterval: number | null = null;
-
-const stopRepeatingOffset = () => {
-  if (offsetHoldDelay !== null) {
-    clearTimeout(offsetHoldDelay);
-    offsetHoldDelay = null;
-  }
-  if (offsetHoldInterval !== null) {
-    clearInterval(offsetHoldInterval);
-    offsetHoldInterval = null;
-  }
-  window.removeEventListener("mouseup", stopRepeatingOffset);
-  window.removeEventListener("touchend", stopRepeatingOffset);
-  window.removeEventListener("touchcancel", stopRepeatingOffset);
-};
-
-const startRepeatingOffset = (delta: number) => {
-  stopRepeatingOffset();
-  adjustLyricsOffset(delta);
-  offsetHoldDelay = window.setTimeout(() => {
-    offsetHoldInterval = window.setInterval(
-      () => adjustLyricsOffset(delta),
-      80,
-    );
-  }, 400);
-  window.addEventListener("mouseup", stopRepeatingOffset);
-  window.addEventListener("touchend", stopRepeatingOffset);
-  window.addEventListener("touchcancel", stopRepeatingOffset);
-};
+// Shared lyrics sync offset; adjusted from the overflow menu while lyrics are
+// open (see openQueueMenu) and fed to the lyrics viewer.
+const { offset: lyricsOffset } = useLyricsOffset();
 
 // Fetch lyrics for the current track (only when fullscreen player is open)
 let lyricsLoadGeneration = 0;
@@ -1085,11 +1064,26 @@ const onArtistClick = async function () {
 
 const openQueueMenu = function (evt: Event) {
   if (!store.activePlayer) return;
-  eventbus.emit("contextmenu", {
-    items: getPlayerMenuItems(store.activePlayer, store.activePlayerQueue, {
+  const menuItems = getPlayerMenuItems(
+    store.activePlayer,
+    store.activePlayerQueue,
+    {
       context: "queue",
       hideShuffleRepeat: mdAndUp.value,
-    }),
+    },
+  );
+  // While lyrics are open, surface the sync-offset stepper at the top of the
+  // overflow menu (only for players that benefit from a latency offset).
+  if (showLyrics.value && showLyricsOffset.value) {
+    menuItems.unshift({
+      label: "lyrics_offset",
+      // markRaw: the menu items land in a reactive array; a bare component
+      // definition there would be needlessly made reactive.
+      component: markRaw(LyricsOffsetMenuControl),
+    });
+  }
+  eventbus.emit("contextmenu", {
+    items: menuItems,
     posX: (evt as PointerEvent).clientX,
     posY: (evt as PointerEvent).clientY,
   });
@@ -1122,7 +1116,6 @@ onMounted(() => {
   window.addEventListener("keydown", onKeydown);
   onBeforeUnmount(() => {
     window.removeEventListener("keydown", onKeydown);
-    stopRepeatingOffset();
   });
 });
 
@@ -1597,6 +1590,14 @@ watchEffect(() => {
 
 .v-toolbar :deep(.v-toolbar-title) {
   text-align: center;
+}
+
+/* Line the trailing menu button up with the per-row menu buttons in the queue
+   list below: those sit 18px from the column's right edge (10px column + 8px
+   row padding) with a 32px button, so this 28px button needs a 20px end margin
+   for the two to share a vertical centre. */
+.v-toolbar :deep(.v-toolbar__append) {
+  margin-inline-end: 20px;
 }
 
 div,

--- a/src/layouts/default/PlayerOSD/PlayerFullscreenHeaderControls.vue
+++ b/src/layouts/default/PlayerOSD/PlayerFullscreenHeaderControls.vue
@@ -6,64 +6,6 @@
     <!-- streaming quality details chip (moved up from under the track info) -->
     <QualityDetailsBtn v-if="store.curQueueItem?.streamdetails" pill />
 
-    <!-- lyrics sync offset (only while lyrics are open) -->
-    <Popover
-      v-if="lyricsActive && showLyricsOffset"
-      v-model:open="offsetOpen"
-      modal
-    >
-      <PopoverTrigger as-child>
-        <Button
-          variant="outline"
-          :size="showLabel ? 'xs' : 'icon-xs'"
-          :class="pillClass"
-          :aria-label="$t('lyrics_offset')"
-        >
-          <ChevronsLeftRight :size="16" />
-          <span v-if="showLabel">{{ lyricsOffsetDisplay }}s</span>
-        </Button>
-      </PopoverTrigger>
-
-      <PopoverContent align="end" :side-offset="6" class="w-auto">
-        <div class="flex flex-col gap-3">
-          <div class="flex items-center gap-2">
-            <ChevronsLeftRight :size="18" />
-            <span class="text-[0.95rem] font-semibold">{{
-              $t("lyrics_offset")
-            }}</span>
-          </div>
-          <div class="flex items-center justify-center gap-4">
-            <Button
-              variant="secondary"
-              size="icon-sm"
-              class="rounded-full"
-              :aria-label="$t('tooltip.decrease_offset')"
-              @click.stop
-              @mousedown.stop="emit('offset-press', -0.1)"
-              @touchstart.stop.prevent="emit('offset-press', -0.1)"
-            >
-              <Minus :size="16" />
-            </Button>
-            <span class="min-w-[3.5ch] text-center text-sm tabular-nums">
-              {{ lyricsOffsetDisplay
-              }}<span class="text-muted-foreground">s</span>
-            </span>
-            <Button
-              variant="secondary"
-              size="icon-sm"
-              class="rounded-full"
-              :aria-label="$t('tooltip.increase_offset')"
-              @click.stop
-              @mousedown.stop="emit('offset-press', 0.1)"
-              @touchstart.stop.prevent="emit('offset-press', 0.1)"
-            >
-              <Plus :size="16" />
-            </Button>
-          </div>
-        </div>
-      </PopoverContent>
-    </Popover>
-
     <!-- lyrics: available -> clickable toggle (fully primary while the panel is open) -->
     <TooltipProvider v-if="lyricsState === 'available'" :delay-duration="200">
       <Tooltip>
@@ -224,17 +166,6 @@
         </TooltipContent>
       </Tooltip>
     </TooltipProvider>
-
-    <!-- subtle scrim/blur behind whichever popout is open -->
-    <Teleport to="body">
-      <Transition name="fs-popover-scrim">
-        <div
-          v-if="offsetOpen"
-          class="fullscreen-popover-scrim"
-          aria-hidden="true"
-        ></div>
-      </Transition>
-    </Teleport>
   </div>
 </template>
 
@@ -242,11 +173,6 @@
 import QualityDetailsBtn from "@/components/QualityDetailsBtn.vue";
 import SleepTimerBtn from "@/layouts/default/PlayerOSD/PlayerControlBtn/SleepTimerBtn.vue";
 import { Button } from "@/components/ui/button";
-import {
-  Popover,
-  PopoverContent,
-  PopoverTrigger,
-} from "@/components/ui/popover";
 import {
   Tooltip,
   TooltipContent,
@@ -259,24 +185,15 @@ import api from "@/plugins/api";
 import { isQueueInfiniteStream } from "@/plugins/api/helpers";
 import { $t } from "@/plugins/i18n";
 import { store } from "@/plugins/store";
-import {
-  ChevronsLeftRight,
-  InfinityIcon,
-  MicVocal,
-  Minus,
-  Plus,
-} from "@lucide/vue";
-import { computed, ref } from "vue";
+import { InfinityIcon, MicVocal } from "@lucide/vue";
+import { computed } from "vue";
 
 const props = defineProps<{
   lyricsState?: string;
   lyricsActive?: boolean;
-  showLyricsOffset?: boolean;
-  lyricsOffsetDisplay?: string;
 }>();
 const emit = defineEmits<{
   (e: "toggle-lyrics"): void;
-  (e: "offset-press", delta: number): void;
 }>();
 
 // Explanation shown in the tooltip when lyrics can't be opened (yet).
@@ -304,9 +221,6 @@ const seedNames = computed(() =>
     .filter(Boolean)
     .join(", "),
 );
-
-// local open-state so we can render a shared scrim behind whichever popout shows
-const offsetOpen = ref(false);
 
 const showLabel = computed(() => !store.mobileLayout);
 
@@ -348,26 +262,5 @@ const toggleCrossfade = () => {
   display: inline-flex;
   align-items: center;
   gap: 8px;
-}
-
-/* subtle blurred scrim behind an open popout to set it apart from the player */
-.fullscreen-popover-scrim {
-  position: fixed;
-  inset: 0;
-  z-index: 9990;
-  background: rgba(0, 0, 0, 0.28);
-  backdrop-filter: blur(3px);
-  -webkit-backdrop-filter: blur(3px);
-  pointer-events: none;
-}
-
-.fs-popover-scrim-enter-active,
-.fs-popover-scrim-leave-active {
-  transition: opacity 0.18s ease;
-}
-
-.fs-popover-scrim-enter-from,
-.fs-popover-scrim-leave-to {
-  opacity: 0;
 }
 </style>

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -733,6 +733,8 @@
     "shuffle_disable": "Disable shuffle",
     "shuffle_enable": "Enable shuffle",
     "shuffle_smart_active": "Smart shuffle is on. Click to turn it off.",
+    "shuffle_dynamic_active": "Smart shuffle is active because the queue is playing in dynamic mode.",
+    "repeat_dynamic_unavailable": "Repeat isn't available while the queue is playing in dynamic mode.",
     "open_dsp_settings": "Open DSP settings",
     "audiobook": "Audiobook",
     "audiobooks": "Audiobooks",


### PR DESCRIPTION
The fullscreen player's header and side panels had a few rough edges: the overflow menu didn't line up with the queue rows, the lyrics sync offset cluttered the header, opening the queue while lyrics were shown did nothing visible, and the disabled shuffle/repeat buttons gave no hint why.

## Changes
- Align the header overflow menu with the per-row menus in the queue list.
- Move the lyrics sync offset out of the header into the overflow menu (shown only while lyrics are open), as an inline stepper.
- Make the queue and lyrics panels mutually exclusive so their buttons always swap the visible panel; closing lyrics returns to the queue when it was open.
- Add tooltips explaining that shuffle and repeat are unavailable while the queue is in dynamic mode.
