### PR TITLE
Fix home widget cleanup

### DIFF
--- a/src/components/HomeWidgetRows.vue
+++ b/src/components/HomeWidgetRows.vue
@@ -301,7 +301,6 @@ import {
   GripVertical,
   RefreshCw,
 } from "@lucide/vue";
-import { useDebounceFn } from "@vueuse/core";
 import {
   computed,
   nextTick,
@@ -739,24 +738,46 @@ const loadGenres = async () => {
   genres.value = ranked.slice(0, 8);
 };
 
-const refreshRecommendations = useDebounceFn(async () => {
-  await loadRecommendations();
-  // Keeps the same picks while the cache is fresh; rebuilds once expired.
-  resolveHeroPicks();
-}, 1500);
+let isUnmounted = false;
+let refreshRecommendationsTimer: ReturnType<typeof setTimeout> | undefined;
+
+const cancelScheduledRecommendationRefresh = () => {
+  if (refreshRecommendationsTimer) {
+    clearTimeout(refreshRecommendationsTimer);
+    refreshRecommendationsTimer = undefined;
+  }
+};
+
+const scheduleRecommendationRefresh = () => {
+  cancelScheduledRecommendationRefresh();
+  refreshRecommendationsTimer = setTimeout(async () => {
+    refreshRecommendationsTimer = undefined;
+    if (isUnmounted) return;
+    await loadRecommendations();
+    if (isUnmounted) return;
+    // Keeps the same picks while the cache is fresh; rebuilds once expired.
+    resolveHeroPicks();
+  }, 1500);
+};
+
+const isFinishedPlaybackEvent = (
+  data: unknown,
+): data is { is_playing: false } =>
+  typeof data === "object" &&
+  data !== null &&
+  "is_playing" in data &&
+  data.is_playing === false;
 
 const unsubscribeRecommendations = api.subscribe(
   EventType.MEDIA_ITEM_PLAYED,
   (evt: EventMessage) => {
     // Only refetch when a track actually finished (is_playing = false),
     // not on the periodic ~30s progress reports that also emit this event.
-    if (evt.data && !(evt.data as Record<string, unknown>).is_playing) {
-      refreshRecommendations();
+    if (isFinishedPlaybackEvent(evt.data)) {
+      scheduleRecommendationRefresh();
     }
   },
 );
-
-let isUnmounted = false;
 
 onMounted(async () => {
   await Promise.all([loadRecommendations(), loadGenres()]);
@@ -773,6 +794,7 @@ onBeforeUnmount(() => {
   isUnmounted = true;
   window.removeEventListener("resize", updateHeroNav);
   unsubscribeRecommendations();
+  cancelScheduledRecommendationRefresh();
   heroRo?.disconnect();
   heroRo = undefined;
   observedHeroGrid = null;

--- a/src/components/HomeWidgetRows.vue
+++ b/src/components/HomeWidgetRows.vue
@@ -518,14 +518,22 @@ const scrollHero = (dir: number) => {
 };
 
 let heroRo: ResizeObserver | undefined;
+let observedHeroGrid: HTMLElement | null = null;
+
 const observeHero = () => {
   const el = heroGrid.value;
-  if (!el) return;
-  updateHeroNav();
-  if ("ResizeObserver" in window && !heroRo) {
-    heroRo = new ResizeObserver(updateHeroNav);
-    heroRo.observe(el);
+  if (!(el instanceof HTMLElement)) {
+    heroRo?.disconnect();
+    observedHeroGrid = null;
+    return;
   }
+  updateHeroNav();
+  if (!("ResizeObserver" in window)) return;
+  heroRo ??= new ResizeObserver(updateHeroNav);
+  if (observedHeroGrid === el) return;
+  heroRo.disconnect();
+  heroRo.observe(el);
+  observedHeroGrid = el;
 };
 
 watch(heroEntries, () => nextTick(observeHero), { deep: false });
@@ -731,35 +739,43 @@ const loadGenres = async () => {
   genres.value = ranked.slice(0, 8);
 };
 
+const refreshRecommendations = useDebounceFn(async () => {
+  await loadRecommendations();
+  // Keeps the same picks while the cache is fresh; rebuilds once expired.
+  resolveHeroPicks();
+}, 1500);
+
+const unsubscribeRecommendations = api.subscribe(
+  EventType.MEDIA_ITEM_PLAYED,
+  (evt: EventMessage) => {
+    // Only refetch when a track actually finished (is_playing = false),
+    // not on the periodic ~30s progress reports that also emit this event.
+    if (evt.data && !(evt.data as Record<string, unknown>).is_playing) {
+      refreshRecommendations();
+    }
+  },
+);
+
+let isUnmounted = false;
+
 onMounted(async () => {
   await Promise.all([loadRecommendations(), loadGenres()]);
+  if (isUnmounted) return;
   resolveHeroPicks();
   loading.value = false;
-  nextTick(observeHero);
+  nextTick(() => {
+    if (!isUnmounted) observeHero();
+  });
   window.addEventListener("resize", updateHeroNav);
-
-  const refreshRecommendations = useDebounceFn(async () => {
-    await loadRecommendations();
-    // Keeps the same picks while the cache is fresh; rebuilds once expired.
-    resolveHeroPicks();
-  }, 1500);
-
-  const unsub = api.subscribe(
-    EventType.MEDIA_ITEM_PLAYED,
-    (evt: EventMessage) => {
-      // Only refetch when a track actually finished (is_playing = false),
-      // not on the periodic ~30s progress reports that also emit this event.
-      if (evt.data && !(evt.data as Record<string, unknown>).is_playing) {
-        refreshRecommendations();
-      }
-    },
-  );
-  onBeforeUnmount(unsub);
 });
 
 onBeforeUnmount(() => {
+  isUnmounted = true;
   window.removeEventListener("resize", updateHeroNav);
+  unsubscribeRecommendations();
   heroRo?.disconnect();
+  heroRo = undefined;
+  observedHeroGrid = null;
 });
 </script>
 


### PR DESCRIPTION
I was playing around with the new Safari MCP server, just to see what it could do. Well, one thing it can do is that it found a bug where the Top Pick's horizontal scrollbar could desync in mobile Safari and a problem with cleaning up MEDIA_ITEM_PLAYED when leaving Discover. The lifecycle bug also affects Chrome.

Commit message:

Guard the Top Picks resize observer against stale or missing DOM refs, and rebind it when the grid element changes. Register recommendation event cleanup synchronously so Vue can dispose it reliably on unmount.