### PR TITLE
Sanitize rendered markdown to prevent stored XSS

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "color": "5.0.3",
+        "dompurify": "^3.4.11",
         "happy-dom": "^20.10.3",
         "marked": "^18.0.5",
         "mitt": "3.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -62,6 +62,9 @@ importers:
       color:
         specifier: 5.0.3
         version: 5.0.3
+      dompurify:
+        specifier: ^3.4.11
+        version: 3.4.11
       happy-dom:
         specifier: ^20.10.3
         version: 20.10.6
@@ -2745,6 +2748,9 @@ packages:
   domhandler@5.0.3:
     resolution: {integrity: sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==}
     engines: {node: '>= 4'}
+
+  dompurify@3.4.11:
+    resolution: {integrity: sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==}
 
   domutils@3.2.2:
     resolution: {integrity: sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==}
@@ -7155,6 +7161,10 @@ snapshots:
   domhandler@5.0.3:
     dependencies:
       domelementtype: 2.3.0
+
+  dompurify@3.4.11:
+    optionalDependencies:
+      '@types/trusted-types': 2.0.7
 
   domutils@3.2.2:
     dependencies:

--- a/src/helpers/utils.ts
+++ b/src/helpers/utils.ts
@@ -620,9 +620,7 @@ export const markdownToHtml = function (text: string): string {
     .replaceAll(/\\n/g, "<br />")
     .replaceAll("\n", "<br />")
     .replaceAll(" \\", "<br />");
-  // Metadata (e.g. track description/copyright) can carry attacker-controlled
-  // HTML that reaches v-html, so sanitize the rendered output. SANITIZE_NAMED_PROPS
-  // guards against DOM clobbering via name/id attributes.
+  // Metadata can carry attacker-controlled HTML that reaches v-html; SANITIZE_NAMED_PROPS also blocks DOM clobbering
   return DOMPurify.sanitize(marked(text) as string, {
     SANITIZE_NAMED_PROPS: true,
   });

--- a/src/helpers/utils.ts
+++ b/src/helpers/utils.ts
@@ -15,6 +15,7 @@ import {
   QueueItem,
 } from "@/plugins/api/interfaces";
 import { getBreakpointValue } from "@/plugins/breakpoint";
+import DOMPurify from "dompurify";
 import { marked } from "marked";
 
 import {
@@ -619,7 +620,12 @@ export const markdownToHtml = function (text: string): string {
     .replaceAll(/\\n/g, "<br />")
     .replaceAll("\n", "<br />")
     .replaceAll(" \\", "<br />");
-  return marked(text) as string;
+  // Metadata (e.g. track description/copyright) can carry attacker-controlled
+  // HTML that reaches v-html, so sanitize the rendered output. SANITIZE_NAMED_PROPS
+  // guards against DOM clobbering via name/id attributes.
+  return DOMPurify.sanitize(marked(text) as string, {
+    SANITIZE_NAMED_PROPS: true,
+  });
 };
 
 /**

--- a/tests/helpers/utils.test.ts
+++ b/tests/helpers/utils.test.ts
@@ -4,6 +4,7 @@ import {
   formatRelativeTime,
   hexToRgb,
   kebabize,
+  markdownToHtml,
   numberRange,
   paletteFromServer,
   parseBool,
@@ -252,6 +253,29 @@ describe("formatRelativeTime", () => {
     expect(formatRelativeTime(3660)).toBe("1h 1m");
     expect(formatRelativeTime(7200)).toBe("2h");
     expect(formatRelativeTime(7380)).toBe("2h 3m");
+  });
+});
+
+describe("markdownToHtml", () => {
+  it("neutralizes an onerror image payload", () => {
+    const html = markdownToHtml('<img src=x onerror="alert(1)">');
+    expect(html).not.toContain("onerror");
+  });
+
+  it("strips script tags", () => {
+    const html = markdownToHtml("<script>alert(1)</script>");
+    expect(html).not.toContain("<script>");
+  });
+
+  it("renders legitimate markdown", () => {
+    expect(markdownToHtml("**bold**")).toContain("<strong>bold</strong>");
+    expect(markdownToHtml("[link](https://example.com)")).toContain(
+      'href="https://example.com"',
+    );
+  });
+
+  it("converts line breaks", () => {
+    expect(markdownToHtml("line1\nline2")).toContain("<br>");
   });
 });
 


### PR DESCRIPTION
**Adds a new dependency: `dompurify` (needs maintainer approval).** It ships its own TypeScript types, so no `@types/dompurify` is required.

`markdownToHtml` in `src/helpers/utils.ts` runs untrusted text through `marked` and the result is rendered with `v-html` (e.g. `InfoHeader.vue` `fullDescription`, plus track/artist/settings views). `marked` preserves raw HTML tags and `v-html` bypasses Vue escaping, so attacker-controlled metadata can execute JS. A track whose embedded `comment`/`copyright` tag is copied by the server into `metadata.description`/`metadata.copyright` reaches this path — e.g. an MP3 with a comment of `<img src=x onerror="alert(1)">` fires when the track is viewed.

This sanitizes the generated HTML with DOMPurify before returning it, so every `markdownToHtml` call site is protected. `SANITIZE_NAMED_PROPS` is enabled to also guard against DOM clobbering via `name`/`id`.

## Changes
- Add `dompurify` dependency.
- Sanitize the output of `markdownToHtml` with `DOMPurify.sanitize(..., { SANITIZE_NAMED_PROPS: true })`.
- Add unit tests covering malicious payloads (onerror image, script tag) and legitimate markdown (bold, links, line breaks).

Security assessment finding: 4.5.1 XSS injection (stored)