### PR TITLE
Make release workflows aware of stable patch builds

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -29,8 +29,10 @@ jobs:
       - name: Check for new commits
         id: check_commits
         run: |
-          # Get the latest PUBLISHED release (exclude drafts)
-          LATEST_RELEASE=$(gh release list --exclude-drafts --limit 1 --json createdAt,tagName --jq '.[0]' 2>/dev/null || echo "")
+          # Get the latest PUBLISHED release (exclude drafts). Only consider plain X.Y.Z
+          # releases so stable patch builds (e.g. 2.17.186.post1) are ignored when
+          # computing the next main-line version.
+          LATEST_RELEASE=$(gh release list --exclude-drafts --limit 30 --json createdAt,tagName --jq 'map(select(.tagName | test("^[0-9]+\\.[0-9]+\\.[0-9]+$"))) | .[0] // empty' 2>/dev/null || echo "")
 
           if [ -z "$LATEST_RELEASE" ]; then
             echo "No previous releases found"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -131,6 +131,17 @@ jobs:
     needs: build-and-publish
     runs-on: ubuntu-latest
     steps:
+      - name: Determine server target branch
+        id: target
+        run: |
+          # Stable patch builds (PEP 440 .post releases) bump the server `stable`
+          # branch; regular releases bump the default (dev) branch.
+          if [[ "${{ inputs.version }}" == *.post* ]]; then
+            echo "branch=stable" >> $GITHUB_OUTPUT
+          else
+            echo "branch=dev" >> $GITHUB_OUTPUT
+          fi
+
       - name: Wait for PyPI availability
         run: |
           echo "Waiting 5 minutes for PyPI to propagate music-assistant-frontend ${{ inputs.version }}..."
@@ -164,6 +175,7 @@ jobs:
         uses: actions/checkout@v7
         with:
           repository: music-assistant/server
+          ref: ${{ steps.target.outputs.branch }}
           token: ${{ secrets.PRIVILEGED_GITHUB_TOKEN }}
           path: .
 
@@ -187,6 +199,7 @@ jobs:
           token: ${{ secrets.PRIVILEGED_GITHUB_TOKEN }}
           commit-message: "⬆️ Update music-assistant-frontend to ${{ inputs.version }}"
           branch: "auto-update-frontend-${{ inputs.version }}"
+          base: ${{ steps.target.outputs.branch }}
           delete-branch: true
           title: "⬆️ Update music-assistant-frontend to ${{ inputs.version }}"
           body: |

--- a/src/views/settings/Diagnostics.vue
+++ b/src/views/settings/Diagnostics.vue
@@ -94,7 +94,7 @@ const logContainer = ref<HTMLDivElement | null>(null);
 const maxLines = 150;
 let refreshInterval: ReturnType<typeof setInterval> | null = null;
 
-const diagnosticsSupported = computed(() => requireServerVersion("2.10.0"));
+const diagnosticsSupported = computed(() => requireServerVersion("2.9.6"));
 
 const displayContent = computed(() => {
   const lines = logContent.value.split("\n");


### PR DESCRIPTION
Stable patch builds (PEP 440 `.post` releases such as `2.17.186.post1`) are published from the `stable` branch. The current release automation assumes every release is a normal main-line `X.Y.Z`, which breaks once a `.post` release exists.

- **auto-release:** ignore `.post`/non `X.Y.Z` tags when picking the latest release, so the nightly still computes the correct next main-line version (a `.post` release would otherwise cause a version collision).
- **release:** for `.post` versions, open the server dependency-bump PR against the server `stable` branch instead of `dev`.
