### PR TITLE
Fix Music Quiz menu item icon and label

### DIFF
--- a/src/components/navigation/utils/getMenuItems.ts
+++ b/src/components/navigation/utils/getMenuItems.ts
@@ -1,5 +1,6 @@
 import ArtistIcon from "@/components/icons/ArtistIcon.vue";
 import GenreIcon from "@/components/icons/GenreIcon.vue";
+import MusicQuizIcon from "@/components/icons/MusicQuizIcon.vue";
 import {
   DEFAULT_MENU_ITEMS,
   MENU_ITEMS_SEEN_PREFERENCE_KEY,
@@ -138,8 +139,8 @@ export const getMenuItems = function () {
     }
     if (enabledMenuItemStr === "music_quiz") {
       items.push({
-        label: "music_quiz.title",
-        icon: () => import("@/components/icons/MusicQuizIcon.vue"),
+        label: "providers.music_quiz.title",
+        icon: MusicQuizIcon,
         path: "/music-quiz",
         isLibraryNode: false,
         hidden: !store.enabledPlugins.has("music_quiz"),


### PR DESCRIPTION
The Music Quiz sidebar item rendered as `[object Promise]` with an untranslated `music_quiz.title` label.

- Import `MusicQuizIcon` as a component instead of a dynamic-import function so the icon renders
- Use the correct translation key `providers.music_quiz.title` for the label