### PR TITLE
Show diagnostics download button on server 2.9.6+ (stable)

### DIFF
--- a/src/views/settings/Diagnostics.vue
+++ b/src/views/settings/Diagnostics.vue
@@ -94,7 +94,7 @@ const logContainer = ref<HTMLDivElement | null>(null);
 const maxLines = 150;
 let refreshInterval: ReturnType<typeof setInterval> | null = null;
 
-const diagnosticsSupported = computed(() => requireServerVersion("2.10.0"));
+const diagnosticsSupported = computed(() => requireServerVersion("2.9.6"));
 
 const displayContent = computed(() => {
   const lines = logContent.value.split("\n");


### PR DESCRIPTION
Stable backport of the diagnostics download button gate.

The diagnostics report backend shipped on the stable line in server 2.9.6, but the frontend only showed the "Download diagnostics" button on 2.10.0+ servers, so stable users couldn't reach it from the UI.

- Lower the version gate from 2.10.0 to 2.9.6 so the button appears on stable 2.9.6+
- Targets `stable-patch-releases` so the change reaches stable 2.9.x users
- Servers below 2.9.6 (no diagnostics backend) correctly keep the button hidden