### PR TITLE
Keep Music Quiz players connected

### DIFF
--- a/src/composables/useMusicQuiz.ts
+++ b/src/composables/useMusicQuiz.ts
@@ -304,6 +304,10 @@ export function getMusicQuizState(player_id: string) {
   });
 }
 
+export function heartbeatMusicQuiz(player_id: string) {
+  return api.sendCommand<boolean>("music_quiz/heartbeat", { player_id });
+}
+
 export function answerMusicQuiz(player_id: string, suggestion_id: string) {
   return api.sendCommand<MusicQuizPersonalizedState>("music_quiz/answer", {
     player_id,

--- a/src/composables/useMusicQuizPlayer.ts
+++ b/src/composables/useMusicQuizPlayer.ts
@@ -30,7 +30,11 @@ export interface UseMusicQuizPlayerOptions {
   notifyError: (message: string) => void;
 }
 
-/** Manage Music Quiz guest state and player actions. */
+/**
+ * Manage Music Quiz guest state, player actions, and reconnection.
+ *
+ * Keeps joined players active and synchronizes state from provider events.
+ */
 export function useMusicQuizPlayer(options: UseMusicQuizPlayerOptions) {
   const { notifyError } = options;
 

--- a/src/composables/useMusicQuizPlayer.ts
+++ b/src/composables/useMusicQuizPlayer.ts
@@ -77,9 +77,11 @@ export function useMusicQuizPlayer(options: UseMusicQuizPlayerOptions) {
     try {
       loading.value = true;
       const nextInfo = await getMusicQuizInfo();
+      if (loadingRequestId !== requestId) return;
       info.value = nextInfo;
       gameRemoved.value = !nextInfo;
     } catch (err) {
+      if (loadingRequestId !== requestId) return;
       notifyError(
         getMusicQuizErrorMessage(
           err,

--- a/src/composables/useMusicQuizPlayer.ts
+++ b/src/composables/useMusicQuizPlayer.ts
@@ -260,7 +260,8 @@ export function useMusicQuizPlayer(options: UseMusicQuizPlayerOptions) {
     if (
       !currentState ||
       !isSupportedMusicQuiz(currentState) ||
-      !isSupportedMusicQuiz(publicState)
+      !isSupportedMusicQuiz(publicState) ||
+      !Array.isArray(publicState.players)
     ) {
       return false;
     }

--- a/src/composables/useMusicQuizPlayer.ts
+++ b/src/composables/useMusicQuizPlayer.ts
@@ -49,6 +49,7 @@ export function useMusicQuizPlayer(options: UseMusicQuizPlayerOptions) {
 
   let unsubscribeProviderEvent: (() => void) | undefined;
   let reconnectPlayerId: string | null = null;
+  let loadingRequestId = 0;
 
   const currentRound = computed<MusicQuizCurrentRound | null>(() => {
     const currentState = state.value;
@@ -72,6 +73,7 @@ export function useMusicQuizPlayer(options: UseMusicQuizPlayerOptions) {
   });
 
   async function fetchInfo() {
+    const requestId = ++loadingRequestId;
     try {
       loading.value = true;
       const nextInfo = await getMusicQuizInfo();
@@ -85,7 +87,7 @@ export function useMusicQuizPlayer(options: UseMusicQuizPlayerOptions) {
         ),
       );
     } finally {
-      loading.value = false;
+      if (loadingRequestId === requestId) loading.value = false;
     }
   }
 
@@ -208,6 +210,7 @@ export function useMusicQuizPlayer(options: UseMusicQuizPlayerOptions) {
   };
 
   async function fetchPlayerState(currentPlayerId: string) {
+    const requestId = ++loadingRequestId;
     try {
       loading.value = true;
       const nextState = await getMusicQuizState(currentPlayerId);
@@ -230,7 +233,7 @@ export function useMusicQuizPlayer(options: UseMusicQuizPlayerOptions) {
         );
       }
     } finally {
-      loading.value = false;
+      if (loadingRequestId === requestId) loading.value = false;
     }
   }
 
@@ -322,6 +325,8 @@ export function useMusicQuizPlayer(options: UseMusicQuizPlayerOptions) {
   function clearActivePlayer() {
     playerId.value = null;
     state.value = null;
+    loadingRequestId += 1;
+    loading.value = false;
     stopHeartbeat();
     clearStoredMusicQuizPlayerId();
   }

--- a/src/composables/useMusicQuizPlayer.ts
+++ b/src/composables/useMusicQuizPlayer.ts
@@ -2,6 +2,7 @@ import {
   answerMusicQuiz,
   getMusicQuizInfo,
   getMusicQuizState,
+  heartbeatMusicQuiz,
   isSupportedMusicQuiz,
   isMusicQuizProviderEvent,
   joinMusicQuiz,
@@ -10,7 +11,9 @@ import {
   type MusicQuizCurrentRound,
   type MusicQuizInfo,
   type MusicQuizPersonalizedState,
+  type MusicQuizPublicState,
 } from "@/composables/useMusicQuiz";
+import { createMusicQuizPlayerHeartbeat } from "@/composables/useMusicQuizPlayerHeartbeat";
 import {
   clearStoredMusicQuizPlayerId,
   getStoredMusicQuizPlayerId,
@@ -27,11 +30,7 @@ export interface UseMusicQuizPlayerOptions {
   notifyError: (message: string) => void;
 }
 
-/**
- * Player-side Music Quiz: manages the guest's player_id credential,
- * fetches info for landing screen, joins the game, and subscribes to
- * PROVIDER_EVENT for real-time state updates. Players are keyed by name.
- */
+/** Manage Music Quiz guest state and player actions. */
 export function useMusicQuizPlayer(options: UseMusicQuizPlayerOptions) {
   const { notifyError } = options;
 
@@ -42,8 +41,14 @@ export function useMusicQuizPlayer(options: UseMusicQuizPlayerOptions) {
   const busy = ref(false);
   const loading = ref(false);
   const providerInstanceId = ref<string | null>(null);
+  const playerHeartbeat = createMusicQuizPlayerHeartbeat({
+    sendHeartbeat: heartbeatMusicQuiz,
+    onResult: handleHeartbeatResult,
+    onError: handleHeartbeatError,
+  });
 
   let unsubscribeProviderEvent: (() => void) | undefined;
+  let reconnectPlayerId: string | null = null;
 
   const currentRound = computed<MusicQuizCurrentRound | null>(() => {
     const currentState = state.value;
@@ -85,51 +90,21 @@ export function useMusicQuizPlayer(options: UseMusicQuizPlayerOptions) {
   }
 
   async function fetchState() {
-    const storedPlayerId = playerId.value ?? getStoredMusicQuizPlayerId();
-    if (!storedPlayerId) {
-      await fetchInfo();
+    const currentPlayerId = playerId.value;
+    if (currentPlayerId) {
+      if (reconnectPlayerId === currentPlayerId) {
+        await heartbeat();
+      } else {
+        await fetchPlayerState(currentPlayerId);
+      }
       return;
     }
-    try {
-      loading.value = true;
-      const nextState = await getMusicQuizState(storedPlayerId);
-      state.value = nextState;
-      playerId.value = storedPlayerId;
-      gameRemoved.value = false;
-    } catch (err) {
-      if (
-        isNoActiveGameError(err) ||
-        getMusicQuizErrorMessage(err).toLowerCase().includes("player not found")
-      ) {
-        await resetToJoinInfo();
-      } else {
-        notifyError(
-          getMusicQuizErrorMessage(
-            err,
-            $t("providers.music_quiz.error_load_state"),
-          ),
-        );
-      }
-    } finally {
-      loading.value = false;
-    }
-  }
 
-  function handleProviderEvent(event: { object_id?: string; data?: unknown }) {
-    if (!isMusicQuizProviderEvent(event.data)) return;
-    const payload = event.data;
-    if (!isScopedProviderEvent(event.object_id)) return;
-    if (payload.event === "game_updated") {
-      if (playerId.value || getStoredMusicQuizPlayerId()) {
-        void fetchState();
-      } else {
-        void fetchInfo();
-      }
-    } else if (payload.event === "game_removed") {
-      state.value = null;
-      playerId.value = null;
-      clearStoredMusicQuizPlayerId();
-      gameRemoved.value = true;
+    const storedPlayerId = getStoredMusicQuizPlayerId();
+    if (storedPlayerId) {
+      await reconnectPlayer(storedPlayerId);
+    } else {
+      await fetchInfo();
     }
   }
 
@@ -137,10 +112,10 @@ export function useMusicQuizPlayer(options: UseMusicQuizPlayerOptions) {
     busy.value = true;
     try {
       const result = await joinMusicQuiz(name);
-      playerId.value = result.player_id;
       storeMusicQuizPlayerId(result.player_id);
       state.value = result.state;
       gameRemoved.value = false;
+      void startHeartbeat(result.player_id);
       return true;
     } catch (err) {
       notifyError(
@@ -198,36 +173,11 @@ export function useMusicQuizPlayer(options: UseMusicQuizPlayerOptions) {
   }
 
   async function leave() {
-    playerId.value = null;
-    state.value = null;
-    clearStoredMusicQuizPlayerId();
-  }
-
-  async function resetToJoinInfo() {
-    state.value = null;
-    playerId.value = null;
-    clearStoredMusicQuizPlayerId();
-    await fetchInfo();
-  }
-
-  function isScopedProviderEvent(objectId?: string) {
-    if (!objectId) return false;
-    if (!providerInstanceId.value) {
-      providerInstanceId.value = objectId;
-      return true;
-    }
-    return providerInstanceId.value === objectId;
+    clearActivePlayer();
   }
 
   onMounted(() => {
-    // Check for stored player_id on mount (reconnect scenario)
-    const storedPlayerId = getStoredMusicQuizPlayerId();
-    if (storedPlayerId) {
-      playerId.value = storedPlayerId;
-      fetchState();
-    } else {
-      fetchInfo();
-    }
+    void fetchState();
     unsubscribeProviderEvent = api.subscribe(
       EventType.PROVIDER_EVENT,
       handleProviderEvent,
@@ -235,6 +185,7 @@ export function useMusicQuizPlayer(options: UseMusicQuizPlayerOptions) {
   });
 
   onBeforeUnmount(() => {
+    stopHeartbeat();
     unsubscribeProviderEvent?.();
   });
 
@@ -255,4 +206,128 @@ export function useMusicQuizPlayer(options: UseMusicQuizPlayerOptions) {
     ready,
     leave,
   };
+
+  async function fetchPlayerState(currentPlayerId: string) {
+    try {
+      loading.value = true;
+      const nextState = await getMusicQuizState(currentPlayerId);
+      if (playerId.value !== currentPlayerId) return;
+      state.value = nextState;
+      gameRemoved.value = false;
+    } catch (err) {
+      if (playerId.value !== currentPlayerId) return;
+      if (
+        isNoActiveGameError(err) ||
+        getMusicQuizErrorMessage(err).toLowerCase().includes("player not found")
+      ) {
+        await resetToJoinInfo();
+      } else {
+        notifyError(
+          getMusicQuizErrorMessage(
+            err,
+            $t("providers.music_quiz.error_load_state"),
+          ),
+        );
+      }
+    } finally {
+      loading.value = false;
+    }
+  }
+
+  function handleProviderEvent(event: { object_id?: string; data?: unknown }) {
+    if (!isMusicQuizProviderEvent(event.data)) return;
+    const payload = event.data;
+    if (!isScopedProviderEvent(event.object_id)) return;
+    if (payload.event === "game_updated") {
+      if (isCurrentPlayerMissing(payload.state)) {
+        void resetToJoinInfo();
+      } else if (playerId.value || getStoredMusicQuizPlayerId()) {
+        void fetchState();
+      } else {
+        void fetchInfo();
+      }
+    } else if (payload.event === "game_removed") {
+      clearActivePlayer();
+      gameRemoved.value = true;
+    }
+  }
+
+  function isCurrentPlayerMissing(publicState: MusicQuizPublicState) {
+    const currentState = state.value;
+    if (
+      !currentState ||
+      !isSupportedMusicQuiz(currentState) ||
+      !isSupportedMusicQuiz(publicState)
+    ) {
+      return false;
+    }
+    return !publicState.players.some(
+      (player) => player.name === currentState.you.name,
+    );
+  }
+
+  function isScopedProviderEvent(objectId?: string) {
+    if (!objectId) return false;
+    if (!providerInstanceId.value) {
+      providerInstanceId.value = objectId;
+      return true;
+    }
+    return providerInstanceId.value === objectId;
+  }
+
+  function reconnectPlayer(storedPlayerId: string) {
+    return startHeartbeat(storedPlayerId, true);
+  }
+
+  function startHeartbeat(currentPlayerId: string, reconnecting = false) {
+    playerId.value = currentPlayerId;
+    reconnectPlayerId = reconnecting ? currentPlayerId : null;
+    return playerHeartbeat.start(currentPlayerId);
+  }
+
+  function stopHeartbeat() {
+    reconnectPlayerId = null;
+    playerHeartbeat.stop();
+  }
+
+  function heartbeat() {
+    const currentPlayerId = playerId.value;
+    if (!currentPlayerId) return Promise.resolve();
+    return playerHeartbeat.refresh();
+  }
+
+  async function handleHeartbeatResult(
+    currentPlayerId: string,
+    active: boolean,
+  ) {
+    if (playerId.value !== currentPlayerId) return;
+    if (!active) {
+      await resetToJoinInfo();
+    } else if (reconnectPlayerId === currentPlayerId) {
+      reconnectPlayerId = null;
+      await fetchPlayerState(currentPlayerId);
+    }
+  }
+
+  function handleHeartbeatError(currentPlayerId: string, err: unknown) {
+    if (playerId.value !== currentPlayerId) return;
+    notifyError(
+      getMusicQuizErrorMessage(
+        err,
+        $t("providers.music_quiz.error_load_state"),
+      ),
+    );
+  }
+
+  function clearActivePlayer() {
+    playerId.value = null;
+    state.value = null;
+    stopHeartbeat();
+    clearStoredMusicQuizPlayerId();
+  }
+
+  async function resetToJoinInfo() {
+    clearActivePlayer();
+    await fetchInfo();
+  }
 }

--- a/src/composables/useMusicQuizPlayerHeartbeat.ts
+++ b/src/composables/useMusicQuizPlayerHeartbeat.ts
@@ -32,6 +32,8 @@ export function createMusicQuizPlayerHeartbeat(
     activePlayerId = null;
     if (timer !== undefined) clearInterval(timer);
     timer = undefined;
+    request = undefined;
+    requestTask = undefined;
     requestQueued = false;
     notifiedErrorPlayerId = null;
     document.removeEventListener("visibilitychange", handleVisibilityChange);

--- a/src/composables/useMusicQuizPlayerHeartbeat.ts
+++ b/src/composables/useMusicQuizPlayerHeartbeat.ts
@@ -1,0 +1,89 @@
+const HEARTBEAT_INTERVAL_MS = 15_000;
+
+interface MusicQuizPlayerHeartbeatOptions {
+  sendHeartbeat: (playerId: string) => Promise<boolean>;
+  onResult: (playerId: string, active: boolean) => Promise<void> | void;
+  onError: (playerId: string, error: unknown) => void;
+}
+
+/** Schedule non-overlapping heartbeats for the active Music Quiz player. */
+export function createMusicQuizPlayerHeartbeat(
+  options: MusicQuizPlayerHeartbeatOptions,
+) {
+  const { sendHeartbeat, onResult, onError } = options;
+
+  let activePlayerId: string | null = null;
+  let timer: ReturnType<typeof setInterval> | undefined;
+  let request: Promise<void> | undefined;
+  let requestTask: Promise<void> | undefined;
+  let requestPlayerId: string | undefined;
+  let requestQueued = false;
+  let notifiedErrorPlayerId: string | null = null;
+
+  function start(playerId: string) {
+    stop();
+    activePlayerId = playerId;
+    document.addEventListener("visibilitychange", handleVisibilityChange);
+    window.addEventListener("focus", refresh);
+    timer = setInterval(() => void refresh(), HEARTBEAT_INTERVAL_MS);
+    return refresh();
+  }
+
+  function stop() {
+    activePlayerId = null;
+    if (timer !== undefined) clearInterval(timer);
+    timer = undefined;
+    requestQueued = false;
+    notifiedErrorPlayerId = null;
+    document.removeEventListener("visibilitychange", handleVisibilityChange);
+    window.removeEventListener("focus", refresh);
+  }
+
+  function refresh() {
+    const playerId = activePlayerId;
+    if (!playerId) return Promise.resolve();
+    if (request) {
+      if (requestPlayerId !== playerId) requestQueued = true;
+      return requestTask ?? request;
+    }
+
+    requestPlayerId = playerId;
+    const outcome = Promise.resolve()
+      .then(() => sendHeartbeat(playerId))
+      .then(
+        (active) => ({ active }) as const,
+        (error: unknown) => ({ error }) as const,
+      );
+    const pendingTask = outcome.then(async (result) => {
+      if ("error" in result) {
+        if (activePlayerId === playerId && notifiedErrorPlayerId !== playerId) {
+          notifiedErrorPlayerId = playerId;
+          onError(playerId, result.error);
+        }
+      } else if (activePlayerId === playerId) {
+        await onResult(playerId, result.active);
+      }
+    });
+    const trackedTask = pendingTask.finally(() => {
+      if (requestTask === trackedTask) requestTask = undefined;
+    });
+    const pendingRequest = outcome.then(() => undefined);
+    const trackedRequest = pendingRequest.finally(() => {
+      if (request !== trackedRequest) return;
+      request = undefined;
+      requestPlayerId = undefined;
+      const shouldRetry = requestQueued;
+      requestQueued = false;
+      if (shouldRetry && activePlayerId) void refresh();
+    });
+    requestTask = trackedTask;
+    request = trackedRequest;
+    return trackedTask;
+  }
+
+  return { start, stop, refresh };
+
+  function handleVisibilityChange() {
+    if (document.visibilityState === "visible") void refresh();
+  }
+}

--- a/src/composables/useMusicQuizPlayerHeartbeat.ts
+++ b/src/composables/useMusicQuizPlayerHeartbeat.ts
@@ -16,7 +16,6 @@ export function createMusicQuizPlayerHeartbeat(
   let timer: ReturnType<typeof setInterval> | undefined;
   let request: Promise<void> | undefined;
   let requestTask: Promise<void> | undefined;
-  let requestPlayerId: string | undefined;
   let requestQueued = false;
   let notifiedErrorPlayerId: string | null = null;
 
@@ -43,11 +42,10 @@ export function createMusicQuizPlayerHeartbeat(
     const playerId = activePlayerId;
     if (!playerId) return Promise.resolve();
     if (request) {
-      if (requestPlayerId !== playerId) requestQueued = true;
+      requestQueued = true;
       return requestTask ?? request;
     }
 
-    requestPlayerId = playerId;
     const outcome = Promise.resolve()
       .then(() => sendHeartbeat(playerId))
       .then(
@@ -61,6 +59,7 @@ export function createMusicQuizPlayerHeartbeat(
           onError(playerId, result.error);
         }
       } else if (activePlayerId === playerId) {
+        notifiedErrorPlayerId = null;
         await onResult(playerId, result.active);
       }
     });
@@ -71,7 +70,6 @@ export function createMusicQuizPlayerHeartbeat(
     const trackedRequest = pendingRequest.finally(() => {
       if (request !== trackedRequest) return;
       request = undefined;
-      requestPlayerId = undefined;
       const shouldRetry = requestQueued;
       requestQueued = false;
       if (shouldRetry && activePlayerId) void refresh();

--- a/src/composables/useMusicQuizPlayerHeartbeat.ts
+++ b/src/composables/useMusicQuizPlayerHeartbeat.ts
@@ -54,13 +54,18 @@ export function createMusicQuizPlayerHeartbeat(
       );
     const pendingTask = outcome.then(async (result) => {
       if ("error" in result) {
-        if (activePlayerId === playerId && notifiedErrorPlayerId !== playerId) {
-          notifiedErrorPlayerId = playerId;
-          onError(playerId, result.error);
-        }
+        reportError(playerId, result.error);
       } else if (activePlayerId === playerId) {
         notifiedErrorPlayerId = null;
-        await onResult(playerId, result.active);
+        try {
+          await onResult(playerId, result.active);
+        } catch (error) {
+          if (activePlayerId === playerId) {
+            reportError(playerId, error);
+          } else {
+            console.error("[Music Quiz] Heartbeat callback failed", error);
+          }
+        }
       }
     });
     const trackedTask = pendingTask.finally(() => {
@@ -83,5 +88,19 @@ export function createMusicQuizPlayerHeartbeat(
 
   function handleVisibilityChange() {
     if (document.visibilityState === "visible") void refresh();
+  }
+
+  function reportError(playerId: string, error: unknown) {
+    if (activePlayerId !== playerId || notifiedErrorPlayerId === playerId)
+      return;
+    notifiedErrorPlayerId = playerId;
+    try {
+      onError(playerId, error);
+    } catch (handlerError) {
+      console.error(
+        "[Music Quiz] Heartbeat error handler failed",
+        handlerError,
+      );
+    }
   }
 }

--- a/src/composables/useMusicQuizPlayerHeartbeat.ts
+++ b/src/composables/useMusicQuizPlayerHeartbeat.ts
@@ -23,7 +23,7 @@ export function createMusicQuizPlayerHeartbeat(
     stop();
     activePlayerId = playerId;
     document.addEventListener("visibilitychange", handleVisibilityChange);
-    window.addEventListener("focus", refresh);
+    window.addEventListener("focus", handleFocus);
     timer = setInterval(() => void refresh(), HEARTBEAT_INTERVAL_MS);
     return refresh();
   }
@@ -37,7 +37,7 @@ export function createMusicQuizPlayerHeartbeat(
     requestQueued = false;
     notifiedErrorPlayerId = null;
     document.removeEventListener("visibilitychange", handleVisibilityChange);
-    window.removeEventListener("focus", refresh);
+    window.removeEventListener("focus", handleFocus);
   }
 
   function refresh() {
@@ -90,6 +90,10 @@ export function createMusicQuizPlayerHeartbeat(
 
   function handleVisibilityChange() {
     if (document.visibilityState === "visible") void refresh();
+  }
+
+  function handleFocus() {
+    void refresh();
   }
 
   function reportError(playerId: string, error: unknown) {

--- a/tests/composables/useMusicQuiz.test.ts
+++ b/tests/composables/useMusicQuiz.test.ts
@@ -13,6 +13,7 @@ vi.mock("@/plugins/api", () => ({
 import {
   answerMusicQuiz,
   createMusicQuiz,
+  heartbeatMusicQuiz,
   isMusicQuizProviderEvent,
   isSupportedMusicQuiz,
   parseMusicQuizAnswerType,
@@ -74,6 +75,15 @@ describe("useMusicQuiz commands", () => {
     expect(mockSendCommand).toHaveBeenCalledWith("music_quiz/answer", {
       player_id: "player-id",
       suggestion_id: "suggestion-id",
+    });
+  });
+
+  it("sends a typed player heartbeat", async () => {
+    mockSendCommand.mockResolvedValue(true);
+
+    await expect(heartbeatMusicQuiz("player-id")).resolves.toBe(true);
+    expect(mockSendCommand).toHaveBeenCalledWith("music_quiz/heartbeat", {
+      player_id: "player-id",
     });
   });
 

--- a/tests/composables/useMusicQuizPlayer.test.ts
+++ b/tests/composables/useMusicQuizPlayer.test.ts
@@ -93,6 +93,11 @@ vi.mock("@/plugins/i18n", () => ({
 import { EventType } from "@/plugins/api/interfaces";
 import { useMusicQuizPlayer } from "@/composables/useMusicQuizPlayer";
 
+const originalVisibilityStateDescriptor = Object.getOwnPropertyDescriptor(
+  document,
+  "visibilityState",
+);
+
 const QUIZ_INFO = {
   quiz_type: "guess_the_song",
   answer_type: "multiple_choice",
@@ -203,6 +208,15 @@ describe("useMusicQuizPlayer", () => {
 
   afterEach(() => {
     for (const unmount of unmountHandlers.splice(0)) unmount();
+    if (originalVisibilityStateDescriptor) {
+      Object.defineProperty(
+        document,
+        "visibilityState",
+        originalVisibilityStateDescriptor,
+      );
+    } else {
+      Reflect.deleteProperty(document, "visibilityState");
+    }
     vi.clearAllTimers();
     vi.useRealTimers();
   });

--- a/tests/composables/useMusicQuizPlayer.test.ts
+++ b/tests/composables/useMusicQuizPlayer.test.ts
@@ -520,6 +520,42 @@ describe("useMusicQuizPlayer", () => {
     expect(notifyError).not.toHaveBeenCalled();
   });
 
+  it("keeps loading until removal recovery finishes", async () => {
+    storedPlayerId.value = "stored-player";
+    mockGetMusicQuizState.mockResolvedValueOnce(PLAYER_STATE);
+    const staleState = deferred<typeof PLAYER_STATE>();
+    const refreshedInfo = deferred<typeof QUIZ_INFO>();
+    mockGetMusicQuizState.mockReturnValueOnce(staleState.promise);
+    mockGetMusicQuizInfo.mockReturnValueOnce(refreshedInfo.promise);
+    const player = useMusicQuizPlayer({ notifyError: vi.fn() });
+    await flushPromises();
+
+    providerHandlers[0]({
+      object_id: "quiz-instance",
+      data: { event: "game_updated", state: PUBLIC_STATE },
+    });
+    await flushPromises();
+    expect(player.loading.value).toBe(true);
+
+    providerHandlers[0]({
+      object_id: "quiz-instance",
+      data: {
+        event: "game_updated",
+        state: { ...PUBLIC_STATE, players: [] },
+      },
+    });
+    await flushPromises();
+
+    staleState.resolve(PLAYER_STATE);
+    await flushPromises();
+    expect(player.loading.value).toBe(true);
+
+    refreshedInfo.resolve(QUIZ_INFO);
+    await flushPromises();
+    expect(player.loading.value).toBe(false);
+    expect(player.playerId.value).toBeNull();
+  });
+
   it("keeps game identity across info, join, and provider refresh", async () => {
     mockGetMusicQuizInfo.mockResolvedValue(QUIZ_INFO);
     mockJoinMusicQuiz.mockResolvedValue({
@@ -573,6 +609,27 @@ describe("useMusicQuizPlayer", () => {
     expect(mockHeartbeatMusicQuiz).toHaveBeenCalledTimes(1);
     expect(player.playerId.value).toBeNull();
     expect(storedPlayerId.value).toBeNull();
+  });
+
+  it("clears loading when leaving during a state fetch", async () => {
+    storedPlayerId.value = "stored-player";
+    mockGetMusicQuizState.mockResolvedValueOnce(PLAYER_STATE);
+    const pendingState = deferred<typeof PLAYER_STATE>();
+    mockGetMusicQuizState.mockReturnValueOnce(pendingState.promise);
+    const player = useMusicQuizPlayer({ notifyError: vi.fn() });
+    await flushPromises();
+
+    void player.fetchState();
+    await flushPromises();
+    expect(player.loading.value).toBe(true);
+
+    await player.leave();
+    expect(player.loading.value).toBe(false);
+
+    pendingState.resolve(PLAYER_STATE);
+    await flushPromises();
+    expect(player.loading.value).toBe(false);
+    expect(player.state.value).toBeNull();
   });
 
   it("stops heartbeat when unmounted", async () => {

--- a/tests/composables/useMusicQuizPlayer.test.ts
+++ b/tests/composables/useMusicQuizPlayer.test.ts
@@ -384,6 +384,27 @@ describe("useMusicQuizPlayer", () => {
     expect(player.playerId.value).toBe("stored-player");
   });
 
+  it("contains heartbeat callback failures", async () => {
+    storedPlayerId.value = "stored-player";
+    mockGetMusicQuizState.mockRejectedValue(new Error("State failed"));
+    const notifyError = vi.fn(() => {
+      throw new Error("Toast failed");
+    });
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+
+    const player = useMusicQuizPlayer({ notifyError });
+    await flushPromises();
+
+    expect(player.playerId.value).toBe("stored-player");
+    expect(consoleError).toHaveBeenCalledWith(
+      "[Music Quiz] Heartbeat error handler failed",
+      expect.objectContaining({ message: "Toast failed" }),
+    );
+    consoleError.mockRestore();
+  });
+
   it("recovers from a stale player token by returning to the join/info state", async () => {
     storedPlayerId.value = "stale-player";
     mockGetMusicQuizState.mockRejectedValue(new Error("player not found"));

--- a/tests/composables/useMusicQuizPlayer.test.ts
+++ b/tests/composables/useMusicQuizPlayer.test.ts
@@ -156,10 +156,12 @@ async function flushPromises() {
 
 function deferred<T>() {
   let resolve!: (value: T) => void;
-  const promise = new Promise<T>((promiseResolve) => {
+  let reject!: (error: unknown) => void;
+  const promise = new Promise<T>((promiseResolve, promiseReject) => {
     resolve = promiseResolve;
+    reject = promiseReject;
   });
-  return { promise, resolve };
+  return { promise, resolve, reject };
 }
 
 describe("useMusicQuizPlayer", () => {
@@ -462,6 +464,83 @@ describe("useMusicQuizPlayer", () => {
 
     expect(player.gameRemoved.value).toBe(false);
     expect(player.info.value).toEqual(QUIZ_INFO);
+  });
+
+  it("ignores pending info after the game is removed", async () => {
+    const pendingInfo = deferred<typeof QUIZ_INFO>();
+    mockGetMusicQuizInfo.mockReturnValueOnce(pendingInfo.promise);
+    const player = useMusicQuizPlayer({ notifyError: vi.fn() });
+    await flushPromises();
+
+    providerHandlers[0]({
+      object_id: "quiz-instance",
+      data: { event: "game_removed" },
+    });
+    pendingInfo.resolve(QUIZ_INFO);
+    await flushPromises();
+
+    expect(player.gameRemoved.value).toBe(true);
+    expect(player.info.value).toBeNull();
+    expect(player.playerId.value).toBeNull();
+    expect(player.state.value).toBeNull();
+    expect(player.loading.value).toBe(false);
+  });
+
+  it("ignores pending info after resetting to join", async () => {
+    const staleInfo = deferred<typeof QUIZ_INFO>();
+    const refreshedInfo = deferred<typeof QUIZ_INFO>();
+    mockGetMusicQuizInfo
+      .mockReturnValueOnce(staleInfo.promise)
+      .mockReturnValueOnce(refreshedInfo.promise);
+    mockJoinMusicQuiz.mockResolvedValue({
+      player_id: "player-id",
+      state: PLAYER_STATE,
+    });
+    const notifyError = vi.fn();
+    const player = useMusicQuizPlayer({ notifyError });
+    await flushPromises();
+    await player.join("Player");
+    await flushPromises();
+
+    providerHandlers[0]({
+      object_id: "quiz-instance",
+      data: {
+        event: "game_updated",
+        state: { ...PUBLIC_STATE, players: [] },
+      },
+    });
+    await flushPromises();
+
+    staleInfo.resolve(QUIZ_INFO);
+    await flushPromises();
+    expect(player.info.value).toBeNull();
+    expect(player.loading.value).toBe(true);
+
+    refreshedInfo.resolve(QUIZ_INFO);
+    await flushPromises();
+    expect(player.info.value).toEqual(QUIZ_INFO);
+    expect(player.playerId.value).toBeNull();
+    expect(player.state.value).toBeNull();
+    expect(player.loading.value).toBe(false);
+    expect(notifyError).not.toHaveBeenCalled();
+  });
+
+  it("ignores pending info errors after leaving", async () => {
+    const pendingInfo = deferred<typeof QUIZ_INFO>();
+    mockGetMusicQuizInfo.mockReturnValueOnce(pendingInfo.promise);
+    const notifyError = vi.fn();
+    const player = useMusicQuizPlayer({ notifyError });
+    await flushPromises();
+
+    await player.leave();
+    pendingInfo.reject(new Error("Late info failure"));
+    await flushPromises();
+
+    expect(player.info.value).toBeNull();
+    expect(player.playerId.value).toBeNull();
+    expect(player.state.value).toBeNull();
+    expect(player.loading.value).toBe(false);
+    expect(notifyError).not.toHaveBeenCalled();
   });
 
   it("stops heartbeat when the game is removed", async () => {

--- a/tests/composables/useMusicQuizPlayer.test.ts
+++ b/tests/composables/useMusicQuizPlayer.test.ts
@@ -280,8 +280,10 @@ describe("useMusicQuizPlayer", () => {
 
     pendingHeartbeat.resolve(true);
     await flushPromises();
-    await vi.advanceTimersByTimeAsync(15_000);
     expect(mockHeartbeatMusicQuiz).toHaveBeenCalledTimes(2);
+
+    await vi.advanceTimersByTimeAsync(15_000);
+    expect(mockHeartbeatMusicQuiz).toHaveBeenCalledTimes(3);
   });
 
   it("refreshes heartbeat when visibility or focus is restored", async () => {
@@ -338,6 +340,8 @@ describe("useMusicQuizPlayer", () => {
     mockHeartbeatMusicQuiz
       .mockRejectedValueOnce(new Error("Connection lost"))
       .mockRejectedValueOnce(new Error("Connection lost"))
+      .mockResolvedValueOnce(true)
+      .mockRejectedValueOnce(new Error("Connection lost"))
       .mockResolvedValue(true);
     mockGetMusicQuizState.mockResolvedValue(PLAYER_STATE);
     const notifyError = vi.fn();
@@ -359,6 +363,11 @@ describe("useMusicQuizPlayer", () => {
     expect(mockGetMusicQuizState).toHaveBeenCalledWith("stored-player");
     expect(player.state.value).toEqual(PLAYER_STATE);
     expect(storedPlayerId.value).toBe("stored-player");
+
+    await vi.advanceTimersByTimeAsync(15_000);
+    expect(mockHeartbeatMusicQuiz).toHaveBeenCalledTimes(4);
+    expect(notifyError).toHaveBeenCalledTimes(2);
+    expect(player.playerId.value).toBe("stored-player");
   });
 
   it("recovers from a stale player token by returning to the join/info state", async () => {

--- a/tests/composables/useMusicQuizPlayer.test.ts
+++ b/tests/composables/useMusicQuizPlayer.test.ts
@@ -1,8 +1,9 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const {
   mockGetMusicQuizInfo,
   mockGetMusicQuizState,
+  mockHeartbeatMusicQuiz,
   mockJoinMusicQuiz,
   mockReadyMusicQuiz,
   mockAnswerMusicQuiz,
@@ -13,9 +14,11 @@ const {
   mockGetMusicQuizErrorMessage,
   storedPlayerId,
   providerHandlers,
+  unmountHandlers,
 } = vi.hoisted(() => ({
   mockGetMusicQuizInfo: vi.fn(),
   mockGetMusicQuizState: vi.fn(),
+  mockHeartbeatMusicQuiz: vi.fn(),
   mockJoinMusicQuiz: vi.fn(),
   mockReadyMusicQuiz: vi.fn(),
   mockAnswerMusicQuiz: vi.fn(),
@@ -28,6 +31,7 @@ const {
   providerHandlers: [] as Array<
     (event: { object_id?: string; data?: unknown }) => void
   >,
+  unmountHandlers: [] as Array<() => void>,
 }));
 
 vi.mock("vue", async () => {
@@ -35,13 +39,14 @@ vi.mock("vue", async () => {
   return {
     ...actual,
     onMounted: (fn: () => void) => fn(),
-    onBeforeUnmount: () => {},
+    onBeforeUnmount: (fn: () => void) => unmountHandlers.push(fn),
   };
 });
 
 vi.mock("@/composables/useMusicQuiz", () => ({
   getMusicQuizInfo: mockGetMusicQuizInfo,
   getMusicQuizState: mockGetMusicQuizState,
+  heartbeatMusicQuiz: mockHeartbeatMusicQuiz,
   joinMusicQuiz: mockJoinMusicQuiz,
   readyMusicQuiz: mockReadyMusicQuiz,
   answerMusicQuiz: mockAnswerMusicQuiz,
@@ -107,7 +112,15 @@ const PLAYER_STATE = {
   suggestion_count: 4,
   answer_duration: 30,
   mode: "venue",
-  players: [],
+  players: [
+    {
+      name: "Player",
+      score: 0,
+      ready: false,
+      answered: false,
+      active_from_round: 0,
+    },
+  ],
   current_round: null,
   you: {
     name: "Player",
@@ -117,17 +130,42 @@ const PLAYER_STATE = {
   },
 } as const;
 
+const PUBLIC_STATE = {
+  quiz_type: "guess_the_song",
+  answer_type: "multiple_choice",
+  phase: "lobby",
+  name: "Quiz",
+  round_count: 5,
+  suggestion_count: 4,
+  answer_duration: 30,
+  mode: "venue",
+  players: PLAYER_STATE.players,
+  current_round: null,
+} as const;
+
 async function flushPromises() {
-  await Promise.resolve();
-  await Promise.resolve();
+  for (let index = 0; index < 8; index += 1) {
+    await Promise.resolve();
+  }
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((promiseResolve) => {
+    resolve = promiseResolve;
+  });
+  return { promise, resolve };
 }
 
 describe("useMusicQuizPlayer", () => {
   beforeEach(() => {
+    vi.useFakeTimers();
     storedPlayerId.value = null;
     providerHandlers.length = 0;
+    unmountHandlers.length = 0;
     mockGetMusicQuizInfo.mockReset();
     mockGetMusicQuizState.mockReset();
+    mockHeartbeatMusicQuiz.mockReset();
     mockJoinMusicQuiz.mockReset();
     mockReadyMusicQuiz.mockReset();
     mockAnswerMusicQuiz.mockReset();
@@ -136,6 +174,7 @@ describe("useMusicQuizPlayer", () => {
     mockGetStoredPlayerId.mockReset();
     mockClearStoredPlayerId.mockReset();
     mockGetMusicQuizErrorMessage.mockReset();
+    mockHeartbeatMusicQuiz.mockResolvedValue(true);
     mockGetStoredPlayerId.mockImplementation(() => storedPlayerId.value);
     mockStorePlayerId.mockImplementation((playerId: string) => {
       storedPlayerId.value = playerId;
@@ -156,6 +195,170 @@ describe("useMusicQuizPlayer", () => {
         return () => {};
       },
     );
+    Object.defineProperty(document, "visibilityState", {
+      configurable: true,
+      value: "visible",
+    });
+  });
+
+  afterEach(() => {
+    for (const unmount of unmountHandlers.splice(0)) unmount();
+    vi.clearAllTimers();
+    vi.useRealTimers();
+  });
+
+  it("validates a stored player before fetching personalized state", async () => {
+    storedPlayerId.value = "stored-player";
+    mockGetMusicQuizState.mockResolvedValue(PLAYER_STATE);
+
+    const player = useMusicQuizPlayer({ notifyError: vi.fn() });
+    await flushPromises();
+
+    expect(mockHeartbeatMusicQuiz).toHaveBeenCalledWith("stored-player");
+    expect(mockGetMusicQuizState).toHaveBeenCalledWith("stored-player");
+    expect(mockHeartbeatMusicQuiz.mock.invocationCallOrder[0]).toBeLessThan(
+      mockGetMusicQuizState.mock.invocationCallOrder[0],
+    );
+    expect(player.playerId.value).toBe("stored-player");
+    expect(player.state.value).toEqual(PLAYER_STATE);
+  });
+
+  it("returns to join info when a stored player is no longer active", async () => {
+    storedPlayerId.value = "missing-player";
+    mockHeartbeatMusicQuiz.mockResolvedValue(false);
+    mockGetMusicQuizInfo.mockResolvedValue(QUIZ_INFO);
+    const notifyError = vi.fn();
+
+    const player = useMusicQuizPlayer({ notifyError });
+    await flushPromises();
+
+    expect(mockGetMusicQuizState).not.toHaveBeenCalled();
+    expect(player.playerId.value).toBeNull();
+    expect(player.state.value).toBeNull();
+    expect(player.info.value).toEqual(QUIZ_INFO);
+    expect(storedPlayerId.value).toBeNull();
+
+    await vi.advanceTimersByTimeAsync(15_000);
+    document.dispatchEvent(new Event("visibilitychange"));
+    window.dispatchEvent(new Event("focus"));
+    await flushPromises();
+    expect(mockHeartbeatMusicQuiz).toHaveBeenCalledTimes(1);
+    expect(notifyError).not.toHaveBeenCalled();
+  });
+
+  it("heartbeats immediately and every 15 seconds", async () => {
+    storedPlayerId.value = "stored-player";
+    mockGetMusicQuizState.mockResolvedValue(PLAYER_STATE);
+
+    useMusicQuizPlayer({ notifyError: vi.fn() });
+    await flushPromises();
+
+    expect(mockHeartbeatMusicQuiz).toHaveBeenCalledTimes(1);
+    await vi.advanceTimersByTimeAsync(14_999);
+    expect(mockHeartbeatMusicQuiz).toHaveBeenCalledTimes(1);
+    await vi.advanceTimersByTimeAsync(1);
+    expect(mockHeartbeatMusicQuiz).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not overlap heartbeat requests", async () => {
+    storedPlayerId.value = "stored-player";
+    const pendingHeartbeat = deferred<boolean>();
+    mockHeartbeatMusicQuiz
+      .mockReturnValueOnce(pendingHeartbeat.promise)
+      .mockResolvedValue(true);
+    mockGetMusicQuizState.mockResolvedValue(PLAYER_STATE);
+
+    useMusicQuizPlayer({ notifyError: vi.fn() });
+    await flushPromises();
+    expect(mockHeartbeatMusicQuiz).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(30_000);
+    document.dispatchEvent(new Event("visibilitychange"));
+    window.dispatchEvent(new Event("focus"));
+    await flushPromises();
+    expect(mockHeartbeatMusicQuiz).toHaveBeenCalledTimes(1);
+
+    pendingHeartbeat.resolve(true);
+    await flushPromises();
+    await vi.advanceTimersByTimeAsync(15_000);
+    expect(mockHeartbeatMusicQuiz).toHaveBeenCalledTimes(2);
+  });
+
+  it("refreshes heartbeat when visibility or focus is restored", async () => {
+    storedPlayerId.value = "stored-player";
+    mockGetMusicQuizState.mockResolvedValue(PLAYER_STATE);
+
+    useMusicQuizPlayer({ notifyError: vi.fn() });
+    await flushPromises();
+
+    Object.defineProperty(document, "visibilityState", {
+      configurable: true,
+      value: "hidden",
+    });
+    document.dispatchEvent(new Event("visibilitychange"));
+    await flushPromises();
+    expect(mockHeartbeatMusicQuiz).toHaveBeenCalledTimes(1);
+
+    Object.defineProperty(document, "visibilityState", {
+      configurable: true,
+      value: "visible",
+    });
+    document.dispatchEvent(new Event("visibilitychange"));
+    await flushPromises();
+    expect(mockHeartbeatMusicQuiz).toHaveBeenCalledTimes(2);
+
+    window.dispatchEvent(new Event("focus"));
+    await flushPromises();
+    expect(mockHeartbeatMusicQuiz).toHaveBeenCalledTimes(3);
+  });
+
+  it("returns to join info when a later heartbeat reports removal", async () => {
+    storedPlayerId.value = "stored-player";
+    mockHeartbeatMusicQuiz
+      .mockResolvedValueOnce(true)
+      .mockResolvedValueOnce(false);
+    mockGetMusicQuizState.mockResolvedValue(PLAYER_STATE);
+    mockGetMusicQuizInfo.mockResolvedValue(QUIZ_INFO);
+    const notifyError = vi.fn();
+
+    const player = useMusicQuizPlayer({ notifyError });
+    await flushPromises();
+    await vi.advanceTimersByTimeAsync(15_000);
+
+    expect(player.playerId.value).toBeNull();
+    expect(player.state.value).toBeNull();
+    expect(player.info.value).toEqual(QUIZ_INFO);
+    expect(storedPlayerId.value).toBeNull();
+    expect(mockGetMusicQuizState).toHaveBeenCalledTimes(1);
+    expect(notifyError).not.toHaveBeenCalled();
+  });
+
+  it("retries transient heartbeat failures without repeated toasts", async () => {
+    storedPlayerId.value = "stored-player";
+    mockHeartbeatMusicQuiz
+      .mockRejectedValueOnce(new Error("Connection lost"))
+      .mockRejectedValueOnce(new Error("Connection lost"))
+      .mockResolvedValue(true);
+    mockGetMusicQuizState.mockResolvedValue(PLAYER_STATE);
+    const notifyError = vi.fn();
+
+    const player = useMusicQuizPlayer({ notifyError });
+    await flushPromises();
+
+    expect(player.playerId.value).toBe("stored-player");
+    expect(mockGetMusicQuizState).not.toHaveBeenCalled();
+    expect(notifyError).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(15_000);
+    expect(mockHeartbeatMusicQuiz).toHaveBeenCalledTimes(2);
+    expect(mockGetMusicQuizState).not.toHaveBeenCalled();
+    expect(notifyError).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(15_000);
+    expect(mockHeartbeatMusicQuiz).toHaveBeenCalledTimes(3);
+    expect(mockGetMusicQuizState).toHaveBeenCalledWith("stored-player");
+    expect(player.state.value).toEqual(PLAYER_STATE);
+    expect(storedPlayerId.value).toBe("stored-player");
   });
 
   it("recovers from a stale player token by returning to the join/info state", async () => {
@@ -189,6 +392,11 @@ describe("useMusicQuizPlayer", () => {
     expect(player.state.value).toBeNull();
     expect(player.info.value).toEqual(QUIZ_INFO);
     expect(storedPlayerId.value).toBeNull();
+
+    await vi.advanceTimersByTimeAsync(15_000);
+    window.dispatchEvent(new Event("focus"));
+    await flushPromises();
+    expect(mockHeartbeatMusicQuiz).toHaveBeenCalledTimes(1);
   });
 
   it("returns from game-removed state when a new game update arrives", async () => {
@@ -212,28 +420,81 @@ describe("useMusicQuizPlayer", () => {
     expect(player.info.value).toEqual(QUIZ_INFO);
   });
 
-  it("only handles provider events from the active quiz instance", async () => {
-    mockGetMusicQuizInfo.mockResolvedValue(QUIZ_INFO);
-    useMusicQuizPlayer({ notifyError: vi.fn() });
+  it("stops heartbeat when the game is removed", async () => {
+    storedPlayerId.value = "stored-player";
+    mockGetMusicQuizState.mockResolvedValue(PLAYER_STATE);
+    const player = useMusicQuizPlayer({ notifyError: vi.fn() });
     await flushPromises();
-    expect(mockGetMusicQuizInfo).toHaveBeenCalledTimes(1);
+
+    providerHandlers[0]({
+      object_id: "quiz-instance",
+      data: { event: "game_removed" },
+    });
+    await vi.advanceTimersByTimeAsync(15_000);
+    document.dispatchEvent(new Event("visibilitychange"));
+    window.dispatchEvent(new Event("focus"));
+    await flushPromises();
+
+    expect(mockHeartbeatMusicQuiz).toHaveBeenCalledTimes(1);
+    expect(player.playerId.value).toBeNull();
+    expect(player.state.value).toBeNull();
+    expect(player.gameRemoved.value).toBe(true);
+    expect(storedPlayerId.value).toBeNull();
+  });
+
+  it("only handles provider events from the active quiz instance", async () => {
+    storedPlayerId.value = "stored-player";
+    mockGetMusicQuizState.mockResolvedValue(PLAYER_STATE);
+    const player = useMusicQuizPlayer({ notifyError: vi.fn() });
+    await flushPromises();
+    expect(mockGetMusicQuizState).toHaveBeenCalledTimes(1);
 
     const handler = providerHandlers[0];
     expect(handler).toBeTypeOf("function");
 
     handler({
       object_id: "quiz-instance",
-      data: { event: "game_updated", state: QUIZ_INFO },
+      data: { event: "game_updated", state: PUBLIC_STATE },
     });
     await flushPromises();
-    expect(mockGetMusicQuizInfo).toHaveBeenCalledTimes(2);
+    expect(mockGetMusicQuizState).toHaveBeenCalledTimes(2);
 
     handler({
       object_id: "other-instance",
-      data: { event: "game_updated", state: QUIZ_INFO },
+      data: {
+        event: "game_updated",
+        state: { ...PUBLIC_STATE, players: [] },
+      },
     });
     await flushPromises();
-    expect(mockGetMusicQuizInfo).toHaveBeenCalledTimes(2);
+    expect(mockGetMusicQuizState).toHaveBeenCalledTimes(2);
+    expect(player.playerId.value).toBe("stored-player");
+  });
+
+  it("uses public updates to detect a removed player", async () => {
+    storedPlayerId.value = "stored-player";
+    mockGetMusicQuizState.mockResolvedValue(PLAYER_STATE);
+    mockGetMusicQuizInfo.mockResolvedValue(QUIZ_INFO);
+    const notifyError = vi.fn();
+    const player = useMusicQuizPlayer({ notifyError });
+    await flushPromises();
+
+    providerHandlers[0]({
+      object_id: "quiz-instance",
+      data: {
+        event: "game_updated",
+        state: { ...PUBLIC_STATE, players: [] },
+      },
+    });
+    await flushPromises();
+
+    expect(mockGetMusicQuizState).toHaveBeenCalledTimes(1);
+    expect(mockGetMusicQuizInfo).toHaveBeenCalledTimes(1);
+    expect(player.playerId.value).toBeNull();
+    expect(player.state.value).toBeNull();
+    expect(player.info.value).toEqual(QUIZ_INFO);
+    expect(storedPlayerId.value).toBeNull();
+    expect(notifyError).not.toHaveBeenCalled();
   });
 
   it("keeps game identity across info, join, and provider refresh", async () => {
@@ -258,7 +519,7 @@ describe("useMusicQuizPlayer", () => {
 
     providerHandlers[0]({
       object_id: "quiz-instance",
-      data: { event: "game_updated", state: PLAYER_STATE },
+      data: { event: "game_updated", state: PUBLIC_STATE },
     });
     await flushPromises();
 
@@ -266,6 +527,79 @@ describe("useMusicQuizPlayer", () => {
     expect(player.state.value?.quiz_type).toBe("guess_the_song");
     expect(player.state.value?.answer_type).toBe("multiple_choice");
     expect(player.state.value?.phase).toBe("answering");
+  });
+
+  it("stops heartbeat when leaving", async () => {
+    mockGetMusicQuizInfo.mockResolvedValue(QUIZ_INFO);
+    mockJoinMusicQuiz.mockResolvedValue({
+      player_id: "player-id",
+      state: PLAYER_STATE,
+    });
+    const player = useMusicQuizPlayer({ notifyError: vi.fn() });
+    await flushPromises();
+    await player.join("Player");
+    await flushPromises();
+
+    expect(mockHeartbeatMusicQuiz).toHaveBeenCalledTimes(1);
+    await player.leave();
+    await vi.advanceTimersByTimeAsync(15_000);
+    document.dispatchEvent(new Event("visibilitychange"));
+    window.dispatchEvent(new Event("focus"));
+    await flushPromises();
+
+    expect(mockHeartbeatMusicQuiz).toHaveBeenCalledTimes(1);
+    expect(player.playerId.value).toBeNull();
+    expect(storedPlayerId.value).toBeNull();
+  });
+
+  it("stops heartbeat when unmounted", async () => {
+    storedPlayerId.value = "stored-player";
+    mockGetMusicQuizState.mockResolvedValue(PLAYER_STATE);
+    useMusicQuizPlayer({ notifyError: vi.fn() });
+    await flushPromises();
+
+    expect(mockHeartbeatMusicQuiz).toHaveBeenCalledTimes(1);
+    unmountHandlers[0]();
+    await vi.advanceTimersByTimeAsync(15_000);
+    document.dispatchEvent(new Event("visibilitychange"));
+    window.dispatchEvent(new Event("focus"));
+    await flushPromises();
+
+    expect(mockHeartbeatMusicQuiz).toHaveBeenCalledTimes(1);
+  });
+
+  it("replaces heartbeat ownership without overlapping requests", async () => {
+    mockGetMusicQuizInfo.mockResolvedValue(QUIZ_INFO);
+    mockJoinMusicQuiz
+      .mockResolvedValueOnce({
+        player_id: "first-player",
+        state: PLAYER_STATE,
+      })
+      .mockResolvedValueOnce({
+        player_id: "second-player",
+        state: PLAYER_STATE,
+      });
+    const firstHeartbeat = deferred<boolean>();
+    mockHeartbeatMusicQuiz
+      .mockReturnValueOnce(firstHeartbeat.promise)
+      .mockResolvedValue(true);
+    const player = useMusicQuizPlayer({ notifyError: vi.fn() });
+    await flushPromises();
+
+    await player.join("Player");
+    await flushPromises();
+    await player.join("Player");
+    await flushPromises();
+    expect(mockHeartbeatMusicQuiz).toHaveBeenCalledTimes(1);
+
+    firstHeartbeat.resolve(false);
+    await flushPromises();
+    expect(mockHeartbeatMusicQuiz).toHaveBeenNthCalledWith(2, "second-player");
+
+    await vi.advanceTimersByTimeAsync(15_000);
+    expect(mockHeartbeatMusicQuiz).toHaveBeenNthCalledWith(3, "second-player");
+    expect(player.playerId.value).toBe("second-player");
+    expect(storedPlayerId.value).toBe("second-player");
   });
 
   it("preserves game identity when reconnecting with a stored player", async () => {

--- a/tests/composables/useMusicQuizPlayer.test.ts
+++ b/tests/composables/useMusicQuizPlayer.test.ts
@@ -541,6 +541,24 @@ describe("useMusicQuizPlayer", () => {
     expect(notifyError).not.toHaveBeenCalled();
   });
 
+  it("refreshes safely when a public update has no player list", async () => {
+    storedPlayerId.value = "stored-player";
+    mockGetMusicQuizState.mockResolvedValue(PLAYER_STATE);
+    const player = useMusicQuizPlayer({ notifyError: vi.fn() });
+    await flushPromises();
+
+    expect(() =>
+      providerHandlers[0]({
+        object_id: "quiz-instance",
+        data: { event: "game_updated", state: QUIZ_INFO },
+      }),
+    ).not.toThrow();
+    await flushPromises();
+
+    expect(mockGetMusicQuizState).toHaveBeenCalledTimes(2);
+    expect(player.playerId.value).toBe("stored-player");
+  });
+
   it("keeps loading until removal recovery finishes", async () => {
     storedPlayerId.value = "stored-player";
     mockGetMusicQuizState.mockResolvedValueOnce(PLAYER_STATE);

--- a/tests/composables/useMusicQuizPlayer.test.ts
+++ b/tests/composables/useMusicQuizPlayer.test.ts
@@ -660,7 +660,9 @@ describe("useMusicQuizPlayer", () => {
     await flushPromises();
 
     expect(mockHeartbeatMusicQuiz).toHaveBeenCalledTimes(1);
-    unmountHandlers[0]();
+    const unmount = unmountHandlers.shift();
+    if (!unmount) throw new Error("Expected an unmount handler");
+    unmount();
     await vi.advanceTimersByTimeAsync(15_000);
     document.dispatchEvent(new Event("visibilitychange"));
     window.dispatchEvent(new Event("focus"));
@@ -691,14 +693,13 @@ describe("useMusicQuizPlayer", () => {
     await flushPromises();
     await player.join("Player");
     await flushPromises();
-    expect(mockHeartbeatMusicQuiz).toHaveBeenCalledTimes(1);
-
-    firstHeartbeat.resolve(false);
-    await flushPromises();
     expect(mockHeartbeatMusicQuiz).toHaveBeenNthCalledWith(2, "second-player");
 
     await vi.advanceTimersByTimeAsync(15_000);
     expect(mockHeartbeatMusicQuiz).toHaveBeenNthCalledWith(3, "second-player");
+
+    firstHeartbeat.resolve(false);
+    await flushPromises();
     expect(player.playerId.value).toBe("second-player");
     expect(storedPlayerId.value).toBe("second-player");
   });


### PR DESCRIPTION
## Feature

- Keep joined players active with periodic heartbeats
- Recover cleanly when a stored or active player has expired
- Avoid stale-player errors by checking public game updates first