### PR TITLE
Fix Music Quiz setup with no active game

### DIFF
--- a/src/composables/useMusicQuiz.ts
+++ b/src/composables/useMusicQuiz.ts
@@ -266,7 +266,7 @@ export function createMusicQuiz(request: MusicQuizCreateRequest) {
 }
 
 export function getMusicQuiz() {
-  return api.sendCommand<MusicQuizHostState>("music_quiz/get");
+  return api.sendCommand<MusicQuizHostState | null>("music_quiz/get");
 }
 
 export function startMusicQuiz() {

--- a/tests/composables/useMusicQuizHost.test.ts
+++ b/tests/composables/useMusicQuizHost.test.ts
@@ -129,13 +129,49 @@ describe("useMusicQuizHost", () => {
     expect(host.gameRemoved.value).toBe(true);
   });
 
-  it("treats a no-active-game error as an empty state without a toast", async () => {
+  it("treats a null response as setup state without a toast", async () => {
+    mockGetMusicQuiz.mockResolvedValue(null);
+    const notifyError = vi.fn();
+    const host = useMusicQuizHost({ notifyError });
+    await flushPromises();
+
+    expect(notifyError).not.toHaveBeenCalled();
+    expect(host.state.value).toBeNull();
+    expect(host.gameRemoved.value).toBe(false);
+  });
+
+  it("treats a no-active-game string as an empty state without a toast", async () => {
     mockGetMusicQuiz.mockRejectedValue("There is no active Music Quiz game");
     const notifyError = vi.fn();
     const host = useMusicQuizHost({ notifyError });
     await flushPromises();
 
     expect(notifyError).not.toHaveBeenCalled();
+    expect(host.state.value).toBeNull();
+    expect(host.gameRemoved.value).toBe(false);
+  });
+
+  it("treats a no-active-game Error as an empty state without a toast", async () => {
+    mockGetMusicQuiz.mockRejectedValue(
+      new Error("There is no active Music Quiz game"),
+    );
+    const notifyError = vi.fn();
+    const host = useMusicQuizHost({ notifyError });
+    await flushPromises();
+
+    expect(notifyError).not.toHaveBeenCalled();
+    expect(host.state.value).toBeNull();
+    expect(host.gameRemoved.value).toBe(false);
+  });
+
+  it("notifies when loading fails for another reason", async () => {
+    mockGetMusicQuiz.mockRejectedValue(new Error("Server unavailable"));
+    const notifyError = vi.fn();
+    const host = useMusicQuizHost({ notifyError });
+    await flushPromises();
+
+    expect(notifyError).toHaveBeenCalledOnce();
+    expect(notifyError).toHaveBeenCalledWith("Server unavailable");
     expect(host.state.value).toBeNull();
     expect(host.gameRemoved.value).toBe(false);
   });

--- a/tests/views/MusicQuizDashboardView.test.ts
+++ b/tests/views/MusicQuizDashboardView.test.ts
@@ -13,17 +13,21 @@ vi.mock("@/components/music-quiz/game_types", () => ({
   resolveMusicQuizDefinition: vi.fn(),
 }));
 
-vi.mock("@/plugins/api", () => ({
-  default: {
+vi.mock("@/plugins/api", () => {
+  const api = {
     sendCommand: mockSendCommand,
     subscribe: mockSubscribe,
     state: { value: "connected" },
-  },
-  ConnectionState: {
-    RECONNECTING: "reconnecting",
-    DISCONNECTED: "disconnected",
-  },
-}));
+  };
+  return {
+    api,
+    default: api,
+    ConnectionState: {
+      RECONNECTING: "reconnecting",
+      DISCONNECTED: "disconnected",
+    },
+  };
+});
 
 vi.mock("@/plugins/auth", () => ({
   authManager: {

--- a/tests/views/MusicQuizDashboardView.test.ts
+++ b/tests/views/MusicQuizDashboardView.test.ts
@@ -1,0 +1,81 @@
+import MusicQuizDashboardView from "@/views/MusicQuizDashboardView.vue";
+import { flushPromises, mount } from "@vue/test-utils";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockSendCommand, mockSubscribe, mockToastError } = vi.hoisted(() => ({
+  mockSendCommand: vi.fn(),
+  mockSubscribe: vi.fn(),
+  mockToastError: vi.fn(),
+}));
+
+vi.mock("@/plugins/api", () => ({
+  default: {
+    sendCommand: mockSendCommand,
+    subscribe: mockSubscribe,
+    state: { value: "connected" },
+  },
+  ConnectionState: {
+    RECONNECTING: "reconnecting",
+    DISCONNECTED: "disconnected",
+  },
+}));
+
+vi.mock("@/plugins/auth", () => ({
+  authManager: {
+    isAdmin: () => false,
+  },
+}));
+
+vi.mock("@/plugins/i18n", () => ({
+  $t: (key: string) => key,
+}));
+
+vi.mock("@/plugins/router", () => ({
+  default: {},
+}));
+
+vi.mock("vue-sonner", () => ({
+  toast: {
+    error: mockToastError,
+  },
+}));
+
+describe("MusicQuizDashboardView", () => {
+  beforeEach(() => {
+    mockSendCommand.mockReset();
+    mockSubscribe.mockReset();
+    mockToastError.mockReset();
+    mockSendCommand.mockResolvedValue(null);
+    mockSubscribe.mockReturnValue(() => {});
+  });
+
+  it("renders the setup state when the host getter returns null", async () => {
+    const wrapper = mount(MusicQuizDashboardView, {
+      global: {
+        stubs: {
+          AlertDialog: true,
+          Card: {
+            template: "<div><slot /></div>",
+          },
+          CardContent: {
+            template: "<div><slot /></div>",
+          },
+          MusicQuizConnectionBanners: true,
+          MusicQuizSetupWizard: {
+            template: '<div data-testid="music-quiz-setup" />',
+          },
+        },
+      },
+    });
+    await flushPromises();
+
+    expect(mockSendCommand).toHaveBeenCalledWith("music_quiz/get");
+    expect(mockToastError).not.toHaveBeenCalled();
+    expect(wrapper.text()).toContain("providers.music_quiz.no_active_game");
+    expect(wrapper.find('[data-testid="music-quiz-setup"]').exists()).toBe(
+      true,
+    );
+
+    wrapper.unmount();
+  });
+});

--- a/tests/views/MusicQuizDashboardView.test.ts
+++ b/tests/views/MusicQuizDashboardView.test.ts
@@ -8,6 +8,11 @@ const { mockSendCommand, mockSubscribe, mockToastError } = vi.hoisted(() => ({
   mockToastError: vi.fn(),
 }));
 
+vi.mock("@/components/music-quiz/game_types", () => ({
+  MUSIC_QUIZ_GAME_TYPES: [],
+  resolveMusicQuizDefinition: vi.fn(),
+}));
+
 vi.mock("@/plugins/api", () => ({
   default: {
     sendCommand: mockSendCommand,
@@ -28,10 +33,6 @@ vi.mock("@/plugins/auth", () => ({
 
 vi.mock("@/plugins/i18n", () => ({
   $t: (key: string) => key,
-}));
-
-vi.mock("@/plugins/router", () => ({
-  default: {},
 }));
 
 vi.mock("vue-sonner", () => ({


### PR DESCRIPTION
Fixes the Music Quiz host screen when no game is active.

Companion to music-assistant/server#4720.

- Treats an empty server response as the normal setup state without an error notification
- Keeps compatibility with older server no-game errors
- Adds coverage for the setup screen and error handling