### PR TITLE
Fix Music Quiz no-game empty state handling

### DIFF
--- a/src/components/music-quiz/MusicQuizReveal.vue
+++ b/src/components/music-quiz/MusicQuizReveal.vue
@@ -142,7 +142,7 @@ const emit = defineEmits<{ ready: []; "copy-title": [] }>();
   height: 100%;
   align-items: center;
   justify-content: center;
-  color: hsl(var(--muted-foreground));
+  color: var(--muted-foreground);
   font-weight: 600;
 }
 

--- a/src/components/music-quiz/MusicQuizReveal.vue
+++ b/src/components/music-quiz/MusicQuizReveal.vue
@@ -142,7 +142,7 @@ const emit = defineEmits<{ ready: []; "copy-title": [] }>();
   height: 100%;
   align-items: center;
   justify-content: center;
-  color: var(--muted-foreground);
+  color: hsl(var(--muted-foreground));
   font-weight: 600;
 }
 

--- a/src/composables/useMusicQuizHost.ts
+++ b/src/composables/useMusicQuizHost.ts
@@ -14,7 +14,10 @@ import { $t } from "@/plugins/i18n";
 import api from "@/plugins/api";
 import { EventType } from "@/plugins/api/interfaces";
 import { computed, onBeforeUnmount, onMounted, ref } from "vue";
-import { getMusicQuizErrorMessage } from "@/helpers/music_quiz";
+import {
+  getMusicQuizErrorMessage,
+  isNoActiveGameError,
+} from "@/helpers/music_quiz";
 
 export interface UseMusicQuizHostOptions {
   notifyError: (message: string) => void;
@@ -69,13 +72,7 @@ export function useMusicQuizHost(options: UseMusicQuizHostOptions) {
       state.value = nextState;
       gameRemoved.value = false;
     } catch (err) {
-      if (
-        err &&
-        typeof err === "object" &&
-        "message" in err &&
-        typeof err.message === "string" &&
-        err.message.toLowerCase().includes("no active game")
-      ) {
+      if (isNoActiveGameError(err)) {
         state.value = null;
         gameRemoved.value = false;
       } else {

--- a/src/composables/useMusicQuizPlayer.ts
+++ b/src/composables/useMusicQuizPlayer.ts
@@ -13,6 +13,8 @@ import {
   getStoredMusicQuizPlayerId,
   storeMusicQuizPlayerId,
   getMusicQuizErrorMessage,
+  isNoActiveGameError,
+  isMusicQuizPlayerNotFoundError,
 } from "@/helpers/music_quiz";
 import { $t } from "@/plugins/i18n";
 import api from "@/plugins/api";
@@ -81,12 +83,8 @@ export function useMusicQuizPlayer(options: UseMusicQuizPlayerOptions) {
       gameRemoved.value = false;
     } catch (err) {
       if (
-        err &&
-        typeof err === "object" &&
-        "message" in err &&
-        typeof err.message === "string" &&
-        (err.message.toLowerCase().includes("no active game") ||
-          err.message.toLowerCase().includes("player not found"))
+        isNoActiveGameError(err) ||
+        isMusicQuizPlayerNotFoundError(err)
       ) {
         await resetToJoinInfo();
       } else {

--- a/src/composables/useMusicQuizPlayer.ts
+++ b/src/composables/useMusicQuizPlayer.ts
@@ -82,10 +82,7 @@ export function useMusicQuizPlayer(options: UseMusicQuizPlayerOptions) {
       playerId.value = storedPlayerId;
       gameRemoved.value = false;
     } catch (err) {
-      if (
-        isNoActiveGameError(err) ||
-        isMusicQuizPlayerNotFoundError(err)
-      ) {
+      if (isNoActiveGameError(err) || isMusicQuizPlayerNotFoundError(err)) {
         await resetToJoinInfo();
       } else {
         notifyError(

--- a/src/helpers/music_quiz.ts
+++ b/src/helpers/music_quiz.ts
@@ -108,26 +108,31 @@ export function getMusicQuizErrorMessage(err: unknown, fallback = "") {
 }
 
 export function isNoActiveGameError(err: unknown) {
-  const normalizedMessage = getMusicQuizErrorMessage(err).toLowerCase();
-  if (normalizedMessage.includes("no active")) return true;
-
-  if (err && typeof err === "object") {
-    const errorCode =
-      "error_code" in err && typeof err.error_code === "string"
-        ? err.error_code.toLowerCase()
-        : "";
-    const errorType =
-      "type" in err && typeof err.type === "string"
-        ? err.type.toLowerCase()
-        : "";
-    return (
-      errorCode.includes("musicquiznogame") ||
-      errorCode.includes("music_quiz_no_game") ||
-      errorType.includes("musicquiznogame") ||
-      errorType.includes("music_quiz_no_game")
-    );
+  if (typeof err === "string") {
+    return err.toLowerCase().includes("no active");
   }
-  return false;
+  if (err instanceof Error) {
+    return err.message.toLowerCase().includes("no active");
+  }
+  if (!err || typeof err !== "object") return false;
+  const message =
+    "message" in err && typeof err.message === "string" ? err.message : "";
+  const details =
+    "details" in err && typeof err.details === "string" ? err.details : "";
+  if (`${message} ${details}`.toLowerCase().includes("no active")) return true;
+
+  const errorCode =
+    "error_code" in err && typeof err.error_code === "string"
+      ? err.error_code.toLowerCase()
+      : "";
+  const errorType =
+    "type" in err && typeof err.type === "string" ? err.type.toLowerCase() : "";
+  return (
+    errorCode === "musicquiznogameerror" ||
+    errorCode === "music_quiz_no_game" ||
+    errorType === "musicquiznogameerror" ||
+    errorType === "music_quiz_no_game"
+  );
 }
 
 export function isMusicQuizPlayerNotFoundError(err: unknown) {

--- a/src/helpers/music_quiz.ts
+++ b/src/helpers/music_quiz.ts
@@ -106,3 +106,42 @@ export function getMusicQuizErrorMessage(err: unknown, fallback = "") {
   }
   return fallback;
 }
+
+export function isNoActiveGameError(err: unknown) {
+  const normalizedMessage = getMusicQuizErrorMessage(err).toLowerCase();
+  if (normalizedMessage.includes("no active")) return true;
+
+  if (err && typeof err === "object") {
+    const errorCode =
+      "error_code" in err && typeof err.error_code === "string"
+        ? err.error_code.toLowerCase()
+        : "";
+    const errorType =
+      "type" in err && typeof err.type === "string"
+        ? err.type.toLowerCase()
+        : "";
+    return (
+      errorCode.includes("musicquiznogame") ||
+      errorCode.includes("music_quiz_no_game") ||
+      errorType.includes("musicquiznogame") ||
+      errorType.includes("music_quiz_no_game")
+    );
+  }
+  return false;
+}
+
+export function isMusicQuizPlayerNotFoundError(err: unknown) {
+  const normalizedMessage = getMusicQuizErrorMessage(err).toLowerCase();
+  if (normalizedMessage.includes("player not found")) return true;
+
+  if (err && typeof err === "object") {
+    const errorCode =
+      "error_code" in err && typeof err.error_code === "string"
+        ? err.error_code.toLowerCase()
+        : "";
+    return (
+      errorCode.includes("player_not_found") && errorCode.includes("music_quiz")
+    );
+  }
+  return false;
+}

--- a/tests/composables/useMusicQuizHost.test.ts
+++ b/tests/composables/useMusicQuizHost.test.ts
@@ -115,4 +115,18 @@ describe("useMusicQuizHost", () => {
     expect(host.state.value).toBeNull();
     expect(host.gameRemoved.value).toBe(true);
   });
+
+  it("treats no active game errors as an empty state without a toast", async () => {
+    const notifyError = vi.fn();
+    mockGetMusicQuiz.mockRejectedValue(
+      new Error("There is no active Music Quiz game"),
+    );
+
+    const host = useMusicQuizHost({ notifyError });
+    await flushPromises();
+
+    expect(host.state.value).toBeNull();
+    expect(host.gameRemoved.value).toBe(false);
+    expect(notifyError).not.toHaveBeenCalled();
+  });
 });

--- a/tests/composables/useMusicQuizHost.test.ts
+++ b/tests/composables/useMusicQuizHost.test.ts
@@ -118,9 +118,7 @@ describe("useMusicQuizHost", () => {
 
   it("treats no active game errors as an empty state without a toast", async () => {
     const notifyError = vi.fn();
-    mockGetMusicQuiz.mockRejectedValue(
-      new Error("There is no active Music Quiz game"),
-    );
+    mockGetMusicQuiz.mockRejectedValue("There is no active Music Quiz game");
 
     const host = useMusicQuizHost({ notifyError });
     await flushPromises();

--- a/tests/composables/useMusicQuizPlayer.test.ts
+++ b/tests/composables/useMusicQuizPlayer.test.ts
@@ -106,13 +106,17 @@ describe("useMusicQuizPlayer", () => {
       storedPlayerId.value = null;
     });
     mockGetMusicQuizErrorMessage.mockImplementation(
-      (error: unknown, fallback = "") =>
-        error instanceof Error ? error.message : fallback,
+      (error: unknown, fallback = "") => {
+        if (typeof error === "string") return error;
+        if (error instanceof Error) return error.message;
+        return fallback;
+      },
     );
-    mockIsNoActiveGameError.mockImplementation(
-      (error: unknown) =>
-        error instanceof Error &&
-        error.message.toLowerCase().includes("no active"),
+    mockIsNoActiveGameError.mockImplementation((error: unknown) =>
+      typeof error === "string"
+        ? error.toLowerCase().includes("no active")
+        : error instanceof Error &&
+          error.message.toLowerCase().includes("no active"),
     );
     mockSubscribe.mockImplementation(
       (
@@ -144,7 +148,7 @@ describe("useMusicQuizPlayer", () => {
     const notifyError = vi.fn();
     storedPlayerId.value = "stale-player";
     mockGetMusicQuizState.mockRejectedValue(
-      new Error("There is no active Music Quiz game"),
+      "There is no active Music Quiz game",
     );
     mockGetMusicQuizInfo.mockResolvedValue(QUIZ_INFO);
 

--- a/tests/composables/useMusicQuizPlayer.test.ts
+++ b/tests/composables/useMusicQuizPlayer.test.ts
@@ -11,6 +11,7 @@ const {
   mockGetStoredPlayerId,
   mockClearStoredPlayerId,
   mockGetMusicQuizErrorMessage,
+  mockIsNoActiveGameError,
   storedPlayerId,
   providerHandlers,
 } = vi.hoisted(() => ({
@@ -24,6 +25,7 @@ const {
   mockGetStoredPlayerId: vi.fn(),
   mockClearStoredPlayerId: vi.fn(),
   mockGetMusicQuizErrorMessage: vi.fn(),
+  mockIsNoActiveGameError: vi.fn(),
   storedPlayerId: { value: null as string | null },
   providerHandlers: [] as Array<
     (event: { object_id?: string; data?: unknown }) => void
@@ -58,6 +60,7 @@ vi.mock("@/helpers/music_quiz", () => ({
   getStoredMusicQuizPlayerId: mockGetStoredPlayerId,
   clearStoredMusicQuizPlayerId: mockClearStoredPlayerId,
   getMusicQuizErrorMessage: mockGetMusicQuizErrorMessage,
+  isNoActiveGameError: mockIsNoActiveGameError,
 }));
 
 vi.mock("@/plugins/i18n", () => ({
@@ -94,6 +97,7 @@ describe("useMusicQuizPlayer", () => {
     mockGetStoredPlayerId.mockReset();
     mockClearStoredPlayerId.mockReset();
     mockGetMusicQuizErrorMessage.mockReset();
+    mockIsNoActiveGameError.mockReset();
     mockGetStoredPlayerId.mockImplementation(() => storedPlayerId.value);
     mockStorePlayerId.mockImplementation((playerId: string) => {
       storedPlayerId.value = playerId;
@@ -104,6 +108,11 @@ describe("useMusicQuizPlayer", () => {
     mockGetMusicQuizErrorMessage.mockImplementation(
       (error: unknown, fallback = "") =>
         error instanceof Error ? error.message : fallback,
+    );
+    mockIsNoActiveGameError.mockImplementation(
+      (error: unknown) =>
+        error instanceof Error &&
+        error.message.toLowerCase().includes("no active"),
     );
     mockSubscribe.mockImplementation(
       (
@@ -129,6 +138,24 @@ describe("useMusicQuizPlayer", () => {
     expect(player.info.value).toEqual(QUIZ_INFO);
     expect(player.gameRemoved.value).toBe(false);
     expect(storedPlayerId.value).toBeNull();
+  });
+
+  it("treats no active game errors as empty state without a toast", async () => {
+    const notifyError = vi.fn();
+    storedPlayerId.value = "stale-player";
+    mockGetMusicQuizState.mockRejectedValue(
+      new Error("There is no active Music Quiz game"),
+    );
+    mockGetMusicQuizInfo.mockResolvedValue(QUIZ_INFO);
+
+    const player = useMusicQuizPlayer({ notifyError });
+    await flushPromises();
+
+    expect(player.playerId.value).toBeNull();
+    expect(player.state.value).toBeNull();
+    expect(player.info.value).toEqual(QUIZ_INFO);
+    expect(player.gameRemoved.value).toBe(false);
+    expect(notifyError).not.toHaveBeenCalled();
   });
 
   it("returns from game-removed state when a new game update arrives", async () => {

--- a/tests/composables/useMusicQuizPlayer.test.ts
+++ b/tests/composables/useMusicQuizPlayer.test.ts
@@ -12,6 +12,7 @@ const {
   mockClearStoredPlayerId,
   mockGetMusicQuizErrorMessage,
   mockIsNoActiveGameError,
+  mockIsMusicQuizPlayerNotFoundError,
   storedPlayerId,
   providerHandlers,
 } = vi.hoisted(() => ({
@@ -26,6 +27,7 @@ const {
   mockClearStoredPlayerId: vi.fn(),
   mockGetMusicQuizErrorMessage: vi.fn(),
   mockIsNoActiveGameError: vi.fn(),
+  mockIsMusicQuizPlayerNotFoundError: vi.fn(),
   storedPlayerId: { value: null as string | null },
   providerHandlers: [] as Array<
     (event: { object_id?: string; data?: unknown }) => void
@@ -61,6 +63,7 @@ vi.mock("@/helpers/music_quiz", () => ({
   clearStoredMusicQuizPlayerId: mockClearStoredPlayerId,
   getMusicQuizErrorMessage: mockGetMusicQuizErrorMessage,
   isNoActiveGameError: mockIsNoActiveGameError,
+  isMusicQuizPlayerNotFoundError: mockIsMusicQuizPlayerNotFoundError,
 }));
 
 vi.mock("@/plugins/i18n", () => ({
@@ -98,6 +101,7 @@ describe("useMusicQuizPlayer", () => {
     mockClearStoredPlayerId.mockReset();
     mockGetMusicQuizErrorMessage.mockReset();
     mockIsNoActiveGameError.mockReset();
+    mockIsMusicQuizPlayerNotFoundError.mockReset();
     mockGetStoredPlayerId.mockImplementation(() => storedPlayerId.value);
     mockStorePlayerId.mockImplementation((playerId: string) => {
       storedPlayerId.value = playerId;
@@ -117,6 +121,12 @@ describe("useMusicQuizPlayer", () => {
         ? error.toLowerCase().includes("no active")
         : error instanceof Error &&
           error.message.toLowerCase().includes("no active"),
+    );
+    mockIsMusicQuizPlayerNotFoundError.mockImplementation((error: unknown) =>
+      typeof error === "string"
+        ? error.toLowerCase().includes("player not found")
+        : error instanceof Error &&
+          error.message.toLowerCase().includes("player not found"),
     );
     mockSubscribe.mockImplementation(
       (


### PR DESCRIPTION
Fixes the quiz no-game flow that could show an error toast instead of the empty state.

- add a shared `isNoActiveGameError` helper for robust no-active-game matching
- use the helper in both host and guest composables so no-game becomes `state = null` without toast
- add focused host/player composable tests to lock the no-toast behavior
