### PR TITLE
Always show the diagnostics download button

### DIFF
--- a/src/views/settings/Diagnostics.vue
+++ b/src/views/settings/Diagnostics.vue
@@ -24,7 +24,6 @@
               {{ $t("settings.download_log") }}
             </Button>
             <Button
-              v-if="diagnosticsSupported"
               variant="outline"
               size="sm"
               :disabled="downloadingDiagnostics"
@@ -82,7 +81,6 @@ import { Label } from "@/components/ui/label";
 import { Spinner } from "@/components/ui/spinner";
 import { Switch } from "@/components/ui/switch";
 import { api } from "@/plugins/api";
-import { requireServerVersion } from "@/plugins/api/helpers";
 
 const logContent = ref("");
 const loading = ref(true);
@@ -93,8 +91,6 @@ const downloadingDiagnostics = ref(false);
 const logContainer = ref<HTMLDivElement | null>(null);
 const maxLines = 150;
 let refreshInterval: ReturnType<typeof setInterval> | null = null;
-
-const diagnosticsSupported = computed(() => requireServerVersion("2.10.0"));
 
 const displayContent = computed(() => {
   const lines = logContent.value.split("\n");


### PR DESCRIPTION
The "Download diagnostics" button was gated behind a server version check. On the 2.10 line that gate is redundant — every 2.10 server ships the diagnostics backend — so the button can simply always show.

- Always render the "Download diagnostics" button (removed the version gate and its now-unused version-check import)

The stable line keeps its 2.9.6 gate (#2057, already merged), since stable spans 2.9.0–2.9.x where the backend isn't always present.