### PR TITLE
Fix long-press context menus on touch devices

### DIFF
--- a/src/components/InfoHeader.vue
+++ b/src/components/InfoHeader.vue
@@ -376,15 +376,18 @@
                 $vuetify.display.mobile ? 15 : 25,
               )"
               :key="genre.item_id"
+              v-hold="(e: Event) => onHold(e, genre)"
               color="blue-grey lighten-1"
               style="margin-right: 5px; margin-bottom: 5px"
               small
               outlined
               class="cursor-pointer"
               @click="handleMediaItemClick(genre, 0, 0)"
+              @click.capture="swallowClickAfterHold"
               @contextmenu.prevent="
                 (e: MouseEvent) => showGenreChipContextMenu(e, genre)
               "
+              @touchstart.passive="onTouchStart"
             >
               {{ genre.name }}
             </v-chip>
@@ -428,6 +431,10 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
+import {
+  getEventPosition,
+  useHoldToOpenMenu,
+} from "@/composables/useHoldToOpenMenu";
 import { useUserPreferences } from "@/composables/userPreferences";
 import { MarqueeTextSync } from "@/helpers/marquee_text_sync";
 import {
@@ -532,7 +539,7 @@ watch(shortcutsPreference, async () => {
   }
 });
 
-const showGenreChipContextMenu = (evt: MouseEvent, genre: Genre) => {
+const showGenreChipContextMenu = (evt: Event, genre: Genre) => {
   if (
     !compProps.item ||
     !isAdmin.value ||
@@ -557,12 +564,17 @@ const showGenreChipContextMenu = (evt: MouseEvent, genre: Genre) => {
       },
     },
   ];
+  const pos = getEventPosition(evt);
   eventbus.emit("contextmenu", {
     items: menuItems,
-    posX: evt.clientX,
-    posY: evt.clientY,
+    posX: pos.x,
+    posY: pos.y,
   });
 };
+
+const { onHold, onTouchStart, swallowClickAfterHold } = useHoldToOpenMenu(
+  showGenreChipContextMenu,
+);
 
 const albumClick = function (item: Album | ItemMapping) {
   // album entry clicked

--- a/src/components/PlayerCard.vue
+++ b/src/components/PlayerCard.vue
@@ -1,5 +1,6 @@
 <template>
   <v-card
+    v-hold="onHold"
     flat
     class="panel-item"
     :class="{
@@ -10,7 +11,9 @@
     :ripple="false"
     :disabled="!player.available"
     @click="$emit('click', player)"
+    @click.capture="swallowClickAfterHold"
     @contextmenu.prevent="openPlayerMenu"
+    @touchstart.passive="onTouchStart"
   >
     <!-- now playing media -->
     <v-list-item class="panel-item-details" flat :ripple="false">
@@ -240,6 +243,10 @@
 import { Button } from "@/components/ui/button";
 import VolumeControl from "@/components/VolumeControl.vue";
 import { useActiveSource } from "@/composables/activeSource";
+import {
+  getEventPosition,
+  useHoldToOpenMenu,
+} from "@/composables/useHoldToOpenMenu";
 import { getPlayerMenuItems } from "@/helpers/player_menu_items";
 import {
   getMediaImageUrl,
@@ -300,14 +307,18 @@ const playerQueue = computed(() => {
 });
 
 const openPlayerMenu = function (evt: Event) {
+  const pos = getEventPosition(evt);
   eventbus.emit("contextmenu", {
     items: getPlayerMenuItems(compProps.player, playerQueue.value, {
       context: "player",
     }),
-    posX: (evt as PointerEvent).clientX,
-    posY: (evt as PointerEvent).clientY,
+    posX: pos.x,
+    posY: pos.y,
   });
 };
+
+const { onHold, onTouchStart, swallowClickAfterHold } =
+  useHoldToOpenMenu(openPlayerMenu);
 
 const canPlayPause = computed(() => {
   if (activeSource.value) {

--- a/src/components/dsp/DSPPipeline.vue
+++ b/src/components/dsp/DSPPipeline.vue
@@ -25,11 +25,14 @@
     <v-timeline-item
       v-for="(filter, index) in dsp.filters"
       :key="index"
+      v-hold="(e: Event) => onHold(e, index)"
       :dot-color="isDotActive(index)"
       size="x-small"
       :hide-dot="isDisabled(index)"
       @click="handleSelect(index)"
+      @click.capture="swallowClickAfterHold"
       @contextmenu.prevent="(e: MouseEvent) => openFilterContextMenu(e, index)"
+      @touchstart.passive="onTouchStart"
     >
       <v-btn
         flat
@@ -84,6 +87,10 @@
 </template>
 
 <script setup lang="ts">
+import {
+  getEventPosition,
+  useHoldToOpenMenu,
+} from "@/composables/useHoldToOpenMenu";
 import { DSPConfig } from "@/plugins/api/interfaces";
 import { eventbus } from "@/plugins/eventbus";
 import { useTheme } from "vuetify";
@@ -167,12 +174,17 @@ const openFilterContextMenu = function (evt: Event, index: number) {
       icon: "mdi-delete",
     },
   ];
+  const pos = getEventPosition(evt);
   eventbus.emit("contextmenu", {
     items: menuItems,
-    posX: (evt as PointerEvent).clientX,
-    posY: (evt as PointerEvent).clientY,
+    posX: pos.x,
+    posY: pos.y,
   });
 };
+
+const { onHold, onTouchStart, swallowClickAfterHold } = useHoldToOpenMenu(
+  openFilterContextMenu,
+);
 </script>
 
 <style scoped>

--- a/src/components/navigation/NavShortcuts.vue
+++ b/src/components/navigation/NavShortcuts.vue
@@ -26,6 +26,10 @@ import {
   SidebarMenuSkeleton,
   useSidebar,
 } from "@/components/ui/sidebar";
+import {
+  getEventPosition,
+  useHoldToOpenMenu,
+} from "@/composables/useHoldToOpenMenu";
 import { useShortcuts, type ShortcutItem } from "@/composables/useShortcuts";
 import { useSidebarScrollbarGutter } from "@/composables/useSidebarScrollbarGutter";
 import { getImageThumbForItem } from "@/helpers/utils";
@@ -97,18 +101,22 @@ const pinnedItemsWithUrls = computed(() =>
   pinnedItems.value.map((item) => ({ item, url: getItemUrl(item) })),
 );
 
-const openContextMenu = async (event: MouseEvent, item: ShortcutItem) => {
+const openContextMenu = async (event: Event, item: ShortcutItem) => {
+  const pos = getEventPosition(event);
   await showContextMenuForMediaItem(
     item,
     undefined,
-    event.clientX,
-    event.clientY,
+    pos.x,
+    pos.y,
     true,
     true,
     undefined,
     { shortcutContext: true },
   );
 };
+
+const { onHold, onTouchStart, swallowClickAfterHold } =
+  useHoldToOpenMenu(openContextMenu);
 
 const { navEl } = useSidebarScrollbarGutter(pinnedItems);
 </script>
@@ -130,7 +138,10 @@ const { navEl } = useSidebarScrollbarGutter(pinnedItems);
           <SidebarMenuItem
             v-for="{ item, url } in pinnedItemsWithUrls"
             :key="item.uri"
+            v-hold="(e: Event) => onHold(e, item)"
             class="mr-1.5"
+            @click.capture="swallowClickAfterHold"
+            @touchstart.passive="onTouchStart"
           >
             <SidebarMenuButton
               :as="RouterLinkComponent"

--- a/src/composables/useHoldToOpenMenu.ts
+++ b/src/composables/useHoldToOpenMenu.ts
@@ -1,0 +1,57 @@
+import { ref } from "vue";
+
+/**
+ * Returns viewport coordinates for mouse, pointer or touch events,
+ * falling back to 0,0 when the event carries none.
+ */
+export function getEventPosition(evt: Event): { x: number; y: number } {
+  if ("touches" in evt) {
+    const touchEvt = evt as TouchEvent;
+    const touch = touchEvt.touches[0] ?? touchEvt.changedTouches[0];
+    return { x: touch?.clientX ?? 0, y: touch?.clientY ?? 0 };
+  }
+  const mouseEvt = evt as MouseEvent;
+  return { x: mouseEvt.clientX ?? 0, y: mouseEvt.clientY ?? 0 };
+}
+
+/**
+ * Open a context menu on touch long-press (via the v-hold directive).
+ *
+ * Mobile browsers do not reliably fire `contextmenu` for touch input
+ * (iOS WebKit never does), so components that only bind `@contextmenu`
+ * lose their menu on real touch devices. Pair this with the existing
+ * `@contextmenu.prevent` binding, on the root element:
+ *
+ *   v-hold="onHold"
+ *   @touchstart.passive="onTouchStart"
+ *   @click.capture="swallowClickAfterHold"
+ *
+ * `swallowClickAfterHold` suppresses the click that fires on finger-lift
+ * after a long-press, so the hold does not also trigger the tap action.
+ * Binding it on the capture phase kills the click before it reaches any
+ * child button or RouterLink handler, so those need no guards of their own.
+ */
+export function useHoldToOpenMenu<A extends unknown[]>(
+  openMenu: (evt: Event, ...args: A) => void,
+) {
+  const holdFired = ref(false);
+
+  const onTouchStart = () => {
+    holdFired.value = false;
+  };
+
+  const onHold = (evt: Event, ...args: A) => {
+    holdFired.value = true;
+    openMenu(evt, ...args);
+  };
+
+  const swallowClickAfterHold = (evt: Event): boolean => {
+    if (!holdFired.value) return false;
+    holdFired.value = false;
+    evt.preventDefault();
+    evt.stopPropagation();
+    return true;
+  };
+
+  return { onHold, onTouchStart, swallowClickAfterHold };
+}

--- a/src/layouts/default/PlayerOSD/QueueListItem.vue
+++ b/src/layouts/default/PlayerOSD/QueueListItem.vue
@@ -8,6 +8,7 @@
 -->
 <template>
   <div
+    v-hold="onHold"
     class="qitem"
     :class="{
       'qitem--played': state === 'played',
@@ -22,10 +23,12 @@
     role="button"
     tabindex="0"
     @click="emit('click', $event)"
+    @click.capture="swallowClickAfterHold"
     @contextmenu.prevent="emit('menu', $event)"
     @keydown.enter.prevent="emit('click', $event)"
     @mouseenter="hovered = true"
     @mouseleave="hovered = false"
+    @touchstart.passive="onTouchStart"
   >
     <!-- thumbnail (with now-playing equalizer overlay) -->
     <div class="qitem__thumb">
@@ -127,6 +130,7 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
+import { useHoldToOpenMenu } from "@/composables/useHoldToOpenMenu";
 import { MarqueeTextSync } from "@/helpers/marquee_text_sync";
 import { formatDuration } from "@/helpers/utils";
 import { QueueItem } from "@/plugins/api/interfaces";
@@ -173,6 +177,10 @@ const emit = defineEmits<{
 }>();
 
 const hovered = ref(false);
+
+const { onHold, onTouchStart, swallowClickAfterHold } = useHoldToOpenMenu(
+  (evt: Event) => emit("menu", evt),
+);
 
 // Only animate the title/album marquee for the now-playing track, or while a
 // row is hovered — keeps the list calm and avoids dozens of scrolling rows.

--- a/src/layouts/default/PlayerOSD/useFullscreenQueue.ts
+++ b/src/layouts/default/PlayerOSD/useFullscreenQueue.ts
@@ -2,6 +2,7 @@
 // items, bidirectional paging, now-playing focus handling, the per-item context
 // menu and audiobook chapter playback. Extracted from PlayerFullscreen.vue to
 // keep that component focused on layout.
+import { getEventPosition } from "@/composables/useHoldToOpenMenu";
 import { usePartyConfig } from "@/composables/usePartyConfig";
 import { MarqueeTextSync } from "@/helpers/marquee_text_sync";
 import { getQueueItemMenuItems } from "@/helpers/queue_item_menu_items";
@@ -272,10 +273,11 @@ export function useFullscreenQueue(showLyrics: Ref<boolean>) {
   const openQueueItemMenu = (evt: Event, index: number) => {
     const item = itemAt(index);
     if (!item) return;
+    const pos = getEventPosition(evt);
     eventbus.emit("contextmenu", {
       items: getQueueItemMenuItems(item, index),
-      posX: (evt as PointerEvent).clientX,
-      posY: (evt as PointerEvent).clientY,
+      posX: pos.x,
+      posY: pos.y,
     });
   };
 

--- a/tests/composables/useHoldToOpenMenu.test.ts
+++ b/tests/composables/useHoldToOpenMenu.test.ts
@@ -1,0 +1,83 @@
+import {
+  getEventPosition,
+  useHoldToOpenMenu,
+} from "@/composables/useHoldToOpenMenu";
+import { describe, expect, it, vi } from "vitest";
+
+const touchEvent = (x: number, y: number): Event =>
+  ({
+    touches: [{ clientX: x, clientY: y }],
+    changedTouches: [{ clientX: x, clientY: y }],
+    preventDefault: vi.fn(),
+    stopPropagation: vi.fn(),
+  }) as unknown as Event;
+
+const mouseEvent = (x: number, y: number): Event =>
+  ({
+    clientX: x,
+    clientY: y,
+    preventDefault: vi.fn(),
+    stopPropagation: vi.fn(),
+  }) as unknown as Event;
+
+describe("getEventPosition", () => {
+  it("reads clientX/clientY from mouse and pointer events", () => {
+    expect(getEventPosition(mouseEvent(10, 20))).toEqual({ x: 10, y: 20 });
+  });
+
+  it("reads coordinates from the first touch of a touch event", () => {
+    expect(getEventPosition(touchEvent(30, 40))).toEqual({ x: 30, y: 40 });
+  });
+
+  it("falls back to changedTouches when touches is empty (touchend)", () => {
+    const evt = {
+      touches: [],
+      changedTouches: [{ clientX: 5, clientY: 6 }],
+    } as unknown as Event;
+    expect(getEventPosition(evt)).toEqual({ x: 5, y: 6 });
+  });
+
+  it("returns 0,0 when no coordinates are available", () => {
+    expect(
+      getEventPosition({ touches: [], changedTouches: [] } as unknown as Event),
+    ).toEqual({ x: 0, y: 0 });
+  });
+});
+
+describe("useHoldToOpenMenu", () => {
+  it("opens the menu on hold, forwarding the event and extra args", () => {
+    const openMenu = vi.fn();
+    const { onHold } = useHoldToOpenMenu(openMenu);
+    const evt = touchEvent(1, 2);
+    onHold(evt, 42);
+    expect(openMenu).toHaveBeenCalledWith(evt, 42);
+  });
+
+  it("swallows exactly one click after a hold", () => {
+    const { onHold, swallowClickAfterHold } = useHoldToOpenMenu(vi.fn());
+    onHold(touchEvent(1, 2));
+
+    const click = mouseEvent(1, 2);
+    expect(swallowClickAfterHold(click)).toBe(true);
+    expect(click.preventDefault).toHaveBeenCalled();
+    expect(click.stopPropagation).toHaveBeenCalled();
+
+    expect(swallowClickAfterHold(mouseEvent(1, 2))).toBe(false);
+  });
+
+  it("does not swallow clicks without a preceding hold", () => {
+    const { swallowClickAfterHold } = useHoldToOpenMenu(vi.fn());
+    const click = mouseEvent(1, 2);
+    expect(swallowClickAfterHold(click)).toBe(false);
+    expect(click.preventDefault).not.toHaveBeenCalled();
+  });
+
+  it("resets the hold flag on the next touchstart", () => {
+    const { onHold, onTouchStart, swallowClickAfterHold } = useHoldToOpenMenu(
+      vi.fn(),
+    );
+    onHold(touchEvent(1, 2));
+    onTouchStart();
+    expect(swallowClickAfterHold(mouseEvent(1, 2))).toBe(false);
+  });
+});


### PR DESCRIPTION
## Problem

Context menus bound only to the `contextmenu` DOM event work with right-click on desktop (and in devtools device emulation, which synthesizes the event on long-press), but real mobile browsers don't reliably fire it for touch input — iOS WebKit never does. So long-press did nothing on phones in several places, and some menus were completely unreachable on mobile.

Fixes https://github.com/music-assistant/support/issues/5743

## Changes

- New `useHoldToOpenMenu` composable: pairs the existing `v-hold` directive with a capture-phase click swallow, so the click fired on finger-lift after a long-press doesn't also trigger the tap action (or any child button / RouterLink navigation)
- Exports `getEventPosition()` so menus are positioned correctly from touch events (the previous `PointerEvent` casts returned `undefined` coordinates for touch)
- Wired into all components that only had a `contextmenu` binding:
  - Player cards on Discover / player selection (the reported issue)
  - DSP pipeline filters (move up/down/delete were unreachable on mobile)
  - Sidebar shortcuts (menu was hover-only + right-click before)
  - Genre chips on detail pages
  - Queue rows in the fullscreen player
- Unit tests for the composable