### PR TITLE
Allow a library-only search from the provider filter

### DIFF
--- a/src/components/FacetedFilter.vue
+++ b/src/components/FacetedFilter.vue
@@ -58,16 +58,14 @@
             v-for="option in filteredOptions"
             :key="option.value"
             class="faceted-filter-item"
-            :class="{ 'faceted-filter-item--locked': option.locked }"
             role="checkbox"
-            :aria-checked="option.locked || selectedSet.has(option.value)"
-            :aria-disabled="option.locked"
-            :tabindex="option.locked ? -1 : 0"
-            @click="toggle(option)"
-            @keydown.space.prevent="toggle(option)"
+            :aria-checked="selectedSet.has(option.value)"
+            tabindex="0"
+            @click="toggle(option.value)"
+            @keydown.space.prevent="toggle(option.value)"
           >
             <Checkbox
-              :model-value="option.locked || selectedSet.has(option.value)"
+              :model-value="selectedSet.has(option.value)"
               class="mr-2 pointer-events-none"
               tabindex="-1"
               aria-hidden="true"
@@ -110,9 +108,6 @@ import { Separator } from "@/components/ui/separator";
 interface FacetedOption {
   label: string;
   value: TValue;
-  // locked options render as permanently checked and cannot be toggled;
-  // they are not part of the model value (e.g. an always-active entry)
-  locked?: boolean;
 }
 
 const props = defineProps<{
@@ -142,13 +137,12 @@ const filteredOptions = computed(() => {
   return props.options.filter((opt) => opt.label.toLowerCase().includes(term));
 });
 
-const toggle = (option: FacetedOption) => {
-  if (option.locked) return;
+const toggle = (value: TValue) => {
   const next = new Set(selectedSet.value);
-  if (next.has(option.value)) {
-    next.delete(option.value);
+  if (next.has(value)) {
+    next.delete(value);
   } else {
-    next.add(option.value);
+    next.add(value);
   }
   emit("update:modelValue", Array.from(next));
 };
@@ -195,15 +189,6 @@ const clear = () => {
 
 .faceted-filter-item:hover {
   background-color: rgba(var(--v-theme-on-surface), 0.04);
-}
-
-.faceted-filter-item--locked {
-  opacity: 0.55;
-  cursor: default;
-}
-
-.faceted-filter-item--locked:hover {
-  background-color: transparent;
 }
 
 .faceted-filter-clear {

--- a/src/components/FacetedFilter.vue
+++ b/src/components/FacetedFilter.vue
@@ -63,6 +63,7 @@
             tabindex="0"
             @click="toggle(option.value)"
             @keydown.space.prevent="toggle(option.value)"
+            @keydown.enter.prevent="toggle(option.value)"
           >
             <Checkbox
               :model-value="selectedSet.has(option.value)"

--- a/src/composables/useProgressiveSearch.ts
+++ b/src/composables/useProgressiveSearch.ts
@@ -40,7 +40,8 @@ export interface SearchTarget {
 export interface ProgressiveSearchOptions {
   // selected media types; an empty selection searches all allowed types
   mediaTypes: Ref<MediaType[]>;
-  // selected provider target ids; an empty selection searches all targets
+  // selected search targets ("library" and/or provider target ids); an
+  // empty selection searches all targets
   providers?: Ref<string[]>;
   // media types this consumer can search at all (default: all searchable)
   allowedMediaTypes?: MediaType[];
@@ -131,22 +132,26 @@ export function useProgressiveSearch(options: ProgressiveSearchOptions) {
     return targets.sort((a, b) => a.name.localeCompare(b.name));
   });
 
-  // the provider selection with stale ids of removed providers dropped
+  // the target selection with stale ids of removed providers dropped
   const selectedProviders = computed(() =>
-    selectedProvidersInput.value.filter((id) =>
-      providerTargets.value.some((target) => target.id === id),
+    selectedProvidersInput.value.filter(
+      (id) =>
+        id === LIBRARY_SEARCH_TARGET ||
+        providerTargets.value.some((target) => target.id === id),
     ),
   );
 
-  // The library is always searched; an empty provider selection means all.
+  // An empty selection searches everything: the library plus all providers.
+  // A non-empty selection searches exactly the selected targets, so a
+  // library-only search is possible too.
   const enabledTargetIds = computed(() => {
-    const selected = selectedProviders.value;
-    return [
+    const allTargetIds = [
       LIBRARY_SEARCH_TARGET,
-      ...providerTargets.value
-        .filter((target) => !selected.length || selected.includes(target.id))
-        .map((target) => target.id),
+      ...providerTargets.value.map((target) => target.id),
     ];
+    const selected = selectedProviders.value;
+    if (!selected.length) return allTargetIds;
+    return allTargetIds.filter((id) => selected.includes(id));
   });
 
   // Merge the per-target results in a stable order (library first, then

--- a/src/views/Search.vue
+++ b/src/views/Search.vue
@@ -156,8 +156,7 @@ const selectedSearchProviders = computed<string[]>({
 });
 
 const providerOptions = computed(() => [
-  // the library is always searched, shown as a locked entry
-  { label: $t("library"), value: LIBRARY_SEARCH_TARGET, locked: true },
+  { label: $t("library"), value: LIBRARY_SEARCH_TARGET },
   ...providerTargets.value.map((target) => ({
     label: target.name,
     value: target.id,

--- a/tests/composables/useProgressiveSearch.test.ts
+++ b/tests/composables/useProgressiveSearch.test.ts
@@ -301,7 +301,7 @@ describe("useProgressiveSearch", () => {
     expect(searchResult.value).toBeUndefined();
   });
 
-  it("drops stale provider ids from the selection and the fan-out", async () => {
+  it("searches exactly the selected targets and drops stale provider ids", async () => {
     const providers = ref(["spotify", "removed-provider"]);
     const { search, selectedProviders } = setup({ providers });
 
@@ -312,7 +312,21 @@ describe("useProgressiveSearch", () => {
     const requestedTargets = mockSearch.mock.calls
       .map((call) => (call[3] as string[])[0])
       .sort();
-    expect(requestedTargets).toEqual([LIBRARY_SEARCH_TARGET, "spotify"]);
+    expect(requestedTargets).toEqual(["spotify"]);
+  });
+
+  it("searches only the library when just the library is selected", async () => {
+    const providers = ref([LIBRARY_SEARCH_TARGET]);
+    const { search, selectedProviders } = setup({ providers });
+
+    expect(selectedProviders.value).toEqual([LIBRARY_SEARCH_TARGET]);
+    await search("query");
+    await flush();
+
+    expect(mockSearch).toHaveBeenCalledTimes(1);
+    expect(mockSearch).toHaveBeenCalledWith("query", undefined, 8, [
+      LIBRARY_SEARCH_TARGET,
+    ]);
   });
 
   it("searches a newly selected provider for the active query", async () => {
@@ -321,13 +335,13 @@ describe("useProgressiveSearch", () => {
 
     await search("query");
     await flush();
-    expect(mockSearch).toHaveBeenCalledTimes(2); // library + fs1
+    expect(mockSearch).toHaveBeenCalledTimes(1); // fs1 only
 
     providers.value = ["fs1", "spotify"];
     await nextTick();
     await flush();
 
-    expect(mockSearch).toHaveBeenCalledTimes(3);
+    expect(mockSearch).toHaveBeenCalledTimes(2);
     expect(mockSearch).toHaveBeenLastCalledWith("query", undefined, 8, [
       "spotify",
     ]);


### PR DESCRIPTION
The library entry in the search provider filter was always selected and could not be turned off, which made a library-only search impossible and behaved differently from the media type filter next to it.

Both filters now work the same way: an empty selection searches everything, a selection searches exactly what you picked.

**Changes:**
- The library is a regular option in the provider filter: select only "Library" for a library-only search, or leave the filter empty to search everything
- Removed the locked/always-on option support from the filter component again (no longer used)
