### PR TITLE
Fix guest join links during frontend development

### DIFF
--- a/src/views/Login.vue
+++ b/src/views/Login.vue
@@ -427,6 +427,7 @@ const STORAGE_KEY_REMOTE_ID = "mass_remote_id";
 const STORAGE_KEY_TOKEN = "ma_access_token";
 // Session storage key for pending guest code (survives SW reload but not browser close)
 const SESSION_KEY_PENDING_JOIN_CODE = "ma_pending_join_code";
+const SESSION_KEY_PENDING_JOIN_TYPE = "ma_pending_join_type";
 
 // Props and emits
 const emit = defineEmits<{
@@ -720,6 +721,41 @@ const tryGuestCodeAuth = async (code: string): Promise<boolean> => {
   }
 };
 
+type PendingGuestAuthResult = "none" | "authenticated" | "failed";
+
+const clearPendingGuestAuth = () => {
+  sessionStorage.removeItem(SESSION_KEY_PENDING_JOIN_CODE);
+  sessionStorage.removeItem(SESSION_KEY_PENDING_JOIN_TYPE);
+};
+
+const setPendingGuestAuth = (code: string, type: "local" | "remote") => {
+  authManager.clearAuth();
+  sessionStorage.setItem(SESSION_KEY_PENDING_JOIN_CODE, code);
+  sessionStorage.setItem(SESSION_KEY_PENDING_JOIN_TYPE, type);
+};
+
+const tryPendingGuestAuth = async (): Promise<PendingGuestAuthResult> => {
+  const code = sessionStorage.getItem(SESSION_KEY_PENDING_JOIN_CODE);
+  if (!code) {
+    return "none";
+  }
+
+  authManager.clearAuth();
+  if (await tryGuestCodeAuth(code)) {
+    clearPendingGuestAuth();
+    return "authenticated";
+  }
+
+  clearPendingGuestAuth();
+  authManager.clearAuth();
+  connectionError.value = t(
+    "login.error_party_auth_failed",
+    "Failed to join party. The code may have expired.",
+  );
+  step.value = "error";
+  return "failed";
+};
+
 /**
  * Try to authenticate in ingress mode (no credentials needed)
  */
@@ -762,6 +798,7 @@ const autoConnect = async () => {
 
   // Also check for pending guest code from sessionStorage (survives SW reload)
   const pendingJoinCode = sessionStorage.getItem(SESSION_KEY_PENDING_JOIN_CODE);
+  const pendingJoinType = sessionStorage.getItem(SESSION_KEY_PENDING_JOIN_TYPE);
   const storedRemoteIdForPending = localStorage.getItem(STORAGE_KEY_REMOTE_ID);
 
   // Determine the effective guest code and remote ID
@@ -771,7 +808,12 @@ const autoConnect = async () => {
 
   // If no guest code in URL but we have a pending one in sessionStorage, use that
   // This handles the case where SW reload cleared the URL but code was stored
-  if (!effectiveJoinCode && pendingJoinCode && storedRemoteIdForPending) {
+  if (
+    !effectiveJoinCode &&
+    pendingJoinCode &&
+    pendingJoinType !== "local" &&
+    storedRemoteIdForPending
+  ) {
     effectiveJoinCode = pendingJoinCode;
     effectiveRemoteId = storedRemoteIdForPending;
   }
@@ -782,14 +824,8 @@ const autoConnect = async () => {
       .replace(/[^A-Z0-9]/g, "");
 
     if (cleanRemoteId.length === 26) {
-      // Clear any stale token before guest code auth
-      if (localStorage.getItem(STORAGE_KEY_TOKEN)) {
-        localStorage.removeItem(STORAGE_KEY_TOKEN);
-      }
-
       localStorage.setItem(STORAGE_KEY_REMOTE_ID, cleanRemoteId);
-      // Store guest code in sessionStorage for SW reload recovery
-      sessionStorage.setItem(SESSION_KEY_PENDING_JOIN_CODE, effectiveJoinCode);
+      setPendingGuestAuth(effectiveJoinCode, "remote");
 
       connectionStatusMessage.value = t(
         "login.connecting_remote_party",
@@ -814,8 +850,7 @@ const autoConnect = async () => {
           const guestAuthResult = await tryGuestCodeAuth(effectiveJoinCode);
 
           if (guestAuthResult) {
-            // Clear the pending guest code - it's been successfully used
-            sessionStorage.removeItem(SESSION_KEY_PENDING_JOIN_CODE);
+            clearPendingGuestAuth();
             // Clean up URL
             const successUrlParams = new URLSearchParams(
               window.location.search,
@@ -838,7 +873,7 @@ const autoConnect = async () => {
         }
 
         // Code exchange failed
-        sessionStorage.removeItem(SESSION_KEY_PENDING_JOIN_CODE);
+        clearPendingGuestAuth();
         connectionError.value = t(
           "login.error_party_auth_failed",
           "Failed to join party. The code may have expired.",
@@ -846,7 +881,7 @@ const autoConnect = async () => {
         step.value = "error";
         return;
       } catch (error) {
-        sessionStorage.removeItem(SESSION_KEY_PENDING_JOIN_CODE);
+        clearPendingGuestAuth();
         console.error("[Login] Remote party connection failed:", error);
         connectionError.value =
           error instanceof Error
@@ -871,7 +906,7 @@ const autoConnect = async () => {
       // Store the join code in sessionStorage so the remote-only auto-connect
       // path can pick it up after establishing the WebRTC connection.
       if (urlJoinCode) {
-        sessionStorage.setItem(SESSION_KEY_PENDING_JOIN_CODE, urlJoinCode);
+        setPendingGuestAuth(urlJoinCode, "remote");
         localStorage.setItem(STORAGE_KEY_REMOTE_ID, cleanRemoteId);
       }
       // Clean up the URL
@@ -903,6 +938,8 @@ const autoConnect = async () => {
 
   // Handle local guest code (no remote_id, just the join code)
   if (urlJoinCode && !urlRemoteId) {
+    setPendingGuestAuth(urlJoinCode, "local");
+
     // Clean up URL - remove join param
     urlParams.delete("join");
     const queryString = urlParams.toString();
@@ -930,11 +967,16 @@ const autoConnect = async () => {
         localStorage.setItem(STORAGE_KEY_SERVER_ADDRESS, address);
 
         if (await waitForApiConnection()) {
-          if (await tryGuestCodeAuth(urlJoinCode)) {
+          const pendingGuestAuthResult = await tryPendingGuestAuth();
+          if (pendingGuestAuthResult === "authenticated") {
             return; // Success - App.vue will take over
+          }
+          if (pendingGuestAuthResult === "failed") {
+            return;
           }
         }
 
+        clearPendingGuestAuth();
         connectionError.value = t(
           "login.error_party_auth_failed",
           "Failed to join party. The code may have expired.",
@@ -1021,12 +1063,12 @@ const autoConnect = async () => {
 
         if (await waitForApiConnection(15000)) {
           if (await tryGuestCodeAuth(hasPendingGuestCode)) {
-            sessionStorage.removeItem(SESSION_KEY_PENDING_JOIN_CODE);
+            clearPendingGuestAuth();
             return;
           }
         }
 
-        sessionStorage.removeItem(SESSION_KEY_PENDING_JOIN_CODE);
+        clearPendingGuestAuth();
         connectionError.value = t(
           "login.error_party_auth_failed",
           "Failed to join party. The code may have expired.",
@@ -1035,11 +1077,11 @@ const autoConnect = async () => {
         return;
       } catch (error) {
         console.error("[Login] Pending guest code recovery error:", error);
-        sessionStorage.removeItem(SESSION_KEY_PENDING_JOIN_CODE);
+        clearPendingGuestAuth();
         // Fall through to show login form
       }
     } else if (hasPendingGuestCode) {
-      sessionStorage.removeItem(SESSION_KEY_PENDING_JOIN_CODE);
+      clearPendingGuestAuth();
     }
 
     // Use stored token for auto-login (only if no pending guest code)
@@ -1117,6 +1159,11 @@ const autoConnect = async () => {
       localStorage.setItem(STORAGE_KEY_SERVER_ADDRESS, address);
 
       if (await waitForApiConnection()) {
+        const pendingGuestAuthResult = await tryPendingGuestAuth();
+        if (pendingGuestAuthResult !== "none") {
+          return;
+        }
+
         if (storedToken && (await tryStoredTokenAuth())) {
           return; // Success - App.vue will take over
         }
@@ -1153,6 +1200,11 @@ const autoConnect = async () => {
       localStorage.setItem(STORAGE_KEY_SERVER_ADDRESS, storedAddress);
 
       if (await waitForApiConnection()) {
+        const pendingGuestAuthResult = await tryPendingGuestAuth();
+        if (pendingGuestAuthResult !== "none") {
+          return;
+        }
+
         if (await tryStoredTokenAuth()) {
           return; // Success - App.vue will take over
         }
@@ -1414,6 +1466,11 @@ const performLocalConnect = async (address: string) => {
     const connected = await waitForApiConnection();
     if (!connected) {
       throw new Error("Connection timeout - server not responding");
+    }
+
+    const pendingGuestAuthResult = await tryPendingGuestAuth();
+    if (pendingGuestAuthResult !== "none") {
+      return;
     }
 
     // Try to fetch auth providers (may fail if server requires auth first)

--- a/src/views/Login.vue
+++ b/src/views/Login.vue
@@ -1062,8 +1062,11 @@ const autoConnect = async () => {
         emit("connected", transport);
 
         if (await waitForApiConnection(15000)) {
-          if (await tryGuestCodeAuth(hasPendingGuestCode)) {
-            clearPendingGuestAuth();
+          const pendingGuestAuthResult = await tryPendingGuestAuth();
+          if (pendingGuestAuthResult === "authenticated") {
+            return;
+          }
+          if (pendingGuestAuthResult === "failed") {
             return;
           }
         }

--- a/tests/views/Login.test.ts
+++ b/tests/views/Login.test.ts
@@ -1,6 +1,6 @@
 import Login from "@/views/Login.vue";
 import { flushPromises, mount, type VueWrapper } from "@vue/test-utils";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
   authenticateWithToken: vi.fn(),
@@ -177,14 +177,8 @@ function mockSuccessfulGuest(username = "party_guest") {
 }
 
 beforeEach(() => {
-  Object.defineProperty(globalThis, "localStorage", {
-    configurable: true,
-    value: new StorageMock(),
-  });
-  Object.defineProperty(globalThis, "sessionStorage", {
-    configurable: true,
-    value: new StorageMock(),
-  });
+  vi.stubGlobal("localStorage", new StorageMock());
+  vi.stubGlobal("sessionStorage", new StorageMock());
   setLocation("");
   vi.clearAllMocks();
   vi.stubGlobal("WebSocket", WebSocketMock);
@@ -194,6 +188,10 @@ beforeEach(() => {
   mocks.getStoredRemoteId.mockReturnValue(null);
   mocks.connectRemote.mockResolvedValue({ id: "transport" });
   mockSuccessfulGuest();
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
 });
 
 describe("guest join login", () => {

--- a/tests/views/Login.test.ts
+++ b/tests/views/Login.test.ts
@@ -1,0 +1,348 @@
+import Login from "@/views/Login.vue";
+import { flushPromises, mount, type VueWrapper } from "@vue/test-utils";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  authenticateWithToken: vi.fn(),
+  clearAuth: vi.fn(),
+  connectRemote: vi.fn(),
+  disconnectRemote: vi.fn(),
+  getStoredRemoteId: vi.fn(),
+  sendCommand: vi.fn(),
+}));
+
+vi.mock("@/plugins/api", () => ({
+  ConnectionState: {
+    AUTHENTICATED: "authenticated",
+    AUTHENTICATING: "authenticating",
+    AUTH_REQUIRED: "auth_required",
+    DISCONNECTED: "disconnected",
+    FAILED: "failed",
+    RECONNECTING: "reconnecting",
+  },
+  api: {
+    authenticateWithToken: mocks.authenticateWithToken,
+    disconnect: vi.fn(),
+    sendCommand: mocks.sendCommand,
+    serverInfo: { value: { server_id: "server-id" } },
+    state: { value: "disconnected" },
+  },
+}));
+
+vi.mock("@/plugins/auth", () => ({
+  authManager: {
+    clearAuth: mocks.clearAuth,
+    setToken: vi.fn((token: string) => {
+      localStorage.setItem("ma_access_token", token);
+    }),
+  },
+}));
+
+vi.mock("@/plugins/remote", () => ({
+  remoteConnectionManager: {
+    connectRemote: mocks.connectRemote,
+    disconnect: mocks.disconnectRemote,
+    getStoredRemoteId: mocks.getStoredRemoteId,
+  },
+}));
+
+vi.mock("vue-i18n", () => ({
+  useI18n: () => ({
+    t: (_key: string, fallback: string) => fallback,
+  }),
+}));
+
+vi.mock("vue-qrcode-reader", () => ({
+  QrcodeStream: { template: "<div />" },
+}));
+
+class WebSocketMock {
+  onclose: (() => void) | null = null;
+  onerror: (() => void) | null = null;
+  onopen: (() => void) | null = null;
+
+  constructor() {
+    queueMicrotask(() => this.onopen?.());
+  }
+
+  close() {
+    this.onclose?.();
+  }
+}
+
+class StorageMock implements Storage {
+  private readonly values = new Map<string, string>();
+
+  get length() {
+    return this.values.size;
+  }
+
+  clear() {
+    this.values.clear();
+  }
+
+  getItem(key: string) {
+    return this.values.get(key) ?? null;
+  }
+
+  key(index: number) {
+    return [...this.values.keys()][index] ?? null;
+  }
+
+  removeItem(key: string) {
+    this.values.delete(key);
+  }
+
+  setItem(key: string, value: string) {
+    this.values.set(key, value);
+  }
+}
+
+const layoutStub = { template: "<div><slot /></div>" };
+const buttonStub = {
+  emits: ["click"],
+  template: '<button type="button" @click="$emit(\'click\')"><slot /></button>',
+};
+const textFieldStub = {
+  props: ["modelValue"],
+  emits: ["update:modelValue"],
+  template:
+    '<input :value="modelValue" @input="$emit(\'update:modelValue\', $event.target.value)" />',
+};
+
+function mountLogin(): VueWrapper {
+  return mount(Login, {
+    global: {
+      mocks: {
+        $t: (_key: string, fallback: string) => fallback,
+      },
+      stubs: {
+        VAlert: layoutStub,
+        VApp: layoutStub,
+        VBtn: buttonStub,
+        VCard: layoutStub,
+        VCardText: layoutStub,
+        VCardTitle: layoutStub,
+        VChip: layoutStub,
+        VCol: layoutStub,
+        VContainer: layoutStub,
+        VDialog: layoutStub,
+        VIcon: layoutStub,
+        VMain: layoutStub,
+        VProgressCircular: true,
+        VRow: layoutStub,
+        VTextField: textFieldStub,
+      },
+    },
+  });
+}
+
+function setLocation(query: string) {
+  window.history.replaceState({}, "", `http://localhost:3000/${query}`);
+}
+
+function mockStandaloneFrontend() {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn().mockResolvedValue({
+      ok: false,
+    }),
+  );
+}
+
+function mockHostedFrontend() {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn().mockResolvedValue({
+      ok: true,
+      json: vi.fn().mockResolvedValue({ server_id: "server-id" }),
+    }),
+  );
+}
+
+function mockSuccessfulGuest(username = "party_guest") {
+  mocks.sendCommand.mockImplementation((command: string) => {
+    if (command === "auth/join_code/exchange") {
+      return Promise.resolve({
+        success: true,
+        access_token: "guest-token",
+        user: { user_id: "guest-id", username, role: "guest" },
+      });
+    }
+    return Promise.resolve([]);
+  });
+  mocks.authenticateWithToken.mockResolvedValue({
+    user: { user_id: "guest-id", username, role: "guest" },
+  });
+}
+
+beforeEach(() => {
+  Object.defineProperty(globalThis, "localStorage", {
+    configurable: true,
+    value: new StorageMock(),
+  });
+  Object.defineProperty(globalThis, "sessionStorage", {
+    configurable: true,
+    value: new StorageMock(),
+  });
+  setLocation("");
+  vi.clearAllMocks();
+  vi.stubGlobal("WebSocket", WebSocketMock);
+  mocks.clearAuth.mockImplementation(() => {
+    localStorage.removeItem("ma_access_token");
+  });
+  mocks.getStoredRemoteId.mockReturnValue(null);
+  mocks.connectRemote.mockResolvedValue({ id: "transport" });
+  mockSuccessfulGuest();
+});
+
+describe("guest join login", () => {
+  it.each(["party_guest", "music_quiz_guest"])(
+    "joins a stored local server as %s from a standalone frontend",
+    async (username) => {
+      setLocation("?join=abcd1234");
+      mockStandaloneFrontend();
+      mockSuccessfulGuest(username);
+      localStorage.setItem(
+        "mass_server_address",
+        "http://music-assistant.local:8095",
+      );
+
+      const wrapper = mountLogin();
+
+      await vi.waitFor(() => {
+        expect(wrapper.emitted("authenticated")).toEqual([
+          [
+            {
+              token: "guest-token",
+              user: { user_id: "guest-id", username, role: "guest" },
+            },
+          ],
+        ]);
+      });
+      expect(wrapper.emitted("local-connect")).toEqual([
+        ["http://music-assistant.local:8095"],
+      ]);
+      expect(mocks.sendCommand).toHaveBeenCalledWith(
+        "auth/join_code/exchange",
+        { code: "ABCD1234" },
+      );
+      expect(sessionStorage.getItem("ma_pending_join_code")).toBeNull();
+    },
+  );
+
+  it("keeps the join code while a standalone user selects a server", async () => {
+    setLocation("?join=abcd1234");
+    mockStandaloneFrontend();
+
+    const wrapper = mountLogin();
+    await flushPromises();
+
+    expect(sessionStorage.getItem("ma_pending_join_code")).toBe("abcd1234");
+    await wrapper.find("input").setValue("http://selected-server:8095");
+    await wrapper.find("button").trigger("click");
+
+    await vi.waitFor(() => {
+      expect(wrapper.emitted("authenticated")).toHaveLength(1);
+    });
+    expect(wrapper.emitted("local-connect")).toEqual([
+      ["http://selected-server:8095"],
+    ]);
+    expect(sessionStorage.getItem("ma_pending_join_code")).toBeNull();
+  });
+
+  it("recovers a pending local join after a service-worker reload", async () => {
+    mockStandaloneFrontend();
+    sessionStorage.setItem("ma_pending_join_code", "abcd1234");
+    sessionStorage.setItem("ma_pending_join_type", "local");
+    localStorage.setItem(
+      "mass_server_address",
+      "http://music-assistant.local:8095",
+    );
+
+    const wrapper = mountLogin();
+
+    await vi.waitFor(() => {
+      expect(wrapper.emitted("authenticated")).toHaveLength(1);
+    });
+    expect(mocks.sendCommand).toHaveBeenCalledWith("auth/join_code/exchange", {
+      code: "ABCD1234",
+    });
+    expect(sessionStorage.getItem("ma_pending_join_code")).toBeNull();
+  });
+
+  it("clears a stored admin token before exchanging a guest code", async () => {
+    setLocation("?join=abcd1234");
+    mockStandaloneFrontend();
+    localStorage.setItem(
+      "mass_server_address",
+      "http://music-assistant.local:8095",
+    );
+    localStorage.setItem("ma_access_token", "admin-token");
+
+    mountLogin();
+
+    await vi.waitFor(() => {
+      expect(mocks.sendCommand).toHaveBeenCalledWith(
+        "auth/join_code/exchange",
+        { code: "ABCD1234" },
+      );
+    });
+    expect(mocks.clearAuth).toHaveBeenCalled();
+    expect(mocks.authenticateWithToken).not.toHaveBeenCalledWith("admin-token");
+  });
+
+  it("shows an error and clears pending auth after a failed exchange", async () => {
+    setLocation("?join=expired1");
+    mockStandaloneFrontend();
+    localStorage.setItem(
+      "mass_server_address",
+      "http://music-assistant.local:8095",
+    );
+    localStorage.setItem("ma_access_token", "admin-token");
+    mocks.sendCommand.mockResolvedValue({
+      success: false,
+      error: "expired",
+    });
+
+    const wrapper = mountLogin();
+
+    await vi.waitFor(() => {
+      expect(wrapper.text()).toContain(
+        "Failed to join party. The code may have expired.",
+      );
+    });
+    expect(sessionStorage.getItem("ma_pending_join_code")).toBeNull();
+    expect(sessionStorage.getItem("ma_pending_join_type")).toBeNull();
+    expect(localStorage.getItem("ma_access_token")).toBeNull();
+    expect(wrapper.emitted("authenticated")).toBeUndefined();
+  });
+
+  it("preserves same-origin hosted guest joining", async () => {
+    setLocation("?join=abcd1234");
+    mockHostedFrontend();
+
+    const wrapper = mountLogin();
+
+    await vi.waitFor(() => {
+      expect(wrapper.emitted("authenticated")).toHaveLength(1);
+    });
+    expect(wrapper.emitted("local-connect")).toEqual([
+      ["http://localhost:3000"],
+    ]);
+  });
+
+  it("preserves remote ID guest joining", async () => {
+    const remoteId = "ABCDEFGH1234512345ABCDEFGH";
+    setLocation(`?remote_id=${remoteId}&join=abcd1234`);
+
+    const wrapper = mountLogin();
+
+    await vi.waitFor(() => {
+      expect(wrapper.emitted("authenticated")).toHaveLength(1);
+    });
+    expect(mocks.connectRemote).toHaveBeenCalledWith(remoteId);
+    expect(wrapper.emitted("connected")).toEqual([[{ id: "transport" }]]);
+    expect(wrapper.emitted("local-connect")).toBeUndefined();
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -10,6 +10,11 @@ export default mergeConfig(
       globals: true,
       css: false,
       setupFiles: [],
+      server: {
+        deps: {
+          inline: ["vuetify"],
+        },
+      },
       // Ignore nested git worktrees so a sibling branch's tests under
       // ./.worktrees aren't picked up by this repo's suite.
       exclude: [...configDefaults.exclude, "**/.worktrees/**"],


### PR DESCRIPTION
Fixes Party and Music Quiz guest links when the frontend and server run on different origins.

- Keep guest join codes while connecting to a saved or selected server
- Clear stale authentication before exchanging a guest code
- Preserve hosted, remote, and reload recovery flows
- Add focused login flow coverage