### PR TITLE
Fix Music Quiz styling and stray error toast

### DIFF
--- a/src/components/icons/MusicQuizIcon.vue
+++ b/src/components/icons/MusicQuizIcon.vue
@@ -1,4 +1,6 @@
 <script setup lang="ts">
+import { MicVocal } from "@lucide/vue";
+
 defineOptions({
   name: "MusicQuizIcon",
 });
@@ -13,51 +15,6 @@ const props = withDefaults(
 );
 </script>
 
-<!-- a microphone with a question mark: the sidebar twin of the provider
-     manifest's mdi-microphone-question, drawn in the lucide stroke style -->
 <template>
-  <svg
-    class="music-quiz-icon"
-    width="18"
-    height="18"
-    viewBox="0 0 24 24"
-    fill="none"
-    xmlns="http://www.w3.org/2000/svg"
-  >
-    <path
-      d="M10 3a2.5 2.5 0 0 0-2.5 2.5v6a2.5 2.5 0 0 0 5 0v-6A2.5 2.5 0 0 0 10 3Z"
-      stroke="currentColor"
-      :stroke-width="props.strokeWidth"
-      stroke-linecap="round"
-      stroke-linejoin="round"
-    />
-    <path
-      d="M16 10.5v1a6 6 0 0 1-12 0v-1"
-      stroke="currentColor"
-      :stroke-width="props.strokeWidth"
-      stroke-linecap="round"
-      stroke-linejoin="round"
-    />
-    <path
-      d="M10 17.5V21"
-      stroke="currentColor"
-      :stroke-width="props.strokeWidth"
-      stroke-linecap="round"
-      stroke-linejoin="round"
-    />
-    <path
-      d="M17.5 5.5a2.25 2.25 0 1 1 3.2 2.05c-.6.28-.95.65-.95 1.25v.7"
-      stroke="currentColor"
-      :stroke-width="props.strokeWidth"
-      stroke-linecap="round"
-      stroke-linejoin="round"
-    />
-    <path
-      d="M19.75 12.75v.01"
-      stroke="currentColor"
-      :stroke-width="props.strokeWidth"
-      stroke-linecap="round"
-      stroke-linejoin="round"
-    />
-  </svg>
+  <MicVocal :stroke-width="props.strokeWidth" />
 </template>

--- a/src/components/music-quiz/MusicQuizAnswerGrid.vue
+++ b/src/components/music-quiz/MusicQuizAnswerGrid.vue
@@ -34,9 +34,9 @@ const emit = defineEmits<{ select: [suggestionId: string] }>();
   display: flex;
   flex-direction: column;
   gap: 0.625rem;
-  border: 1px solid hsl(var(--border));
+  border: 1px solid var(--border);
   border-radius: 8px;
-  background: hsl(var(--card));
+  background: var(--card);
   padding: 0.875rem;
 }
 

--- a/src/components/music-quiz/MusicQuizAnswerStatus.vue
+++ b/src/components/music-quiz/MusicQuizAnswerStatus.vue
@@ -34,9 +34,9 @@ defineProps<{
   display: flex;
   flex-direction: column;
   gap: 0.625rem;
-  border: 1px solid hsl(var(--border));
+  border: 1px solid var(--border);
   border-radius: 8px;
-  background: hsl(var(--card));
+  background: var(--card);
   padding: 0.875rem;
 }
 
@@ -49,7 +49,7 @@ defineProps<{
 }
 
 .quiz-answer-status small {
-  color: hsl(var(--muted-foreground));
+  color: var(--muted-foreground);
 }
 
 .quiz-answer-status ul {
@@ -66,15 +66,15 @@ defineProps<{
   display: flex;
   align-items: center;
   gap: 0.5rem;
-  border: 1px solid hsl(var(--border));
+  border: 1px solid var(--border);
   border-radius: 6px;
-  background: hsl(var(--background));
+  background: var(--background);
   padding: 0.55rem 0.65rem;
-  color: hsl(var(--muted-foreground));
+  color: var(--muted-foreground);
 }
 
 .quiz-answer-status li.is-answered {
-  color: hsl(var(--foreground));
+  color: var(--foreground);
 }
 
 .quiz-answer-status svg {
@@ -82,7 +82,7 @@ defineProps<{
 }
 
 .quiz-answer-status li.is-answered svg {
-  color: hsl(var(--primary));
+  color: var(--primary);
 }
 
 .quiz-answer-status li span {

--- a/src/components/music-quiz/MusicQuizConnectionBanners.vue
+++ b/src/components/music-quiz/MusicQuizConnectionBanners.vue
@@ -16,11 +16,11 @@ defineProps<{ degraded: boolean }>();
   display: flex;
   align-items: center;
   gap: 0.5rem;
-  border: 1px solid hsl(var(--border));
+  border: 1px solid var(--border);
   border-radius: 8px;
-  background: hsl(var(--card));
+  background: var(--card);
   padding: 0.625rem 0.875rem;
   font-size: 0.875rem;
-  color: hsl(var(--muted-foreground));
+  color: var(--muted-foreground);
 }
 </style>

--- a/src/components/music-quiz/MusicQuizHostPanel.vue
+++ b/src/components/music-quiz/MusicQuizHostPanel.vue
@@ -228,7 +228,7 @@ onBeforeUnmount(() => {
 .quiz-host__qr-error {
   margin: 0;
   max-width: 220px;
-  color: hsl(var(--muted-foreground));
+  color: var(--muted-foreground);
   font-size: 0.875rem;
 }
 
@@ -245,9 +245,9 @@ onBeforeUnmount(() => {
 .quiz-host__session-sources {
   flex: 1 1 320px;
   min-width: min(100%, 280px);
-  border: 1px solid hsl(var(--border));
+  border: 1px solid var(--border);
   border-radius: 8px;
-  background: hsl(var(--background));
+  background: var(--background);
   overflow: hidden;
 }
 
@@ -261,8 +261,8 @@ onBeforeUnmount(() => {
   font-weight: 600;
   list-style: none;
   padding: 0.75rem 0.9rem;
-  background: hsl(var(--muted));
-  color: hsl(var(--foreground));
+  background: var(--muted);
+  color: var(--foreground);
   user-select: none;
 }
 
@@ -274,7 +274,7 @@ onBeforeUnmount(() => {
 .quiz-host__now-playing-details summary strong,
 .quiz-host__session-sources summary strong {
   margin-left: auto;
-  color: hsl(var(--muted-foreground));
+  color: var(--muted-foreground);
   font-size: 0.8rem;
   font-weight: 500;
 }
@@ -282,7 +282,7 @@ onBeforeUnmount(() => {
 .quiz-host__now-playing-details summary svg,
 .quiz-host__session-sources summary svg {
   flex: 0 0 auto;
-  color: hsl(var(--muted-foreground));
+  color: var(--muted-foreground);
   transition: transform 0.15s ease;
 }
 
@@ -304,7 +304,7 @@ onBeforeUnmount(() => {
   aspect-ratio: 1;
   border-radius: 8px;
   object-fit: cover;
-  background: hsl(var(--muted));
+  background: var(--muted);
 }
 
 .quiz-host__now-playing div {
@@ -315,7 +315,7 @@ onBeforeUnmount(() => {
 }
 
 .quiz-host__now-playing span {
-  color: hsl(var(--muted-foreground));
+  color: var(--muted-foreground);
   font-size: 0.875rem;
 }
 
@@ -337,9 +337,9 @@ onBeforeUnmount(() => {
 
 .quiz-host__session-source {
   min-width: 0;
-  border: 1px solid hsl(var(--border));
+  border: 1px solid var(--border);
   border-radius: 6px;
-  background: hsl(var(--card));
+  background: var(--card);
   padding: 0.6rem 0.75rem;
 }
 
@@ -352,7 +352,7 @@ onBeforeUnmount(() => {
 }
 
 .quiz-host__session-source small {
-  color: hsl(var(--muted-foreground));
+  color: var(--muted-foreground);
 }
 
 .quiz-host__actions {

--- a/src/components/music-quiz/MusicQuizJoinForm.vue
+++ b/src/components/music-quiz/MusicQuizJoinForm.vue
@@ -45,9 +45,9 @@ onMounted(async () => {
   display: flex;
   flex-direction: column;
   gap: 0.625rem;
-  border: 1px solid hsl(var(--border));
+  border: 1px solid var(--border);
   border-radius: 8px;
-  background: hsl(var(--card));
+  background: var(--card);
   padding: 0.875rem;
 }
 
@@ -61,12 +61,13 @@ onMounted(async () => {
   min-height: 2.75rem;
   width: 100%;
   appearance: none;
-  border: 2px solid hsl(var(--foreground) / 0.58);
+  border: 2px solid color-mix(in srgb, var(--foreground) 58%, transparent);
   border-radius: 6px;
-  background: hsl(var(--background));
-  box-shadow: inset 0 1px 0 hsl(var(--foreground) / 0.06);
+  background: var(--background);
+  box-shadow: inset 0 1px 0
+    color-mix(in srgb, var(--foreground) 6%, transparent);
   padding: 0.5rem 0.625rem;
-  color: hsl(var(--foreground));
+  color: var(--foreground);
   outline: none;
   transition:
     border-color 0.15s ease,
@@ -74,9 +75,9 @@ onMounted(async () => {
 }
 
 .quiz-join input:focus {
-  border-color: hsl(var(--primary));
+  border-color: var(--primary);
   box-shadow:
-    0 0 0 3px hsl(var(--primary) / 0.22),
-    inset 0 1px 0 hsl(var(--foreground) / 0.06);
+    0 0 0 3px color-mix(in srgb, var(--primary) 22%, transparent),
+    inset 0 1px 0 color-mix(in srgb, var(--foreground) 6%, transparent);
 }
 </style>

--- a/src/components/music-quiz/MusicQuizLeaderboard.vue
+++ b/src/components/music-quiz/MusicQuizLeaderboard.vue
@@ -41,9 +41,9 @@ defineProps<{
   display: flex;
   flex-direction: column;
   gap: 0.625rem;
-  border: 1px solid hsl(var(--border));
+  border: 1px solid var(--border);
   border-radius: 8px;
-  background: hsl(var(--card));
+  background: var(--card);
   padding: 0.875rem;
 }
 
@@ -77,21 +77,21 @@ defineProps<{
 }
 
 .quiz-leaderboard li.is-current-player {
-  background: hsl(var(--primary) / 0.12);
+  background: color-mix(in srgb, var(--primary) 12%, transparent);
 }
 
 .quiz-leaderboard li.is-current-player .quiz-leaderboard__name {
-  color: hsl(var(--primary));
+  color: var(--primary);
   font-weight: 800;
 }
 
 .quiz-leaderboard li.is-current-player small {
-  color: hsl(var(--primary));
+  color: var(--primary);
 }
 
 .quiz-leaderboard small {
   margin-right: 0.5rem;
-  color: hsl(var(--muted-foreground));
+  color: var(--muted-foreground);
 }
 
 .quiz-leaderboard__score {
@@ -103,7 +103,7 @@ defineProps<{
 }
 
 .quiz-leaderboard__score span {
-  color: hsl(var(--primary));
+  color: var(--primary);
   font-size: 0.8rem;
 }
 </style>

--- a/src/components/music-quiz/MusicQuizPlayerHeader.vue
+++ b/src/components/music-quiz/MusicQuizPlayerHeader.vue
@@ -34,9 +34,9 @@ defineProps<{
   align-items: center;
   justify-content: space-between;
   gap: 0.75rem;
-  border: 1px solid hsl(var(--border));
+  border: 1px solid var(--border);
   border-radius: 8px;
-  background: hsl(var(--card));
+  background: var(--card);
   padding: 0.875rem;
 }
 
@@ -52,14 +52,14 @@ defineProps<{
 }
 
 .quiz-header__rank {
-  color: hsl(var(--muted-foreground));
+  color: var(--muted-foreground);
   font-size: 0.85em;
   font-weight: 600;
   white-space: nowrap;
 }
 
 .quiz-header__round-progress {
-  color: hsl(var(--muted-foreground));
+  color: var(--muted-foreground);
   font-size: 0.85rem;
   font-weight: 600;
 }
@@ -73,7 +73,7 @@ defineProps<{
 }
 
 .quiz-header__score span {
-  color: hsl(var(--primary));
+  color: var(--primary);
   font-size: 0.85rem;
 }
 
@@ -82,11 +82,11 @@ defineProps<{
   align-items: center;
   justify-content: center;
   min-height: 2.4rem;
-  border: 1px solid hsl(var(--primary) / 0.35);
+  border: 1px solid color-mix(in srgb, var(--primary) 35%, transparent);
   border-radius: 8px;
-  background: hsl(var(--primary) / 0.1);
+  background: color-mix(in srgb, var(--primary) 10%, transparent);
   padding: 0.5rem 0.75rem;
-  color: hsl(var(--foreground));
+  color: var(--foreground);
   font-size: 0.95rem;
   font-weight: 800;
   text-align: center;

--- a/src/components/music-quiz/MusicQuizReveal.vue
+++ b/src/components/music-quiz/MusicQuizReveal.vue
@@ -85,9 +85,9 @@ const emit = defineEmits<{ ready: []; "copy-title": [] }>();
   display: flex;
   flex-direction: column;
   gap: 0.625rem;
-  border: 1px solid hsl(var(--border));
+  border: 1px solid var(--border);
   border-radius: 8px;
-  background: hsl(var(--card));
+  background: var(--card);
   padding: 0.875rem;
 }
 
@@ -116,9 +116,9 @@ const emit = defineEmits<{ ready: []; "copy-title": [] }>();
   height: clamp(220px, 34dvh, 360px);
   min-height: 220px;
   overflow: hidden;
-  border: 1px solid hsl(var(--border));
+  border: 1px solid var(--border);
   border-radius: 8px;
-  background: hsl(var(--background));
+  background: var(--background);
   padding: 0.25rem;
 }
 
@@ -128,7 +128,7 @@ const emit = defineEmits<{ ready: []; "copy-title": [] }>();
   align-items: center;
   justify-content: center;
   gap: 0.5rem;
-  color: hsl(var(--muted-foreground));
+  color: var(--muted-foreground);
   font-weight: 600;
 }
 
@@ -158,7 +158,7 @@ const emit = defineEmits<{ ready: []; "copy-title": [] }>();
   align-self: center;
   border-radius: 8px;
   object-fit: cover;
-  background: hsl(var(--muted));
+  background: var(--muted);
 }
 
 /* this component only renders during the reveal phase, so the wide layout

--- a/src/components/music-quiz/MusicQuizSessionPanels.vue
+++ b/src/components/music-quiz/MusicQuizSessionPanels.vue
@@ -103,9 +103,9 @@ const answeredPlayerCount = computed(
 }
 
 .quiz-panels__panel {
-  border: 1px solid hsl(var(--border));
+  border: 1px solid var(--border);
   border-radius: 8px;
-  background: hsl(var(--card));
+  background: var(--card);
   padding: 1rem;
 }
 
@@ -125,7 +125,7 @@ const answeredPlayerCount = computed(
 }
 
 .quiz-panels__answer-status small {
-  color: hsl(var(--muted-foreground));
+  color: var(--muted-foreground);
 }
 
 .quiz-panels__answer-status ul {
@@ -142,15 +142,15 @@ const answeredPlayerCount = computed(
   display: flex;
   align-items: center;
   gap: 0.5rem;
-  border: 1px solid hsl(var(--border));
+  border: 1px solid var(--border);
   border-radius: 6px;
-  background: hsl(var(--background));
+  background: var(--background);
   padding: 0.55rem 0.65rem;
-  color: hsl(var(--muted-foreground));
+  color: var(--muted-foreground);
 }
 
 .quiz-panels__answer-status li.is-answered {
-  color: hsl(var(--foreground));
+  color: var(--foreground);
 }
 
 .quiz-panels__answer-status svg {
@@ -158,7 +158,7 @@ const answeredPlayerCount = computed(
 }
 
 .quiz-panels__answer-status li.is-answered svg {
-  color: hsl(var(--primary));
+  color: var(--primary);
 }
 
 .quiz-panels__answer-status li span {
@@ -188,7 +188,7 @@ const answeredPlayerCount = computed(
 
 .quiz-panels__leaderboard small {
   margin-right: 0.5rem;
-  color: hsl(var(--muted-foreground));
+  color: var(--muted-foreground);
 }
 
 @media (max-width: 800px) {

--- a/src/components/music-quiz/MusicQuizSetupForm.vue
+++ b/src/components/music-quiz/MusicQuizSetupForm.vue
@@ -255,7 +255,8 @@ onBeforeUnmount(() => {
 <style scoped>
 .quiz-setup {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(170px, 210px));
+  justify-content: start;
   gap: 0.75rem;
 }
 
@@ -269,12 +270,13 @@ onBeforeUnmount(() => {
 .quiz-setup input,
 .quiz-setup select {
   min-height: 2.5rem;
-  border: 1px solid hsl(var(--foreground) / 0.35);
+  border: 1px solid color-mix(in srgb, var(--foreground) 35%, transparent);
   border-radius: 6px;
-  background: hsl(var(--muted));
-  box-shadow: inset 0 1px 0 hsl(var(--foreground) / 0.06);
+  background: var(--muted);
+  box-shadow: inset 0 1px 0
+    color-mix(in srgb, var(--foreground) 6%, transparent);
   padding: 0.5rem;
-  color: hsl(var(--foreground));
+  color: var(--foreground);
   outline: none;
   transition:
     border-color 0.15s ease,
@@ -283,10 +285,10 @@ onBeforeUnmount(() => {
 
 .quiz-setup input:focus,
 .quiz-setup select:focus {
-  border-color: hsl(var(--primary));
+  border-color: var(--primary);
   box-shadow:
-    inset 0 1px 0 hsl(var(--foreground) / 0.06),
-    0 0 0 3px hsl(var(--primary) / 0.2);
+    inset 0 1px 0 color-mix(in srgb, var(--foreground) 6%, transparent),
+    0 0 0 3px color-mix(in srgb, var(--primary) 20%, transparent);
 }
 
 .quiz-setup__wide {
@@ -312,9 +314,9 @@ onBeforeUnmount(() => {
   max-height: 18rem;
   overflow-y: auto;
   overscroll-behavior: contain;
-  border: 1px solid hsl(var(--border));
+  border: 1px solid var(--border);
   border-radius: 6px;
-  background: hsl(var(--background));
+  background: var(--background);
   padding: 0.35rem;
 }
 
@@ -333,9 +335,9 @@ onBeforeUnmount(() => {
   justify-content: space-between;
   gap: 0.75rem;
   min-height: 2.5rem;
-  border: 1px solid hsl(var(--border));
+  border: 1px solid var(--border);
   border-radius: 6px;
-  background: hsl(var(--background));
+  background: var(--background);
   padding: 0.5rem 0.75rem;
   font-size: 0.875rem;
 }
@@ -354,7 +356,7 @@ onBeforeUnmount(() => {
 }
 
 .quiz-setup__source-row:hover {
-  background: hsl(var(--muted));
+  background: var(--muted);
 }
 
 .quiz-setup__source-row span {
@@ -372,7 +374,7 @@ onBeforeUnmount(() => {
 
 .quiz-setup__source-row small,
 .quiz-setup__muted {
-  color: hsl(var(--muted-foreground));
+  color: var(--muted-foreground);
 }
 
 .quiz-setup__source-chip {
@@ -381,9 +383,9 @@ onBeforeUnmount(() => {
   align-items: center;
   gap: 0.75rem;
   width: 100%;
-  border: 1px solid hsl(var(--border));
+  border: 1px solid var(--border);
   border-radius: 6px;
-  background: hsl(var(--muted));
+  background: var(--muted);
   padding: 0.6rem 0.75rem;
   text-align: left;
 }

--- a/src/components/music-quiz/MusicQuizSetupForm.vue
+++ b/src/components/music-quiz/MusicQuizSetupForm.vue
@@ -310,6 +310,11 @@ onBeforeUnmount(() => {
   gap: 0.75rem;
 }
 
+.quiz-setup__source-search input {
+  border-color: var(--border);
+  background: var(--background);
+}
+
 .quiz-setup__source-results {
   max-height: 18rem;
   overflow-y: auto;
@@ -318,6 +323,7 @@ onBeforeUnmount(() => {
   border-radius: 6px;
   background: var(--background);
   padding: 0.35rem;
+  box-shadow: 0 2px 10px color-mix(in srgb, var(--foreground) 6%, transparent);
 }
 
 .quiz-setup__selected-sources {
@@ -348,15 +354,25 @@ onBeforeUnmount(() => {
   align-items: center;
   gap: 0.75rem;
   width: 100%;
-  border: 0;
+  border: 1px solid transparent;
   border-radius: 5px;
   background: transparent;
   padding: 0.45rem;
   text-align: left;
+  cursor: pointer;
+  transition:
+    background-color 0.15s ease,
+    border-color 0.15s ease;
 }
 
 .quiz-setup__source-row:hover {
-  background: var(--muted);
+  border-color: color-mix(in srgb, var(--border) 70%, transparent);
+  background: color-mix(in srgb, var(--primary) 10%, var(--background));
+}
+
+.quiz-setup__source-row:focus-visible {
+  border-color: var(--primary);
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--primary) 20%, transparent);
 }
 
 .quiz-setup__source-row span {

--- a/src/composables/useMusicQuizHost.ts
+++ b/src/composables/useMusicQuizHost.ts
@@ -14,7 +14,10 @@ import { $t } from "@/plugins/i18n";
 import api from "@/plugins/api";
 import { EventType } from "@/plugins/api/interfaces";
 import { computed, onBeforeUnmount, onMounted, ref } from "vue";
-import { getMusicQuizErrorMessage } from "@/helpers/music_quiz";
+import {
+  getMusicQuizErrorMessage,
+  isNoActiveMusicQuizError,
+} from "@/helpers/music_quiz";
 
 export interface UseMusicQuizHostOptions {
   notifyError: (message: string) => void;
@@ -68,13 +71,7 @@ export function useMusicQuizHost(options: UseMusicQuizHostOptions) {
       state.value = nextState;
       gameRemoved.value = false;
     } catch (err) {
-      if (
-        err &&
-        typeof err === "object" &&
-        "message" in err &&
-        typeof err.message === "string" &&
-        err.message.toLowerCase().includes("no active game")
-      ) {
+      if (isNoActiveMusicQuizError(err)) {
         state.value = null;
         gameRemoved.value = false;
       } else {

--- a/src/composables/useMusicQuizPlayer.ts
+++ b/src/composables/useMusicQuizPlayer.ts
@@ -13,6 +13,7 @@ import {
   getStoredMusicQuizPlayerId,
   storeMusicQuizPlayerId,
   getMusicQuizErrorMessage,
+  isNoActiveMusicQuizError,
 } from "@/helpers/music_quiz";
 import { $t } from "@/plugins/i18n";
 import api from "@/plugins/api";
@@ -81,14 +82,13 @@ export function useMusicQuizPlayer(options: UseMusicQuizPlayerOptions) {
       playerId.value = storedPlayerId;
       gameRemoved.value = false;
     } catch (err) {
-      if (
+      const isPlayerNotFound =
         err &&
         typeof err === "object" &&
         "message" in err &&
         typeof err.message === "string" &&
-        (err.message.toLowerCase().includes("no active game") ||
-          err.message.toLowerCase().includes("player not found"))
-      ) {
+        err.message.toLowerCase().includes("player not found");
+      if (isNoActiveMusicQuizError(err) || isPlayerNotFound) {
         state.value = null;
         playerId.value = null;
         clearStoredMusicQuizPlayerId();

--- a/src/composables/useMusicQuizPlayer.ts
+++ b/src/composables/useMusicQuizPlayer.ts
@@ -14,6 +14,7 @@ import {
   storeMusicQuizPlayerId,
   getMusicQuizErrorMessage,
   isNoActiveMusicQuizError,
+  isMusicQuizPlayerNotFoundError,
 } from "@/helpers/music_quiz";
 import { $t } from "@/plugins/i18n";
 import api from "@/plugins/api";
@@ -82,13 +83,10 @@ export function useMusicQuizPlayer(options: UseMusicQuizPlayerOptions) {
       playerId.value = storedPlayerId;
       gameRemoved.value = false;
     } catch (err) {
-      const isPlayerNotFound =
-        err &&
-        typeof err === "object" &&
-        "message" in err &&
-        typeof err.message === "string" &&
-        err.message.toLowerCase().includes("player not found");
-      if (isNoActiveMusicQuizError(err) || isPlayerNotFound) {
+      if (
+        isNoActiveMusicQuizError(err) ||
+        isMusicQuizPlayerNotFoundError(err)
+      ) {
         state.value = null;
         playerId.value = null;
         clearStoredMusicQuizPlayerId();

--- a/src/helpers/music_quiz.ts
+++ b/src/helpers/music_quiz.ts
@@ -109,7 +109,13 @@ export function getMusicQuizErrorMessage(err: unknown, fallback = "") {
 
 export function isNoActiveMusicQuizError(err: unknown) {
   const normalizedMessage = getMusicQuizErrorMessage(err).toLowerCase();
-  if (normalizedMessage.includes("no active")) return true;
+  if (
+    normalizedMessage.includes("no active music quiz game") ||
+    (normalizedMessage.includes("no active") &&
+      normalizedMessage.includes("music quiz"))
+  ) {
+    return true;
+  }
 
   if (err && typeof err === "object") {
     const errorCode =
@@ -121,12 +127,28 @@ export function isNoActiveMusicQuizError(err: unknown) {
         ? err.type.toLowerCase()
         : "";
     if (
-      errorCode.includes("no_active") ||
       errorCode.includes("musicquiznogame") ||
+      (errorCode.includes("music_quiz") && errorCode.includes("no_active")) ||
       errorType.includes("musicquiznogame")
     ) {
       return true;
     }
+  }
+  return false;
+}
+
+export function isMusicQuizPlayerNotFoundError(err: unknown) {
+  const normalizedMessage = getMusicQuizErrorMessage(err).toLowerCase();
+  if (normalizedMessage.includes("player not found")) return true;
+
+  if (err && typeof err === "object") {
+    const errorCode =
+      "error_code" in err && typeof err.error_code === "string"
+        ? err.error_code.toLowerCase()
+        : "";
+    return (
+      errorCode.includes("player_not_found") && errorCode.includes("music_quiz")
+    );
   }
   return false;
 }

--- a/src/helpers/music_quiz.ts
+++ b/src/helpers/music_quiz.ts
@@ -106,3 +106,27 @@ export function getMusicQuizErrorMessage(err: unknown, fallback = "") {
   }
   return fallback;
 }
+
+export function isNoActiveMusicQuizError(err: unknown) {
+  const normalizedMessage = getMusicQuizErrorMessage(err).toLowerCase();
+  if (normalizedMessage.includes("no active")) return true;
+
+  if (err && typeof err === "object") {
+    const errorCode =
+      "error_code" in err && typeof err.error_code === "string"
+        ? err.error_code.toLowerCase()
+        : "";
+    const errorType =
+      "type" in err && typeof err.type === "string"
+        ? err.type.toLowerCase()
+        : "";
+    if (
+      errorCode.includes("no_active") ||
+      errorCode.includes("musicquiznogame") ||
+      errorType.includes("musicquiznogame")
+    ) {
+      return true;
+    }
+  }
+  return false;
+}

--- a/src/views/MusicQuizDashboardView.vue
+++ b/src/views/MusicQuizDashboardView.vue
@@ -59,7 +59,7 @@
             :lyrics="''"
             :lrc-lyrics="''"
             :lyrics-position="0"
-            :lyrics-text-color="'hsl(var(--foreground))'"
+            :lyrics-text-color="'var(--foreground)'"
             :show-ready-button="false"
             :show-copy-button="false"
             @ready="noop"
@@ -172,7 +172,7 @@
             :lyrics="''"
             :lrc-lyrics="''"
             :lyrics-position="0"
-            :lyrics-text-color="'hsl(var(--foreground))'"
+            :lyrics-text-color="'var(--foreground)'"
             :show-ready-button="false"
             @ready="noop"
             @copy-title="copyCurrentRoundTitle"
@@ -373,9 +373,9 @@ onBeforeUnmount(() => {
 
 .dashboard-shell__header,
 .dashboard-shell__card {
-  border: 1px solid hsl(var(--border));
+  border: 1px solid var(--border);
   border-radius: 10px;
-  background: hsl(var(--card));
+  background: var(--card);
   padding: 1rem;
 }
 
@@ -394,7 +394,7 @@ onBeforeUnmount(() => {
 .dashboard-shell__header p,
 .dashboard-shell__card p {
   margin: 0.35rem 0 0;
-  color: hsl(var(--muted-foreground));
+  color: var(--muted-foreground);
 }
 
 .dashboard-shell__content {
@@ -415,7 +415,7 @@ onBeforeUnmount(() => {
   display: flex;
   flex-direction: column;
   gap: 1rem;
-  background: hsl(var(--background));
+  background: var(--background);
   padding: 1.2rem;
 }
 
@@ -434,7 +434,7 @@ onBeforeUnmount(() => {
 .present-mode__heading p {
   margin: 0.35rem 0 0;
   font-size: clamp(1rem, 1.8vw, 1.5rem);
-  color: hsl(var(--muted-foreground));
+  color: var(--muted-foreground);
 }
 
 .present-mode__body {

--- a/src/views/MusicQuizPlayerView.vue
+++ b/src/views/MusicQuizPlayerView.vue
@@ -99,7 +99,7 @@
           :lyrics="revealLyrics || ''"
           :lrc-lyrics="revealLrcLyrics || ''"
           :lyrics-position="lyricsPosition"
-          :lyrics-text-color="'hsl(var(--foreground))'"
+          :lyrics-text-color="'var(--foreground)'"
           @ready="handleReady"
           @copy-title="copyCurrentRoundTitle"
         />
@@ -365,9 +365,9 @@ onBeforeUnmount(() => {
 
 .quiz-shell--join,
 .quiz-shell--game {
-  border: 1px solid hsl(var(--border));
+  border: 1px solid var(--border);
   border-radius: 12px;
-  background: hsl(var(--card));
+  background: var(--card);
   padding: 0.9rem;
 }
 
@@ -378,7 +378,7 @@ onBeforeUnmount(() => {
 
 .quiz-shell__intro p {
   margin: 0.3rem 0 0;
-  color: hsl(var(--muted-foreground));
+  color: var(--muted-foreground);
 }
 
 .quiz-shell__stats {
@@ -389,9 +389,9 @@ onBeforeUnmount(() => {
 }
 
 .quiz-shell__stats span {
-  border: 1px solid hsl(var(--border));
+  border: 1px solid var(--border);
   border-radius: 999px;
-  background: hsl(var(--muted));
+  background: var(--muted);
   padding: 0.2rem 0.6rem;
   font-size: 0.82rem;
 }
@@ -410,7 +410,7 @@ onBeforeUnmount(() => {
 
 .quiz-shell__hint {
   margin: 0;
-  color: hsl(var(--muted-foreground));
+  color: var(--muted-foreground);
   text-align: center;
 }
 

--- a/tests/composables/useMusicQuizHost.noActiveGame.test.ts
+++ b/tests/composables/useMusicQuizHost.noActiveGame.test.ts
@@ -1,0 +1,68 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockGetMusicQuiz, mockSubscribe } = vi.hoisted(() => ({
+  mockGetMusicQuiz: vi.fn(),
+  mockSubscribe: vi.fn(() => () => {}),
+}));
+
+vi.mock("vue", async () => {
+  const actual = await vi.importActual<typeof import("vue")>("vue");
+  return {
+    ...actual,
+    onMounted: (fn: () => void) => fn(),
+    onBeforeUnmount: () => {},
+  };
+});
+
+vi.mock("@/composables/useMusicQuiz", () => ({
+  getMusicQuiz: mockGetMusicQuiz,
+  createMusicQuiz: vi.fn(),
+  startMusicQuiz: vi.fn(),
+  revealMusicQuiz: vi.fn(),
+  nextMusicQuiz: vi.fn(),
+  resetMusicQuiz: vi.fn(),
+  deleteMusicQuiz: vi.fn(),
+}));
+
+vi.mock("@/plugins/api", () => ({
+  default: {
+    subscribe: mockSubscribe,
+  },
+}));
+
+vi.mock("@/plugins/i18n", () => ({
+  $t: (key: string) => key,
+  i18n: {
+    global: {
+      locale: { value: "en" },
+    },
+  },
+}));
+
+import { useMusicQuizHost } from "@/composables/useMusicQuizHost";
+
+async function flushPromises() {
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+describe("useMusicQuizHost no active game handling", () => {
+  beforeEach(() => {
+    mockGetMusicQuiz.mockReset();
+    mockSubscribe.mockClear();
+  });
+
+  it("treats 'no active game' as an empty state without notifying", async () => {
+    mockGetMusicQuiz.mockRejectedValue(
+      new Error("There is no active Music Quiz game"),
+    );
+    const notifyError = vi.fn();
+
+    const host = useMusicQuizHost({ notifyError });
+    await flushPromises();
+
+    expect(host.state.value).toBeNull();
+    expect(host.gameRemoved.value).toBe(false);
+    expect(notifyError).not.toHaveBeenCalled();
+  });
+});

--- a/tests/composables/useMusicQuizPlayer.noActiveGame.test.ts
+++ b/tests/composables/useMusicQuizPlayer.noActiveGame.test.ts
@@ -1,0 +1,94 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const {
+  mockGetMusicQuizInfo,
+  mockGetMusicQuizState,
+  mockJoinMusicQuiz,
+  mockReadyMusicQuiz,
+  mockAnswerMusicQuiz,
+  mockSubscribe,
+  storedPlayerId,
+} = vi.hoisted(() => ({
+  mockGetMusicQuizInfo: vi.fn(),
+  mockGetMusicQuizState: vi.fn(),
+  mockJoinMusicQuiz: vi.fn(),
+  mockReadyMusicQuiz: vi.fn(),
+  mockAnswerMusicQuiz: vi.fn(),
+  mockSubscribe: vi.fn(() => () => {}),
+  storedPlayerId: { value: "player-1" as string | null },
+}));
+
+vi.mock("vue", async () => {
+  const actual = await vi.importActual<typeof import("vue")>("vue");
+  return {
+    ...actual,
+    onMounted: (fn: () => void) => fn(),
+    onBeforeUnmount: () => {},
+  };
+});
+
+vi.mock("@/composables/useMusicQuiz", () => ({
+  getMusicQuizInfo: mockGetMusicQuizInfo,
+  getMusicQuizState: mockGetMusicQuizState,
+  joinMusicQuiz: mockJoinMusicQuiz,
+  readyMusicQuiz: mockReadyMusicQuiz,
+  answerMusicQuiz: mockAnswerMusicQuiz,
+}));
+
+vi.mock("@/helpers/music_quiz", () => ({
+  clearStoredMusicQuizPlayerId: () => {
+    storedPlayerId.value = null;
+  },
+  getStoredMusicQuizPlayerId: () => storedPlayerId.value,
+  storeMusicQuizPlayerId: (playerId: string) => {
+    storedPlayerId.value = playerId;
+  },
+  getMusicQuizErrorMessage: (err: unknown, fallback = "") =>
+    err instanceof Error ? err.message : fallback,
+  isNoActiveMusicQuizError: (err: unknown) =>
+    err instanceof Error && err.message.toLowerCase().includes("no active"),
+}));
+
+vi.mock("@/plugins/api", () => ({
+  default: {
+    subscribe: mockSubscribe,
+  },
+}));
+
+vi.mock("@/plugins/i18n", () => ({
+  $t: (key: string) => key,
+}));
+
+import { useMusicQuizPlayer } from "@/composables/useMusicQuizPlayer";
+
+async function flushPromises() {
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+describe("useMusicQuizPlayer no active game handling", () => {
+  beforeEach(() => {
+    storedPlayerId.value = "player-1";
+    mockGetMusicQuizInfo.mockReset();
+    mockGetMusicQuizState.mockReset();
+    mockJoinMusicQuiz.mockReset();
+    mockReadyMusicQuiz.mockReset();
+    mockAnswerMusicQuiz.mockReset();
+    mockSubscribe.mockClear();
+  });
+
+  it("does not notify on no-active-game state fetch errors", async () => {
+    mockGetMusicQuizState.mockRejectedValue(
+      new Error("There is no active Music Quiz game"),
+    );
+    const notifyError = vi.fn();
+
+    const player = useMusicQuizPlayer({ notifyError });
+    await flushPromises();
+
+    expect(player.state.value).toBeNull();
+    expect(player.playerId.value).toBeNull();
+    expect(player.gameRemoved.value).toBe(true);
+    expect(notifyError).not.toHaveBeenCalled();
+  });
+});

--- a/tests/helpers/music_quiz.test.ts
+++ b/tests/helpers/music_quiz.test.ts
@@ -9,7 +9,10 @@ vi.mock("@/plugins/i18n", () => ({
   },
 }));
 
-import { isNoActiveMusicQuizError } from "@/helpers/music_quiz";
+import {
+  isMusicQuizPlayerNotFoundError,
+  isNoActiveMusicQuizError,
+} from "@/helpers/music_quiz";
 
 describe("music quiz error helpers", () => {
   it("matches the no-active-game server message", () => {
@@ -22,5 +25,17 @@ describe("music quiz error helpers", () => {
     expect(isNoActiveMusicQuizError(new Error("temporary network error"))).toBe(
       false,
     );
+  });
+
+  it("does not match generic non-quiz 'no active' errors", () => {
+    expect(
+      isNoActiveMusicQuizError(new Error("No active output device selected")),
+    ).toBe(false);
+  });
+
+  it("matches player-not-found errors", () => {
+    expect(
+      isMusicQuizPlayerNotFoundError(new Error("Music Quiz player not found")),
+    ).toBe(true);
   });
 });

--- a/tests/helpers/music_quiz.test.ts
+++ b/tests/helpers/music_quiz.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@/plugins/i18n", () => ({
+  $t: (key: string) => key,
+  i18n: {
+    global: {
+      locale: { value: "en" },
+    },
+  },
+}));
+
+import { isNoActiveMusicQuizError } from "@/helpers/music_quiz";
+
+describe("music quiz error helpers", () => {
+  it("matches the no-active-game server message", () => {
+    expect(
+      isNoActiveMusicQuizError(new Error("There is no active Music Quiz game")),
+    ).toBe(true);
+  });
+
+  it("does not match unrelated errors", () => {
+    expect(isNoActiveMusicQuizError(new Error("temporary network error"))).toBe(
+      false,
+    );
+  });
+});


### PR DESCRIPTION
Fixes the current Music Quiz rendering breakage and the no-game load error toast.

- convert quiz styles from invalid hsl(var(--token)) usage to MA-compatible token/color-mix usage
- tighten setup form field layout so core settings render as a compact form
- treat no-active-game responses as a normal empty state via a shared helper (no toast)
- align the quiz menu icon with the Lucide icon set
- add focused tests for no-active-game detection and no-toast behavior