### PR TITLE
Show the Music Quiz item in the menu and surface newly added menu items

### DIFF
--- a/src/components/navigation/utils/getMenuItems.ts
+++ b/src/components/navigation/utils/getMenuItems.ts
@@ -1,6 +1,10 @@
 import ArtistIcon from "@/components/icons/ArtistIcon.vue";
 import GenreIcon from "@/components/icons/GenreIcon.vue";
-import { DEFAULT_MENU_ITEMS } from "@/constants";
+import {
+  DEFAULT_MENU_ITEMS,
+  MENU_ITEMS_SEEN_PREFERENCE_KEY,
+  PLUGIN_MENU_ITEMS,
+} from "@/constants";
 import { store } from "@/plugins/store";
 import {
   BookAudio,
@@ -29,20 +33,54 @@ export interface MenuItem {
   disabled?: boolean;
 }
 
+const MENU_ITEMS_STORAGE_KEY = "frontend.settings.menu_items";
+const MENU_ITEMS_SEEN_STORAGE_KEY = "frontend.settings.menu_items_seen";
+const pluginMenuItems = new Set(PLUGIN_MENU_ITEMS);
+
+function parseMenuItemsPreference(value?: string | string[]): string[] {
+  if (!value) return [];
+  return Array.isArray(value) ? value : value.split(",");
+}
+
+function getSeenMenuItems(enabledItems: string[]): Set<string> {
+  const userSeenMenuItems = parseMenuItemsPreference(
+    store.currentUser?.preferences?.[MENU_ITEMS_SEEN_PREFERENCE_KEY] as
+      | string
+      | string[]
+      | undefined,
+  );
+  if (userSeenMenuItems.length > 0) {
+    return new Set(userSeenMenuItems);
+  }
+
+  const storedSeenMenuItems = parseMenuItemsPreference(
+    localStorage.getItem(MENU_ITEMS_SEEN_STORAGE_KEY) ?? undefined,
+  );
+  if (storedSeenMenuItems.length > 0) {
+    return new Set(storedSeenMenuItems);
+  }
+
+  const seededSeenItems = new Set(enabledItems);
+  for (const menuItem of DEFAULT_MENU_ITEMS) {
+    if (!pluginMenuItems.has(menuItem)) {
+      seededSeenItems.add(menuItem);
+    }
+  }
+  return seededSeenItems;
+}
+
 export const getMenuItems = function () {
   // TODO: Remove localStorage fallback once migration period is over (menu_items moved to user preferences)
   const userMenuItems = store.currentUser?.preferences?.menu_items as
     | string
     | string[]
     | undefined;
-  const storedMenuConf = localStorage.getItem("frontend.settings.menu_items");
+  const storedMenuConf = localStorage.getItem(MENU_ITEMS_STORAGE_KEY);
 
   let enabledItems: string[];
-  if (userMenuItems) {
+  if (userMenuItems !== undefined) {
     // If user preferences has menu_items, use it (it could be array or comma-separated string)
-    enabledItems = Array.isArray(userMenuItems)
-      ? userMenuItems
-      : userMenuItems.split(",");
+    enabledItems = parseMenuItemsPreference(userMenuItems);
   } else if (storedMenuConf) {
     // Fallback to localStorage during migration
     enabledItems = storedMenuConf.split(",");
@@ -50,12 +88,17 @@ export const getMenuItems = function () {
     // Final fallback to defaults
     enabledItems = DEFAULT_MENU_ITEMS;
   }
+
+  const enabledItemsSet = new Set(enabledItems);
+  const seenMenuItems = getSeenMenuItems(enabledItems);
   const items: MenuItem[] = [];
-  // we loop through DEFAULT_MENU_ITEMS to respect default order;
-  // new items added to DEFAULT_MENU_ITEMS automatically appear unless explicitly disabled
+
+  // Loop through defaults to keep menu order stable.
   for (const enabledMenuItemStr of DEFAULT_MENU_ITEMS) {
-    // Check if item is enabled (user preferences or localStorage migration fallback)
-    if (!enabledItems.includes(enabledMenuItemStr)) continue;
+    const explicitlyEnabled = enabledItemsSet.has(enabledMenuItemStr);
+    const isNewDefaultItem = !seenMenuItems.has(enabledMenuItemStr);
+    if (!explicitlyEnabled && !isNewDefaultItem) continue;
+
     if (enabledMenuItemStr === "discover") {
       items.push({
         label: "discover",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -15,6 +15,9 @@ export const DEFAULT_MENU_ITEMS = [
   "settings",
 ];
 
+export const PLUGIN_MENU_ITEMS = ["party", "music_quiz"];
+export const MENU_ITEMS_SEEN_PREFERENCE_KEY = "menu_items_seen";
+
 export const SYNCGROUP_PREFIX = "syncgroup_";
 
 // Frontend setting keys that are persisted per-device in localStorage.

--- a/src/views/settings/FrontendConfig.vue
+++ b/src/views/settings/FrontendConfig.vue
@@ -51,7 +51,11 @@ import {
 } from "@/components/ui/card";
 import { Spinner } from "@/components/ui/spinner";
 import { useUserPreferences } from "@/composables/userPreferences";
-import { DEFAULT_MENU_ITEMS, DEVICE_SETTING_KEYS } from "@/constants";
+import {
+  DEFAULT_MENU_ITEMS,
+  DEVICE_SETTING_KEYS,
+  MENU_ITEMS_SEEN_PREFERENCE_KEY,
+} from "@/constants";
 import {
   ConfigEntry,
   ConfigEntryType,
@@ -124,6 +128,9 @@ onMounted(() => {
         { title: $t("search"), value: "search" },
         ...(store.enabledPlugins.has("party")
           ? [{ title: $t("party_mode"), value: "party" }]
+          : []),
+        ...(store.enabledPlugins.has("music_quiz")
+          ? [{ title: $t("music_quiz.title"), value: "music_quiz" }]
           : []),
         { title: $t("artists"), value: "artists" },
         { title: $t("albums"), value: "albums" },
@@ -260,6 +267,12 @@ const saveValues = async function (values: Record<string, ConfigValueType>) {
       } else {
         // Save to backend via user preferences
         await setPreference(key, values[key]);
+        if (key === "menu_items") {
+          await setPreference(
+            MENU_ITEMS_SEEN_PREFERENCE_KEY,
+            DEFAULT_MENU_ITEMS,
+          );
+        }
         hasPerUserChanges = true;
       }
     }

--- a/tests/components/navigation/getMenuItems.test.ts
+++ b/tests/components/navigation/getMenuItems.test.ts
@@ -1,0 +1,93 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { DEFAULT_MENU_ITEMS } from "@/constants";
+
+const { storeMock } = vi.hoisted(() => ({
+  storeMock: {
+    currentUser: null as { preferences?: Record<string, unknown> } | null,
+    enabledPlugins: new Set<string>(),
+    libraryAudiobooksCount: 1,
+    libraryPodcastsCount: 1,
+  },
+}));
+
+vi.mock("@/plugins/store", () => ({
+  store: storeMock,
+}));
+
+const localStorageMock = (() => {
+  const values = new Map<string, string>();
+  return {
+    getItem(key: string) {
+      return values.get(key) ?? null;
+    },
+    setItem(key: string, value: string) {
+      values.set(key, value);
+    },
+    removeItem(key: string) {
+      values.delete(key);
+    },
+    clear() {
+      values.clear();
+    },
+    key(index: number) {
+      return Array.from(values.keys())[index] ?? null;
+    },
+    get length() {
+      return values.size;
+    },
+  } satisfies Storage;
+})();
+
+vi.stubGlobal("localStorage", localStorageMock);
+
+import { getMenuItems } from "@/components/navigation/utils/getMenuItems";
+
+function getPaths() {
+  return getMenuItems()
+    .filter((item) => !item.hidden)
+    .map((item) => item.path);
+}
+
+describe("getMenuItems", () => {
+  beforeEach(() => {
+    localStorageMock.clear();
+    storeMock.enabledPlugins = new Set<string>();
+    storeMock.libraryAudiobooksCount = 1;
+    storeMock.libraryPodcastsCount = 1;
+    storeMock.currentUser = { preferences: {} };
+  });
+
+  it("shows music quiz for legacy users when the plugin is enabled", () => {
+    storeMock.enabledPlugins = new Set(["music_quiz"]);
+    storeMock.currentUser = {
+      preferences: {
+        menu_items: DEFAULT_MENU_ITEMS.filter((item) => item !== "music_quiz"),
+      },
+    };
+
+    expect(getPaths()).toContain("/music-quiz");
+  });
+
+  it("keeps legacy non-plugin removals hidden", () => {
+    storeMock.enabledPlugins = new Set(["music_quiz"]);
+    storeMock.currentUser = {
+      preferences: {
+        menu_items: DEFAULT_MENU_ITEMS.filter((item) => item !== "browse"),
+      },
+    };
+
+    expect(getPaths()).not.toContain("/browse");
+  });
+
+  it("respects explicit removals once defaults are marked as seen", () => {
+    storeMock.enabledPlugins = new Set(["music_quiz"]);
+    storeMock.currentUser = {
+      preferences: {
+        menu_items: DEFAULT_MENU_ITEMS.filter((item) => item !== "music_quiz"),
+        menu_items_seen: DEFAULT_MENU_ITEMS,
+      },
+    };
+
+    expect(getPaths()).not.toContain("/music-quiz");
+  });
+});


### PR DESCRIPTION
## Problem
Existing users with saved menu preferences never saw newly added default menu items, and Music Quiz was missing from the Frontend settings menu options.

## Changes
- add a plugin-gated `music_quiz` option in Frontend settings menu-item options (right after Party)
- add a `menu_items_seen` preference flow so new default menu items can appear without resetting user settings
- preserve legacy removals for non-plugin defaults while still surfacing plugin-backed defaults (`party`, `music_quiz`)
- add `getMenuItems` tests for new-item surfacing and removal-respected behavior

## Legacy behavior note
For users without a `menu_items_seen` marker, plugin-backed default items may reappear once when their plugin is enabled; this is the tradeoff that lets us surface newly added plugin menu entries without re-enabling removed non-plugin defaults.