### PR TITLE
Convert config label and alert entries to shadcn

### DIFF
--- a/src/components/ui/alert/Alert.vue
+++ b/src/components/ui/alert/Alert.vue
@@ -1,0 +1,21 @@
+<script setup lang="ts">
+import type { HTMLAttributes } from "vue";
+import type { AlertVariants } from ".";
+import { cn } from "@/lib/utils";
+import { alertVariants } from ".";
+
+const props = defineProps<{
+  class?: HTMLAttributes["class"];
+  variant?: AlertVariants["variant"];
+}>();
+</script>
+
+<template>
+  <div
+    data-slot="alert"
+    role="alert"
+    :class="cn(alertVariants({ variant }), props.class)"
+  >
+    <slot></slot>
+  </div>
+</template>

--- a/src/components/ui/alert/AlertDescription.vue
+++ b/src/components/ui/alert/AlertDescription.vue
@@ -1,0 +1,22 @@
+<script setup lang="ts">
+import type { HTMLAttributes } from "vue";
+import { cn } from "@/lib/utils";
+
+const props = defineProps<{
+  class?: HTMLAttributes["class"];
+}>();
+</script>
+
+<template>
+  <div
+    data-slot="alert-description"
+    :class="
+      cn(
+        'text-current/80 col-start-2 grid justify-items-start gap-1 text-sm [&_p]:leading-relaxed',
+        props.class,
+      )
+    "
+  >
+    <slot></slot>
+  </div>
+</template>

--- a/src/components/ui/alert/AlertTitle.vue
+++ b/src/components/ui/alert/AlertTitle.vue
@@ -1,0 +1,22 @@
+<script setup lang="ts">
+import type { HTMLAttributes } from "vue";
+import { cn } from "@/lib/utils";
+
+const props = defineProps<{
+  class?: HTMLAttributes["class"];
+}>();
+</script>
+
+<template>
+  <div
+    data-slot="alert-title"
+    :class="
+      cn(
+        'col-start-2 line-clamp-1 min-h-4 font-medium tracking-tight',
+        props.class,
+      )
+    "
+  >
+    <slot></slot>
+  </div>
+</template>

--- a/src/components/ui/alert/index.ts
+++ b/src/components/ui/alert/index.ts
@@ -1,0 +1,27 @@
+import type { VariantProps } from "class-variance-authority";
+import { cva } from "class-variance-authority";
+
+export { default as Alert } from "./Alert.vue";
+export { default as AlertTitle } from "./AlertTitle.vue";
+export { default as AlertDescription } from "./AlertDescription.vue";
+
+export const alertVariants = cva(
+  "relative grid w-full grid-cols-[0_1fr] has-[>svg]:grid-cols-[calc(var(--spacing)*4)_1fr] has-[>svg]:gap-x-3 gap-y-0.5 items-start rounded-lg border px-4 py-3 text-sm [&>svg]:size-4 [&>svg]:translate-y-0.5 [&>svg]:text-current",
+  {
+    variants: {
+      variant: {
+        default: "bg-card text-card-foreground",
+        destructive:
+          "text-destructive bg-card *:data-[slot=alert-description]:text-destructive/90",
+        info: "border-blue-500/30 bg-blue-500/10 text-blue-600 dark:text-blue-400",
+        warning:
+          "border-yellow-500/40 bg-yellow-500/10 text-yellow-700 dark:border-yellow-500/40 dark:bg-yellow-500/15 dark:text-yellow-400",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  },
+);
+
+export type AlertVariants = VariantProps<typeof alertVariants>;

--- a/src/views/settings/ConfigEntryField.vue
+++ b/src/views/settings/ConfigEntryField.vue
@@ -12,26 +12,16 @@
     </div>
 
     <!-- label value -->
-    <v-alert
+    <LabelField
       v-else-if="confEntry.type == ConfigEntryType.LABEL"
-      variant="tonal"
-      type="info"
-      density="comfortable"
-      class="config-alert"
-    >
-      {{ displayLabel() }}
-    </v-alert>
+      :text="displayLabel()"
+    />
 
     <!-- alert value -->
-    <v-alert
+    <AlertField
       v-else-if="confEntry.type == ConfigEntryType.ALERT"
-      density="comfortable"
-      type="warning"
-      variant="tonal"
-      class="config-alert"
-    >
-      {{ displayLabel() }}
-    </v-alert>
+      :text="displayLabel()"
+    />
 
     <!-- action type -->
     <v-btn
@@ -289,6 +279,8 @@ import {
   SECURE_STRING_SUBSTITUTE,
 } from "@/plugins/api/interfaces";
 import IconPicker from "@/components/IconPicker.vue";
+import AlertField from "./fields/AlertField.vue";
+import LabelField from "./fields/LabelField.vue";
 import { ConfigEntryUI, isDspLinkEntry } from "@/helpers/config_entry_ui";
 import { $t } from "@/plugins/i18n";
 import { computed } from "vue";
@@ -374,10 +366,6 @@ const displayOptions = computed(() => {
   margin-top: 12px;
   font-weight: 600;
   font-size: 0.875rem;
-}
-
-.config-alert {
-  margin: 8px 0;
 }
 
 .action-btn {

--- a/src/views/settings/fields/AlertField.vue
+++ b/src/views/settings/fields/AlertField.vue
@@ -1,0 +1,17 @@
+<script setup lang="ts">
+import { TriangleAlert } from "@lucide/vue";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { markdownToHtml } from "@/helpers/utils";
+
+defineProps<{ text: string }>();
+</script>
+
+<template>
+  <Alert variant="warning" class="mt-2 mb-4">
+    <TriangleAlert />
+    <AlertDescription class="[&_a]:underline [&_p]:mb-2 [&_p:last-child]:mb-0">
+      <!-- eslint-disable-next-line vue/no-v-html -->
+      <div v-html="markdownToHtml(text)"></div>
+    </AlertDescription>
+  </Alert>
+</template>

--- a/src/views/settings/fields/LabelField.vue
+++ b/src/views/settings/fields/LabelField.vue
@@ -1,0 +1,14 @@
+<script setup lang="ts">
+import { markdownToHtml } from "@/helpers/utils";
+
+defineProps<{ text: string }>();
+</script>
+
+<template>
+  <div
+    class="text-muted-foreground mt-2 mb-4 rounded-md bg-muted/50 px-3 py-2 text-sm leading-relaxed [&_a]:underline [&_p]:mb-2 [&_p:last-child]:mb-0"
+  >
+    <!-- eslint-disable-next-line vue/no-v-html -->
+    <div v-html="markdownToHtml(text)"></div>
+  </div>
+</template>


### PR DESCRIPTION
Continuing the incremental shadcn refactor of the config editor — the `LABEL` and `ALERT` config entry types still used Vuetify `v-alert` boxes that were heavy and inconsistent.

- Add a shadcn `alert` component (info/warning variants)
- Split `LABEL`/`ALERT` rendering into dedicated `LabelField` and `AlertField` components (new `settings/fields/` folder)
- `LABEL` is now a lighter muted note (no icon); `ALERT` is a more prominent warning with a triangle icon
- Both render markdown and newlines via the existing `markdownToHtml` helper
