### PR TITLE
Show rankings during Music Quiz

### DIFF
--- a/src/components/music-quiz/MusicQuizLeaderboard.vue
+++ b/src/components/music-quiz/MusicQuizLeaderboard.vue
@@ -1,25 +1,41 @@
 <template>
-  <Card class="gap-4 py-4">
-    <CardHeader class="px-4">
-      <CardTitle class="text-base">
+  <Card :class="compact ? 'gap-2 py-2' : 'gap-4 py-4'">
+    <CardHeader :class="compact ? 'px-3' : 'px-4'">
+      <CardTitle :class="compact ? 'text-sm' : 'text-base'">
         {{ title ?? $t("providers.music_quiz.leaderboard") }}
       </CardTitle>
     </CardHeader>
-    <CardContent class="px-4">
-      <TransitionGroup tag="ol" name="quiz-rank" class="flex flex-col gap-1">
+    <CardContent
+      :class="
+        compact ? 'max-h-56 overflow-y-auto overscroll-contain px-2' : 'px-4'
+      "
+    >
+      <TransitionGroup
+        tag="ol"
+        name="quiz-rank"
+        class="flex flex-col"
+        :class="compact ? 'gap-0.5' : 'gap-1'"
+      >
         <li
           v-for="row in rows"
           :key="row.name"
-          class="flex items-center gap-3 rounded-lg px-2 py-1.5"
-          :class="{ 'bg-primary/10': row.name === currentPlayerName }"
+          class="flex items-center rounded-lg"
+          :class="[
+            compact ? 'gap-2 px-1.5 py-1 text-sm' : 'gap-3 px-2 py-1.5',
+            { 'bg-primary/10': row.name === currentPlayerName },
+          ]"
           :aria-current="row.name === currentPlayerName ? 'true' : undefined"
         >
           <span
-            class="text-muted-foreground w-6 shrink-0 text-center font-bold tabular-nums"
+            class="text-muted-foreground shrink-0 text-center font-bold tabular-nums"
+            :class="compact ? 'w-5' : 'w-6'"
           >
             {{ row.rank }}
           </span>
-          <MusicQuizAvatar :name="row.name" class="size-8 shrink-0" />
+          <MusicQuizAvatar
+            :name="row.name"
+            :class="compact ? 'size-6 shrink-0' : 'size-8 shrink-0'"
+          />
           <span
             class="min-w-0 flex-1 truncate font-medium"
             :class="{
@@ -57,6 +73,7 @@ defineProps<{
   rows: MusicQuizLeaderboardRow[];
   currentPlayerName?: string;
   title?: string;
+  compact?: boolean;
 }>();
 </script>
 

--- a/src/components/music-quiz/MusicQuizPlayerStage.vue
+++ b/src/components/music-quiz/MusicQuizPlayerStage.vue
@@ -10,7 +10,9 @@
   </section>
 
   <section
-    v-else-if="state.phase === 'answering' && currentRound"
+    v-else-if="
+      (state.phase === 'answering' || state.phase === 'reveal') && currentRound
+    "
     class="flex flex-col gap-3"
   >
     <component
@@ -27,30 +29,10 @@
       :busy="busy"
       @submit="onSubmitAnswer"
     />
-  </section>
-
-  <section
-    v-else-if="state.phase === 'reveal' && currentRound"
-    class="flex flex-col gap-3"
-  >
-    <component
-      :is="gameComponent"
-      :state="state"
-      :current-round="currentRound"
-      :busy="busy"
-      @ready="emit('ready')"
-    />
-    <component
-      :is="answerComponent"
-      :state="state"
-      :current-round="currentRound"
-      :busy="busy"
-      @submit="onSubmitAnswer"
-    />
-
     <MusicQuizLeaderboard
       :rows="leaderboardRows"
       :current-player-name="state.you.name"
+      compact
     />
   </section>
 

--- a/tests/components/music-quiz/MusicQuizLeaderboard.test.ts
+++ b/tests/components/music-quiz/MusicQuizLeaderboard.test.ts
@@ -1,0 +1,68 @@
+import MusicQuizLeaderboard, {
+  type MusicQuizLeaderboardRow,
+} from "@/components/music-quiz/MusicQuizLeaderboard.vue";
+import { mount } from "@vue/test-utils";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@/plugins/i18n", () => ({
+  $t: (key: string) => key,
+}));
+
+const rows: MusicQuizLeaderboardRow[] = [
+  {
+    name: "Leader",
+    score: 20,
+    ready: false,
+    answered: true,
+    active_from_round: 0,
+    rank: 1,
+    roundScoreLabel: "+10",
+  },
+  {
+    name: "Current Player",
+    score: 10,
+    ready: false,
+    answered: true,
+    active_from_round: 0,
+    rank: 2,
+    roundScoreLabel: "",
+  },
+];
+
+describe("MusicQuizLeaderboard", () => {
+  it("renders compact rows in a bounded ranking card", () => {
+    const wrapper = mount(MusicQuizLeaderboard, {
+      props: {
+        rows,
+        currentPlayerName: "Current Player",
+        compact: true,
+      },
+    });
+
+    expect(wrapper.get('[data-slot="card"]').classes()).toEqual(
+      expect.arrayContaining(["gap-2", "py-2"]),
+    );
+    expect(wrapper.get('[data-slot="card-header"]').classes()).toContain(
+      "px-3",
+    );
+    expect(wrapper.get('[data-slot="card-title"]').classes()).toContain(
+      "text-sm",
+    );
+    expect(wrapper.get('[data-slot="card-content"]').classes()).toEqual(
+      expect.arrayContaining(["max-h-56", "overflow-y-auto", "px-2"]),
+    );
+
+    const renderedRows = wrapper.findAll("li");
+    expect(renderedRows).toHaveLength(2);
+    expect(renderedRows[0].text()).toContain("Leader");
+    expect(renderedRows[0].text()).toContain("20");
+    expect(renderedRows[0].text()).toContain("+10");
+    expect(renderedRows[1].text()).toContain("Current Player");
+    expect(renderedRows[1].text()).toContain("10");
+    expect(renderedRows[1].attributes("aria-current")).toBe("true");
+    expect(renderedRows[1].classes()).toContain("bg-primary/10");
+    expect(
+      renderedRows[1].findComponent({ name: "MusicQuizAvatar" }).classes(),
+    ).toContain("size-6");
+  });
+});

--- a/tests/components/music-quiz/MusicQuizStages.test.ts
+++ b/tests/components/music-quiz/MusicQuizStages.test.ts
@@ -4,7 +4,12 @@ import type {
   MusicQuizGuessTheSongHostState,
   MusicQuizGuessTheSongPersonalizedState,
   MusicQuizGuessTheSongRound,
+  MusicQuizHitsterPersonalizedState,
 } from "@/composables/useMusicQuiz";
+import {
+  baseRound as hitsterRound,
+  baseState as hitsterState,
+} from "./timelinePlayerFixtures";
 import { mount } from "@vue/test-utils";
 import { describe, expect, it, vi } from "vitest";
 
@@ -42,6 +47,23 @@ const answerAdapter = {
   emits: ["submit"],
   template:
     "<button data-testid=\"answer-adapter\" @click=\"$emit('submit', { answer_type: 'multiple_choice', suggestion_id: 'one' })\">Answer<slot name=\"leaderboard\" /></button>",
+};
+const timelineAnswerAdapter = {
+  props: {
+    state: { type: Object, required: true },
+    currentRound: { type: Object, required: true },
+    busy: Boolean,
+  },
+  emits: ["submit"],
+  template:
+    "<button data-testid=\"timeline-answer-adapter\" @click=\"$emit('submit', { answer_type: 'timeline', action: 'finish' })\">Timeline answer</button>",
+};
+const leaderboardStub = {
+  props: {
+    compact: Boolean,
+  },
+  template:
+    "<div data-testid=\"leaderboard\" :data-compact=\"compact ? 'true' : 'false'\" />",
 };
 const gameDefinition = {
   id: "guess_the_song",
@@ -140,6 +162,94 @@ describe("Music Quiz shared stages", () => {
         },
       ],
     ]);
+  });
+
+  it("keeps the compact leaderboard last while answering", () => {
+    const wrapper = mount(MusicQuizPlayerStage, {
+      props: {
+        state: playerState,
+        currentRound,
+        busy: false,
+        leaderboardRows,
+        winnerText: "",
+        gameComponent: gameAdapter,
+        answerComponent: answerAdapter,
+      },
+      global: {
+        stubs: {
+          MusicQuizLeaderboard: leaderboardStub,
+          MusicQuizPodium: true,
+        },
+      },
+    });
+
+    const leaderboard = wrapper.get('[data-testid="leaderboard"]');
+    expect(leaderboard.attributes("data-compact")).toBe("true");
+    expect(wrapper.get("section").element.lastElementChild).toBe(
+      leaderboard.element,
+    );
+  });
+
+  it("keeps the compact leaderboard last during timeline reveal", () => {
+    const state = {
+      ...hitsterState,
+      phase: "reveal",
+    } satisfies MusicQuizHitsterPersonalizedState;
+    const wrapper = mount(MusicQuizPlayerStage, {
+      props: {
+        state,
+        currentRound: hitsterRound,
+        busy: false,
+        leaderboardRows,
+        winnerText: "",
+        gameComponent: gameAdapter,
+        answerComponent: timelineAnswerAdapter,
+      },
+      global: {
+        stubs: {
+          MusicQuizLeaderboard: leaderboardStub,
+          MusicQuizPodium: true,
+        },
+      },
+    });
+
+    const leaderboard = wrapper.get('[data-testid="leaderboard"]');
+    expect(
+      wrapper.find('[data-testid="timeline-answer-adapter"]').exists(),
+    ).toBe(true);
+    expect(leaderboard.attributes("data-compact")).toBe("true");
+    expect(wrapper.get("section").element.lastElementChild).toBe(
+      leaderboard.element,
+    );
+  });
+
+  it("keeps the full leaderboard for final player results", () => {
+    const state = {
+      ...playerState,
+      phase: "finished",
+      current_round: null,
+    } satisfies MusicQuizGuessTheSongPersonalizedState;
+    const wrapper = mount(MusicQuizPlayerStage, {
+      props: {
+        state,
+        currentRound: null,
+        busy: false,
+        leaderboardRows,
+        winnerText: "Player wins",
+        gameComponent: gameAdapter,
+        answerComponent: answerAdapter,
+      },
+      global: {
+        stubs: {
+          MusicQuizLeaderboard: leaderboardStub,
+          MusicQuizPodium: true,
+        },
+      },
+    });
+
+    expect(
+      wrapper.get('[data-testid="leaderboard"]').attributes("data-compact"),
+    ).toBe("false");
   });
 
   it("keeps the shared leaderboard in the present answer slot", () => {


### PR DESCRIPTION
Guests can now follow the current standings throughout active Music Quiz rounds.

- Add a compact, mobile-friendly ranking table below gameplay
- Show it while answering and during reveals across all quiz types
- Keep the full leaderboard and podium for final results