### PR TITLE
Restore the clear queue option in the player menu

### DIFF
--- a/src/helpers/player_menu_items.ts
+++ b/src/helpers/player_menu_items.ts
@@ -152,8 +152,8 @@ export const getPlayerMenuItems = (
     });
   }
 
-  // clear queue (queue menu only)
-  if (isQueue && playerQueue?.items && playerQueue.items > 0) {
+  // clear queue (both menus; only when the queue has items)
+  if (playerQueue?.items && playerQueue.items > 0) {
     menuItems.push({
       label: "queue_clear",
       labelArgs: [],


### PR DESCRIPTION
The "clear queue" option disappeared from the player's 3-dots menu in the player select list. It was unintentionally restricted to the fullscreen player when the player menu was split into "queue" and "player" contexts, so the player list menu no longer reached it.

## Changes
- Show "clear queue" in the player select menu again (previously only available in the fullscreen player).
- Only show it when the player actually has a non-empty queue.
