### PR TITLE
Fix Music Quiz styling and menu icon

### DIFF
--- a/src/components/icons/MusicQuizIcon.vue
+++ b/src/components/icons/MusicQuizIcon.vue
@@ -13,8 +13,7 @@ const props = withDefaults(
 );
 </script>
 
-<!-- a microphone with a question mark: the sidebar twin of the provider
-     manifest's mdi-microphone-question, drawn in the lucide stroke style -->
+<!-- sidebar Music Quiz icon, drawn in a lucide-like microphone stroke style -->
 <template>
   <svg
     class="music-quiz-icon"

--- a/src/components/icons/MusicQuizIcon.vue
+++ b/src/components/icons/MusicQuizIcon.vue
@@ -25,35 +25,28 @@ const props = withDefaults(
     xmlns="http://www.w3.org/2000/svg"
   >
     <path
-      d="M10 3a2.5 2.5 0 0 0-2.5 2.5v6a2.5 2.5 0 0 0 5 0v-6A2.5 2.5 0 0 0 10 3Z"
+      d="M12 12a3 3 0 0 0 3-3V5a3 3 0 0 0-6 0v4a3 3 0 0 0 3 3Z"
       stroke="currentColor"
       :stroke-width="props.strokeWidth"
       stroke-linecap="round"
       stroke-linejoin="round"
     />
     <path
-      d="M16 10.5v1a6 6 0 0 1-12 0v-1"
+      d="M19 10v1a7 7 0 0 1-14 0v-1"
       stroke="currentColor"
       :stroke-width="props.strokeWidth"
       stroke-linecap="round"
       stroke-linejoin="round"
     />
     <path
-      d="M10 17.5V21"
+      d="M12 18v3"
       stroke="currentColor"
       :stroke-width="props.strokeWidth"
       stroke-linecap="round"
       stroke-linejoin="round"
     />
     <path
-      d="M17.5 5.5a2.25 2.25 0 1 1 3.2 2.05c-.6.28-.95.65-.95 1.25v.7"
-      stroke="currentColor"
-      :stroke-width="props.strokeWidth"
-      stroke-linecap="round"
-      stroke-linejoin="round"
-    />
-    <path
-      d="M19.75 12.75v.01"
+      d="M8 21h8"
       stroke="currentColor"
       :stroke-width="props.strokeWidth"
       stroke-linecap="round"

--- a/src/components/music-quiz/MusicQuizAnswerGrid.vue
+++ b/src/components/music-quiz/MusicQuizAnswerGrid.vue
@@ -34,9 +34,9 @@ const emit = defineEmits<{ select: [suggestionId: string] }>();
   display: flex;
   flex-direction: column;
   gap: 0.625rem;
-  border: 1px solid hsl(var(--border));
+  border: 1px solid var(--border);
   border-radius: 8px;
-  background: hsl(var(--card));
+  background: var(--card);
   padding: 0.875rem;
 }
 

--- a/src/components/music-quiz/MusicQuizAnswerStatus.vue
+++ b/src/components/music-quiz/MusicQuizAnswerStatus.vue
@@ -34,9 +34,9 @@ defineProps<{
   display: flex;
   flex-direction: column;
   gap: 0.625rem;
-  border: 1px solid hsl(var(--border));
+  border: 1px solid var(--border);
   border-radius: 8px;
-  background: hsl(var(--card));
+  background: var(--card);
   padding: 0.875rem;
 }
 
@@ -49,7 +49,7 @@ defineProps<{
 }
 
 .quiz-answer-status small {
-  color: hsl(var(--muted-foreground));
+  color: var(--muted-foreground);
 }
 
 .quiz-answer-status ul {
@@ -66,15 +66,15 @@ defineProps<{
   display: flex;
   align-items: center;
   gap: 0.5rem;
-  border: 1px solid hsl(var(--border));
+  border: 1px solid var(--border);
   border-radius: 6px;
-  background: hsl(var(--background));
+  background: var(--background);
   padding: 0.55rem 0.65rem;
-  color: hsl(var(--muted-foreground));
+  color: var(--muted-foreground);
 }
 
 .quiz-answer-status li.is-answered {
-  color: hsl(var(--foreground));
+  color: var(--foreground);
 }
 
 .quiz-answer-status svg {
@@ -82,7 +82,7 @@ defineProps<{
 }
 
 .quiz-answer-status li.is-answered svg {
-  color: hsl(var(--primary));
+  color: var(--primary);
 }
 
 .quiz-answer-status li span {

--- a/src/components/music-quiz/MusicQuizConnectionBanners.vue
+++ b/src/components/music-quiz/MusicQuizConnectionBanners.vue
@@ -16,11 +16,11 @@ defineProps<{ degraded: boolean }>();
   display: flex;
   align-items: center;
   gap: 0.5rem;
-  border: 1px solid hsl(var(--border));
+  border: 1px solid var(--border);
   border-radius: 8px;
-  background: hsl(var(--card));
+  background: var(--card);
   padding: 0.625rem 0.875rem;
   font-size: 0.875rem;
-  color: hsl(var(--muted-foreground));
+  color: var(--muted-foreground);
 }
 </style>

--- a/src/components/music-quiz/MusicQuizHostPanel.vue
+++ b/src/components/music-quiz/MusicQuizHostPanel.vue
@@ -228,7 +228,7 @@ onBeforeUnmount(() => {
 .quiz-host__qr-error {
   margin: 0;
   max-width: 220px;
-  color: hsl(var(--muted-foreground));
+  color: var(--muted-foreground);
   font-size: 0.875rem;
 }
 
@@ -245,9 +245,9 @@ onBeforeUnmount(() => {
 .quiz-host__session-sources {
   flex: 1 1 320px;
   min-width: min(100%, 280px);
-  border: 1px solid hsl(var(--border));
+  border: 1px solid var(--border);
   border-radius: 8px;
-  background: hsl(var(--background));
+  background: var(--background);
   overflow: hidden;
 }
 
@@ -261,8 +261,8 @@ onBeforeUnmount(() => {
   font-weight: 600;
   list-style: none;
   padding: 0.75rem 0.9rem;
-  background: hsl(var(--muted));
-  color: hsl(var(--foreground));
+  background: var(--muted);
+  color: var(--foreground);
   user-select: none;
 }
 
@@ -274,7 +274,7 @@ onBeforeUnmount(() => {
 .quiz-host__now-playing-details summary strong,
 .quiz-host__session-sources summary strong {
   margin-left: auto;
-  color: hsl(var(--muted-foreground));
+  color: var(--muted-foreground);
   font-size: 0.8rem;
   font-weight: 500;
 }
@@ -282,7 +282,7 @@ onBeforeUnmount(() => {
 .quiz-host__now-playing-details summary svg,
 .quiz-host__session-sources summary svg {
   flex: 0 0 auto;
-  color: hsl(var(--muted-foreground));
+  color: var(--muted-foreground);
   transition: transform 0.15s ease;
 }
 
@@ -304,7 +304,7 @@ onBeforeUnmount(() => {
   aspect-ratio: 1;
   border-radius: 8px;
   object-fit: cover;
-  background: hsl(var(--muted));
+  background: var(--muted);
 }
 
 .quiz-host__now-playing div {
@@ -315,7 +315,7 @@ onBeforeUnmount(() => {
 }
 
 .quiz-host__now-playing span {
-  color: hsl(var(--muted-foreground));
+  color: var(--muted-foreground);
   font-size: 0.875rem;
 }
 
@@ -337,9 +337,9 @@ onBeforeUnmount(() => {
 
 .quiz-host__session-source {
   min-width: 0;
-  border: 1px solid hsl(var(--border));
+  border: 1px solid var(--border);
   border-radius: 6px;
-  background: hsl(var(--card));
+  background: var(--card);
   padding: 0.6rem 0.75rem;
 }
 
@@ -352,7 +352,7 @@ onBeforeUnmount(() => {
 }
 
 .quiz-host__session-source small {
-  color: hsl(var(--muted-foreground));
+  color: var(--muted-foreground);
 }
 
 .quiz-host__actions {

--- a/src/components/music-quiz/MusicQuizJoinForm.vue
+++ b/src/components/music-quiz/MusicQuizJoinForm.vue
@@ -45,9 +45,9 @@ onMounted(async () => {
   display: flex;
   flex-direction: column;
   gap: 0.625rem;
-  border: 1px solid hsl(var(--border));
+  border: 1px solid var(--border);
   border-radius: 8px;
-  background: hsl(var(--card));
+  background: var(--card);
   padding: 0.875rem;
 }
 
@@ -61,12 +61,13 @@ onMounted(async () => {
   min-height: 2.75rem;
   width: 100%;
   appearance: none;
-  border: 2px solid hsl(var(--foreground) / 0.58);
+  border: 2px solid color-mix(in srgb, var(--foreground) 58%, transparent);
   border-radius: 6px;
-  background: hsl(var(--background));
-  box-shadow: inset 0 1px 0 hsl(var(--foreground) / 0.06);
+  background: var(--background);
+  box-shadow: inset 0 1px 0
+    color-mix(in srgb, var(--foreground) 6%, transparent);
   padding: 0.5rem 0.625rem;
-  color: hsl(var(--foreground));
+  color: var(--foreground);
   outline: none;
   transition:
     border-color 0.15s ease,
@@ -74,9 +75,9 @@ onMounted(async () => {
 }
 
 .quiz-join input:focus {
-  border-color: hsl(var(--primary));
+  border-color: var(--primary);
   box-shadow:
-    0 0 0 3px hsl(var(--primary) / 0.22),
-    inset 0 1px 0 hsl(var(--foreground) / 0.06);
+    0 0 0 3px color-mix(in srgb, var(--primary) 22%, transparent),
+    inset 0 1px 0 color-mix(in srgb, var(--foreground) 6%, transparent);
 }
 </style>

--- a/src/components/music-quiz/MusicQuizLeaderboard.vue
+++ b/src/components/music-quiz/MusicQuizLeaderboard.vue
@@ -41,9 +41,9 @@ defineProps<{
   display: flex;
   flex-direction: column;
   gap: 0.625rem;
-  border: 1px solid hsl(var(--border));
+  border: 1px solid var(--border);
   border-radius: 8px;
-  background: hsl(var(--card));
+  background: var(--card);
   padding: 0.875rem;
 }
 
@@ -77,21 +77,21 @@ defineProps<{
 }
 
 .quiz-leaderboard li.is-current-player {
-  background: hsl(var(--primary) / 0.12);
+  background: color-mix(in srgb, var(--primary) 12%, transparent);
 }
 
 .quiz-leaderboard li.is-current-player .quiz-leaderboard__name {
-  color: hsl(var(--primary));
+  color: var(--primary);
   font-weight: 800;
 }
 
 .quiz-leaderboard li.is-current-player small {
-  color: hsl(var(--primary));
+  color: var(--primary);
 }
 
 .quiz-leaderboard small {
   margin-right: 0.5rem;
-  color: hsl(var(--muted-foreground));
+  color: var(--muted-foreground);
 }
 
 .quiz-leaderboard__score {
@@ -103,7 +103,7 @@ defineProps<{
 }
 
 .quiz-leaderboard__score span {
-  color: hsl(var(--primary));
+  color: var(--primary);
   font-size: 0.8rem;
 }
 </style>

--- a/src/components/music-quiz/MusicQuizPlayerHeader.vue
+++ b/src/components/music-quiz/MusicQuizPlayerHeader.vue
@@ -34,9 +34,9 @@ defineProps<{
   align-items: center;
   justify-content: space-between;
   gap: 0.75rem;
-  border: 1px solid hsl(var(--border));
+  border: 1px solid var(--border);
   border-radius: 8px;
-  background: hsl(var(--card));
+  background: var(--card);
   padding: 0.875rem;
 }
 
@@ -52,14 +52,14 @@ defineProps<{
 }
 
 .quiz-header__rank {
-  color: hsl(var(--muted-foreground));
+  color: var(--muted-foreground);
   font-size: 0.85em;
   font-weight: 600;
   white-space: nowrap;
 }
 
 .quiz-header__round-progress {
-  color: hsl(var(--muted-foreground));
+  color: var(--muted-foreground);
   font-size: 0.85rem;
   font-weight: 600;
 }
@@ -73,7 +73,7 @@ defineProps<{
 }
 
 .quiz-header__score span {
-  color: hsl(var(--primary));
+  color: var(--primary);
   font-size: 0.85rem;
 }
 
@@ -82,11 +82,11 @@ defineProps<{
   align-items: center;
   justify-content: center;
   min-height: 2.4rem;
-  border: 1px solid hsl(var(--primary) / 0.35);
+  border: 1px solid color-mix(in srgb, var(--primary) 35%, transparent);
   border-radius: 8px;
-  background: hsl(var(--primary) / 0.1);
+  background: color-mix(in srgb, var(--primary) 10%, transparent);
   padding: 0.5rem 0.75rem;
-  color: hsl(var(--foreground));
+  color: var(--foreground);
   font-size: 0.95rem;
   font-weight: 800;
   text-align: center;

--- a/src/components/music-quiz/MusicQuizReveal.vue
+++ b/src/components/music-quiz/MusicQuizReveal.vue
@@ -85,9 +85,9 @@ const emit = defineEmits<{ ready: []; "copy-title": [] }>();
   display: flex;
   flex-direction: column;
   gap: 0.625rem;
-  border: 1px solid hsl(var(--border));
+  border: 1px solid var(--border);
   border-radius: 8px;
-  background: hsl(var(--card));
+  background: var(--card);
   padding: 0.875rem;
 }
 
@@ -116,9 +116,9 @@ const emit = defineEmits<{ ready: []; "copy-title": [] }>();
   height: clamp(220px, 34dvh, 360px);
   min-height: 220px;
   overflow: hidden;
-  border: 1px solid hsl(var(--border));
+  border: 1px solid var(--border);
   border-radius: 8px;
-  background: hsl(var(--background));
+  background: var(--background);
   padding: 0.25rem;
 }
 
@@ -128,7 +128,7 @@ const emit = defineEmits<{ ready: []; "copy-title": [] }>();
   align-items: center;
   justify-content: center;
   gap: 0.5rem;
-  color: hsl(var(--muted-foreground));
+  color: var(--muted-foreground);
   font-weight: 600;
 }
 
@@ -158,7 +158,7 @@ const emit = defineEmits<{ ready: []; "copy-title": [] }>();
   align-self: center;
   border-radius: 8px;
   object-fit: cover;
-  background: hsl(var(--muted));
+  background: var(--muted);
 }
 
 /* this component only renders during the reveal phase, so the wide layout

--- a/src/components/music-quiz/MusicQuizSessionPanels.vue
+++ b/src/components/music-quiz/MusicQuizSessionPanels.vue
@@ -103,9 +103,9 @@ const answeredPlayerCount = computed(
 }
 
 .quiz-panels__panel {
-  border: 1px solid hsl(var(--border));
+  border: 1px solid var(--border);
   border-radius: 8px;
-  background: hsl(var(--card));
+  background: var(--card);
   padding: 1rem;
 }
 
@@ -125,7 +125,7 @@ const answeredPlayerCount = computed(
 }
 
 .quiz-panels__answer-status small {
-  color: hsl(var(--muted-foreground));
+  color: var(--muted-foreground);
 }
 
 .quiz-panels__answer-status ul {
@@ -142,15 +142,15 @@ const answeredPlayerCount = computed(
   display: flex;
   align-items: center;
   gap: 0.5rem;
-  border: 1px solid hsl(var(--border));
+  border: 1px solid var(--border);
   border-radius: 6px;
-  background: hsl(var(--background));
+  background: var(--background);
   padding: 0.55rem 0.65rem;
-  color: hsl(var(--muted-foreground));
+  color: var(--muted-foreground);
 }
 
 .quiz-panels__answer-status li.is-answered {
-  color: hsl(var(--foreground));
+  color: var(--foreground);
 }
 
 .quiz-panels__answer-status svg {
@@ -158,7 +158,7 @@ const answeredPlayerCount = computed(
 }
 
 .quiz-panels__answer-status li.is-answered svg {
-  color: hsl(var(--primary));
+  color: var(--primary);
 }
 
 .quiz-panels__answer-status li span {
@@ -188,7 +188,7 @@ const answeredPlayerCount = computed(
 
 .quiz-panels__leaderboard small {
   margin-right: 0.5rem;
-  color: hsl(var(--muted-foreground));
+  color: var(--muted-foreground);
 }
 
 @media (max-width: 800px) {

--- a/src/components/music-quiz/MusicQuizSetupForm.vue
+++ b/src/components/music-quiz/MusicQuizSetupForm.vue
@@ -255,7 +255,8 @@ onBeforeUnmount(() => {
 <style scoped>
 .quiz-setup {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(170px, 210px));
+  justify-content: start;
   gap: 0.75rem;
 }
 
@@ -269,12 +270,13 @@ onBeforeUnmount(() => {
 .quiz-setup input,
 .quiz-setup select {
   min-height: 2.5rem;
-  border: 1px solid hsl(var(--foreground) / 0.35);
+  border: 1px solid color-mix(in srgb, var(--foreground) 35%, transparent);
   border-radius: 6px;
-  background: hsl(var(--muted));
-  box-shadow: inset 0 1px 0 hsl(var(--foreground) / 0.06);
+  background: var(--muted);
+  box-shadow: inset 0 1px 0
+    color-mix(in srgb, var(--foreground) 6%, transparent);
   padding: 0.5rem;
-  color: hsl(var(--foreground));
+  color: var(--foreground);
   outline: none;
   transition:
     border-color 0.15s ease,
@@ -283,10 +285,10 @@ onBeforeUnmount(() => {
 
 .quiz-setup input:focus,
 .quiz-setup select:focus {
-  border-color: hsl(var(--primary));
+  border-color: var(--primary);
   box-shadow:
-    inset 0 1px 0 hsl(var(--foreground) / 0.06),
-    0 0 0 3px hsl(var(--primary) / 0.2);
+    inset 0 1px 0 color-mix(in srgb, var(--foreground) 6%, transparent),
+    0 0 0 3px color-mix(in srgb, var(--primary) 20%, transparent);
 }
 
 .quiz-setup__wide {
@@ -308,14 +310,20 @@ onBeforeUnmount(() => {
   gap: 0.75rem;
 }
 
+.quiz-setup__source-search input {
+  border-color: var(--border);
+  background: var(--background);
+}
+
 .quiz-setup__source-results {
   max-height: 18rem;
   overflow-y: auto;
   overscroll-behavior: contain;
-  border: 1px solid hsl(var(--border));
+  border: 1px solid var(--border);
   border-radius: 6px;
-  background: hsl(var(--background));
+  background: var(--background);
   padding: 0.35rem;
+  box-shadow: 0 2px 10px color-mix(in srgb, var(--foreground) 6%, transparent);
 }
 
 .quiz-setup__selected-sources {
@@ -333,9 +341,9 @@ onBeforeUnmount(() => {
   justify-content: space-between;
   gap: 0.75rem;
   min-height: 2.5rem;
-  border: 1px solid hsl(var(--border));
+  border: 1px solid var(--border);
   border-radius: 6px;
-  background: hsl(var(--background));
+  background: var(--background);
   padding: 0.5rem 0.75rem;
   font-size: 0.875rem;
 }
@@ -346,15 +354,25 @@ onBeforeUnmount(() => {
   align-items: center;
   gap: 0.75rem;
   width: 100%;
-  border: 0;
+  border: 1px solid transparent;
   border-radius: 5px;
   background: transparent;
   padding: 0.45rem;
   text-align: left;
+  cursor: pointer;
+  transition:
+    background-color 0.15s ease,
+    border-color 0.15s ease;
 }
 
 .quiz-setup__source-row:hover {
-  background: hsl(var(--muted));
+  border-color: color-mix(in srgb, var(--border) 70%, transparent);
+  background: color-mix(in srgb, var(--primary) 10%, var(--background));
+}
+
+.quiz-setup__source-row:focus-visible {
+  border-color: var(--primary);
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--primary) 20%, transparent);
 }
 
 .quiz-setup__source-row span {
@@ -372,7 +390,7 @@ onBeforeUnmount(() => {
 
 .quiz-setup__source-row small,
 .quiz-setup__muted {
-  color: hsl(var(--muted-foreground));
+  color: var(--muted-foreground);
 }
 
 .quiz-setup__source-chip {
@@ -381,9 +399,9 @@ onBeforeUnmount(() => {
   align-items: center;
   gap: 0.75rem;
   width: 100%;
-  border: 1px solid hsl(var(--border));
+  border: 1px solid var(--border);
   border-radius: 6px;
-  background: hsl(var(--muted));
+  background: var(--muted);
   padding: 0.6rem 0.75rem;
   text-align: left;
 }

--- a/src/components/music-quiz/MusicQuizSetupForm.vue
+++ b/src/components/music-quiz/MusicQuizSetupForm.vue
@@ -371,6 +371,7 @@ onBeforeUnmount(() => {
 }
 
 .quiz-setup__source-row:focus-visible {
+  outline: none;
   border-color: var(--primary);
   box-shadow: 0 0 0 2px color-mix(in srgb, var(--primary) 20%, transparent);
 }

--- a/src/views/MusicQuizDashboardView.vue
+++ b/src/views/MusicQuizDashboardView.vue
@@ -373,9 +373,9 @@ onBeforeUnmount(() => {
 
 .dashboard-shell__header,
 .dashboard-shell__card {
-  border: 1px solid hsl(var(--border));
+  border: 1px solid var(--border);
   border-radius: 10px;
-  background: hsl(var(--card));
+  background: var(--card);
   padding: 1rem;
 }
 
@@ -394,7 +394,7 @@ onBeforeUnmount(() => {
 .dashboard-shell__header p,
 .dashboard-shell__card p {
   margin: 0.35rem 0 0;
-  color: hsl(var(--muted-foreground));
+  color: var(--muted-foreground);
 }
 
 .dashboard-shell__content {
@@ -415,7 +415,7 @@ onBeforeUnmount(() => {
   display: flex;
   flex-direction: column;
   gap: 1rem;
-  background: hsl(var(--background));
+  background: var(--background);
   padding: 1.2rem;
 }
 
@@ -434,7 +434,7 @@ onBeforeUnmount(() => {
 .present-mode__heading p {
   margin: 0.35rem 0 0;
   font-size: clamp(1rem, 1.8vw, 1.5rem);
-  color: hsl(var(--muted-foreground));
+  color: var(--muted-foreground);
 }
 
 .present-mode__body {

--- a/src/views/MusicQuizPlayerView.vue
+++ b/src/views/MusicQuizPlayerView.vue
@@ -365,9 +365,9 @@ onBeforeUnmount(() => {
 
 .quiz-shell--join,
 .quiz-shell--game {
-  border: 1px solid hsl(var(--border));
+  border: 1px solid var(--border);
   border-radius: 12px;
-  background: hsl(var(--card));
+  background: var(--card);
   padding: 0.9rem;
 }
 
@@ -378,7 +378,7 @@ onBeforeUnmount(() => {
 
 .quiz-shell__intro p {
   margin: 0.3rem 0 0;
-  color: hsl(var(--muted-foreground));
+  color: var(--muted-foreground);
 }
 
 .quiz-shell__stats {
@@ -389,9 +389,9 @@ onBeforeUnmount(() => {
 }
 
 .quiz-shell__stats span {
-  border: 1px solid hsl(var(--border));
+  border: 1px solid var(--border);
   border-radius: 999px;
-  background: hsl(var(--muted));
+  background: var(--muted);
   padding: 0.2rem 0.6rem;
   font-size: 0.82rem;
 }
@@ -410,7 +410,7 @@ onBeforeUnmount(() => {
 
 .quiz-shell__hint {
   margin: 0;
-  color: hsl(var(--muted-foreground));
+  color: var(--muted-foreground);
   text-align: center;
 }
 


### PR DESCRIPTION
Fixes Music Quiz presentation issues that made setup controls hard to use.

- convert quiz styles from invalid hsl(var(--token)) usage to MA-compatible token/color-mix usage across quiz views/components
- tighten the setup form field grid so core controls render as a compact form instead of stretching edge-to-edge
- make the source search/results picker visually obvious and clickable (input, panel, hover/focus row states)
- align the quiz sidebar icon stroke/shape with the Lucide menu icon style