### PR TITLE
Refresh library views as each media type finishes syncing

### DIFF
--- a/src/composables/useLibrarySync.ts
+++ b/src/composables/useLibrarySync.ts
@@ -1,0 +1,94 @@
+import { api } from "@/plugins/api";
+import {
+  type BackgroundTask,
+  type EventMessage,
+  EventType,
+  MediaType,
+  TaskStatus,
+} from "@/plugins/api/interfaces";
+
+const MUSIC_SYNC_TASK_DOMAIN = "music_sync";
+const ACTIVE_STATUSES: ReadonlySet<TaskStatus> = new Set([
+  TaskStatus.PENDING,
+  TaskStatus.RUNNING,
+]);
+const COMPLETED_STATUSES: ReadonlySet<TaskStatus> = new Set([
+  TaskStatus.SUCCESS,
+  TaskStatus.PARTIAL_SUCCESS,
+]);
+
+interface SyncCompletedListener {
+  mediaType: MediaType;
+  callback: () => void;
+}
+
+// The server suppresses per-item MEDIA_ITEM_ADDED/UPDATED events while a
+// provider library sync runs, and creates one background task per
+// (provider, media_type) — each streamed via TASKS_UPDATED with its media_type
+// in the metadata. We watch those tasks transition from active to a successful
+// terminal status and notify the matching library view, so each view refreshes
+// as soon as its own media type finishes syncing. The task manager is the
+// source of truth here; the server keeps MUSIC_SYNC_COMPLETED for its own
+// batch-level work and the frontend does not depend on it.
+const lastStatusByTaskId = new Map<string, TaskStatus>();
+const listeners = new Set<SyncCompletedListener>();
+let unsubscribe: (() => void) | undefined;
+
+const notify = (mediaType: MediaType) => {
+  for (const listener of listeners) {
+    if (listener.mediaType === mediaType) listener.callback();
+  }
+};
+
+const handleTasksUpdated = (evt: EventMessage) => {
+  const tasks = (evt.data as BackgroundTask[] | undefined) ?? [];
+  for (const task of tasks) {
+    if (task.metadata.task_domain !== MUSIC_SYNC_TASK_DOMAIN) continue;
+    const previous = lastStatusByTaskId.get(task.id);
+    lastStatusByTaskId.set(task.id, task.status);
+    if (
+      previous !== undefined &&
+      ACTIVE_STATUSES.has(previous) &&
+      COMPLETED_STATUSES.has(task.status)
+    ) {
+      const mediaType = task.metadata.media_type;
+      if (typeof mediaType === "string") notify(mediaType as MediaType);
+    }
+  }
+};
+
+const ensureSubscribed = () => {
+  if (unsubscribe) return;
+  unsubscribe = api.subscribe(EventType.TASKS_UPDATED, handleTasksUpdated);
+};
+
+const teardownIfIdle = () => {
+  if (listeners.size > 0 || !unsubscribe) return;
+  unsubscribe();
+  unsubscribe = undefined;
+  lastStatusByTaskId.clear();
+};
+
+/**
+ * Register a callback that runs when a provider library sync for the given media
+ * type finishes.
+ *
+ * Fires once each time a music_sync background task for `mediaType` transitions
+ * from running to a successful state, so a view can flag that fresh items may be
+ * available. Only completions observed while subscribed are reported; sync tasks
+ * that already finished before the caller registered are ignored.
+ *
+ * Returns an unsubscribe function; call it in onBeforeUnmount.
+ */
+export function onLibrarySyncCompleted(
+  mediaType: MediaType,
+  callback: () => void,
+): () => void {
+  const listener: SyncCompletedListener = { mediaType, callback };
+  listeners.add(listener);
+  ensureSubscribed();
+  return () => {
+    listeners.delete(listener);
+    teardownIfIdle();
+  };
+}

--- a/src/views/LibraryAlbums.vue
+++ b/src/views/LibraryAlbums.vue
@@ -21,8 +21,9 @@
 
 <script setup lang="ts">
 import ItemsListing, { LoadDataParams } from "@/components/ItemsListing.vue";
+import { onLibrarySyncCompleted } from "@/composables/useLibrarySync";
 import api from "@/plugins/api";
-import { EventMessage, EventType } from "@/plugins/api/interfaces";
+import { EventMessage, EventType, MediaType } from "@/plugins/api/interfaces";
 import { store } from "@/plugins/store";
 import { Disc3 } from "@lucide/vue";
 import { onBeforeUnmount, onMounted, ref } from "vue";
@@ -57,12 +58,18 @@ onMounted(() => {
     EventType.MEDIA_ITEM_ADDED,
     (evt: EventMessage) => {
       // signal user that there might be updated info available for this item
-      if (evt.object_id?.startsWith("library://artist")) {
+      if (evt.object_id?.startsWith("library://album")) {
         updateAvailable.value = true;
       }
     },
   );
   onBeforeUnmount(unsub);
+  // per-item add events are suppressed during provider library syncs; also
+  // refresh when a sync covering this media type finishes
+  const unsubSync = onLibrarySyncCompleted(MediaType.ALBUM, () => {
+    updateAvailable.value = true;
+  });
+  onBeforeUnmount(unsubSync);
 });
 
 const loadItems = async function (params: LoadDataParams) {

--- a/src/views/LibraryArtists.vue
+++ b/src/views/LibraryArtists.vue
@@ -22,8 +22,9 @@
 <script setup lang="ts">
 import ArtistIcon from "@/components/icons/ArtistIcon.vue";
 import ItemsListing, { LoadDataParams } from "@/components/ItemsListing.vue";
+import { onLibrarySyncCompleted } from "@/composables/useLibrarySync";
 import api from "@/plugins/api";
-import { EventMessage, EventType } from "@/plugins/api/interfaces";
+import { EventMessage, EventType, MediaType } from "@/plugins/api/interfaces";
 import { store } from "@/plugins/store";
 import { onBeforeUnmount, onMounted, ref } from "vue";
 
@@ -91,5 +92,11 @@ onMounted(() => {
     },
   );
   onBeforeUnmount(unsub);
+  // per-item add events are suppressed during provider library syncs; also
+  // refresh when a sync covering this media type finishes
+  const unsubSync = onLibrarySyncCompleted(MediaType.ARTIST, () => {
+    updateAvailable.value = true;
+  });
+  onBeforeUnmount(unsubSync);
 });
 </script>

--- a/src/views/LibraryAudiobooks.vue
+++ b/src/views/LibraryAudiobooks.vue
@@ -22,8 +22,9 @@
 
 <script setup lang="ts">
 import ItemsListing, { LoadDataParams } from "@/components/ItemsListing.vue";
+import { onLibrarySyncCompleted } from "@/composables/useLibrarySync";
 import api from "@/plugins/api";
-import { EventMessage, EventType } from "@/plugins/api/interfaces";
+import { EventMessage, EventType, MediaType } from "@/plugins/api/interfaces";
 import { store } from "@/plugins/store";
 import { BookAudio } from "@lucide/vue";
 import { onBeforeUnmount, onMounted, ref } from "vue";
@@ -92,5 +93,11 @@ onMounted(() => {
     },
   );
   onBeforeUnmount(unsub);
+  // per-item add events are suppressed during provider library syncs; also
+  // refresh when a sync covering this media type finishes
+  const unsubSync = onLibrarySyncCompleted(MediaType.AUDIOBOOK, () => {
+    updateAvailable.value = true;
+  });
+  onBeforeUnmount(unsubSync);
 });
 </script>

--- a/src/views/LibraryPlaylists.vue
+++ b/src/views/LibraryPlaylists.vue
@@ -26,10 +26,12 @@
 import ItemsListing, { LoadDataParams } from "@/components/ItemsListing.vue";
 import { SMART_PLAYLIST_PROVIDER_DOMAIN } from "@/components/smart_playlist/constants";
 import { ToolBarMenuItem } from "@/components/Toolbar.vue";
+import { onLibrarySyncCompleted } from "@/composables/useLibrarySync";
 import api from "@/plugins/api";
 import {
   EventMessage,
   EventType,
+  MediaType,
   ProviderFeature,
 } from "@/plugins/api/interfaces";
 import { eventbus } from "@/plugins/eventbus";
@@ -170,6 +172,12 @@ onMounted(() => {
     },
   );
   onBeforeUnmount(unsub);
+  // per-item events are suppressed during provider library syncs; also refresh
+  // when a sync covering playlists finishes
+  const unsubSync = onLibrarySyncCompleted(MediaType.PLAYLIST, () => {
+    updateAvailable.value = true;
+  });
+  onBeforeUnmount(unsubSync);
 });
 
 const newPlaylist = function (provId: string) {

--- a/src/views/LibraryPodcasts.vue
+++ b/src/views/LibraryPodcasts.vue
@@ -22,8 +22,9 @@
 
 <script setup lang="ts">
 import ItemsListing, { LoadDataParams } from "@/components/ItemsListing.vue";
+import { onLibrarySyncCompleted } from "@/composables/useLibrarySync";
 import api from "@/plugins/api";
-import { EventMessage, EventType } from "@/plugins/api/interfaces";
+import { EventMessage, EventType, MediaType } from "@/plugins/api/interfaces";
 import { store } from "@/plugins/store";
 import { Podcast } from "@lucide/vue";
 import { onBeforeUnmount, onMounted, ref } from "vue";
@@ -92,5 +93,11 @@ onMounted(() => {
     },
   );
   onBeforeUnmount(unsub);
+  // per-item add events are suppressed during provider library syncs; also
+  // refresh when a sync covering this media type finishes
+  const unsubSync = onLibrarySyncCompleted(MediaType.PODCAST, () => {
+    updateAvailable.value = true;
+  });
+  onBeforeUnmount(unsubSync);
 });
 </script>

--- a/src/views/LibraryRadios.vue
+++ b/src/views/LibraryRadios.vue
@@ -37,6 +37,7 @@
 <script setup lang="ts">
 import AddManualLink from "@/components/AddManualLink.vue";
 import ItemsListing, { LoadDataParams } from "@/components/ItemsListing.vue";
+import { onLibrarySyncCompleted } from "@/composables/useLibrarySync";
 import api from "@/plugins/api";
 import { EventMessage, EventType, MediaType } from "@/plugins/api/interfaces";
 import { store } from "@/plugins/store";
@@ -77,6 +78,12 @@ onMounted(() => {
     },
   );
   onBeforeUnmount(unsub);
+  // per-item add events are suppressed during provider library syncs; also
+  // refresh when a sync covering this media type finishes
+  const unsubSync = onLibrarySyncCompleted(MediaType.RADIO, () => {
+    updateAvailable.value = true;
+  });
+  onBeforeUnmount(unsubSync);
 });
 
 const loadItems = async function (params: LoadDataParams) {

--- a/src/views/LibraryTracks.vue
+++ b/src/views/LibraryTracks.vue
@@ -39,6 +39,7 @@
 <script setup lang="ts">
 import AddManualLink from "@/components/AddManualLink.vue";
 import ItemsListing, { LoadDataParams } from "@/components/ItemsListing.vue";
+import { onLibrarySyncCompleted } from "@/composables/useLibrarySync";
 import api from "@/plugins/api";
 import { EventMessage, EventType, MediaType } from "@/plugins/api/interfaces";
 import { store } from "@/plugins/store";
@@ -81,6 +82,12 @@ onMounted(() => {
     },
   );
   onBeforeUnmount(unsub);
+  // per-item add events are suppressed during provider library syncs; also
+  // refresh when a sync covering this media type finishes
+  const unsubSync = onLibrarySyncCompleted(MediaType.TRACK, () => {
+    updateAvailable.value = true;
+  });
+  onBeforeUnmount(unsubSync);
 });
 
 const loadItems = async function (params: LoadDataParams) {


### PR DESCRIPTION
The library views show the "new items available" refresh banner by listening for per-item `MEDIA_ITEM_ADDED` events. [music-assistant/server#4578](https://github.com/music-assistant/server/pull/4578) suppresses those during provider library syncs to stop event spam, so the banner stopped appearing for newly synced items.

Rather than lean on the global `MUSIC_SYNC_COMPLETED` event, this uses the task manager, which already carries per-type completion: the server creates one `music_sync` task per `(provider, media_type)`, streamed via `TASKS_UPDATED` with `media_type` in its metadata and a terminal status when it finishes.

- Add a `useLibrarySync` composable that watches `music_sync` tasks transition from running to a successful status and notifies the matching library view — so each view refreshes **as soon as its own media type finishes**, even while other providers are still syncing. No dependency on the global `MUSIC_SYNC_COMPLETED` event, which the server keeps for its own batch-level work (e.g. the genre-mapping scanner).
- Wire the seven synced `Library*` views to it, keeping the existing `MEDIA_ITEM_ADDED` handling so single, non-sync adds still work.
- Fix the `LibraryAlbums` add filter that checked `library://artist` instead of `library://album`, so single album adds surface the banner too.

Genres need no change: the genre-mapping scanner runs *after* sync completes — outside the event-suppression window — so its per-item events already refresh that view.
