### PR TITLE
Fix guest listen-in audio on iOS and refine the listen-in UI

### DIFF
--- a/src/components/SendspinPlayer.vue
+++ b/src/components/SendspinPlayer.vue
@@ -18,7 +18,11 @@ import api from "@/plugins/api";
 import authManager from "@/plugins/auth";
 import { PlaybackState } from "@/plugins/api/interfaces";
 import { store } from "@/plugins/store";
-import { webPlayer } from "@/plugins/web_player";
+import {
+  webPlayer,
+  registerWebPlayerAudioUnlock,
+  clearWebPlayerAudioUnlock,
+} from "@/plugins/web_player";
 import {
   prepareSendspinSession,
   isDirectConnection,
@@ -47,6 +51,31 @@ const isMobileOutput = isAndroid || isIOS;
 
 // Sendspin Player instance
 let player: SendspinPlayer | null = null;
+
+// Internal sendspin-js scheduler hooks used to unlock audio within a user
+// gesture; the pinned 3.2.0 release exposes no public equivalent.
+interface SendspinAudioUnlock {
+  initAudioContext?: () => void;
+  resumeAudioContext?: () => void | Promise<void>;
+}
+
+// iOS only lets audio start inside a user gesture, but listen-in audio starts
+// asynchronously (after the server groups this player), so the library would
+// create and resume its AudioContext outside the gesture and stay silent.
+// Create and resume that context now, while the gesture is still active, so the
+// stream plays reliably once it arrives.
+const primeAudio = () => {
+  if (!isIOS) return;
+  try {
+    const scheduler = (
+      player as unknown as { scheduler?: SendspinAudioUnlock } | null
+    )?.scheduler;
+    scheduler?.initAudioContext?.();
+    void scheduler?.resumeAudioContext?.();
+  } catch (error) {
+    console.debug("Sendspin: failed to prime audio for listen-in", error);
+  }
+};
 
 // Reactive state
 const isPlaying = ref(false);
@@ -211,6 +240,8 @@ watch(correctionMode, (mode) => {
 // Setup on mount
 onMounted(() => {
   console.debug("Sendspin: Component mounted, connecting...");
+
+  registerWebPlayerAudioUnlock(primeAudio);
 
   // If already showing active player metadata, play silent audio now that silentAudioRef exists
   if (
@@ -393,6 +424,7 @@ onMounted(() => {
 
 // Cleanup on unmount
 onBeforeUnmount(() => {
+  clearWebPlayerAudioUnlock(primeAudio);
   if (player) {
     player.disconnect();
     player = null;

--- a/src/components/party/PartyListenIn.vue
+++ b/src/components/party/PartyListenIn.vue
@@ -4,33 +4,38 @@
     class="listen-in"
     :class="{ 'listen-in--active': isListeningIn }"
   >
-    <Headphones :size="20" class="listen-in__icon" />
-    <div class="listen-in__text">
-      <span class="listen-in__title">{{ title }}</span>
-      <span class="listen-in__desc">{{ description }}</span>
+    <div class="listen-in__row">
+      <Headphones :size="20" class="listen-in__icon" />
+      <div class="listen-in__text">
+        <span class="listen-in__title">{{ title }}</span>
+        <span class="listen-in__desc">{{ description }}</span>
+      </div>
+      <Button
+        v-if="mode === 'remote'"
+        :variant="isListeningIn ? 'secondary' : 'default'"
+        size="sm"
+        :disabled="busy"
+        class="listen-in__action"
+        @click="isListeningIn ? disableListenIn() : enableListenIn()"
+      >
+        {{
+          isListeningIn
+            ? $t("providers.party.guest_page.listen_in_stop")
+            : $t("providers.party.guest_page.listen_in_tap")
+        }}
+      </Button>
+      <Switch
+        v-else
+        :model-value="isListeningIn"
+        :disabled="busy"
+        :aria-label="title"
+        class="listen-in__action"
+        @update:model-value="onToggle"
+      />
     </div>
-    <Button
-      v-if="mode === 'remote'"
-      :variant="isListeningIn ? 'secondary' : 'default'"
-      size="sm"
-      :disabled="busy"
-      class="listen-in__action"
-      @click="isListeningIn ? disableListenIn() : enableListenIn()"
-    >
-      {{
-        isListeningIn
-          ? $t("providers.party.guest_page.listen_in_stop")
-          : $t("providers.party.guest_page.listen_in_tap")
-      }}
-    </Button>
-    <Switch
-      v-else
-      :model-value="isListeningIn"
-      :disabled="busy"
-      :aria-label="title"
-      class="listen-in__action"
-      @update:model-value="onToggle"
-    />
+    <span class="listen-in__attribution">
+      {{ $t("providers.party.guest_page.listen_in_powered_by") }}
+    </span>
   </div>
 </template>
 
@@ -107,14 +112,20 @@ function onToggle(enabled: boolean) {
 <style scoped>
 .listen-in {
   display: flex;
-  align-items: center;
-  gap: 0.75rem;
+  flex-direction: column;
+  gap: 0.4rem;
   padding: 0.6rem 0.9rem;
   margin-bottom: 1rem;
   border-radius: 12px;
   background: rgba(var(--v-theme-primary), 0.08);
   border: 1px solid rgba(var(--v-theme-primary), 0.2);
   flex-shrink: 0;
+}
+
+.listen-in__row {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
 }
 
 .listen-in--active {
@@ -146,5 +157,11 @@ function onToggle(enabled: boolean) {
 
 .listen-in__action {
   flex-shrink: 0;
+}
+
+.listen-in__attribution {
+  font-size: 0.68rem;
+  color: rgba(var(--v-theme-on-surface), 0.5);
+  text-align: center;
 }
 </style>

--- a/src/composables/useListenIn.ts
+++ b/src/composables/useListenIn.ts
@@ -86,6 +86,9 @@ export function useListenIn(options: UseListenInOptions) {
       notifyError(errorMessages.noWebPlayer);
       return false;
     }
+    // Unlock this browser's audio output within the user gesture; listen-in
+    // audio starts asynchronously and would otherwise be blocked on iOS.
+    webPlayer.primeAudio();
     busy.value = true;
     try {
       await api.sendCommand<void>(`${domain}/listen_in`, {

--- a/src/plugins/web_player.ts
+++ b/src/plugins/web_player.ts
@@ -23,6 +23,20 @@ export const isPlaybackMode = (mode: WebPlayerMode) =>
   mode === WebPlayerMode.SENDSPIN_ONLY ||
   mode === WebPlayerMode.SENDSPIN_WITH_CONTROLS;
 
+// The active SendspinPlayer registers a handler that unlocks this browser's
+// audio output from within a user gesture. Listen-in audio starts
+// asynchronously, so iOS would otherwise block it; priming during the gesture
+// keeps playback reliable. See SendspinPlayer.vue and useListenIn.
+let audioUnlockHandler: (() => void) | null = null;
+
+export function registerWebPlayerAudioUnlock(handler: () => void): void {
+  audioUnlockHandler = handler;
+}
+
+export function clearWebPlayerAudioUnlock(handler: () => void): void {
+  if (audioUnlockHandler === handler) audioUnlockHandler = null;
+}
+
 let unsubSubscriptions: (() => void)[] = [];
 
 // We use a channel to communicate with all other tabs of MA open.
@@ -398,6 +412,11 @@ export const webPlayer = reactive({
   async setInteracted() {
     if (this.interacted) return;
     this.interacted = true;
+  },
+  // Unlock this browser's audio output from within a user gesture so
+  // asynchronously-started listen-in audio can play (notably on iOS).
+  primeAudio() {
+    audioUnlockHandler?.();
   },
   timedOutDueToThrottling() {
     return Date.now() - webPlayer.lastUpdate >= TIMEOUT_DURATION_MS;

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1106,6 +1106,7 @@
                 "listen_in_remote": "Shared listening — listen on your own device",
                 "listen_in_tap": "Tap to listen",
                 "listen_in_stop": "Stop listening",
+                "listen_in_powered_by": "Powered by Sendspin",
                 "listen_in_error_no_web_player": "Audio isn't available on this device.",
                 "listen_in_error_start": "Couldn't start listening. Please try again.",
                 "listen_in_error_stop": "Couldn't stop listening. Please try again.",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1103,7 +1103,7 @@
                 "listen_in": "Listen in",
                 "listen_in_active": "You're listening",
                 "listen_in_venue": "Play the party audio on this device",
-                "listen_in_remote": "Silent disco — listen on your own device",
+                "listen_in_remote": "Shared listening — listen on your own device",
                 "listen_in_tap": "Tap to listen",
                 "listen_in_stop": "Stop listening",
                 "listen_in_error_no_web_player": "Audio isn't available on this device.",

--- a/tests/composables/useListenIn.test.ts
+++ b/tests/composables/useListenIn.test.ts
@@ -2,10 +2,13 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { nextTick } from "vue";
 import { EventType } from "@/plugins/api/interfaces";
 
-const { mockSendCommand, mockSubscribeMulti } = vi.hoisted(() => ({
-  mockSendCommand: vi.fn(),
-  mockSubscribeMulti: vi.fn(() => () => {}),
-}));
+const { mockSendCommand, mockSubscribeMulti, mockPrimeAudio } = vi.hoisted(
+  () => ({
+    mockSendCommand: vi.fn(),
+    mockSubscribeMulti: vi.fn(() => () => {}),
+    mockPrimeAudio: vi.fn(),
+  }),
+);
 
 // Run lifecycle hooks eagerly so the composable can be exercised without a
 // host component (mirrors the pattern used by other composable tests).
@@ -27,7 +30,12 @@ vi.mock("@/plugins/api", () => ({
 
 vi.mock("@/plugins/web_player", async () => {
   const { reactive } = await vi.importActual<typeof import("vue")>("vue");
-  return { webPlayer: reactive({ player_id: "wp-1" as string | null }) };
+  return {
+    webPlayer: reactive({
+      player_id: "wp-1" as string | null,
+      primeAudio: mockPrimeAudio,
+    }),
+  };
 });
 
 import { webPlayer } from "@/plugins/web_player";
@@ -56,6 +64,7 @@ describe("useListenIn", () => {
     mockSendCommand.mockReset();
     mockSubscribeMulti.mockReset();
     mockSubscribeMulti.mockReturnValue(() => {});
+    mockPrimeAudio.mockReset();
     webPlayer.player_id = "wp-1";
   });
 
@@ -170,6 +179,30 @@ describe("useListenIn", () => {
       expect(notifyError).toHaveBeenCalledWith("no-web-player");
       expect(mockSendCommand).not.toHaveBeenCalled();
       expect(isListeningIn.value).toBe(false);
+    });
+
+    it("primes the audio output before sending the command", async () => {
+      const { enableListenIn } = create();
+      mockPrimeAudio.mockClear();
+      let primedBeforeCommand = false;
+      mockSendCommand.mockImplementation(async () => {
+        primedBeforeCommand = mockPrimeAudio.mock.calls.length > 0;
+        return undefined;
+      });
+
+      await enableListenIn();
+
+      expect(mockPrimeAudio).toHaveBeenCalledTimes(1);
+      expect(primedBeforeCommand).toBe(true);
+    });
+
+    it("does not prime the audio output without a web player", async () => {
+      webPlayer.player_id = null;
+      const { enableListenIn } = create();
+
+      await enableListenIn();
+
+      expect(mockPrimeAudio).not.toHaveBeenCalled();
     });
 
     it("reports the failure message and does not mark listening on error", async () => {


### PR DESCRIPTION
Party guests who tapped "listen in" heard no audio on a cold load in iOS Safari. iOS only unlocks audio inside a user gesture, but the listen-in stream starts asynchronously (after the server groups the guest's web player onto the party), so Safari left it silent. This primes and resumes the Sendspin audio context synchronously within the enable gesture so playback is reliable, and folds in two small UI tweaks.

- Prime the browser's audio output in `useListenIn.enableListenIn`, inside the tap/toggle gesture and before the awaited command (shared, so the quiz inherits it later).
- Add a small audio-unlock hook on the web player that `SendspinPlayer` registers/clears; iOS-gated and defensive.
- Reword the remote-mode label to "Shared listening — listen on your own device".
- Add a subtle "Powered by Sendspin" attribution under the listen-in control.