### PR TITLE
Faster search for party guests

### DIFF
--- a/src/components/FacetedFilter.vue
+++ b/src/components/FacetedFilter.vue
@@ -61,17 +61,15 @@
             v-for="option in filteredOptions"
             :key="option.value"
             class="faceted-filter-item"
-            :class="{ 'faceted-filter-item--locked': option.locked }"
             role="checkbox"
-            :aria-checked="option.locked || selectedSet.has(option.value)"
-            :aria-disabled="option.locked"
-            :tabindex="option.locked ? -1 : 0"
-            @click="toggle(option)"
-            @keydown.space.prevent="toggle(option)"
-            @keydown.enter.prevent="toggle(option)"
+            :aria-checked="selectedSet.has(option.value)"
+            tabindex="0"
+            @click="toggle(option.value)"
+            @keydown.space.prevent="toggle(option.value)"
+            @keydown.enter.prevent="toggle(option.value)"
           >
             <Checkbox
-              :model-value="option.locked || selectedSet.has(option.value)"
+              :model-value="selectedSet.has(option.value)"
               class="mr-2 pointer-events-none"
               tabindex="-1"
               aria-hidden="true"
@@ -114,9 +112,6 @@ import { Separator } from "@/components/ui/separator";
 interface FacetedOption {
   label: string;
   value: TValue;
-  // locked options render as permanently checked and cannot be toggled;
-  // they are not part of the model value (e.g. an always-active entry)
-  locked?: boolean;
 }
 
 const props = defineProps<{
@@ -146,13 +141,12 @@ const filteredOptions = computed(() => {
   return props.options.filter((opt) => opt.label.toLowerCase().includes(term));
 });
 
-const toggle = (option: FacetedOption) => {
-  if (option.locked) return;
+const toggle = (value: TValue) => {
   const next = new Set(selectedSet.value);
-  if (next.has(option.value)) {
-    next.delete(option.value);
+  if (next.has(value)) {
+    next.delete(value);
   } else {
-    next.add(option.value);
+    next.add(value);
   }
   emit("update:modelValue", Array.from(next));
 };
@@ -199,15 +193,6 @@ const clear = () => {
 
 .faceted-filter-item:hover {
   background-color: rgba(var(--v-theme-on-surface), 0.04);
-}
-
-.faceted-filter-item--locked {
-  opacity: 0.55;
-  cursor: default;
-}
-
-.faceted-filter-item--locked:hover {
-  background-color: transparent;
 }
 
 .faceted-filter-clear {

--- a/src/composables/useGuestSearch.ts
+++ b/src/composables/useGuestSearch.ts
@@ -1,23 +1,80 @@
 /**
  * Guest search composable for search, filtering, artist drill-down,
  * and infinite scroll on search results.
+ *
+ * Search runs through the progressive engine: the library and fast providers
+ * show up right away and slower providers merge in while the guest watches.
  */
 
-import { ref, computed, watch } from "vue";
+import { useProgressiveSearch } from "@/composables/useProgressiveSearch";
+import { sortByRelevance } from "@/helpers/relevanceScoring";
 import api from "@/plugins/api";
 import { MediaType, type Artist, type Track } from "@/plugins/api/interfaces";
-import { sortByRelevance } from "@/helpers/relevanceScoring";
 import { $t } from "@/plugins/i18n";
+import { computed, ref, watch } from "vue";
 import { toast } from "vue-sonner";
+
+const MIN_SEARCH_LENGTH = 2;
+const SEARCH_DEBOUNCE_MS = 500;
+const PAGE_SIZE = 10;
+
+const dedupeKey = (item: Track | Artist): string | null => {
+  if (!item.name) return null;
+  if (item.media_type === MediaType.ARTIST)
+    return `artist:${item.name.toLowerCase()}`;
+  const artist =
+    "artists" in item ? item.artists?.[0]?.name?.toLowerCase() || "" : "";
+  return `track:${item.name.toLowerCase()}:${artist}`;
+};
 
 export function useGuestSearch() {
   // Search state
   const searchQuery = ref("");
-  const searchResults = ref<(Track | Artist)[]>([]);
-  const searching = ref(false);
   const hasSearched = ref(false);
   const searchFilter = ref<"all" | "track" | "artist">("all");
   let searchDebounceTimer: ReturnType<typeof setTimeout> | null = null;
+
+  const selectedMediaTypes = computed<MediaType[]>(() => {
+    if (searchFilter.value === "track") return [MediaType.TRACK];
+    if (searchFilter.value === "artist") return [MediaType.ARTIST];
+    return [MediaType.TRACK, MediaType.ARTIST];
+  });
+
+  const {
+    activeSearchTerm,
+    loading: searching,
+    searchResult,
+    search,
+  } = useProgressiveSearch({
+    mediaTypes: selectedMediaTypes,
+    allowedMediaTypes: [MediaType.TRACK, MediaType.ARTIST],
+    limits: { single: 25, multi: 25 },
+  });
+
+  const searchResults = computed<(Track | Artist)[]>(() => {
+    const result = searchResult.value;
+    if (!result) return [];
+    let combined: (Track | Artist)[];
+    if (searchFilter.value === "track") {
+      combined = result.tracks;
+    } else if (searchFilter.value === "artist") {
+      combined = result.artists;
+    } else {
+      combined = [...result.tracks, ...result.artists];
+    }
+    // Guests see no provider badges, so the same artist/track from several
+    // providers reads as plain duplicates: keep the first occurrence only
+    // (the engine merges library results first).
+    const seen = new Set<string>();
+    combined = combined.filter((item) => {
+      const key = dedupeKey(item);
+      if (!key) return true;
+      if (seen.has(key)) return false;
+      seen.add(key);
+      return true;
+    });
+    return sortByRelevance(combined, activeSearchTerm.value);
+  });
 
   // Artist drill-down state
   const selectedArtist = ref<Artist | null>(null);
@@ -26,7 +83,7 @@ export function useGuestSearch() {
 
   // Infinite scroll state
   const resultsListRef = ref<HTMLElement | null>(null);
-  const displayedResultsCount = ref(10);
+  const displayedResultsCount = ref(PAGE_SIZE);
   const displayedResults = computed(() =>
     searchResults.value.slice(0, displayedResultsCount.value),
   );
@@ -36,8 +93,9 @@ export function useGuestSearch() {
     (document.activeElement as HTMLElement)?.blur();
   };
 
-  const performSearch = async () => {
-    if (!searchQuery.value || searchQuery.value.length < 2) return;
+  const performSearch = () => {
+    if (!searchQuery.value || searchQuery.value.length < MIN_SEARCH_LENGTH)
+      return;
 
     // Cancel any pending debounce to prevent double-fire when Enter triggers
     // an immediate search while a debounce timer is still pending
@@ -47,55 +105,26 @@ export function useGuestSearch() {
     }
 
     blurActiveElement();
-
-    searching.value = true;
     hasSearched.value = true;
-    try {
-      const mediaTypes: MediaType[] = [];
-      if (searchFilter.value === "all" || searchFilter.value === "track") {
-        mediaTypes.push(MediaType.TRACK);
-      }
-      if (searchFilter.value === "all" || searchFilter.value === "artist") {
-        mediaTypes.push(MediaType.ARTIST);
-      }
-
-      const results = await api.search(searchQuery.value, mediaTypes);
-
-      let combinedResults: (Track | Artist)[];
-      if (searchFilter.value === "track") {
-        combinedResults = results.tracks;
-      } else if (searchFilter.value === "artist") {
-        combinedResults = results.artists;
-      } else {
-        combinedResults = [...results.tracks, ...results.artists];
-      }
-
-      searchResults.value = sortByRelevance(combinedResults, searchQuery.value);
-      displayedResultsCount.value = 10;
-    } catch (error) {
-      console.error("Search failed:", error);
-      toast.error($t("providers.party.guest_page.search_failed"));
-    } finally {
-      searching.value = false;
-    }
+    search(searchQuery.value);
   };
 
   const debouncedSearch = () => {
     if (searchDebounceTimer) {
       clearTimeout(searchDebounceTimer);
     }
-    if (searchQuery.value && searchQuery.value.length >= 2) {
+    if (searchQuery.value && searchQuery.value.length >= MIN_SEARCH_LENGTH) {
       searchDebounceTimer = setTimeout(() => {
         performSearch();
-      }, 2000);
+      }, SEARCH_DEBOUNCE_MS);
     }
   };
 
   // Watch for search query changes
   watch(searchQuery, (newQuery) => {
-    if (!newQuery || newQuery.length < 2) {
+    if (!newQuery || newQuery.length < MIN_SEARCH_LENGTH) {
       if (hasSearched.value) {
-        searchResults.value = [];
+        search("");
         hasSearched.value = false;
       }
     } else {
@@ -103,11 +132,9 @@ export function useGuestSearch() {
     }
   });
 
-  // Watch for filter changes and re-search
-  watch(searchFilter, () => {
-    if (searchQuery.value && searchQuery.value.length >= 2) {
-      performSearch();
-    }
+  // a new search or filter change starts the result list from the top
+  watch([activeSearchTerm, searchFilter], () => {
+    displayedResultsCount.value = PAGE_SIZE;
   });
 
   const clearSearch = () => {
@@ -115,8 +142,8 @@ export function useGuestSearch() {
       clearTimeout(searchDebounceTimer);
     }
     searchQuery.value = "";
-    searchResults.value = [];
-    displayedResultsCount.value = 10;
+    search("");
+    displayedResultsCount.value = PAGE_SIZE;
     hasSearched.value = false;
     selectedArtist.value = null;
     artistTracks.value = [];
@@ -169,9 +196,8 @@ export function useGuestSearch() {
   };
 
   const loadMoreResults = () => {
-    const increment = 10;
     displayedResultsCount.value = Math.min(
-      displayedResultsCount.value + increment,
+      displayedResultsCount.value + PAGE_SIZE,
       searchResults.value.length,
     );
   };

--- a/src/views/PartyGuestView.vue
+++ b/src/views/PartyGuestView.vue
@@ -20,8 +20,12 @@
       @submit="performSearch"
     />
 
-    <!-- Search Loading State -->
-    <div v-if="searching && !selectedArtist" class="loading-state">
+    <!-- Search Loading State (results stream in progressively, so the big
+         spinner only shows while there is nothing to display yet) -->
+    <div
+      v-if="searching && searchResults.length === 0 && !selectedArtist"
+      class="loading-state"
+    >
       <Spinner class="size-12 text-primary" />
       <p>{{ $t("providers.party.guest_page.searching") }}</p>
     </div>
@@ -98,10 +102,7 @@
     </div>
 
     <!-- Search Results -->
-    <div
-      v-else-if="!searching && searchResults.length > 0"
-      class="results-section"
-    >
+    <div v-else-if="searchResults.length > 0" class="results-section">
       <div class="section-header">
         <h2 class="section-title">
           {{

--- a/tests/composables/useGuestSearch.test.ts
+++ b/tests/composables/useGuestSearch.test.ts
@@ -1,28 +1,49 @@
-import { MediaType, type Artist, type Track } from "@/plugins/api/interfaces";
+import {
+  MediaType,
+  ProviderFeature,
+  type Artist,
+  type SearchResults,
+  type Track,
+} from "@/plugins/api/interfaces";
 import { $t } from "@/plugins/i18n";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeEach, afterEach, describe, expect, it, vi } from "vitest";
+import { effectScope, type EffectScope } from "vue";
 
-const { mockSearch, mockGetArtistTracks, mockSortByRelevance, mockToast } =
-  vi.hoisted(() => {
-    return {
-      mockSearch: vi.fn(),
-      mockGetArtistTracks: vi.fn(),
-      mockSortByRelevance: vi.fn(<T>(items: T[], _query: string): T[] => items),
-      mockToast: {
-        success: vi.fn(),
-        error: vi.fn(),
-        warning: vi.fn(),
-        info: vi.fn(),
-      },
-    };
-  });
+const {
+  mockSearch,
+  mockGetArtistTracks,
+  mockGetLibraryGenres,
+  mockSortByRelevance,
+  mockToast,
+  mockProviders,
+  mockManifests,
+} = vi.hoisted(() => {
+  return {
+    mockSearch: vi.fn(),
+    mockGetArtistTracks: vi.fn(),
+    mockGetLibraryGenres: vi.fn(),
+    mockSortByRelevance: vi.fn(<T>(items: T[], _query: string): T[] => items),
+    mockToast: {
+      success: vi.fn(),
+      error: vi.fn(),
+      warning: vi.fn(),
+      info: vi.fn(),
+    },
+    mockProviders: {} as Record<string, unknown>,
+    mockManifests: {} as Record<string, unknown>,
+  };
+});
 
-vi.mock("@/plugins/api", () => ({
-  default: {
+vi.mock("@/plugins/api", () => {
+  const mockApi = {
+    providers: mockProviders,
+    providerManifests: mockManifests,
     search: mockSearch,
+    getLibraryGenres: mockGetLibraryGenres,
     getArtistTracks: mockGetArtistTracks,
-  },
-}));
+  };
+  return { api: mockApi, default: mockApi };
+});
 
 vi.mock("@/helpers/relevanceScoring", () => ({
   sortByRelevance: mockSortByRelevance,
@@ -34,22 +55,59 @@ vi.mock("vue-sonner", () => ({
 
 import { useGuestSearch } from "@/composables/useGuestSearch";
 
+const emptyResults = (): SearchResults => ({
+  artists: [],
+  albums: [],
+  tracks: [],
+  playlists: [],
+  radio: [],
+  podcasts: [],
+  audiobooks: [],
+  genres: [],
+});
+
+const results = (partial: Partial<SearchResults>): SearchResults => ({
+  ...emptyResults(),
+  ...partial,
+});
+
+const flush = () => new Promise((resolve) => setTimeout(resolve, 0));
+
 describe("useGuestSearch", () => {
+  const scopes: EffectScope[] = [];
+
+  const setup = function () {
+    const scope = effectScope();
+    scopes.push(scope);
+    return scope.run(() => useGuestSearch())!;
+  };
+
   beforeEach(() => {
     mockSearch.mockReset();
+    mockSearch.mockResolvedValue(emptyResults());
     mockGetArtistTracks.mockReset();
+    mockGetLibraryGenres.mockReset();
+    mockGetLibraryGenres.mockResolvedValue([]);
     mockSortByRelevance.mockClear();
     mockToast.success.mockReset();
     mockToast.error.mockReset();
     mockToast.warning.mockReset();
     mockToast.info.mockReset();
+    for (const key of Object.keys(mockProviders)) delete mockProviders[key];
+    for (const key of Object.keys(mockManifests)) delete mockManifests[key];
+  });
+
+  afterEach(() => {
+    while (scopes.length) scopes.pop()!.stop();
   });
 
   it("performs search with correct media types for 'all' filter", async () => {
-    mockSearch.mockResolvedValueOnce({
-      tracks: [{ type: "track", id: "t1" }],
-      artists: [{ type: "artist", id: "a1" }],
-    });
+    mockSearch.mockResolvedValueOnce(
+      results({
+        tracks: [{ type: "track", id: "t1" } as unknown as Track],
+        artists: [{ type: "artist", id: "a1" } as unknown as Artist],
+      }),
+    );
 
     const {
       searchQuery,
@@ -57,37 +115,46 @@ describe("useGuestSearch", () => {
       searchResults,
       displayedResultsCount,
       performSearch,
-    } = useGuestSearch();
+    } = setup();
 
     searchQuery.value = "test";
     searchFilter.value = "all";
 
-    await performSearch();
+    performSearch();
+    await flush();
 
-    expect(mockSearch).toHaveBeenCalledWith("test", [
-      MediaType.TRACK,
-      MediaType.ARTIST,
-    ]);
-    expect(mockSortByRelevance).toHaveBeenCalledTimes(1);
+    expect(mockSearch).toHaveBeenCalledWith(
+      "test",
+      [MediaType.TRACK, MediaType.ARTIST],
+      25,
+      ["library"],
+    );
     expect(searchResults.value).toHaveLength(2);
     expect(displayedResultsCount.value).toBe(10);
   });
 
   it("performs search with track-only filter", async () => {
-    mockSearch.mockResolvedValue({
-      tracks: [{ type: "track", id: "t1" }],
-      artists: [{ type: "artist", id: "a1" }],
-    });
+    mockSearch.mockResolvedValue(
+      results({
+        tracks: [{ type: "track", id: "t1" } as unknown as Track],
+        artists: [{ type: "artist", id: "a1" } as unknown as Artist],
+      }),
+    );
 
-    const { searchQuery, searchFilter, searchResults, performSearch } =
-      useGuestSearch();
+    const { searchQuery, searchFilter, searchResults, performSearch } = setup();
 
     searchQuery.value = "track search";
     searchFilter.value = "track";
 
-    await performSearch();
+    performSearch();
+    await flush();
 
-    expect(mockSearch).toHaveBeenCalledWith("track search", [MediaType.TRACK]);
+    expect(mockSearch).toHaveBeenCalledWith(
+      "track search",
+      [MediaType.TRACK],
+      25,
+      ["library"],
+    );
     expect(searchResults.value).toHaveLength(1);
     const typedResults = searchResults.value as unknown as Array<{
       type: string;
@@ -95,28 +162,115 @@ describe("useGuestSearch", () => {
     expect(typedResults.every((item) => item.type === "track")).toBe(true);
   });
 
-  it("handles search errors and shows snackbar", async () => {
+  it("shows results from fast providers while slower ones are searching", async () => {
+    mockProviders["spotify1"] = {
+      instance_id: "spotify1",
+      domain: "spotify",
+      name: "Spotify",
+      available: true,
+      is_streaming_provider: true,
+      supported_features: [ProviderFeature.SEARCH],
+    };
+    mockManifests["spotify"] = { name: "Spotify" };
+    let resolveSpotify!: (value: SearchResults) => void;
+    mockSearch.mockImplementation(
+      (_query, _mediaTypes, _limit, providers: string[]) => {
+        if (providers[0] === "library")
+          return Promise.resolve(
+            results({
+              tracks: [{ type: "track", id: "lib1" } as unknown as Track],
+            }),
+          );
+        return new Promise<SearchResults>((resolve) => {
+          resolveSpotify = resolve;
+        });
+      },
+    );
+
+    const { searchQuery, searchResults, searching, performSearch } = setup();
+
+    searchQuery.value = "progressive";
+    performSearch();
+    await flush();
+
+    // the library result is visible while spotify is still searching
+    expect(searchResults.value).toHaveLength(1);
+    expect(searching.value).toBe(true);
+
+    resolveSpotify(
+      results({
+        tracks: [{ type: "track", id: "sp1" } as unknown as Track],
+      }),
+    );
+    await flush();
+
+    expect(searchResults.value).toHaveLength(2);
+    expect(searching.value).toBe(false);
+  });
+
+  it("collapses the same item from multiple providers into one row", async () => {
+    mockProviders["spotify1"] = {
+      instance_id: "spotify1",
+      domain: "spotify",
+      name: "Spotify",
+      available: true,
+      is_streaming_provider: true,
+      supported_features: [ProviderFeature.SEARCH],
+    };
+    mockManifests["spotify"] = { name: "Spotify" };
+    mockSearch.mockImplementation(
+      (_query, _mediaTypes, _limit, providers: string[]) =>
+        Promise.resolve(
+          results({
+            artists: [
+              {
+                media_type: MediaType.ARTIST,
+                name: "Queen",
+                provider: providers[0],
+              } as unknown as Artist,
+            ],
+          }),
+        ),
+    );
+
+    const { searchQuery, searchResults, performSearch } = setup();
+
+    searchQuery.value = "queen";
+    performSearch();
+    await flush();
+
+    // one "Queen" row remains and it is the library one (merged first)
+    expect(searchResults.value).toHaveLength(1);
+    expect((searchResults.value[0] as Artist).provider).toBe("library");
+  });
+
+  it("handles search errors gracefully", async () => {
     mockSearch.mockRejectedValueOnce(new Error("Search failed"));
 
-    const { searchQuery, performSearch, searching, hasSearched } =
-      useGuestSearch();
+    const {
+      searchQuery,
+      searchResults,
+      performSearch,
+      searching,
+      hasSearched,
+    } = setup();
 
     searchQuery.value = "error";
 
-    await performSearch();
+    performSearch();
+    await flush();
 
-    expect(mockToast.error).toHaveBeenCalledWith(
-      $t("providers.party.guest_page.search_failed"),
-    );
+    expect(searchResults.value).toEqual([]);
     expect(searching.value).toBe(false);
     expect(hasSearched.value).toBe(true);
   });
 
   it("clears search state correctly", async () => {
-    mockSearch.mockResolvedValueOnce({
-      tracks: [{ type: "track", id: "t1" }],
-      artists: [],
-    });
+    mockSearch.mockResolvedValueOnce(
+      results({
+        tracks: [{ type: "track", id: "t1" } as unknown as Track],
+      }),
+    );
 
     const {
       searchQuery,
@@ -127,10 +281,11 @@ describe("useGuestSearch", () => {
       hasSearched,
       performSearch,
       clearSearch,
-    } = useGuestSearch();
+    } = setup();
 
     searchQuery.value = "something";
-    await performSearch();
+    performSearch();
+    await flush();
 
     hasSearched.value = true;
     selectedArtist.value = {} as unknown as Artist;
@@ -151,7 +306,7 @@ describe("useGuestSearch", () => {
     mockGetArtistTracks.mockResolvedValueOnce(tracks);
 
     const { selectedArtist, artistTracks, loadingArtistTracks, selectArtist } =
-      useGuestSearch();
+      setup();
 
     const artist = {
       provider_mappings: [
@@ -173,7 +328,7 @@ describe("useGuestSearch", () => {
     );
 
     const { selectedArtist, artistTracks, loadingArtistTracks, selectArtist } =
-      useGuestSearch();
+      setup();
 
     const artist = {
       provider_mappings: [
@@ -192,13 +347,14 @@ describe("useGuestSearch", () => {
   });
 
   it("loads more results when scrolling near the bottom", async () => {
-    mockSearch.mockResolvedValueOnce({
-      tracks: Array.from({ length: 30 }, (_, i) => ({
-        type: "track",
-        id: `t${i}`,
-      })),
-      artists: [],
-    });
+    mockSearch.mockResolvedValueOnce(
+      results({
+        tracks: Array.from(
+          { length: 30 },
+          (_, i) => ({ type: "track", id: `t${i}` }) as unknown as Track,
+        ),
+      }),
+    );
 
     const {
       searchQuery,
@@ -206,10 +362,11 @@ describe("useGuestSearch", () => {
       displayedResultsCount,
       performSearch,
       handleScroll,
-    } = useGuestSearch();
+    } = setup();
 
     searchQuery.value = "scroll";
-    await performSearch();
+    performSearch();
+    await flush();
 
     expect(searchResults.value.length).toBe(30);
     expect(displayedResultsCount.value).toBe(10);


### PR DESCRIPTION
The party guest search waited for the slowest music provider before showing anything, hidden behind a long debounce and a full-screen spinner.

Guest search now runs on the same progressive engine as the Search page: the library and fast providers appear right away and slower providers merge in while the guest watches.

**Changes:**
- Results show as each provider responds; the spinner only covers the moment where nothing has arrived yet
- Typing triggers the search after half a second instead of two
- The same artist or track returned by multiple providers is shown only once (guests see no provider labels, so duplicates were just noise); the library copy wins
- Also removes the unused locked-option support in the filter component that accidentally came back with #2075
