### PR TITLE
Show the base protocol for bridged outputs and explain their locked toggle

### DIFF
--- a/src/plugins/api/interfaces.ts
+++ b/src/plugins/api/interfaces.ts
@@ -942,6 +942,9 @@ export interface OutputProtocol {
   protocol_domain: string | null; // e.g., "airplay", "dlna" (null for native)
   priority: number; // Lower = more preferred (native = 0 if supported)
   available: boolean; // Whether this output protocol is currently available
+  // derived_from: for a derived transport that rides on another protocol (e.g. a Sendspin
+  // bridge over an AirPlay player), the output_protocol_id of the base output; null for direct outputs
+  derived_from?: string | null;
 }
 
 export interface DeviceInfo {

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -457,6 +457,7 @@
         "protocol_multi_info": "This player supports multiple output protocols. Music Assistant links them automatically so they act as a single player — enable the ones you want to use.",
         "protocol_enable_label": "Enable output protocols",
         "protocol_configure_title": "Configure {name}",
+        "protocol_configure_title_via": "Configure {name} (over {base})",
         "protocol_configure_label": "Configure output protocols",
         "show_advanced_settings": "Show advanced settings",
         "advanced": "Advanced",

--- a/src/views/settings/EditConfig.vue
+++ b/src/views/settings/EditConfig.vue
@@ -39,6 +39,7 @@
       :visible-entries-by-category="visibleEntriesByCategory"
       :show-password-values="showPasswordValues"
       :is-disabled="isDisabled"
+      :output-protocols="outputProtocols"
       @update:value="onValueUpdate"
       @action="onEntryAction"
       @help="onEntryHelp"
@@ -163,6 +164,7 @@ import { markdownToHtml } from "@/helpers/utils";
 import {
   ConfigEntryType,
   ConfigValueType,
+  OutputProtocol,
   SECURE_STRING_SUBSTITUTE,
 } from "@/plugins/api/interfaces";
 import { $t } from "@/plugins/i18n";
@@ -193,6 +195,9 @@ const allowNavigation = ref(false);
 export interface Props {
   configEntries: ConfigEntryUI[];
   disabled: boolean;
+  // Output protocols of the player being configured; drives derived-transport labelling
+  // in the protocol section. Omitted for provider/core configs.
+  outputProtocols?: OutputProtocol[];
 }
 
 const emit = defineEmits<{

--- a/src/views/settings/EditPlayer.vue
+++ b/src/views/settings/EditPlayer.vue
@@ -186,6 +186,7 @@
       v-if="config"
       :disabled="!config?.enabled"
       :config-entries="config_entries"
+      :output-protocols="api.players[config.player_id]?.output_protocols || []"
       @submit="onSubmit"
       @action="onAction"
       @immediate-apply="onImmediateApply"

--- a/src/views/settings/ProtocolConfigSection.vue
+++ b/src/views/settings/ProtocolConfigSection.vue
@@ -39,29 +39,55 @@
         <p class="text-muted-foreground mt-4 mb-2 border-b pb-1 text-xs">
           {{ $t("settings.protocol_enable_label") }}
         </p>
-        <div
-          v-for="panel of optionalProtocolPanels"
-          :key="'toggle-' + panel"
-          class="flex items-center gap-3 py-2.5"
-        >
-          <ProviderIcon
-            v-if="getProtocolDomain(panel)"
-            :domain="getProtocolDomain(panel)!"
-            :size="22"
-            class="shrink-0"
-          />
-          <span class="min-w-0 flex-1 text-sm">
-            {{ getCategoryTranslation(panel) }}
-          </span>
-          <Switch
-            :model-value="!!getProtocolEnabledEntry(panel)?.value"
-            :disabled="!isProtocolProviderAvailable(panel)"
-            class="shrink-0"
-            @update:model-value="
-              emit('update:value', getProtocolEnabledEntry(panel)!, $event)
-            "
-          />
-        </div>
+        <TooltipProvider :delay-duration="200">
+          <div
+            v-for="panel of optionalProtocolPanels"
+            :key="'toggle-' + panel"
+            class="flex items-center gap-3 py-2.5"
+          >
+            <ProviderIcon
+              v-if="getProtocolDomain(panel)"
+              :domain="getProtocolDomain(panel)!"
+              :size="22"
+              class="shrink-0"
+            />
+            <span class="min-w-0 flex-1 text-sm">
+              {{ getCategoryTranslation(panel) }}
+            </span>
+            <!-- A read_only toggle cannot be changed right now (e.g. a derived protocol
+                 whose base protocol is disabled); the entry description explains why -->
+            <Tooltip
+              v-if="
+                isProtocolToggleReadOnly(panel) &&
+                getProtocolEnabledEntry(panel)?.description
+              "
+            >
+              <TooltipTrigger as-child>
+                <button
+                  type="button"
+                  class="text-muted-foreground shrink-0 opacity-60 hover:opacity-100"
+                  :aria-label="$t('tooltip.help')"
+                >
+                  <Info :size="16" />
+                </button>
+              </TooltipTrigger>
+              <TooltipContent side="top" class="max-w-[300px]">
+                {{ getProtocolEnabledEntry(panel)?.description }}
+              </TooltipContent>
+            </Tooltip>
+            <Switch
+              :model-value="!!getProtocolEnabledEntry(panel)?.value"
+              :disabled="
+                !isProtocolProviderAvailable(panel) ||
+                isProtocolToggleReadOnly(panel)
+              "
+              class="shrink-0"
+              @update:model-value="
+                emit('update:value', getProtocolEnabledEntry(panel)!, $event)
+              "
+            />
+          </div>
+        </TooltipProvider>
       </template>
 
       <!-- Per-protocol configuration: native (always on) + enabled optional -->
@@ -87,11 +113,7 @@
                   :domain="getProtocolDomain(panel)!"
                   :size="22"
                 />
-                <span>{{
-                  $t("settings.protocol_configure_title", {
-                    name: getProtocolName(panel),
-                  })
-                }}</span>
+                <span>{{ getProtocolConfigureTitle(panel) }}</span>
               </span>
             </AccordionTrigger>
             <AccordionContent class="pt-3">
@@ -131,11 +153,17 @@ import {
   AccordionTrigger,
 } from "@/components/ui/accordion";
 import { Switch } from "@/components/ui/switch";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 import { ConfigEntryUI } from "@/helpers/config_entry_ui";
 import { api } from "@/plugins/api";
-import { ConfigValueType } from "@/plugins/api/interfaces";
+import { ConfigValueType, OutputProtocol } from "@/plugins/api/interfaces";
 import { $t } from "@/plugins/i18n";
-import { Antenna } from "@lucide/vue";
+import { Antenna, Info } from "@lucide/vue";
 import { computed, ref } from "vue";
 import ConfigEntryRow from "./ConfigEntryRow.vue";
 
@@ -145,6 +173,9 @@ const props = defineProps<{
   visibleEntriesByCategory: Record<string, ConfigEntryUI[]>;
   showPasswordValues: boolean;
   isDisabled: (entry: ConfigEntryUI) => boolean;
+  // The player's output protocols, used to resolve derived-transport relationships.
+  // Empty for non-player configs (providers/core), which have no output protocols.
+  outputProtocols?: OutputProtocol[];
 }>();
 
 const emit = defineEmits<{
@@ -192,6 +223,12 @@ const getProtocolEnabledEntry = function (
   );
 };
 
+// The server serves the toggle read_only when it cannot be changed right now, e.g. a
+// derived protocol (Sendspin over AirPlay) while its base protocol is disabled.
+const isProtocolToggleReadOnly = function (category: string): boolean {
+  return !!getProtocolEnabledEntry(category)?.read_only;
+};
+
 // Optional protocols (those with an enable/disable entry) get a dedicated toggle
 // and, once enabled, a configuration section. The native protocol has no separate
 // toggleable provider, so it is always on.
@@ -229,14 +266,50 @@ const isProtocolProviderAvailable = function (category: string): boolean {
 };
 
 // Display name for a protocol — the provider's own name, falling back to the
-// category label with the "Enable … support" scaffolding stripped.
+// category label with the "Enable … support (over …)" scaffolding stripped.
 const getProtocolName = function (category: string): string {
   const domain = getProtocolDomain(category);
   const provider = domain ? api.getProvider(domain) : undefined;
   if (provider?.name) return provider.name;
   return getCategoryTranslation(category)
+    .replace(/\s*\(over\s+[^)]+\)\s*$/i, "")
     .replace(/^Enable\s+/i, "")
     .replace(/\s+support$/i, "");
+};
+
+// The output protocol backing a panel, matched by domain.
+const getOutputProtocol = function (
+  category: string,
+): OutputProtocol | undefined {
+  const domain = getProtocolDomain(category);
+  if (!domain) return undefined;
+  return props.outputProtocols?.find((p) => p.protocol_domain === domain);
+};
+
+// Display name of the protocol a derived transport rides on (e.g. AirPlay for a Sendspin
+// bridge), or undefined for direct outputs. The relationship is resolved structurally from
+// `derived_from`; the name is a provider proper-noun, so no translation is involved.
+const getProtocolBaseName = function (category: string): string | undefined {
+  const derivedFrom = getOutputProtocol(category)?.derived_from;
+  if (!derivedFrom) return undefined;
+  const base = props.outputProtocols?.find(
+    (p) => p.output_protocol_id === derivedFrom,
+  );
+  if (!base) return undefined;
+  const provider = base.protocol_domain
+    ? api.getProvider(base.protocol_domain)
+    : undefined;
+  return provider?.name || base.name;
+};
+
+// Accordion title for a protocol's configuration section; derived transports include
+// the protocol they ride on, e.g. "Configure Sendspin (over AirPlay)".
+const getProtocolConfigureTitle = function (category: string): string {
+  const name = getProtocolName(category);
+  const base = getProtocolBaseName(category);
+  return base
+    ? $t("settings.protocol_configure_title_via", { name, base })
+    : $t("settings.protocol_configure_title", { name });
 };
 
 const hasHiddenAdvancedSettings = function (category: string): boolean {


### PR DESCRIPTION
Bridged output protocols (a derived transport riding on another, e.g. a Sendspin bridge over an AirPlay player) were shown identically to direct outputs. The "Configure X" accordion just read "Configure Sendspin", and when a derived toggle was locked because its base protocol is disabled, the UI showed only a greyed-out switch with no explanation.

## Changes
- Accordion header now names the base protocol for derived transports, e.g. **"Configure Sendspin (over AirPlay)"**. The relationship is resolved structurally from `OutputProtocol.derived_from` via the player's `output_protocols`, and composed with a frontend template — no parsing of server-translated strings.
- A locked derived toggle (base protocol disabled) now shows an info tooltip with the server's dependency explanation, instead of a bare disabled switch.
- Thread `output_protocols` from `EditPlayer` through `EditConfig` into the protocol section; add the optional `derived_from` field to the `OutputProtocol` type.

The "(over …)" label lights up once the server populates `derived_from` (models#288); the locked-toggle tooltip works today.
