### PR TITLE
Add subtle grey ring to unselected editorial card checkbox

### DIFF
--- a/src/components/discover/EditorialMediaCard.vue
+++ b/src/components/discover/EditorialMediaCard.vue
@@ -329,6 +329,22 @@ const onMenu = (e: MouseEvent) => {
 .ed-card__select--on {
   background: rgba(0, 0, 0, 0.45);
 }
+/* subtle grey ring on the outside so the white unselected circle stays visible on light thumbs */
+.ed-card__select:not(.ed-card__select--on) .v-icon {
+  position: relative;
+}
+.ed-card__select:not(.ed-card__select--on) .v-icon::after {
+  content: "";
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 83%;
+  height: 83%;
+  transform: translate(-50%, -50%);
+  border-radius: 50%;
+  box-shadow: 0 0 0 2px rgba(192, 192, 192, 0.85);
+  pointer-events: none;
+}
 .ed-card__play {
   position: absolute;
   bottom: 2px;


### PR DESCRIPTION
Satisifes: https://github.com/music-assistant/backlog/issues/23#issue-3589082828

On a white background the current select ring is not visible. This adds a subtle grey ring around it so its visible on all backgrounds


BEFORE

<img width="823" height="237" alt="image" src="https://github.com/user-attachments/assets/b091e9ef-9515-4ee9-8efc-d5aa42adcb04" />

<img width="1435" height="242" alt="image" src="https://github.com/user-attachments/assets/24e9587f-d49f-431c-bc64-dc790a36f815" />

<img width="192" height="244" alt="image" src="https://github.com/user-attachments/assets/b2336933-a768-4f05-8748-1d9956fe236e" />


AFTER

<img width="826" height="237" alt="image" src="https://github.com/user-attachments/assets/b2c86fd1-754a-4a3d-9c14-74c66e40c60a" />

<img width="1444" height="245" alt="image" src="https://github.com/user-attachments/assets/ac403c80-5d56-43e1-b6fd-6ccf80c6ac79" />

<img width="192" height="246" alt="image" src="https://github.com/user-attachments/assets/7005e564-b06a-4556-aa96-202c96292b1f" />

