### PR TITLE
Faster global search with media type and provider filters

### DIFF
--- a/src/components/FacetedFilter.vue
+++ b/src/components/FacetedFilter.vue
@@ -58,14 +58,16 @@
             v-for="option in filteredOptions"
             :key="option.value"
             class="faceted-filter-item"
+            :class="{ 'faceted-filter-item--locked': option.locked }"
             role="checkbox"
-            :aria-checked="selectedSet.has(option.value)"
-            tabindex="0"
-            @click="toggle(option.value)"
-            @keydown.space.prevent="toggle(option.value)"
+            :aria-checked="option.locked || selectedSet.has(option.value)"
+            :aria-disabled="option.locked"
+            :tabindex="option.locked ? -1 : 0"
+            @click="toggle(option)"
+            @keydown.space.prevent="toggle(option)"
           >
             <Checkbox
-              :model-value="selectedSet.has(option.value)"
+              :model-value="option.locked || selectedSet.has(option.value)"
               class="mr-2 pointer-events-none"
               tabindex="-1"
               aria-hidden="true"
@@ -108,6 +110,9 @@ import { Separator } from "@/components/ui/separator";
 interface FacetedOption {
   label: string;
   value: string;
+  // locked options render as permanently checked and cannot be toggled;
+  // they are not part of the model value (e.g. an always-active entry)
+  locked?: boolean;
 }
 
 const props = defineProps<{
@@ -137,12 +142,13 @@ const filteredOptions = computed(() => {
   return props.options.filter((opt) => opt.label.toLowerCase().includes(term));
 });
 
-const toggle = (value: string) => {
+const toggle = (option: FacetedOption) => {
+  if (option.locked) return;
   const next = new Set(selectedSet.value);
-  if (next.has(value)) {
-    next.delete(value);
+  if (next.has(option.value)) {
+    next.delete(option.value);
   } else {
-    next.add(value);
+    next.add(option.value);
   }
   emit("update:modelValue", Array.from(next));
 };
@@ -189,6 +195,15 @@ const clear = () => {
 
 .faceted-filter-item:hover {
   background-color: rgba(var(--v-theme-on-surface), 0.04);
+}
+
+.faceted-filter-item--locked {
+  opacity: 0.55;
+  cursor: default;
+}
+
+.faceted-filter-item--locked:hover {
+  background-color: transparent;
 }
 
 .faceted-filter-clear {

--- a/src/components/FacetedFilter.vue
+++ b/src/components/FacetedFilter.vue
@@ -91,7 +91,7 @@
   </Popover>
 </template>
 
-<script setup lang="ts">
+<script setup lang="ts" generic="TValue extends string">
 import { PlusCircle, X } from "@lucide/vue";
 import type { HTMLAttributes } from "vue";
 import { computed, ref } from "vue";
@@ -109,7 +109,7 @@ import { Separator } from "@/components/ui/separator";
 
 interface FacetedOption {
   label: string;
-  value: string;
+  value: TValue;
   // locked options render as permanently checked and cannot be toggled;
   // they are not part of the model value (e.g. an always-active entry)
   locked?: boolean;
@@ -118,12 +118,12 @@ interface FacetedOption {
 const props = defineProps<{
   title: string;
   options: FacetedOption[];
-  modelValue: string[];
+  modelValue: TValue[];
   class?: HTMLAttributes["class"];
 }>();
 
 const emit = defineEmits<{
-  (e: "update:modelValue", value: string[]): void;
+  (e: "update:modelValue", value: TValue[]): void;
 }>();
 
 const search = ref("");
@@ -153,7 +153,7 @@ const toggle = (option: FacetedOption) => {
   emit("update:modelValue", Array.from(next));
 };
 
-const removeFilter = (value: string) => {
+const removeFilter = (value: TValue) => {
   const next = new Set(selectedSet.value);
   next.delete(value);
   emit("update:modelValue", Array.from(next));

--- a/src/components/ItemsListing.vue
+++ b/src/components/ItemsListing.vue
@@ -802,23 +802,18 @@ const providerFilterSubItems = () =>
 
 const redirectSearch = function () {
   store.globalSearchTerm = params.value.search;
-  if (props.itemtype == "artists") {
-    store.globalSearchType = MediaType.ARTIST;
-  } else if (props.itemtype == "albums") {
-    store.globalSearchType = MediaType.ALBUM;
-  } else if (props.itemtype == "tracks") {
-    store.globalSearchType = MediaType.TRACK;
-  } else if (props.itemtype == "playlists") {
-    store.globalSearchType = MediaType.PLAYLIST;
-  } else if (props.itemtype == "audiobooks") {
-    store.globalSearchType = MediaType.AUDIOBOOK;
-  } else if (props.itemtype == "podcasts") {
-    store.globalSearchType = MediaType.PODCAST;
-  } else if (props.itemtype == "radios") {
-    store.globalSearchType = MediaType.RADIO;
-  } else if (props.itemtype == "genres") {
-    store.globalSearchType = MediaType.GENRE;
-  }
+  const mediaTypeByItemtype: Record<string, MediaType> = {
+    artists: MediaType.ARTIST,
+    albums: MediaType.ALBUM,
+    tracks: MediaType.TRACK,
+    playlists: MediaType.PLAYLIST,
+    audiobooks: MediaType.AUDIOBOOK,
+    podcasts: MediaType.PODCAST,
+    radios: MediaType.RADIO,
+    genres: MediaType.GENRE,
+  };
+  const mediaType = mediaTypeByItemtype[props.itemtype];
+  store.globalSearchMediaTypes = mediaType ? [mediaType] : [];
   router.push({ name: "search" });
 };
 

--- a/src/plugins/api/index.ts
+++ b/src/plugins/api/index.ts
@@ -1410,12 +1410,16 @@ export class MusicAssistantApi {
     search_query: string,
     media_types?: MediaType[],
     limit?: number,
+    providers?: string[],
   ): Promise<SearchResults> {
-    // Perform global search for media items on all providers.
+    // Perform global search for media items on the given providers.
+    // providers: provider instance ids/domains and/or "library";
+    // omit to search the library and all available providers combined.
     return this.sendCommand("music/search", {
       search_query,
       media_types,
       limit,
+      providers,
     });
   }
 

--- a/src/plugins/store.ts
+++ b/src/plugins/store.ts
@@ -38,7 +38,8 @@ interface Store {
   activePlayerQueue?: PlayerQueue;
   curQueueItem?: QueueItem;
   globalSearchTerm?: string;
-  globalSearchType?: MediaType;
+  // media type filter for the global search; empty means all media types
+  globalSearchMediaTypes: MediaType[];
   prevState?: StoredState;
   prevRoute?: string;
   libraryArtistsCount?: number;
@@ -103,7 +104,7 @@ export const store: Store = reactive({
     return undefined;
   }),
   globalSearchTerm: undefined,
-  globalSearchType: undefined,
+  globalSearchMediaTypes: [],
   prevState: undefined,
   prevRoute: undefined,
   libraryArtistsCount: undefined,

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -713,6 +713,7 @@
     "check_item_on_provider": "Check {0} on {1}",
     "check_item_in_library": "Check {0} in the library",
     "media_details": "Media details",
+    "media_type": "Media type",
     "mapped_providers": "Provider details",
     "item_in_library": "This item is available in the library",
     "back": "Back",

--- a/src/views/Search.vue
+++ b/src/views/Search.vue
@@ -11,30 +11,21 @@
         @blur="searchHasFocus = false"
       />
 
-      <v-chip-group
-        v-model="selectedSearchType"
-        style="margin-top: 10px; margin-left: 10px"
-        selected-class="text-primary"
-        mandatory
-      >
-        <v-chip
-          v-for="item in [
-            SEARCH_TYPE_ALL,
-            MediaType.TRACK,
-            MediaType.ARTIST,
-            MediaType.ALBUM,
-            MediaType.PLAYLIST,
-            MediaType.PODCAST,
-            MediaType.AUDIOBOOK,
-            MediaType.RADIO,
-            MediaType.GENRE,
-          ]"
-          :key="item"
-          :text="$t(item === SEARCH_TYPE_ALL ? 'searchtype_all' : item + 's')"
-          :value="item"
-          filter
+      <!-- faceted filters (like the settings pages): media type(s) and
+           search target(s); an empty selection means no filtering -->
+      <div class="search-filter-row">
+        <FacetedFilter
+          v-model="selectedMediaTypes"
+          :title="$t('media_type')"
+          :options="mediaTypeOptions"
         />
-      </v-chip-group>
+        <FacetedFilter
+          v-if="providerTargets.length && !genreOnly"
+          v-model="selectedSearchProviders"
+          :title="$t('settings.providers')"
+          :options="providerOptions"
+        />
+      </div>
 
       <v-progress-linear
         v-if="loading"
@@ -45,8 +36,8 @@
         style="margin-top: 15px"
       />
 
-      <!-- compact all-media-types searchresult -->
-      <div v-if="!store.globalSearchType" class="search-shelves">
+      <!-- compact searchresult shelves per media type -->
+      <div v-if="!singleType" class="search-shelves">
         <EditorialShelf
           v-for="section in searchSections"
           :key="section.key"
@@ -62,20 +53,22 @@
           />
         </EditorialShelf>
       </div>
-      <!-- tracks-only searchresult -->
-      <div v-else-if="!loading">
+      <!-- single media type searchresult; mounted as soon as the first
+           target returns items so slower providers merge in progressively -->
+      <div v-else-if="searchResult && (singleTypeHasItems || !loading)">
         <ItemsListing
-          :itemtype="`${store.globalSearchType}s`"
+          ref="listingRef"
+          :itemtype="`${singleType}s`"
           :show-provider="true"
           :show-favorites-only-filter="false"
           :show-select-button="false"
           :show-refresh-button="false"
           :load-items="
             async (params) => {
-              return filteredItems(store.globalSearchType!);
+              return filteredItems(singleType!);
             }
           "
-          :title="$t(`${store.globalSearchType}s`)"
+          :title="$t(`${singleType}s`)"
           :allow-key-hooks="false"
           :show-search-button="false"
           :infinite-scroll="true"
@@ -91,52 +84,251 @@
 import Container from "@/components/Container.vue";
 import EditorialMediaCard from "@/components/discover/EditorialMediaCard.vue";
 import EditorialShelf from "@/components/discover/EditorialShelf.vue";
+import FacetedFilter from "@/components/FacetedFilter.vue";
 import ItemsListing from "@/components/ItemsListing.vue";
 import { SearchInput } from "@/components/ui/search-input";
 import { useUserPreferences } from "@/composables/userPreferences";
 import { panelViewItemResponsive } from "@/helpers/utils";
 import { api } from "@/plugins/api";
 import { itemIsAvailable } from "@/plugins/api/helpers";
-import { MediaType, SearchResults } from "@/plugins/api/interfaces";
+import {
+  Genre,
+  MediaType,
+  ProviderFeature,
+  SearchResults,
+} from "@/plugins/api/interfaces";
 import { $t } from "@/plugins/i18n";
 import { store } from "@/plugins/store";
 import { computed, onBeforeUnmount, onMounted, ref, watch } from "vue";
 
-const SEARCH_TYPE_ALL = "all";
+// virtual search target for the server's library search
+const LIBRARY_TARGET = "library";
 
-// computed to bridge between chip-group (needs a real value) and store (uses undefined for "all")
-const selectedSearchType = computed({
-  get: () => store.globalSearchType || SEARCH_TYPE_ALL,
-  set: (val: string) => {
-    store.globalSearchType =
-      val === SEARCH_TYPE_ALL ? undefined : (val as MediaType);
-  },
-});
+const SEARCHABLE_MEDIA_TYPES = [
+  MediaType.TRACK,
+  MediaType.ARTIST,
+  MediaType.ALBUM,
+  MediaType.PLAYLIST,
+  MediaType.PODCAST,
+  MediaType.AUDIOBOOK,
+  MediaType.RADIO,
+  MediaType.GENRE,
+];
+
+// The server answers each per-provider search request within a soft timeout;
+// a provider that is slower returns an empty result while its search continues
+// in the background server-side (and gets cached once done). An empty result
+// that took at least this long is treated as such a soft timeout and retried
+// shortly after, picking up the cached result.
+const SOFT_TIMEOUT_MS = 7000;
+const SOFT_TIMEOUT_RETRY_DELAY_MS = 2500;
+const MAX_SOFT_TIMEOUT_RETRIES = 3;
+
+interface SearchTarget {
+  // instance_id for local providers, domain for streaming providers
+  id: string;
+  name: string;
+  iconDomain: string;
+}
 
 // local refs
 const searchHasFocus = ref(false);
-const searchResult = ref<SearchResults>();
-const loading = ref(false);
+const activeSearchTerm = ref("");
+const providerResults = ref<{ [targetId: string]: SearchResults }>({});
+const pendingTargets = ref(new Set<string>());
+const libraryGenresFallback = ref<Genre[]>([]);
 const throttleId = ref();
+const listingRef = ref<InstanceType<typeof ItemsListing>>();
+const retryTimers = new Map<string, ReturnType<typeof setTimeout>>();
+let listingReloadTimer: ReturnType<typeof setTimeout> | undefined;
+// guards stale responses: bumped on every new search, responses for an older
+// search id are discarded
+let currentSearchId = 0;
 const { getPreference, setPreference } = useUserPreferences();
+// search targets stored as the included subset; empty means all targets
+const selectedProvidersPref = getPreference<string[]>(
+  "globalSearchProviders",
+  [],
+);
+
+const loading = computed(() => pendingTargets.value.size > 0);
 
 // Responsive tile sizing, shared curve with the rest of the app.
 const tilesPerView = computed(() => panelViewItemResponsive(0) + 0.5);
 
-// Compact "all" results as horizontal shelves; empty categories are hidden.
+const selectedMediaTypes = computed<string[]>({
+  get: () => store.globalSearchMediaTypes,
+  set: (val) => {
+    store.globalSearchMediaTypes = val as MediaType[];
+  },
+});
+
+const mediaTypeOptions = computed(() =>
+  SEARCHABLE_MEDIA_TYPES.map((mediaType) => ({
+    label: $t(mediaType + "s"),
+    value: mediaType,
+  })),
+);
+
+// exactly one selected media type: results are shown as a single listing
+const singleType = computed(() =>
+  store.globalSearchMediaTypes.length === 1
+    ? store.globalSearchMediaTypes[0]
+    : undefined,
+);
+
+// genres live in the library only, so a genre-only search skips the providers
+const genreOnly = computed(() => singleType.value === MediaType.GENRE);
+
+// All selectable search targets, mirroring the server's provider
+// de-duplication: streaming providers are collapsed to one target per domain
+// (the server only ever searches a single instance of the same streaming
+// service), local/plugin providers get one target per instance.
+const providerTargets = computed<SearchTarget[]>(() => {
+  const targets: SearchTarget[] = [];
+  const seenStreamingDomains = new Set<string>();
+  for (const provider of Object.values(api.providers)) {
+    if (!provider.available) continue;
+    if (!provider.supported_features.includes(ProviderFeature.SEARCH)) continue;
+    if (provider.is_streaming_provider) {
+      if (seenStreamingDomains.has(provider.domain)) continue;
+      seenStreamingDomains.add(provider.domain);
+      targets.push({
+        id: provider.domain,
+        name: api.providerManifests[provider.domain]?.name || provider.name,
+        iconDomain: provider.domain,
+      });
+    } else {
+      targets.push({
+        id: provider.instance_id,
+        name: provider.name,
+        iconDomain: provider.domain,
+      });
+    }
+  }
+  return targets.sort((a, b) => a.name.localeCompare(b.name));
+});
+
+const providerOptions = computed(() => [
+  // the library is always searched, shown as a locked entry
+  { label: $t("library"), value: LIBRARY_TARGET, locked: true },
+  ...providerTargets.value.map((target) => ({
+    label: target.name,
+    value: target.id,
+  })),
+]);
+
+const selectedSearchProviders = computed<string[]>({
+  // ignore stale ids of removed providers so the filter count stays accurate
+  get: () => {
+    const stored = Array.isArray(selectedProvidersPref.value)
+      ? selectedProvidersPref.value
+      : [];
+    return stored.filter((id) =>
+      providerTargets.value.some((target) => target.id === id),
+    );
+  },
+  set: (val) => {
+    setPreference("globalSearchProviders", val);
+  },
+});
+
+// The library is always searched; an empty provider selection means all.
+const enabledTargetIds = computed(() => {
+  const selected = selectedSearchProviders.value;
+  return [
+    LIBRARY_TARGET,
+    ...providerTargets.value
+      .filter((target) => !selected.length || selected.includes(target.id))
+      .map((target) => target.id),
+  ];
+});
+
+// Merge the per-target results in a stable order (library first, then
+// providers) and float exact name matches to the top, approximating the
+// ranking of the server's combined search.
+const searchResult = computed<SearchResults | undefined>(() => {
+  if (!activeSearchTerm.value) return undefined;
+  const query = activeSearchTerm.value.toLowerCase().trim();
+  const ordered = enabledTargetIds.value
+    .map((targetId) => providerResults.value[targetId])
+    .filter((result) => !!result);
+  const merged: SearchResults = {
+    artists: collectField(ordered, (r) => r.artists, query),
+    albums: collectField(ordered, (r) => r.albums, query),
+    tracks: collectField(ordered, (r) => r.tracks, query),
+    playlists: collectField(ordered, (r) => r.playlists, query),
+    radio: collectField(ordered, (r) => r.radio, query),
+    podcasts: collectField(ordered, (r) => r.podcasts, query),
+    audiobooks: collectField(ordered, (r) => r.audiobooks, query),
+    genres: collectField(ordered, (r) => r.genres, query),
+  };
+  if (!merged.genres.length) merged.genres = [...libraryGenresFallback.value];
+  return merged;
+});
+
+const singleTypeHasItems = computed(
+  () => !!singleType.value && filteredItems(singleType.value).length > 0,
+);
+
+// Compact results as horizontal shelves, restricted to the selected media
+// types; empty categories are hidden.
 const searchSections = computed(() => {
   const r = searchResult.value;
-  if (!r || loading.value) return [];
+  if (!r) return [];
+  const selected = store.globalSearchMediaTypes;
   return [
-    { key: "tracks", title: $t("tracks"), items: r.tracks },
-    { key: "artists", title: $t("artists"), items: r.artists },
-    { key: "albums", title: $t("albums"), items: r.albums },
-    { key: "playlists", title: $t("playlists"), items: r.playlists },
-    { key: "podcasts", title: $t("podcasts"), items: r.podcasts },
-    { key: "audiobooks", title: $t("audiobooks"), items: r.audiobooks },
-    { key: "radios", title: $t("radios"), items: r.radio },
-    { key: "genres", title: $t("genres"), items: r.genres },
-  ].filter((s) => s.items?.length);
+    {
+      key: "tracks",
+      type: MediaType.TRACK,
+      title: $t("tracks"),
+      items: r.tracks,
+    },
+    {
+      key: "artists",
+      type: MediaType.ARTIST,
+      title: $t("artists"),
+      items: r.artists,
+    },
+    {
+      key: "albums",
+      type: MediaType.ALBUM,
+      title: $t("albums"),
+      items: r.albums,
+    },
+    {
+      key: "playlists",
+      type: MediaType.PLAYLIST,
+      title: $t("playlists"),
+      items: r.playlists,
+    },
+    {
+      key: "podcasts",
+      type: MediaType.PODCAST,
+      title: $t("podcasts"),
+      items: r.podcasts,
+    },
+    {
+      key: "audiobooks",
+      type: MediaType.AUDIOBOOK,
+      title: $t("audiobooks"),
+      items: r.audiobooks,
+    },
+    {
+      key: "radios",
+      type: MediaType.RADIO,
+      title: $t("radios"),
+      items: r.radio,
+    },
+    {
+      key: "genres",
+      type: MediaType.GENRE,
+      title: $t("genres"),
+      items: r.genres,
+    },
+  ].filter(
+    (s) => s.items?.length && (!selected.length || selected.includes(s.type)),
+  );
 });
 
 // watchers
@@ -145,71 +337,82 @@ watch(
   () => {
     clearTimeout(throttleId.value);
     throttleId.value = setTimeout(() => {
-      loadSearchResults(store.globalSearchTerm, store.globalSearchType);
+      loadSearchResults(store.globalSearchTerm);
     }, 1000);
   },
   { immediate: true },
 );
 watch(
-  () => store.globalSearchType,
+  () => store.globalSearchMediaTypes.join(","),
   () => {
-    setPreference(
-      "globalSearchType",
-      store.globalSearchType || SEARCH_TYPE_ALL,
-    );
-    loadSearchResults(store.globalSearchTerm, store.globalSearchType);
+    setPreference("globalSearchMediaTypes", store.globalSearchMediaTypes);
+    loadSearchResults(store.globalSearchTerm);
   },
 );
+// selection changes and (re)connected providers: search any enabled target
+// that has no result yet for the active query
+watch(
+  () => enabledTargetIds.value.join(","),
+  () => ensureTargetResults(),
+);
+// The single-media-type listing pulls its items through the load-items
+// callback; nudge it to reload when new provider results stream in (coalesced,
+// results arrive in bursts).
+watch(searchResult, () => {
+  if (!singleType.value) return;
+  clearTimeout(listingReloadTimer);
+  listingReloadTimer = setTimeout(() => listingRef.value?.reload(), 150);
+});
 
-const loadSearchResults = async function (
-  searchTerm?: string,
-  filter?: MediaType,
-) {
-  loading.value = true;
+const loadSearchResults = async function (searchTerm?: string) {
+  currentSearchId += 1;
+  const searchId = currentSearchId;
+  for (const timer of retryTimers.values()) clearTimeout(timer);
+  retryTimers.clear();
+  providerResults.value = {};
+  pendingTargets.value = new Set();
+  libraryGenresFallback.value = [];
+  activeSearchTerm.value = searchTerm || "";
   setPreference("globalSearch", searchTerm || "");
-  const limit = store.globalSearchType ? 50 : 8;
-  const mediaTypes = filter ? [filter] : undefined;
-  if (searchTerm) {
-    if (filter === MediaType.GENRE) {
-      // Genre-only search: use library search directly
+  if (!searchTerm) return;
+
+  if (genreOnly.value) {
+    // Genre-only search: use library search directly
+    pendingTargets.value.add(LIBRARY_TARGET);
+    try {
       const genres = await api.getLibraryGenres({
         search: searchTerm,
-        limit,
+        limit: 50,
         offset: 0,
         order_by: "name",
       });
-      searchResult.value = {
-        artists: [],
-        albums: [],
-        tracks: [],
-        playlists: [],
-        radio: [],
-        podcasts: [],
-        audiobooks: [],
-        genres,
-      };
-    } else {
-      // Standard search + supplement with genre results
-      const [results, genres] = await Promise.all([
-        api.search(searchTerm, mediaTypes, limit),
-        !filter
-          ? api.getLibraryGenres({
-              search: searchTerm,
-              limit,
-              offset: 0,
-              order_by: "name",
-            })
-          : Promise.resolve([]),
-      ]);
-      searchResult.value = {
-        ...results,
-        genres: results.genres?.length ? results.genres : genres,
-      };
+      if (searchId !== currentSearchId) return;
+      providerResults.value[LIBRARY_TARGET] = { ...emptyResults(), genres };
+    } catch (err) {
+      console.error("Genre search failed", err);
     }
-  } else {
-    searchResult.value = undefined;
+    if (searchId === currentSearchId) {
+      pendingTargets.value.delete(LIBRARY_TARGET);
+    }
+    return;
   }
-  loading.value = false;
+
+  const mediaTypes = store.globalSearchMediaTypes;
+  if (!mediaTypes.length || mediaTypes.includes(MediaType.GENRE)) {
+    // supplement the shelves with (library) genre results
+    api
+      .getLibraryGenres({
+        search: searchTerm,
+        limit: 8,
+        offset: 0,
+        order_by: "name",
+      })
+      .then((genres) => {
+        if (searchId === currentSearchId) libraryGenresFallback.value = genres;
+      })
+      .catch((err) => console.error("Genre search failed", err));
+  }
+  ensureTargetResults();
 };
 
 onMounted(() => {
@@ -219,13 +422,24 @@ onMounted(() => {
       store.globalSearchTerm = savedSearch;
     }
   }
-  const savedSearchType = getPreference<string>("globalSearchType").value;
-  if (
-    savedSearchType &&
-    savedSearchType !== "null" &&
-    savedSearchType !== SEARCH_TYPE_ALL
-  ) {
-    store.globalSearchType = savedSearchType as MediaType;
+  // restore the media type filter, unless it was just set deliberately
+  // (e.g. redirected here from a library listing's search)
+  if (!store.globalSearchMediaTypes.length) {
+    const savedTypes = getPreference<MediaType[]>(
+      "globalSearchMediaTypes",
+    ).value;
+    // legacy single-type preference from the previous chip selector
+    const legacyType = getPreference<string>("globalSearchType").value;
+    if (Array.isArray(savedTypes)) {
+      store.globalSearchMediaTypes = savedTypes.filter((mediaType) =>
+        SEARCHABLE_MEDIA_TYPES.includes(mediaType),
+      );
+    } else if (
+      legacyType &&
+      SEARCHABLE_MEDIA_TYPES.includes(legacyType as MediaType)
+    ) {
+      store.globalSearchMediaTypes = [legacyType as MediaType];
+    }
   }
 });
 
@@ -250,6 +464,10 @@ document.addEventListener("keyup", keyListener);
 
 onBeforeUnmount(() => {
   document.removeEventListener("keyup", keyListener);
+  clearTimeout(throttleId.value);
+  clearTimeout(listingReloadTimer);
+  for (const timer of retryTimers.values()) clearTimeout(timer);
+  retryTimers.clear();
 });
 
 const filteredItems = function (mediaType: MediaType) {
@@ -264,4 +482,115 @@ const filteredItems = function (mediaType: MediaType) {
   if (mediaType == MediaType.GENRE) return searchResult.value.genres;
   return [];
 };
+
+const emptyResults = (): SearchResults => ({
+  artists: [],
+  albums: [],
+  tracks: [],
+  playlists: [],
+  radio: [],
+  podcasts: [],
+  audiobooks: [],
+  genres: [],
+});
+
+const isEmptyResult = (result: SearchResults): boolean =>
+  !result.artists?.length &&
+  !result.albums?.length &&
+  !result.tracks?.length &&
+  !result.playlists?.length &&
+  !result.radio?.length &&
+  !result.podcasts?.length &&
+  !result.audiobooks?.length &&
+  !result.genres?.length;
+
+// Keeps the relative order but floats items whose name matches the query
+// exactly, so a late provider with the exact hit still lands on top.
+const floatExactMatches = function <T extends { name?: string }>(
+  items: T[],
+  query: string,
+): T[] {
+  if (items.length < 2 || !query) return items;
+  const exact: T[] = [];
+  const rest: T[] = [];
+  for (const item of items) {
+    (item.name?.toLowerCase() === query ? exact : rest).push(item);
+  }
+  return exact.length ? exact.concat(rest) : items;
+};
+
+const collectField = function <T extends { name?: string }>(
+  results: SearchResults[],
+  pick: (result: SearchResults) => T[] | undefined,
+  query: string,
+): T[] {
+  const items: T[] = [];
+  for (const result of results) items.push(...(pick(result) || []));
+  return floatExactMatches(items, query);
+};
+
+// Fire a search for every enabled target that has no result yet; used on
+// search start, on selection changes and when providers (re)connect.
+const ensureTargetResults = function () {
+  if (!activeSearchTerm.value) return;
+  if (genreOnly.value) return;
+  for (const targetId of enabledTargetIds.value) {
+    if (providerResults.value[targetId]) continue;
+    if (pendingTargets.value.has(targetId)) continue;
+    searchTarget(currentSearchId, targetId);
+  }
+};
+
+// One search request for a single target (library or one provider); the
+// response is merged into the view as soon as it arrives.
+const searchTarget = async function (
+  searchId: number,
+  targetId: string,
+  attempt = 0,
+) {
+  if (searchId !== currentSearchId) return;
+  const selectedTypes = store.globalSearchMediaTypes;
+  const limit = singleType.value ? 50 : 8;
+  const mediaTypes = selectedTypes.length ? selectedTypes : undefined;
+  pendingTargets.value.add(targetId);
+  const started = Date.now();
+  let result: SearchResults | undefined;
+  try {
+    result = await api.search(activeSearchTerm.value, mediaTypes, limit, [
+      targetId,
+    ]);
+  } catch (err) {
+    console.error(`Search on ${targetId} failed`, err);
+  }
+  if (searchId !== currentSearchId) return;
+  if (
+    result &&
+    isEmptyResult(result) &&
+    Date.now() - started >= SOFT_TIMEOUT_MS &&
+    attempt < MAX_SOFT_TIMEOUT_RETRIES
+  ) {
+    // soft timeout: the provider search continues in the background
+    // server-side, retry shortly to pick up the cached result
+    retryTimers.set(
+      targetId,
+      setTimeout(() => {
+        retryTimers.delete(targetId);
+        searchTarget(searchId, targetId, attempt + 1);
+      }, SOFT_TIMEOUT_RETRY_DELAY_MS),
+    );
+    return;
+  }
+  providerResults.value[targetId] = result || emptyResults();
+  pendingTargets.value.delete(targetId);
+};
 </script>
+
+<style scoped>
+.search-filter-row {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin: 12px 0 20px;
+}
+</style>

--- a/src/views/Search.vue
+++ b/src/views/Search.vue
@@ -156,10 +156,10 @@ const loading = computed(() => pendingTargets.value.size > 0);
 // Responsive tile sizing, shared curve with the rest of the app.
 const tilesPerView = computed(() => panelViewItemResponsive(0) + 0.5);
 
-const selectedMediaTypes = computed<string[]>({
+const selectedMediaTypes = computed<MediaType[]>({
   get: () => store.globalSearchMediaTypes,
   set: (val) => {
-    store.globalSearchMediaTypes = val as MediaType[];
+    store.globalSearchMediaTypes = val;
   },
 });
 


### PR DESCRIPTION
Global search sent a single combined request to the server, so the slowest music provider determined how long you had to wait before *any* result appeared.

Search results now load progressively: the library and fast providers appear right away and slower providers fill in as they respond. Two new filters (same style as the settings pages) let you narrow the search when needed.

**Changes:**
- One search request per provider instead of one combined request; results merge in as each provider responds, library results first
- New media type filter: select one or more media types to search (previously one-or-all)
- New provider filter: select which providers to search; the library is always searched
- Filter selections are stored in user preferences; an empty selection means no filtering
- Providers that respond slowly keep searching in the background and their results are picked up automatically
