### PR TITLE
Fix Music Quiz guest recovery, lyrics state, and setup edge cases

### DIFF
--- a/src/components/music-quiz/MusicQuizHostPanel.vue
+++ b/src/components/music-quiz/MusicQuizHostPanel.vue
@@ -19,10 +19,7 @@
         }}
       </Button>
     </div>
-    <details
-      v-if="state.phase !== 'finished' && currentRound"
-      class="quiz-host__now-playing-details"
-    >
+    <details v-if="nowPlayingRound" class="quiz-host__now-playing-details">
       <summary>
         <span>{{ $t("providers.music_quiz.now_playing") }}</span>
         <ChevronDown class="size-4" />
@@ -31,11 +28,11 @@
         <img
           v-if="currentRoundImageUrl"
           :src="currentRoundImageUrl"
-          :alt="currentRound.answer_label"
+          :alt="nowPlayingRound.answer_label"
         />
         <div>
           <span>{{ $t("providers.music_quiz.current_music") }}</span>
-          <strong>{{ currentRound.answer_label }}</strong>
+          <strong>{{ nowPlayingRound.answer_label }}</strong>
         </div>
       </div>
     </details>
@@ -164,6 +161,11 @@ let copiedTimeout: ReturnType<typeof setTimeout> | undefined;
 const currentRoundImageUrl = computed(() =>
   getMediaImageUrl(props.currentRound?.image_url ?? ""),
 );
+const nowPlayingRound = computed(() => {
+  const round = props.currentRound;
+  if (props.state.phase === "finished" || !round?.answer_label) return null;
+  return round;
+});
 const sessionSourcesSummary = computed(() =>
   getMusicQuizSourceSummary(props.state.sources ?? []),
 );

--- a/src/components/music-quiz/MusicQuizReveal.vue
+++ b/src/components/music-quiz/MusicQuizReveal.vue
@@ -42,9 +42,12 @@
         :text-color="lyricsTextColor"
         :anticipation="0"
       />
-      <div v-else class="quiz-reveal__lyrics-loading">
+      <div v-else-if="lyricsLoading" class="quiz-reveal__lyrics-loading">
         <Loader2 class="size-5 animate-spin" />
         <span>{{ $t("providers.music_quiz.loading_lyrics") }}</span>
+      </div>
+      <div v-else class="quiz-reveal__lyrics-empty">
+        <span>{{ $t("no_lyrics_available") }}</span>
       </div>
     </div>
   </section>
@@ -65,6 +68,7 @@ withDefaults(
     imageUrl: string;
     showLyrics: boolean;
     hasLyrics: boolean;
+    lyricsLoading?: boolean;
     lyrics: string;
     lrcLyrics: string;
     lyricsPosition: number;
@@ -75,6 +79,7 @@ withDefaults(
   {
     showReadyButton: true,
     showCopyButton: true,
+    lyricsLoading: false,
   },
 );
 const emit = defineEmits<{ ready: []; "copy-title": [] }>();
@@ -128,6 +133,15 @@ const emit = defineEmits<{ ready: []; "copy-title": [] }>();
   align-items: center;
   justify-content: center;
   gap: 0.5rem;
+  color: hsl(var(--muted-foreground));
+  font-weight: 600;
+}
+
+.quiz-reveal__lyrics-empty {
+  display: flex;
+  height: 100%;
+  align-items: center;
+  justify-content: center;
   color: hsl(var(--muted-foreground));
   font-weight: 600;
 }

--- a/src/components/music-quiz/MusicQuizSetupForm.vue
+++ b/src/components/music-quiz/MusicQuizSetupForm.vue
@@ -153,6 +153,7 @@ const sourceResults = ref<SourceItem[]>([]);
 const selectedSources = ref<SourceItem[]>([]);
 const sourceSearching = ref(false);
 let sourceSearchTimer: ReturnType<typeof setTimeout> | undefined;
+let sourceSearchRequestId = 0;
 
 const sourceUris = computed(() =>
   selectedSources.value.map((item) => item.uri),
@@ -193,6 +194,7 @@ function scheduleSourceSearch() {
 }
 
 async function searchSources() {
+  const requestId = ++sourceSearchRequestId;
   const query = sourceSearchQuery.value.trim();
   if (query.length < 2) {
     sourceResults.value = [];
@@ -206,18 +208,22 @@ async function searchSources() {
       [MediaType.TRACK, MediaType.PLAYLIST],
       8,
     );
+    if (requestId !== sourceSearchRequestId) return;
     const selected = new Set(selectedSources.value.map((item) => item.uri));
     sourceResults.value = [...result.tracks, ...result.playlists].filter(
       (item) => !selected.has(item.uri),
     );
   } catch (err) {
+    if (requestId !== sourceSearchRequestId) return;
     toast.error(
       err instanceof Error
         ? err.message
         : $t("providers.music_quiz.source_search_failed"),
     );
   } finally {
-    sourceSearching.value = false;
+    if (requestId === sourceSearchRequestId) {
+      sourceSearching.value = false;
+    }
   }
 }
 

--- a/src/composables/useMusicQuizHost.ts
+++ b/src/composables/useMusicQuizHost.ts
@@ -23,8 +23,8 @@ export interface UseMusicQuizHostOptions {
 /**
  * Host-side Music Quiz management: single game per provider instance,
  * PROVIDER_EVENT driven (no polling). Fetches music_quiz/get on mount,
- * subscribes to PROVIDER_EVENT (game_updated -> re-fetch, game_removed -> clear),
- * and wraps all host actions.
+ * subscribes to PROVIDER_EVENT for the active provider instance
+ * (game_updated -> re-fetch, game_removed -> clear), and wraps all host actions.
  */
 export function useMusicQuizHost(options: UseMusicQuizHostOptions) {
   const { notifyError } = options;
@@ -33,6 +33,7 @@ export function useMusicQuizHost(options: UseMusicQuizHostOptions) {
   const gameRemoved = ref(false);
   const busy = ref(false);
   const loading = ref(false);
+  const providerInstanceId = ref<string | null>(null);
 
   let unsubscribeProviderEvent: (() => void) | undefined;
 
@@ -91,20 +92,31 @@ export function useMusicQuizHost(options: UseMusicQuizHostOptions) {
   }
 
   function handleProviderEvent(event: { object_id?: string; data?: unknown }) {
-    // object_id is the provider instance_id; we don't filter on it here
-    // because there's only one music_quiz provider instance per server
     if (!event.data || typeof event.data !== "object") return;
     const payload = event.data as {
       event?: string;
       state?: MusicQuizHostState;
     };
+    if (payload.event !== "game_updated" && payload.event !== "game_removed") {
+      return;
+    }
+    if (!isScopedProviderEvent(event.object_id)) return;
     if (payload.event === "game_updated") {
       // Re-fetch on game_updated to get the latest host state
-      fetchState();
+      void fetchState();
     } else if (payload.event === "game_removed") {
       state.value = null;
       gameRemoved.value = true;
     }
+  }
+
+  function isScopedProviderEvent(objectId?: string) {
+    if (!objectId) return false;
+    if (!providerInstanceId.value) {
+      providerInstanceId.value = objectId;
+      return true;
+    }
+    return providerInstanceId.value === objectId;
   }
 
   async function create(

--- a/src/composables/useMusicQuizPlayer.ts
+++ b/src/composables/useMusicQuizPlayer.ts
@@ -37,6 +37,7 @@ export function useMusicQuizPlayer(options: UseMusicQuizPlayerOptions) {
   const gameRemoved = ref(false);
   const busy = ref(false);
   const loading = ref(false);
+  const providerInstanceId = ref<string | null>(null);
 
   let unsubscribeProviderEvent: (() => void) | undefined;
 
@@ -53,9 +54,7 @@ export function useMusicQuizPlayer(options: UseMusicQuizPlayerOptions) {
       loading.value = true;
       const nextInfo = await getMusicQuizInfo();
       info.value = nextInfo;
-      if (!nextInfo) {
-        gameRemoved.value = true;
-      }
+      gameRemoved.value = !nextInfo;
     } catch (err) {
       notifyError(
         getMusicQuizErrorMessage(
@@ -71,7 +70,7 @@ export function useMusicQuizPlayer(options: UseMusicQuizPlayerOptions) {
   async function fetchState() {
     const storedPlayerId = playerId.value ?? getStoredMusicQuizPlayerId();
     if (!storedPlayerId) {
-      // No stored player_id, can't fetch state
+      await fetchInfo();
       return;
     }
     try {
@@ -89,10 +88,7 @@ export function useMusicQuizPlayer(options: UseMusicQuizPlayerOptions) {
         (err.message.toLowerCase().includes("no active game") ||
           err.message.toLowerCase().includes("player not found"))
       ) {
-        state.value = null;
-        playerId.value = null;
-        clearStoredMusicQuizPlayerId();
-        gameRemoved.value = true;
+        await resetToJoinInfo();
       } else {
         notifyError(
           getMusicQuizErrorMessage(
@@ -112,9 +108,16 @@ export function useMusicQuizPlayer(options: UseMusicQuizPlayerOptions) {
       event?: string;
       state?: MusicQuizPersonalizedState;
     };
+    if (payload.event !== "game_updated" && payload.event !== "game_removed") {
+      return;
+    }
+    if (!isScopedProviderEvent(event.object_id)) return;
     if (payload.event === "game_updated") {
-      // Re-fetch personalized state on game_updated
-      fetchState();
+      if (playerId.value || getStoredMusicQuizPlayerId()) {
+        void fetchState();
+      } else {
+        void fetchInfo();
+      }
     } else if (payload.event === "game_removed") {
       state.value = null;
       playerId.value = null;
@@ -188,6 +191,22 @@ export function useMusicQuizPlayer(options: UseMusicQuizPlayerOptions) {
     playerId.value = null;
     state.value = null;
     clearStoredMusicQuizPlayerId();
+  }
+
+  async function resetToJoinInfo() {
+    state.value = null;
+    playerId.value = null;
+    clearStoredMusicQuizPlayerId();
+    await fetchInfo();
+  }
+
+  function isScopedProviderEvent(objectId?: string) {
+    if (!objectId) return false;
+    if (!providerInstanceId.value) {
+      providerInstanceId.value = objectId;
+      return true;
+    }
+    return providerInstanceId.value === objectId;
   }
 
   onMounted(() => {

--- a/src/views/MusicQuizPlayerView.vue
+++ b/src/views/MusicQuizPlayerView.vue
@@ -94,8 +94,9 @@
           :is-ready="state.you.ready"
           :ready-label="readyLabel"
           :image-url="currentRoundImageUrl"
-          :show-lyrics="true"
+          :show-lyrics="showRevealLyrics"
           :has-lyrics="hasRevealLyrics"
+          :lyrics-loading="isRevealLyricsLoading"
           :lyrics="revealLyrics || ''"
           :lrc-lyrics="revealLrcLyrics || ''"
           :lyrics-position="lyricsPosition"
@@ -280,26 +281,38 @@ const isConnectionDegraded = computed(
 
 const revealLyrics = ref<string | null>(null);
 const revealLrcLyrics = ref<string | null>(null);
-const hasRevealLyrics = computed(
-  () => !!(revealLyrics.value || revealLrcLyrics.value),
+const revealLyricsStatus = ref<
+  "idle" | "loading" | "ready" | "empty" | "error"
+>("idle");
+const hasRevealLyrics = computed(() => revealLyricsStatus.value === "ready");
+const isRevealLyricsLoading = computed(
+  () => revealLyricsStatus.value === "loading",
 );
+const showRevealLyrics = computed(() => revealLyricsStatus.value !== "error");
 let lyricsRequestCounter = 0;
 
 async function loadRevealLyrics(trackUri: string) {
   const requestId = ++lyricsRequestCounter;
+  revealLyricsStatus.value = "loading";
   revealLyrics.value = null;
   revealLrcLyrics.value = null;
   try {
     const item = await api.getItemByUri(trackUri);
     if (requestId !== lyricsRequestCounter) return;
-    if (item.media_type !== MediaType.TRACK) return;
+    if (item.media_type !== MediaType.TRACK) {
+      revealLyricsStatus.value = "empty";
+      return;
+    }
     const [lyrics, lrcLyrics] = await api.getTrackLyrics(item as Track);
     if (requestId !== lyricsRequestCounter) return;
     revealLyrics.value = lyrics;
     revealLrcLyrics.value = lrcLyrics;
+    revealLyricsStatus.value =
+      (lyrics ?? "").trim() || (lrcLyrics ?? "").trim() ? "ready" : "empty";
   } catch (error) {
     if (requestId === lyricsRequestCounter) {
       console.warn("Failed to load quiz lyrics:", error);
+      revealLyricsStatus.value = "error";
     }
   }
 }
@@ -311,6 +324,7 @@ watch(
       lyricsRequestCounter += 1;
       revealLyrics.value = null;
       revealLrcLyrics.value = null;
+      revealLyricsStatus.value = "idle";
       return;
     }
     void loadRevealLyrics(trackUri);

--- a/tests/components/music-quiz/MusicQuizReveal.test.ts
+++ b/tests/components/music-quiz/MusicQuizReveal.test.ts
@@ -1,0 +1,72 @@
+import MusicQuizReveal from "@/components/music-quiz/MusicQuizReveal.vue";
+import { mount } from "@vue/test-utils";
+import { describe, expect, it } from "vitest";
+
+const baseProps = {
+  round: {
+    round_index: 0,
+    started_at: 0,
+    deadline: 0,
+    suggestions: [],
+    answer_label: "Song",
+  },
+  busy: false,
+  isReady: false,
+  readyLabel: "Ready",
+  imageUrl: "",
+  showLyrics: true,
+  hasLyrics: false,
+  lyrics: "",
+  lrcLyrics: "",
+  lyricsPosition: 0,
+  lyricsTextColor: "white",
+  showReadyButton: false,
+};
+
+describe("MusicQuizReveal", () => {
+  it("shows a loading state while lyrics are still being fetched", () => {
+    const wrapper = mount(MusicQuizReveal, {
+      props: {
+        ...baseProps,
+        lyricsLoading: true,
+      },
+      global: {
+        stubs: {
+          LyricsViewer: true,
+          Button: {
+            template: "<button><slot /></button>",
+          },
+        },
+        mocks: {
+          $t: (key: string) => key,
+        },
+      },
+    });
+
+    expect(wrapper.text()).toContain("providers.music_quiz.loading_lyrics");
+    expect(wrapper.text()).not.toContain("no_lyrics_available");
+  });
+
+  it("shows a no-lyrics terminal state after loading completes without lyrics", () => {
+    const wrapper = mount(MusicQuizReveal, {
+      props: {
+        ...baseProps,
+        lyricsLoading: false,
+      },
+      global: {
+        stubs: {
+          LyricsViewer: true,
+          Button: {
+            template: "<button><slot /></button>",
+          },
+        },
+        mocks: {
+          $t: (key: string) => key,
+        },
+      },
+    });
+
+    expect(wrapper.text()).toContain("no_lyrics_available");
+    expect(wrapper.text()).not.toContain("providers.music_quiz.loading_lyrics");
+  });
+});

--- a/tests/components/music-quiz/MusicQuizSetupForm.test.ts
+++ b/tests/components/music-quiz/MusicQuizSetupForm.test.ts
@@ -1,0 +1,137 @@
+import MusicQuizSetupForm from "@/components/music-quiz/MusicQuizSetupForm.vue";
+import { MediaType } from "@/plugins/api/interfaces";
+import { mount } from "@vue/test-utils";
+import { nextTick } from "vue";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockSearch, mockToastError } = vi.hoisted(() => ({
+  mockSearch: vi.fn(),
+  mockToastError: vi.fn(),
+}));
+
+vi.mock("@/plugins/api", () => ({
+  default: {
+    search: mockSearch,
+  },
+}));
+
+vi.mock("vue-sonner", () => ({
+  toast: {
+    error: mockToastError,
+  },
+}));
+
+vi.mock("@/plugins/i18n", () => ({
+  $t: (key: string) => key,
+}));
+
+vi.mock("@/components/MediaItemThumb.vue", () => ({
+  default: {
+    name: "MediaItemThumb",
+    template: "<div />",
+  },
+}));
+
+type SearchResult = {
+  tracks: Array<{ uri: string; name: string; media_type: MediaType }>;
+  playlists: Array<{ uri: string; name: string; media_type: MediaType }>;
+};
+
+type DeferredSearch = {
+  promise: Promise<SearchResult>;
+  resolve: (value: SearchResult) => void;
+};
+
+function deferredSearch(): DeferredSearch {
+  let resolvePromise: (value: SearchResult) => void = () => {};
+  const promise = new Promise<SearchResult>((resolve) => {
+    resolvePromise = resolve;
+  });
+  return {
+    promise,
+    resolve: resolvePromise,
+  };
+}
+
+async function flushPromises() {
+  await Promise.resolve();
+  await nextTick();
+}
+
+describe("MusicQuizSetupForm", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    mockSearch.mockReset();
+    mockToastError.mockReset();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("keeps the latest source-search result when older requests finish later", async () => {
+    const oldSearch = deferredSearch();
+    const newSearch = deferredSearch();
+    mockSearch.mockImplementation((query: string) =>
+      query === "old" ? oldSearch.promise : newSearch.promise,
+    );
+
+    const wrapper = mount(MusicQuizSetupForm, {
+      props: {
+        busy: false,
+      },
+      global: {
+        stubs: {
+          Button: {
+            template: "<button><slot /></button>",
+          },
+        },
+      },
+    });
+
+    const searchInput = wrapper.find('input[type="search"]');
+    await searchInput.setValue("old");
+    await vi.advanceTimersByTimeAsync(250);
+    expect(mockSearch).toHaveBeenCalledWith(
+      "old",
+      [MediaType.TRACK, MediaType.PLAYLIST],
+      8,
+    );
+
+    await searchInput.setValue("new");
+    await vi.advanceTimersByTimeAsync(250);
+    expect(mockSearch).toHaveBeenCalledWith(
+      "new",
+      [MediaType.TRACK, MediaType.PLAYLIST],
+      8,
+    );
+
+    newSearch.resolve({
+      tracks: [
+        {
+          uri: "track:new",
+          name: "Newest result",
+          media_type: MediaType.TRACK,
+        },
+      ],
+      playlists: [],
+    });
+    await flushPromises();
+    expect(wrapper.text()).toContain("Newest result");
+
+    oldSearch.resolve({
+      tracks: [
+        {
+          uri: "track:old",
+          name: "Older result",
+          media_type: MediaType.TRACK,
+        },
+      ],
+      playlists: [],
+    });
+    await flushPromises();
+
+    expect(wrapper.text()).toContain("Newest result");
+    expect(wrapper.text()).not.toContain("Older result");
+  });
+});

--- a/tests/composables/useMusicQuizHost.test.ts
+++ b/tests/composables/useMusicQuizHost.test.ts
@@ -1,0 +1,118 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockGetMusicQuiz, mockSubscribe, providerHandlers } = vi.hoisted(
+  () => ({
+    mockGetMusicQuiz: vi.fn(),
+    mockSubscribe: vi.fn(),
+    providerHandlers: [] as Array<
+      (event: { object_id?: string; data?: unknown }) => void
+    >,
+  }),
+);
+
+vi.mock("vue", async () => {
+  const actual = await vi.importActual<typeof import("vue")>("vue");
+  return {
+    ...actual,
+    onMounted: (fn: () => void) => fn(),
+    onBeforeUnmount: () => {},
+  };
+});
+
+vi.mock("@/composables/useMusicQuiz", () => ({
+  getMusicQuiz: mockGetMusicQuiz,
+  createMusicQuiz: vi.fn(),
+  startMusicQuiz: vi.fn(),
+  revealMusicQuiz: vi.fn(),
+  nextMusicQuiz: vi.fn(),
+  resetMusicQuiz: vi.fn(),
+  deleteMusicQuiz: vi.fn(),
+}));
+
+vi.mock("@/plugins/api", () => ({
+  default: {
+    subscribe: mockSubscribe,
+  },
+}));
+
+vi.mock("@/plugins/i18n", () => ({
+  $t: (key: string) => key,
+}));
+
+import { EventType } from "@/plugins/api/interfaces";
+import { useMusicQuizHost } from "@/composables/useMusicQuizHost";
+
+const HOST_STATE = {
+  phase: "lobby",
+  name: "Quiz",
+  round_count: 5,
+  suggestion_count: 4,
+  answer_duration: 30,
+  mode: "venue",
+  players: [],
+  created_at: 1,
+  sources: [],
+  join_url: "http://join",
+  rounds: [],
+  current_round: null,
+} as const;
+
+async function flushPromises() {
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+describe("useMusicQuizHost", () => {
+  beforeEach(() => {
+    providerHandlers.length = 0;
+    mockGetMusicQuiz.mockReset();
+    mockSubscribe.mockReset();
+    mockGetMusicQuiz.mockResolvedValue({ ...HOST_STATE });
+    mockSubscribe.mockImplementation(
+      (
+        _event: EventType,
+        handler: (event: { object_id?: string; data?: unknown }) => void,
+      ) => {
+        providerHandlers.push(handler);
+        return () => {};
+      },
+    );
+  });
+
+  it("scopes provider updates to a single provider instance", async () => {
+    const host = useMusicQuizHost({ notifyError: vi.fn() });
+    await flushPromises();
+    expect(mockGetMusicQuiz).toHaveBeenCalledTimes(1);
+
+    const handler = providerHandlers[0];
+    expect(handler).toBeTypeOf("function");
+
+    handler({
+      object_id: "quiz-instance",
+      data: { event: "game_updated" },
+    });
+    await flushPromises();
+    expect(mockGetMusicQuiz).toHaveBeenCalledTimes(2);
+
+    handler({
+      object_id: "other-instance",
+      data: { event: "game_updated" },
+    });
+    await flushPromises();
+    expect(mockGetMusicQuiz).toHaveBeenCalledTimes(2);
+
+    handler({
+      object_id: "other-instance",
+      data: { event: "game_removed" },
+    });
+    expect(host.state.value).not.toBeNull();
+    expect(host.gameRemoved.value).toBe(false);
+
+    handler({
+      object_id: "quiz-instance",
+      data: { event: "game_removed" },
+    });
+    expect(host.state.value).toBeNull();
+    expect(host.gameRemoved.value).toBe(true);
+  });
+});

--- a/tests/composables/useMusicQuizPlayer.test.ts
+++ b/tests/composables/useMusicQuizPlayer.test.ts
@@ -1,0 +1,178 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const {
+  mockGetMusicQuizInfo,
+  mockGetMusicQuizState,
+  mockJoinMusicQuiz,
+  mockReadyMusicQuiz,
+  mockAnswerMusicQuiz,
+  mockSubscribe,
+  mockStorePlayerId,
+  mockGetStoredPlayerId,
+  mockClearStoredPlayerId,
+  mockGetMusicQuizErrorMessage,
+  storedPlayerId,
+  providerHandlers,
+} = vi.hoisted(() => ({
+  mockGetMusicQuizInfo: vi.fn(),
+  mockGetMusicQuizState: vi.fn(),
+  mockJoinMusicQuiz: vi.fn(),
+  mockReadyMusicQuiz: vi.fn(),
+  mockAnswerMusicQuiz: vi.fn(),
+  mockSubscribe: vi.fn(),
+  mockStorePlayerId: vi.fn(),
+  mockGetStoredPlayerId: vi.fn(),
+  mockClearStoredPlayerId: vi.fn(),
+  mockGetMusicQuizErrorMessage: vi.fn(),
+  storedPlayerId: { value: null as string | null },
+  providerHandlers: [] as Array<
+    (event: { object_id?: string; data?: unknown }) => void
+  >,
+}));
+
+vi.mock("vue", async () => {
+  const actual = await vi.importActual<typeof import("vue")>("vue");
+  return {
+    ...actual,
+    onMounted: (fn: () => void) => fn(),
+    onBeforeUnmount: () => {},
+  };
+});
+
+vi.mock("@/composables/useMusicQuiz", () => ({
+  getMusicQuizInfo: mockGetMusicQuizInfo,
+  getMusicQuizState: mockGetMusicQuizState,
+  joinMusicQuiz: mockJoinMusicQuiz,
+  readyMusicQuiz: mockReadyMusicQuiz,
+  answerMusicQuiz: mockAnswerMusicQuiz,
+}));
+
+vi.mock("@/plugins/api", () => ({
+  default: {
+    subscribe: mockSubscribe,
+  },
+}));
+
+vi.mock("@/helpers/music_quiz", () => ({
+  storeMusicQuizPlayerId: mockStorePlayerId,
+  getStoredMusicQuizPlayerId: mockGetStoredPlayerId,
+  clearStoredMusicQuizPlayerId: mockClearStoredPlayerId,
+  getMusicQuizErrorMessage: mockGetMusicQuizErrorMessage,
+}));
+
+vi.mock("@/plugins/i18n", () => ({
+  $t: (key: string) => key,
+}));
+
+import { EventType } from "@/plugins/api/interfaces";
+import { useMusicQuizPlayer } from "@/composables/useMusicQuizPlayer";
+
+const QUIZ_INFO = {
+  name: "Quiz",
+  phase: "lobby",
+  player_count: 2,
+  round_count: 5,
+  mode: "venue",
+} as const;
+
+async function flushPromises() {
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+describe("useMusicQuizPlayer", () => {
+  beforeEach(() => {
+    storedPlayerId.value = null;
+    providerHandlers.length = 0;
+    mockGetMusicQuizInfo.mockReset();
+    mockGetMusicQuizState.mockReset();
+    mockJoinMusicQuiz.mockReset();
+    mockReadyMusicQuiz.mockReset();
+    mockAnswerMusicQuiz.mockReset();
+    mockSubscribe.mockReset();
+    mockStorePlayerId.mockReset();
+    mockGetStoredPlayerId.mockReset();
+    mockClearStoredPlayerId.mockReset();
+    mockGetMusicQuizErrorMessage.mockReset();
+    mockGetStoredPlayerId.mockImplementation(() => storedPlayerId.value);
+    mockStorePlayerId.mockImplementation((playerId: string) => {
+      storedPlayerId.value = playerId;
+    });
+    mockClearStoredPlayerId.mockImplementation(() => {
+      storedPlayerId.value = null;
+    });
+    mockGetMusicQuizErrorMessage.mockImplementation(
+      (error: unknown, fallback = "") =>
+        error instanceof Error ? error.message : fallback,
+    );
+    mockSubscribe.mockImplementation(
+      (
+        _event: EventType,
+        handler: (event: { object_id?: string; data?: unknown }) => void,
+      ) => {
+        providerHandlers.push(handler);
+        return () => {};
+      },
+    );
+  });
+
+  it("recovers from a stale player token by returning to the join/info state", async () => {
+    storedPlayerId.value = "stale-player";
+    mockGetMusicQuizState.mockRejectedValue(new Error("player not found"));
+    mockGetMusicQuizInfo.mockResolvedValue(QUIZ_INFO);
+
+    const player = useMusicQuizPlayer({ notifyError: vi.fn() });
+    await flushPromises();
+
+    expect(player.playerId.value).toBeNull();
+    expect(player.state.value).toBeNull();
+    expect(player.info.value).toEqual(QUIZ_INFO);
+    expect(player.gameRemoved.value).toBe(false);
+    expect(storedPlayerId.value).toBeNull();
+  });
+
+  it("returns from game-removed state when a new game update arrives", async () => {
+    mockGetMusicQuizInfo
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(QUIZ_INFO);
+    const player = useMusicQuizPlayer({ notifyError: vi.fn() });
+    await flushPromises();
+
+    expect(player.gameRemoved.value).toBe(true);
+
+    const handler = providerHandlers[0];
+    expect(handler).toBeTypeOf("function");
+    handler({
+      object_id: "quiz-instance",
+      data: { event: "game_updated" },
+    });
+    await flushPromises();
+
+    expect(player.gameRemoved.value).toBe(false);
+    expect(player.info.value).toEqual(QUIZ_INFO);
+  });
+
+  it("only handles provider events from the active quiz instance", async () => {
+    mockGetMusicQuizInfo.mockResolvedValue(QUIZ_INFO);
+    useMusicQuizPlayer({ notifyError: vi.fn() });
+    await flushPromises();
+    expect(mockGetMusicQuizInfo).toHaveBeenCalledTimes(1);
+
+    const handler = providerHandlers[0];
+    expect(handler).toBeTypeOf("function");
+
+    handler({
+      object_id: "quiz-instance",
+      data: { event: "game_updated" },
+    });
+    await flushPromises();
+    expect(mockGetMusicQuizInfo).toHaveBeenCalledTimes(2);
+
+    handler({
+      object_id: "other-instance",
+      data: { event: "game_updated" },
+    });
+    await flushPromises();
+    expect(mockGetMusicQuizInfo).toHaveBeenCalledTimes(2);
+  });
+});


### PR DESCRIPTION
Fixes several Music Quiz frontend edge cases that could leave guests stuck or show incomplete reveal/setup behavior.

- recover guests to the join/info screen when stale tokens or game removal events occur
- scope host/player PROVIDER_EVENT handling to the active quiz provider instance
- stop reveal lyrics from spinning forever by adding terminal no-lyrics/error handling
- guard setup source search against stale async responses and hide host now-playing until reveal data exists
- add focused tests for guest recovery, provider-event scoping, reveal lyric states, and source-search race ordering