### PR TITLE
Fix genre merge cross taxonomy

### DIFF
--- a/src/components/InfoHeader.vue
+++ b/src/components/InfoHeader.vue
@@ -673,6 +673,7 @@ const mergeGenre = () => {
   eventbus.emit("mergeGenreDialog", {
     genreIds: [compProps.item.item_id],
     genreNames: [compProps.item.name],
+    genreContentTypes: [(compProps.item as Genre).content_type],
   });
 };
 

--- a/src/components/genre/MergeGenreDialog.vue
+++ b/src/components/genre/MergeGenreDialog.vue
@@ -85,7 +85,6 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from "@/components/ui/popover";
-import { normalizeGenreTaxonomy } from "@/helpers/genreTaxonomy";
 import { api } from "@/plugins/api";
 import type { Genre, MediaType } from "@/plugins/api/interfaces";
 import { eventbus, type MergeGenreDialogEvent } from "@/plugins/eventbus";
@@ -112,7 +111,7 @@ const availableGenres = computed(() =>
   allGenres.value.filter(
     (g) =>
       !genreIds.value.includes(g.item_id) &&
-      normalizeGenreTaxonomy(g.content_type) === sourceContentType.value,
+      (g.content_type ?? null) === sourceContentType.value,
   ),
 );
 
@@ -173,7 +172,7 @@ onMounted(() => {
     reset();
     genreIds.value = evt.genreIds;
     genreNames.value = evt.genreNames;
-    sourceContentType.value = normalizeGenreTaxonomy(evt.genreContentTypes[0]);
+    sourceContentType.value = evt.genreContentTypes[0] ?? null;
     allGenres.value = await api.getLibraryGenres({ hide_empty: false });
     open.value = true;
   });

--- a/src/components/genre/MergeGenreDialog.vue
+++ b/src/components/genre/MergeGenreDialog.vue
@@ -173,9 +173,7 @@ onMounted(() => {
     reset();
     genreIds.value = evt.genreIds;
     genreNames.value = evt.genreNames;
-    sourceContentType.value = normalizeGenreTaxonomy(
-      evt.genreContentTypes[0],
-    );
+    sourceContentType.value = normalizeGenreTaxonomy(evt.genreContentTypes[0]);
     allGenres.value = await api.getLibraryGenres({ hide_empty: false });
     open.value = true;
   });

--- a/src/components/genre/MergeGenreDialog.vue
+++ b/src/components/genre/MergeGenreDialog.vue
@@ -85,8 +85,9 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from "@/components/ui/popover";
+import { normalizeGenreTaxonomy } from "@/helpers/genreTaxonomy";
 import { api } from "@/plugins/api";
-import type { Genre } from "@/plugins/api/interfaces";
+import type { Genre, MediaType } from "@/plugins/api/interfaces";
 import { eventbus, type MergeGenreDialogEvent } from "@/plugins/eventbus";
 import { store } from "@/plugins/store";
 import { Check, ChevronsUpDown } from "@lucide/vue";
@@ -103,11 +104,16 @@ const popoverOpen = ref(false);
 const loading = ref(false);
 const genreIds = ref<string[]>([]);
 const genreNames = ref<string[]>([]);
+const sourceContentType = ref<MediaType | null>(null);
 const allGenres = ref<Genre[]>([]);
 const selectedTargetId = ref<string | null>(null);
 
 const availableGenres = computed(() =>
-  allGenres.value.filter((g) => !genreIds.value.includes(g.item_id)),
+  allGenres.value.filter(
+    (g) =>
+      !genreIds.value.includes(g.item_id) &&
+      normalizeGenreTaxonomy(g.content_type) === sourceContentType.value,
+  ),
 );
 
 const selectedGenreName = computed(() => {
@@ -151,6 +157,7 @@ const handleMerge = async () => {
 const reset = () => {
   genreIds.value = [];
   genreNames.value = [];
+  sourceContentType.value = null;
   allGenres.value = [];
   selectedTargetId.value = null;
   loading.value = false;
@@ -166,6 +173,9 @@ onMounted(() => {
     reset();
     genreIds.value = evt.genreIds;
     genreNames.value = evt.genreNames;
+    sourceContentType.value = normalizeGenreTaxonomy(
+      evt.genreContentTypes[0],
+    );
     allGenres.value = await api.getLibraryGenres({ hide_empty: false });
     open.value = true;
   });

--- a/src/helpers/genreTaxonomy.ts
+++ b/src/helpers/genreTaxonomy.ts
@@ -1,16 +1,9 @@
 import type { MediaType } from "@/plugins/api/interfaces";
 
 // null/undefined content_type both mean the music/general taxonomy.
-export function normalizeGenreTaxonomy(
-  contentType?: MediaType | null,
-): MediaType | null {
-  return contentType ?? null;
-}
-
 export function genresShareTaxonomy(
   contentTypes: Array<MediaType | null | undefined>,
 ): boolean {
-  if (contentTypes.length === 0) return true;
-  const first = normalizeGenreTaxonomy(contentTypes[0]);
-  return contentTypes.every((ct) => normalizeGenreTaxonomy(ct) === first);
+  const taxonomies = new Set(contentTypes.map((ct) => ct ?? null));
+  return taxonomies.size <= 1;
 }

--- a/src/helpers/genreTaxonomy.ts
+++ b/src/helpers/genreTaxonomy.ts
@@ -1,0 +1,16 @@
+import type { MediaType } from "@/plugins/api/interfaces";
+
+// null/undefined content_type both mean the music/general taxonomy.
+export function normalizeGenreTaxonomy(
+  contentType?: MediaType | null,
+): MediaType | null {
+  return contentType ?? null;
+}
+
+export function genresShareTaxonomy(
+  contentTypes: Array<MediaType | null | undefined>,
+): boolean {
+  if (contentTypes.length === 0) return true;
+  const first = normalizeGenreTaxonomy(contentTypes[0]);
+  return contentTypes.every((ct) => normalizeGenreTaxonomy(ct) === first);
+}

--- a/src/layouts/default/ItemContextMenu.vue
+++ b/src/layouts/default/ItemContextMenu.vue
@@ -212,6 +212,7 @@ import {
   pinShortcutStandalone,
   unpinShortcutStandaloneItem,
 } from "@/composables/useShortcuts";
+import { genresShareTaxonomy } from "@/helpers/genreTaxonomy";
 import {
   gotoRadio,
   radioActionLabelKey,
@@ -224,6 +225,7 @@ import {
   Album,
   BrowseFolder,
   EventType,
+  Genre,
   MediaItemType,
   MediaItemTypeOrItemMapping,
   MediaType,
@@ -997,11 +999,12 @@ export const getContextMenuItems = async function (
       icon: GenreIcon,
     });
   }
-  // merge genres (admin only, all items must be library genres)
+  // merge genres (admin only, all items must be library genres of the same taxonomy)
   if (
     items.every(
       (i) => i.media_type === MediaType.GENRE && i.provider === "library",
     ) &&
+    genresShareTaxonomy(items.map((i) => (i as Genre).content_type)) &&
     authManager.isAdmin()
   ) {
     contextMenuItems.push({
@@ -1011,6 +1014,7 @@ export const getContextMenuItems = async function (
         eventbus.emit("mergeGenreDialog", {
           genreIds: items.map((i) => i.item_id),
           genreNames: items.map((i) => i.name),
+          genreContentTypes: items.map((i) => (i as Genre).content_type),
         });
         eventbus.emit("clearSelection");
       },

--- a/src/plugins/eventbus.ts
+++ b/src/plugins/eventbus.ts
@@ -5,6 +5,7 @@ import mitt, { Emitter } from "mitt";
 import {
   MediaItemType,
   MediaItemTypeOrItemMapping,
+  MediaType,
   Playlist,
   Radio,
   Track,
@@ -30,6 +31,7 @@ export type CreatePlaylistEvent = {
 export type MergeGenreDialogEvent = {
   genreIds: string[];
   genreNames: string[];
+  genreContentTypes: (MediaType | null | undefined)[];
 };
 
 export type DeleteGenreDialogEvent = {

--- a/tests/helpers/genreTaxonomy.test.ts
+++ b/tests/helpers/genreTaxonomy.test.ts
@@ -33,9 +33,9 @@ describe("genresShareTaxonomy", () => {
   });
 
   it("is true when all genres share the podcast taxonomy", () => {
-    expect(
-      genresShareTaxonomy([MediaType.PODCAST, MediaType.PODCAST]),
-    ).toBe(true);
+    expect(genresShareTaxonomy([MediaType.PODCAST, MediaType.PODCAST])).toBe(
+      true,
+    );
   });
 
   it("is false when music and podcast genres are mixed", () => {
@@ -43,8 +43,8 @@ describe("genresShareTaxonomy", () => {
   });
 
   it("is false when podcast and audiobook genres are mixed", () => {
-    expect(
-      genresShareTaxonomy([MediaType.PODCAST, MediaType.AUDIOBOOK]),
-    ).toBe(false);
+    expect(genresShareTaxonomy([MediaType.PODCAST, MediaType.AUDIOBOOK])).toBe(
+      false,
+    );
   });
 });

--- a/tests/helpers/genreTaxonomy.test.ts
+++ b/tests/helpers/genreTaxonomy.test.ts
@@ -1,23 +1,6 @@
-import {
-  genresShareTaxonomy,
-  normalizeGenreTaxonomy,
-} from "@/helpers/genreTaxonomy";
+import { genresShareTaxonomy } from "@/helpers/genreTaxonomy";
 import { MediaType } from "@/plugins/api/interfaces";
 import { describe, expect, it } from "vitest";
-
-describe("normalizeGenreTaxonomy", () => {
-  it("treats null and undefined as the same music taxonomy", () => {
-    expect(normalizeGenreTaxonomy(null)).toBe(null);
-    expect(normalizeGenreTaxonomy(undefined)).toBe(null);
-  });
-
-  it("passes through a real content_type", () => {
-    expect(normalizeGenreTaxonomy(MediaType.PODCAST)).toBe(MediaType.PODCAST);
-    expect(normalizeGenreTaxonomy(MediaType.AUDIOBOOK)).toBe(
-      MediaType.AUDIOBOOK,
-    );
-  });
-});
 
 describe("genresShareTaxonomy", () => {
   it("is true for an empty selection", () => {

--- a/tests/helpers/genreTaxonomy.test.ts
+++ b/tests/helpers/genreTaxonomy.test.ts
@@ -1,0 +1,50 @@
+import {
+  genresShareTaxonomy,
+  normalizeGenreTaxonomy,
+} from "@/helpers/genreTaxonomy";
+import { MediaType } from "@/plugins/api/interfaces";
+import { describe, expect, it } from "vitest";
+
+describe("normalizeGenreTaxonomy", () => {
+  it("treats null and undefined as the same music taxonomy", () => {
+    expect(normalizeGenreTaxonomy(null)).toBe(null);
+    expect(normalizeGenreTaxonomy(undefined)).toBe(null);
+  });
+
+  it("passes through a real content_type", () => {
+    expect(normalizeGenreTaxonomy(MediaType.PODCAST)).toBe(MediaType.PODCAST);
+    expect(normalizeGenreTaxonomy(MediaType.AUDIOBOOK)).toBe(
+      MediaType.AUDIOBOOK,
+    );
+  });
+});
+
+describe("genresShareTaxonomy", () => {
+  it("is true for an empty selection", () => {
+    expect(genresShareTaxonomy([])).toBe(true);
+  });
+
+  it("is true for a single genre", () => {
+    expect(genresShareTaxonomy([null])).toBe(true);
+  });
+
+  it("is true when all genres are music (null/undefined mixed)", () => {
+    expect(genresShareTaxonomy([null, undefined, null])).toBe(true);
+  });
+
+  it("is true when all genres share the podcast taxonomy", () => {
+    expect(
+      genresShareTaxonomy([MediaType.PODCAST, MediaType.PODCAST]),
+    ).toBe(true);
+  });
+
+  it("is false when music and podcast genres are mixed", () => {
+    expect(genresShareTaxonomy([null, MediaType.PODCAST])).toBe(false);
+  });
+
+  it("is false when podcast and audiobook genres are mixed", () => {
+    expect(
+      genresShareTaxonomy([MediaType.PODCAST, MediaType.AUDIOBOOK]),
+    ).toBe(false);
+  });
+});


### PR DESCRIPTION
Only show  same taxonomy genres in merge dialog
Disable merge option in management table when multiple taxonomy genres are selected