### PR TITLE
Add issue chooser redirecting to the support repo

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,14 @@
+blank_issues_enabled: false
+contact_links:
+  - name: "\U0001F41B Report a bug"
+    url: https://github.com/music-assistant/support/issues/new/choose
+    about: All Music Assistant bug reports (including frontend/UI bugs) are tracked in our central support repository.
+  - name: "\U0001F4AC Discord community & support"
+    url: https://discord.gg/kaVm8hGpne
+    about: Chat with the community and get help from other users.
+  - name: "❓ Questions & how-to (Q&A)"
+    url: https://github.com/music-assistant/support/discussions/categories/q-a
+    about: Ask how-to questions and search previous answers.
+  - name: "\U0001F4A1 Feature requests & ideas"
+    url: https://github.com/music-assistant/support/discussions/categories/feature-requests-and-ideas
+    about: Suggest and vote on new features and enhancements.


### PR DESCRIPTION
This repo is re-enabling Issues purely as a signpost. Instead of hosting issue forms here, the "New issue" button now shows a chooser that redirects people to the right place.
