### PR TITLE
Add waveform option to player menu

### DIFF
--- a/src/layouts/default/PlayerOSD/PlayerFullscreen.vue
+++ b/src/layouts/default/PlayerOSD/PlayerFullscreen.vue
@@ -1140,6 +1140,7 @@ const openQueueMenu = function (evt: Event) {
     },
     icon: "mdi-waveform",
     selected: showWaveformPref.value,
+    close_on_click: false,
   });
   // While lyrics are open, surface the sync-offset stepper at the top of the
   // overflow menu (only for players that benefit from a latency offset).

--- a/src/layouts/default/PlayerOSD/PlayerFullscreen.vue
+++ b/src/layouts/default/PlayerOSD/PlayerFullscreen.vue
@@ -745,10 +745,8 @@ watch(
 
 // Waveform for the current track, rendered by PlayerTimeline instead of the flat bar.
 const waveformData = ref<number[] | null>(null);
-const showWaveformPref = useUserPreferences().getPreference(
-  "show_waveform",
-  true,
-);
+const { getPreference, setPreference } = useUserPreferences();
+const showWaveformPref = getPreference("show_waveform", true);
 let waveformLoadGeneration = 0;
 const fetchWaveform = async () => {
   const generation = ++waveformLoadGeneration;
@@ -1135,6 +1133,14 @@ const openQueueMenu = function (evt: Event) {
       hideShuffleRepeat: mdAndUp.value,
     },
   );
+  menuItems.push({
+    label: "settings.show_waveform.label",
+    action: () => {
+      void setPreference("show_waveform", !showWaveformPref.value);
+    },
+    icon: "mdi-waveform",
+    selected: showWaveformPref.value,
+  });
   // While lyrics are open, surface the sync-offset stepper at the top of the
   // overflow menu (only for players that benefit from a latency offset).
   if (showLyrics.value && showLyricsOffset.value) {

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -312,7 +312,7 @@
             "description": "Force the mobile layout (with the menu-navigation at the bottom), even on larger screens."
         },
         "show_waveform": {
-            "label": "Show waveform as progress bar",
+            "label": "Prefer waveform progress bar",
             "description": "Show a waveform-style progress bar in the fullscreen player when audio analysis data is available for the playing track."
         },
         "providers_description": "Manage your music sources, player providers and plugins",


### PR DESCRIPTION
The waveform progress bar preference was only available in UI settings.

- Add a checked “Prefer waveform progress bar” option to the fullscreen player menu
- Apply and save the preference immediately
