### PR TITLE
Show a waveform progress bar in the fullscreen player

### DIFF
--- a/src/layouts/default/PlayerOSD/PlayerFullscreen.vue
+++ b/src/layouts/default/PlayerOSD/PlayerFullscreen.vue
@@ -1585,9 +1585,10 @@ watchEffect(() => {
   align-items: center;
   justify-content: center;
   max-width: 100%;
-  /* Side padding matches the 5% margins of the timeline/volume rows above
-     and below, so the outermost buttons align with the sliders. */
-  padding: 15px 5%;
+  padding: 15px;
+  /* Breathing room below the timeline, matching the visual gap between the
+     controls and the volume bar underneath. */
+  margin-top: 10px;
   height: 100px;
 }
 

--- a/src/layouts/default/PlayerOSD/PlayerFullscreen.vue
+++ b/src/layouts/default/PlayerOSD/PlayerFullscreen.vue
@@ -743,8 +743,7 @@ watch(
   },
 );
 
-// Fetch the waveform for the current track (only when fullscreen player is
-// open); rendered by PlayerTimeline instead of the flat progress bar.
+// Waveform for the current track, rendered by PlayerTimeline instead of the flat bar.
 const waveformData = ref<number[] | null>(null);
 const showWaveformPref = useUserPreferences().getPreference(
   "show_waveform",
@@ -756,8 +755,7 @@ const fetchWaveform = async () => {
   waveformData.value = null;
 
   const mediaItem = store.curQueueItem?.media_item;
-  // Analysis data is keyed by the provider-native item id (the one used for
-  // streaming), so resolve it from streamdetails - not the library item id.
+  // Analysis is keyed by the provider-native (streaming) item id, not the library id.
   const streamDetails = store.curQueueItem?.streamdetails;
   if (
     !showWaveformPref.value ||
@@ -777,15 +775,13 @@ const fetchWaveform = async () => {
     if (generation !== waveformLoadGeneration) return;
     waveformData.value = waveform?.length ? waveform : null;
   } catch {
-    // No analysis available or server without audio_analysis support;
-    // PlayerTimeline falls back to the flat progress bar.
+    // No analysis available; PlayerTimeline falls back to the flat progress bar.
     if (generation !== waveformLoadGeneration) return;
     waveformData.value = null;
   }
 };
 
-// Streamdetails can arrive after the queue item switches, so key the watch on
-// the streamdetails item id (with the queue item id as fallback trigger).
+// Streamdetails can arrive after the queue item switches, so watch both ids.
 watch(
   () => [
     store.curQueueItem?.queue_item_id,
@@ -795,8 +791,7 @@ watch(
   { immediate: true },
 );
 
-// Defensive: FrontendConfig reloads the app after saving user preferences,
-// but react to live preference changes anyway (e.g. multi-tab sync).
+// FrontendConfig reloads the app on save, but react to live changes anyway (multi-tab sync).
 watch(showWaveformPref, fetchWaveform);
 
 watch(
@@ -1586,8 +1581,7 @@ watchEffect(() => {
   justify-content: center;
   max-width: 100%;
   padding: 15px;
-  /* Breathing room below the timeline, matching the visual gap between the
-     controls and the volume bar underneath. */
+  /* match the visual gap between the controls and the volume bar below */
   margin-top: 10px;
   height: 100px;
 }

--- a/src/layouts/default/PlayerOSD/PlayerFullscreen.vue
+++ b/src/layouts/default/PlayerOSD/PlayerFullscreen.vue
@@ -324,7 +324,11 @@
       <div class="player-bottom">
         <!-- timeline / progressbar-->
         <div class="row" style="margin-left: 5%; margin-right: 5%">
-          <PlayerTimeline :show-labels="true" :color="sliderColor" />
+          <PlayerTimeline
+            :show-labels="true"
+            :color="sliderColor"
+            :waveform="waveformData"
+          />
         </div>
 
         <!-- main media control buttons (play, next, previous etc.)-->
@@ -735,6 +739,49 @@ watch(
     if (isOpen) {
       fetchLyrics();
     }
+  },
+);
+
+// Fetch the waveform for the current track (only when fullscreen player is
+// open); rendered by PlayerTimeline instead of the flat progress bar.
+const waveformData = ref<number[] | null>(null);
+let waveformLoadGeneration = 0;
+const fetchWaveform = async () => {
+  const generation = ++waveformLoadGeneration;
+  waveformData.value = null;
+
+  const mediaItem = store.curQueueItem?.media_item;
+  if (
+    !store.showFullscreenPlayer ||
+    mediaItem?.media_type !== MediaType.TRACK
+  ) {
+    return;
+  }
+
+  try {
+    const waveform = await api.getWaveForm(
+      mediaItem.item_id,
+      mediaItem.provider,
+    );
+    // a newer track change started while awaiting; this result is stale
+    if (generation !== waveformLoadGeneration) return;
+    waveformData.value = waveform?.length ? waveform : null;
+  } catch {
+    // No analysis available or server without audio_analysis support;
+    // PlayerTimeline falls back to the flat progress bar.
+    if (generation !== waveformLoadGeneration) return;
+    waveformData.value = null;
+  }
+};
+
+watch(() => store.curQueueItem?.media_item?.item_id, fetchWaveform, {
+  immediate: true,
+});
+
+watch(
+  () => store.showFullscreenPlayer,
+  (isOpen) => {
+    if (isOpen) fetchWaveform();
   },
 );
 

--- a/src/layouts/default/PlayerOSD/PlayerFullscreen.vue
+++ b/src/layouts/default/PlayerOSD/PlayerFullscreen.vue
@@ -1585,7 +1585,9 @@ watchEffect(() => {
   align-items: center;
   justify-content: center;
   max-width: 100%;
-  padding: 15px;
+  /* Side padding matches the 5% margins of the timeline/volume rows above
+     and below, so the outermost buttons align with the sliders. */
+  padding: 15px 5%;
   height: 100px;
 }
 

--- a/src/layouts/default/PlayerOSD/PlayerFullscreen.vue
+++ b/src/layouts/default/PlayerOSD/PlayerFullscreen.vue
@@ -469,6 +469,7 @@ import PlayerVolume from "@/layouts/default/PlayerOSD/PlayerVolume.vue";
 import QueueListItem from "@/layouts/default/PlayerOSD/QueueListItem.vue";
 import QueueModeBanner from "@/layouts/default/PlayerOSD/QueueModeBanner.vue";
 import { useFullscreenQueue } from "@/layouts/default/PlayerOSD/useFullscreenQueue";
+import { useUserPreferences } from "@/composables/userPreferences";
 import api from "@/plugins/api";
 import { getSourceName } from "@/plugins/api/helpers";
 import {
@@ -745,6 +746,10 @@ watch(
 // Fetch the waveform for the current track (only when fullscreen player is
 // open); rendered by PlayerTimeline instead of the flat progress bar.
 const waveformData = ref<number[] | null>(null);
+const showWaveformPref = useUserPreferences().getPreference(
+  "show_waveform",
+  true,
+);
 let waveformLoadGeneration = 0;
 const fetchWaveform = async () => {
   const generation = ++waveformLoadGeneration;
@@ -755,6 +760,7 @@ const fetchWaveform = async () => {
   // streaming), so resolve it from streamdetails - not the library item id.
   const streamDetails = store.curQueueItem?.streamdetails;
   if (
+    !showWaveformPref.value ||
     !store.showFullscreenPlayer ||
     mediaItem?.media_type !== MediaType.TRACK ||
     !streamDetails
@@ -788,6 +794,10 @@ watch(
   fetchWaveform,
   { immediate: true },
 );
+
+// Defensive: FrontendConfig reloads the app after saving user preferences,
+// but react to live preference changes anyway (e.g. multi-tab sync).
+watch(showWaveformPref, fetchWaveform);
 
 watch(
   () => store.showFullscreenPlayer,

--- a/src/layouts/default/PlayerOSD/PlayerFullscreen.vue
+++ b/src/layouts/default/PlayerOSD/PlayerFullscreen.vue
@@ -751,17 +751,21 @@ const fetchWaveform = async () => {
   waveformData.value = null;
 
   const mediaItem = store.curQueueItem?.media_item;
+  // Analysis data is keyed by the provider-native item id (the one used for
+  // streaming), so resolve it from streamdetails - not the library item id.
+  const streamDetails = store.curQueueItem?.streamdetails;
   if (
     !store.showFullscreenPlayer ||
-    mediaItem?.media_type !== MediaType.TRACK
+    mediaItem?.media_type !== MediaType.TRACK ||
+    !streamDetails
   ) {
     return;
   }
 
   try {
     const waveform = await api.getWaveForm(
-      mediaItem.item_id,
-      mediaItem.provider,
+      streamDetails.item_id,
+      streamDetails.provider,
     );
     // a newer track change started while awaiting; this result is stale
     if (generation !== waveformLoadGeneration) return;
@@ -774,9 +778,16 @@ const fetchWaveform = async () => {
   }
 };
 
-watch(() => store.curQueueItem?.media_item?.item_id, fetchWaveform, {
-  immediate: true,
-});
+// Streamdetails can arrive after the queue item switches, so key the watch on
+// the streamdetails item id (with the queue item id as fallback trigger).
+watch(
+  () => [
+    store.curQueueItem?.queue_item_id,
+    store.curQueueItem?.streamdetails?.item_id,
+  ],
+  fetchWaveform,
+  { immediate: true },
+);
 
 watch(
   () => store.showFullscreenPlayer,

--- a/src/layouts/default/PlayerOSD/PlayerTimeline.vue
+++ b/src/layouts/default/PlayerOSD/PlayerTimeline.vue
@@ -1,10 +1,11 @@
 <template>
-  <div class="w-auto h-6">
+  <div class="w-auto" :class="hasWaveform ? 'h-12' : 'h-6'">
     <div v-if="store.activePlayer">
       <SliderRoot
         v-model="wrappedCurTimeValue"
         data-slot="slider"
-        class="relative flex items-center select-none touch-none w-full h-8"
+        class="relative flex items-center select-none touch-none w-full"
+        :class="hasWaveform ? 'h-14' : 'h-8'"
         :disabled="!canSeek"
         :min="0"
         :max="store.activePlayer?.current_media?.duration ?? 0"
@@ -17,7 +18,7 @@
         <SliderTrack
           data-slot="slider-track"
           class="relative grow rounded-full"
-          :class="hasWaveform ? 'h-6' : 'h-1'"
+          :class="hasWaveform ? 'h-12' : 'h-1'"
           :style="
             hasWaveform
               ? undefined

--- a/src/layouts/default/PlayerOSD/PlayerTimeline.vue
+++ b/src/layouts/default/PlayerOSD/PlayerTimeline.vue
@@ -134,8 +134,7 @@ import WaveformTrack from "./WaveformTrack.vue";
 export interface Props {
   showLabels?: boolean;
   color?: string;
-  // Precomputed waveform bins (normalized 0.0-1.0); when set, the flat
-  // track is replaced by a waveform-style progress bar.
+  // Precomputed waveform bins (0.0-1.0); when set, replaces the flat track.
   waveform?: number[] | null;
 }
 

--- a/src/layouts/default/PlayerOSD/PlayerTimeline.vue
+++ b/src/layouts/default/PlayerOSD/PlayerTimeline.vue
@@ -16,12 +16,24 @@
         <!-- color-mix is the same logic as tailwind's bg-color/30 -->
         <SliderTrack
           data-slot="slider-track"
-          class="relative grow rounded-full h-1"
-          :style="{
-            'background-color': `color-mix(in oklab, ${color} 30%, transparent)`,
-          }"
+          class="relative grow rounded-full"
+          :class="hasWaveform ? 'h-6' : 'h-1'"
+          :style="
+            hasWaveform
+              ? undefined
+              : {
+                  'background-color': `color-mix(in oklab, ${color} 30%, transparent)`,
+                }
+          "
         >
+          <WaveformTrack
+            v-if="hasWaveform"
+            :data="waveform!"
+            :color="color"
+            :progress-percent="progressPercent"
+          />
           <SliderRange
+            v-else
             data-slot="slider-range"
             class="absolute rounded-full h-1 top-1/2 -translate-y-1/2"
             :style="{ 'background-color': color }"
@@ -105,16 +117,21 @@ import computeElapsedTime from "@/helpers/elapsed";
 import { computeChapterTicks } from "@/helpers/chapters";
 import { SliderRange, SliderRoot, SliderThumb, SliderTrack } from "reka-ui";
 import { cn } from "@/lib/utils";
+import WaveformTrack from "./WaveformTrack.vue";
 
 // properties
 export interface Props {
   showLabels?: boolean;
   color?: string;
+  // Precomputed waveform bins (normalized 0.0-1.0); when set, the flat
+  // track is replaced by a waveform-style progress bar.
+  waveform?: number[] | null;
 }
 
-withDefaults(defineProps<Props>(), {
+const props = withDefaults(defineProps<Props>(), {
   showLabels: false,
   color: "var(--foreground)",
+  waveform: null,
 });
 
 const { activeSource } = useActiveSource(toRef(store, "activePlayer"));
@@ -314,6 +331,14 @@ const chapterTicks = computed(() =>
     store.activePlayer?.current_media?.duration,
   ),
 );
+
+const hasWaveform = computed(() => !!props.waveform?.length);
+
+const progressPercent = computed(() => {
+  const duration = store.activePlayer?.current_media?.duration;
+  if (!duration) return 0;
+  return (curTimeValue.value / duration) * 100;
+});
 
 //watch
 watch(computedElapsedTime, (newTime) => {

--- a/src/layouts/default/PlayerOSD/PlayerTimeline.vue
+++ b/src/layouts/default/PlayerOSD/PlayerTimeline.vue
@@ -5,14 +5,21 @@
         v-model="wrappedCurTimeValue"
         data-slot="slider"
         class="relative flex items-center select-none touch-none w-full"
-        :class="hasWaveform ? 'h-11 md:h-12 lg:h-14' : 'h-8'"
+        :class="[
+          hasWaveform ? 'h-11 md:h-12 lg:h-14' : 'h-8',
+          hasWaveform && canSeek ? 'cursor-pointer' : '',
+        ]"
         :disabled="!canSeek"
         :min="0"
         :max="store.activePlayer?.current_media?.duration ?? 0"
         :step="0.1"
         @value-commit="stopDragging"
         @pointerenter="isThumbHidden = !canSeek"
-        @pointerleave="isThumbHidden = true"
+        @pointermove="onTrackPointerMove"
+        @pointerleave="
+          isThumbHidden = true;
+          hoverPercent = null;
+        "
       >
         <!-- color-mix is the same logic as tailwind's bg-color/30 -->
         <SliderTrack
@@ -32,6 +39,7 @@
             :data="waveform!"
             :color="color"
             :progress-percent="progressPercent"
+            :hover-percent="hoverPercent"
           />
           <SliderRange
             v-else
@@ -62,7 +70,9 @@
           :class="
             cn(
               'w-2.5 h-2.5 rounded-full shadow-sm',
-              !isThumbHidden || isDragging ? 'block' : 'hidden',
+              !hasWaveform && (!isThumbHidden || isDragging)
+                ? 'block'
+                : 'hidden',
             )
           "
         />
@@ -340,6 +350,16 @@ const progressPercent = computed(() => {
   if (!duration) return 0;
   return (curTimeValue.value / duration) * 100;
 });
+
+// Hover seek-preview position (waveform mode only), as 0-100 percent.
+const hoverPercent = ref<number | null>(null);
+
+const onTrackPointerMove = (evt: PointerEvent) => {
+  if (!hasWaveform.value || !canSeek.value) return;
+  const rect = (evt.currentTarget as HTMLElement).getBoundingClientRect();
+  if (!rect.width) return;
+  hoverPercent.value = ((evt.clientX - rect.left) / rect.width) * 100;
+};
 
 //watch
 watch(computedElapsedTime, (newTime) => {

--- a/src/layouts/default/PlayerOSD/PlayerTimeline.vue
+++ b/src/layouts/default/PlayerOSD/PlayerTimeline.vue
@@ -1,11 +1,11 @@
 <template>
-  <div class="w-auto" :class="hasWaveform ? 'h-12' : 'h-6'">
+  <div class="w-auto" :class="hasWaveform ? 'h-8 md:h-10 lg:h-12' : 'h-6'">
     <div v-if="store.activePlayer">
       <SliderRoot
         v-model="wrappedCurTimeValue"
         data-slot="slider"
         class="relative flex items-center select-none touch-none w-full"
-        :class="hasWaveform ? 'h-14' : 'h-8'"
+        :class="hasWaveform ? 'h-11 md:h-12 lg:h-14' : 'h-8'"
         :disabled="!canSeek"
         :min="0"
         :max="store.activePlayer?.current_media?.duration ?? 0"
@@ -18,7 +18,7 @@
         <SliderTrack
           data-slot="slider-track"
           class="relative grow rounded-full"
-          :class="hasWaveform ? 'h-12' : 'h-1'"
+          :class="hasWaveform ? 'h-8 md:h-10 lg:h-12' : 'h-1'"
           :style="
             hasWaveform
               ? undefined

--- a/src/layouts/default/PlayerOSD/WaveformTrack.vue
+++ b/src/layouts/default/PlayerOSD/WaveformTrack.vue
@@ -48,14 +48,12 @@ const clampedHover = computed(() =>
   Math.min(100, Math.max(0, props.hoverPercent ?? 0)),
 );
 
-// While hovering, the fill previews the seek target: it follows the cursor
-// in both directions instead of the playback position.
+// While hovering, the fill previews the seek target instead of the playback position.
 const brightClipEnd = computed(() =>
   props.hoverPercent == null ? clampedProgress.value : clampedHover.value,
 );
 
-// Max-pool the source bins into one peak per visible bar; max (not average)
-// preserves the visual transients that make the waveform recognizable.
+// Max-pool bins into one peak per bar; max (not average) preserves the transients.
 const computePeaks = (bins: number[], barCount: number): number[] => {
   const peaks = Array.from({ length: barCount }, () => 0);
   for (let i = 0; i < barCount; i++) {
@@ -136,8 +134,7 @@ const draw = () => {
   );
 };
 
-// Progress and hover are intentionally excluded: they only move canvas
-// clip-paths, so pointer movement and playback never trigger a redraw.
+// Progress/hover only move clip-paths, so playback and pointer movement never redraw.
 watch([width, height, () => props.data, () => props.color], draw, {
   flush: "post",
 });

--- a/src/layouts/default/PlayerOSD/WaveformTrack.vue
+++ b/src/layouts/default/PlayerOSD/WaveformTrack.vue
@@ -2,6 +2,12 @@
   <div ref="containerEl" class="waveform-track">
     <canvas ref="dimCanvasEl" class="waveform-canvas" />
     <canvas
+      v-show="hoverPercent != null"
+      ref="hoverCanvasEl"
+      class="waveform-canvas"
+      :style="{ clipPath: `inset(0 ${100 - clampedHover}% 0 0)` }"
+    />
+    <canvas
       ref="brightCanvasEl"
       class="waveform-canvas"
       :style="{ clipPath: `inset(0 ${100 - clampedProgress}% 0 0)` }"
@@ -19,9 +25,13 @@ export interface Props {
   color: string;
   // Played portion of the track, 0-100.
   progressPercent: number;
+  // Hovered seek-preview position, 0-100; null when not hovering.
+  hoverPercent?: number | null;
 }
 
-const props = defineProps<Props>();
+const props = withDefaults(defineProps<Props>(), {
+  hoverPercent: null,
+});
 
 // 2px bar + 1px gap
 const BAR_PITCH = 3;
@@ -29,15 +39,22 @@ const BAR_WIDTH = 2;
 // Keep silent sections visible as a thin baseline.
 const MIN_BAR_HEIGHT = 2;
 const DIM_ALPHA = 0.3;
+// Seek-preview fill; halfway between the unplayed and played bar opacity.
+const HOVER_ALPHA = 0.6;
 
 const containerEl = ref<HTMLDivElement>();
 const dimCanvasEl = ref<HTMLCanvasElement>();
+const hoverCanvasEl = ref<HTMLCanvasElement>();
 const brightCanvasEl = ref<HTMLCanvasElement>();
 
 const { width, height } = useElementSize(containerEl);
 
 const clampedProgress = computed(() =>
   Math.min(100, Math.max(0, props.progressPercent)),
+);
+
+const clampedHover = computed(() =>
+  Math.min(100, Math.max(0, props.hoverPercent ?? 0)),
 );
 
 // Max-pool the source bins into one peak per visible bar; max (not average)
@@ -90,6 +107,7 @@ const draw = () => {
   const cssHeight = height.value;
   if (
     !dimCanvasEl.value ||
+    !hoverCanvasEl.value ||
     !brightCanvasEl.value ||
     !props.data.length ||
     cssWidth <= 0 ||
@@ -102,11 +120,12 @@ const draw = () => {
   const peaks = computePeaks(props.data, barCount);
 
   drawBars(dimCanvasEl.value, peaks, cssWidth, cssHeight, dpr, DIM_ALPHA);
+  drawBars(hoverCanvasEl.value, peaks, cssWidth, cssHeight, dpr, HOVER_ALPHA);
   drawBars(brightCanvasEl.value, peaks, cssWidth, cssHeight, dpr, 1);
 };
 
-// Progress is intentionally excluded: it only moves the bright canvas'
-// clip-path, so playback never triggers a canvas redraw.
+// Progress and hover are intentionally excluded: they only move canvas
+// clip-paths, so pointer movement and playback never trigger a redraw.
 watch([width, height, () => props.data, () => props.color], draw, {
   flush: "post",
 });

--- a/src/layouts/default/PlayerOSD/WaveformTrack.vue
+++ b/src/layouts/default/PlayerOSD/WaveformTrack.vue
@@ -5,12 +5,12 @@
       v-show="hoverPercent != null"
       ref="hoverCanvasEl"
       class="waveform-canvas"
-      :style="{ clipPath: `inset(0 ${100 - clampedHover}% 0 0)` }"
+      :style="{ clipPath: `inset(0 ${100 - hoverClipEnd}% 0 0)` }"
     />
     <canvas
       ref="brightCanvasEl"
       class="waveform-canvas"
-      :style="{ clipPath: `inset(0 ${100 - clampedProgress}% 0 0)` }"
+      :style="{ clipPath: `inset(0 ${100 - brightClipEnd}% 0 0)` }"
     />
   </div>
 </template>
@@ -39,8 +39,6 @@ const BAR_WIDTH = 2;
 // Keep silent sections visible as a thin baseline.
 const MIN_BAR_HEIGHT = 2;
 const DIM_ALPHA = 0.3;
-// Seek-preview fill; halfway between the unplayed and played bar opacity.
-const HOVER_ALPHA = 0.6;
 
 const containerEl = ref<HTMLDivElement>();
 const dimCanvasEl = ref<HTMLCanvasElement>();
@@ -55,6 +53,22 @@ const clampedProgress = computed(() =>
 
 const clampedHover = computed(() =>
   Math.min(100, Math.max(0, props.hoverPercent ?? 0)),
+);
+
+// The bright (played) layer ends at the hover point when hovering before the
+// current position, so the would-be rewound stretch shows the preview color
+// instead of the played color.
+const brightClipEnd = computed(() =>
+  props.hoverPercent == null
+    ? clampedProgress.value
+    : Math.min(clampedProgress.value, clampedHover.value),
+);
+
+// The preview layer covers up to whichever of hover/progress is furthest; the
+// bright layer on top then leaves exactly the hover<->progress stretch in the
+// preview color.
+const hoverClipEnd = computed(() =>
+  Math.max(clampedHover.value, clampedProgress.value),
 );
 
 // Max-pool the source bins into one peak per visible bar; max (not average)
@@ -82,6 +96,7 @@ const drawBars = (
   cssWidth: number,
   cssHeight: number,
   dpr: number,
+  color: string,
   alpha: number,
 ) => {
   canvas.width = Math.round(cssWidth * dpr);
@@ -90,7 +105,7 @@ const drawBars = (
   if (!ctx) return;
   ctx.scale(dpr, dpr);
   ctx.clearRect(0, 0, cssWidth, cssHeight);
-  ctx.fillStyle = props.color;
+  ctx.fillStyle = color;
   ctx.globalAlpha = alpha;
   for (let i = 0; i < peaks.length; i++) {
     const barHeight = Math.max(MIN_BAR_HEIGHT, peaks[i] * cssHeight);
@@ -119,9 +134,32 @@ const draw = () => {
   const barCount = Math.ceil(cssWidth / BAR_PITCH);
   const peaks = computePeaks(props.data, barCount);
 
-  drawBars(dimCanvasEl.value, peaks, cssWidth, cssHeight, dpr, DIM_ALPHA);
-  drawBars(hoverCanvasEl.value, peaks, cssWidth, cssHeight, dpr, HOVER_ALPHA);
-  drawBars(brightCanvasEl.value, peaks, cssWidth, cssHeight, dpr, 1);
+  // Seek-preview fill uses the MA brand blue (--primary); canvas fillStyle
+  // cannot resolve CSS vars, so resolve it here.
+  const hoverColor =
+    getComputedStyle(document.documentElement)
+      .getPropertyValue("--primary")
+      .trim() || props.color;
+
+  drawBars(
+    dimCanvasEl.value,
+    peaks,
+    cssWidth,
+    cssHeight,
+    dpr,
+    props.color,
+    DIM_ALPHA,
+  );
+  drawBars(hoverCanvasEl.value, peaks, cssWidth, cssHeight, dpr, hoverColor, 1);
+  drawBars(
+    brightCanvasEl.value,
+    peaks,
+    cssWidth,
+    cssHeight,
+    dpr,
+    props.color,
+    1,
+  );
 };
 
 // Progress and hover are intentionally excluded: they only move canvas

--- a/src/layouts/default/PlayerOSD/WaveformTrack.vue
+++ b/src/layouts/default/PlayerOSD/WaveformTrack.vue
@@ -1,0 +1,128 @@
+<template>
+  <div ref="containerEl" class="waveform-track">
+    <canvas ref="dimCanvasEl" class="waveform-canvas" />
+    <canvas
+      ref="brightCanvasEl"
+      class="waveform-canvas"
+      :style="{ clipPath: `inset(0 ${100 - clampedProgress}% 0 0)` }"
+    />
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, ref, watch } from "vue";
+import { useElementSize } from "@vueuse/core";
+
+export interface Props {
+  // Normalized (0.0-1.0) RMS energy bins covering the full track duration.
+  data: number[];
+  color: string;
+  // Played portion of the track, 0-100.
+  progressPercent: number;
+}
+
+const props = defineProps<Props>();
+
+// 2px bar + 1px gap
+const BAR_PITCH = 3;
+const BAR_WIDTH = 2;
+// Keep silent sections visible as a thin baseline.
+const MIN_BAR_HEIGHT = 2;
+const DIM_ALPHA = 0.3;
+
+const containerEl = ref<HTMLDivElement>();
+const dimCanvasEl = ref<HTMLCanvasElement>();
+const brightCanvasEl = ref<HTMLCanvasElement>();
+
+const { width, height } = useElementSize(containerEl);
+
+const clampedProgress = computed(() =>
+  Math.min(100, Math.max(0, props.progressPercent)),
+);
+
+// Max-pool the source bins into one peak per visible bar; max (not average)
+// preserves the visual transients that make the waveform recognizable.
+const computePeaks = (bins: number[], barCount: number): number[] => {
+  const peaks = Array.from({ length: barCount }, () => 0);
+  for (let i = 0; i < barCount; i++) {
+    const start = Math.floor((i * bins.length) / barCount);
+    const end = Math.max(
+      start + 1,
+      Math.floor(((i + 1) * bins.length) / barCount),
+    );
+    let max = 0;
+    for (let j = start; j < end; j++) {
+      if (bins[j] > max) max = bins[j];
+    }
+    peaks[i] = max;
+  }
+  return peaks;
+};
+
+const drawBars = (
+  canvas: HTMLCanvasElement,
+  peaks: number[],
+  cssWidth: number,
+  cssHeight: number,
+  dpr: number,
+  alpha: number,
+) => {
+  canvas.width = Math.round(cssWidth * dpr);
+  canvas.height = Math.round(cssHeight * dpr);
+  const ctx = canvas.getContext("2d");
+  if (!ctx) return;
+  ctx.scale(dpr, dpr);
+  ctx.clearRect(0, 0, cssWidth, cssHeight);
+  ctx.fillStyle = props.color;
+  ctx.globalAlpha = alpha;
+  for (let i = 0; i < peaks.length; i++) {
+    const barHeight = Math.max(MIN_BAR_HEIGHT, peaks[i] * cssHeight);
+    const x = i * BAR_PITCH;
+    const y = (cssHeight - barHeight) / 2;
+    ctx.beginPath();
+    ctx.roundRect(x, y, BAR_WIDTH, barHeight, BAR_WIDTH / 2);
+    ctx.fill();
+  }
+};
+
+const draw = () => {
+  const cssWidth = width.value;
+  const cssHeight = height.value;
+  if (
+    !dimCanvasEl.value ||
+    !brightCanvasEl.value ||
+    !props.data.length ||
+    cssWidth <= 0 ||
+    cssHeight <= 0
+  )
+    return;
+
+  const dpr = window.devicePixelRatio || 1;
+  const barCount = Math.ceil(cssWidth / BAR_PITCH);
+  const peaks = computePeaks(props.data, barCount);
+
+  drawBars(dimCanvasEl.value, peaks, cssWidth, cssHeight, dpr, DIM_ALPHA);
+  drawBars(brightCanvasEl.value, peaks, cssWidth, cssHeight, dpr, 1);
+};
+
+// Progress is intentionally excluded: it only moves the bright canvas'
+// clip-path, so playback never triggers a canvas redraw.
+watch([width, height, () => props.data, () => props.color], draw, {
+  flush: "post",
+});
+</script>
+
+<style scoped>
+.waveform-track {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
+}
+.waveform-canvas {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+}
+</style>

--- a/src/layouts/default/PlayerOSD/WaveformTrack.vue
+++ b/src/layouts/default/PlayerOSD/WaveformTrack.vue
@@ -2,12 +2,6 @@
   <div ref="containerEl" class="waveform-track">
     <canvas ref="dimCanvasEl" class="waveform-canvas" />
     <canvas
-      v-show="hoverPercent != null"
-      ref="hoverCanvasEl"
-      class="waveform-canvas"
-      :style="{ clipPath: `inset(0 ${100 - hoverClipEnd}% 0 0)` }"
-    />
-    <canvas
       ref="brightCanvasEl"
       class="waveform-canvas"
       :style="{ clipPath: `inset(0 ${100 - brightClipEnd}% 0 0)` }"
@@ -42,7 +36,6 @@ const DIM_ALPHA = 0.3;
 
 const containerEl = ref<HTMLDivElement>();
 const dimCanvasEl = ref<HTMLCanvasElement>();
-const hoverCanvasEl = ref<HTMLCanvasElement>();
 const brightCanvasEl = ref<HTMLCanvasElement>();
 
 const { width, height } = useElementSize(containerEl);
@@ -55,20 +48,10 @@ const clampedHover = computed(() =>
   Math.min(100, Math.max(0, props.hoverPercent ?? 0)),
 );
 
-// The bright (played) layer ends at the hover point when hovering before the
-// current position, so the would-be rewound stretch shows the preview color
-// instead of the played color.
+// While hovering, the fill previews the seek target: it follows the cursor
+// in both directions instead of the playback position.
 const brightClipEnd = computed(() =>
-  props.hoverPercent == null
-    ? clampedProgress.value
-    : Math.min(clampedProgress.value, clampedHover.value),
-);
-
-// The preview layer covers up to whichever of hover/progress is furthest; the
-// bright layer on top then leaves exactly the hover<->progress stretch in the
-// preview color.
-const hoverClipEnd = computed(() =>
-  Math.max(clampedHover.value, clampedProgress.value),
+  props.hoverPercent == null ? clampedProgress.value : clampedHover.value,
 );
 
 // Max-pool the source bins into one peak per visible bar; max (not average)
@@ -122,7 +105,6 @@ const draw = () => {
   const cssHeight = height.value;
   if (
     !dimCanvasEl.value ||
-    !hoverCanvasEl.value ||
     !brightCanvasEl.value ||
     !props.data.length ||
     cssWidth <= 0 ||
@@ -134,13 +116,6 @@ const draw = () => {
   const barCount = Math.ceil(cssWidth / BAR_PITCH);
   const peaks = computePeaks(props.data, barCount);
 
-  // Seek-preview fill uses the MA brand blue (--primary); canvas fillStyle
-  // cannot resolve CSS vars, so resolve it here.
-  const hoverColor =
-    getComputedStyle(document.documentElement)
-      .getPropertyValue("--primary")
-      .trim() || props.color;
-
   drawBars(
     dimCanvasEl.value,
     peaks,
@@ -150,7 +125,6 @@ const draw = () => {
     props.color,
     DIM_ALPHA,
   );
-  drawBars(hoverCanvasEl.value, peaks, cssWidth, cssHeight, dpr, hoverColor, 1);
   drawBars(
     brightCanvasEl.value,
     peaks,

--- a/src/layouts/default/PlayerOSD/WaveformTrack.vue
+++ b/src/layouts/default/PlayerOSD/WaveformTrack.vue
@@ -93,7 +93,11 @@ const drawBars = (
     const x = i * BAR_PITCH;
     const y = (cssHeight - barHeight) / 2;
     ctx.beginPath();
-    ctx.roundRect(x, y, BAR_WIDTH, barHeight, BAR_WIDTH / 2);
+    if (typeof (ctx as CanvasRenderingContext2D).roundRect === "function") {
+      ctx.roundRect(x, y, BAR_WIDTH, barHeight, BAR_WIDTH / 2);
+    } else {
+      ctx.rect(x, y, BAR_WIDTH, barHeight);
+    }
     ctx.fill();
   }
 };

--- a/src/layouts/default/PlayerOSD/WaveformTrack.vue
+++ b/src/layouts/default/PlayerOSD/WaveformTrack.vue
@@ -116,13 +116,6 @@ const draw = () => {
   const barCount = Math.ceil(cssWidth / BAR_PITCH);
   const peaks = computePeaks(props.data, barCount);
 
-  // The active fill uses the MA brand blue (--primary); canvas fillStyle
-  // cannot resolve CSS vars, so resolve it here.
-  const activeColor =
-    getComputedStyle(document.documentElement)
-      .getPropertyValue("--primary")
-      .trim() || props.color;
-
   drawBars(
     dimCanvasEl.value,
     peaks,
@@ -138,7 +131,7 @@ const draw = () => {
     cssWidth,
     cssHeight,
     dpr,
-    activeColor,
+    props.color,
     1,
   );
 };

--- a/src/layouts/default/PlayerOSD/WaveformTrack.vue
+++ b/src/layouts/default/PlayerOSD/WaveformTrack.vue
@@ -116,6 +116,13 @@ const draw = () => {
   const barCount = Math.ceil(cssWidth / BAR_PITCH);
   const peaks = computePeaks(props.data, barCount);
 
+  // The active fill uses the MA brand blue (--primary); canvas fillStyle
+  // cannot resolve CSS vars, so resolve it here.
+  const activeColor =
+    getComputedStyle(document.documentElement)
+      .getPropertyValue("--primary")
+      .trim() || props.color;
+
   drawBars(
     dimCanvasEl.value,
     peaks,
@@ -131,7 +138,7 @@ const draw = () => {
     cssWidth,
     cssHeight,
     dpr,
-    props.color,
+    activeColor,
     1,
   );
 };

--- a/src/plugins/api/index.ts
+++ b/src/plugins/api/index.ts
@@ -1305,6 +1305,17 @@ export class MusicAssistantApi {
     });
   }
 
+  public getWaveForm(
+    item_id: string,
+    provider_instance_id_or_domain: string,
+  ): Promise<number[] | null> {
+    // Get the waveform (RMS energy bins, normalized 0.0-1.0) for a track.
+    return this.sendCommand("audio_analysis/wave_form", {
+      item_id,
+      provider_instance_id_or_domain,
+    });
+  }
+
   public getItem(
     media_type: MediaType,
     item_id: string,

--- a/src/plugins/api/index.ts
+++ b/src/plugins/api/index.ts
@@ -1309,7 +1309,7 @@ export class MusicAssistantApi {
     item_id: string,
     provider_instance_id_or_domain: string,
   ): Promise<number[] | null> {
-    // Get the waveform (RMS energy bins, normalized 0.0-1.0) for a track.
+    // Returns RMS energy bins normalized 0.0-1.0, or null when no analysis exists.
     return this.sendCommand("audio_analysis/wave_form", {
       item_id,
       provider_instance_id_or_domain,

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -303,6 +303,10 @@
             "label": "Force mobile layout",
             "description": "Force the mobile layout (with the menu-navigation at the bottom), even on larger screens."
         },
+        "show_waveform": {
+            "label": "Show waveform",
+            "description": "Show a waveform-style progress bar in the fullscreen player when audio analysis data is available for the playing track."
+        },
         "providers_description": "Manage your music sources, player providers and plugins",
         "players_description": "Configure and manage your audio output devices",
         "frontend_description": "Customize the user interface theme and appearance",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -304,7 +304,7 @@
             "description": "Force the mobile layout (with the menu-navigation at the bottom), even on larger screens."
         },
         "show_waveform": {
-            "label": "Show waveform",
+            "label": "Show waveform as progressbar",
             "description": "Show a waveform-style progress bar in the fullscreen player when audio analysis data is available for the playing track."
         },
         "providers_description": "Manage your music sources, player providers and plugins",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -304,7 +304,7 @@
             "description": "Force the mobile layout (with the menu-navigation at the bottom), even on larger screens."
         },
         "show_waveform": {
-            "label": "Show waveform as progressbar",
+            "label": "Show waveform as progress bar",
             "description": "Show a waveform-style progress bar in the fullscreen player when audio analysis data is available for the playing track."
         },
         "providers_description": "Manage your music sources, player providers and plugins",

--- a/src/views/settings/FrontendConfig.vue
+++ b/src/views/settings/FrontendConfig.vue
@@ -168,6 +168,16 @@ onMounted(() => {
         "true",
     },
     {
+      key: "show_waveform",
+      type: ConfigEntryType.BOOLEAN,
+      label: "show_waveform",
+      default_value: true,
+      required: false,
+      multi_value: false,
+      category: "display_settings",
+      value: (store.currentUser?.preferences?.show_waveform as boolean) ?? true,
+    },
+    {
       key: "mobile_sidebar_side",
       type: ConfigEntryType.STRING,
       label: "mobile_sidebar_side",


### PR DESCRIPTION
The server now exposes precomputed track waveforms via the `audio_analysis/wave_form` API command (music-assistant/server#4626): 1800 normalized RMS energy bins covering the track duration. This renders that data as a SoundCloud-style waveform progress bar in the fullscreen now-playing view, giving a visual preview of the track's dynamics with the played portion highlighted.

- Add `api.getWaveForm()` wrapper for the `audio_analysis/wave_form` command
- New `WaveformTrack.vue`: two stacked canvases (dim + bright bars); the played portion is revealed via `clip-path: inset()`, so playback never triggers a canvas redraw
- Downsample the 1800 bins to one bar per 3px via max-pooling, re-rendered on resize at device pixel ratio
- Waveform height scales per breakpoint (32/40/48px) while the seek hit area stays ≥44px for touch
- `PlayerTimeline.vue` accepts an optional `waveform` prop that swaps the flat track for the waveform; seek/drag/keyboard interaction is unchanged (same reka-ui slider) and theming follows the existing artwork-derived slider color
- `PlayerFullscreen.vue` fetches the waveform (keyed by the streamdetails provider item id) on track change and falls back to the flat progress bar when no data is available; the footer/homescreen progress bar is untouched
- New per-user "Show waveform" setting (default on) under frontend display settings to opt back into the flat timeline