### PR TITLE
Keep Quiz guests on the Quiz screen

### DIFF
--- a/src/composables/useGuestEntryResolver.ts
+++ b/src/composables/useGuestEntryResolver.ts
@@ -2,8 +2,13 @@ import {
   getMusicQuizInfo,
   isMusicQuizProviderEvent,
 } from "@/composables/useMusicQuiz";
+import {
+  createGuestQuizAffinity,
+  type GuestQuizAffinity,
+} from "@/helpers/guest_quiz_affinity";
 import { consumeMusicQuizJoinedGameEnded } from "@/helpers/music_quiz_guest_state";
 import api, { ConnectionState } from "@/plugins/api";
+import { authManager } from "@/plugins/auth";
 import { EventType, type EventMessage } from "@/plugins/api/interfaces";
 import {
   onBeforeUnmount,
@@ -27,24 +32,20 @@ export type GuestEntryState =
 export const guestEntryStateKey: InjectionKey<Readonly<Ref<GuestEntryState>>> =
   Symbol("guest-entry-state");
 
-export async function resolveGuestEntry(): Promise<GuestEntryState> {
-  const providerDomains = new Set(
-    Object.values(api.providers).map((provider) => provider.domain),
-  );
-  const hasMusicQuiz = providerDomains.has("music_quiz");
-
-  if (hasMusicQuiz) {
-    const game = await getMusicQuizInfo();
-    if (game) return "quiz";
-  }
-  if (providerDomains.has("party")) return "party";
-  return hasMusicQuiz ? "quiz-inactive" : "inactive";
+export async function resolveGuestEntry(
+  quizAffinity: GuestQuizAffinity = createGuestQuizAffinity(getGuestIdentity()),
+): Promise<GuestEntryState> {
+  const state = await resolveGuestEntryState(quizAffinity);
+  if (state === "quiz") quizAffinity.record();
+  return state;
 }
 
 export function useGuestEntryResolver() {
   const route = useRoute();
   const router = useRouter();
   const state = ref<GuestEntryState>("loading");
+  let guestIdentity = getGuestIdentity();
+  let quizAffinity = createGuestQuizAffinity(guestIdentity);
   let active = false;
   let requestedVersion = 0;
   let preserveEndedState = false;
@@ -100,12 +101,20 @@ export function useGuestEntryResolver() {
   async function processResolutions() {
     while (active) {
       const version = requestedVersion;
-      const nextState = await resolveGuestEntry();
+      const resolutionAffinity = getQuizAffinity();
+      const nextState = await resolveGuestEntryState(resolutionAffinity);
       if (!active) return;
       if (version !== requestedVersion) continue;
+      if (resolutionAffinity !== getQuizAffinity()) {
+        requestedVersion += 1;
+        continue;
+      }
 
+      if (nextState === "quiz") resolutionAffinity.record();
       state.value =
-        preserveEndedState && nextState === "quiz-inactive"
+        preserveEndedState &&
+        nextState === "quiz-inactive" &&
+        !quizAffinity.active
           ? "quiz-ended"
           : nextState;
       preserveEndedState = false;
@@ -149,6 +158,38 @@ export function useGuestEntryResolver() {
       await router.replace(target);
     }
   }
+
+  function getQuizAffinity(): GuestQuizAffinity {
+    const currentIdentity = getGuestIdentity();
+    if (currentIdentity !== guestIdentity) {
+      guestIdentity = currentIdentity;
+      quizAffinity = createGuestQuizAffinity(currentIdentity);
+      preserveEndedState = false;
+    }
+    return quizAffinity;
+  }
+}
+
+function getGuestIdentity(): string | undefined {
+  if (!authManager.isGuestAccessSession()) return undefined;
+  return authManager.getClaim("jti") || undefined;
+}
+
+async function resolveGuestEntryState(
+  quizAffinity: GuestQuizAffinity,
+): Promise<GuestEntryState> {
+  const providerDomains = new Set(
+    Object.values(api.providers).map((provider) => provider.domain),
+  );
+  const hasMusicQuiz = providerDomains.has("music_quiz");
+
+  if (hasMusicQuiz) {
+    const game = await getMusicQuizInfo();
+    if (game) return "quiz";
+  }
+  if (quizAffinity.active) return "quiz-inactive";
+  if (providerDomains.has("party")) return "party";
+  return hasMusicQuiz ? "quiz-inactive" : "inactive";
 }
 
 function getGuestEntryPath(state: GuestEntryState): string | undefined {

--- a/src/helpers/guest_quiz_affinity.ts
+++ b/src/helpers/guest_quiz_affinity.ts
@@ -1,0 +1,113 @@
+const STORAGE_KEY = "music_quiz_guest_affinity";
+const STORAGE_VERSION = 1;
+
+interface StoredGuestQuizAffinity {
+  version: typeof STORAGE_VERSION;
+  guestIdentity: string;
+}
+
+export interface GuestQuizAffinity {
+  readonly active: boolean;
+  record(): boolean;
+}
+
+/**
+ * Track Music Quiz affinity for one authenticated guest identity.
+ */
+export function createGuestQuizAffinity(
+  guestIdentity: string | undefined,
+): GuestQuizAffinity {
+  if (!guestIdentity) {
+    clearGuestQuizAffinity();
+    return {
+      active: false,
+      record: () => false,
+    };
+  }
+
+  let active = readGuestQuizAffinity(guestIdentity);
+  let persisted = active;
+  return {
+    get active() {
+      return active;
+    },
+    record() {
+      if (active) return persisted;
+      active = true;
+      persisted = writeGuestQuizAffinity(guestIdentity);
+      return persisted;
+    },
+  };
+}
+
+/**
+ * Remove any stored Music Quiz guest affinity.
+ */
+export function clearGuestQuizAffinity(): boolean {
+  try {
+    localStorage.removeItem(STORAGE_KEY);
+    return true;
+  } catch (error) {
+    console.warn("Unable to clear Music Quiz guest affinity.", error);
+    return false;
+  }
+}
+
+function readGuestQuizAffinity(guestIdentity: string): boolean {
+  let rawValue: string | null;
+  try {
+    rawValue = localStorage.getItem(STORAGE_KEY);
+  } catch (error) {
+    console.warn("Unable to read Music Quiz guest affinity.", error);
+    return false;
+  }
+  if (rawValue === null) return false;
+
+  let storedValue: unknown;
+  try {
+    storedValue = JSON.parse(rawValue);
+  } catch (error) {
+    console.warn("Ignoring corrupt Music Quiz guest affinity.", error);
+    clearGuestQuizAffinity();
+    return false;
+  }
+
+  if (!isStoredGuestQuizAffinity(storedValue)) {
+    console.warn("Ignoring invalid Music Quiz guest affinity.");
+    clearGuestQuizAffinity();
+    return false;
+  }
+  if (storedValue.guestIdentity !== guestIdentity) {
+    clearGuestQuizAffinity();
+    return false;
+  }
+  return true;
+}
+
+function writeGuestQuizAffinity(guestIdentity: string): boolean {
+  const value: StoredGuestQuizAffinity = {
+    version: STORAGE_VERSION,
+    guestIdentity,
+  };
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(value));
+    return true;
+  } catch (error) {
+    console.warn("Unable to store Music Quiz guest affinity.", error);
+    return false;
+  }
+}
+
+function isStoredGuestQuizAffinity(
+  value: unknown,
+): value is StoredGuestQuizAffinity {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "version" in value &&
+    value.version === STORAGE_VERSION &&
+    "guestIdentity" in value &&
+    typeof value.guestIdentity === "string" &&
+    value.guestIdentity.length > 0
+  );
+}

--- a/src/plugins/auth.ts
+++ b/src/plugins/auth.ts
@@ -3,6 +3,7 @@
  * Handles token storage, JWT claims, and authentication state
  */
 
+import { clearGuestQuizAffinity } from "@/helpers/guest_quiz_affinity";
 import type { User } from "./api/interfaces";
 import { store } from "./store";
 
@@ -35,6 +36,7 @@ export class AuthManager {
     if (this.token) {
       this.claims = this.decodeJWT(this.token);
     }
+    if (!this.isGuestAccessSession()) clearGuestQuizAffinity();
   }
 
   /**
@@ -100,8 +102,17 @@ export class AuthManager {
    * Automatically decodes JWT claims for frontend use
    */
   setToken(token: string): void {
+    const previousGuestIdentity = this.isGuestAccessSession()
+      ? this.claims?.jti
+      : undefined;
     this.token = token;
     this.claims = this.decodeJWT(token);
+    const nextGuestIdentity = this.isGuestAccessSession()
+      ? this.claims?.jti
+      : undefined;
+    if (!nextGuestIdentity || previousGuestIdentity !== nextGuestIdentity) {
+      clearGuestQuizAffinity();
+    }
     localStorage.setItem(TOKEN_STORAGE_KEY, token);
   }
 
@@ -159,6 +170,7 @@ export class AuthManager {
     this.token = null;
     this.claims = null;
     store.currentUser = undefined;
+    clearGuestQuizAffinity();
     localStorage.removeItem(TOKEN_STORAGE_KEY);
   }
 

--- a/tests/composables/useGuestEntryResolver.test.ts
+++ b/tests/composables/useGuestEntryResolver.test.ts
@@ -9,25 +9,36 @@ import { mount } from "@vue/test-utils";
 import { defineComponent, h, type DeepReadonly, type Ref } from "vue";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-const { apiMock, routeMock, routerReplace } = vi.hoisted(() => {
-  const routeMock = { path: "/guest" };
-  return {
-    apiMock: {
-      providers: {} as Record<string, { domain: string }>,
-      sendCommand: vi.fn(),
-      state: { value: "initialized" },
-      subscribe: vi.fn(),
-    },
-    routeMock,
-    routerReplace: vi.fn(async (path: string) => {
-      routeMock.path = path;
-    }),
-  };
-});
+const { apiMock, authManagerMock, guestIdentity, routeMock, routerReplace } =
+  vi.hoisted(() => {
+    const routeMock = { path: "/guest" };
+    const guestIdentity = { value: "guest-token-1" as string | undefined };
+    return {
+      apiMock: {
+        providers: {} as Record<string, { domain: string }>,
+        sendCommand: vi.fn(),
+        state: { value: "initialized" },
+        subscribe: vi.fn(),
+      },
+      authManagerMock: {
+        getClaim: vi.fn(() => guestIdentity.value),
+        isGuestAccessSession: vi.fn(() => true),
+      },
+      guestIdentity,
+      routeMock,
+      routerReplace: vi.fn(async (path: string) => {
+        routeMock.path = path;
+      }),
+    };
+  });
 
 vi.mock("@/plugins/api", () => ({
   default: apiMock,
   ConnectionState: { INITIALIZED: "initialized" },
+}));
+
+vi.mock("@/plugins/auth", () => ({
+  authManager: authManagerMock,
 }));
 
 vi.mock("vue-router", () => ({
@@ -35,12 +46,21 @@ vi.mock("vue-router", () => ({
   useRouter: () => ({ replace: routerReplace }),
 }));
 
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
 describe("guest entry decisions", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     apiMock.providers = {};
     apiMock.sendCommand.mockResolvedValue(null);
     apiMock.subscribe.mockImplementation(() => () => {});
+    authManagerMock.getClaim.mockImplementation(() => guestIdentity.value);
+    authManagerMock.isGuestAccessSession.mockReturnValue(true);
+    guestIdentity.value = "guest-token-1";
+    vi.stubGlobal("localStorage", createStorage());
     routeMock.path = "/guest";
   });
 
@@ -50,6 +70,29 @@ describe("guest entry decisions", () => {
 
     await expect(resolveGuestEntry()).resolves.toBe("quiz");
     expect(apiMock.sendCommand).toHaveBeenCalledWith("music_quiz/info");
+    expect(getStoredAffinity()).toEqual({
+      version: 1,
+      guestIdentity: "guest-token-1",
+    });
+  });
+
+  it("keeps an entered Music Quiz ahead of Party after it disappears", async () => {
+    setProviders("party", "music_quiz");
+    apiMock.sendCommand.mockResolvedValueOnce({ game_id: "active" });
+    await expect(resolveGuestEntry()).resolves.toBe("quiz");
+
+    apiMock.sendCommand.mockResolvedValue(null);
+    await expect(resolveGuestEntry()).resolves.toBe("quiz-inactive");
+  });
+
+  it("keeps showing a finished Music Quiz while it still exists", async () => {
+    setProviders("party", "music_quiz");
+    apiMock.sendCommand.mockResolvedValue({
+      game_id: "finished",
+      phase: "finished",
+    });
+
+    await expect(resolveGuestEntry()).resolves.toBe("quiz");
   });
 
   it("routes to Party when Music Quiz is inactive", async () => {
@@ -75,6 +118,30 @@ describe("guest entry decisions", () => {
     await expect(resolveGuestEntry()).resolves.toBe("party");
     expect(apiMock.sendCommand).not.toHaveBeenCalled();
   });
+
+  it("does not restore Quiz affinity for a different guest identity", async () => {
+    setProviders("party", "music_quiz");
+    apiMock.sendCommand.mockResolvedValueOnce({ game_id: "active" });
+    await expect(resolveGuestEntry()).resolves.toBe("quiz");
+
+    guestIdentity.value = "guest-token-2";
+    apiMock.sendCommand.mockResolvedValue(null);
+    await expect(resolveGuestEntry()).resolves.toBe("party");
+    expect(getStoredAffinity()).toBeNull();
+  });
+
+  it("ignores corrupt affinity without misrouting a Party guest", async () => {
+    setProviders("party", "music_quiz");
+    localStorage.setItem("music_quiz_guest_affinity", "{broken");
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    await expect(resolveGuestEntry()).resolves.toBe("party");
+    expect(getStoredAffinity()).toBeNull();
+    expect(warn).toHaveBeenCalledWith(
+      "Ignoring corrupt Music Quiz guest affinity.",
+      expect.any(SyntaxError),
+    );
+  });
 });
 
 describe("guest entry transitions", () => {
@@ -87,6 +154,10 @@ describe("guest entry transitions", () => {
     apiMock.state.value = "initialized";
     apiMock.sendCommand.mockResolvedValue(null);
     apiMock.subscribe.mockImplementation(() => () => {});
+    authManagerMock.getClaim.mockImplementation(() => guestIdentity.value);
+    authManagerMock.isGuestAccessSession.mockReturnValue(true);
+    guestIdentity.value = "guest-token-1";
+    vi.stubGlobal("localStorage", createStorage());
     routeMock.path = "/guest";
   });
 
@@ -94,7 +165,7 @@ describe("guest entry transitions", () => {
     wrapper?.unmount();
   });
 
-  it("moves from Party to Quiz and back through the empty states", async () => {
+  it("keeps a Party guest in Quiz context and returns to the next game", async () => {
     setProviders("party", "music_quiz");
     wrapper = mountResolver((state) => {
       resolverState = state;
@@ -106,23 +177,58 @@ describe("guest entry transitions", () => {
     await expectState("quiz");
 
     apiMock.sendCommand.mockResolvedValue(null);
+    markMusicQuizJoinedGameEnded();
     signalProviderEvent({ event: "game_removed" });
-    await expectState("party");
-
-    setProviders("music_quiz");
-    signalProvidersUpdated();
     await expectState("quiz-inactive");
+    expect(routeMock.path).toBe("/guest");
 
-    setProviders();
-    signalProvidersUpdated();
-    await expectState("inactive");
+    apiMock.sendCommand.mockResolvedValue({ game_id: "next" });
+    signalProviderEvent({ event: "game_updated", state: {} });
+    await expectState("quiz");
 
     expect(routerReplace.mock.calls.map(([path]) => path)).toEqual([
       "/guest/party",
       "/guest/quiz",
-      "/guest/party",
       "/guest",
+      "/guest/quiz",
     ]);
+  });
+
+  it("restores Quiz affinity when the resolver is recreated", async () => {
+    setProviders("party", "music_quiz");
+    apiMock.sendCommand.mockResolvedValue({ game_id: "active" });
+    wrapper = mountResolver((state) => {
+      resolverState = state;
+    });
+    await expectState("quiz");
+
+    wrapper.unmount();
+    wrapper = undefined;
+    routeMock.path = "/guest";
+    apiMock.sendCommand.mockResolvedValue(null);
+    wrapper = mountResolver((state) => {
+      resolverState = state;
+    });
+
+    await expectState("quiz-inactive");
+    expect(routeMock.path).toBe("/guest");
+  });
+
+  it("drops live affinity when the guest identity changes", async () => {
+    setProviders("party", "music_quiz");
+    apiMock.sendCommand.mockResolvedValue({ game_id: "active" });
+    wrapper = mountResolver((state) => {
+      resolverState = state;
+    });
+    await expectState("quiz");
+
+    guestIdentity.value = "guest-token-2";
+    apiMock.sendCommand.mockResolvedValue(null);
+    signalProviderEvent({ event: "game_updated", state: {} });
+
+    await expectState("party");
+    expect(routeMock.path).toBe("/guest/party");
+    expect(getStoredAffinity()).toBeNull();
   });
 
   it("does not let a stale resolution override a newer game event", async () => {
@@ -153,7 +259,33 @@ describe("guest entry transitions", () => {
     expect(routerReplace).toHaveBeenCalledWith("/guest/quiz");
   });
 
-  it("keeps a joined guest on the Quiz route when their game ends", async () => {
+  it("does not record affinity from a stale active Quiz result", async () => {
+    setProviders("party", "music_quiz");
+    let resolveFirstRequest!: (value: { game_id: string }) => void;
+    apiMock.sendCommand
+      .mockImplementationOnce(
+        () =>
+          new Promise<{ game_id: string }>((resolve) => {
+            resolveFirstRequest = resolve;
+          }),
+      )
+      .mockResolvedValue(null);
+
+    wrapper = mountResolver((state) => {
+      resolverState = state;
+    });
+    await vi.waitFor(() => expect(apiMock.sendCommand).toHaveBeenCalledOnce());
+
+    signalProviderEvent({ event: "game_updated", state: {} });
+    resolveFirstRequest({ game_id: "stale" });
+
+    await expectState("party");
+    expect(getStoredAffinity()).toBeNull();
+    expect(routerReplace).toHaveBeenCalledOnce();
+    expect(routerReplace).toHaveBeenCalledWith("/guest/party");
+  });
+
+  it("shows the no-active Quiz state when a joined game ends", async () => {
     setProviders("music_quiz");
     apiMock.sendCommand.mockResolvedValue({ game_id: "active" });
     wrapper = mountResolver((state) => {
@@ -164,13 +296,13 @@ describe("guest entry transitions", () => {
     markMusicQuizJoinedGameEnded();
     apiMock.sendCommand.mockResolvedValue(null);
     signalProviderEvent({ event: "game_removed" });
-    await expectState("quiz-ended");
+    await expectState("quiz-inactive");
 
-    expect(routeMock.path).toBe("/guest/quiz");
+    expect(routeMock.path).toBe("/guest");
     expect(apiMock.sendCommand).toHaveBeenCalledTimes(2);
   });
 
-  it("routes an ended Quiz guest to an available Party", async () => {
+  it("does not route an ended Quiz guest to an available Party", async () => {
     setProviders("music_quiz", "party");
     apiMock.sendCommand.mockResolvedValue({ game_id: "active" });
     wrapper = mountResolver((state) => {
@@ -181,9 +313,9 @@ describe("guest entry transitions", () => {
     markMusicQuizJoinedGameEnded();
     apiMock.sendCommand.mockResolvedValue(null);
     signalProviderEvent({ event: "game_removed" });
-    await expectState("party");
+    await expectState("quiz-inactive");
 
-    expect(routeMock.path).toBe("/guest/party");
+    expect(routeMock.path).toBe("/guest");
   });
 
   it("does not let an in-flight refresh overwrite the ended state", async () => {
@@ -211,15 +343,16 @@ describe("guest entry transitions", () => {
     markMusicQuizJoinedGameEnded();
     signalProviderEvent({ event: "game_removed" });
     resolveRefresh(null);
-    await expectState("quiz-ended");
+    await expectState("quiz-inactive");
 
-    expect(routeMock.path).toBe("/guest/quiz");
+    expect(routeMock.path).toBe("/guest");
     expect(apiMock.sendCommand).toHaveBeenCalledTimes(3);
   });
 
-  it("preserves an ended game while the guest route is still loading", async () => {
+  it("restores the no-active state while the guest route is loading", async () => {
     setProviders("music_quiz");
     routeMock.path = "/guest/quiz";
+    storeAffinity("guest-token-1");
     let resolveInitialRequest!: (value: null) => void;
     apiMock.sendCommand
       .mockImplementationOnce(
@@ -238,10 +371,38 @@ describe("guest entry transitions", () => {
     markMusicQuizJoinedGameEnded();
     signalProviderEvent({ event: "game_removed" });
     resolveInitialRequest(null);
-    await expectState("quiz-ended");
+    await expectState("quiz-inactive");
 
-    expect(routeMock.path).toBe("/guest/quiz");
+    expect(routeMock.path).toBe("/guest");
     expect(apiMock.sendCommand).toHaveBeenCalledTimes(2);
+  });
+
+  it("keeps live affinity when persistent storage is unavailable", async () => {
+    const storageError = new DOMException("Storage denied", "SecurityError");
+    vi.stubGlobal("localStorage", {
+      getItem: vi.fn(() => {
+        throw storageError;
+      }),
+      removeItem: vi.fn(() => {
+        throw storageError;
+      }),
+      setItem: vi.fn(() => {
+        throw storageError;
+      }),
+    });
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    setProviders("party", "music_quiz");
+    apiMock.sendCommand.mockResolvedValue({ game_id: "active" });
+    wrapper = mountResolver((state) => {
+      resolverState = state;
+    });
+    await expectState("quiz");
+
+    apiMock.sendCommand.mockResolvedValue(null);
+    signalProviderEvent({ event: "game_removed" });
+    await expectState("quiz-inactive");
+
+    expect(routeMock.path).toBe("/guest");
   });
 
   it("ignores a provider event from an unrelated instance once scoped", async () => {
@@ -306,4 +467,30 @@ function getSubscriber(eventType: EventType) {
   );
   expect(call).toBeDefined();
   return call?.[1] as (event: unknown) => void;
+}
+
+function storeAffinity(guestIdentity: string) {
+  localStorage.setItem(
+    "music_quiz_guest_affinity",
+    JSON.stringify({ version: 1, guestIdentity }),
+  );
+}
+
+function getStoredAffinity(): unknown {
+  const value = localStorage.getItem("music_quiz_guest_affinity");
+  return value === null ? null : JSON.parse(value);
+}
+
+function createStorage() {
+  const values = new Map<string, string>();
+  return {
+    clear: () => values.clear(),
+    getItem: (key: string) => values.get(key) ?? null,
+    removeItem: (key: string) => {
+      values.delete(key);
+    },
+    setItem: (key: string, value: string) => {
+      values.set(key, value);
+    },
+  };
 }

--- a/tests/helpers/guest_quiz_affinity.test.ts
+++ b/tests/helpers/guest_quiz_affinity.test.ts
@@ -1,0 +1,84 @@
+import {
+  clearGuestQuizAffinity,
+  createGuestQuizAffinity,
+} from "@/helpers/guest_quiz_affinity";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+describe("Music Quiz guest affinity", () => {
+  beforeEach(() => {
+    vi.stubGlobal("localStorage", createStorage());
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it("persists and restores affinity for the same guest identity", () => {
+    const affinity = createGuestQuizAffinity("guest-token-1");
+    expect(affinity.active).toBe(false);
+
+    expect(affinity.record()).toBe(true);
+
+    expect(affinity.active).toBe(true);
+    expect(createGuestQuizAffinity("guest-token-1").active).toBe(true);
+  });
+
+  it("clears affinity when no guest identity is available", () => {
+    createGuestQuizAffinity("guest-token-1").record();
+
+    const affinity = createGuestQuizAffinity(undefined);
+
+    expect(affinity.active).toBe(false);
+    expect(affinity.record()).toBe(false);
+    expect(affinity.active).toBe(false);
+    expect(localStorage.getItem("music_quiz_guest_affinity")).toBeNull();
+  });
+
+  it("keeps affinity in memory when storage is denied", () => {
+    const storageError = new DOMException("Storage denied", "SecurityError");
+    const storage = {
+      getItem: vi.fn(() => {
+        throw storageError;
+      }),
+      removeItem: vi.fn(() => {
+        throw storageError;
+      }),
+      setItem: vi.fn(() => {
+        throw storageError;
+      }),
+    };
+    vi.stubGlobal("localStorage", storage);
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    const affinity = createGuestQuizAffinity("guest-token-1");
+    expect(affinity.record()).toBe(false);
+
+    expect(affinity.active).toBe(true);
+    expect(storage.getItem).toHaveBeenCalledOnce();
+    expect(storage.setItem).toHaveBeenCalledOnce();
+    expect(warn).toHaveBeenCalledWith(
+      "Unable to read Music Quiz guest affinity.",
+      storageError,
+    );
+    expect(warn).toHaveBeenCalledWith(
+      "Unable to store Music Quiz guest affinity.",
+      storageError,
+    );
+    expect(clearGuestQuizAffinity()).toBe(false);
+  });
+});
+
+function createStorage() {
+  const values = new Map<string, string>();
+  return {
+    clear: () => values.clear(),
+    getItem: (key: string) => values.get(key) ?? null,
+    removeItem: (key: string) => {
+      values.delete(key);
+    },
+    setItem: (key: string, value: string) => {
+      values.set(key, value);
+    },
+  };
+}

--- a/tests/plugins/auth.test.ts
+++ b/tests/plugins/auth.test.ts
@@ -1,0 +1,65 @@
+import { createGuestQuizAffinity } from "@/helpers/guest_quiz_affinity";
+import { AuthManager } from "@/plugins/auth";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { storage } = vi.hoisted(() => {
+  const values = new Map<string, string>();
+  const storage = {
+    clear: () => values.clear(),
+    getItem: (key: string) => values.get(key) ?? null,
+    removeItem: (key: string) => {
+      values.delete(key);
+    },
+    setItem: (key: string, value: string) => {
+      values.set(key, value);
+    },
+  };
+  vi.stubGlobal("localStorage", storage);
+  return { storage };
+});
+
+describe("AuthManager guest affinity", () => {
+  beforeEach(() => {
+    storage.clear();
+  });
+
+  it("preserves affinity only while the same guest token remains active", () => {
+    const firstToken = createToken("guest-token-1", "party_guest");
+    localStorage.setItem("ma_access_token", firstToken);
+    createGuestQuizAffinity("guest-token-1").record();
+    const authManager = new AuthManager();
+
+    authManager.setToken(firstToken);
+    expect(localStorage.getItem("music_quiz_guest_affinity")).not.toBeNull();
+
+    authManager.setToken(createToken("guest-token-2", "party_guest"));
+    expect(localStorage.getItem("music_quiz_guest_affinity")).toBeNull();
+  });
+
+  it("clears affinity for non-guest sessions and logout", () => {
+    createGuestQuizAffinity("guest-token-1").record();
+    const authManager = new AuthManager();
+    expect(localStorage.getItem("music_quiz_guest_affinity")).toBeNull();
+
+    authManager.setToken(createToken("guest-token-1", "music_quiz_guest"));
+    createGuestQuizAffinity("guest-token-1").record();
+    authManager.clearAuth();
+
+    expect(localStorage.getItem("music_quiz_guest_affinity")).toBeNull();
+  });
+});
+
+function createToken(jti: string, username: string): string {
+  const payload = btoa(
+    JSON.stringify({
+      sub: "shared-guest-user",
+      jti,
+      username,
+      role: "guest",
+    }),
+  )
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/, "");
+  return `header.${payload}.signature`;
+}

--- a/tests/plugins/auth.test.ts
+++ b/tests/plugins/auth.test.ts
@@ -1,6 +1,6 @@
 import { createGuestQuizAffinity } from "@/helpers/guest_quiz_affinity";
 import { AuthManager } from "@/plugins/auth";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
 
 const { storage } = vi.hoisted(() => {
   const values = new Map<string, string>();
@@ -21,6 +21,10 @@ const { storage } = vi.hoisted(() => {
 describe("AuthManager guest affinity", () => {
   beforeEach(() => {
     storage.clear();
+  });
+
+  afterAll(() => {
+    vi.unstubAllGlobals();
   });
 
   it("preserves affinity only while the same guest token remains active", () => {


### PR DESCRIPTION
## Problem
Quiz guests were redirected to the Party screen after the host closed a Quiz, causing an unexpected context switch.

## Changes
- Remember Quiz affinity per authenticated guest token without storing credentials
- Keep returning Quiz guests on the no-active Quiz screen and route them into the next game
- Preserve Party fallback for guests without Quiz history and handle unavailable storage safely