### PR TITLE
Support Music Quiz game types

### DIFF
--- a/src/components/music-quiz/MusicQuizGuessTheSongConfig.vue
+++ b/src/components/music-quiz/MusicQuizGuessTheSongConfig.vue
@@ -186,7 +186,7 @@ import {
 import { SearchInput } from "@/components/ui/search-input";
 import type {
   MusicQuizDifficulty,
-  MusicQuizGuessTheSongConfig,
+  MusicQuizGuessTheSongCreateRequest,
 } from "@/composables/useMusicQuiz";
 import {
   useMusicQuizSourceSearch,
@@ -206,7 +206,9 @@ const MIN_SECONDS = 5;
 const MAX_SECONDS = 120;
 
 defineProps<{ busy: boolean }>();
-const emit = defineEmits<{ create: [config: MusicQuizGuessTheSongConfig] }>();
+const emit = defineEmits<{
+  create: [request: MusicQuizGuessTheSongCreateRequest];
+}>();
 
 const name = ref(generateMusicQuizSessionName());
 const roundCount = ref(5);
@@ -230,12 +232,16 @@ const {
 function create() {
   if (!canCreate.value) return;
   emit("create", {
-    round_count: roundCount.value,
-    suggestion_count: suggestionCount.value,
-    answer_duration: answerDuration.value,
-    difficulty: difficulty.value,
-    source_uris: sourceUris.value,
-    name: name.value.trim() || generateMusicQuizSessionName(),
+    quiz_type: "guess_the_song",
+    answer_type: "multiple_choice",
+    config: {
+      round_count: roundCount.value,
+      suggestion_count: suggestionCount.value,
+      answer_duration: answerDuration.value,
+      difficulty: difficulty.value,
+      source_uris: sourceUris.value,
+      name: name.value.trim() || generateMusicQuizSessionName(),
+    },
   });
 }
 

--- a/src/components/music-quiz/MusicQuizHostPanel.vue
+++ b/src/components/music-quiz/MusicQuizHostPanel.vue
@@ -134,7 +134,7 @@ import {
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
 import type {
-  MusicQuizHostState,
+  MusicQuizSupportedHostState,
   MusicQuizRound,
 } from "@/composables/useMusicQuiz";
 import {
@@ -148,7 +148,7 @@ import { computed } from "vue";
 
 const props = withDefaults(
   defineProps<{
-    state: MusicQuizHostState;
+    state: MusicQuizSupportedHostState;
     busy: boolean;
     joinLink: string;
     currentRound: MusicQuizRound | null;

--- a/src/components/music-quiz/MusicQuizPlayerStage.vue
+++ b/src/components/music-quiz/MusicQuizPlayerStage.vue
@@ -118,7 +118,7 @@ import MusicQuizPodium from "@/components/music-quiz/MusicQuizPodium.vue";
 import MusicQuizReveal from "@/components/music-quiz/MusicQuizReveal.vue";
 import type {
   MusicQuizCurrentRound,
-  MusicQuizPersonalizedState,
+  MusicQuizSupportedPersonalizedState,
 } from "@/composables/useMusicQuiz";
 import { $t } from "@/plugins/i18n";
 import api from "@/plugins/api";
@@ -127,7 +127,7 @@ import { CircleCheck, CircleX, Trophy } from "@lucide/vue";
 import { computed, ref, watch } from "vue";
 
 const props = defineProps<{
-  state: MusicQuizPersonalizedState;
+  state: MusicQuizSupportedPersonalizedState;
   currentRound: MusicQuizCurrentRound | null;
   busy: boolean;
   leaderboardRows: MusicQuizLeaderboardRow[];

--- a/src/components/music-quiz/MusicQuizPresentStage.vue
+++ b/src/components/music-quiz/MusicQuizPresentStage.vue
@@ -5,7 +5,7 @@
     <header class="flex items-start justify-between gap-4">
       <div class="min-w-0">
         <h1 class="truncate text-3xl font-black sm:text-4xl lg:text-5xl">
-          {{ state.name }}
+          {{ state.name || $t("providers.music_quiz.title") }}
         </h1>
         <p class="text-muted-foreground text-base sm:text-lg lg:text-xl">
           {{ phaseLabel }}

--- a/src/components/music-quiz/MusicQuizPresentStage.vue
+++ b/src/components/music-quiz/MusicQuizPresentStage.vue
@@ -145,7 +145,7 @@ import MusicQuizReveal from "@/components/music-quiz/MusicQuizReveal.vue";
 import { Button } from "@/components/ui/button";
 import type {
   MusicQuizCurrentRound,
-  MusicQuizHostState,
+  MusicQuizSupportedHostState,
 } from "@/composables/useMusicQuiz";
 import { useMusicQuizCelebration } from "@/composables/useMusicQuizCelebration";
 import { $t } from "@/plugins/i18n";
@@ -153,7 +153,7 @@ import { Minimize2 } from "@lucide/vue";
 import { computed, watch } from "vue";
 
 const props = defineProps<{
-  state: MusicQuizHostState;
+  state: MusicQuizSupportedHostState;
   currentRound: MusicQuizCurrentRound | null;
   leaderboardRows: MusicQuizLeaderboardRow[];
   answeredCount: number;

--- a/src/components/music-quiz/MusicQuizSessionPanels.vue
+++ b/src/components/music-quiz/MusicQuizSessionPanels.vue
@@ -26,7 +26,7 @@ import MusicQuizAnswerStatus from "@/components/music-quiz/MusicQuizAnswerStatus
 import MusicQuizLeaderboard, {
   type MusicQuizLeaderboardRow,
 } from "@/components/music-quiz/MusicQuizLeaderboard.vue";
-import type { MusicQuizHostState } from "@/composables/useMusicQuiz";
+import type { MusicQuizSupportedHostState } from "@/composables/useMusicQuiz";
 import {
   getMusicQuizRoundScoreLabel,
   getMusicQuizWinnerText,
@@ -35,7 +35,7 @@ import {
 import { $t } from "@/plugins/i18n";
 import { computed } from "vue";
 
-const props = defineProps<{ state: MusicQuizHostState }>();
+const props = defineProps<{ state: MusicQuizSupportedHostState }>();
 
 const currentRound = computed(() => props.state.current_round ?? null);
 

--- a/src/components/music-quiz/MusicQuizSetupWizard.vue
+++ b/src/components/music-quiz/MusicQuizSetupWizard.vue
@@ -105,10 +105,7 @@ import {
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Progress } from "@/components/ui/progress";
-import type {
-  MusicQuizCreateArgs,
-  MusicQuizGuessTheSongConfig,
-} from "@/composables/useMusicQuiz";
+import type { MusicQuizCreateRequest } from "@/composables/useMusicQuiz";
 import { $t } from "@/plugins/i18n";
 import { ArrowLeft, PartyPopper, Sparkles } from "@lucide/vue";
 import { ref } from "vue";
@@ -116,7 +113,7 @@ import { ref } from "vue";
 const TOTAL_STEPS = 3;
 
 defineProps<{ busy: boolean }>();
-const emit = defineEmits<{ create: [args: MusicQuizCreateArgs] }>();
+const emit = defineEmits<{ create: [request: MusicQuizCreateRequest] }>();
 
 const gameTypes = MUSIC_QUIZ_GAME_TYPES;
 const step = ref<1 | 2 | 3>(1);
@@ -136,8 +133,7 @@ function back() {
   }
 }
 
-function onConfigCreate(config: MusicQuizGuessTheSongConfig) {
-  if (!selectedType.value) return;
-  emit("create", { ...config, quiz_type: selectedType.value.id });
+function onConfigCreate(request: MusicQuizCreateRequest) {
+  emit("create", request);
 }
 </script>

--- a/src/components/music-quiz/MusicQuizUnsupportedGame.vue
+++ b/src/components/music-quiz/MusicQuizUnsupportedGame.vue
@@ -1,0 +1,45 @@
+<template>
+  <Card>
+    <CardHeader class="items-center text-center">
+      <span
+        class="bg-destructive/10 text-destructive grid size-12 place-items-center rounded-full"
+      >
+        <TriangleAlert class="size-6" />
+      </span>
+      <CardTitle>{{ $t("providers.music_quiz.unsupported_title") }}</CardTitle>
+      <CardDescription>
+        {{ $t("providers.music_quiz.unsupported_description") }}
+      </CardDescription>
+    </CardHeader>
+    <CardFooter v-if="canDelete" class="justify-center">
+      <Button
+        type="button"
+        variant="outline"
+        :disabled="busy"
+        @click="emit('delete')"
+      >
+        <Trash2 class="size-4" />
+        {{ $t("delete") }}
+      </Button>
+    </CardFooter>
+  </Card>
+</template>
+
+<script setup lang="ts">
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { $t } from "@/plugins/i18n";
+import { Trash2, TriangleAlert } from "@lucide/vue";
+
+withDefaults(defineProps<{ canDelete?: boolean; busy?: boolean }>(), {
+  canDelete: false,
+  busy: false,
+});
+const emit = defineEmits<{ delete: [] }>();
+</script>

--- a/src/components/music-quiz/game_types.ts
+++ b/src/components/music-quiz/game_types.ts
@@ -1,12 +1,13 @@
 import MusicQuizGuessTheSongConfig from "@/components/music-quiz/MusicQuizGuessTheSongConfig.vue";
+import type { MusicQuizType } from "@/composables/useMusicQuiz";
 import { Disc3 } from "@lucide/vue";
 import { markRaw, type Component } from "vue";
 
-export const DEFAULT_MUSIC_QUIZ_GAME_TYPE = "guess_the_song";
+export const DEFAULT_MUSIC_QUIZ_GAME_TYPE: MusicQuizType = "guess_the_song";
 
 export interface MusicQuizGameTypeOption {
   /** Value sent to the server as `quiz_type`. */
-  id: string;
+  id: MusicQuizType;
   labelKey: string;
   descriptionKey: string;
   icon: Component;
@@ -20,8 +21,11 @@ export interface MusicQuizGameTypeOption {
  * Registry of Music Quiz game types. Adding a type here (with its config step)
  * makes it appear in the setup wizard without touching the wizard itself.
  */
-export const MUSIC_QUIZ_GAME_TYPES: MusicQuizGameTypeOption[] = [
-  {
+const MUSIC_QUIZ_GAME_TYPE_REGISTRY: Record<
+  MusicQuizType,
+  MusicQuizGameTypeOption
+> = {
+  guess_the_song: {
     id: "guess_the_song",
     labelKey: "providers.music_quiz.game_type_guess_the_song",
     descriptionKey: "providers.music_quiz.game_type_guess_the_song_description",
@@ -29,7 +33,11 @@ export const MUSIC_QUIZ_GAME_TYPES: MusicQuizGameTypeOption[] = [
     available: true,
     configComponent: markRaw(MusicQuizGuessTheSongConfig),
   },
-];
+};
+
+export const MUSIC_QUIZ_GAME_TYPES = Object.values(
+  MUSIC_QUIZ_GAME_TYPE_REGISTRY,
+);
 
 export function getMusicQuizGameType(
   id: string,

--- a/src/composables/useMusicQuiz.ts
+++ b/src/composables/useMusicQuiz.ts
@@ -204,7 +204,7 @@ export function isMusicQuizProviderEvent(
   value: unknown,
 ): value is MusicQuizProviderEvent {
   if (!value || typeof value !== "object" || !("event" in value)) return false;
-  if (value.event === "game_removed") return true;
+  if (value.event === "game_removed") return !("state" in value);
   return value.event === "game_updated" && "state" in value;
 }
 

--- a/src/composables/useMusicQuiz.ts
+++ b/src/composables/useMusicQuiz.ts
@@ -26,7 +26,7 @@ interface MusicQuizStateIdentity<
   quiz_type: TQuizType;
   answer_type: TAnswerType;
   phase: MusicQuizPhase;
-  name: string;
+  name: string | null;
 }
 
 interface MusicQuizSupportedStateBase extends MusicQuizStateIdentity {
@@ -119,7 +119,7 @@ export interface MusicQuizYourAnswer {
 }
 
 export interface MusicQuizCurrentRound {
-  question: string;
+  question: string | null;
   round_index: number;
   started_at: number;
   deadline: number;
@@ -127,7 +127,7 @@ export interface MusicQuizCurrentRound {
   // post-reveal fields:
   correct_suggestion_id?: string;
   answer_label?: string;
-  track_uri?: string;
+  track_uri?: string | null;
   image_url?: string | null;
   duration?: number | null;
   ended_at?: number;

--- a/src/composables/useMusicQuiz.ts
+++ b/src/composables/useMusicQuiz.ts
@@ -205,7 +205,12 @@ export function isMusicQuizProviderEvent(
 ): value is MusicQuizProviderEvent {
   if (!value || typeof value !== "object" || !("event" in value)) return false;
   if (value.event === "game_removed") return !("state" in value);
-  return value.event === "game_updated" && "state" in value;
+  return (
+    value.event === "game_updated" &&
+    "state" in value &&
+    !!value.state &&
+    typeof value.state === "object"
+  );
 }
 
 // Host commands (Scope.USERS_INVITE)

--- a/src/composables/useMusicQuiz.ts
+++ b/src/composables/useMusicQuiz.ts
@@ -3,14 +3,35 @@ import api from "@/plugins/api";
 export type MusicQuizPhase = "lobby" | "answering" | "reveal" | "finished";
 export type MusicQuizMode = "venue" | "remote";
 export type MusicQuizDifficulty = "easy" | "normal" | "hard";
+export type MusicQuizType = "guess_the_song";
+export type MusicQuizAnswerType = "multiple_choice";
 
-/**
- * Public state shape (guest-safe): exposed in game_updated events,
- * music_quiz/state, music_quiz/join, music_quiz/info, and all host responses.
- */
-export interface MusicQuizPublicState {
+declare const unsupportedMusicQuizType: unique symbol;
+export type MusicQuizUnsupportedType = string & {
+  readonly [unsupportedMusicQuizType]: true;
+};
+declare const unsupportedMusicQuizAnswerType: unique symbol;
+export type MusicQuizUnsupportedAnswerType = string & {
+  readonly [unsupportedMusicQuizAnswerType]: true;
+};
+export type MusicQuizRuntimeType = MusicQuizType | MusicQuizUnsupportedType;
+export type MusicQuizRuntimeAnswerType =
+  | MusicQuizAnswerType
+  | MusicQuizUnsupportedAnswerType;
+
+interface MusicQuizStateIdentity<
+  TQuizType extends MusicQuizRuntimeType = MusicQuizRuntimeType,
+  TAnswerType extends MusicQuizRuntimeAnswerType = MusicQuizRuntimeAnswerType,
+> {
+  quiz_type: TQuizType;
+  answer_type: TAnswerType;
   phase: MusicQuizPhase;
   name: string;
+}
+
+interface MusicQuizSupportedStateBase extends MusicQuizStateIdentity {
+  quiz_type: "guess_the_song";
+  answer_type: "multiple_choice";
   round_count: number;
   suggestion_count: number;
   answer_duration: number;
@@ -19,33 +40,53 @@ export interface MusicQuizPublicState {
   current_round?: MusicQuizCurrentRound | null;
 }
 
-/**
- * Personalized state = public state + you (the authenticated guest's own data).
- */
-export interface MusicQuizPersonalizedState extends MusicQuizPublicState {
+export type MusicQuizSupportedPublicState = MusicQuizSupportedStateBase;
+
+type MusicQuizUnsupportedStateIdentity =
+  | MusicQuizStateIdentity<MusicQuizUnsupportedType, MusicQuizRuntimeAnswerType>
+  | MusicQuizStateIdentity<MusicQuizType, MusicQuizUnsupportedAnswerType>;
+
+export type MusicQuizUnsupportedPublicState = MusicQuizUnsupportedStateIdentity;
+
+export type MusicQuizPublicState =
+  | MusicQuizSupportedPublicState
+  | MusicQuizUnsupportedPublicState;
+
+export interface MusicQuizSupportedPersonalizedState extends MusicQuizSupportedStateBase {
   you: MusicQuizYou;
 }
 
-/**
- * Host state = public state + created_at, sources, join_url, full rounds array.
- */
-export interface MusicQuizHostState extends MusicQuizPublicState {
+export type MusicQuizUnsupportedPersonalizedState =
+  MusicQuizUnsupportedPublicState;
+
+export type MusicQuizPersonalizedState =
+  | MusicQuizSupportedPersonalizedState
+  | MusicQuizUnsupportedPersonalizedState;
+
+export interface MusicQuizSupportedHostState extends MusicQuizSupportedStateBase {
   created_at: number;
   sources: MusicQuizSource[];
   join_url: string;
   rounds: MusicQuizRound[];
 }
 
-/**
- * Pre-join info (music_quiz/info): subset for landing screen before join.
- */
-export interface MusicQuizInfo {
-  name: string;
-  phase: MusicQuizPhase;
+export type MusicQuizUnsupportedHostState = MusicQuizUnsupportedPublicState;
+
+export type MusicQuizHostState =
+  | MusicQuizSupportedHostState
+  | MusicQuizUnsupportedHostState;
+
+export interface MusicQuizSupportedInfo extends MusicQuizStateIdentity {
+  quiz_type: "guess_the_song";
+  answer_type: "multiple_choice";
   player_count: number;
   round_count: number;
   mode: MusicQuizMode;
 }
+
+export type MusicQuizUnsupportedInfo = MusicQuizUnsupportedStateIdentity;
+
+export type MusicQuizInfo = MusicQuizSupportedInfo | MusicQuizUnsupportedInfo;
 
 export interface MusicQuizPlayer {
   name: string;
@@ -78,6 +119,7 @@ export interface MusicQuizYourAnswer {
 }
 
 export interface MusicQuizCurrentRound {
+  question: string;
   round_index: number;
   started_at: number;
   deadline: number;
@@ -91,9 +133,7 @@ export interface MusicQuizCurrentRound {
   ended_at?: number;
 }
 
-export interface MusicQuizRound extends MusicQuizCurrentRound {
-  // Host state includes full history; current_round is a live subset
-}
+export type MusicQuizRound = MusicQuizCurrentRound;
 
 export interface MusicQuizSuggestion {
   suggestion_id: string;
@@ -111,10 +151,6 @@ export interface MusicQuizJoinResult {
   state: MusicQuizPersonalizedState;
 }
 
-/**
- * Host setup arguments for a specific game type (everything except which game
- * type is being created).
- */
 export interface MusicQuizGuessTheSongConfig {
   round_count: number;
   suggestion_count: number;
@@ -124,31 +160,60 @@ export interface MusicQuizGuessTheSongConfig {
   name: string;
 }
 
-/**
- * Host setup-form arguments for creating a game, including the selected game type.
- */
-export interface MusicQuizCreateArgs extends MusicQuizGuessTheSongConfig {
-  quiz_type: string;
+export interface MusicQuizGuessTheSongCreateRequest {
+  quiz_type: "guess_the_song";
+  answer_type: "multiple_choice";
+  config: MusicQuizGuessTheSongConfig;
+}
+
+export type MusicQuizCreateRequest = MusicQuizGuessTheSongCreateRequest;
+
+export type MusicQuizProviderEvent =
+  | { event: "game_updated"; state: MusicQuizPublicState }
+  | { event: "game_removed"; state?: never };
+
+export function isSupportedMusicQuiz<
+  T extends MusicQuizInfo | MusicQuizPublicState,
+>(
+  value: T,
+): value is Extract<
+  T,
+  { quiz_type: "guess_the_song"; answer_type: "multiple_choice" }
+> {
+  return (
+    value.quiz_type === "guess_the_song" &&
+    value.answer_type === "multiple_choice"
+  );
+}
+
+export function parseMusicQuizType(value: string): MusicQuizRuntimeType {
+  return value === "guess_the_song"
+    ? value
+    : (value as MusicQuizUnsupportedType);
+}
+
+export function parseMusicQuizAnswerType(
+  value: string,
+): MusicQuizRuntimeAnswerType {
+  return value === "multiple_choice"
+    ? value
+    : (value as MusicQuizUnsupportedAnswerType);
+}
+
+export function isMusicQuizProviderEvent(
+  value: unknown,
+): value is MusicQuizProviderEvent {
+  if (!value || typeof value !== "object" || !("event" in value)) return false;
+  if (value.event === "game_removed") return true;
+  return value.event === "game_updated" && "state" in value;
 }
 
 // Host commands (Scope.USERS_INVITE)
-export function createMusicQuiz(
-  quiz_type: string,
-  round_count: number,
-  suggestion_count: number,
-  answer_duration: number,
-  difficulty: MusicQuizDifficulty,
-  source_uris: string[],
-  name?: string,
-) {
+export function createMusicQuiz(request: MusicQuizCreateRequest) {
+  const { quiz_type, config } = request;
   return api.sendCommand<MusicQuizHostState>("music_quiz/create", {
     quiz_type,
-    round_count,
-    suggestion_count,
-    answer_duration,
-    difficulty,
-    source_uris,
-    name,
+    ...config,
   });
 }
 

--- a/src/composables/useMusicQuizHost.ts
+++ b/src/composables/useMusicQuizHost.ts
@@ -50,10 +50,11 @@ export function useMusicQuizHost(options: UseMusicQuizHostOptions) {
   });
 
   const isLastRound = computed(() => {
-    if (!state.value || !isSupportedMusicQuiz(state.value)) return false;
+    const currentState = state.value;
+    if (!currentState || !isSupportedMusicQuiz(currentState)) return false;
     return (
-      state.value.current_round &&
-      state.value.current_round.round_index >= state.value.round_count - 1
+      currentState.current_round &&
+      currentState.current_round.round_index >= currentState.round_count - 1
     );
   });
 

--- a/src/composables/useMusicQuizHost.ts
+++ b/src/composables/useMusicQuizHost.ts
@@ -2,11 +2,13 @@ import {
   createMusicQuiz,
   deleteMusicQuiz,
   getMusicQuiz,
-  type MusicQuizDifficulty,
+  isSupportedMusicQuiz,
+  isMusicQuizProviderEvent,
   nextMusicQuiz,
   resetMusicQuiz,
   revealMusicQuiz,
   startMusicQuiz,
+  type MusicQuizCreateRequest,
   type MusicQuizCurrentRound,
   type MusicQuizHostState,
 } from "@/composables/useMusicQuiz";
@@ -41,18 +43,26 @@ export function useMusicQuizHost(options: UseMusicQuizHostOptions) {
   let unsubscribeProviderEvent: (() => void) | undefined;
 
   const currentRound = computed<MusicQuizCurrentRound | null>(() => {
-    return state.value?.current_round ?? null;
+    const currentState = state.value;
+    return currentState && isSupportedMusicQuiz(currentState)
+      ? (currentState.current_round ?? null)
+      : null;
   });
 
   const isLastRound = computed(() => {
-    if (!state.value) return false;
+    if (!state.value || !isSupportedMusicQuiz(state.value)) return false;
     return (
       state.value.current_round &&
       state.value.current_round.round_index >= state.value.round_count - 1
     );
   });
 
-  const joinLink = computed(() => state.value?.join_url ?? "");
+  const joinLink = computed(() => {
+    const currentState = state.value;
+    return currentState && isSupportedMusicQuiz(currentState)
+      ? currentState.join_url
+      : "";
+  });
 
   const phaseLabel = computed(() => {
     if (!state.value) return "";
@@ -89,14 +99,8 @@ export function useMusicQuizHost(options: UseMusicQuizHostOptions) {
   }
 
   function handleProviderEvent(event: { object_id?: string; data?: unknown }) {
-    if (!event.data || typeof event.data !== "object") return;
-    const payload = event.data as {
-      event?: string;
-      state?: MusicQuizHostState;
-    };
-    if (payload.event !== "game_updated" && payload.event !== "game_removed") {
-      return;
-    }
+    if (!isMusicQuizProviderEvent(event.data)) return;
+    const payload = event.data;
     if (!isScopedProviderEvent(event.object_id)) return;
     if (payload.event === "game_updated") {
       // Re-fetch on game_updated to get the latest host state
@@ -116,26 +120,10 @@ export function useMusicQuizHost(options: UseMusicQuizHostOptions) {
     return providerInstanceId.value === objectId;
   }
 
-  async function create(
-    quiz_type: string,
-    round_count: number,
-    suggestion_count: number,
-    answer_duration: number,
-    difficulty: MusicQuizDifficulty,
-    source_uris: string[],
-    name?: string,
-  ) {
+  async function create(request: MusicQuizCreateRequest) {
     busy.value = true;
     try {
-      const nextState = await createMusicQuiz(
-        quiz_type,
-        round_count,
-        suggestion_count,
-        answer_duration,
-        difficulty,
-        source_uris,
-        name,
-      );
+      const nextState = await createMusicQuiz(request);
       state.value = nextState;
       gameRemoved.value = false;
       return true;

--- a/src/composables/useMusicQuizPlayer.ts
+++ b/src/composables/useMusicQuizPlayer.ts
@@ -2,6 +2,8 @@ import {
   answerMusicQuiz,
   getMusicQuizInfo,
   getMusicQuizState,
+  isSupportedMusicQuiz,
+  isMusicQuizProviderEvent,
   joinMusicQuiz,
   readyMusicQuiz,
   type MusicQuizCurrentRound,
@@ -43,12 +45,25 @@ export function useMusicQuizPlayer(options: UseMusicQuizPlayerOptions) {
   let unsubscribeProviderEvent: (() => void) | undefined;
 
   const currentRound = computed<MusicQuizCurrentRound | null>(() => {
-    return state.value?.current_round ?? null;
+    const currentState = state.value;
+    return currentState && isSupportedMusicQuiz(currentState)
+      ? (currentState.current_round ?? null)
+      : null;
   });
 
-  const yourName = computed(() => state.value?.you.name ?? "");
+  const yourName = computed(() => {
+    const currentState = state.value;
+    return currentState && isSupportedMusicQuiz(currentState)
+      ? currentState.you.name
+      : "";
+  });
 
-  const players = computed(() => state.value?.players ?? []);
+  const players = computed(() => {
+    const currentState = state.value;
+    return currentState && isSupportedMusicQuiz(currentState)
+      ? currentState.players
+      : [];
+  });
 
   async function fetchInfo() {
     try {
@@ -100,14 +115,8 @@ export function useMusicQuizPlayer(options: UseMusicQuizPlayerOptions) {
   }
 
   function handleProviderEvent(event: { object_id?: string; data?: unknown }) {
-    if (!event.data || typeof event.data !== "object") return;
-    const payload = event.data as {
-      event?: string;
-      state?: MusicQuizPersonalizedState;
-    };
-    if (payload.event !== "game_updated" && payload.event !== "game_removed") {
-      return;
-    }
+    if (!isMusicQuizProviderEvent(event.data)) return;
+    const payload = event.data;
     if (!isScopedProviderEvent(event.object_id)) return;
     if (payload.event === "game_updated") {
       if (playerId.value || getStoredMusicQuizPlayerId()) {

--- a/src/composables/useMusicQuizRoundClocks.ts
+++ b/src/composables/useMusicQuizRoundClocks.ts
@@ -1,6 +1,6 @@
 import type {
   MusicQuizCurrentRound,
-  MusicQuizPublicState,
+  MusicQuizSupportedPublicState,
 } from "@/composables/useMusicQuiz";
 import { computed, ref, watch, type Ref } from "vue";
 
@@ -10,7 +10,7 @@ import { computed, ref, watch, type Ref } from "vue";
  * Timestamps are epoch SECONDS as float on the SERVER clock.
  */
 export function useMusicQuizRoundClocks(
-  state: Ref<MusicQuizPublicState | null>,
+  state: Ref<MusicQuizSupportedPublicState | null>,
   currentRound: Ref<MusicQuizCurrentRound | null>,
 ) {
   const answerRemainingSeconds = ref<number | null>(null);

--- a/src/helpers/music_quiz.ts
+++ b/src/helpers/music_quiz.ts
@@ -1,7 +1,7 @@
 import type {
   MusicQuizPhase,
   MusicQuizPlayer,
-  MusicQuizPublicState,
+  MusicQuizSupportedPublicState,
 } from "@/composables/useMusicQuiz";
 import { $t, i18n } from "@/plugins/i18n";
 
@@ -76,7 +76,7 @@ export function isMusicQuizWinner(
 }
 
 export function getMusicQuizRoundScoreLabel(
-  state: MusicQuizPublicState,
+  state: MusicQuizSupportedPublicState,
   playerName: string,
 ) {
   if (state.phase !== "reveal" || !state.current_round) return "";

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1181,6 +1181,8 @@
             "game_ended": "Game Ended",
             "game_ended_detail": "This quiz game has ended.",
             "game_no_longer_available": "This game is no longer available",
+            "unsupported_title": "Update required",
+            "unsupported_description": "This game type requires a newer version of the Music Assistant frontend.",
             "delete_confirm": "Are you sure you want to delete this game?",
             "delete": "Delete Game",
             "start": "Start Quiz",

--- a/src/views/MusicQuizDashboardView.vue
+++ b/src/views/MusicQuizDashboardView.vue
@@ -1,8 +1,8 @@
 <template>
   <div ref="presentRootRef" class="mx-auto w-full max-w-6xl p-4 sm:p-5">
     <MusicQuizPresentStage
-      v-if="presentMode && state"
-      :state="state"
+      v-if="presentMode && guessTheSongState"
+      :state="guessTheSongState"
       :current-round="currentRound"
       :leaderboard-rows="leaderboardRows"
       :answered-count="answeredCount"
@@ -33,7 +33,7 @@
           </p>
         </div>
         <Button
-          v-if="state"
+          v-if="guessTheSongState"
           variant="ghost-outline"
           size="sm"
           :disabled="busy"
@@ -61,9 +61,16 @@
         </CardContent>
       </Card>
 
-      <div v-else-if="state" class="flex flex-col gap-4">
+      <MusicQuizUnsupportedGame
+        v-else-if="state && !guessTheSongState"
+        :busy="busy"
+        :can-delete="true"
+        @delete="showDeleteDialog = true"
+      />
+
+      <div v-else-if="guessTheSongState" class="flex flex-col gap-4">
         <MusicQuizHostPanel
-          :state="state"
+          :state="guessTheSongState"
           :busy="busy"
           :join-link="joinLink"
           :current-round="currentRound"
@@ -75,7 +82,7 @@
           @reset="host.reset"
         />
 
-        <Card v-if="state.phase === 'answering' && currentRound">
+        <Card v-if="guessTheSongState.phase === 'answering' && currentRound">
           <CardContent class="flex flex-col items-center gap-4">
             <MusicQuizCountdown
               :size="120"
@@ -93,7 +100,7 @@
         </Card>
 
         <MusicQuizReveal
-          v-else-if="state.phase === 'reveal' && currentRound"
+          v-else-if="guessTheSongState.phase === 'reveal' && currentRound"
           :round="currentRound"
           :busy="true"
           :is-ready="true"
@@ -110,7 +117,7 @@
           @copy-title="copyCurrentRoundTitle"
         />
 
-        <MusicQuizSessionPanels :state="state" />
+        <MusicQuizSessionPanels :state="guessTheSongState" />
       </div>
     </section>
 
@@ -143,6 +150,7 @@ import MusicQuizPresentStage from "@/components/music-quiz/MusicQuizPresentStage
 import MusicQuizReveal from "@/components/music-quiz/MusicQuizReveal.vue";
 import MusicQuizSessionPanels from "@/components/music-quiz/MusicQuizSessionPanels.vue";
 import MusicQuizSetupWizard from "@/components/music-quiz/MusicQuizSetupWizard.vue";
+import MusicQuizUnsupportedGame from "@/components/music-quiz/MusicQuizUnsupportedGame.vue";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -162,7 +170,10 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
-import type { MusicQuizCreateArgs } from "@/composables/useMusicQuiz";
+import {
+  isSupportedMusicQuiz,
+  type MusicQuizCreateRequest,
+} from "@/composables/useMusicQuiz";
 import { useMusicQuizHost } from "@/composables/useMusicQuizHost";
 import { useMusicQuizRoundClocks } from "@/composables/useMusicQuizRoundClocks";
 import {
@@ -192,18 +203,27 @@ const {
   phaseLabel,
 } = host;
 
+const guessTheSongState = computed(() => {
+  const currentState = state.value;
+  return currentState && isSupportedMusicQuiz(currentState)
+    ? currentState
+    : null;
+});
+
 const clocks = useMusicQuizRoundClocks(
-  computed(() => state.value),
+  guessTheSongState,
   computed(() => currentRound.value),
 );
 const { answerRemainingLabel, answerRemainingFraction } = clocks;
 
 const rankedPlayers = computed(() =>
-  state.value ? rankMusicQuizPlayers(state.value.players) : [],
+  guessTheSongState.value
+    ? rankMusicQuizPlayers(guessTheSongState.value.players)
+    : [],
 );
 
 const leaderboardRows = computed<MusicQuizLeaderboardRow[]>(() => {
-  const currentState = state.value;
+  const currentState = guessTheSongState.value;
   if (!currentState) return [];
   return rankedPlayers.value.map((player) => ({
     ...player,
@@ -212,19 +232,22 @@ const leaderboardRows = computed<MusicQuizLeaderboardRow[]>(() => {
 });
 
 const answeredCount = computed(
-  () => state.value?.players.filter((player) => player.answered).length ?? 0,
+  () =>
+    guessTheSongState.value?.players.filter((player) => player.answered)
+      .length ?? 0,
 );
 const winnerText = computed(() => getMusicQuizWinnerText(rankedPlayers.value));
 
 const roundLabel = computed(() => {
-  if (!state.value || !currentRound.value) return "";
-  return `${$t("providers.music_quiz.round_label")} ${currentRound.value.round_index + 1} / ${state.value.round_count}`;
+  if (!guessTheSongState.value || !currentRound.value) return "";
+  return `${$t("providers.music_quiz.round_label")} ${currentRound.value.round_index + 1} / ${guessTheSongState.value.round_count}`;
 });
 
 const statusText = computed(() => {
   if (loading.value) return $t("providers.music_quiz.loading");
   if (gameRemoved.value) return $t("providers.music_quiz.game_removed");
-  if (state.value) return phaseLabel.value;
+  if (guessTheSongState.value) return phaseLabel.value;
+  if (state.value) return $t("providers.music_quiz.unsupported_title");
   return $t("providers.music_quiz.no_active_game");
 });
 
@@ -254,16 +277,8 @@ async function copyCurrentRoundTitle() {
   }
 }
 
-async function handleCreate(args: MusicQuizCreateArgs) {
-  await host.create(
-    args.quiz_type,
-    args.round_count,
-    args.suggestion_count,
-    args.answer_duration,
-    args.difficulty,
-    args.source_uris,
-    args.name,
-  );
+async function handleCreate(request: MusicQuizCreateRequest) {
+  await host.create(request);
 }
 
 async function enterPresentMode() {

--- a/src/views/MusicQuizPlayerView.vue
+++ b/src/views/MusicQuizPlayerView.vue
@@ -8,6 +8,8 @@
       </CardContent>
     </Card>
 
+    <MusicQuizUnsupportedGame v-else-if="unsupportedGame" />
+
     <Card v-else-if="!playerId && !loading">
       <CardHeader class="items-center text-center">
         <span
@@ -16,36 +18,49 @@
           <PartyPopper class="size-7" />
         </span>
         <CardTitle class="text-2xl">
-          {{ info?.name || $t("providers.music_quiz.title") }}
+          {{ guessTheSongInfo?.name || $t("providers.music_quiz.title") }}
         </CardTitle>
-        <div v-if="info" class="flex flex-wrap justify-center gap-2 pt-1">
+        <div
+          v-if="guessTheSongInfo"
+          class="flex flex-wrap justify-center gap-2 pt-1"
+        >
           <Badge variant="secondary">
-            {{ $t("providers.music_quiz.players_count", [info.player_count]) }}
+            {{
+              $t("providers.music_quiz.players_count", [
+                guessTheSongInfo.player_count,
+              ])
+            }}
           </Badge>
           <Badge variant="secondary">
-            {{ $t("providers.music_quiz.rounds_count", [info.round_count]) }}
+            {{
+              $t("providers.music_quiz.rounds_count", [
+                guessTheSongInfo.round_count,
+              ])
+            }}
           </Badge>
           <Badge variant="secondary">{{ modeLabel }}</Badge>
         </div>
       </CardHeader>
       <CardContent>
         <MusicQuizJoinForm
-          :session-name="info?.name || $t('providers.music_quiz.title')"
+          :session-name="
+            guessTheSongInfo?.name || $t('providers.music_quiz.title')
+          "
           :busy="busy"
           @join="handleJoin"
         />
       </CardContent>
     </Card>
 
-    <template v-else-if="state">
+    <template v-else-if="guessTheSongState">
       <MusicQuizConnectionBanners :degraded="isConnectionDegraded" />
 
       <MusicQuizPlayerHeader
-        :player-name="state.you.name"
+        :player-name="guessTheSongState.you.name"
         :rank="playerRank"
         :round-progress="roundProgress"
         :round-fraction="roundFraction"
-        :score="state.you.score"
+        :score="guessTheSongState.you.score"
         :score-delta="playerRoundScoreLabel"
         :phase-label="phaseText"
       />
@@ -59,7 +74,7 @@
       />
 
       <MusicQuizPlayerStage
-        :state="state"
+        :state="guessTheSongState"
         :current-round="currentRound"
         :busy="busy"
         :leaderboard-rows="leaderboardRows"
@@ -93,11 +108,13 @@ import MusicQuizJoinForm from "@/components/music-quiz/MusicQuizJoinForm.vue";
 import { type MusicQuizLeaderboardRow } from "@/components/music-quiz/MusicQuizLeaderboard.vue";
 import MusicQuizPlayerHeader from "@/components/music-quiz/MusicQuizPlayerHeader.vue";
 import MusicQuizPlayerStage from "@/components/music-quiz/MusicQuizPlayerStage.vue";
+import MusicQuizUnsupportedGame from "@/components/music-quiz/MusicQuizUnsupportedGame.vue";
 import { Badge } from "@/components/ui/badge";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { useMusicQuizCelebration } from "@/composables/useMusicQuizCelebration";
 import { useMusicQuizPlayer } from "@/composables/useMusicQuizPlayer";
 import { useMusicQuizRoundClocks } from "@/composables/useMusicQuizRoundClocks";
+import { isSupportedMusicQuiz } from "@/composables/useMusicQuiz";
 import {
   getMusicQuizErrorMessage,
   getMusicQuizRoundScoreLabel,
@@ -119,8 +136,23 @@ const player = useMusicQuizPlayer({
 const { info, state, playerId, gameRemoved, busy, loading, currentRound } =
   player;
 
+const guessTheSongState = computed(() => {
+  const currentState = state.value;
+  return currentState && isSupportedMusicQuiz(currentState)
+    ? currentState
+    : null;
+});
+const guessTheSongInfo = computed(() => {
+  const currentInfo = info.value;
+  return currentInfo && isSupportedMusicQuiz(currentInfo) ? currentInfo : null;
+});
+const unsupportedGame = computed(() => {
+  const activeGame = state.value ?? info.value;
+  return !!activeGame && !isSupportedMusicQuiz(activeGame);
+});
+
 const clocks = useMusicQuizRoundClocks(
-  computed(() => state.value),
+  guessTheSongState,
   computed(() => currentRound.value),
 );
 const { answerRemainingLabel, answerRemainingFraction, lyricsPosition } =
@@ -128,7 +160,10 @@ const { answerRemainingLabel, answerRemainingFraction, lyricsPosition } =
 
 const { celebrate } = useMusicQuizCelebration();
 
-const mode = computed(() => state.value?.mode ?? info.value?.mode);
+const mode = computed(() => {
+  if (guessTheSongState.value) return guessTheSongState.value.mode;
+  return guessTheSongInfo.value?.mode;
+});
 const modeLabel = computed(() =>
   mode.value === "remote"
     ? $t("providers.music_quiz.mode_remote")
@@ -150,11 +185,13 @@ const listenInLabels = computed<ListenInLabels>(() => ({
 }));
 
 const rankedPlayers = computed(() =>
-  state.value ? rankMusicQuizPlayers(state.value.players) : [],
+  guessTheSongState.value
+    ? rankMusicQuizPlayers(guessTheSongState.value.players)
+    : [],
 );
 
 const playerRank = computed(() => {
-  const currentState = state.value;
+  const currentState = guessTheSongState.value;
   if (!currentState) return null;
   return (
     rankedPlayers.value.find((row) => row.name === currentState.you.name)
@@ -163,7 +200,7 @@ const playerRank = computed(() => {
 });
 
 const leaderboardRows = computed<MusicQuizLeaderboardRow[]>(() => {
-  const currentState = state.value;
+  const currentState = guessTheSongState.value;
   if (!currentState) return [];
   return rankedPlayers.value.map((playerRow) => ({
     ...playerRow,
@@ -173,21 +210,22 @@ const leaderboardRows = computed<MusicQuizLeaderboardRow[]>(() => {
 
 const answeredCount = computed(
   () =>
-    state.value?.players.filter((playerRow) => playerRow.answered).length ?? 0,
+    guessTheSongState.value?.players.filter((playerRow) => playerRow.answered)
+      .length ?? 0,
 );
 const winnerText = computed(() => getMusicQuizWinnerText(rankedPlayers.value));
 
 const roundProgress = computed(() => {
-  if (!state.value) return "";
+  if (!guessTheSongState.value) return "";
   const label = $t("providers.music_quiz.round_label");
   if (!currentRound.value) {
-    return `${label} ${state.value.round_count}/${state.value.round_count}`;
+    return `${label} ${guessTheSongState.value.round_count}/${guessTheSongState.value.round_count}`;
   }
-  return `${label} ${currentRound.value.round_index + 1}/${state.value.round_count}`;
+  return `${label} ${currentRound.value.round_index + 1}/${guessTheSongState.value.round_count}`;
 });
 
 const roundFraction = computed(() => {
-  const currentState = state.value;
+  const currentState = guessTheSongState.value;
   if (!currentState || currentState.round_count <= 0) return 0;
   if (!currentRound.value) return 100;
   return (
@@ -196,24 +234,27 @@ const roundFraction = computed(() => {
 });
 
 const playerRoundScoreLabel = computed(() =>
-  state.value
-    ? getMusicQuizRoundScoreLabel(state.value, state.value.you.name)
+  guessTheSongState.value
+    ? getMusicQuizRoundScoreLabel(
+        guessTheSongState.value,
+        guessTheSongState.value.you.name,
+      )
     : "",
 );
 
 const readyLabel = computed(() =>
-  state.value?.you.ready
+  guessTheSongState.value?.you.ready
     ? $t("providers.music_quiz.waiting_for_next")
     : $t("providers.music_quiz.ready"),
 );
 
 const phaseText = computed(() => {
-  if (!state.value) return "";
-  if (state.value.phase === "lobby")
+  if (!guessTheSongState.value) return "";
+  if (guessTheSongState.value.phase === "lobby")
     return $t("providers.music_quiz.phase_waiting_for_players");
-  if (state.value.phase === "answering")
+  if (guessTheSongState.value.phase === "answering")
     return $t("providers.music_quiz.phase_answers_open");
-  if (state.value.phase === "reveal")
+  if (guessTheSongState.value.phase === "reveal")
     return $t("providers.music_quiz.phase_enjoy_track");
   return $t("providers.music_quiz.phase_finished");
 });
@@ -229,7 +270,7 @@ const isConnectionDegraded = computed(
 );
 
 watch(
-  () => state.value?.phase,
+  () => guessTheSongState.value?.phase,
   (phase) => {
     if (phase === "finished") void celebrate();
   },

--- a/tests/components/music-quiz/MusicQuizGuessTheSongConfig.test.ts
+++ b/tests/components/music-quiz/MusicQuizGuessTheSongConfig.test.ts
@@ -132,4 +132,44 @@ describe("MusicQuizGuessTheSongConfig", () => {
     expect(wrapper.text()).toContain("Newest result");
     expect(wrapper.text()).not.toContain("Older result");
   });
+
+  it("emits a discriminated create request", async () => {
+    mockSearch.mockResolvedValue({
+      tracks: [
+        {
+          uri: "track:test",
+          name: "Test track",
+          media_type: MediaType.TRACK,
+        },
+      ],
+      playlists: [],
+    });
+    const wrapper = mountConfig();
+
+    await wrapper
+      .find('input[placeholder="providers.music_quiz.search_music"]')
+      .setValue("test");
+    await vi.advanceTimersByTimeAsync(250);
+    await flushPromises();
+    await wrapper
+      .findAll("button")
+      .find((button) => button.text().includes("Test track"))
+      ?.trigger("click");
+    await wrapper
+      .findAll("button")
+      .find((button) => button.text().includes("create"))
+      ?.trigger("click");
+
+    expect(wrapper.emitted("create")?.[0]?.[0]).toMatchObject({
+      quiz_type: "guess_the_song",
+      answer_type: "multiple_choice",
+      config: {
+        round_count: 5,
+        suggestion_count: 4,
+        answer_duration: 30,
+        difficulty: "normal",
+        source_uris: ["track:test"],
+      },
+    });
+  });
 });

--- a/tests/components/music-quiz/MusicQuizReveal.test.ts
+++ b/tests/components/music-quiz/MusicQuizReveal.test.ts
@@ -8,6 +8,7 @@ vi.mock("@/plugins/i18n", () => ({
 
 const baseProps = {
   round: {
+    question: "Which song is playing?",
     round_index: 0,
     started_at: 0,
     deadline: 0,

--- a/tests/components/music-quiz/MusicQuizSetupWizard.test.ts
+++ b/tests/components/music-quiz/MusicQuizSetupWizard.test.ts
@@ -1,0 +1,89 @@
+import MusicQuizSetupWizard from "@/components/music-quiz/MusicQuizSetupWizard.vue";
+import { mount } from "@vue/test-utils";
+import { nextTick } from "vue";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@/plugins/i18n", () => ({
+  $t: (key: string) => key,
+}));
+
+vi.mock("@/components/music-quiz/game_types", async () => {
+  const { defineComponent, h } = await import("vue");
+  const configComponent = defineComponent({
+    emits: ["create"],
+    setup(_, { emit }) {
+      return () =>
+        h(
+          "button",
+          {
+            "data-testid": "create-game",
+            onClick: () =>
+              emit("create", {
+                quiz_type: "guess_the_song",
+                answer_type: "multiple_choice",
+                config: {
+                  round_count: 5,
+                  suggestion_count: 4,
+                  answer_duration: 30,
+                  difficulty: "normal",
+                  source_uris: ["track:test"],
+                  name: "Test Quiz",
+                },
+              }),
+          },
+          "Create",
+        );
+    },
+  });
+
+  return {
+    MUSIC_QUIZ_GAME_TYPES: [
+      {
+        id: "guess_the_song",
+        labelKey: "game_type",
+        descriptionKey: "game_type_description",
+        icon: { template: "<span />" },
+        available: true,
+        configComponent,
+      },
+    ],
+  };
+});
+
+const request = {
+  quiz_type: "guess_the_song",
+  answer_type: "multiple_choice",
+  config: {
+    round_count: 5,
+    suggestion_count: 4,
+    answer_duration: 30,
+    difficulty: "normal",
+    source_uris: ["track:test"],
+    name: "Test Quiz",
+  },
+} as const;
+
+describe("MusicQuizSetupWizard", () => {
+  it("forwards the selected game component's create request", async () => {
+    const wrapper = mount(MusicQuizSetupWizard, {
+      props: { busy: false },
+      global: {
+        stubs: {
+          Badge: true,
+          Button: {
+            template: "<button><slot /></button>",
+          },
+          Progress: true,
+        },
+      },
+    });
+
+    await wrapper.find("section button").trigger("click");
+    await nextTick();
+    await wrapper.find("section button").trigger("click");
+    await nextTick();
+    await wrapper.get('[data-testid="create-game"]').trigger("click");
+
+    expect(wrapper.emitted("create")).toEqual([[request]]);
+  });
+});

--- a/tests/components/music-quiz/MusicQuizUnsupportedGame.test.ts
+++ b/tests/components/music-quiz/MusicQuizUnsupportedGame.test.ts
@@ -1,0 +1,28 @@
+import MusicQuizUnsupportedGame from "@/components/music-quiz/MusicQuizUnsupportedGame.vue";
+import { mount } from "@vue/test-utils";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@/plugins/i18n", () => ({
+  $t: (key: string) => key,
+}));
+
+describe("MusicQuizUnsupportedGame", () => {
+  it("shows an update-required state without player actions", () => {
+    const wrapper = mount(MusicQuizUnsupportedGame);
+
+    expect(wrapper.text()).toContain(
+      "providers.music_quiz.unsupported_description",
+    );
+    expect(wrapper.find("button").exists()).toBe(false);
+  });
+
+  it("lets the host delete an unsupported game", async () => {
+    const wrapper = mount(MusicQuizUnsupportedGame, {
+      props: { canDelete: true },
+    });
+
+    await wrapper.get("button").trigger("click");
+
+    expect(wrapper.emitted("delete")).toHaveLength(1);
+  });
+});

--- a/tests/composables/useMusicQuiz.test.ts
+++ b/tests/composables/useMusicQuiz.test.ts
@@ -10,7 +10,31 @@ vi.mock("@/plugins/api", () => ({
   },
 }));
 
-import { createMusicQuiz } from "@/composables/useMusicQuiz";
+import {
+  createMusicQuiz,
+  isMusicQuizProviderEvent,
+  isSupportedMusicQuiz,
+  parseMusicQuizAnswerType,
+  parseMusicQuizType,
+  type MusicQuizProviderEvent,
+  type MusicQuizPublicState,
+} from "@/composables/useMusicQuiz";
+
+function unsupportedQuizType(value: string) {
+  const quizType = parseMusicQuizType(value);
+  if (quizType === "guess_the_song") {
+    throw new Error("Expected an unsupported quiz type");
+  }
+  return quizType;
+}
+
+function unsupportedAnswerType(value: string) {
+  const answerType = parseMusicQuizAnswerType(value);
+  if (answerType === "multiple_choice") {
+    throw new Error("Expected an unsupported answer type");
+  }
+  return answerType;
+}
 
 describe("useMusicQuiz commands", () => {
   beforeEach(() => {
@@ -19,15 +43,18 @@ describe("useMusicQuiz commands", () => {
   });
 
   it("sends difficulty in the create payload", async () => {
-    await createMusicQuiz(
-      "guess_the_song",
-      5,
-      4,
-      30,
-      "hard",
-      ["library://track/1"],
-      "Test Quiz",
-    );
+    await createMusicQuiz({
+      quiz_type: "guess_the_song",
+      answer_type: "multiple_choice",
+      config: {
+        round_count: 5,
+        suggestion_count: 4,
+        answer_duration: 30,
+        difficulty: "hard",
+        source_uris: ["library://track/1"],
+        name: "Test Quiz",
+      },
+    });
 
     expect(mockSendCommand).toHaveBeenCalledWith("music_quiz/create", {
       quiz_type: "guess_the_song",
@@ -38,5 +65,51 @@ describe("useMusicQuiz commands", () => {
       source_uris: ["library://track/1"],
       name: "Test Quiz",
     });
+  });
+
+  it("only narrows the supported quiz and answer pair", () => {
+    const known = {
+      quiz_type: "guess_the_song",
+      answer_type: "multiple_choice",
+      phase: "lobby",
+      name: "Quiz",
+      round_count: 5,
+      suggestion_count: 4,
+      answer_duration: 30,
+      mode: "venue",
+      players: [],
+    } satisfies MusicQuizPublicState;
+    const unsupported = {
+      quiz_type: unsupportedQuizType("future_game"),
+      answer_type: "multiple_choice",
+      phase: "lobby",
+      name: "Future Quiz",
+    } satisfies MusicQuizPublicState;
+    const unsupportedAnswer = {
+      quiz_type: "guess_the_song",
+      answer_type: unsupportedAnswerType("timeline"),
+      phase: "lobby",
+      name: "Future Quiz",
+    } satisfies MusicQuizPublicState;
+
+    expect(isSupportedMusicQuiz(known)).toBe(true);
+    expect(isSupportedMusicQuiz(unsupported)).toBe(false);
+    expect(isSupportedMusicQuiz(unsupportedAnswer)).toBe(false);
+  });
+
+  it("accepts public provider events as invalidation payloads", () => {
+    const event = {
+      event: "game_updated",
+      state: {
+        quiz_type: unsupportedQuizType("future_game"),
+        answer_type: "multiple_choice",
+        phase: "lobby",
+        name: "Future Quiz",
+      },
+    } satisfies MusicQuizProviderEvent;
+
+    expect(isMusicQuizProviderEvent(event)).toBe(true);
+    expect(isMusicQuizProviderEvent({ event: "game_updated" })).toBe(false);
+    expect(isMusicQuizProviderEvent({ event: "other" })).toBe(false);
   });
 });

--- a/tests/composables/useMusicQuiz.test.ts
+++ b/tests/composables/useMusicQuiz.test.ts
@@ -97,6 +97,33 @@ describe("useMusicQuiz commands", () => {
     expect(isSupportedMusicQuiz(unsupportedAnswer)).toBe(false);
   });
 
+  it("preserves nullable server fields in supported state", () => {
+    const state = {
+      quiz_type: "guess_the_song",
+      answer_type: "multiple_choice",
+      phase: "reveal",
+      name: null,
+      round_count: 1,
+      suggestion_count: 2,
+      answer_duration: 30,
+      mode: "venue",
+      players: [],
+      current_round: {
+        question: null,
+        round_index: 0,
+        started_at: 1,
+        deadline: 2,
+        suggestions: [],
+        track_uri: null,
+      },
+    } satisfies MusicQuizPublicState;
+
+    expect(isSupportedMusicQuiz(state)).toBe(true);
+    expect(state.name).toBeNull();
+    expect(state.current_round.question).toBeNull();
+    expect(state.current_round.track_uri).toBeNull();
+  });
+
   it("accepts public provider events as invalidation payloads", () => {
     const event = {
       event: "game_updated",

--- a/tests/composables/useMusicQuiz.test.ts
+++ b/tests/composables/useMusicQuiz.test.ts
@@ -138,6 +138,9 @@ describe("useMusicQuiz commands", () => {
     expect(isMusicQuizProviderEvent(event)).toBe(true);
     expect(isMusicQuizProviderEvent({ event: "game_updated" })).toBe(false);
     expect(
+      isMusicQuizProviderEvent({ event: "game_updated", state: null }),
+    ).toBe(false);
+    expect(
       isMusicQuizProviderEvent({
         event: "game_removed",
         state: event.state,

--- a/tests/composables/useMusicQuiz.test.ts
+++ b/tests/composables/useMusicQuiz.test.ts
@@ -137,6 +137,12 @@ describe("useMusicQuiz commands", () => {
 
     expect(isMusicQuizProviderEvent(event)).toBe(true);
     expect(isMusicQuizProviderEvent({ event: "game_updated" })).toBe(false);
+    expect(
+      isMusicQuizProviderEvent({
+        event: "game_removed",
+        state: event.state,
+      }),
+    ).toBe(false);
     expect(isMusicQuizProviderEvent({ event: "other" })).toBe(false);
   });
 });

--- a/tests/composables/useMusicQuizHost.test.ts
+++ b/tests/composables/useMusicQuizHost.test.ts
@@ -27,6 +27,17 @@ vi.mock("@/composables/useMusicQuiz", () => ({
   nextMusicQuiz: vi.fn(),
   resetMusicQuiz: vi.fn(),
   deleteMusicQuiz: vi.fn(),
+  isSupportedMusicQuiz: (value: { quiz_type?: string; answer_type?: string }) =>
+    value.quiz_type === "guess_the_song" &&
+    value.answer_type === "multiple_choice",
+  isMusicQuizProviderEvent: (value: unknown) => {
+    if (!value || typeof value !== "object" || !("event" in value))
+      return false;
+    return (
+      value.event === "game_removed" ||
+      (value.event === "game_updated" && "state" in value)
+    );
+  },
 }));
 
 vi.mock("@/plugins/api", () => ({
@@ -43,6 +54,8 @@ import { EventType } from "@/plugins/api/interfaces";
 import { useMusicQuizHost } from "@/composables/useMusicQuizHost";
 
 const HOST_STATE = {
+  quiz_type: "guess_the_song",
+  answer_type: "multiple_choice",
   phase: "lobby",
   name: "Quiz",
   round_count: 5,
@@ -89,14 +102,14 @@ describe("useMusicQuizHost", () => {
 
     handler({
       object_id: "quiz-instance",
-      data: { event: "game_updated" },
+      data: { event: "game_updated", state: HOST_STATE },
     });
     await flushPromises();
     expect(mockGetMusicQuiz).toHaveBeenCalledTimes(2);
 
     handler({
       object_id: "other-instance",
-      data: { event: "game_updated" },
+      data: { event: "game_updated", state: HOST_STATE },
     });
     await flushPromises();
     expect(mockGetMusicQuiz).toHaveBeenCalledTimes(2);
@@ -125,5 +138,38 @@ describe("useMusicQuizHost", () => {
     expect(notifyError).not.toHaveBeenCalled();
     expect(host.state.value).toBeNull();
     expect(host.gameRemoved.value).toBe(false);
+  });
+
+  it("does not expose guess-the-song state for an unknown game type", async () => {
+    mockGetMusicQuiz.mockResolvedValue({
+      quiz_type: "future_game",
+      answer_type: "multiple_choice",
+      phase: "lobby",
+      name: "Future Quiz",
+    });
+
+    const host = useMusicQuizHost({ notifyError: vi.fn() });
+    await flushPromises();
+
+    expect(host.state.value?.quiz_type).toBe("future_game");
+    expect(host.currentRound.value).toBeNull();
+    expect(host.joinLink.value).toBe("");
+    expect(host.isLastRound.value).toBe(false);
+  });
+
+  it("does not expose gameplay for an unknown answer type", async () => {
+    mockGetMusicQuiz.mockResolvedValue({
+      quiz_type: "guess_the_song",
+      answer_type: "timeline",
+      phase: "lobby",
+      name: "Future Quiz",
+    });
+
+    const host = useMusicQuizHost({ notifyError: vi.fn() });
+    await flushPromises();
+
+    expect(host.state.value?.answer_type).toBe("timeline");
+    expect(host.currentRound.value).toBeNull();
+    expect(host.joinLink.value).toBe("");
   });
 });

--- a/tests/composables/useMusicQuizPlayer.test.ts
+++ b/tests/composables/useMusicQuizPlayer.test.ts
@@ -45,6 +45,17 @@ vi.mock("@/composables/useMusicQuiz", () => ({
   joinMusicQuiz: mockJoinMusicQuiz,
   readyMusicQuiz: mockReadyMusicQuiz,
   answerMusicQuiz: mockAnswerMusicQuiz,
+  isSupportedMusicQuiz: (value: { quiz_type?: string; answer_type?: string }) =>
+    value.quiz_type === "guess_the_song" &&
+    value.answer_type === "multiple_choice",
+  isMusicQuizProviderEvent: (value: unknown) => {
+    if (!value || typeof value !== "object" || !("event" in value))
+      return false;
+    return (
+      value.event === "game_removed" ||
+      (value.event === "game_updated" && "state" in value)
+    );
+  },
 }));
 
 vi.mock("@/plugins/api", () => ({
@@ -78,11 +89,32 @@ import { EventType } from "@/plugins/api/interfaces";
 import { useMusicQuizPlayer } from "@/composables/useMusicQuizPlayer";
 
 const QUIZ_INFO = {
+  quiz_type: "guess_the_song",
+  answer_type: "multiple_choice",
   name: "Quiz",
   phase: "lobby",
   player_count: 2,
   round_count: 5,
   mode: "venue",
+} as const;
+
+const PLAYER_STATE = {
+  quiz_type: "guess_the_song",
+  answer_type: "multiple_choice",
+  phase: "lobby",
+  name: "Quiz",
+  round_count: 5,
+  suggestion_count: 4,
+  answer_duration: 30,
+  mode: "venue",
+  players: [],
+  current_round: null,
+  you: {
+    name: "Player",
+    score: 0,
+    ready: false,
+    active_from_round: 0,
+  },
 } as const;
 
 async function flushPromises() {
@@ -172,7 +204,7 @@ describe("useMusicQuizPlayer", () => {
     expect(handler).toBeTypeOf("function");
     handler({
       object_id: "quiz-instance",
-      data: { event: "game_updated" },
+      data: { event: "game_updated", state: QUIZ_INFO },
     });
     await flushPromises();
 
@@ -191,16 +223,93 @@ describe("useMusicQuizPlayer", () => {
 
     handler({
       object_id: "quiz-instance",
-      data: { event: "game_updated" },
+      data: { event: "game_updated", state: QUIZ_INFO },
     });
     await flushPromises();
     expect(mockGetMusicQuizInfo).toHaveBeenCalledTimes(2);
 
     handler({
       object_id: "other-instance",
-      data: { event: "game_updated" },
+      data: { event: "game_updated", state: QUIZ_INFO },
     });
     await flushPromises();
     expect(mockGetMusicQuizInfo).toHaveBeenCalledTimes(2);
+  });
+
+  it("keeps game identity across info, join, and provider refresh", async () => {
+    mockGetMusicQuizInfo.mockResolvedValue(QUIZ_INFO);
+    mockJoinMusicQuiz.mockResolvedValue({
+      player_id: "player-id",
+      state: PLAYER_STATE,
+    });
+    mockGetMusicQuizState.mockResolvedValue({
+      ...PLAYER_STATE,
+      phase: "answering",
+    });
+
+    const player = useMusicQuizPlayer({ notifyError: vi.fn() });
+    await flushPromises();
+    expect(player.info.value?.quiz_type).toBe("guess_the_song");
+    expect(player.info.value?.answer_type).toBe("multiple_choice");
+
+    await player.join("Player");
+    expect(player.state.value?.quiz_type).toBe("guess_the_song");
+    expect(player.state.value?.answer_type).toBe("multiple_choice");
+
+    providerHandlers[0]({
+      object_id: "quiz-instance",
+      data: { event: "game_updated", state: PLAYER_STATE },
+    });
+    await flushPromises();
+
+    expect(mockGetMusicQuizState).toHaveBeenCalledWith("player-id");
+    expect(player.state.value?.quiz_type).toBe("guess_the_song");
+    expect(player.state.value?.answer_type).toBe("multiple_choice");
+    expect(player.state.value?.phase).toBe("answering");
+  });
+
+  it("preserves game identity when reconnecting with a stored player", async () => {
+    storedPlayerId.value = "stored-player";
+    mockGetMusicQuizState.mockResolvedValue(PLAYER_STATE);
+
+    const player = useMusicQuizPlayer({ notifyError: vi.fn() });
+    await flushPromises();
+
+    expect(player.playerId.value).toBe("stored-player");
+    expect(player.state.value?.quiz_type).toBe("guess_the_song");
+    expect(player.state.value?.answer_type).toBe("multiple_choice");
+  });
+
+  it("does not expose guess-the-song fields for an unknown game type", async () => {
+    mockGetMusicQuizInfo.mockResolvedValue({
+      quiz_type: "future_game",
+      answer_type: "multiple_choice",
+      phase: "lobby",
+      name: "Future Quiz",
+    });
+
+    const player = useMusicQuizPlayer({ notifyError: vi.fn() });
+    await flushPromises();
+
+    expect(player.info.value?.quiz_type).toBe("future_game");
+    expect(player.currentRound.value).toBeNull();
+    expect(player.players.value).toEqual([]);
+    expect(player.yourName.value).toBe("");
+  });
+
+  it("does not expose gameplay for an unknown answer type", async () => {
+    mockGetMusicQuizInfo.mockResolvedValue({
+      quiz_type: "guess_the_song",
+      answer_type: "timeline",
+      phase: "lobby",
+      name: "Future Quiz",
+    });
+
+    const player = useMusicQuizPlayer({ notifyError: vi.fn() });
+    await flushPromises();
+
+    expect(player.info.value?.answer_type).toBe("timeline");
+    expect(player.currentRound.value).toBeNull();
+    expect(player.players.value).toEqual([]);
   });
 });


### PR DESCRIPTION
Adds frontend support for the Music Quiz game and answer identity contract.

- Carry `quiz_type` and `answer_type` through game, player, reconnect, and event state
- Show a safe update-required state for unsupported combinations while keeping host deletion available
- Decouple setup creation from the Guess the Song configuration without changing server create fields

Depends on music-assistant/server#4713, music-assistant/server#4714, and music-assistant/server#4718.