### PR TITLE
Add link to global queue settings from the queue settings page

### DIFF
--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -570,7 +570,9 @@
         "provider_saved": "Provider settings saved",
         "provider_reloading": "Reloading provider…",
         "provider_removed": "Provider removed",
-        "queue_settings": "Queue settings"
+        "queue_settings": "Queue settings",
+        "queue_global_settings_hint": "These settings apply to this queue only. You can also configure the defaults that apply to all player queues.",
+        "queue_global_settings_link": "Open global queue settings"
     },
     "show_info": "Show info",
     "show_select_boxes": "Show selection boxes",

--- a/src/views/settings/EditPlayerQueue.vue
+++ b/src/views/settings/EditPlayerQueue.vue
@@ -12,6 +12,21 @@
       </div>
     </v-card>
 
+    <!-- Global queue settings hint -->
+    <div
+      class="border-primary/20 bg-primary/5 mb-4 flex flex-wrap items-center gap-4 rounded-xl border px-4 py-3"
+    >
+      <Info class="text-primary size-5 shrink-0" />
+      <p class="text-muted-foreground m-0 flex-1 text-sm">
+        {{ $t("settings.queue_global_settings_hint") }}
+      </p>
+      <Button as-child variant="outline" size="sm">
+        <RouterLink to="/settings/editcore/player_queues" class="no-underline">
+          {{ $t("settings.queue_global_settings_link") }}
+        </RouterLink>
+      </Button>
+    </div>
+
     <edit-config
       v-if="config"
       :config-entries="allConfigEntries"
@@ -34,8 +49,10 @@
 <script setup lang="ts">
 import { api } from "@/plugins/api";
 import { ConfigValueType, PlayerQueueConfig } from "@/plugins/api/interfaces";
+import { Button } from "@/components/ui/button";
+import { Info } from "@lucide/vue";
 import { computed, ref, watch } from "vue";
-import { useRouter } from "vue-router";
+import { RouterLink, useRouter } from "vue-router";
 import { toast } from "vue-sonner";
 import EditConfig from "./EditConfig.vue";
 


### PR DESCRIPTION
When configuring the settings for an individual player queue, there was nothing pointing to the global queue settings — the defaults that apply to all player queues. It was easy to miss that those global settings even exist.

This adds an informational hint at the top of the per-queue settings page with a link straight to the global queue settings.

## Changes
- Add an info banner at the top of the player queue settings page linking to the global queue settings (`player_queues` core config)
- Built with shadcn-vue + Tailwind (in line with the ongoing migration away from Vuetify)
- Add `queue_global_settings_hint` / `queue_global_settings_link` strings to `en.json`