### PR TITLE
Show per-option description in config-entry select

### DIFF
--- a/src/plugins/api/interfaces.ts
+++ b/src/plugins/api/interfaces.ts
@@ -516,6 +516,8 @@ export interface ConfigValueOption {
   disabled?: boolean;
   // disabled_reason: optional explanation of why the option is disabled
   disabled_reason?: string;
+  // description: optional per-option help text shown under the option
+  description?: string;
 }
 
 export interface ConfigEntry {

--- a/src/views/settings/ConfigEntryField.vue
+++ b/src/views/settings/ConfigEntryField.vue
@@ -178,7 +178,7 @@
           title: item.title,
           value: item.value,
           disabled: item.disabled,
-          subtitle: item.disabled ? item.disabled_reason : undefined,
+          subtitle: item.disabled ? item.disabled_reason : item.description,
         })
       "
       :disabled="isFieldDisabled"
@@ -348,6 +348,7 @@ const displayOptions = computed(() => {
       value: orgOption.value,
       disabled: orgOption.disabled,
       disabled_reason: orgOption.disabled_reason,
+      description: orgOption.description,
     };
     if (option.value == props.confEntry.default_value) {
       option.title += ` [${$t("settings.default")}]`;


### PR DESCRIPTION
Renders the new optional per-option `description` (from `ConfigValueOption`) as the option's subtitle in config-entry selects, so an individual option can carry its own help text instead of overloading the option title or the shared entry description. Disabled options keep showing their disabled reason.

Depends on the models field ([music-assistant/models#285](https://github.com/music-assistant/models/pull/285)); it's a no-op until a server ships options that set a description.