### PR TITLE
Fix DSP parametric EQ layout on narrow and rotated displays

### DIFF
--- a/src/components/dsp/DSPParametricEQ.vue
+++ b/src/components/dsp/DSPParametricEQ.vue
@@ -14,17 +14,30 @@
         <v-icon start>mdi-speaker-multiple</v-icon>
         {{ $t("settings.dsp.parametric_eq.show_multichannel_controls") }}
       </v-btn>
-      <v-select
-        v-else
-        v-model="editedChannel"
-        class="pa-2"
-        :items="channelTypes"
-        :label="$t('settings.dsp.parametric_eq.edited_channel')"
-        variant="outlined"
-        density="comfortable"
-        style="min-width: 250px"
-        hide-details
-      />
+      <!-- Channel selector + collapse button behave as one action-sized unit so
+           they wrap together and stay within the original button's width. -->
+      <div v-else class="eq-channel">
+        <!-- Collapse back to the single-channel button. Only offered while no
+             per-channel data exists; adding any L/R band re-locks the dropdown. -->
+        <v-btn
+          v-if="!isMultiChannel"
+          class="eq-collapse"
+          icon="mdi-close"
+          variant="text"
+          :aria-label="
+            $t('settings.dsp.parametric_eq.disable_multichannel_controls')
+          "
+          @click="disableMultiChannel"
+        />
+        <v-select
+          v-model="editedChannel"
+          :items="channelTypes"
+          :aria-label="$t('settings.dsp.parametric_eq.edited_channel')"
+          variant="outlined"
+          density="compact"
+          hide-details
+        />
+      </div>
 
       <!-- Import/Export Buttons to Load/Save Equalizer APO Settings -->
       <v-btn variant="outlined" @click="openApoFileImport">
@@ -736,6 +749,14 @@ const selectedBandIndex = ref(-1);
 
 const editedChannel = ref(AudioChannel.ALL);
 
+// Collapse the channel dropdown back to the plain button. Safe only when there
+// is no per-channel data (the template gates this on !isMultiChannel), so the
+// auto-enable watchEffect won't immediately re-open it.
+const disableMultiChannel = () => {
+  editedChannel.value = AudioChannel.ALL;
+  showMultiChannelControls.value = false;
+};
+
 // Computed property for the selected band
 const selectedBand = computed(() => peq.value.bands[selectedBandIndex.value]);
 
@@ -927,15 +948,41 @@ onMounted(() => {
 /* Give every action the same width so they stay aligned (not staggered)
    however many wrap per row on narrow displays */
 .eq-actions > .v-btn,
-.eq-actions > .v-select {
+.eq-actions > .eq-channel {
   flex: 0 1 18rem;
   min-width: 0;
+}
+/* Channel selector + collapse button share one action-sized slot: the select
+   flexes to fill, the collapse icon takes a fixed compact footprint. */
+.eq-channel {
+  display: flex;
+  align-items: center;
+  /* Fixed to the button height so toggling button <-> dropdown can't shift the row */
+  height: 40px;
+}
+.eq-channel > .v-select {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+/* Cap the compact field to the button height (its rendered height can otherwise
+   exceed the 40px control height and push the row down on toggle) */
+.eq-channel :deep(.v-field) {
+  height: 40px;
+}
+.eq-channel > .eq-collapse {
+  flex: 0 0 auto;
+  width: 2.25rem;
+  min-width: 0;
+  margin-inline-end: 3px;
+  transform: translateY(2px);
 }
 /* Smaller text and tighter letter-spacing so the longest label fits on one
    line while the buttons stay narrow enough to share a single row */
 .eq-actions > .v-btn {
   height: auto;
-  min-height: var(--v-btn-height);
+  /* 40px matches the compact channel select so switching between the button
+     and the dropdown doesn't shift the content below */
+  min-height: 40px;
   font-size: 0.8125rem;
   letter-spacing: 0.02em;
 }

--- a/src/components/dsp/DSPParametricEQ.vue
+++ b/src/components/dsp/DSPParametricEQ.vue
@@ -1,6 +1,6 @@
 <template>
-  <v-container class="pa-2">
-    <div class="d-flex flex-wrap justify-end align-center ga-2 pr-2">
+  <v-container fluid class="pa-2">
+    <div class="d-flex flex-wrap justify-end align-center ga-2 pr-2 eq-actions">
       <!-- Multichannel options -->
       <v-btn
         v-if="!showMultiChannelControls"
@@ -481,6 +481,7 @@ interface Viewport {
   min_freq: number;
   max_freq: number;
   padding_lr: number;
+  padding_right: number;
   padding_tb: number;
 }
 
@@ -492,6 +493,9 @@ const viewport = ref<Viewport>({
   min_freq: 20,
   max_freq: 20000,
   padding_lr: 40,
+  // Smaller inset on the right (no axis labels there) so the plot reaches the
+  // right edge, aligning with the action button row above it
+  padding_right: 8,
   padding_tb: 20,
 });
 
@@ -548,7 +552,7 @@ const drawGraph = () => {
 
     for (
       let x = viewport.value.padding_lr;
-      x < width - viewport.value.padding_lr;
+      x < width - viewport.value.padding_right;
       x++
     ) {
       const response = 20 * Math.log10(magResponse[x]);
@@ -591,7 +595,7 @@ const drawGraph = () => {
     ctx.beginPath();
     for (
       let x = viewport.value.padding_lr;
-      x < width - viewport.value.padding_lr;
+      x < width - viewport.value.padding_right;
       x++
     ) {
       const y = gainToY(response[x], viewport.value);
@@ -808,7 +812,8 @@ const freqToX = (freq: number, viewport: Viewport): number => {
   const logFreq = Math.log2(freq / viewport.min_freq);
   const logMax = Math.log2(viewport.max_freq / viewport.min_freq);
   return (
-    (logFreq / logMax) * (viewport.width - viewport.padding_lr * 2) +
+    (logFreq / logMax) *
+      (viewport.width - viewport.padding_lr - viewport.padding_right) +
     viewport.padding_lr
   );
 };
@@ -819,7 +824,8 @@ const xToFreq = (x: number, viewport: Viewport): number => {
     viewport.min_freq *
     Math.pow(
       2,
-      ((x - viewport.padding_lr) / (viewport.width - viewport.padding_lr * 2)) *
+      ((x - viewport.padding_lr) /
+        (viewport.width - viewport.padding_lr - viewport.padding_right)) *
         logMax,
     );
   return Math.min(Math.max(freq, viewport.min_freq), viewport.max_freq);
@@ -891,7 +897,7 @@ const drawGrid = (ctx: CanvasRenderingContext2D, viewport: Viewport) => {
     const y = gainToY(gain, viewport);
     ctx.beginPath();
     ctx.moveTo(viewport.padding_lr, y);
-    ctx.lineTo(width - viewport.padding_lr, y);
+    ctx.lineTo(width - viewport.padding_right, y);
     ctx.stroke();
 
     // Draw gain labels
@@ -918,6 +924,25 @@ onMounted(() => {
 </script>
 
 <style scoped>
+/* Give every action the same width so they stay aligned (not staggered)
+   however many wrap per row on narrow displays */
+.eq-actions > .v-btn,
+.eq-actions > .v-select {
+  flex: 0 1 18rem;
+  min-width: 0;
+}
+/* Smaller text and tighter letter-spacing so the longest label fits on one
+   line while the buttons stay narrow enough to share a single row */
+.eq-actions > .v-btn {
+  height: auto;
+  min-height: var(--v-btn-height);
+  font-size: 0.8125rem;
+  letter-spacing: 0.02em;
+}
+.eq-actions :deep(.v-btn__content) {
+  white-space: normal;
+}
+
 .graph-container {
   position: relative;
   aspect-ratio: 7/2;

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -231,7 +231,8 @@
                 "preamp": "Preamp",
                 "add_band_channel": "Add Band ({channel} only)",
                 "band_channel": "Band {index} ({channel} only)",
-                "show_multichannel_controls": "Show Multi-Channel controls",
+                "show_multichannel_controls": "Enable Multi-Channel controls",
+                "disable_multichannel_controls": "Disable Multi-Channel controls",
                 "edited_channel": "Plot the EQs response for this channel(s)",
                 "channel": "This band will be applied to",
                 "per_channel_preamp": "Additional preamp gain for {channel}"

--- a/src/views/settings/EditPlayerDsp.vue
+++ b/src/views/settings/EditPlayerDsp.vue
@@ -51,7 +51,7 @@
       </v-btn>
     </v-toolbar>
 
-    <v-container class="pa-4">
+    <v-container fluid class="pa-4">
       <v-alert v-if="!dsp.enabled" type="info" class="mt-4" color="transparent">
         {{ $t("settings.dsp.disabled_message") }}
       </v-alert>


### PR DESCRIPTION
- The three action buttons (Show Multi-Channel Controls / Import APO-REW Preset / Export APO Preset) were staggered at different widths when they wrapped, and their text spilled outside the buttons on narrow screens. I gave them all a uniform width so they line up neatly however they wrap, let long labels wrap instead of overflow, and tuned the width, font size, and letter-spacing so all three sit on one row with the "Show Multi-Channel Controls" label on a single line, while still stacking cleanly on phones.
- iPad rotation: when you rotated to landscape, the main content stayed narrow while the header used the full width. That was Vuetify's container capping its width at wider screen sizes. I made the DSP containers full-width so the view now uses the whole screen.
- The frequency graph stopped short of the right edge, not lining up with the buttons above it. I trimmed the graph's right-side padding (keeping the left padding for the dB labels) so the plot now reaches the same right edge as the button row.
- Satisifed https://github.com/orgs/music-assistant/projects/2/views/1?pane=issue&itemId=101956147 by changing the label and adding a X when there is no individual channel band added.

BEFORE:

<img width="1651" height="223" alt="image" src="https://github.com/user-attachments/assets/dfd0715e-e9e7-48b6-9388-0212999e14b1" />

<img width="855" height="224" alt="image" src="https://github.com/user-attachments/assets/653b00ce-c956-4753-9157-6af34aedc9b1" />


<img width="538" height="331" alt="image" src="https://github.com/user-attachments/assets/b0b2653c-1035-457f-a40b-3ba967530b95" />

AFTER:

<img width="1645" height="222" alt="image" src="https://github.com/user-attachments/assets/37774c10-0eab-4fba-b67f-3cc4ff417119" />

<img width="1012" height="189" alt="image" src="https://github.com/user-attachments/assets/aa80061b-b33d-42f0-b49e-4978460334ac" />

<img width="508" height="319" alt="image" src="https://github.com/user-attachments/assets/26f23d76-e367-4781-ab67-0c4aa83f1368" />

<img width="1645" height="185" alt="image" src="https://github.com/user-attachments/assets/774e074a-777d-4f98-886f-2e30e2f6df6e" />

<img width="802" height="319" alt="image" src="https://github.com/user-attachments/assets/24f6ee23-9f04-4b9b-886f-eb4b85153629" />

<img width="1626" height="564" alt="image" src="https://github.com/user-attachments/assets/54876c80-b43e-404a-9f5a-3b92a634b61e" />
