### PR TITLE
Choose Music Trivia language

### DIFF
--- a/src/components/music-quiz/game-types/trivia/TriviaHostPanel.vue
+++ b/src/components/music-quiz/game-types/trivia/TriviaHostPanel.vue
@@ -1,6 +1,19 @@
 <template>
-  <Card v-if="state.sources.length" class="gap-0 py-2">
-    <Accordion type="multiple" :default-value="['sources']">
+  <Card class="gap-0 py-2">
+    <div class="flex items-center justify-between gap-3 px-4 py-3">
+      <span class="font-medium">
+        {{ $t("providers.music_quiz.question_language") }}
+      </span>
+      <span class="text-muted-foreground text-sm" data-testid="trivia-language">
+        {{ languageLabel }}
+      </span>
+    </div>
+
+    <Accordion
+      v-if="state.sources.length"
+      type="multiple"
+      :default-value="['sources']"
+    >
       <AccordionItem value="sources" class="border-b-0 px-4">
         <AccordionTrigger>
           <span class="flex w-full items-center justify-between gap-3 pr-2">
@@ -48,7 +61,7 @@ import {
   getMusicQuizSourceSummary,
   musicQuizSourceTypeLabel,
 } from "@/helpers/music_quiz_sources";
-import { $t } from "@/plugins/i18n";
+import { $t, getLocaleDisplayName, i18n } from "@/plugins/i18n";
 import { computed } from "vue";
 
 const props =
@@ -61,5 +74,8 @@ const props =
 
 const sourceSummary = computed(() =>
   getMusicQuizSourceSummary(props.state.sources),
+);
+const languageLabel = computed(() =>
+  getLocaleDisplayName(props.state.language || "en", i18n.global.locale.value),
 );
 </script>

--- a/src/components/music-quiz/game-types/trivia/TriviaSetup.vue
+++ b/src/components/music-quiz/game-types/trivia/TriviaSetup.vue
@@ -75,6 +75,21 @@
           </option>
         </NativeSelect>
       </Field>
+
+      <Field class="sm:col-span-2">
+        <FieldLabel for="trivia-language">
+          {{ $t("providers.music_quiz.question_language") }}
+        </FieldLabel>
+        <NativeSelect id="trivia-language" v-model="language" class="w-full">
+          <option
+            v-for="option in languageOptions"
+            :key="option.value"
+            :value="option.value"
+          >
+            {{ option.label }}
+          </option>
+        </NativeSelect>
+      </Field>
     </div>
 
     <MusicQuizSourceSelector
@@ -109,7 +124,7 @@ import type {
   MusicQuizDifficulty,
   MusicQuizTriviaConfig,
 } from "@/composables/useMusicQuiz";
-import { $t } from "@/plugins/i18n";
+import { $t, canonicalizeLocale, getLocaleOptions, i18n } from "@/plugins/i18n";
 import { Brain } from "@lucide/vue";
 import { computed, ref } from "vue";
 
@@ -127,12 +142,17 @@ const roundCount = ref(5);
 const suggestionCount = ref(4);
 const answerDuration = ref(30);
 const difficulty = ref<MusicQuizDifficulty>("normal");
+const language = ref(i18n.global.locale.value);
 const sourceUris = ref<string[]>([]);
 const canCreate = computed(() => sourceUris.value.length > 0);
+const languageOptions = computed(() =>
+  getLocaleOptions(i18n.global.availableLocales, i18n.global.locale.value),
+);
 
 function create() {
   if (!canCreate.value) return;
   const config: MusicQuizTriviaConfig = {
+    language: canonicalizeLocale(language.value),
     round_count: roundCount.value,
     suggestion_count: suggestionCount.value,
     answer_duration: answerDuration.value,

--- a/src/composables/useMusicQuiz.ts
+++ b/src/composables/useMusicQuiz.ts
@@ -115,6 +115,7 @@ export type MusicQuizTimelinePublicState = MusicQuizTimelineStateBase;
 interface MusicQuizTriviaStateBase extends MusicQuizStateIdentity {
   quiz_type: "trivia";
   answer_type: "multiple_choice";
+  language: string;
   round_count: number;
   suggestion_count: number;
   answer_duration: number;
@@ -235,6 +236,7 @@ export interface MusicQuizTimelineInfo extends MusicQuizStateIdentity {
 export interface MusicQuizTriviaInfo extends MusicQuizStateIdentity {
   quiz_type: "trivia";
   answer_type: "multiple_choice";
+  language: string;
   player_count: number;
   round_count: number;
   mode: MusicQuizMode;
@@ -553,6 +555,7 @@ export interface MusicQuizTimelineCreateRequest {
 }
 
 export interface MusicQuizTriviaConfig {
+  language: string;
   round_count: number;
   suggestion_count: number;
   answer_duration: number;

--- a/src/plugins/i18n.ts
+++ b/src/plugins/i18n.ts
@@ -1,5 +1,63 @@
 import { createI18n } from "vue-i18n";
 
+export interface LocaleOption {
+  value: string;
+  label: string;
+}
+
+export function canonicalizeLocale(locale: string): string {
+  const normalizedLocale = locale.trim().replaceAll("_", "-");
+  try {
+    return Intl.getCanonicalLocales(normalizedLocale)[0] ?? normalizedLocale;
+  } catch {
+    return normalizedLocale;
+  }
+}
+
+export function getLocaleDisplayName(
+  locale: string,
+  displayLocale: string,
+): string {
+  const canonicalLocale = canonicalizeLocale(locale);
+  if (typeof Intl.DisplayNames !== "function") return canonicalLocale;
+
+  try {
+    const displayNames = new Intl.DisplayNames(
+      [canonicalizeLocale(displayLocale)],
+      { type: "language" },
+    );
+    return displayNames.of(canonicalLocale) ?? canonicalLocale;
+  } catch {
+    return canonicalLocale;
+  }
+}
+
+export function getLocaleOptions(
+  locales: readonly string[],
+  displayLocale: string,
+): LocaleOption[] {
+  const options = locales.map((locale) => ({
+    value: locale,
+    label: getLocaleDisplayName(locale, displayLocale),
+  }));
+
+  try {
+    const collator = new Intl.Collator(canonicalizeLocale(displayLocale), {
+      sensitivity: "base",
+    });
+    return options.sort(
+      (a, b) =>
+        collator.compare(a.label, b.label) ||
+        collator.compare(a.value, b.value),
+    );
+  } catch {
+    return options.sort(
+      (a, b) =>
+        a.label.localeCompare(b.label) || a.value.localeCompare(b.value),
+    );
+  }
+}
+
 /*
  * All i18n resources specified in the plugin `include` option can be loaded
  * at once using the import syntax

--- a/src/plugins/i18n.ts
+++ b/src/plugins/i18n.ts
@@ -24,7 +24,11 @@ export function getLocaleDisplayName(
   try {
     const displayNames = new Intl.DisplayNames(
       [canonicalizeLocale(displayLocale)],
-      { type: "language" },
+      {
+        type: "language",
+        fallback: "code",
+        languageDisplay: "dialect",
+      },
     );
     return displayNames.of(canonicalLocale) ?? canonicalLocale;
   } catch {

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1248,6 +1248,7 @@
             "suggestions": "Answer choices",
             "answer_seconds": "Answer time (seconds)",
             "difficulty": "Difficulty",
+            "question_language": "Question language",
             "difficulty_easy": "Easy",
             "difficulty_normal": "Normal",
             "difficulty_hard": "Hard",

--- a/tests/components/music-quiz/TriviaAdapters.test.ts
+++ b/tests/components/music-quiz/TriviaAdapters.test.ts
@@ -85,6 +85,11 @@ const triviaSurfaces: Array<{
 
 describe("Trivia adapters", () => {
   it("shows the canonical server language after a host state refresh", async () => {
+    const displayNames = new Intl.DisplayNames(["en"], {
+      type: "language",
+      fallback: "code",
+      languageDisplay: "dialect",
+    });
     const wrapper = mount(TriviaHostPanel, {
       props: {
         state: { ...hostState, language: "pt-BR" },
@@ -93,14 +98,14 @@ describe("Trivia adapters", () => {
     });
 
     expect(wrapper.get('[data-testid="trivia-language"]').text()).toBe(
-      "Brazilian Portuguese",
+      displayNames.of("pt-BR"),
     );
 
     await wrapper.setProps({
       state: { ...hostState, language: "sr-Latn" },
     });
     expect(wrapper.get('[data-testid="trivia-language"]').text()).toBe(
-      "Serbian (Latin)",
+      displayNames.of("sr-Latn"),
     );
   });
 

--- a/tests/components/music-quiz/TriviaAdapters.test.ts
+++ b/tests/components/music-quiz/TriviaAdapters.test.ts
@@ -1,5 +1,6 @@
 import MultipleChoiceGrid from "@/components/music-quiz/answer-types/multiple-choice/MultipleChoiceGrid.vue";
 import MultipleChoicePlayerAnswer from "@/components/music-quiz/answer-types/multiple-choice/MultipleChoicePlayerAnswer.vue";
+import TriviaHostPanel from "@/components/music-quiz/game-types/trivia/TriviaHostPanel.vue";
 import TriviaHostRound from "@/components/music-quiz/game-types/trivia/TriviaHostRound.vue";
 import TriviaPlayerRound from "@/components/music-quiz/game-types/trivia/TriviaPlayerRound.vue";
 import TriviaPresentRound from "@/components/music-quiz/game-types/trivia/TriviaPresentRound.vue";
@@ -12,8 +13,14 @@ import { mount, shallowMount } from "@vue/test-utils";
 import type { Component } from "vue";
 import { describe, expect, it, vi } from "vitest";
 
-vi.mock("@/plugins/i18n", () => ({
+vi.mock("@/plugins/i18n", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/plugins/i18n")>()),
   $t: (key: string) => key,
+  i18n: {
+    global: {
+      locale: { value: "en" },
+    },
+  },
 }));
 
 const answeringRound = {
@@ -41,6 +48,7 @@ const revealRound = {
 const playerState = {
   quiz_type: "trivia",
   answer_type: "multiple_choice",
+  language: "en",
   phase: "answering",
   name: "Music Trivia",
   round_count: 1,
@@ -76,6 +84,26 @@ const triviaSurfaces: Array<{
 ];
 
 describe("Trivia adapters", () => {
+  it("shows the canonical server language after a host state refresh", async () => {
+    const wrapper = mount(TriviaHostPanel, {
+      props: {
+        state: { ...hostState, language: "pt-BR" },
+        currentRound: hostState.current_round,
+      },
+    });
+
+    expect(wrapper.get('[data-testid="trivia-language"]').text()).toBe(
+      "Brazilian Portuguese",
+    );
+
+    await wrapper.setProps({
+      state: { ...hostState, language: "sr-Latn" },
+    });
+    expect(wrapper.get('[data-testid="trivia-language"]').text()).toBe(
+      "Serbian (Latin)",
+    );
+  });
+
   it.each(triviaSurfaces)(
     "shows the server question in the $name state",
     ({ component, state }) => {

--- a/tests/components/music-quiz/TriviaSetup.test.ts
+++ b/tests/components/music-quiz/TriviaSetup.test.ts
@@ -1,7 +1,16 @@
 import TriviaSetup from "@/components/music-quiz/game-types/trivia/TriviaSetup.vue";
 import { mount } from "@vue/test-utils";
 import { nextTick } from "vue";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockI18n } = vi.hoisted(() => ({
+  mockI18n: {
+    global: {
+      locale: { value: "en" },
+      availableLocales: ["de", "en", "en_AU", "pt_BR", "sr_Latn"],
+    },
+  },
+}));
 
 vi.mock("@/plugins/api", () => ({
   api: {
@@ -12,8 +21,10 @@ vi.mock("@/plugins/api", () => ({
   },
 }));
 
-vi.mock("@/plugins/i18n", () => ({
+vi.mock("@/plugins/i18n", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/plugins/i18n")>()),
   $t: (key: string) => key,
+  i18n: mockI18n,
 }));
 
 vi.mock("@/helpers/utils", () => ({
@@ -28,30 +39,20 @@ vi.mock("@/components/MediaItemThumb.vue", () => ({
 }));
 
 describe("TriviaSetup", () => {
-  it("preserves selected sources and difficulty in the create request", async () => {
-    const wrapper = mount(TriviaSetup, {
-      props: { busy: false },
-      global: {
-        stubs: {
-          MusicQuizSourceSelector: {
-            template:
-              "<button data-testid=\"select-sources\" @click=\"$emit('update:modelValue', ['library://playlist/1', 'library://genre/rock'])\" />",
-          },
-          NumberField: {
-            template: "<div><slot /></div>",
-          },
-          NumberFieldContent: {
-            template: "<div><slot /></div>",
-          },
-          NumberFieldDecrement: true,
-          NumberFieldIncrement: true,
-          NumberFieldInput: true,
-        },
-      },
-    });
+  beforeEach(() => {
+    mockI18n.global.locale.value = "en";
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("preserves selected sources, difficulty, and language in the create request", async () => {
+    const wrapper = mountSetup();
 
     await wrapper.get('[data-testid="select-sources"]').trigger("click");
     await wrapper.get("#trivia-difficulty").setValue("hard");
+    await wrapper.get("#trivia-language").setValue("sr_Latn");
     await nextTick();
     await wrapper
       .findAll("button")
@@ -64,6 +65,7 @@ describe("TriviaSetup", () => {
           quiz_type: "trivia",
           answer_type: "multiple_choice",
           config: {
+            language: "sr-Latn",
             round_count: 5,
             suggestion_count: 4,
             answer_duration: 30,
@@ -76,26 +78,7 @@ describe("TriviaSetup", () => {
   });
 
   it("never renders or emits a session name", async () => {
-    const wrapper = mount(TriviaSetup, {
-      props: { busy: false },
-      global: {
-        stubs: {
-          MusicQuizSourceSelector: {
-            template:
-              "<button data-testid=\"select-sources\" @click=\"$emit('update:modelValue', ['library://playlist/1'])\" />",
-          },
-          NumberField: {
-            template: "<div><slot /></div>",
-          },
-          NumberFieldContent: {
-            template: "<div><slot /></div>",
-          },
-          NumberFieldDecrement: true,
-          NumberFieldIncrement: true,
-          NumberFieldInput: true,
-        },
-      },
-    });
+    const wrapper = mountSetup();
 
     expect(wrapper.find("#trivia-name").exists()).toBe(false);
     await wrapper.get('[data-testid="select-sources"]').trigger("click");
@@ -109,12 +92,78 @@ describe("TriviaSetup", () => {
       quiz_type: "trivia",
       answer_type: "multiple_choice",
       config: {
+        language: "en",
         round_count: 5,
         suggestion_count: 4,
         answer_duration: 30,
         difficulty: "normal",
-        source_uris: ["library://playlist/1"],
+        source_uris: ["library://playlist/1", "library://genre/rock"],
       },
     });
   });
+
+  it("defaults to the current effective UI locale", () => {
+    mockI18n.global.locale.value = "pt_BR";
+    vi.spyOn(window.navigator, "language", "get").mockReturnValue("en-US");
+
+    const wrapper = mountSetup();
+
+    expect(
+      (wrapper.get("#trivia-language").element as HTMLSelectElement).value,
+    ).toBe("pt_BR");
+  });
+
+  it("offers only shipped locales with localized, predictable labels", () => {
+    mockI18n.global.locale.value = "de";
+    const wrapper = mountSetup();
+    const options = wrapper
+      .get("#trivia-language")
+      .findAll("option")
+      .map((option) => ({
+        value: option.attributes("value"),
+        label: option.text(),
+      }));
+    const labelByValue = Object.fromEntries(
+      options.map((option) => [option.value, option.label]),
+    );
+
+    expect(options.map((option) => option.value).sort()).toEqual(
+      [...mockI18n.global.availableLocales].sort(),
+    );
+    expect(labelByValue).toMatchObject({
+      de: "Deutsch",
+      en: "Englisch",
+      en_AU: "Englisch (Australien)",
+      pt_BR: "Portugiesisch (Brasilien)",
+      sr_Latn: "Serbisch (Lateinisch)",
+    });
+    expect(options.map((option) => option.label)).toEqual(
+      options
+        .map((option) => option.label)
+        .toSorted(new Intl.Collator("de", { sensitivity: "base" }).compare),
+    );
+  });
 });
+
+function mountSetup() {
+  return mount(TriviaSetup, {
+    props: { busy: false },
+    global: {
+      stubs: {
+        MusicQuizSourceSelector: {
+          template:
+            "<button data-testid=\"select-sources\" @click=\"$emit('update:modelValue', ['library://playlist/1', 'library://genre/rock'])\" />",
+        },
+        NumberField: {
+          template: "<div><slot /></div>",
+        },
+        NumberFieldContent: {
+          template: "<div><slot /></div>",
+        },
+        NumberFieldDecrement: true,
+        NumberFieldIncrement: true,
+        NumberFieldInput: true,
+      },
+    },
+  });
+}

--- a/tests/components/music-quiz/TriviaSetup.test.ts
+++ b/tests/components/music-quiz/TriviaSetup.test.ts
@@ -7,7 +7,7 @@ const { mockI18n } = vi.hoisted(() => ({
   mockI18n: {
     global: {
       locale: { value: "en" },
-      availableLocales: ["de", "en", "en_AU", "pt_BR", "sr_Latn"],
+      availableLocales: ["de", "en", "en_AU", "pt_BR", "sr", "sr_Latn"],
     },
   },
 }));
@@ -126,17 +126,25 @@ describe("TriviaSetup", () => {
     const labelByValue = Object.fromEntries(
       options.map((option) => [option.value, option.label]),
     );
+    const displayNames = new Intl.DisplayNames(["de"], {
+      type: "language",
+      fallback: "code",
+      languageDisplay: "dialect",
+    });
 
     expect(options.map((option) => option.value).sort()).toEqual(
       [...mockI18n.global.availableLocales].sort(),
     );
     expect(labelByValue).toMatchObject({
-      de: "Deutsch",
-      en: "Englisch",
-      en_AU: "Englisch (Australien)",
-      pt_BR: "Portugiesisch (Brasilien)",
-      sr_Latn: "Serbisch (Lateinisch)",
+      de: displayNames.of("de"),
+      en: displayNames.of("en"),
+      en_AU: displayNames.of("en-AU"),
+      pt_BR: displayNames.of("pt-BR"),
+      sr: displayNames.of("sr"),
+      sr_Latn: displayNames.of("sr-Latn"),
     });
+    expect(labelByValue.en_AU).not.toBe(labelByValue.en);
+    expect(labelByValue.sr_Latn).not.toBe(labelByValue.sr);
     expect(options.map((option) => option.label)).toEqual(
       options
         .map((option) => option.label)

--- a/tests/components/music-quiz/registry.test.ts
+++ b/tests/components/music-quiz/registry.test.ts
@@ -176,6 +176,7 @@ const triviaRound = {
 const triviaPlayerState = {
   quiz_type: "trivia",
   answer_type: "multiple_choice",
+  language: "en",
   phase: "answering",
   name: "Trivia",
   round_count: 5,

--- a/tests/composables/useMusicQuiz.test.ts
+++ b/tests/composables/useMusicQuiz.test.ts
@@ -119,6 +119,7 @@ describe("useMusicQuiz commands", () => {
       quiz_type: "trivia",
       answer_type: "multiple_choice",
       config: {
+        language: "sr-Latn",
         round_count: 8,
         suggestion_count: 6,
         answer_duration: 45,
@@ -130,6 +131,7 @@ describe("useMusicQuiz commands", () => {
 
     expect(mockSendCommand).toHaveBeenCalledWith("music_quiz/create", {
       quiz_type: "trivia",
+      language: "sr-Latn",
       round_count: 8,
       suggestion_count: 6,
       answer_duration: 45,
@@ -267,6 +269,7 @@ describe("useMusicQuiz commands", () => {
     const trivia = {
       quiz_type: "trivia",
       answer_type: "multiple_choice",
+      language: "pt-BR",
       phase: "lobby",
       name: "Trivia",
       round_count: 5,
@@ -286,6 +289,7 @@ describe("useMusicQuiz commands", () => {
     expect(isSupportedMusicQuiz(known)).toBe(true);
     expect(isSupportedMusicQuiz(musicTimeline)).toBe(true);
     expect(isSupportedMusicQuiz(trivia)).toBe(true);
+    expect(trivia.language).toBe("pt-BR");
     expect(isSupportedMusicQuiz(unsupported)).toBe(false);
     expect(isSupportedMusicQuiz(unsupportedAnswer)).toBe(false);
     expect(isSupportedMusicQuiz(mismatched)).toBe(false);

--- a/tests/plugins/i18n.test.ts
+++ b/tests/plugins/i18n.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { resolveLocale } from "@/plugins/i18n";
+import {
+  canonicalizeLocale,
+  getLocaleDisplayName,
+  resolveLocale,
+} from "@/plugins/i18n";
 
 // Mirrors the real translation filenames (POSIX `ll_CC` convention, as shipped by Lokalise).
 const AVAILABLE = [
@@ -56,5 +60,25 @@ describe("resolveLocale", () => {
   it("falls back to English for an unknown language", () => {
     expect(resolveLocale("ja", AVAILABLE)).toBe("en");
     expect(resolveLocale("xx-YY", AVAILABLE)).toBe("en");
+  });
+});
+
+describe("locale presentation", () => {
+  it("canonicalizes underscore, script, and region subtags", () => {
+    expect(canonicalizeLocale("pt_BR")).toBe("pt-BR");
+    expect(canonicalizeLocale("sr_Latn_RS")).toBe("sr-Latn-RS");
+    expect(canonicalizeLocale("es_419")).toBe("es-419");
+  });
+
+  it("uses friendly localized names with script and region distinctions", () => {
+    expect(getLocaleDisplayName("pt_BR", "en")).toBe("Brazilian Portuguese");
+    expect(getLocaleDisplayName("sr_Latn", "en")).toBe("Serbian (Latin)");
+    expect(getLocaleDisplayName("en_AU", "de")).toBe("Englisch (Australien)");
+  });
+
+  it("falls back safely to the normalized code", () => {
+    expect(getLocaleDisplayName("invalid_locale!", "en")).toBe(
+      "invalid-locale!",
+    );
   });
 });

--- a/tests/plugins/i18n.test.ts
+++ b/tests/plugins/i18n.test.ts
@@ -71,9 +71,22 @@ describe("locale presentation", () => {
   });
 
   it("uses friendly localized names with script and region distinctions", () => {
-    expect(getLocaleDisplayName("pt_BR", "en")).toBe("Brazilian Portuguese");
-    expect(getLocaleDisplayName("sr_Latn", "en")).toBe("Serbian (Latin)");
-    expect(getLocaleDisplayName("en_AU", "de")).toBe("Englisch (Australien)");
+    const englishNames = new Intl.DisplayNames(["en"], {
+      type: "language",
+      fallback: "code",
+      languageDisplay: "dialect",
+    });
+    const germanNames = new Intl.DisplayNames(["de"], {
+      type: "language",
+      fallback: "code",
+      languageDisplay: "dialect",
+    });
+
+    expect(getLocaleDisplayName("pt_BR", "en")).toBe(englishNames.of("pt-BR"));
+    expect(getLocaleDisplayName("sr_Latn", "en")).toBe(
+      englishNames.of("sr-Latn"),
+    );
+    expect(getLocaleDisplayName("en_AU", "de")).toBe(germanNames.of("en-AU"));
   });
 
   it("falls back safely to the normalized code", () => {

--- a/tests/views/MusicQuizPlayerView.test.ts
+++ b/tests/views/MusicQuizPlayerView.test.ts
@@ -158,6 +158,7 @@ const triviaRound = {
 const triviaState = {
   quiz_type: "trivia",
   answer_type: "multiple_choice",
+  language: "en",
   phase: "answering",
   name: "Trivia",
   round_count: 1,
@@ -304,6 +305,7 @@ describe("MusicQuizPlayerView routing", () => {
       info: ref({
         quiz_type: "trivia",
         answer_type: "multiple_choice",
+        language: "en",
         phase: "lobby",
         name: "Trivia",
         player_count: 2,


### PR DESCRIPTION
Adds a host-selectable question language to Music Trivia, matching the server support in music-assistant/server#4753.

- Default to the host's active interface language
- List supported languages with localized names
- Show the chosen language in host settings after reconnects