### PR TITLE
Fix vertical alignment of rail dots in the stream details chain

### DIFF
--- a/src/components/StreamDetailsChain.vue
+++ b/src/components/StreamDetailsChain.vue
@@ -103,7 +103,7 @@
       </div>
       <div class="w-full">
         <!-- Input header -->
-        <div class="flex">
+        <div class="streamdetails-header">
           <div
             class="streamdetails-separator"
             style="width: 40px; margin-right: 10px"
@@ -289,7 +289,7 @@
           :key="player_id"
         >
           <!-- Separator -->
-          <div class="flex">
+          <div class="streamdetails-header">
             <div
               class="streamdetails-separator"
               style="width: 40px; margin-right: 10px"
@@ -812,16 +812,15 @@ div.streamdetails-icon {
   filter: none;
 }
 
-.streamdetails-separator {
-  height: calc(var(--sd-row) / 4);
+/* fixed half-row height: sizing from the label's line-height would drift the rail */
+.streamdetails-header {
+  height: calc(var(--sd-row) / 2);
   display: flex;
   align-items: center;
-  margin-top: calc(var(--sd-row) / 4);
-  border-style: dotted;
-  border-width: 1px;
-  border-bottom: none;
-  border-left: none;
-  border-right: none;
+}
+
+.streamdetails-separator {
+  border-top: 1px dotted;
 }
 
 .line-space {
@@ -908,8 +907,9 @@ div.streamdetails-icon {
 .line-with-dot::before {
   content: "";
   position: absolute;
+  top: 50%;
+  left: 0;
   transform: translate(-50%, -50%);
-  margin-top: calc(var(--sd-row) / 2);
   height: 14px;
   width: 14px;
   background-color: var(--foreground);
@@ -919,8 +919,9 @@ div.streamdetails-icon {
 .line-with-dot::after {
   content: "";
   position: absolute;
+  top: 50%;
+  left: 0;
   transform: translate(-50%, -50%);
-  margin-top: calc(var(--sd-row) / 2);
   height: 10px;
   width: 10px;
   background-color: var(--primary);


### PR DESCRIPTION
Since the shadcn migration of the quality details popover, the blue node dots on the connector rail no longer lined up with their rows.

The Input/Output header rows sized themselves from the label's line-height (21px) instead of the rail rhythm (17px, half a `--sd-row`), so every header pushed all rows below it out of sync with the rail — 4px drift after the Input header, 8px after Output.

- Add a `.streamdetails-header` class giving the section header rows a fixed `calc(var(--sd-row) / 2)` height
- Simplify `.streamdetails-separator` to a vertically centered dotted line
- Anchor the rail node dots with explicit `top`/`left` instead of relying on their static position