### PR TITLE
Fix Music Quiz stray error on no active game

### DIFF
--- a/src/composables/useMusicQuizHost.ts
+++ b/src/composables/useMusicQuizHost.ts
@@ -14,7 +14,10 @@ import { $t } from "@/plugins/i18n";
 import api from "@/plugins/api";
 import { EventType } from "@/plugins/api/interfaces";
 import { computed, onBeforeUnmount, onMounted, ref } from "vue";
-import { getMusicQuizErrorMessage } from "@/helpers/music_quiz";
+import {
+  getMusicQuizErrorMessage,
+  isNoActiveGameError,
+} from "@/helpers/music_quiz";
 
 export interface UseMusicQuizHostOptions {
   notifyError: (message: string) => void;
@@ -69,13 +72,7 @@ export function useMusicQuizHost(options: UseMusicQuizHostOptions) {
       state.value = nextState;
       gameRemoved.value = false;
     } catch (err) {
-      if (
-        err &&
-        typeof err === "object" &&
-        "message" in err &&
-        typeof err.message === "string" &&
-        err.message.toLowerCase().includes("no active game")
-      ) {
+      if (isNoActiveGameError(err)) {
         state.value = null;
         gameRemoved.value = false;
       } else {

--- a/src/composables/useMusicQuizPlayer.ts
+++ b/src/composables/useMusicQuizPlayer.ts
@@ -13,6 +13,7 @@ import {
   getStoredMusicQuizPlayerId,
   storeMusicQuizPlayerId,
   getMusicQuizErrorMessage,
+  isNoActiveGameError,
 } from "@/helpers/music_quiz";
 import { $t } from "@/plugins/i18n";
 import api from "@/plugins/api";
@@ -81,12 +82,8 @@ export function useMusicQuizPlayer(options: UseMusicQuizPlayerOptions) {
       gameRemoved.value = false;
     } catch (err) {
       if (
-        err &&
-        typeof err === "object" &&
-        "message" in err &&
-        typeof err.message === "string" &&
-        (err.message.toLowerCase().includes("no active game") ||
-          err.message.toLowerCase().includes("player not found"))
+        isNoActiveGameError(err) ||
+        getMusicQuizErrorMessage(err).toLowerCase().includes("player not found")
       ) {
         await resetToJoinInfo();
       } else {

--- a/src/helpers/music_quiz.ts
+++ b/src/helpers/music_quiz.ts
@@ -106,3 +106,33 @@ export function getMusicQuizErrorMessage(err: unknown, fallback = "") {
   }
   return fallback;
 }
+
+// Detects the backend "no active Music Quiz game" error across its possible
+// shapes (plain string / Error / structured payload), since WS command
+// failures can arrive as strings rather than Error instances.
+export function isNoActiveGameError(err: unknown): boolean {
+  const message = getMusicQuizErrorMessage(err).toLowerCase();
+  if (
+    message.includes("no active music quiz game") ||
+    (message.includes("no active") && message.includes("music quiz"))
+  ) {
+    return true;
+  }
+  if (err && typeof err === "object") {
+    const errorCode =
+      "error_code" in err && typeof err.error_code === "string"
+        ? err.error_code.toLowerCase()
+        : "";
+    const errorType =
+      "type" in err && typeof err.type === "string"
+        ? err.type.toLowerCase()
+        : "";
+    return (
+      errorCode === "musicquiznogameerror" ||
+      errorCode === "music_quiz_no_game" ||
+      errorType === "musicquiznogameerror" ||
+      errorType === "music_quiz_no_game"
+    );
+  }
+  return false;
+}

--- a/src/helpers/music_quiz.ts
+++ b/src/helpers/music_quiz.ts
@@ -113,6 +113,7 @@ export function getMusicQuizErrorMessage(err: unknown, fallback = "") {
 export function isNoActiveGameError(err: unknown): boolean {
   const message = getMusicQuizErrorMessage(err).toLowerCase();
   if (
+    message.includes("no active game") ||
     message.includes("no active music quiz game") ||
     (message.includes("no active") && message.includes("music quiz"))
   ) {

--- a/tests/composables/useMusicQuizHost.test.ts
+++ b/tests/composables/useMusicQuizHost.test.ts
@@ -115,4 +115,15 @@ describe("useMusicQuizHost", () => {
     expect(host.state.value).toBeNull();
     expect(host.gameRemoved.value).toBe(true);
   });
+
+  it("treats a no-active-game error as an empty state without a toast", async () => {
+    mockGetMusicQuiz.mockRejectedValue("There is no active Music Quiz game");
+    const notifyError = vi.fn();
+    const host = useMusicQuizHost({ notifyError });
+    await flushPromises();
+
+    expect(notifyError).not.toHaveBeenCalled();
+    expect(host.state.value).toBeNull();
+    expect(host.gameRemoved.value).toBe(false);
+  });
 });

--- a/tests/composables/useMusicQuizPlayer.test.ts
+++ b/tests/composables/useMusicQuizPlayer.test.ts
@@ -59,9 +59,14 @@ vi.mock("@/helpers/music_quiz", () => ({
   clearStoredMusicQuizPlayerId: mockClearStoredPlayerId,
   getMusicQuizErrorMessage: mockGetMusicQuizErrorMessage,
   isNoActiveGameError: (err: unknown) => {
-    const message =
-      err instanceof Error ? err.message : typeof err === "string" ? err : "";
-    return message.toLowerCase().includes("no active");
+    const message = (
+      err instanceof Error ? err.message : typeof err === "string" ? err : ""
+    ).toLowerCase();
+    return (
+      message.includes("no active game") ||
+      message.includes("no active music quiz game") ||
+      (message.includes("no active") && message.includes("music quiz"))
+    );
   },
 }));
 

--- a/tests/composables/useMusicQuizPlayer.test.ts
+++ b/tests/composables/useMusicQuizPlayer.test.ts
@@ -58,6 +58,11 @@ vi.mock("@/helpers/music_quiz", () => ({
   getStoredMusicQuizPlayerId: mockGetStoredPlayerId,
   clearStoredMusicQuizPlayerId: mockClearStoredPlayerId,
   getMusicQuizErrorMessage: mockGetMusicQuizErrorMessage,
+  isNoActiveGameError: (err: unknown) => {
+    const message =
+      err instanceof Error ? err.message : typeof err === "string" ? err : "";
+    return message.toLowerCase().includes("no active");
+  },
 }));
 
 vi.mock("@/plugins/i18n", () => ({
@@ -128,6 +133,24 @@ describe("useMusicQuizPlayer", () => {
     expect(player.state.value).toBeNull();
     expect(player.info.value).toEqual(QUIZ_INFO);
     expect(player.gameRemoved.value).toBe(false);
+    expect(storedPlayerId.value).toBeNull();
+  });
+
+  it("recovers from a no-active-game error (string rejection) without a toast", async () => {
+    storedPlayerId.value = "some-player";
+    mockGetMusicQuizState.mockRejectedValue(
+      "There is no active Music Quiz game",
+    );
+    mockGetMusicQuizInfo.mockResolvedValue(QUIZ_INFO);
+    const notifyError = vi.fn();
+
+    const player = useMusicQuizPlayer({ notifyError });
+    await flushPromises();
+
+    expect(notifyError).not.toHaveBeenCalled();
+    expect(player.playerId.value).toBeNull();
+    expect(player.state.value).toBeNull();
+    expect(player.info.value).toEqual(QUIZ_INFO);
     expect(storedPlayerId.value).toBeNull();
   });
 


### PR DESCRIPTION
When no Music Quiz game is active, the host dashboard showed a red error toast, and guests whose game had ended couldn't get back to the join screen. The frontend only recognised the literal `"no active game"`, but the server returns `"There is no active Music Quiz game"`, so that check never matched.

- Add a shared `isNoActiveGameError` helper that reliably detects the backend error across its possible shapes (plain string / Error / structured payload — WS command errors can arrive as strings)
- Host: show the empty "create a game" state instead of an error toast
- Guest: treat it as recoverable and return to the join/info screen
- Add focused tests for both paths
