### PR TITLE
Clarify Music Quiz replay actions

### DIFF
--- a/src/components/music-quiz/MusicQuizHostPanel.vue
+++ b/src/components/music-quiz/MusicQuizHostPanel.vue
@@ -60,14 +60,41 @@
               : $t("providers.music_quiz.next")
           }}
         </Button>
-        <Button
-          v-if="state.phase === 'finished'"
-          :disabled="busy"
-          @click="emit('reset')"
-        >
-          <RotateCcw class="size-4" />
-          {{ $t("providers.music_quiz.new_game") }}
-        </Button>
+        <ButtonGroup v-if="state.phase === 'finished'" class="w-full sm:w-fit">
+          <Button
+            class="grow sm:grow-0"
+            data-testid="play-again"
+            :disabled="busy"
+            type="button"
+            @click="emit('reset')"
+          >
+            <RotateCcw class="size-4" />
+            {{ $t("providers.music_quiz.play_again") }}
+          </Button>
+          <DropdownMenu>
+            <DropdownMenuTrigger as-child>
+              <Button
+                size="icon"
+                data-testid="play-again-menu"
+                :aria-label="$t('providers.music_quiz.set_up_new_game')"
+                :disabled="busy"
+                type="button"
+              >
+                <ChevronDown class="size-4" aria-hidden="true" />
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end">
+              <DropdownMenuItem
+                data-testid="set-up-new-game"
+                :disabled="busy"
+                @click="emit('setUpNewGame')"
+              >
+                <Plus class="size-4" />
+                {{ $t("providers.music_quiz.set_up_new_game") }}
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
+        </ButtonGroup>
       </div>
     </div>
   </div>
@@ -76,12 +103,21 @@
 <script setup lang="ts">
 import MusicQuizQrCard from "@/components/music-quiz/MusicQuizQrCard.vue";
 import { Button } from "@/components/ui/button";
+import { ButtonGroup } from "@/components/ui/button-group";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 import type { MusicQuizSupportedHostState } from "@/composables/useMusicQuiz";
 import { $t } from "@/plugins/i18n";
 import {
+  ChevronDown,
   Eye,
   Maximize2,
   Play,
+  Plus,
   RotateCcw,
   SkipForward,
   Square,
@@ -108,5 +144,6 @@ const emit = defineEmits<{
   reveal: [];
   next: [];
   reset: [];
+  setUpNewGame: [];
 }>();
 </script>

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1205,6 +1205,8 @@
             "finish": "Finish Quiz",
             "reset": "Reset Quiz",
             "new_game": "New Game",
+            "play_again": "Play again",
+            "set_up_new_game": "Set up new game…",
             "phase_waiting_for_players": "Waiting for players to join",
             "phase_answers_open": "Answers are open!",
             "phase_enjoy_track": "Enjoy the track!",

--- a/src/views/MusicQuizDashboardView.vue
+++ b/src/views/MusicQuizDashboardView.vue
@@ -98,7 +98,8 @@
           @start="host.start"
           @reveal="host.reveal"
           @next="host.next"
-          @reset="host.reset"
+          @reset="handleReplay"
+          @set-up-new-game="handleSetUpNewGame"
         >
           <template #game>
             <component
@@ -314,6 +315,16 @@ const showSetupDialog = ref(false);
 
 async function handleCreate(request: MusicQuizCreateRequest) {
   if (await host.create(request)) showSetupDialog.value = false;
+}
+
+async function handleReplay() {
+  if (busy.value) return;
+  await host.reset();
+}
+
+async function handleSetUpNewGame() {
+  if (busy.value) return;
+  if (await host.deleteGame()) showSetupDialog.value = true;
 }
 
 async function enterPresentMode() {

--- a/tests/components/music-quiz/MusicQuizHostPanel.test.ts
+++ b/tests/components/music-quiz/MusicQuizHostPanel.test.ts
@@ -3,12 +3,16 @@ import type {
   MusicQuizPhase,
   MusicQuizSupportedHostState,
 } from "@/composables/useMusicQuiz";
-import { mount } from "@vue/test-utils";
+import { flushPromises, mount } from "@vue/test-utils";
 import { describe, expect, it, vi } from "vitest";
 
 vi.mock("@/plugins/i18n", () => ({
   $t: (key: string) =>
-    key === "providers.music_quiz.end_game" ? "End game" : key,
+    ({
+      "providers.music_quiz.end_game": "End game",
+      "providers.music_quiz.play_again": "Play again",
+      "providers.music_quiz.set_up_new_game": "Set up new game…",
+    })[key] ?? key,
 }));
 
 vi.mock("@/helpers/utils", () => ({
@@ -33,16 +37,24 @@ const HOST_STATE: MusicQuizSupportedHostState = {
 };
 
 describe("MusicQuizHostPanel", () => {
-  it("offers the host an end-game action", async () => {
+  it("keeps Present mode and End game available", async () => {
     const wrapper = mountPanel("lobby");
 
+    const presentButton = wrapper
+      .findAll("button")
+      .find((button) =>
+        button.text().includes("providers.music_quiz.enter_present_mode"),
+      );
     const endGameButton = wrapper
       .findAll("button")
       .find((button) => button.text().includes("End game"));
+    expect(presentButton).toBeDefined();
     expect(endGameButton).toBeDefined();
     expect(wrapper.text()).not.toContain("Delete");
 
+    await presentButton?.trigger("click");
     await endGameButton?.trigger("click");
+    expect(wrapper.emitted("present")).toHaveLength(1);
     expect(wrapper.emitted("endGame")).toHaveLength(1);
   });
 
@@ -50,7 +62,7 @@ describe("MusicQuizHostPanel", () => {
     ["lobby", "providers.music_quiz.start"],
     ["answering", "providers.music_quiz.phase_reveal"],
     ["reveal", "providers.music_quiz.next"],
-    ["finished", "providers.music_quiz.new_game"],
+    ["finished", "Play again"],
   ] as const)(
     "keeps the %s lifecycle action in the shared control bar",
     (phase, actionLabel) => {
@@ -64,13 +76,58 @@ describe("MusicQuizHostPanel", () => {
       expect(actions.text()).toContain(actionLabel);
     },
   );
+
+  it("keeps replay separate from fresh setup", async () => {
+    const wrapper = mountPanel("finished");
+    const replayButton = wrapper.get('[data-testid="play-again"]');
+    const menuButton = wrapper.get('[data-testid="play-again-menu"]');
+
+    expect(replayButton.text()).toContain("Play again");
+    expect(wrapper.text()).not.toContain("New Game");
+    expect(menuButton.attributes("aria-label")).toBe("Set up new game…");
+    expect(menuButton.attributes("aria-haspopup")).toBe("menu");
+
+    await replayButton.trigger("click");
+    expect(wrapper.emitted("reset")).toHaveLength(1);
+    expect(wrapper.emitted("setUpNewGame")).toBeUndefined();
+
+    await menuButton.trigger("keydown", { key: "Enter" });
+    await flushPromises();
+    const setupItem = document.body.querySelector<HTMLElement>(
+      '[data-testid="set-up-new-game"]',
+    );
+    expect(setupItem?.textContent).toContain("Set up new game…");
+
+    setupItem?.dispatchEvent(
+      new KeyboardEvent("keydown", { key: "Enter", bubbles: true }),
+    );
+    await flushPromises();
+    expect(wrapper.emitted("setUpNewGame")).toHaveLength(1);
+    expect(wrapper.emitted("reset")).toHaveLength(1);
+
+    wrapper.unmount();
+  });
+
+  it("disables both finished-state actions while busy", async () => {
+    const wrapper = mountPanel("finished", true);
+    const replayButton = wrapper.get('[data-testid="play-again"]');
+    const menuButton = wrapper.get('[data-testid="play-again-menu"]');
+
+    expect(replayButton.attributes("disabled")).toBeDefined();
+    expect(menuButton.attributes("disabled")).toBeDefined();
+
+    await replayButton.trigger("click");
+    await menuButton.trigger("click");
+    expect(wrapper.emitted("reset")).toBeUndefined();
+    expect(wrapper.emitted("setUpNewGame")).toBeUndefined();
+  });
 });
 
-function mountPanel(phase: MusicQuizPhase) {
+function mountPanel(phase: MusicQuizPhase, busy = false) {
   return mount(MusicQuizHostPanel, {
     props: {
       state: { ...HOST_STATE, phase },
-      busy: false,
+      busy,
       joinLink: HOST_STATE.join_url,
       isLastRound: false,
     },

--- a/tests/views/MusicQuizDashboardHostActions.test.ts
+++ b/tests/views/MusicQuizDashboardHostActions.test.ts
@@ -1,14 +1,19 @@
 import MusicQuizDashboardView from "@/views/MusicQuizDashboardView.vue";
-import { mount } from "@vue/test-utils";
+import { flushPromises, mount } from "@vue/test-utils";
 import { nextTick, ref, type Ref } from "vue";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const { mockDeleteGame, mockResolveMusicQuizDefinition, mockUseMusicQuizHost } =
-  vi.hoisted(() => ({
-    mockDeleteGame: vi.fn(),
-    mockResolveMusicQuizDefinition: vi.fn(),
-    mockUseMusicQuizHost: vi.fn(),
-  }));
+const {
+  mockDeleteGame,
+  mockReset,
+  mockResolveMusicQuizDefinition,
+  mockUseMusicQuizHost,
+} = vi.hoisted(() => ({
+  mockDeleteGame: vi.fn(),
+  mockReset: vi.fn(),
+  mockResolveMusicQuizDefinition: vi.fn(),
+  mockUseMusicQuizHost: vi.fn(),
+}));
 
 vi.mock("@/composables/useMusicQuizHost", () => ({
   useMusicQuizHost: mockUseMusicQuizHost,
@@ -59,7 +64,7 @@ vi.mock("vue-sonner", () => ({
 const HOST_STATE = {
   quiz_type: "guess_the_song",
   answer_type: "multiple_choice",
-  phase: "lobby",
+  phase: "finished",
   name: "Quiz",
   round_count: 5,
   suggestion_count: 4,
@@ -74,12 +79,16 @@ const HOST_STATE = {
 } as const;
 
 let state: Ref<typeof HOST_STATE | null>;
+let busy: Ref<boolean>;
 
 describe("MusicQuizDashboardView host actions", () => {
   beforeEach(() => {
     state = ref({ ...HOST_STATE });
+    busy = ref(false);
     mockDeleteGame.mockReset();
     mockDeleteGame.mockResolvedValue(true);
+    mockReset.mockReset();
+    mockReset.mockResolvedValue(true);
     mockResolveMusicQuizDefinition.mockReset();
     mockResolveMusicQuizDefinition.mockReturnValue({
       answer: { adapters: {} },
@@ -87,7 +96,7 @@ describe("MusicQuizDashboardView host actions", () => {
     });
     mockUseMusicQuizHost.mockReset();
     mockUseMusicQuizHost.mockReturnValue({
-      busy: ref(false),
+      busy,
       availableQuizTypes: ref(["guess_the_song", "hitster"]),
       create: vi.fn(),
       currentRound: ref(null),
@@ -96,7 +105,7 @@ describe("MusicQuizDashboardView host actions", () => {
       joinLink: ref(HOST_STATE.join_url),
       loading: ref(false),
       next: vi.fn(),
-      reset: vi.fn(),
+      reset: mockReset,
       reveal: vi.fn(),
       start: vi.fn(),
       state,
@@ -124,6 +133,77 @@ describe("MusicQuizDashboardView host actions", () => {
 
     await confirmButton.trigger("click");
     expect(mockDeleteGame).toHaveBeenCalledOnce();
+  });
+
+  it("replays through reset without deleting or opening setup", async () => {
+    const wrapper = mountDashboard();
+
+    await wrapper.get('[data-testid="play-again"]').trigger("click");
+    await flushPromises();
+
+    expect(mockReset).toHaveBeenCalledOnce();
+    expect(mockDeleteGame).not.toHaveBeenCalled();
+    expect(wrapper.find('[data-testid="setup-wizard"]').exists()).toBe(false);
+  });
+
+  it("deletes the finished game before opening fresh setup", async () => {
+    let finishDelete!: () => void;
+    mockDeleteGame.mockImplementation(
+      () =>
+        new Promise<boolean>((resolve) => {
+          finishDelete = () => {
+            state.value = null;
+            resolve(true);
+          };
+        }),
+    );
+    const wrapper = mountDashboard();
+
+    await wrapper.get('[data-testid="set-up-new-game"]').trigger("click");
+    expect(mockDeleteGame).toHaveBeenCalledOnce();
+    expect(wrapper.find('[data-testid="setup-wizard"]').exists()).toBe(false);
+
+    finishDelete();
+    await flushPromises();
+    expect(wrapper.find('[data-testid="setup-wizard"]').exists()).toBe(true);
+  });
+
+  it("retains the finished game when fresh setup deletion fails", async () => {
+    mockDeleteGame.mockResolvedValue(false);
+    const wrapper = mountDashboard();
+
+    await wrapper.get('[data-testid="set-up-new-game"]').trigger("click");
+    await flushPromises();
+
+    expect(mockDeleteGame).toHaveBeenCalledOnce();
+    expect(state.value).toEqual(HOST_STATE);
+    expect(wrapper.find('[data-testid="setup-wizard"]').exists()).toBe(false);
+    expect(wrapper.find('[data-testid="play-again"]').exists()).toBe(true);
+  });
+
+  it("prevents overlapping replay and fresh setup actions", async () => {
+    mockReset.mockImplementation(() => {
+      busy.value = true;
+      return Promise.resolve(true);
+    });
+    const wrapper = mountDashboard();
+
+    const replayClick = wrapper
+      .get('[data-testid="play-again"]')
+      .trigger("click");
+    await wrapper.get('[data-testid="set-up-new-game"]').trigger("click");
+    await replayClick;
+
+    expect(mockReset).toHaveBeenCalledOnce();
+    expect(mockDeleteGame).not.toHaveBeenCalled();
+  });
+
+  it("keeps Present mode available", async () => {
+    const wrapper = mountDashboard();
+
+    await wrapper.get('[data-testid="enter-present"]').trigger("click");
+
+    expect(wrapper.find('[data-testid="present-stage"]').exists()).toBe(true);
   });
 
   it("returns to the compact empty state when the host state is cleared", async () => {
@@ -179,11 +259,14 @@ function mountDashboard() {
         MusicQuizConnectionBanners: true,
         MusicQuizSessionHeader: true,
         MusicQuizHostPanel: {
-          emits: ["endGame"],
+          props: ["busy"],
+          emits: ["endGame", "present", "reset", "setUpNewGame"],
           template:
-            '<button data-testid="open-end-dialog" @click="$emit(\'endGame\')" />',
+            '<div><button data-testid="open-end-dialog" @click="$emit(\'endGame\')" /><button data-testid="enter-present" :disabled="busy" @click="$emit(\'present\')" /><button data-testid="play-again" :disabled="busy" @click="$emit(\'reset\')" /><button data-testid="set-up-new-game" :disabled="busy" @click="$emit(\'setUpNewGame\')" /></div>',
         },
-        MusicQuizPresentStage: true,
+        MusicQuizPresentStage: {
+          template: '<div data-testid="present-stage" />',
+        },
         MusicQuizSessionPanels: true,
         MusicQuizSetupWizard: {
           template: '<div data-testid="setup-wizard" />',


### PR DESCRIPTION
The finished Music Quiz screen called its replay action “New Game,” even though it restarted the same configured game. It now clearly separates replaying from setting up a new game.

- Add a split **Play again** control that keeps the current quiz settings, sources, and players
- Add **Set up new game…** to close the finished game before opening the existing setup flow
- Keep both replay options disabled while host actions are busy