### PR TITLE
Move the progressive search logic into a reusable composable

### DIFF
--- a/src/composables/useProgressiveSearch.ts
+++ b/src/composables/useProgressiveSearch.ts
@@ -60,8 +60,7 @@ export interface ProgressiveSearchOptions {
  * `mediaTypes`/`providers` refs re-search automatically.
  */
 export function useProgressiveSearch(options: ProgressiveSearchOptions) {
-  const selectedMediaTypes = options.mediaTypes;
-  const selectedProvidersInput = options.providers ?? ref([]);
+  const selectedProvidersInput = options.providers ?? ref<string[]>([]);
   const allowedMediaTypes = options.allowedMediaTypes ?? SEARCHABLE_MEDIA_TYPES;
   const limits = options.limits ?? { single: 50, multi: 8 };
 
@@ -75,6 +74,13 @@ export function useProgressiveSearch(options: ProgressiveSearchOptions) {
   let currentSearchId = 0;
 
   const loading = computed(() => pendingTargets.value.size > 0);
+
+  // the media type selection clamped to the allowed set
+  const selectedMediaTypes = computed(() =>
+    options.mediaTypes.value.filter((mediaType) =>
+      allowedMediaTypes.includes(mediaType),
+    ),
+  );
 
   // exactly one selected media type: consumers typically show a single flat
   // listing for this and a per-type split otherwise
@@ -167,6 +173,8 @@ export function useProgressiveSearch(options: ProgressiveSearchOptions) {
   });
 
   const search = async function (searchTerm?: string) {
+    // a whitespace-only term is a reset, same as an empty one
+    const trimmedTerm = searchTerm?.trim() || "";
     currentSearchId += 1;
     const searchId = currentSearchId;
     for (const timer of retryTimers.values()) clearTimeout(timer);
@@ -174,15 +182,15 @@ export function useProgressiveSearch(options: ProgressiveSearchOptions) {
     providerResults.value = {};
     pendingTargets.value = new Set();
     libraryGenresFallback.value = [];
-    activeSearchTerm.value = searchTerm || "";
-    if (!searchTerm) return;
+    activeSearchTerm.value = trimmedTerm;
+    if (!trimmedTerm) return;
 
     if (genreOnly.value) {
       // Genre-only search: use library search directly
       pendingTargets.value.add(LIBRARY_SEARCH_TARGET);
       try {
         const genres = await api.getLibraryGenres({
-          search: searchTerm,
+          search: trimmedTerm,
           limit: limits.single,
           offset: 0,
           order_by: "name",
@@ -206,7 +214,7 @@ export function useProgressiveSearch(options: ProgressiveSearchOptions) {
       // supplement the results with (library) genre results
       api
         .getLibraryGenres({
-          search: searchTerm,
+          search: trimmedTerm,
           limit: limits.multi,
           offset: 0,
           order_by: "name",

--- a/src/composables/useProgressiveSearch.ts
+++ b/src/composables/useProgressiveSearch.ts
@@ -1,0 +1,366 @@
+import { api } from "@/plugins/api";
+import {
+  Genre,
+  MediaType,
+  ProviderFeature,
+  SearchResults,
+} from "@/plugins/api/interfaces";
+import { computed, onScopeDispose, ref, watch, type Ref } from "vue";
+
+// virtual search target for the server's library search
+export const LIBRARY_SEARCH_TARGET = "library";
+
+export const SEARCHABLE_MEDIA_TYPES = [
+  MediaType.TRACK,
+  MediaType.ARTIST,
+  MediaType.ALBUM,
+  MediaType.PLAYLIST,
+  MediaType.PODCAST,
+  MediaType.AUDIOBOOK,
+  MediaType.RADIO,
+  MediaType.GENRE,
+];
+
+// The server answers each per-provider search request within a soft timeout;
+// a provider that is slower returns an empty result while its search continues
+// in the background server-side (and gets cached once done). An empty result
+// that took at least this long is treated as such a soft timeout and retried
+// shortly after, picking up the cached result.
+const SOFT_TIMEOUT_MS = 7000;
+const SOFT_TIMEOUT_RETRY_DELAY_MS = 2500;
+const MAX_SOFT_TIMEOUT_RETRIES = 3;
+
+export interface SearchTarget {
+  // instance_id for local providers, domain for streaming providers
+  id: string;
+  name: string;
+  iconDomain: string;
+}
+
+export interface ProgressiveSearchOptions {
+  // selected media types; an empty selection searches all allowed types
+  mediaTypes: Ref<MediaType[]>;
+  // selected provider target ids; an empty selection searches all targets
+  providers?: Ref<string[]>;
+  // media types this consumer can search at all (default: all searchable)
+  allowedMediaTypes?: MediaType[];
+  // per-target result limit: single = exactly one media type selected
+  limits?: { single: number; multi: number };
+}
+
+/**
+ * Progressive multi-provider media search.
+ *
+ * Fires one search request per target (the library plus every selectable
+ * provider) and merges the results into the reactive `searchResult` as each
+ * target responds, library results first. Targets mirror the server's
+ * provider de-duplication and slow providers are retried automatically to
+ * pick up their server-side cached result. Call `search(term)` to start a
+ * new search (an empty term resets); selection changes on the given
+ * `mediaTypes`/`providers` refs re-search automatically.
+ */
+export function useProgressiveSearch(options: ProgressiveSearchOptions) {
+  const selectedMediaTypes = options.mediaTypes;
+  const selectedProvidersInput = options.providers ?? ref([]);
+  const allowedMediaTypes = options.allowedMediaTypes ?? SEARCHABLE_MEDIA_TYPES;
+  const limits = options.limits ?? { single: 50, multi: 8 };
+
+  const activeSearchTerm = ref("");
+  const providerResults = ref<{ [targetId: string]: SearchResults }>({});
+  const pendingTargets = ref(new Set<string>());
+  const libraryGenresFallback = ref<Genre[]>([]);
+  const retryTimers = new Map<string, ReturnType<typeof setTimeout>>();
+  // guards stale responses: bumped on every new search, responses for an
+  // older search id are discarded
+  let currentSearchId = 0;
+
+  const loading = computed(() => pendingTargets.value.size > 0);
+
+  // exactly one selected media type: consumers typically show a single flat
+  // listing for this and a per-type split otherwise
+  const singleType = computed(() =>
+    selectedMediaTypes.value.length === 1
+      ? selectedMediaTypes.value[0]
+      : undefined,
+  );
+
+  // genres live in the library only, so a genre-only search skips the providers
+  const genreOnly = computed(() => singleType.value === MediaType.GENRE);
+
+  // the media types actually sent with a search request; undefined = all
+  const effectiveMediaTypes = computed<MediaType[] | undefined>(() => {
+    if (selectedMediaTypes.value.length) return selectedMediaTypes.value;
+    if (allowedMediaTypes.length < SEARCHABLE_MEDIA_TYPES.length)
+      return allowedMediaTypes;
+    return undefined;
+  });
+
+  // All selectable search targets, mirroring the server's provider
+  // de-duplication: streaming providers are collapsed to one target per domain
+  // (the server only ever searches a single instance of the same streaming
+  // service), local/plugin providers get one target per instance.
+  const providerTargets = computed<SearchTarget[]>(() => {
+    const targets: SearchTarget[] = [];
+    const seenStreamingDomains = new Set<string>();
+    for (const provider of Object.values(api.providers)) {
+      if (!provider.available) continue;
+      if (!provider.supported_features.includes(ProviderFeature.SEARCH))
+        continue;
+      if (provider.is_streaming_provider) {
+        if (seenStreamingDomains.has(provider.domain)) continue;
+        seenStreamingDomains.add(provider.domain);
+        targets.push({
+          id: provider.domain,
+          name: api.providerManifests[provider.domain]?.name || provider.name,
+          iconDomain: provider.domain,
+        });
+      } else {
+        targets.push({
+          id: provider.instance_id,
+          name: provider.name,
+          iconDomain: provider.domain,
+        });
+      }
+    }
+    return targets.sort((a, b) => a.name.localeCompare(b.name));
+  });
+
+  // the provider selection with stale ids of removed providers dropped
+  const selectedProviders = computed(() =>
+    selectedProvidersInput.value.filter((id) =>
+      providerTargets.value.some((target) => target.id === id),
+    ),
+  );
+
+  // The library is always searched; an empty provider selection means all.
+  const enabledTargetIds = computed(() => {
+    const selected = selectedProviders.value;
+    return [
+      LIBRARY_SEARCH_TARGET,
+      ...providerTargets.value
+        .filter((target) => !selected.length || selected.includes(target.id))
+        .map((target) => target.id),
+    ];
+  });
+
+  // Merge the per-target results in a stable order (library first, then
+  // providers) and float exact name matches to the top, approximating the
+  // ranking of the server's combined search.
+  const searchResult = computed<SearchResults | undefined>(() => {
+    if (!activeSearchTerm.value) return undefined;
+    const query = activeSearchTerm.value.toLowerCase().trim();
+    const ordered = enabledTargetIds.value
+      .map((targetId) => providerResults.value[targetId])
+      .filter((result) => !!result);
+    const merged: SearchResults = {
+      artists: collectField(ordered, (r) => r.artists, query),
+      albums: collectField(ordered, (r) => r.albums, query),
+      tracks: collectField(ordered, (r) => r.tracks, query),
+      playlists: collectField(ordered, (r) => r.playlists, query),
+      radio: collectField(ordered, (r) => r.radio, query),
+      podcasts: collectField(ordered, (r) => r.podcasts, query),
+      audiobooks: collectField(ordered, (r) => r.audiobooks, query),
+      genres: collectField(ordered, (r) => r.genres, query),
+    };
+    if (!merged.genres.length) merged.genres = [...libraryGenresFallback.value];
+    return merged;
+  });
+
+  const search = async function (searchTerm?: string) {
+    currentSearchId += 1;
+    const searchId = currentSearchId;
+    for (const timer of retryTimers.values()) clearTimeout(timer);
+    retryTimers.clear();
+    providerResults.value = {};
+    pendingTargets.value = new Set();
+    libraryGenresFallback.value = [];
+    activeSearchTerm.value = searchTerm || "";
+    if (!searchTerm) return;
+
+    if (genreOnly.value) {
+      // Genre-only search: use library search directly
+      pendingTargets.value.add(LIBRARY_SEARCH_TARGET);
+      try {
+        const genres = await api.getLibraryGenres({
+          search: searchTerm,
+          limit: limits.single,
+          offset: 0,
+          order_by: "name",
+        });
+        if (searchId !== currentSearchId) return;
+        providerResults.value[LIBRARY_SEARCH_TARGET] = {
+          ...emptyResults(),
+          genres,
+        };
+      } catch (err) {
+        console.error("Genre search failed", err);
+      }
+      if (searchId === currentSearchId) {
+        pendingTargets.value.delete(LIBRARY_SEARCH_TARGET);
+      }
+      return;
+    }
+
+    const mediaTypes = effectiveMediaTypes.value;
+    if (!mediaTypes || mediaTypes.includes(MediaType.GENRE)) {
+      // supplement the results with (library) genre results
+      api
+        .getLibraryGenres({
+          search: searchTerm,
+          limit: limits.multi,
+          offset: 0,
+          order_by: "name",
+        })
+        .then((genres) => {
+          if (searchId === currentSearchId)
+            libraryGenresFallback.value = genres;
+        })
+        .catch((err) => console.error("Genre search failed", err));
+    }
+    ensureTargetResults();
+  };
+
+  const filteredItems = function (mediaType: MediaType) {
+    if (!searchResult.value) return [];
+    if (mediaType == MediaType.TRACK) return searchResult.value.tracks;
+    if (mediaType == MediaType.ARTIST) return searchResult.value.artists;
+    if (mediaType == MediaType.ALBUM) return searchResult.value.albums;
+    if (mediaType == MediaType.PLAYLIST) return searchResult.value.playlists;
+    if (mediaType == MediaType.PODCAST) return searchResult.value.podcasts;
+    if (mediaType == MediaType.AUDIOBOOK) return searchResult.value.audiobooks;
+    if (mediaType == MediaType.RADIO) return searchResult.value.radio;
+    if (mediaType == MediaType.GENRE) return searchResult.value.genres;
+    return [];
+  };
+
+  // Fire a search for every enabled target that has no result yet; used on
+  // search start, on selection changes and when providers (re)connect.
+  const ensureTargetResults = function () {
+    if (!activeSearchTerm.value) return;
+    if (genreOnly.value) return;
+    for (const targetId of enabledTargetIds.value) {
+      if (providerResults.value[targetId]) continue;
+      if (pendingTargets.value.has(targetId)) continue;
+      searchTarget(currentSearchId, targetId);
+    }
+  };
+
+  // One search request for a single target (library or one provider); the
+  // response is merged into the view as soon as it arrives.
+  const searchTarget = async function (
+    searchId: number,
+    targetId: string,
+    attempt = 0,
+  ) {
+    if (searchId !== currentSearchId) return;
+    const limit = singleType.value ? limits.single : limits.multi;
+    const mediaTypes = effectiveMediaTypes.value;
+    pendingTargets.value.add(targetId);
+    const started = Date.now();
+    let result: SearchResults | undefined;
+    try {
+      result = await api.search(activeSearchTerm.value, mediaTypes, limit, [
+        targetId,
+      ]);
+    } catch (err) {
+      console.error(`Search on ${targetId} failed`, err);
+    }
+    if (searchId !== currentSearchId) return;
+    if (
+      result &&
+      isEmptyResult(result) &&
+      Date.now() - started >= SOFT_TIMEOUT_MS &&
+      attempt < MAX_SOFT_TIMEOUT_RETRIES
+    ) {
+      // soft timeout: the provider search continues in the background
+      // server-side, retry shortly to pick up the cached result
+      retryTimers.set(
+        targetId,
+        setTimeout(() => {
+          retryTimers.delete(targetId);
+          searchTarget(searchId, targetId, attempt + 1);
+        }, SOFT_TIMEOUT_RETRY_DELAY_MS),
+      );
+      return;
+    }
+    providerResults.value[targetId] = result || emptyResults();
+    pendingTargets.value.delete(targetId);
+  };
+
+  // media type selection changes affect limits and per-request media types:
+  // rerun the whole search
+  watch(
+    () => selectedMediaTypes.value.join(","),
+    () => search(activeSearchTerm.value),
+  );
+  // selection changes and (re)connected providers: search any enabled target
+  // that has no result yet for the active query
+  watch(
+    () => enabledTargetIds.value.join(","),
+    () => ensureTargetResults(),
+  );
+
+  onScopeDispose(() => {
+    for (const timer of retryTimers.values()) clearTimeout(timer);
+    retryTimers.clear();
+  });
+
+  return {
+    activeSearchTerm,
+    loading,
+    pendingTargets,
+    searchResult,
+    providerTargets,
+    selectedProviders,
+    singleType,
+    genreOnly,
+    search,
+    filteredItems,
+  };
+}
+
+const emptyResults = (): SearchResults => ({
+  artists: [],
+  albums: [],
+  tracks: [],
+  playlists: [],
+  radio: [],
+  podcasts: [],
+  audiobooks: [],
+  genres: [],
+});
+
+const isEmptyResult = (result: SearchResults): boolean =>
+  !result.artists?.length &&
+  !result.albums?.length &&
+  !result.tracks?.length &&
+  !result.playlists?.length &&
+  !result.radio?.length &&
+  !result.podcasts?.length &&
+  !result.audiobooks?.length &&
+  !result.genres?.length;
+
+// Keeps the relative order but floats items whose name matches the query
+// exactly, so a late provider with the exact hit still lands on top.
+const floatExactMatches = function <T extends { name?: string }>(
+  items: T[],
+  query: string,
+): T[] {
+  if (items.length < 2 || !query) return items;
+  const exact: T[] = [];
+  const rest: T[] = [];
+  for (const item of items) {
+    (item.name?.toLowerCase() === query ? exact : rest).push(item);
+  }
+  return exact.length ? exact.concat(rest) : items;
+};
+
+const collectField = function <T extends { name?: string }>(
+  results: SearchResults[],
+  pick: (result: SearchResults) => T[] | undefined,
+  query: string,
+): T[] {
+  const items: T[] = [];
+  for (const result of results) items.push(...(pick(result) || []));
+  return floatExactMatches(items, query);
+};

--- a/src/views/Search.vue
+++ b/src/views/Search.vue
@@ -87,71 +87,30 @@ import EditorialShelf from "@/components/discover/EditorialShelf.vue";
 import FacetedFilter from "@/components/FacetedFilter.vue";
 import ItemsListing from "@/components/ItemsListing.vue";
 import { SearchInput } from "@/components/ui/search-input";
+import {
+  LIBRARY_SEARCH_TARGET,
+  SEARCHABLE_MEDIA_TYPES,
+  useProgressiveSearch,
+} from "@/composables/useProgressiveSearch";
 import { useUserPreferences } from "@/composables/userPreferences";
 import { panelViewItemResponsive } from "@/helpers/utils";
-import { api } from "@/plugins/api";
 import { itemIsAvailable } from "@/plugins/api/helpers";
-import {
-  Genre,
-  MediaType,
-  ProviderFeature,
-  SearchResults,
-} from "@/plugins/api/interfaces";
+import { MediaType } from "@/plugins/api/interfaces";
 import { $t } from "@/plugins/i18n";
 import { store } from "@/plugins/store";
 import { computed, onBeforeUnmount, onMounted, ref, watch } from "vue";
 
-// virtual search target for the server's library search
-const LIBRARY_TARGET = "library";
-
-const SEARCHABLE_MEDIA_TYPES = [
-  MediaType.TRACK,
-  MediaType.ARTIST,
-  MediaType.ALBUM,
-  MediaType.PLAYLIST,
-  MediaType.PODCAST,
-  MediaType.AUDIOBOOK,
-  MediaType.RADIO,
-  MediaType.GENRE,
-];
-
-// The server answers each per-provider search request within a soft timeout;
-// a provider that is slower returns an empty result while its search continues
-// in the background server-side (and gets cached once done). An empty result
-// that took at least this long is treated as such a soft timeout and retried
-// shortly after, picking up the cached result.
-const SOFT_TIMEOUT_MS = 7000;
-const SOFT_TIMEOUT_RETRY_DELAY_MS = 2500;
-const MAX_SOFT_TIMEOUT_RETRIES = 3;
-
-interface SearchTarget {
-  // instance_id for local providers, domain for streaming providers
-  id: string;
-  name: string;
-  iconDomain: string;
-}
-
 // local refs
 const searchHasFocus = ref(false);
-const activeSearchTerm = ref("");
-const providerResults = ref<{ [targetId: string]: SearchResults }>({});
-const pendingTargets = ref(new Set<string>());
-const libraryGenresFallback = ref<Genre[]>([]);
 const throttleId = ref();
 const listingRef = ref<InstanceType<typeof ItemsListing>>();
-const retryTimers = new Map<string, ReturnType<typeof setTimeout>>();
 let listingReloadTimer: ReturnType<typeof setTimeout> | undefined;
-// guards stale responses: bumped on every new search, responses for an older
-// search id are discarded
-let currentSearchId = 0;
 const { getPreference, setPreference } = useUserPreferences();
 // search targets stored as the included subset; empty means all targets
 const selectedProvidersPref = getPreference<string[]>(
   "globalSearchProviders",
   [],
 );
-
-const loading = computed(() => pendingTargets.value.size > 0);
 
 // Responsive tile sizing, shared curve with the rest of the app.
 const tilesPerView = computed(() => panelViewItemResponsive(0) + 0.5);
@@ -170,102 +129,40 @@ const mediaTypeOptions = computed(() =>
   })),
 );
 
-// exactly one selected media type: results are shown as a single listing
-const singleType = computed(() =>
-  store.globalSearchMediaTypes.length === 1
-    ? store.globalSearchMediaTypes[0]
-    : undefined,
+const storedProviders = computed<string[]>(() =>
+  Array.isArray(selectedProvidersPref.value) ? selectedProvidersPref.value : [],
 );
 
-// genres live in the library only, so a genre-only search skips the providers
-const genreOnly = computed(() => singleType.value === MediaType.GENRE);
-
-// All selectable search targets, mirroring the server's provider
-// de-duplication: streaming providers are collapsed to one target per domain
-// (the server only ever searches a single instance of the same streaming
-// service), local/plugin providers get one target per instance.
-const providerTargets = computed<SearchTarget[]>(() => {
-  const targets: SearchTarget[] = [];
-  const seenStreamingDomains = new Set<string>();
-  for (const provider of Object.values(api.providers)) {
-    if (!provider.available) continue;
-    if (!provider.supported_features.includes(ProviderFeature.SEARCH)) continue;
-    if (provider.is_streaming_provider) {
-      if (seenStreamingDomains.has(provider.domain)) continue;
-      seenStreamingDomains.add(provider.domain);
-      targets.push({
-        id: provider.domain,
-        name: api.providerManifests[provider.domain]?.name || provider.name,
-        iconDomain: provider.domain,
-      });
-    } else {
-      targets.push({
-        id: provider.instance_id,
-        name: provider.name,
-        iconDomain: provider.domain,
-      });
-    }
-  }
-  return targets.sort((a, b) => a.name.localeCompare(b.name));
+const {
+  loading,
+  searchResult,
+  providerTargets,
+  selectedProviders,
+  singleType,
+  genreOnly,
+  search,
+  filteredItems,
+} = useProgressiveSearch({
+  mediaTypes: selectedMediaTypes,
+  providers: storedProviders,
 });
 
-const providerOptions = computed(() => [
-  // the library is always searched, shown as a locked entry
-  { label: $t("library"), value: LIBRARY_TARGET, locked: true },
-  ...providerTargets.value.map((target) => ({
-    label: target.name,
-    value: target.id,
-  })),
-]);
-
 const selectedSearchProviders = computed<string[]>({
-  // ignore stale ids of removed providers so the filter count stays accurate
-  get: () => {
-    const stored = Array.isArray(selectedProvidersPref.value)
-      ? selectedProvidersPref.value
-      : [];
-    return stored.filter((id) =>
-      providerTargets.value.some((target) => target.id === id),
-    );
-  },
+  // the composable drops stale ids of removed providers from the selection
+  get: () => selectedProviders.value,
   set: (val) => {
     setPreference("globalSearchProviders", val);
   },
 });
 
-// The library is always searched; an empty provider selection means all.
-const enabledTargetIds = computed(() => {
-  const selected = selectedSearchProviders.value;
-  return [
-    LIBRARY_TARGET,
-    ...providerTargets.value
-      .filter((target) => !selected.length || selected.includes(target.id))
-      .map((target) => target.id),
-  ];
-});
-
-// Merge the per-target results in a stable order (library first, then
-// providers) and float exact name matches to the top, approximating the
-// ranking of the server's combined search.
-const searchResult = computed<SearchResults | undefined>(() => {
-  if (!activeSearchTerm.value) return undefined;
-  const query = activeSearchTerm.value.toLowerCase().trim();
-  const ordered = enabledTargetIds.value
-    .map((targetId) => providerResults.value[targetId])
-    .filter((result) => !!result);
-  const merged: SearchResults = {
-    artists: collectField(ordered, (r) => r.artists, query),
-    albums: collectField(ordered, (r) => r.albums, query),
-    tracks: collectField(ordered, (r) => r.tracks, query),
-    playlists: collectField(ordered, (r) => r.playlists, query),
-    radio: collectField(ordered, (r) => r.radio, query),
-    podcasts: collectField(ordered, (r) => r.podcasts, query),
-    audiobooks: collectField(ordered, (r) => r.audiobooks, query),
-    genres: collectField(ordered, (r) => r.genres, query),
-  };
-  if (!merged.genres.length) merged.genres = [...libraryGenresFallback.value];
-  return merged;
-});
+const providerOptions = computed(() => [
+  // the library is always searched, shown as a locked entry
+  { label: $t("library"), value: LIBRARY_SEARCH_TARGET, locked: true },
+  ...providerTargets.value.map((target) => ({
+    label: target.name,
+    value: target.id,
+  })),
+]);
 
 const singleTypeHasItems = computed(
   () => !!singleType.value && filteredItems(singleType.value).length > 0,
@@ -337,23 +234,18 @@ watch(
   () => {
     clearTimeout(throttleId.value);
     throttleId.value = setTimeout(() => {
-      loadSearchResults(store.globalSearchTerm);
+      setPreference("globalSearch", store.globalSearchTerm || "");
+      search(store.globalSearchTerm);
     }, 1000);
   },
   { immediate: true },
 );
+// selection changes re-search via the composable; only persist them here
 watch(
   () => store.globalSearchMediaTypes.join(","),
   () => {
     setPreference("globalSearchMediaTypes", store.globalSearchMediaTypes);
-    loadSearchResults(store.globalSearchTerm);
   },
-);
-// selection changes and (re)connected providers: search any enabled target
-// that has no result yet for the active query
-watch(
-  () => enabledTargetIds.value.join(","),
-  () => ensureTargetResults(),
 );
 // The single-media-type listing pulls its items through the load-items
 // callback; nudge it to reload when new provider results stream in (coalesced,
@@ -363,57 +255,6 @@ watch(searchResult, () => {
   clearTimeout(listingReloadTimer);
   listingReloadTimer = setTimeout(() => listingRef.value?.reload(), 150);
 });
-
-const loadSearchResults = async function (searchTerm?: string) {
-  currentSearchId += 1;
-  const searchId = currentSearchId;
-  for (const timer of retryTimers.values()) clearTimeout(timer);
-  retryTimers.clear();
-  providerResults.value = {};
-  pendingTargets.value = new Set();
-  libraryGenresFallback.value = [];
-  activeSearchTerm.value = searchTerm || "";
-  setPreference("globalSearch", searchTerm || "");
-  if (!searchTerm) return;
-
-  if (genreOnly.value) {
-    // Genre-only search: use library search directly
-    pendingTargets.value.add(LIBRARY_TARGET);
-    try {
-      const genres = await api.getLibraryGenres({
-        search: searchTerm,
-        limit: 50,
-        offset: 0,
-        order_by: "name",
-      });
-      if (searchId !== currentSearchId) return;
-      providerResults.value[LIBRARY_TARGET] = { ...emptyResults(), genres };
-    } catch (err) {
-      console.error("Genre search failed", err);
-    }
-    if (searchId === currentSearchId) {
-      pendingTargets.value.delete(LIBRARY_TARGET);
-    }
-    return;
-  }
-
-  const mediaTypes = store.globalSearchMediaTypes;
-  if (!mediaTypes.length || mediaTypes.includes(MediaType.GENRE)) {
-    // supplement the shelves with (library) genre results
-    api
-      .getLibraryGenres({
-        search: searchTerm,
-        limit: 8,
-        offset: 0,
-        order_by: "name",
-      })
-      .then((genres) => {
-        if (searchId === currentSearchId) libraryGenresFallback.value = genres;
-      })
-      .catch((err) => console.error("Genre search failed", err));
-  }
-  ensureTargetResults();
-};
 
 onMounted(() => {
   if (!store.globalSearchTerm) {
@@ -466,123 +307,7 @@ onBeforeUnmount(() => {
   document.removeEventListener("keyup", keyListener);
   clearTimeout(throttleId.value);
   clearTimeout(listingReloadTimer);
-  for (const timer of retryTimers.values()) clearTimeout(timer);
-  retryTimers.clear();
 });
-
-const filteredItems = function (mediaType: MediaType) {
-  if (!searchResult.value) return [];
-  if (mediaType == MediaType.TRACK) return searchResult.value.tracks;
-  if (mediaType == MediaType.ARTIST) return searchResult.value.artists;
-  if (mediaType == MediaType.ALBUM) return searchResult.value.albums;
-  if (mediaType == MediaType.PLAYLIST) return searchResult.value.playlists;
-  if (mediaType == MediaType.PODCAST) return searchResult.value.podcasts;
-  if (mediaType == MediaType.AUDIOBOOK) return searchResult.value.audiobooks;
-  if (mediaType == MediaType.RADIO) return searchResult.value.radio;
-  if (mediaType == MediaType.GENRE) return searchResult.value.genres;
-  return [];
-};
-
-const emptyResults = (): SearchResults => ({
-  artists: [],
-  albums: [],
-  tracks: [],
-  playlists: [],
-  radio: [],
-  podcasts: [],
-  audiobooks: [],
-  genres: [],
-});
-
-const isEmptyResult = (result: SearchResults): boolean =>
-  !result.artists?.length &&
-  !result.albums?.length &&
-  !result.tracks?.length &&
-  !result.playlists?.length &&
-  !result.radio?.length &&
-  !result.podcasts?.length &&
-  !result.audiobooks?.length &&
-  !result.genres?.length;
-
-// Keeps the relative order but floats items whose name matches the query
-// exactly, so a late provider with the exact hit still lands on top.
-const floatExactMatches = function <T extends { name?: string }>(
-  items: T[],
-  query: string,
-): T[] {
-  if (items.length < 2 || !query) return items;
-  const exact: T[] = [];
-  const rest: T[] = [];
-  for (const item of items) {
-    (item.name?.toLowerCase() === query ? exact : rest).push(item);
-  }
-  return exact.length ? exact.concat(rest) : items;
-};
-
-const collectField = function <T extends { name?: string }>(
-  results: SearchResults[],
-  pick: (result: SearchResults) => T[] | undefined,
-  query: string,
-): T[] {
-  const items: T[] = [];
-  for (const result of results) items.push(...(pick(result) || []));
-  return floatExactMatches(items, query);
-};
-
-// Fire a search for every enabled target that has no result yet; used on
-// search start, on selection changes and when providers (re)connect.
-const ensureTargetResults = function () {
-  if (!activeSearchTerm.value) return;
-  if (genreOnly.value) return;
-  for (const targetId of enabledTargetIds.value) {
-    if (providerResults.value[targetId]) continue;
-    if (pendingTargets.value.has(targetId)) continue;
-    searchTarget(currentSearchId, targetId);
-  }
-};
-
-// One search request for a single target (library or one provider); the
-// response is merged into the view as soon as it arrives.
-const searchTarget = async function (
-  searchId: number,
-  targetId: string,
-  attempt = 0,
-) {
-  if (searchId !== currentSearchId) return;
-  const selectedTypes = store.globalSearchMediaTypes;
-  const limit = singleType.value ? 50 : 8;
-  const mediaTypes = selectedTypes.length ? selectedTypes : undefined;
-  pendingTargets.value.add(targetId);
-  const started = Date.now();
-  let result: SearchResults | undefined;
-  try {
-    result = await api.search(activeSearchTerm.value, mediaTypes, limit, [
-      targetId,
-    ]);
-  } catch (err) {
-    console.error(`Search on ${targetId} failed`, err);
-  }
-  if (searchId !== currentSearchId) return;
-  if (
-    result &&
-    isEmptyResult(result) &&
-    Date.now() - started >= SOFT_TIMEOUT_MS &&
-    attempt < MAX_SOFT_TIMEOUT_RETRIES
-  ) {
-    // soft timeout: the provider search continues in the background
-    // server-side, retry shortly to pick up the cached result
-    retryTimers.set(
-      targetId,
-      setTimeout(() => {
-        retryTimers.delete(targetId);
-        searchTarget(searchId, targetId, attempt + 1);
-      }, SOFT_TIMEOUT_RETRY_DELAY_MS),
-    );
-    return;
-  }
-  providerResults.value[targetId] = result || emptyResults();
-  pendingTargets.value.delete(targetId);
-};
 </script>
 
 <style scoped>

--- a/tests/composables/useProgressiveSearch.test.ts
+++ b/tests/composables/useProgressiveSearch.test.ts
@@ -1,0 +1,335 @@
+import {
+  MediaType,
+  ProviderFeature,
+  type SearchResults,
+  type Track,
+} from "@/plugins/api/interfaces";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { effectScope, nextTick, ref, type EffectScope } from "vue";
+
+const { mockSearch, mockGetLibraryGenres, mockProviders, mockManifests } =
+  vi.hoisted(() => {
+    return {
+      mockSearch: vi.fn(),
+      mockGetLibraryGenres: vi.fn(),
+      mockProviders: {} as Record<string, unknown>,
+      mockManifests: {} as Record<string, unknown>,
+    };
+  });
+
+vi.mock("@/plugins/api", () => ({
+  api: {
+    providers: mockProviders,
+    providerManifests: mockManifests,
+    search: mockSearch,
+    getLibraryGenres: mockGetLibraryGenres,
+  },
+}));
+
+import {
+  LIBRARY_SEARCH_TARGET,
+  useProgressiveSearch,
+  type ProgressiveSearchOptions,
+} from "@/composables/useProgressiveSearch";
+
+const emptyResults = (): SearchResults => ({
+  artists: [],
+  albums: [],
+  tracks: [],
+  playlists: [],
+  radio: [],
+  podcasts: [],
+  audiobooks: [],
+  genres: [],
+});
+
+const results = (partial: Partial<SearchResults>): SearchResults => ({
+  ...emptyResults(),
+  ...partial,
+});
+
+const track = (itemId: string, name: string): Track =>
+  ({
+    item_id: itemId,
+    name,
+    uri: `test://track/${itemId}`,
+    media_type: MediaType.TRACK,
+  }) as Track;
+
+const provider = (
+  instanceId: string,
+  domain: string,
+  name: string,
+  overrides: Record<string, unknown> = {},
+) => ({
+  instance_id: instanceId,
+  domain,
+  name,
+  available: true,
+  is_streaming_provider: false,
+  supported_features: [ProviderFeature.SEARCH],
+  ...overrides,
+});
+
+const flush = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+describe("useProgressiveSearch", () => {
+  const scopes: EffectScope[] = [];
+
+  const setup = function (options: Partial<ProgressiveSearchOptions> = {}) {
+    const mediaTypes = options.mediaTypes ?? ref<MediaType[]>([]);
+    const scope = effectScope();
+    scopes.push(scope);
+    const composable = scope.run(() =>
+      useProgressiveSearch({ ...options, mediaTypes }),
+    )!;
+    return { ...composable, mediaTypes };
+  };
+
+  beforeEach(() => {
+    mockSearch.mockReset();
+    mockSearch.mockResolvedValue(emptyResults());
+    mockGetLibraryGenres.mockReset();
+    mockGetLibraryGenres.mockResolvedValue([]);
+    for (const key of Object.keys(mockProviders)) delete mockProviders[key];
+    for (const key of Object.keys(mockManifests)) delete mockManifests[key];
+    Object.assign(mockProviders, {
+      "spotify-a": provider("spotify-a", "spotify", "Spotify A", {
+        is_streaming_provider: true,
+      }),
+      "spotify-b": provider("spotify-b", "spotify", "Spotify B", {
+        is_streaming_provider: true,
+      }),
+      fs1: provider("fs1", "filesystem_local", "Filesystem music"),
+      offline: provider("offline", "tidal", "Tidal", {
+        is_streaming_provider: true,
+        available: false,
+      }),
+      nosearch: provider("nosearch", "sonos", "Sonos", {
+        supported_features: [],
+      }),
+    });
+    Object.assign(mockManifests, {
+      spotify: { name: "Spotify" },
+      filesystem_local: { name: "Filesystem" },
+    });
+  });
+
+  afterEach(() => {
+    while (scopes.length) scopes.pop()!.stop();
+    vi.useRealTimers();
+  });
+
+  it("collapses streaming providers per domain and skips unusable providers", () => {
+    const { providerTargets } = setup();
+
+    expect(providerTargets.value).toEqual([
+      { id: "fs1", name: "Filesystem music", iconDomain: "filesystem_local" },
+      { id: "spotify", name: "Spotify", iconDomain: "spotify" },
+    ]);
+  });
+
+  it("fires one request per target and merges results library first", async () => {
+    mockSearch.mockImplementation(
+      (_query, _mediaTypes, _limit, providers: string[]) => {
+        if (providers[0] === LIBRARY_SEARCH_TARGET)
+          return Promise.resolve(results({ tracks: [track("l1", "Lib hit")] }));
+        if (providers[0] === "spotify")
+          return Promise.resolve(
+            results({ tracks: [track("s1", "Spotify hit")] }),
+          );
+        return Promise.resolve(emptyResults());
+      },
+    );
+    const { search, searchResult, loading } = setup();
+
+    await search("hit");
+    await flush();
+
+    const requestedTargets = mockSearch.mock.calls.map(
+      (call) => call[3],
+    ) as string[][];
+    expect(requestedTargets).toEqual(
+      expect.arrayContaining([[LIBRARY_SEARCH_TARGET], ["fs1"], ["spotify"]]),
+    );
+    expect(searchResult.value?.tracks.map((item) => item.name)).toEqual([
+      "Lib hit",
+      "Spotify hit",
+    ]);
+    expect(loading.value).toBe(false);
+  });
+
+  it("floats exact name matches above earlier fuzzy results", async () => {
+    mockSearch.mockImplementation(
+      (_query, _mediaTypes, _limit, providers: string[]) => {
+        if (providers[0] === LIBRARY_SEARCH_TARGET)
+          return Promise.resolve(
+            results({ tracks: [track("l1", "Queen tribute")] }),
+          );
+        if (providers[0] === "spotify")
+          return Promise.resolve(results({ tracks: [track("s1", "Queen")] }));
+        return Promise.resolve(emptyResults());
+      },
+    );
+    const { search, searchResult } = setup();
+
+    await search("queen");
+    await flush();
+
+    expect(searchResult.value?.tracks.map((item) => item.name)).toEqual([
+      "Queen",
+      "Queen tribute",
+    ]);
+  });
+
+  it("passes the selected media types and the single-type limit", async () => {
+    const mediaTypes = ref<MediaType[]>([MediaType.TRACK]);
+    const { search } = setup({
+      mediaTypes,
+      limits: { single: 50, multi: 8 },
+    });
+
+    await search("query");
+    await flush();
+
+    expect(mockSearch).toHaveBeenCalledWith(
+      "query",
+      [MediaType.TRACK],
+      50,
+      expect.anything(),
+    );
+  });
+
+  it("clamps the selection and requests to the allowed media types", async () => {
+    const mediaTypes = ref<MediaType[]>([MediaType.RADIO]);
+    const { search, singleType } = setup({
+      mediaTypes,
+      allowedMediaTypes: [MediaType.TRACK, MediaType.PLAYLIST],
+    });
+
+    // out-of-scope selection is ignored: all allowed types are searched
+    expect(singleType.value).toBeUndefined();
+    await search("query");
+    await flush();
+
+    expect(mockSearch).toHaveBeenCalledWith(
+      "query",
+      [MediaType.TRACK, MediaType.PLAYLIST],
+      8,
+      expect.anything(),
+    );
+  });
+
+  it("discards responses of a superseded search", async () => {
+    let resolveFirst!: (value: SearchResults) => void;
+    mockSearch.mockImplementation((query: string) => {
+      if (query === "first")
+        return new Promise<SearchResults>((resolve) => {
+          resolveFirst = resolve;
+        });
+      return Promise.resolve(results({ tracks: [track("t2", "Second")] }));
+    });
+    const { search, searchResult } = setup();
+
+    await search("first");
+    await search("second");
+    resolveFirst(results({ tracks: [track("t1", "First")] }));
+    await flush();
+
+    expect(searchResult.value?.tracks.map((item) => item.name)).toEqual([
+      "Second",
+      "Second",
+      "Second",
+    ]);
+  });
+
+  it("retries a provider that hit the server's soft timeout", async () => {
+    vi.useFakeTimers();
+    let spotifyCalls = 0;
+    mockSearch.mockImplementation(
+      (_query, _mediaTypes, _limit, providers: string[]) => {
+        if (providers[0] !== "spotify") return Promise.resolve(emptyResults());
+        spotifyCalls += 1;
+        if (spotifyCalls === 1) {
+          // empty response only after the soft timeout elapsed
+          return new Promise<SearchResults>((resolve) =>
+            setTimeout(() => resolve(emptyResults()), 8000),
+          );
+        }
+        return Promise.resolve(results({ tracks: [track("s1", "Late")] }));
+      },
+    );
+    const { search, searchResult, loading } = setup();
+
+    await search("late");
+    await vi.advanceTimersByTimeAsync(8000);
+    expect(spotifyCalls).toBe(1);
+    expect(loading.value).toBe(true);
+
+    await vi.advanceTimersByTimeAsync(2500);
+    expect(spotifyCalls).toBe(2);
+    expect(searchResult.value?.tracks.map((item) => item.name)).toEqual([
+      "Late",
+    ]);
+    expect(loading.value).toBe(false);
+  });
+
+  it("searches only the library for a genre-only search", async () => {
+    const genres = [{ item_id: "g1", name: "Rock" }];
+    mockGetLibraryGenres.mockResolvedValue(genres);
+    const mediaTypes = ref<MediaType[]>([MediaType.GENRE]);
+    const { search, searchResult } = setup({ mediaTypes });
+
+    await search("rock");
+    await flush();
+
+    expect(mockSearch).not.toHaveBeenCalled();
+    expect(mockGetLibraryGenres).toHaveBeenCalledWith(
+      expect.objectContaining({ search: "rock", limit: 50 }),
+    );
+    expect(searchResult.value?.genres).toEqual(genres);
+  });
+
+  it("treats a whitespace-only term as a reset", async () => {
+    const { search, searchResult, activeSearchTerm } = setup();
+
+    await search("   ");
+    await flush();
+
+    expect(mockSearch).not.toHaveBeenCalled();
+    expect(activeSearchTerm.value).toBe("");
+    expect(searchResult.value).toBeUndefined();
+  });
+
+  it("drops stale provider ids from the selection and the fan-out", async () => {
+    const providers = ref(["spotify", "removed-provider"]);
+    const { search, selectedProviders } = setup({ providers });
+
+    expect(selectedProviders.value).toEqual(["spotify"]);
+    await search("query");
+    await flush();
+
+    const requestedTargets = mockSearch.mock.calls
+      .map((call) => (call[3] as string[])[0])
+      .sort();
+    expect(requestedTargets).toEqual([LIBRARY_SEARCH_TARGET, "spotify"]);
+  });
+
+  it("searches a newly selected provider for the active query", async () => {
+    const providers = ref(["fs1"]);
+    const { search } = setup({ providers });
+
+    await search("query");
+    await flush();
+    expect(mockSearch).toHaveBeenCalledTimes(2); // library + fs1
+
+    providers.value = ["fs1", "spotify"];
+    await nextTick();
+    await flush();
+
+    expect(mockSearch).toHaveBeenCalledTimes(3);
+    expect(mockSearch).toHaveBeenLastCalledWith("query", undefined, 8, [
+      "spotify",
+    ]);
+  });
+});


### PR DESCRIPTION
Prep work for reusing the fast global search beyond the Search page: party mode, the Music Quiz and other places where users quickly search for media.

**Changes:**
- Moved the progressive search engine (per-provider requests, result merging, slow-provider retries) out of the Search view into a reusable `useProgressiveSearch` composable
- The composable takes options for allowed media types, selected media types/providers and result limits, so embedded consumers can restrict what gets searched
- Stale provider ids are now dropped from the selection inside the composable, keeping every consumer robust against removed providers
- No functional changes to the Search page
