### PR TITLE
Exit selection mode when the browse path changes

### DIFF
--- a/src/components/ItemsListing.vue
+++ b/src/components/ItemsListing.vue
@@ -1577,6 +1577,10 @@ watch(
 watch(
   () => props.path,
   (newVal) => {
+    // always leave selection mode: the selection belongs to the previous
+    // folder, and the target may not offer the toggle to turn it off
+    selectedItems.value = [];
+    showCheckboxes.value = false;
     if (loading.value == true) return;
     // completely reset if the path changes
     pagedItems.value = [];


### PR DESCRIPTION
Selection mode survived breadcrumb navigation, so landing somewhere that hides the multi-select toggle (e.g. the browse root) left it stuck on with no way to disable it, and item clicks no longer navigated. The selection belongs to the folder it was made in, so clear it and leave selection mode whenever the path changes.