### PR TITLE
Fix Music Quiz screens showing raw text keys

### DIFF
--- a/src/components/music-quiz/MusicQuizAnswerStatus.vue
+++ b/src/components/music-quiz/MusicQuizAnswerStatus.vue
@@ -1,7 +1,7 @@
 <template>
   <section class="quiz-answer-status">
     <header>
-      <span>{{ $t("music_quiz.answers") }}</span>
+      <span>{{ $t("providers.music_quiz.answers") }}</span>
       <small>{{ answeredCount }} / {{ statuses.length }}</small>
     </header>
     <ul>

--- a/src/components/music-quiz/MusicQuizConnectionBanners.vue
+++ b/src/components/music-quiz/MusicQuizConnectionBanners.vue
@@ -1,7 +1,7 @@
 <template>
   <div v-if="degraded" class="quiz-banner" role="status">
     <Loader2 class="size-4 animate-spin" />
-    {{ $t("music_quiz.connection_lost") }}
+    {{ $t("providers.music_quiz.connection_lost") }}
   </div>
 </template>
 

--- a/src/components/music-quiz/MusicQuizHostPanel.vue
+++ b/src/components/music-quiz/MusicQuizHostPanel.vue
@@ -3,7 +3,7 @@
     <div class="quiz-host__qr">
       <canvas ref="qrCanvas"></canvas>
       <p v-if="qrError" class="quiz-host__qr-error" role="alert">
-        {{ $t("music_quiz.qr_unavailable") }}
+        {{ $t("providers.music_quiz.qr_unavailable") }}
       </p>
       <Button
         class="quiz-host__copy"
@@ -12,7 +12,11 @@
         @click="copyLink"
       >
         <Copy class="size-4" />
-        {{ copied ? $t("music_quiz.copied") : $t("music_quiz.copy_link") }}
+        {{
+          copied
+            ? $t("providers.music_quiz.copied")
+            : $t("providers.music_quiz.copy_link")
+        }}
       </Button>
     </div>
     <details
@@ -20,7 +24,7 @@
       class="quiz-host__now-playing-details"
     >
       <summary>
-        <span>{{ $t("music_quiz.now_playing") }}</span>
+        <span>{{ $t("providers.music_quiz.now_playing") }}</span>
         <ChevronDown class="size-4" />
       </summary>
       <div class="quiz-host__now-playing">
@@ -30,7 +34,7 @@
           :alt="currentRound.answer_label"
         />
         <div>
-          <span>{{ $t("music_quiz.current_music") }}</span>
+          <span>{{ $t("providers.music_quiz.current_music") }}</span>
           <strong>{{ currentRound.answer_label }}</strong>
         </div>
       </div>
@@ -41,7 +45,7 @@
       open
     >
       <summary>
-        <span>{{ $t("music_quiz.selected_music") }}</span>
+        <span>{{ $t("providers.music_quiz.selected_music") }}</span>
         <strong>{{ sessionSourcesSummary }}</strong>
         <ChevronDown class="size-4" />
       </summary>
@@ -72,7 +76,7 @@
         @click="emit('start')"
       >
         <Play class="size-4" />
-        {{ $t("music_quiz.start") }}
+        {{ $t("providers.music_quiz.start") }}
       </Button>
       <Button
         v-if="state.phase === 'answering'"
@@ -80,7 +84,7 @@
         @click="emit('reveal')"
       >
         <Eye class="size-4" />
-        {{ $t("music_quiz.phase_reveal") }}
+        {{ $t("providers.music_quiz.phase_reveal") }}
       </Button>
       <Button
         v-if="state.phase === 'reveal'"
@@ -88,7 +92,11 @@
         @click="emit('next')"
       >
         <SkipForward class="size-4" />
-        {{ isLastRound ? $t("music_quiz.finish") : $t("music_quiz.next") }}
+        {{
+          isLastRound
+            ? $t("providers.music_quiz.finish")
+            : $t("providers.music_quiz.next")
+        }}
       </Button>
       <Button
         v-if="state.phase === 'finished'"
@@ -96,7 +104,7 @@
         @click="emit('reset')"
       >
         <RotateCcw class="size-4" />
-        {{ $t("music_quiz.new_game") }}
+        {{ $t("providers.music_quiz.new_game") }}
       </Button>
     </div>
   </div>
@@ -175,7 +183,7 @@ async function copyLink() {
   if (!props.joinLink) return;
   copied.value = await copyToClipboard(props.joinLink);
   if (!copied.value) {
-    toast.error($t("music_quiz.copy_join_link_failed"));
+    toast.error($t("providers.music_quiz.copy_join_link_failed"));
   }
   if (copiedTimeout) clearTimeout(copiedTimeout);
   copiedTimeout = setTimeout(() => {

--- a/src/components/music-quiz/MusicQuizJoinForm.vue
+++ b/src/components/music-quiz/MusicQuizJoinForm.vue
@@ -2,7 +2,7 @@
   <form class="quiz-join" @submit.prevent="submit">
     <h1>{{ sessionName }}</h1>
     <label>
-      {{ $t("music_quiz.player_name") }}
+      {{ $t("providers.music_quiz.player_name") }}
       <input
         ref="nameInput"
         v-model="playerName"
@@ -14,7 +14,7 @@
       />
     </label>
     <Button :disabled="busy || !playerName.trim()" type="submit">{{
-      $t("music_quiz.join")
+      $t("providers.music_quiz.join")
     }}</Button>
   </form>
 </template>

--- a/src/components/music-quiz/MusicQuizLeaderboard.vue
+++ b/src/components/music-quiz/MusicQuizLeaderboard.vue
@@ -1,6 +1,6 @@
 <template>
   <section class="quiz-leaderboard">
-    <h2>{{ $t("music_quiz.leaderboard") }}</h2>
+    <h2>{{ $t("providers.music_quiz.leaderboard") }}</h2>
     <ol>
       <li
         v-for="player in rows"

--- a/src/components/music-quiz/MusicQuizReveal.vue
+++ b/src/components/music-quiz/MusicQuizReveal.vue
@@ -26,7 +26,7 @@
           size="icon"
           type="button"
           variant="outline"
-          :title="$t('music_quiz.copy_music_name')"
+          :title="$t('providers.music_quiz.copy_music_name')"
           @click="emit('copy-title')"
         >
           <Copy class="size-4" />
@@ -44,7 +44,7 @@
       />
       <div v-else class="quiz-reveal__lyrics-loading">
         <Loader2 class="size-5 animate-spin" />
-        <span>{{ $t("music_quiz.loading_lyrics") }}</span>
+        <span>{{ $t("providers.music_quiz.loading_lyrics") }}</span>
       </div>
     </div>
   </section>

--- a/src/components/music-quiz/MusicQuizSessionPanels.vue
+++ b/src/components/music-quiz/MusicQuizSessionPanels.vue
@@ -4,13 +4,13 @@
     :class="{ 'quiz-panels--finished': state.phase === 'finished' }"
   >
     <div v-if="state.phase !== 'finished'" class="quiz-panels__panel">
-      <h2>{{ $t("music_quiz.round") }}</h2>
+      <h2>{{ $t("providers.music_quiz.round") }}</h2>
       <p v-if="currentRound">
         {{ currentRound.round_index + 1 }} / {{ state.round_count }}
       </p>
       <div v-if="showRoundPlayerStatus" class="quiz-panels__answer-status">
         <header>
-          <span>{{ $t("music_quiz.answers") }}</span>
+          <span>{{ $t("providers.music_quiz.answers") }}</span>
           <small>
             {{ answeredPlayerCount }} / {{ roundPlayerStatuses.length }}
           </small>
@@ -33,7 +33,7 @@
       <h2>
         {{
           state.phase === "finished"
-            ? $t("music_quiz.final_leaderboard")
+            ? $t("providers.music_quiz.final_leaderboard")
             : $t("players")
         }}
       </h2>

--- a/src/components/music-quiz/MusicQuizSetupForm.vue
+++ b/src/components/music-quiz/MusicQuizSetupForm.vue
@@ -1,29 +1,29 @@
 <template>
   <div class="quiz-setup">
     <label>
-      {{ $t("music_quiz.session_name") }}
+      {{ $t("providers.music_quiz.session_name") }}
       <input v-model="name" type="text" />
     </label>
     <label>
-      {{ $t("music_quiz.rounds") }}
+      {{ $t("providers.music_quiz.rounds") }}
       <input v-model.number="roundCount" min="2" type="number" />
     </label>
     <label>
-      {{ $t("music_quiz.suggestions") }}
+      {{ $t("providers.music_quiz.suggestions") }}
       <input v-model.number="suggestionCount" min="2" type="number" />
     </label>
     <label>
-      {{ $t("music_quiz.answer_seconds") }}
+      {{ $t("providers.music_quiz.answer_seconds") }}
       <input v-model.number="answerDuration" min="1" type="number" />
     </label>
     <div class="quiz-setup__wide quiz-setup__sources">
       <div class="quiz-setup__source-search">
         <label>
-          {{ $t("music_quiz.add_tracks_or_playlists") }}
+          {{ $t("providers.music_quiz.add_tracks_or_playlists") }}
           <input
             v-model="sourceSearchQuery"
             type="search"
-            :placeholder="$t('music_quiz.search_music')"
+            :placeholder="$t('providers.music_quiz.search_music')"
           />
         </label>
         <div
@@ -31,7 +31,7 @@
           class="quiz-setup__source-results"
         >
           <p v-if="sourceSearching" class="quiz-setup__muted">
-            {{ $t("music_quiz.searching") }}
+            {{ $t("providers.music_quiz.searching") }}
           </p>
           <button
             v-for="item in sourceResults"
@@ -51,14 +51,14 @@
             v-if="!sourceSearching && sourceResults.length === 0"
             class="quiz-setup__muted"
           >
-            {{ $t("music_quiz.no_sources_found") }}
+            {{ $t("providers.music_quiz.no_sources_found") }}
           </p>
         </div>
       </div>
 
       <div class="quiz-setup__selected">
         <div class="quiz-setup__selected-header">
-          <span>{{ $t("music_quiz.selected_music") }}</span>
+          <span>{{ $t("providers.music_quiz.selected_music") }}</span>
           <strong>{{ selectedSourcesSummary }}</strong>
         </div>
         <div
@@ -80,7 +80,7 @@
           </button>
         </div>
         <p v-else class="quiz-setup__muted">
-          {{ $t("music_quiz.pick_at_least_one_source") }}
+          {{ $t("providers.music_quiz.pick_at_least_one_source") }}
         </p>
       </div>
     </div>
@@ -198,7 +198,7 @@ async function searchSources() {
     toast.error(
       err instanceof Error
         ? err.message
-        : $t("music_quiz.source_search_failed"),
+        : $t("providers.music_quiz.source_search_failed"),
     );
   } finally {
     sourceSearching.value = false;
@@ -221,11 +221,12 @@ function removeSource(uri: string) {
 }
 
 function sourceSubtitle(item: SourceItem) {
-  if (item.media_type === MediaType.PLAYLIST) return $t("music_quiz.playlist");
+  if (item.media_type === MediaType.PLAYLIST)
+    return $t("providers.music_quiz.playlist");
   const artist = (item as Track).artists?.[0]?.name;
   return artist
-    ? $t("music_quiz.track_with_artist", [artist])
-    : $t("music_quiz.track");
+    ? $t("providers.music_quiz.track_with_artist", [artist])
+    : $t("providers.music_quiz.track");
 }
 
 watch(sourceSearchQuery, () => scheduleSourceSearch());

--- a/src/composables/useMusicQuizHost.ts
+++ b/src/composables/useMusicQuizHost.ts
@@ -52,12 +52,12 @@ export function useMusicQuizHost(options: UseMusicQuizHostOptions) {
   const phaseLabel = computed(() => {
     if (!state.value) return "";
     if (state.value.phase === "lobby")
-      return $t("music_quiz.phase_waiting_for_players");
+      return $t("providers.music_quiz.phase_waiting_for_players");
     if (state.value.phase === "answering")
-      return $t("music_quiz.phase_answers_open");
+      return $t("providers.music_quiz.phase_answers_open");
     if (state.value.phase === "reveal")
-      return $t("music_quiz.phase_enjoy_track");
-    return $t("music_quiz.phase_finished");
+      return $t("providers.music_quiz.phase_enjoy_track");
+    return $t("providers.music_quiz.phase_finished");
   });
 
   async function fetchState() {
@@ -78,7 +78,10 @@ export function useMusicQuizHost(options: UseMusicQuizHostOptions) {
         gameRemoved.value = false;
       } else {
         notifyError(
-          getMusicQuizErrorMessage(err, $t("music_quiz.error_load_state")),
+          getMusicQuizErrorMessage(
+            err,
+            $t("providers.music_quiz.error_load_state"),
+          ),
         );
       }
     } finally {
@@ -125,7 +128,9 @@ export function useMusicQuizHost(options: UseMusicQuizHostOptions) {
       gameRemoved.value = false;
       return true;
     } catch (err) {
-      notifyError(getMusicQuizErrorMessage(err, $t("music_quiz.error_create")));
+      notifyError(
+        getMusicQuizErrorMessage(err, $t("providers.music_quiz.error_create")),
+      );
       return false;
     } finally {
       busy.value = false;
@@ -139,7 +144,9 @@ export function useMusicQuizHost(options: UseMusicQuizHostOptions) {
       state.value = nextState;
       return true;
     } catch (err) {
-      notifyError(getMusicQuizErrorMessage(err, $t("music_quiz.error_start")));
+      notifyError(
+        getMusicQuizErrorMessage(err, $t("providers.music_quiz.error_start")),
+      );
       return false;
     } finally {
       busy.value = false;
@@ -153,7 +160,9 @@ export function useMusicQuizHost(options: UseMusicQuizHostOptions) {
       state.value = nextState;
       return true;
     } catch (err) {
-      notifyError(getMusicQuizErrorMessage(err, $t("music_quiz.error_reveal")));
+      notifyError(
+        getMusicQuizErrorMessage(err, $t("providers.music_quiz.error_reveal")),
+      );
       return false;
     } finally {
       busy.value = false;
@@ -167,7 +176,9 @@ export function useMusicQuizHost(options: UseMusicQuizHostOptions) {
       state.value = nextState;
       return true;
     } catch (err) {
-      notifyError(getMusicQuizErrorMessage(err, $t("music_quiz.error_next")));
+      notifyError(
+        getMusicQuizErrorMessage(err, $t("providers.music_quiz.error_next")),
+      );
       return false;
     } finally {
       busy.value = false;
@@ -181,7 +192,9 @@ export function useMusicQuizHost(options: UseMusicQuizHostOptions) {
       state.value = nextState;
       return true;
     } catch (err) {
-      notifyError(getMusicQuizErrorMessage(err, $t("music_quiz.error_reset")));
+      notifyError(
+        getMusicQuizErrorMessage(err, $t("providers.music_quiz.error_reset")),
+      );
       return false;
     } finally {
       busy.value = false;
@@ -196,7 +209,9 @@ export function useMusicQuizHost(options: UseMusicQuizHostOptions) {
       gameRemoved.value = false;
       return true;
     } catch (err) {
-      notifyError(getMusicQuizErrorMessage(err, $t("music_quiz.error_delete")));
+      notifyError(
+        getMusicQuizErrorMessage(err, $t("providers.music_quiz.error_delete")),
+      );
       return false;
     } finally {
       busy.value = false;

--- a/src/composables/useMusicQuizPlayer.ts
+++ b/src/composables/useMusicQuizPlayer.ts
@@ -58,7 +58,10 @@ export function useMusicQuizPlayer(options: UseMusicQuizPlayerOptions) {
       }
     } catch (err) {
       notifyError(
-        getMusicQuizErrorMessage(err, $t("music_quiz.error_load_info")),
+        getMusicQuizErrorMessage(
+          err,
+          $t("providers.music_quiz.error_load_info"),
+        ),
       );
     } finally {
       loading.value = false;
@@ -92,7 +95,10 @@ export function useMusicQuizPlayer(options: UseMusicQuizPlayerOptions) {
         gameRemoved.value = true;
       } else {
         notifyError(
-          getMusicQuizErrorMessage(err, $t("music_quiz.error_load_state")),
+          getMusicQuizErrorMessage(
+            err,
+            $t("providers.music_quiz.error_load_state"),
+          ),
         );
       }
     } finally {
@@ -127,7 +133,9 @@ export function useMusicQuizPlayer(options: UseMusicQuizPlayerOptions) {
       gameRemoved.value = false;
       return true;
     } catch (err) {
-      notifyError(getMusicQuizErrorMessage(err, $t("music_quiz.error_join")));
+      notifyError(
+        getMusicQuizErrorMessage(err, $t("providers.music_quiz.error_join")),
+      );
       return false;
     } finally {
       busy.value = false;
@@ -137,7 +145,7 @@ export function useMusicQuizPlayer(options: UseMusicQuizPlayerOptions) {
   async function answer(suggestionId: string) {
     const currentPlayerId = playerId.value;
     if (!currentPlayerId) {
-      notifyError($t("music_quiz.error_not_joined"));
+      notifyError($t("providers.music_quiz.error_not_joined"));
       return false;
     }
     busy.value = true;
@@ -146,7 +154,9 @@ export function useMusicQuizPlayer(options: UseMusicQuizPlayerOptions) {
       state.value = nextState;
       return true;
     } catch (err) {
-      notifyError(getMusicQuizErrorMessage(err, $t("music_quiz.error_answer")));
+      notifyError(
+        getMusicQuizErrorMessage(err, $t("providers.music_quiz.error_answer")),
+      );
       return false;
     } finally {
       busy.value = false;
@@ -156,7 +166,7 @@ export function useMusicQuizPlayer(options: UseMusicQuizPlayerOptions) {
   async function ready() {
     const currentPlayerId = playerId.value;
     if (!currentPlayerId) {
-      notifyError($t("music_quiz.error_not_joined"));
+      notifyError($t("providers.music_quiz.error_not_joined"));
       return false;
     }
     busy.value = true;
@@ -165,7 +175,9 @@ export function useMusicQuizPlayer(options: UseMusicQuizPlayerOptions) {
       state.value = nextState;
       return true;
     } catch (err) {
-      notifyError(getMusicQuizErrorMessage(err, $t("music_quiz.error_ready")));
+      notifyError(
+        getMusicQuizErrorMessage(err, $t("providers.music_quiz.error_ready")),
+      );
       return false;
     } finally {
       busy.value = false;

--- a/src/helpers/music_quiz.ts
+++ b/src/helpers/music_quiz.ts
@@ -55,12 +55,12 @@ export function formatNameList(names: string[]) {
 
 export function getMusicQuizWinnerText(players: RankedMusicQuizPlayer[]) {
   const topScore = players[0]?.score ?? 0;
-  if (topScore <= 0) return $t("music_quiz.no_winner");
+  if (topScore <= 0) return $t("providers.music_quiz.no_winner");
   const winners = players.filter((player) => player.rank === 1);
   const names = formatNameList(winners.map((player) => player.name));
   return winners.length === 1
-    ? $t("music_quiz.winner_single", [names, topScore])
-    : $t("music_quiz.winner_multiple", [names, topScore]);
+    ? $t("providers.music_quiz.winner_single", [names, topScore])
+    : $t("providers.music_quiz.winner_multiple", [names, topScore]);
 }
 
 export function isMusicQuizWinner(

--- a/src/helpers/music_quiz_sources.ts
+++ b/src/helpers/music_quiz_sources.ts
@@ -20,8 +20,8 @@ export function getMusicQuizSourceSummary(sources: SourceLike[]) {
     parts.push(
       $t(
         counts.tracks === 1
-          ? "music_quiz.track_count"
-          : "music_quiz.tracks_count",
+          ? "providers.music_quiz.track_count"
+          : "providers.music_quiz.tracks_count",
         [counts.tracks],
       ),
     );
@@ -30,23 +30,23 @@ export function getMusicQuizSourceSummary(sources: SourceLike[]) {
     parts.push(
       $t(
         counts.playlists === 1
-          ? "music_quiz.playlist_count"
-          : "music_quiz.playlists_count",
+          ? "providers.music_quiz.playlist_count"
+          : "providers.music_quiz.playlists_count",
         [counts.playlists],
       ),
     );
   }
-  return parts.join(", ") || $t("music_quiz.tracks_count", [0]);
+  return parts.join(", ") || $t("providers.music_quiz.tracks_count", [0]);
 }
 
 export function musicQuizSourceTypeLabel(mediaType?: string | null) {
   if (mediaType === MediaType.PLAYLIST || mediaType === "playlist") {
-    return $t("music_quiz.playlist");
+    return $t("providers.music_quiz.playlist");
   }
   if (mediaType === MediaType.TRACK || mediaType === "track") {
-    return $t("music_quiz.track");
+    return $t("providers.music_quiz.track");
   }
-  return $t("music_quiz.source_music");
+  return $t("providers.music_quiz.source_music");
 }
 
 function isPlaylistSource(source: SourceLike) {

--- a/src/views/MusicQuizDashboardView.vue
+++ b/src/views/MusicQuizDashboardView.vue
@@ -15,7 +15,7 @@
         </div>
         <Button variant="ghost-outline" size="lg" @click="exitPresentMode">
           <Minimize2 class="size-5" />
-          {{ $t("music_quiz.exit_present_mode") }}
+          {{ $t("providers.music_quiz.exit_present_mode") }}
         </Button>
       </header>
 
@@ -24,7 +24,10 @@
       <section class="present-mode__body">
         <template v-if="state.phase === 'answering' && currentRound">
           <p class="present-mode__countdown">
-            {{ answerRemainingLabel || $t("music_quiz.waiting_for_answers") }}
+            {{
+              answerRemainingLabel ||
+              $t("providers.music_quiz.waiting_for_answers")
+            }}
           </p>
           <MusicQuizAnswerGrid
             class="present-mode__answers"
@@ -49,7 +52,7 @@
             :round="currentRound"
             :busy="true"
             :is-ready="true"
-            :ready-label="$t('music_quiz.ready')"
+            :ready-label="$t('providers.music_quiz.ready')"
             :image-url="currentRoundImageUrl"
             :show-lyrics="false"
             :has-lyrics="false"
@@ -70,7 +73,7 @@
 
         <template v-else-if="state.phase === 'finished'">
           <section class="present-mode__finished">
-            <h2>{{ $t("music_quiz.final_leaderboard") }}</h2>
+            <h2>{{ $t("providers.music_quiz.final_leaderboard") }}</h2>
             <p>{{ winnerText }}</p>
           </section>
           <MusicQuizLeaderboard
@@ -98,7 +101,7 @@
     <section v-else class="dashboard-shell">
       <header class="dashboard-shell__header">
         <div>
-          <h1>{{ $t("music_quiz.title") }}</h1>
+          <h1>{{ $t("providers.music_quiz.title") }}</h1>
           <p>{{ statusText }}</p>
         </div>
         <Button
@@ -109,19 +112,19 @@
           @click="enterPresentMode"
         >
           <Maximize2 class="size-4" />
-          {{ $t("music_quiz.enter_present_mode") }}
+          {{ $t("providers.music_quiz.enter_present_mode") }}
         </Button>
       </header>
 
       <MusicQuizConnectionBanners :degraded="isConnectionDegraded" />
 
       <div v-if="gameRemoved" class="dashboard-shell__card">
-        <h2>{{ $t("music_quiz.game_ended") }}</h2>
-        <p>{{ $t("music_quiz.game_ended_detail") }}</p>
+        <h2>{{ $t("providers.music_quiz.game_ended") }}</h2>
+        <p>{{ $t("providers.music_quiz.game_ended_detail") }}</p>
       </div>
 
       <div v-else-if="!state && !loading" class="dashboard-shell__card">
-        <p>{{ $t("music_quiz.create_intro") }}</p>
+        <p>{{ $t("providers.music_quiz.create_intro") }}</p>
         <MusicQuizSetupForm :busy="busy" @create="handleCreate" />
       </div>
 
@@ -144,7 +147,10 @@
           class="dashboard-shell__card"
         >
           <p class="dashboard-shell__countdown">
-            {{ answerRemainingLabel || $t("music_quiz.waiting_for_answers") }}
+            {{
+              answerRemainingLabel ||
+              $t("providers.music_quiz.waiting_for_answers")
+            }}
           </p>
           <MusicQuizAnswerGrid
             :suggestions="currentRound.suggestions"
@@ -159,7 +165,7 @@
             :round="currentRound"
             :busy="true"
             :is-ready="true"
-            :ready-label="$t('music_quiz.ready')"
+            :ready-label="$t('providers.music_quiz.ready')"
             :image-url="currentRoundImageUrl"
             :show-lyrics="false"
             :has-lyrics="false"
@@ -249,14 +255,14 @@ const winnerText = computed(() => getMusicQuizWinnerText(rankedPlayers.value));
 
 const roundLabel = computed(() => {
   if (!state.value || !currentRound.value) return "";
-  return `${$t("music_quiz.round_label")} ${currentRound.value.round_index + 1} / ${state.value.round_count}`;
+  return `${$t("providers.music_quiz.round_label")} ${currentRound.value.round_index + 1} / ${state.value.round_count}`;
 });
 
 const statusText = computed(() => {
-  if (loading.value) return $t("music_quiz.loading");
-  if (gameRemoved.value) return $t("music_quiz.game_removed");
+  if (loading.value) return $t("providers.music_quiz.loading");
+  if (gameRemoved.value) return $t("providers.music_quiz.game_removed");
   if (state.value) return phaseLabel.value;
-  return $t("music_quiz.no_active_game");
+  return $t("providers.music_quiz.no_active_game");
 });
 
 const currentRoundImageUrl = computed(() =>
@@ -280,7 +286,7 @@ async function copyCurrentRoundTitle() {
   if (!currentRound.value?.answer_label) return;
   const copied = await copyToClipboard(currentRound.value.answer_label);
   if (!copied) {
-    toast.error($t("music_quiz.copy_music_name_failed"));
+    toast.error($t("providers.music_quiz.copy_music_name_failed"));
   }
 }
 
@@ -331,7 +337,7 @@ watch(state, (nextState) => {
 });
 
 async function deleteGame() {
-  if (!window.confirm($t("music_quiz.delete_confirm"))) return;
+  if (!window.confirm($t("providers.music_quiz.delete_confirm"))) return;
   await host.deleteGame();
 }
 

--- a/src/views/MusicQuizPlayerView.vue
+++ b/src/views/MusicQuizPlayerView.vue
@@ -1,21 +1,25 @@
 <template>
   <div class="music-quiz-player">
     <div v-if="gameRemoved" class="quiz-shell">
-      <p>{{ $t("music_quiz.game_no_longer_available") }}</p>
+      <p>{{ $t("providers.music_quiz.game_no_longer_available") }}</p>
     </div>
 
     <div v-else-if="!playerId && !loading" class="quiz-shell quiz-shell--join">
       <header class="quiz-shell__intro">
-        <h1>{{ $t("music_quiz.title") }}</h1>
+        <h1>{{ $t("providers.music_quiz.title") }}</h1>
         <p v-if="info?.name">{{ info.name }}</p>
         <div v-if="info" class="quiz-shell__stats">
-          <span>{{ $t("music_quiz.players_count", [info.player_count]) }}</span>
-          <span>{{ $t("music_quiz.rounds_count", [info.round_count]) }}</span>
+          <span>{{
+            $t("providers.music_quiz.players_count", [info.player_count])
+          }}</span>
+          <span>{{
+            $t("providers.music_quiz.rounds_count", [info.round_count])
+          }}</span>
           <span>{{ modeLabel }}</span>
         </div>
       </header>
       <MusicQuizJoinForm
-        :session-name="info?.name || $t('music_quiz.title')"
+        :session-name="info?.name || $t('providers.music_quiz.title')"
         :busy="busy"
         @join="handleJoin"
       />
@@ -42,7 +46,9 @@
       />
 
       <section v-if="state.phase === 'lobby'" class="quiz-shell__section">
-        <p class="quiz-shell__hint">{{ $t("music_quiz.waiting_for_start") }}</p>
+        <p class="quiz-shell__hint">
+          {{ $t("providers.music_quiz.waiting_for_start") }}
+        </p>
         <MusicQuizLeaderboard
           :rows="leaderboardRows"
           :current-player-name="state.you.name"
@@ -53,9 +59,14 @@
         v-else-if="state.phase === 'answering' && currentRound"
         class="quiz-shell__section"
       >
-        <p class="quiz-shell__title">{{ $t("music_quiz.choose_answer") }}</p>
+        <p class="quiz-shell__title">
+          {{ $t("providers.music_quiz.choose_answer") }}
+        </p>
         <p class="quiz-shell__countdown">
-          {{ answerRemainingLabel || $t("music_quiz.waiting_for_answers") }}
+          {{
+            answerRemainingLabel ||
+            $t("providers.music_quiz.waiting_for_answers")
+          }}
         </p>
         <MusicQuizAnswerGrid
           class="quiz-shell__answers"
@@ -65,7 +76,7 @@
           @select="handleAnswer"
         />
         <p v-if="state.you.answer" class="quiz-shell__hint">
-          {{ $t("music_quiz.answered") }}
+          {{ $t("providers.music_quiz.answered") }}
         </p>
         <MusicQuizAnswerStatus
           :statuses="state.players"
@@ -97,7 +108,7 @@
           v-if="state.you.answer?.correct"
           class="quiz-shell__answer-result quiz-shell__answer-result--correct"
         >
-          {{ $t("music_quiz.correct") }}
+          {{ $t("providers.music_quiz.correct") }}
           <span>+{{ state.you.answer.points ?? 0 }}</span>
         </p>
         <p
@@ -106,8 +117,8 @@
         >
           {{
             state.you.answer
-              ? $t("music_quiz.incorrect")
-              : $t("music_quiz.no_answer_submitted")
+              ? $t("providers.music_quiz.incorrect")
+              : $t("providers.music_quiz.no_answer_submitted")
           }}
         </p>
 
@@ -121,7 +132,9 @@
         v-else-if="state.phase === 'finished'"
         class="quiz-shell__section"
       >
-        <h2 class="quiz-shell__title">{{ $t("music_quiz.game_over") }}</h2>
+        <h2 class="quiz-shell__title">
+          {{ $t("providers.music_quiz.game_over") }}
+        </h2>
         <p class="quiz-shell__hint">{{ winnerText }}</p>
         <MusicQuizLeaderboard
           :rows="leaderboardRows"
@@ -131,7 +144,7 @@
     </div>
 
     <div v-else class="quiz-shell">
-      <p>{{ $t("music_quiz.loading") }}</p>
+      <p>{{ $t("providers.music_quiz.loading") }}</p>
     </div>
   </div>
 </template>
@@ -178,22 +191,22 @@ const { answerRemainingLabel, lyricsPosition } = clocks;
 const mode = computed(() => state.value?.mode ?? info.value?.mode);
 const modeLabel = computed(() =>
   mode.value === "remote"
-    ? $t("music_quiz.mode_remote")
-    : $t("music_quiz.mode_venue"),
+    ? $t("providers.music_quiz.mode_remote")
+    : $t("providers.music_quiz.mode_venue"),
 );
 
 const listenInRecheckEvents = [EventType.PROVIDER_EVENT];
 const listenInLabels = computed<ListenInLabels>(() => ({
-  title: $t("music_quiz.listen_in"),
-  titleActive: $t("music_quiz.listen_in_active"),
-  descriptionVenue: $t("music_quiz.listen_in_venue"),
-  descriptionRemote: $t("music_quiz.listen_in_remote"),
-  tap: $t("music_quiz.listen_in_tap"),
-  stop: $t("music_quiz.listen_in_stop"),
-  poweredBy: $t("music_quiz.listen_in_powered_by"),
-  errorNoWebPlayer: $t("music_quiz.error_no_web_player"),
-  errorListenIn: $t("music_quiz.error_listen_in"),
-  errorStopListenIn: $t("music_quiz.error_stop_listen_in"),
+  title: $t("providers.music_quiz.listen_in"),
+  titleActive: $t("providers.music_quiz.listen_in_active"),
+  descriptionVenue: $t("providers.music_quiz.listen_in_venue"),
+  descriptionRemote: $t("providers.music_quiz.listen_in_remote"),
+  tap: $t("providers.music_quiz.listen_in_tap"),
+  stop: $t("providers.music_quiz.listen_in_stop"),
+  poweredBy: $t("providers.music_quiz.listen_in_powered_by"),
+  errorNoWebPlayer: $t("providers.music_quiz.error_no_web_player"),
+  errorListenIn: $t("providers.music_quiz.error_listen_in"),
+  errorStopListenIn: $t("providers.music_quiz.error_stop_listen_in"),
 }));
 
 const rankedPlayers = computed(() => {
@@ -228,9 +241,9 @@ const winnerText = computed(() => getMusicQuizWinnerText(rankedPlayers.value));
 const roundProgress = computed(() => {
   if (!state.value) return "";
   if (!currentRound.value) {
-    return `${$t("music_quiz.round_label")} ${state.value.round_count}/${state.value.round_count}`;
+    return `${$t("providers.music_quiz.round_label")} ${state.value.round_count}/${state.value.round_count}`;
   }
-  return `${$t("music_quiz.round_label")} ${currentRound.value.round_index + 1}/${state.value.round_count}`;
+  return `${$t("providers.music_quiz.round_label")} ${currentRound.value.round_index + 1}/${state.value.round_count}`;
 });
 
 const playerRoundScoreLabel = computed(() => {
@@ -239,18 +252,20 @@ const playerRoundScoreLabel = computed(() => {
 });
 
 const readyLabel = computed(() => {
-  if (state.value?.you.ready) return $t("music_quiz.waiting_for_next");
-  return $t("music_quiz.ready");
+  if (state.value?.you.ready)
+    return $t("providers.music_quiz.waiting_for_next");
+  return $t("providers.music_quiz.ready");
 });
 
 const phaseText = computed(() => {
   if (!state.value) return "";
   if (state.value.phase === "lobby")
-    return $t("music_quiz.phase_waiting_for_players");
+    return $t("providers.music_quiz.phase_waiting_for_players");
   if (state.value.phase === "answering")
-    return $t("music_quiz.phase_answers_open");
-  if (state.value.phase === "reveal") return $t("music_quiz.phase_enjoy_track");
-  return $t("music_quiz.phase_finished");
+    return $t("providers.music_quiz.phase_answers_open");
+  if (state.value.phase === "reveal")
+    return $t("providers.music_quiz.phase_enjoy_track");
+  return $t("providers.music_quiz.phase_finished");
 });
 
 const currentRoundImageUrl = computed(() =>
@@ -307,7 +322,7 @@ async function copyCurrentRoundTitle() {
   if (!currentRound.value?.answer_label) return;
   const copied = await copyToClipboard(currentRound.value.answer_label);
   if (!copied) {
-    toast.error($t("music_quiz.copy_music_name_failed"));
+    toast.error($t("providers.music_quiz.copy_music_name_failed"));
   }
 }
 

--- a/src/views/settings/FrontendConfig.vue
+++ b/src/views/settings/FrontendConfig.vue
@@ -130,7 +130,7 @@ onMounted(() => {
           ? [{ title: $t("party_mode"), value: "party" }]
           : []),
         ...(store.enabledPlugins.has("music_quiz")
-          ? [{ title: $t("music_quiz.title"), value: "music_quiz" }]
+          ? [{ title: $t("providers.music_quiz.title"), value: "music_quiz" }]
           : []),
         { title: $t("artists"), value: "artists" },
         { title: $t("albums"), value: "albums" },


### PR DESCRIPTION
Music Quiz screens were resolving translation keys from the wrong namespace, so users saw raw key strings instead of labels.

- prefix quiz translation lookups from `music_quiz.*` to `providers.music_quiz.*` across quiz views/components/helpers/composables
- keep all quiz provider domain/command identifiers (`music_quiz`) unchanged
- align related menu/settings quiz title lookups to the same namespace