### PR TITLE
Make release workflows aware of stable patch builds

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -29,8 +29,10 @@ jobs:
       - name: Check for new commits
         id: check_commits
         run: |
-          # Get the latest PUBLISHED release (exclude drafts)
-          LATEST_RELEASE=$(gh release list --exclude-drafts --limit 1 --json createdAt,tagName --jq '.[0]' 2>/dev/null || echo "")
+          # Get the latest PUBLISHED release (exclude drafts). Only consider plain X.Y.Z
+          # releases so stable patch builds (e.g. 2.17.186.post1) are ignored when
+          # computing the next main-line version.
+          LATEST_RELEASE=$(gh release list --exclude-drafts --limit 30 --json createdAt,tagName --jq 'map(select(.tagName | test("^[0-9]+\\.[0-9]+\\.[0-9]+$"))) | .[0] // empty' 2>/dev/null || echo "")
 
           if [ -z "$LATEST_RELEASE" ]; then
             echo "No previous releases found"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -131,6 +131,17 @@ jobs:
     needs: build-and-publish
     runs-on: ubuntu-latest
     steps:
+      - name: Determine server target branch
+        id: target
+        run: |
+          # Stable patch builds (PEP 440 .post releases) bump the server `stable`
+          # branch; regular releases bump the default (dev) branch.
+          if [[ "${{ inputs.version }}" == *.post* ]]; then
+            echo "branch=stable" >> $GITHUB_OUTPUT
+          else
+            echo "branch=dev" >> $GITHUB_OUTPUT
+          fi
+
       - name: Wait for PyPI availability
         run: |
           echo "Waiting 5 minutes for PyPI to propagate music-assistant-frontend ${{ inputs.version }}..."
@@ -164,6 +175,7 @@ jobs:
         uses: actions/checkout@v7
         with:
           repository: music-assistant/server
+          ref: ${{ steps.target.outputs.branch }}
           token: ${{ secrets.PRIVILEGED_GITHUB_TOKEN }}
           path: .
 
@@ -187,6 +199,7 @@ jobs:
           token: ${{ secrets.PRIVILEGED_GITHUB_TOKEN }}
           commit-message: "⬆️ Update music-assistant-frontend to ${{ inputs.version }}"
           branch: "auto-update-frontend-${{ inputs.version }}"
+          base: ${{ steps.target.outputs.branch }}
           delete-branch: true
           title: "⬆️ Update music-assistant-frontend to ${{ inputs.version }}"
           body: |


### PR DESCRIPTION
The release automation didn't distinguish stable patch builds (PEP 440 `.post` versions) from regular main-line releases, so stable patches could skew the next computed version and were pushed to the wrong server branch.

- `auto-release.yml`: ignore `.post` stable-patch tags when determining the next main-line version (only match plain `X.Y.Z`)
- `release.yml`: send `.post` builds to the server `stable` branch and regular releases to `dev`

Supersedes #2055: brings only the two release-workflow changes onto main, avoiding the whole-branch merge that would re-introduce the 2.10 diagnostics button gate that #2056 intentionally removed. The stable branch (and its 2.9.6 gate) is left untouched.