### PR TITLE
Keep Music Quiz guest audio receive-only

### DIFF
--- a/src/plugins/web_player.ts
+++ b/src/plugins/web_player.ts
@@ -189,7 +189,7 @@ function resolvePreferredMode(): WebPlayerMode {
 
   // Force sendspin mode for music quiz guests (listen-in audio support)
   if (authManager.isMusicQuizGuest()) {
-    return WebPlayerMode.SENDSPIN_WITH_CONTROLS;
+    return WebPlayerMode.SENDSPIN_ONLY;
   }
 
   const webPlayerEnabledPref =

--- a/tests/plugins/web_player.test.ts
+++ b/tests/plugins/web_player.test.ts
@@ -1,0 +1,146 @@
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { authState, routerAfterEach } = vi.hoisted(() => {
+  vi.stubGlobal(
+    "BroadcastChannel",
+    class {
+      onmessage: ((event: MessageEvent) => void) | null = null;
+
+      postMessage() {}
+    },
+  );
+
+  return {
+    authState: {
+      guest: null as "music_quiz" | "party" | null,
+    },
+    routerAfterEach: vi.fn(),
+  };
+});
+
+vi.mock("@/plugins/auth", () => ({
+  default: {
+    isMusicQuizGuest: () => authState.guest === "music_quiz",
+    isPartyGuest: () => authState.guest === "party",
+  },
+}));
+
+vi.mock("@/plugins/api", () => ({
+  default: {
+    subscribe: vi.fn(() => () => {}),
+  },
+}));
+
+vi.mock("@/plugins/companion", async () => {
+  const { ref } = await vi.importActual<typeof import("vue")>("vue");
+  return { companionMode: ref(false) };
+});
+
+vi.mock("@/plugins/router", async () => {
+  const { ref } = await vi.importActual<typeof import("vue")>("vue");
+  return {
+    default: {
+      afterEach: routerAfterEach,
+      currentRoute: ref({ matched: [] }),
+      isReady: vi.fn().mockResolvedValue(undefined),
+    },
+  };
+});
+
+vi.mock("@/plugins/sendspin-connection", () => ({
+  resetSendspinConnection: vi.fn(),
+}));
+
+import { companionMode } from "@/plugins/companion";
+import {
+  initializeWebPlayerModeSync,
+  partyListenInEnabled,
+  webPlayer,
+  WebPlayerMode,
+} from "@/plugins/web_player";
+
+function createStorage(): Storage {
+  const values = new Map<string, string>();
+  return {
+    get length() {
+      return values.size;
+    },
+    clear: () => values.clear(),
+    getItem: (key) => values.get(key) ?? null,
+    key: (index) => Array.from(values.keys())[index] ?? null,
+    removeItem: (key) => values.delete(key),
+    setItem: (key, value) => values.set(key, value),
+  };
+}
+
+async function applyPreferredMode(): Promise<WebPlayerMode> {
+  webPlayer.mode = WebPlayerMode.CONTROLS_ONLY;
+  webPlayer.tabMode = WebPlayerMode.CONTROLS_ONLY;
+  await initializeWebPlayerModeSync();
+  return webPlayer.mode;
+}
+
+function setRegularPreferences(
+  webPlayerEnabled: boolean,
+  browserControlsEnabled: boolean,
+): void {
+  window.localStorage.setItem(
+    "frontend.settings.web_player_enabled",
+    String(webPlayerEnabled),
+  );
+  window.localStorage.setItem(
+    "frontend.settings.enable_browser_controls",
+    String(browserControlsEnabled),
+  );
+}
+
+describe("web player preferred mode", () => {
+  beforeAll(() => {
+    vi.spyOn(webPlayer, "setMode").mockImplementation(async (mode) => {
+      webPlayer.mode = mode;
+      webPlayer.tabMode = mode;
+    });
+  });
+
+  beforeEach(() => {
+    authState.guest = null;
+    companionMode.value = false;
+    partyListenInEnabled.value = false;
+    vi.stubGlobal("localStorage", createStorage());
+    window.localStorage.clear();
+  });
+
+  it("uses receive-only Sendspin for Music Quiz guests", async () => {
+    authState.guest = "music_quiz";
+    setRegularPreferences(false, true);
+
+    expect(await applyPreferredMode()).toBe(WebPlayerMode.SENDSPIN_ONLY);
+  });
+
+  it.each([
+    [WebPlayerMode.DISABLED, false],
+    [WebPlayerMode.SENDSPIN_ONLY, true],
+  ])(
+    "keeps Party guests in %s when listen-in is %s",
+    async (expectedMode, listenInEnabled) => {
+      authState.guest = "party";
+      partyListenInEnabled.value = listenInEnabled;
+
+      expect(await applyPreferredMode()).toBe(expectedMode);
+    },
+  );
+
+  it.each([
+    [true, true, WebPlayerMode.SENDSPIN_WITH_CONTROLS],
+    [true, false, WebPlayerMode.SENDSPIN_ONLY],
+    [false, true, WebPlayerMode.CONTROLS_ONLY],
+    [false, false, WebPlayerMode.DISABLED],
+  ])(
+    "keeps regular user preferences (%s, %s) mapped to %s",
+    async (webPlayerEnabled, browserControlsEnabled, expectedMode) => {
+      setRegularPreferences(webPlayerEnabled, browserControlsEnabled);
+
+      expect(await applyPreferredMode()).toBe(expectedMode);
+    },
+  );
+});

--- a/tests/plugins/web_player.test.ts
+++ b/tests/plugins/web_player.test.ts
@@ -1,4 +1,12 @@
-import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
 
 const { authState, routerAfterEach } = vi.hoisted(() => {
   vi.stubGlobal(
@@ -100,6 +108,11 @@ describe("web player preferred mode", () => {
       webPlayer.mode = mode;
       webPlayer.tabMode = mode;
     });
+  });
+
+  afterAll(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
   });
 
   beforeEach(() => {


### PR DESCRIPTION
Music Quiz guests currently expose browser and OS media controls while listening to game audio.

- Keep dedicated Music Quiz guests in receive-only Sendspin mode
- Add regression coverage for Music Quiz, Party, and regular-user web-player modes