### PR TITLE
Show diagnostics download button on server 2.9.6+

### DIFF
--- a/src/views/settings/Diagnostics.vue
+++ b/src/views/settings/Diagnostics.vue
@@ -94,7 +94,7 @@ const logContainer = ref<HTMLDivElement | null>(null);
 const maxLines = 150;
 let refreshInterval: ReturnType<typeof setInterval> | null = null;
 
-const diagnosticsSupported = computed(() => requireServerVersion("2.10.0"));
+const diagnosticsSupported = computed(() => requireServerVersion("2.9.6"));
 
 const displayContent = computed(() => {
   const lines = logContent.value.split("\n");


### PR DESCRIPTION
The diagnostics report feature is being backported to the stable 2.9.6 release, but the frontend only showed the "Download diagnostics" button on 2.10.0+ servers.

- Lower the version gate so the button also appears for 2.9.6+ stable users once the backport lands