### PR TITLE
Exclude parent directory ("..") item from selection in browse mode

### DIFF
--- a/src/components/ItemsListing.vue
+++ b/src/components/ItemsListing.vue
@@ -90,7 +90,7 @@
             <PanelviewItem
               :item="item"
               :is-selected="isSelected(item)"
-              :show-checkboxes="showCheckboxes"
+              :show-checkboxes="showCheckboxes && !isParentDirItem(item)"
               :show-actions="
                 [
                   'tracks',
@@ -122,7 +122,7 @@
             <PanelviewItemCompact
               :item="item"
               :is-selected="isSelected(item)"
-              :show-checkboxes="showCheckboxes"
+              :show-checkboxes="showCheckboxes && !isParentDirItem(item)"
               :is-available="itemIsAvailable(item)"
               :is-playing="isPlaying(item, itemtype)"
               :disable-play-button="isPlayActionInProgress"
@@ -156,7 +156,7 @@
               :show-menu="item.is_playable"
               :show-provider="showProvider"
               :show-album="showAlbum"
-              :show-checkboxes="showCheckboxes"
+              :show-checkboxes="showCheckboxes && !isParentDirItem(item)"
               :is-selected="isSelected(item)"
               :is-available="itemIsAvailable(item)"
               :is-playing="isPlaying(item, itemtype)"
@@ -642,6 +642,12 @@ const isSelected = function (item: MediaItemTypeOrItemMapping) {
   return selectedItems.value.includes(item);
 };
 
+const isParentDirItem = function (item: MediaItemTypeOrItemMapping) {
+  // the parent directory ("..") link injected in browse listings
+  // must never be selectable as it breaks the action/context menu
+  return item.media_type == MediaType.FOLDER && item.name == "..";
+};
+
 const isPlaying = function (item: MediaItemType, itemtype: string): boolean {
   if (store.activePlayer?.playback_state != PlaybackState.PLAYING) return false;
   const current = store.curQueueItem?.media_item as
@@ -691,6 +697,7 @@ const onSelect = function (
   selected: boolean,
 ) {
   if (selected) {
+    if (isParentDirItem(item)) return;
     if (!selectedItems.value.includes(item)) selectedItems.value.push(item);
   } else {
     for (let i = 0; i < selectedItems.value.length; i++) {
@@ -1955,7 +1962,7 @@ const selectAll = async function () {
 
   if (confirmed) {
     await loadAllItems();
-    selectedItems.value = pagedItems.value;
+    selectedItems.value = pagedItems.value.filter((x) => !isParentDirItem(x));
     showCheckboxes.value = true;
   }
 };


### PR DESCRIPTION
## Summary

Fixes music-assistant/support#5796

In Browse mode, pressing Ctrl+A (select all) also selected the ".." (parent directory) link that the server injects as the first item in browse listings. Having this pseudo-item in the selection broke the action/context menu until it was manually deselected.

## Changes

In `src/components/ItemsListing.vue`:

- Added an `isParentDirItem` helper (matching the existing guard pattern in `ItemContextMenu.vue`: `media_type == FOLDER && name == ".."`).
- `selectAll` now filters the ".." item out of the selection.
- `onSelect` ignores select attempts for the ".." item, so it can't be selected via its checkbox either.
- No checkbox is rendered for the ".." item in list, panel, and compact panel views while selection mode is active.

## Testing

- `vue-tsc --noEmit` passes
- oxlint / eslint / prettier pass on the changed file