### PR TITLE
Simplify Music Quiz setup

### DIFF
--- a/src/components/music-quiz/game-types/guess-the-song/GuessTheSongSetup.vue
+++ b/src/components/music-quiz/game-types/guess-the-song/GuessTheSongSetup.vue
@@ -1,13 +1,6 @@
 <template>
   <div class="flex flex-col gap-5">
     <div class="grid gap-4 sm:grid-cols-2">
-      <Field class="sm:col-span-2">
-        <FieldLabel for="quiz-name">
-          {{ $t("providers.music_quiz.session_name") }}
-        </FieldLabel>
-        <Input id="quiz-name" v-model="name" />
-      </Field>
-
       <Field>
         <FieldLabel for="quiz-rounds">
           {{ $t("providers.music_quiz.rounds") }}
@@ -100,7 +93,6 @@ import type {
 } from "@/components/music-quiz/adapter_contracts";
 import { Button } from "@/components/ui/button";
 import { Field, FieldLabel } from "@/components/ui/field";
-import { Input } from "@/components/ui/input";
 import { NativeSelect } from "@/components/ui/native-select";
 import {
   NumberField,
@@ -127,7 +119,6 @@ const MAX_SECONDS = 120;
 defineProps<MusicQuizSetupAdapterProps>();
 const emit = defineEmits<MusicQuizSetupAdapterEmits>();
 
-const name = ref("");
 const roundCount = ref(5);
 const suggestionCount = ref(4);
 const answerDuration = ref(30);
@@ -144,8 +135,6 @@ function create() {
     difficulty: difficulty.value,
     source_uris: sourceUris.value,
   };
-  const trimmedName = name.value.trim();
-  if (trimmedName) config.name = trimmedName;
   emit("create", {
     quiz_type: "guess_the_song",
     answer_type: "multiple_choice",

--- a/src/components/music-quiz/game-types/hitster/HitsterSetup.vue
+++ b/src/components/music-quiz/game-types/hitster/HitsterSetup.vue
@@ -1,13 +1,6 @@
 <template>
   <div class="flex flex-col gap-5">
     <div class="grid gap-4 sm:grid-cols-2">
-      <Field class="sm:col-span-2">
-        <FieldLabel for="hitster-name">
-          {{ $t("providers.music_quiz.session_name") }}
-        </FieldLabel>
-        <Input id="hitster-name" v-model="name" />
-      </Field>
-
       <Field>
         <FieldLabel for="hitster-rounds">
           {{ $t("providers.music_quiz.rounds") }}
@@ -103,7 +96,6 @@ import type {
 } from "@/components/music-quiz/adapter_contracts";
 import { Button } from "@/components/ui/button";
 import { Field, FieldLabel } from "@/components/ui/field";
-import { Input } from "@/components/ui/input";
 import { NativeSelect } from "@/components/ui/native-select";
 import {
   NumberField,
@@ -128,7 +120,6 @@ const MAX_SECONDS = 300;
 defineProps<MusicQuizSetupAdapterProps>();
 const emit = defineEmits<MusicQuizSetupAdapterEmits>();
 
-const name = ref("");
 const roundCount = ref(5);
 const answerDuration = ref(30);
 const artistBonusMode = ref<MusicQuizTimelineBonusMode>("off");
@@ -159,8 +150,6 @@ function create() {
     artist_bonus_mode: artistBonusMode.value,
     title_bonus_mode: titleBonusMode.value,
   };
-  const trimmedName = name.value.trim();
-  if (trimmedName) config.name = trimmedName;
   emit("create", {
     quiz_type: "hitster",
     answer_type: "timeline",

--- a/src/components/music-quiz/game-types/trivia/TriviaSetup.vue
+++ b/src/components/music-quiz/game-types/trivia/TriviaSetup.vue
@@ -1,13 +1,6 @@
 <template>
   <div class="flex flex-col gap-5">
     <div class="grid gap-4 sm:grid-cols-2">
-      <Field class="sm:col-span-2">
-        <FieldLabel for="trivia-name">
-          {{ $t("providers.music_quiz.session_name") }}
-        </FieldLabel>
-        <Input id="trivia-name" v-model="name" />
-      </Field>
-
       <Field>
         <FieldLabel for="trivia-rounds">
           {{ $t("providers.music_quiz.rounds") }}
@@ -104,7 +97,6 @@ import type {
 } from "@/components/music-quiz/adapter_contracts";
 import { Button } from "@/components/ui/button";
 import { Field, FieldLabel } from "@/components/ui/field";
-import { Input } from "@/components/ui/input";
 import { NativeSelect } from "@/components/ui/native-select";
 import {
   NumberField,
@@ -131,7 +123,6 @@ const MAX_SECONDS = 300;
 defineProps<MusicQuizSetupAdapterProps>();
 const emit = defineEmits<MusicQuizSetupAdapterEmits>();
 
-const name = ref("");
 const roundCount = ref(5);
 const suggestionCount = ref(4);
 const answerDuration = ref(30);
@@ -148,8 +139,6 @@ function create() {
     difficulty: difficulty.value,
     source_uris: sourceUris.value,
   };
-  const trimmedName = name.value.trim();
-  if (trimmedName) config.name = trimmedName;
   emit("create", {
     quiz_type: "trivia",
     answer_type: "multiple_choice",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1240,7 +1240,6 @@
             "final_leaderboard": "Final leaderboard",
             "setup_placeholder": "Setup form coming soon",
             "connection_lost": "Connection lost, reconnecting...",
-            "session_name": "Quiz name",
             "rounds": "Rounds",
             "suggestions": "Answer choices",
             "answer_seconds": "Answer time (seconds)",

--- a/tests/components/music-quiz/GuessTheSongSetup.test.ts
+++ b/tests/components/music-quiz/GuessTheSongSetup.test.ts
@@ -149,7 +149,7 @@ describe("GuessTheSongSetup", () => {
     expect(wrapper.text()).not.toContain("Older result");
   });
 
-  it("emits a discriminated create request", async () => {
+  it("emits a name-free discriminated create request", async () => {
     mockSearch.mockResolvedValue({
       tracks: [],
       playlists: [
@@ -161,7 +161,7 @@ describe("GuessTheSongSetup", () => {
       ],
     });
     const wrapper = mountConfig();
-    expect(wrapper.get("#quiz-name").element).toHaveProperty("value", "");
+    expect(wrapper.find("#quiz-name").exists()).toBe(false);
 
     await wrapper
       .find('input[placeholder="providers.music_quiz.search_music"]')

--- a/tests/components/music-quiz/HitsterSetup.test.ts
+++ b/tests/components/music-quiz/HitsterSetup.test.ts
@@ -74,7 +74,7 @@ describe("HitsterSetup", () => {
     });
     expect(wrapper.text()).not.toContain("providers.music_quiz.difficulty");
     expect(wrapper.text()).not.toContain("providers.music_quiz.answer_choices");
-    expect(wrapper.get("#hitster-name").element).toHaveProperty("value", "");
+    expect(wrapper.find("#hitster-name").exists()).toBe(false);
 
     await wrapper
       .find('input[placeholder="providers.music_quiz.search_music"]')
@@ -103,7 +103,7 @@ describe("HitsterSetup", () => {
     });
   });
 
-  it("keeps the name optional and bonus modes independent", async () => {
+  it("keeps bonus modes independent without adding a name", async () => {
     const wrapper = mount(HitsterSetup, {
       props: { busy: false },
       global: {
@@ -113,7 +113,6 @@ describe("HitsterSetup", () => {
       },
     });
 
-    await wrapper.get("#hitster-name").setValue("  Friday Hitster  ");
     await wrapper.get("#hitster-artist-bonus").setValue("free_text");
     await wrapper.get("#hitster-title-bonus").setValue("multiple_choice");
     await wrapper
@@ -130,13 +129,14 @@ describe("HitsterSetup", () => {
       .find((button) => button.text().includes("create"))
       ?.trigger("click");
 
-    expect(wrapper.emitted("create")?.[0]?.[0]).toMatchObject({
+    const request = wrapper.emitted("create")?.[0]?.[0];
+    expect(request).toMatchObject({
       config: {
-        name: "Friday Hitster",
         artist_bonus_mode: "free_text",
         title_bonus_mode: "multiple_choice",
       },
     });
+    expect(request).not.toHaveProperty("config.name");
   });
 
   it("labels removable sources for keyboard and screen-reader users", async () => {

--- a/tests/components/music-quiz/MusicQuizSessionHeader.test.ts
+++ b/tests/components/music-quiz/MusicQuizSessionHeader.test.ts
@@ -34,7 +34,7 @@ function game(
 }
 
 describe("MusicQuizSessionHeader", () => {
-  it("shows the game identity, session, phase, round, and audio mode", () => {
+  it("uses a custom session name as the heading for named games", () => {
     const wrapper = mount(MusicQuizSessionHeader, {
       props: {
         game: game("guess_the_song", true),
@@ -55,7 +55,7 @@ describe("MusicQuizSessionHeader", () => {
         .attributes("aria-label"),
     ).toBeUndefined();
     expect(wrapper.text()).toContain("game.guess_the_song");
-    expect(wrapper.text()).toContain("Friday Quiz");
+    expect(wrapper.get("h2").text()).toBe("Friday Quiz");
     expect(wrapper.text()).toContain("Answers open");
     expect(wrapper.text()).toContain("Round 2 / 5");
     expect(wrapper.text()).toContain("providers.music_quiz.mode_remote");
@@ -64,7 +64,7 @@ describe("MusicQuizSessionHeader", () => {
     );
   });
 
-  it("never exposes playback mode for Trivia", () => {
+  it("uses the game label for unnamed games without playback mode", () => {
     const wrapper = mount(MusicQuizSessionHeader, {
       props: {
         game: game("trivia", false),
@@ -73,7 +73,7 @@ describe("MusicQuizSessionHeader", () => {
       },
     });
 
-    expect(wrapper.text()).toContain("game.trivia");
+    expect(wrapper.get("h2").text()).toBe("game.trivia");
     expect(wrapper.find('[data-testid="music-quiz-mode"]').exists()).toBe(
       false,
     );

--- a/tests/components/music-quiz/TriviaSetup.test.ts
+++ b/tests/components/music-quiz/TriviaSetup.test.ts
@@ -52,7 +52,6 @@ describe("TriviaSetup", () => {
 
     await wrapper.get('[data-testid="select-sources"]').trigger("click");
     await wrapper.get("#trivia-difficulty").setValue("hard");
-    await wrapper.get("#trivia-name").setValue("Friday Trivia");
     await nextTick();
     await wrapper
       .findAll("button")
@@ -70,14 +69,13 @@ describe("TriviaSetup", () => {
             answer_duration: 30,
             difficulty: "hard",
             source_uris: ["library://playlist/1", "library://genre/rock"],
-            name: "Friday Trivia",
           },
         },
       ],
     ]);
   });
 
-  it("omits a blank optional session name", async () => {
+  it("never renders or emits a session name", async () => {
     const wrapper = mount(TriviaSetup, {
       props: { busy: false },
       global: {
@@ -99,7 +97,7 @@ describe("TriviaSetup", () => {
       },
     });
 
-    expect(wrapper.get("#trivia-name").element).toHaveProperty("value", "");
+    expect(wrapper.find("#trivia-name").exists()).toBe(false);
     await wrapper.get('[data-testid="select-sources"]').trigger("click");
     await nextTick();
     await wrapper


### PR DESCRIPTION
Music Quiz setup currently asks hosts to name a game even though only one game can run at a time.

- Remove the quiz-name field from Guess the Song, Hitster, and Trivia
- Keep support for named games created by older clients or the API
- Cover name-free setup requests and named/unnamed game titles