### PR TITLE
Show track BPM and musical key on the track details page

### DIFF
--- a/src/components/AudioAnalysisMetadata.vue
+++ b/src/components/AudioAnalysisMetadata.vue
@@ -1,0 +1,71 @@
+<template>
+  <!-- audio analysis details (bpm / musical key), only present on full track details -->
+  <Popover v-if="bpm || musicalKey" v-model:open="open">
+    <PopoverTrigger as-child>
+      <AudioWaveform
+        :size="24"
+        class="cursor-pointer"
+        :title="$t('audio_analysis')"
+        @mouseenter="scheduleOpen"
+        @mouseleave="scheduleClose"
+        @click="open = !open"
+      />
+    </PopoverTrigger>
+    <PopoverContent
+      side="bottom"
+      align="center"
+      :collision-padding="12"
+      class="w-fit p-3"
+      @open-auto-focus.prevent
+      @mouseenter="scheduleOpen"
+      @mouseleave="scheduleClose"
+    >
+      <div class="text-sm font-medium pb-1">{{ $t("audio_analysis") }}</div>
+      <div v-if="bpm" class="d-flex align-center ga-2 text-sm">
+        <v-icon size="18" color="primary" icon="mdi-metronome" />
+        <span :title="$t('tooltip.bpm')">{{ bpm }} {{ $t("bpm") }}</span>
+      </div>
+      <div v-if="musicalKey" class="d-flex align-center ga-2 text-sm">
+        <v-icon size="18" color="primary" icon="mdi-music-clef-treble" />
+        <span :title="$t('tooltip.musical_key')">{{ musicalKey }}</span>
+      </div>
+    </PopoverContent>
+  </Popover>
+</template>
+
+<script setup lang="ts">
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import type { AudioMetadata } from "@/plugins/api/interfaces";
+import { AudioWaveform } from "@lucide/vue";
+import { computed, ref } from "vue";
+
+const props = defineProps<{
+  audioMetadata?: AudioMetadata | null;
+}>();
+
+const open = ref(false);
+let closeTimer: ReturnType<typeof setTimeout> | undefined;
+
+const bpm = computed(() =>
+  props.audioMetadata?.bpm ? Math.round(props.audioMetadata.bpm) : undefined,
+);
+const musicalKey = computed(
+  () => props.audioMetadata?.musical_key || undefined,
+);
+
+// hover opens on desktop; the small close delay keeps the popover alive while
+// the pointer travels from trigger to content. Click/tap still toggles (mobile).
+const scheduleOpen = function () {
+  clearTimeout(closeTimer);
+  open.value = true;
+};
+
+const scheduleClose = function () {
+  clearTimeout(closeTimer);
+  closeTimer = setTimeout(() => (open.value = false), 150);
+};
+</script>

--- a/src/components/AudioAnalysisMetadata.vue
+++ b/src/components/AudioAnalysisMetadata.vue
@@ -12,24 +12,37 @@
       side="bottom"
       align="center"
       :collision-padding="12"
-      class="audio-analysis-popover overflow-y-auto p-3"
-      :style="{
-        width: 'fit-content',
-        minWidth: '180px',
-        maxWidth: 'calc(100vw - 25px)',
-      }"
+      class="w-auto min-w-[210px] p-3"
       @open-auto-focus.prevent
     >
-      <div class="font-medium audio-analysis-item">
-        {{ $t("audio_analysis") }}
-      </div>
-      <div v-if="bpm" class="audio-analysis-item">
-        <v-icon size="20" color="primary" icon="mdi-metronome" />
-        <span :title="$t('tooltip.bpm')">{{ bpm }} {{ $t("bpm") }}</span>
-      </div>
-      <div v-if="musicalKey" class="audio-analysis-item">
-        <v-icon size="20" color="primary" icon="mdi-music-clef-treble" />
-        <span :title="$t('tooltip.musical_key')">{{ musicalKey }}</span>
+      <div class="flex flex-col gap-3">
+        <div class="flex items-center gap-2">
+          <AudioWaveform :size="18" />
+          <span class="text-[0.95rem] font-semibold">
+            {{ $t("audio_analysis") }}
+          </span>
+        </div>
+
+        <div class="grid auto-cols-fr grid-flow-col gap-2">
+          <div
+            v-if="bpm"
+            class="bg-accent/50 rounded-md px-3 py-2 text-center"
+            :title="$t('tooltip.bpm')"
+          >
+            <div class="text-base font-semibold tabular-nums">{{ bpm }}</div>
+            <div class="text-muted-foreground text-xs">{{ $t("bpm") }}</div>
+          </div>
+          <div
+            v-if="musicalKey"
+            class="bg-accent/50 rounded-md px-3 py-2 text-center"
+            :title="$t('tooltip.musical_key')"
+          >
+            <div class="text-base font-semibold">{{ musicalKey }}</div>
+            <div class="text-muted-foreground text-xs">
+              {{ $t("musical_key") }}
+            </div>
+          </div>
+        </div>
       </div>
     </PopoverContent>
   </Popover>
@@ -56,17 +69,3 @@ const musicalKey = computed(
   () => props.audioMetadata?.musical_key || undefined,
 );
 </script>
-
-<style>
-.audio-analysis-popover {
-  /* match the streamdetails (quality) popover typography and row rhythm */
-  font-size: 0.875rem;
-}
-
-.audio-analysis-item {
-  height: 34px;
-  display: flex;
-  align-items: center;
-  gap: 10px;
-}
-</style>

--- a/src/components/AudioAnalysisMetadata.vue
+++ b/src/components/AudioAnalysisMetadata.vue
@@ -1,32 +1,34 @@
 <template>
   <!-- audio analysis details (bpm / musical key), only present on full track details -->
-  <Popover v-if="bpm || musicalKey" v-model:open="open">
+  <Popover v-if="bpm || musicalKey">
     <PopoverTrigger as-child>
       <AudioWaveform
-        :size="24"
+        :size="26"
         class="cursor-pointer"
         :title="$t('audio_analysis')"
-        @mouseenter="scheduleOpen"
-        @mouseleave="scheduleClose"
-        @click="open = !open"
       />
     </PopoverTrigger>
     <PopoverContent
       side="bottom"
       align="center"
       :collision-padding="12"
-      class="w-fit p-3"
+      class="audio-analysis-popover overflow-y-auto p-3"
+      :style="{
+        width: 'fit-content',
+        minWidth: '180px',
+        maxWidth: 'calc(100vw - 25px)',
+      }"
       @open-auto-focus.prevent
-      @mouseenter="scheduleOpen"
-      @mouseleave="scheduleClose"
     >
-      <div class="text-sm font-medium pb-1">{{ $t("audio_analysis") }}</div>
-      <div v-if="bpm" class="d-flex align-center ga-2 text-sm">
-        <v-icon size="18" color="primary" icon="mdi-metronome" />
+      <div class="font-medium audio-analysis-item">
+        {{ $t("audio_analysis") }}
+      </div>
+      <div v-if="bpm" class="audio-analysis-item">
+        <v-icon size="20" color="primary" icon="mdi-metronome" />
         <span :title="$t('tooltip.bpm')">{{ bpm }} {{ $t("bpm") }}</span>
       </div>
-      <div v-if="musicalKey" class="d-flex align-center ga-2 text-sm">
-        <v-icon size="18" color="primary" icon="mdi-music-clef-treble" />
+      <div v-if="musicalKey" class="audio-analysis-item">
+        <v-icon size="20" color="primary" icon="mdi-music-clef-treble" />
         <span :title="$t('tooltip.musical_key')">{{ musicalKey }}</span>
       </div>
     </PopoverContent>
@@ -41,14 +43,11 @@ import {
 } from "@/components/ui/popover";
 import type { AudioMetadata } from "@/plugins/api/interfaces";
 import { AudioWaveform } from "@lucide/vue";
-import { computed, ref } from "vue";
+import { computed } from "vue";
 
 const props = defineProps<{
   audioMetadata?: AudioMetadata | null;
 }>();
-
-const open = ref(false);
-let closeTimer: ReturnType<typeof setTimeout> | undefined;
 
 const bpm = computed(() =>
   props.audioMetadata?.bpm ? Math.round(props.audioMetadata.bpm) : undefined,
@@ -56,16 +55,18 @@ const bpm = computed(() =>
 const musicalKey = computed(
   () => props.audioMetadata?.musical_key || undefined,
 );
-
-// hover opens on desktop; the small close delay keeps the popover alive while
-// the pointer travels from trigger to content. Click/tap still toggles (mobile).
-const scheduleOpen = function () {
-  clearTimeout(closeTimer);
-  open.value = true;
-};
-
-const scheduleClose = function () {
-  clearTimeout(closeTimer);
-  closeTimer = setTimeout(() => (open.value = false), 150);
-};
 </script>
+
+<style>
+.audio-analysis-popover {
+  /* match the streamdetails (quality) popover typography and row rhythm */
+  font-size: 0.875rem;
+}
+
+.audio-analysis-item {
+  height: 34px;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+</style>

--- a/src/components/InfoHeader.vue
+++ b/src/components/InfoHeader.vue
@@ -270,39 +270,6 @@
                 ></MarqueeText
               >
             </v-card-subtitle>
-
-            <!-- track bpm / musical key (only present on full track details) -->
-            <v-card-subtitle
-              v-if="trackBpm || trackMusicalKey"
-              class="title d-flex"
-            >
-              <template v-if="trackBpm">
-                <v-icon
-                  style="margin-left: -3px; margin-right: 3px"
-                  small
-                  color="primary"
-                  icon="mdi-metronome"
-                />
-                <span :title="$t('tooltip.bpm')"
-                  >{{ trackBpm }} {{ $t("bpm") }}</span
-                >
-              </template>
-              <template v-if="trackMusicalKey">
-                <v-icon
-                  small
-                  color="primary"
-                  icon="mdi-music-clef-treble"
-                  :style="
-                    trackBpm
-                      ? 'margin-left: 12px; margin-right: 3px'
-                      : 'margin-left: -3px; margin-right: 3px'
-                  "
-                />
-                <span :title="$t('tooltip.musical_key')">{{
-                  trackMusicalKey
-                }}</span>
-              </template>
-            </v-card-subtitle>
           </div>
 
           <!-- play/info buttons -->
@@ -350,6 +317,11 @@
               <!-- details can be reached out of library context, so always show
               the membership badge (bookshelf when in library, else source) -->
               <provider-icon :domain="getProviderIconDomain(item)" :size="25" />
+              <!-- audio analysis details (full track details only) -->
+              <AudioAnalysisMetadata
+                v-if="item.media_type == MediaType.TRACK"
+                :audio-metadata="(item as Track).audio_metadata"
+              />
               <!-- slot for extra action icons (e.g. smart playlist edit) -->
               <slot name="append-actions"></slot>
               <!-- merge genre button (admin only) -->
@@ -453,6 +425,7 @@
 
 <script setup lang="ts">
 import Toolbar from "@/components/Toolbar.vue";
+import AudioAnalysisMetadata from "@/components/AudioAnalysisMetadata.vue";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -520,17 +493,6 @@ const { getPreference } = useUserPreferences();
 const headerTitle = computed(() => {
   if (!compProps.item) return "";
   return compProps.item.name;
-});
-
-const trackBpm = computed(() => {
-  if (compProps.item?.media_type !== MediaType.TRACK) return undefined;
-  const bpm = (compProps.item as Track).audio_metadata?.bpm;
-  return bpm ? Math.round(bpm) : undefined;
-});
-
-const trackMusicalKey = computed(() => {
-  if (compProps.item?.media_type !== MediaType.TRACK) return undefined;
-  return (compProps.item as Track).audio_metadata?.musical_key || undefined;
 });
 
 watch(

--- a/src/components/InfoHeader.vue
+++ b/src/components/InfoHeader.vue
@@ -136,39 +136,6 @@
               {{ new Date(item.metadata.release_date).getFullYear() }}
             </v-card-subtitle>
 
-            <!-- track bpm / musical key (only present on full track details) -->
-            <v-card-subtitle
-              v-if="trackBpm || trackMusicalKey"
-              class="title d-flex"
-            >
-              <template v-if="trackBpm">
-                <v-icon
-                  style="margin-left: -3px; margin-right: 3px"
-                  small
-                  color="primary"
-                  icon="mdi-metronome"
-                />
-                <span :title="$t('tooltip.bpm')"
-                  >{{ trackBpm }} {{ $t("bpm") }}</span
-                >
-              </template>
-              <template v-if="trackMusicalKey">
-                <v-icon
-                  small
-                  color="primary"
-                  icon="mdi-music-clef-treble"
-                  :style="
-                    trackBpm
-                      ? 'margin-left: 12px; margin-right: 3px'
-                      : 'margin-left: -3px; margin-right: 3px'
-                  "
-                />
-                <span :title="$t('tooltip.musical_key')">{{
-                  trackMusicalKey
-                }}</span>
-              </template>
-            </v-card-subtitle>
-
             <!-- item artists -->
             <v-card-subtitle
               v-if="'artists' in item && item.artists"
@@ -302,6 +269,39 @@
                   • {{ item.album.year }}</span
                 ></MarqueeText
               >
+            </v-card-subtitle>
+
+            <!-- track bpm / musical key (only present on full track details) -->
+            <v-card-subtitle
+              v-if="trackBpm || trackMusicalKey"
+              class="title d-flex"
+            >
+              <template v-if="trackBpm">
+                <v-icon
+                  style="margin-left: -3px; margin-right: 3px"
+                  small
+                  color="primary"
+                  icon="mdi-metronome"
+                />
+                <span :title="$t('tooltip.bpm')"
+                  >{{ trackBpm }} {{ $t("bpm") }}</span
+                >
+              </template>
+              <template v-if="trackMusicalKey">
+                <v-icon
+                  small
+                  color="primary"
+                  icon="mdi-music-clef-treble"
+                  :style="
+                    trackBpm
+                      ? 'margin-left: 12px; margin-right: 3px'
+                      : 'margin-left: -3px; margin-right: 3px'
+                  "
+                />
+                <span :title="$t('tooltip.musical_key')">{{
+                  trackMusicalKey
+                }}</span>
+              </template>
             </v-card-subtitle>
           </div>
 

--- a/src/components/InfoHeader.vue
+++ b/src/components/InfoHeader.vue
@@ -136,6 +136,39 @@
               {{ new Date(item.metadata.release_date).getFullYear() }}
             </v-card-subtitle>
 
+            <!-- track bpm / musical key (only present on full track details) -->
+            <v-card-subtitle
+              v-if="trackBpm || trackMusicalKey"
+              class="title d-flex"
+            >
+              <template v-if="trackBpm">
+                <v-icon
+                  style="margin-left: -3px; margin-right: 3px"
+                  small
+                  color="primary"
+                  icon="mdi-metronome"
+                />
+                <span :title="$t('tooltip.bpm')"
+                  >{{ trackBpm }} {{ $t("bpm") }}</span
+                >
+              </template>
+              <template v-if="trackMusicalKey">
+                <v-icon
+                  small
+                  color="primary"
+                  icon="mdi-music-clef-treble"
+                  :style="
+                    trackBpm
+                      ? 'margin-left: 12px; margin-right: 3px'
+                      : 'margin-left: -3px; margin-right: 3px'
+                  "
+                />
+                <span :title="$t('tooltip.musical_key')">{{
+                  trackMusicalKey
+                }}</span>
+              </template>
+            </v-card-subtitle>
+
             <!-- item artists -->
             <v-card-subtitle
               v-if="'artists' in item && item.artists"
@@ -487,6 +520,17 @@ const { getPreference } = useUserPreferences();
 const headerTitle = computed(() => {
   if (!compProps.item) return "";
   return compProps.item.name;
+});
+
+const trackBpm = computed(() => {
+  if (compProps.item?.media_type !== MediaType.TRACK) return undefined;
+  const bpm = (compProps.item as Track).audio_metadata?.bpm;
+  return bpm ? Math.round(bpm) : undefined;
+});
+
+const trackMusicalKey = computed(() => {
+  if (compProps.item?.media_type !== MediaType.TRACK) return undefined;
+  return (compProps.item as Track).audio_metadata?.musical_key || undefined;
 });
 
 watch(

--- a/src/layouts/default/PlayerOSD/PlayerFullscreen.vue
+++ b/src/layouts/default/PlayerOSD/PlayerFullscreen.vue
@@ -1517,8 +1517,7 @@ watchEffect(() => {
   align-items: center;
   justify-content: center;
   max-width: 100%;
-  /* 5% side padding aligns the outer icons with the volume bar below */
-  padding: 15px 5%;
+  padding: 15px;
   height: 100px;
 }
 

--- a/src/layouts/default/PlayerOSD/PlayerFullscreen.vue
+++ b/src/layouts/default/PlayerOSD/PlayerFullscreen.vue
@@ -1517,7 +1517,8 @@ watchEffect(() => {
   align-items: center;
   justify-content: center;
   max-width: 100%;
-  padding: 15px;
+  /* 5% side padding aligns the outer icons with the volume bar below */
+  padding: 15px 5%;
   height: 100px;
 }
 

--- a/src/plugins/api/interfaces.ts
+++ b/src/plugins/api/interfaces.ts
@@ -712,6 +712,12 @@ export interface Album extends MediaItem {
   album_type: AlbumType;
 }
 
+export interface AudioMetadata {
+  // Audio analysis details (e.g. bpm, musical key).
+  bpm?: number | null;
+  musical_key?: string | null;
+}
+
 export interface Track extends MediaItem {
   duration: number;
   artists: Array<ItemMapping | Artist>;
@@ -719,6 +725,8 @@ export interface Track extends MediaItem {
   album: ItemMapping | Album;
   disc_number?: number;
   track_number?: number;
+  // only populated when the full track is requested (get_track), never on listings
+  audio_metadata?: AudioMetadata | null;
 }
 
 export interface Playlist extends MediaItem {

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1428,5 +1428,6 @@
         "60": "1 hour",
         "120": "2 hours"
     },
-    "bpm": "BPM"
+    "bpm": "BPM",
+    "musical_key": "Key"
 }

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -623,10 +623,12 @@
     "sync_running": "One or more music providers are being synchronized.",
     "tooltip": {
         "album_artist_filter": "Toggle album-artist filter",
+        "bpm": "Tempo (beats per minute)",
         "explicit": "Explicit",
         "filter_library": "Toggle in-library\/favorite filter",
         "library": "Toggle in-library\/favorite",
         "linked": "This provideritem is linked to the current itemdetails",
+        "musical_key": "Musical key",
         "refresh": "Refresh the items listing",
         "refresh_new_content": "New content is available, click to refresh the listing",
         "search": "Show\/hide search input",
@@ -1424,5 +1426,6 @@
         "45": "45 minutes",
         "60": "1 hour",
         "120": "2 hours"
-    }
+    },
+    "bpm": "BPM"
 }

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -749,6 +749,7 @@
     "open_dsp_settings": "Open DSP settings",
     "audiobook": "Audiobook",
     "audiobooks": "Audiobooks",
+    "audio_analysis": "Audio analysis",
     "chapter": "Chapter",
     "chapters": "Chapters",
     "podcast": "Podcast",


### PR DESCRIPTION
Adds display of the new track audio analysis metadata (BPM + musical key) on the track details page.

Depends on music-assistant/server#4626 (server exposes `Track.audio_metadata` via music-assistant-models 1.1.154).

- Add `AudioMetadata` interface and optional `audio_metadata` field to `Track` (only populated on full track requests, never on listings)
- Show BPM (rounded) and musical key rows in the track details header, hidden when absent
- Add English translation strings for the new labels