### PR TITLE
Simplify player selection

### DIFF
--- a/src/components/HomeWidgetRows.vue
+++ b/src/components/HomeWidgetRows.vue
@@ -70,8 +70,8 @@
                 :player="player"
                 :show-volume-control="false"
                 :show-menu-button="false"
-                :show-sub-players="false"
-                :show-sync-controls="false"
+                :show-child-volumes="false"
+                :show-group-controls="false"
                 @click="playerClicked(player)"
               />
             </div>

--- a/src/components/ItemsListing.vue
+++ b/src/components/ItemsListing.vue
@@ -1506,7 +1506,7 @@ const restoreSettings = async function () {
 
 // lifecycle hooks
 const keyListener = function (e: KeyboardEvent) {
-  if (store.dialogActive) return;
+  if (store.dialogActive || store.showPlayersMenu) return;
   if (loading.value) return;
   if (e.key === "Escape") closeSearch();
   // Let searchInput handle this.

--- a/src/components/PlayerCard.vue
+++ b/src/components/PlayerCard.vue
@@ -1,247 +1,177 @@
 <template>
-  <v-card
+  <Card
     v-hold="onHold"
-    flat
-    class="panel-item"
+    class="gap-0 rounded-lg p-2 shadow-none transition-colors"
     :class="{
-      'panel-item-selected': player.player_id == store.activePlayerId,
-      'panel-item-idle': player.playback_state == PlaybackState.IDLE,
-      'panel-item-off': player.powered == false,
+      'border-primary bg-primary/15': player.player_id === store.activePlayerId,
+      'opacity-80': player.playback_state === PlaybackState.IDLE,
+      'opacity-60': player.powered === false,
+      'opacity-40': !player.available,
     }"
-    :ripple="false"
-    :disabled="!player.available"
-    @click="$emit('click', player)"
     @click.capture="swallowClickAfterHold"
     @contextmenu.prevent="openPlayerMenu"
     @touchstart.passive="onTouchStart"
   >
-    <!-- now playing media -->
-    <v-list-item class="panel-item-details" flat :ripple="false">
-      <!-- prepend: media thumb -->
-      <template #prepend>
-        <div class="player-media-thumb">
-          <!-- current media image -->
-          <div
-            v-if="player.powered != false && player.current_media?.image_url"
-          >
-            <v-img
-              class="media-thumb"
-              size="44"
-              :src="getMediaImageUrl(player.current_media.image_url)"
-              :alt="$t('tooltip.artwork')"
-            />
-          </div>
-          <!-- fallback: display player icon -->
-          <div v-else class="icon-thumb">
-            <PlayerIcon
-              :icon="player.icon"
-              :grouped="
-                player.type == PlayerType.PLAYER &&
-                !!player.group_members.length
-              "
-              :size="24"
-              style="opacity: 0.8"
-            />
-          </div>
-        </div>
-      </template>
-
-      <!-- playername -->
-      <template #title>
-        <!-- special builtin player (web player or companion native player) -->
+    <div class="flex min-w-0 items-center gap-1">
+      <button
+        type="button"
+        class="player-select-action focus-visible:ring-ring flex min-w-0 flex-1 items-center gap-3 rounded-md text-left outline-none focus-visible:ring-2"
+        :disabled="!player.available"
+        @click="emit('click', player)"
+      >
+        <span class="sr-only">{{ $t("tooltip.select_player") }}: </span>
         <div
-          v-if="isBuiltinPlayer(player)"
-          style="font-size: 0.88rem; line-height: 1.3"
+          class="bg-muted flex size-11 shrink-0 items-center justify-center overflow-hidden rounded-md"
         >
-          <span>{{ getPlayerName(player, 12) }}</span>
-          <!-- append small icon to the title -->
-          <v-chip density="compact" size="small" class="ml-2" outlined>
-            <v-icon
-              size="14"
-              :icon="
-                store.deviceType == 'phone' ? 'mdi-cellphone' : 'mdi-monitor'
-              "
-            />
-            <span v-if="store.deviceType != 'phone'" style="margin-left: 6px">{{
-              $t("this_device")
-            }}</span>
-          </v-chip>
-        </div>
-        <!-- regular player -->
-        <div v-else style="font-size: 0.88rem; line-height: 1.3">
-          {{ getPlayerName(player, 27) }}
-        </div>
-      </template>
-
-      <!-- subtitle: media item title -->
-      <template #subtitle>
-        <div
-          v-if="player.powered != false"
-          style="
-            font-size: 0.8rem;
-            font-weight: 500;
-            white-space: nowrap;
-            line-height: 1.3;
-          "
-        >
-          <div v-if="player.current_media?.title">
-            {{ player.current_media.title }}
-          </div>
-        </div>
-      </template>
-
-      <!-- subtitle -->
-      <template #default>
-        <div
-          class="v-list-item-subtitle"
-          style="font-size: 0.78rem; white-space: nowrap; line-height: 1.3"
-        >
-          <!-- player powered off -->
-          <div v-if="player.powered == false"></div>
-
-          <!-- artist + album -->
-          <div
-            v-else-if="
-              player.current_media?.artist && player.current_media?.album
+          <img
+            v-if="artworkUrl"
+            :src="artworkUrl"
+            alt=""
+            class="size-full object-cover"
+            loading="lazy"
+            @error="artworkFailed = true"
+          />
+          <PlayerIcon
+            v-else
+            :icon="player.icon"
+            :grouped="
+              player.type === PlayerType.PLAYER &&
+              player.group_members.some(
+                (playerId) => playerId !== player.player_id,
+              )
             "
-          >
-            {{ player.current_media.artist }} •
-            {{ player.current_media.album }}
-          </div>
-
-          <!-- artist only -->
-          <div v-else-if="player.current_media?.artist">
-            {{ player.current_media.artist }}
-          </div>
-
-          <!-- album only -->
-          <div v-else-if="player.current_media?.album">
-            {{ player.current_media.album }}
-          </div>
-          <!-- queue empty (hidden visually, announced by screen readers) -->
-          <div
-            v-else-if="playerQueue?.items == 0"
-            :aria-label="$t('queue_empty')"
-          ></div>
+            :size="24"
+            class="opacity-80"
+          />
         </div>
-      </template>
 
-      <!-- power/play/pause + menu button -->
-      <template #append>
-        <!-- power button -->
+        <div class="min-w-0 flex-1 py-0.5">
+          <div class="flex min-w-0 items-center gap-1.5">
+            <span class="truncate text-sm font-medium">
+              {{ getPlayerName(player, 27) }}
+            </span>
+            <Badge
+              v-if="isBuiltinPlayer(player)"
+              as="span"
+              variant="secondary"
+              class="h-5 shrink-0 gap-1 px-1.5 text-[11px]"
+            >
+              <Smartphone v-if="store.deviceType === 'phone'" class="size-3" />
+              <Monitor v-else class="size-3" />
+              <span v-if="store.deviceType !== 'phone'">
+                {{ $t("this_device") }}
+              </span>
+            </Badge>
+          </div>
+          <p
+            v-if="player.powered !== false && player.current_media?.title"
+            class="truncate text-xs font-medium"
+          >
+            {{ player.current_media.title }}
+          </p>
+          <p
+            v-if="player.powered !== false && mediaByline"
+            class="text-muted-foreground truncate text-xs"
+          >
+            {{ mediaByline }}
+          </p>
+          <span
+            v-else-if="playerQueue?.items === 0"
+            class="sr-only"
+            :aria-label="$t('queue_empty')"
+          ></span>
+        </div>
+      </button>
+
+      <div class="flex shrink-0 items-center">
         <Button
           v-if="
-            player.power_control != PLAYER_CONTROL_NONE &&
+            player.power_control !== PLAYER_CONTROL_NONE &&
             allowPowerControl &&
             !player.powered
           "
-          variant="ghost-icon"
-          size="icon"
-          class="player-command-btn"
+          variant="ghost"
+          size="icon-sm"
+          :disabled="!player.available"
           :aria-label="$t('tooltip.toggle_power')"
-          @click.stop="
-            api.playerCommandPowerToggle(player.player_id);
-            store.activePlayerId = player.player_id;
-          "
+          @click.stop="api.playerCommandPowerToggle(player.player_id)"
         >
-          <Power
-            :size="getBreakpointValue({ breakpoint: 'phone' }) ? 30 : 32"
-          />
+          <Power class="size-5" />
         </Button>
 
-        <!-- group members button -->
         <Button
-          v-if="
-            showSyncControls &&
-            player.can_group_with.length > 0 &&
-            showVolumeControl
-          "
-          variant="ghost-icon"
-          size="icon"
-          class="player-command-btn group-expand-btn"
-          :aria-label="$t('tooltip.group_members')"
-          @click.stop="$emit('toggle-expand', player)"
+          v-if="canEditGroupMembers"
+          variant="ghost"
+          size="icon-sm"
+          class="relative"
+          :disabled="!player.available"
+          :aria-label="`${$t('tooltip.group_members')}: ${groupMemberCount}`"
+          :aria-pressed="showMemberControls"
+          @click.stop="emit('toggle-member-controls', player)"
         >
-          <v-badge
-            color="primary"
-            :offset-x="-5"
-            :offset-y="-5"
-            :model-value="
-              player.type == PlayerType.GROUP ||
-              player.group_members.length >= 2
-            "
-            :content="player.group_members.length"
-            class="group-badge"
+          <Speaker class="size-5" />
+          <Badge
+            as="span"
+            class="absolute -top-1 -right-1 h-4 min-w-4 rounded-full px-1 text-[10px]"
           >
-            <Speaker
-              :size="getBreakpointValue({ breakpoint: 'phone' }) ? 24 : 26"
-            />
-          </v-badge>
+            {{ groupMemberCount }}
+          </Badge>
         </Button>
 
-        <!-- play/pause button -->
         <Button
           v-if="canPlayPause"
-          variant="ghost-icon"
-          size="icon"
-          class="player-command-btn"
-          :disabled="
-            api.queues[player.player_id]?.extra_attributes
-              ?.play_action_in_progress === true
+          variant="ghost"
+          size="icon-sm"
+          :class="{ 'ml-1': canEditGroupMembers }"
+          :disabled="!player.available || playActionInProgress"
+          :aria-label="
+            player.playback_state === PlaybackState.PLAYING
+              ? $t('pause')
+              : $t('play')
           "
-          @click.stop="
-            api.playerCommandPlayPause(player.player_id);
-            store.activePlayerId = player.player_id;
-          "
+          @click.stop="api.playerCommandPlayPause(player.player_id)"
         >
-          <v-progress-circular
-            v-if="
-              api.queues[player.player_id]?.extra_attributes
-                ?.play_action_in_progress === true
-            "
-            indeterminate
-            :size="getBreakpointValue({ breakpoint: 'phone' }) ? 24 : 26"
-            :width="2"
+          <Spinner v-if="playActionInProgress" class="size-5" />
+          <Pause
+            v-else-if="player.playback_state === PlaybackState.PLAYING"
+            class="size-5"
           />
-          <component
-            :is="player.playback_state == PlaybackState.PLAYING ? Pause : Play"
-            v-else
-            :size="getBreakpointValue({ breakpoint: 'phone' }) ? 30 : 32"
-          />
+          <Play v-else class="size-5" />
         </Button>
 
-        <!-- menu button -->
         <Button
           v-if="showMenuButton"
-          variant="ghost-icon"
-          size="icon"
-          class="player-command-btn"
-          style="margin-right: -5px"
+          variant="ghost"
+          size="icon-sm"
+          :class="{ '-ml-1': canPlayPause }"
+          :disabled="!player.available"
           :aria-label="$t('tooltip.more_options')"
           @click.stop="openPlayerMenu"
         >
-          <MoreVertical
-            :size="getBreakpointValue({ breakpoint: 'phone' }) ? 26 : 30"
-          />
+          <EllipsisVertical class="size-5" />
         </Button>
-      </template>
-    </v-list-item>
+      </div>
+    </div>
+
     <VolumeControl
       v-if="showVolumeControl"
       :player="player"
-      :show-sync-controls="showSyncControls"
-      :show-heading-row="false"
-      :show-sub-players="showSubPlayers"
-      :show-volume-control="player.powered != false"
+      :show-member-controls="player.available && showMemberControls"
+      :show-child-volumes="player.available && showChildVolumes"
+      :show-volume-control="player.powered !== false"
       :allow-wheel="false"
-      @toggle-expand="$emit('toggle-expand', player)"
+      @toggle-child-volumes="emit('toggle-child-volumes', player)"
     />
-  </v-card>
+  </Card>
 </template>
 
 <script setup lang="ts">
-import { Button } from "@/components/ui/button";
+import PlayerIcon from "@/components/PlayerIcon.vue";
 import VolumeControl from "@/components/VolumeControl.vue";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card } from "@/components/ui/card";
+import { Spinner } from "@/components/ui/spinner";
 import { useActiveSource } from "@/composables/activeSource";
 import {
   getEventPosition,
@@ -251,222 +181,128 @@ import { getPlayerMenuItems } from "@/helpers/player_menu_items";
 import {
   getMediaImageUrl,
   getPlayerName,
-  ImageColorPalette,
   isBuiltinPlayer,
-  paletteFromServer,
 } from "@/helpers/utils";
 import api from "@/plugins/api";
 import {
   PlaybackState,
-  Player,
+  type Player,
   PLAYER_CONTROL_NONE,
+  PlayerFeature,
   PlayerType,
 } from "@/plugins/api/interfaces";
-import { getBreakpointValue } from "@/plugins/breakpoint";
 import { eventbus } from "@/plugins/eventbus";
 import { store } from "@/plugins/store";
-import { MoreVertical, Pause, Play, Power, Speaker } from "@lucide/vue";
-import PlayerIcon from "@/components/PlayerIcon.vue";
-import { computed, toRef } from "vue";
+import {
+  EllipsisVertical,
+  Monitor,
+  Pause,
+  Play,
+  Power,
+  Smartphone,
+  Speaker,
+} from "@lucide/vue";
+import { computed, ref, toRef, watch } from "vue";
 
-// properties
 export interface Props {
   player: Player;
   showVolumeControl?: boolean;
   showMenuButton?: boolean;
-  showSubPlayers?: boolean;
-  showSyncControls?: boolean;
+  showChildVolumes?: boolean;
+  showMemberControls?: boolean;
+  showGroupControls?: boolean;
   allowPowerControl?: boolean;
 }
 
-const compProps = defineProps<Props>();
-const { activeSource } = useActiveSource(toRef(compProps, "player"));
-
-// emits
-defineEmits<{
-  (e: "click", player: Player): void;
-  (e: "toggle-expand", player: Player): void;
+const props = defineProps<Props>();
+const emit = defineEmits<{
+  (event: "click", player: Player): void;
+  (event: "toggle-child-volumes", player: Player): void;
+  (event: "toggle-member-controls", player: Player): void;
 }>();
 
+const artworkFailed = ref(false);
+const { activeSource } = useActiveSource(toRef(props, "player"));
+
 const playerQueue = computed(() => {
-  if (
-    compProps.player &&
-    compProps.player.active_source &&
-    compProps.player.active_source in api.queues
-  ) {
-    return api.queues[compProps.player.active_source];
+  if (props.player.active_source && props.player.active_source in api.queues) {
+    return api.queues[props.player.active_source];
   }
-  if (
-    compProps.player &&
-    !compProps.player.active_source &&
-    compProps.player.player_id in api.queues
-  ) {
-    return api.queues[compProps.player.player_id];
+  if (!props.player.active_source && props.player.player_id in api.queues) {
+    return api.queues[props.player.player_id];
   }
   return undefined;
 });
 
-const openPlayerMenu = function (evt: Event) {
-  const pos = getEventPosition(evt);
+const artworkUrl = computed(() => {
+  if (
+    artworkFailed.value ||
+    props.player.powered === false ||
+    !props.player.current_media?.image_url ||
+    (props.player.playback_state !== PlaybackState.PLAYING &&
+      props.player.playback_state !== PlaybackState.PAUSED)
+  ) {
+    return undefined;
+  }
+  return getMediaImageUrl(props.player.current_media.image_url);
+});
+
+const mediaByline = computed(() =>
+  [props.player.current_media?.artist, props.player.current_media?.album]
+    .filter(Boolean)
+    .join(" • "),
+);
+
+const canPlayPause = computed(
+  () => activeSource.value?.can_play_pause === true,
+);
+
+const playActionInProgress = computed(
+  () =>
+    api.queues[props.player.player_id]?.extra_attributes
+      ?.play_action_in_progress === true,
+);
+
+const canEditGroupMembers = computed(
+  () =>
+    props.showGroupControls &&
+    props.player.supported_features.includes(PlayerFeature.SET_MEMBERS) &&
+    (props.player.can_group_with.length > 0 ||
+      props.player.group_members.some(
+        (playerId) =>
+          playerId !== props.player.player_id &&
+          !props.player.static_group_members.includes(playerId),
+      )),
+);
+
+const groupMemberCount = computed(() => {
+  const childCount = new Set(
+    props.player.group_members.filter(
+      (playerId) => playerId !== props.player.player_id,
+    ),
+  ).size;
+  return props.player.type === PlayerType.GROUP ? childCount : childCount + 1;
+});
+
+watch(
+  () => props.player.current_media?.image_url,
+  () => {
+    artworkFailed.value = false;
+  },
+);
+
+function openPlayerMenu(event: Event) {
+  if (!props.player.available) return;
+  const position = getEventPosition(event);
   eventbus.emit("contextmenu", {
-    items: getPlayerMenuItems(compProps.player, playerQueue.value, {
+    items: getPlayerMenuItems(props.player, playerQueue.value, {
       context: "player",
     }),
-    posX: pos.x,
-    posY: pos.y,
+    posX: position.x,
+    posY: position.y,
   });
-};
+}
 
 const { onHold, onTouchStart, swallowClickAfterHold } =
   useHoldToOpenMenu(openPlayerMenu);
-
-const canPlayPause = computed(() => {
-  if (activeSource.value) {
-    return activeSource.value.can_play_pause;
-  }
-  return false;
-});
-
-// Use the server-derived palette from the now-playing media.
-const coverImageColorPalette = computed<ImageColorPalette>(() =>
-  paletteFromServer(compProps.player.current_media?.palette),
-);
 </script>
-
-<style scoped>
-.panel-item-details {
-  width: 100%;
-  margin: 0px !important;
-  padding: 0px !important;
-  min-height: 58px;
-}
-
-.panel-item-details :deep(.v-list-item__content) {
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  min-height: 50px;
-  gap: 0px;
-}
-
-.panel-item-details :deep(.v-list-item-title) {
-  padding: 0;
-  margin: 0;
-}
-
-.panel-item-details :deep(.v-list-item-subtitle) {
-  padding: 0;
-  margin: 0;
-}
-
-.panel-item-details :deep(.v-list-item__spacer) {
-  width: 10px;
-}
-
-.player-media-thumb {
-  margin-right: 0px;
-}
-
-.volumesliderrow {
-  margin-top: 0px;
-  padding-top: 0px;
-  padding-bottom: 0px;
-  height: 24px;
-  min-height: 24px;
-}
-
-.volumecaption {
-  width: 25px;
-  text-align: right;
-  margin-right: 0px;
-}
-
-.volumesliderrow :deep(.v-list-item__prepend) {
-  width: 40px;
-  margin-left: -25px;
-}
-.volumesliderrow :deep(.v-expansion-panel-text__wrapper) {
-  padding: 0;
-}
-
-.media-thumb {
-  width: 65px;
-  height: 65px;
-  border-radius: 4px;
-  background-color: rgba(var(--v-theme-on-surface), 0.08);
-}
-
-.icon-thumb {
-  width: 65px;
-  height: 65px;
-  border-radius: 4px;
-  background-color: rgba(var(--v-theme-on-surface), 0.08);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-}
-
-.media-thumb {
-  width: 44px;
-  height: 44px;
-  border-radius: 4px;
-  background-color: rgba(var(--v-theme-on-surface), 0.08);
-}
-.icon-thumb {
-  width: 44px;
-  height: 44px;
-  margin-top: 4px;
-  border-radius: 4px;
-  background-color: rgba(var(--v-theme-on-surface), 0.08);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-}
-
-.panel-item {
-  border-style: ridge;
-  border-width: thin;
-  border-color: rgba(var(--v-theme-on-surface), 0.12);
-  padding-left: 8px;
-  padding-right: 8px;
-  padding-top: 4px;
-  padding-bottom: 4px;
-  background-color: rgba(var(--v-theme-primary), 0.04);
-  opacity: 1;
-  transition: opacity 0.4s ease-in-out;
-  border-radius: 6px;
-  margin-left: 0px;
-  margin-right: 0px;
-  margin-top: 4px;
-  margin-bottom: 4px;
-  height: 100%;
-  width: auto;
-}
-.panel-item-idle {
-  opacity: 0.8;
-}
-.panel-item-off {
-  opacity: 0.6;
-}
-.panel-item-selected {
-  border-color: rgba(var(--v-theme-primary), 0.6);
-  background-color: rgba(var(--v-theme-primary), 0.3);
-}
-
-.player-command-btn {
-  width: 35px;
-  min-width: 35px;
-  margin-left: 5px;
-}
-
-.player-command-btn.group-expand-btn {
-  margin-right: 3px;
-}
-
-.group-badge :deep(.v-badge__badge) {
-  font-size: 13px;
-  height: 16px;
-  min-width: 16px;
-  padding: 0 4px 0 4px;
-}
-</style>

--- a/src/components/PlayerChildVolumes.vue
+++ b/src/components/PlayerChildVolumes.vue
@@ -1,0 +1,39 @@
+<template>
+  <div>
+    <Separator class="my-2" />
+    <div
+      v-for="player in players"
+      :key="player.player_id"
+      class="space-y-0.5 py-1"
+      :class="{ 'opacity-50': player.powered === false }"
+    >
+      <div class="flex items-center gap-2 pr-2">
+        <span
+          class="player-child-volume-icon flex h-6 w-[30px] shrink-0 items-center justify-center"
+        >
+          <PlayerIcon
+            :icon="player.icon"
+            :size="18"
+            class="text-muted-foreground"
+          />
+        </span>
+        <span class="min-w-0 flex-1 truncate text-xs font-medium">
+          {{ player.name }}
+        </span>
+      </div>
+      <PlayerVolume :player="player" :allow-wheel="allowWheel" width="100%" />
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import PlayerIcon from "@/components/PlayerIcon.vue";
+import { Separator } from "@/components/ui/separator";
+import PlayerVolume from "@/layouts/default/PlayerOSD/PlayerVolume.vue";
+import type { Player } from "@/plugins/api/interfaces";
+
+defineProps<{
+  players: Player[];
+  allowWheel?: boolean;
+}>();
+</script>

--- a/src/components/PlayerGroupMembers.vue
+++ b/src/components/PlayerGroupMembers.vue
@@ -53,7 +53,7 @@ import {
   PlayerFeature,
   PlayerType,
 } from "@/plugins/api/interfaces";
-import { computed, ref } from "vue";
+import { computed, onUnmounted, ref } from "vue";
 
 const props = defineProps<{
   player: Player;
@@ -62,7 +62,9 @@ const props = defineProps<{
 
 const playersToAdd = ref<string[]>([]);
 const playersToRemove = ref<string[]>([]);
-const timeoutId = ref<ReturnType<typeof setTimeout>>();
+let timeoutId: ReturnType<typeof setTimeout> | undefined;
+
+onUnmounted(flushPendingMemberUpdate);
 
 const candidates = computed(() => {
   const players = [...props.members];
@@ -154,26 +156,34 @@ function updateGroupMember(playerId: string, selected: boolean) {
 }
 
 function scheduleMemberUpdate() {
-  if (timeoutId.value) clearTimeout(timeoutId.value);
+  if (timeoutId) clearTimeout(timeoutId);
   if (playersToAdd.value.length === 0 && playersToRemove.value.length === 0) {
     return;
   }
 
-  timeoutId.value = setTimeout(() => {
-    const playerIdsToAdd = [...playersToAdd.value];
-    const playerIdsToRemove = [...playersToRemove.value];
-    playersToAdd.value = [];
-    playersToRemove.value = [];
-    timeoutId.value = undefined;
+  timeoutId = setTimeout(sendMemberUpdate, 500);
+}
 
-    api
-      .playerCommandSetMembers(
-        props.player.player_id,
-        playerIdsToAdd.length ? playerIdsToAdd : undefined,
-        playerIdsToRemove.length ? playerIdsToRemove : undefined,
-      )
-      .catch(restorePlayer);
-  }, 500);
+function sendMemberUpdate() {
+  const playerIdsToAdd = [...playersToAdd.value];
+  const playerIdsToRemove = [...playersToRemove.value];
+  playersToAdd.value = [];
+  playersToRemove.value = [];
+  timeoutId = undefined;
+
+  api
+    .playerCommandSetMembers(
+      props.player.player_id,
+      playerIdsToAdd.length ? playerIdsToAdd : undefined,
+      playerIdsToRemove.length ? playerIdsToRemove : undefined,
+    )
+    .catch(restorePlayer);
+}
+
+function flushPendingMemberUpdate() {
+  if (!timeoutId) return;
+  clearTimeout(timeoutId);
+  sendMemberUpdate();
 }
 
 async function restorePlayer() {

--- a/src/components/PlayerGroupMembers.vue
+++ b/src/components/PlayerGroupMembers.vue
@@ -1,0 +1,191 @@
+<template>
+  <div v-if="candidates.length > 0">
+    <Separator class="my-2" />
+    <p class="text-muted-foreground px-2 pb-1 text-xs font-medium">
+      {{ $t("settings.group_members") }}
+    </p>
+    <label
+      v-for="candidate in candidates"
+      :key="candidate.player_id"
+      :for="getCheckboxId(candidate)"
+      class="player-group-member flex min-h-10 items-center gap-2 rounded-md pr-2 transition-colors"
+      :class="{
+        'bg-primary/10': isGroupMember(candidate),
+        'hover:bg-accent/50 cursor-pointer': !isRequiredMember(candidate),
+        'cursor-not-allowed': isRequiredMember(candidate),
+      }"
+    >
+      <span
+        class="player-group-member-icon flex h-6 w-[30px] shrink-0 items-center justify-center"
+      >
+        <PlayerIcon
+          :icon="candidate.icon"
+          :size="18"
+          class="text-muted-foreground"
+          :class="{ 'opacity-50': candidate.powered === false }"
+        />
+      </span>
+      <span class="min-w-0 flex-1 truncate text-xs font-medium">
+        {{ candidate.name }}
+      </span>
+      <Checkbox
+        :id="getCheckboxId(candidate)"
+        :model-value="isGroupMember(candidate)"
+        :disabled="isRequiredMember(candidate)"
+        :aria-label="candidate.name"
+        class="border-muted-foreground/70 bg-background/70 size-5 border-2 shadow-sm"
+        @update:model-value="
+          updateGroupMember(candidate.player_id, $event === true)
+        "
+      />
+    </label>
+  </div>
+</template>
+
+<script setup lang="ts">
+import PlayerIcon from "@/components/PlayerIcon.vue";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Separator } from "@/components/ui/separator";
+import { groupMemberPickerVisible } from "@/helpers/utils";
+import { api } from "@/plugins/api";
+import {
+  type Player,
+  PlayerFeature,
+  PlayerType,
+} from "@/plugins/api/interfaces";
+import { computed, ref } from "vue";
+
+const props = defineProps<{
+  player: Player;
+  members: Player[];
+}>();
+
+const playersToAdd = ref<string[]>([]);
+const playersToRemove = ref<string[]>([]);
+const timeoutId = ref<ReturnType<typeof setTimeout>>();
+
+const candidates = computed(() => {
+  const players = [...props.members];
+  const playerIds = new Set(players.map((player) => player.player_id));
+  if (!props.player.supported_features.includes(PlayerFeature.SET_MEMBERS)) {
+    return sortPlayers(players);
+  }
+
+  for (const player of Object.values(api.players)) {
+    if (
+      player.player_id === props.player.player_id ||
+      playerIds.has(player.player_id) ||
+      !canGroupWithPlayer(player) ||
+      !player.available ||
+      !groupMemberPickerVisible(player) ||
+      player.type === PlayerType.GROUP ||
+      (player.active_group && player.active_group !== props.player.player_id)
+    ) {
+      continue;
+    }
+    players.push(player);
+    playerIds.add(player.player_id);
+  }
+
+  return sortPlayers(players);
+});
+
+function getCheckboxId(player: Player) {
+  return `group-member-${props.player.player_id}-${player.player_id}`;
+}
+
+function isGroupMember(player: Player) {
+  return props.player.group_members.includes(player.player_id);
+}
+
+function isRequiredMember(player: Player) {
+  return (
+    props.player.static_group_members.includes(player.player_id) &&
+    isGroupMember(player)
+  );
+}
+
+function canGroupWithPlayer(player: Player) {
+  return (
+    props.player.can_group_with.includes(player.player_id) ||
+    // Providers remain supported until the server always supplies player IDs.
+    props.player.can_group_with.includes(player.provider)
+  );
+}
+
+function sortPlayers(players: Player[]) {
+  return players.sort((left, right) =>
+    left.name.localeCompare(right.name, undefined, {
+      sensitivity: "base",
+    }),
+  );
+}
+
+function updateGroupMember(playerId: string, selected: boolean) {
+  const parentPlayerId = props.player.player_id;
+
+  if (selected) {
+    playersToRemove.value = playersToRemove.value.filter(
+      (id) => id !== playerId,
+    );
+    if (!playersToAdd.value.includes(playerId)) {
+      playersToAdd.value.push(playerId);
+    }
+    if (!api.players[parentPlayerId].group_members.includes(playerId)) {
+      api.players[parentPlayerId].group_members.push(playerId);
+    }
+  } else {
+    playersToAdd.value = playersToAdd.value.filter((id) => id !== playerId);
+    if (!playersToRemove.value.includes(playerId)) {
+      playersToRemove.value.push(playerId);
+    }
+    const remainingPlayerIds = api.players[parentPlayerId].group_members.filter(
+      (id) => id !== playerId,
+    );
+    api.players[parentPlayerId].group_members =
+      props.player.type !== PlayerType.GROUP &&
+      remainingPlayerIds.length === 1 &&
+      remainingPlayerIds[0] === parentPlayerId
+        ? []
+        : remainingPlayerIds;
+  }
+
+  scheduleMemberUpdate();
+}
+
+function scheduleMemberUpdate() {
+  if (timeoutId.value) clearTimeout(timeoutId.value);
+  if (playersToAdd.value.length === 0 && playersToRemove.value.length === 0) {
+    return;
+  }
+
+  timeoutId.value = setTimeout(() => {
+    const playerIdsToAdd = [...playersToAdd.value];
+    const playerIdsToRemove = [...playersToRemove.value];
+    playersToAdd.value = [];
+    playersToRemove.value = [];
+    timeoutId.value = undefined;
+
+    api
+      .playerCommandSetMembers(
+        props.player.player_id,
+        playerIdsToAdd.length ? playerIdsToAdd : undefined,
+        playerIdsToRemove.length ? playerIdsToRemove : undefined,
+      )
+      .catch(restorePlayer);
+  }, 500);
+}
+
+async function restorePlayer() {
+  const restoredPlayer = await api.getPlayer(props.player.player_id);
+  for (const playerId of playersToAdd.value) {
+    if (!restoredPlayer.group_members.includes(playerId)) {
+      restoredPlayer.group_members.push(playerId);
+    }
+  }
+  restoredPlayer.group_members = restoredPlayer.group_members.filter(
+    (playerId) => !playersToRemove.value.includes(playerId),
+  );
+  api.players[props.player.player_id] = restoredPlayer;
+}
+</script>

--- a/src/components/PlayerIcon.vue
+++ b/src/components/PlayerIcon.vue
@@ -1,14 +1,11 @@
 <template>
-  <v-icon
-    v-if="grouped"
-    icon="mdi-speaker-multiple"
-    :size="size"
-    v-bind="$attrs"
-  />
-  <v-icon
+  <Speaker v-if="grouped" :size="size" v-bind="$attrs" />
+  <i
     v-else-if="isMdiIcon(icon)"
-    :icon="icon ?? undefined"
-    :size="size"
+    aria-hidden="true"
+    class="mdi"
+    :class="icon"
+    :style="{ fontSize: `${size ?? 24}px`, lineHeight: 1 }"
     v-bind="$attrs"
   />
   <component :is="lucideIcon || Speaker" v-else :size="size" v-bind="$attrs" />
@@ -25,7 +22,7 @@ defineOptions({
 
 const props = defineProps<{
   icon?: string | null;
-  size?: number | string;
+  size?: number;
   grouped?: boolean;
 }>();
 

--- a/src/components/VolumeControl.vue
+++ b/src/components/VolumeControl.vue
@@ -1,373 +1,112 @@
 <template>
-  <v-list style="overflow: hidden; padding: 0" lines="two">
-    <!-- main (or group) volume/power -->
-    <!-- mute btn + player name + optional sync checkbox-->
-    <v-list-item
-      v-if="showHeadingRow"
-      class="volumesliderrow heading"
-      :link="false"
-      :style="player.powered == false ? 'opacity: 0.6' : 'opacity: 1'"
-    >
-      <template #prepend>
-        <PlayerIcon
-          :icon="player.icon"
-          :size="25"
-          style="margin-left: 6px; opacity: 0.6"
-        />
-      </template>
-      <template #default>
-        <h5>{{ getPlayerName(player, 27) }}</h5>
-      </template>
-      <template #append>
-        <!-- power button -->
-        <Button
-          v-if="player.power_control != PLAYER_CONTROL_NONE"
-          class="powerbtn"
-          variant="icon"
-          :aria-label="$t('tooltip.toggle_power')"
-          @click.stop="api.playerCommandPowerToggle(player.player_id)"
-        >
-          <v-icon :size="25" icon="mdi-power" />
-        </Button>
-      </template>
-    </v-list-item>
-    <!-- volume slider row with integrated mute + level -->
+  <div class="overflow-hidden" @click.stop>
     <div
       v-if="showVolumeControl"
-      class="volume-row"
-      :style="player.powered == false ? 'opacity: 0.35' : 'opacity: 0.75'"
+      class="flex min-h-8 items-center gap-1 opacity-75"
     >
       <PlayerVolume
         :player="player"
         :allow-wheel="allowWheel"
-        :show-volume-level="!canExpand"
+        :show-volume-level="!canExpandChildVolumes"
         :prefer-group-volume="true"
         :enable-popout="false"
+        :request-expand-on-group-tap="canExpandChildVolumes"
         width="100%"
-        @click.stop
+        @toggle-group-expansion="emit('toggle-child-volumes', player)"
       />
-      <v-icon
-        v-if="canExpand"
-        variant="plain"
-        :icon="showSubPlayers ? 'mdi-chevron-up' : 'mdi-chevron-down'"
-        class="expandbtn"
+      <Button
+        v-if="canExpandChildVolumes"
+        variant="ghost"
+        size="icon-xs"
+        class="size-8 shrink-0"
+        :disabled="!player.available"
         :aria-label="$t('tooltip.toggle_subplayers')"
-        @click.stop="$emit('toggle-expand', player)"
-      />
-    </div>
-
-    <!-- (child) volume player rows -->
-    <div
-      v-if="
-        showSubPlayers &&
-        (player.group_members.length > 0 || showSyncControls) &&
-        getChildPlayers(player).length > 0
-      "
-      @click.stop
-    >
-      <v-divider style="margin-top: 4px; margin-bottom: 4px" />
-
-      <div
-        v-for="childPlayer in getChildPlayers(player)"
-        :key="childPlayer.player_id"
+        :aria-expanded="showChildVolumes"
+        @click.stop="emit('toggle-child-volumes', player)"
       >
-        <!-- player icon + player name + optional sync checkbox-->
-        <v-list-item
-          class="volumesliderrow"
-          :link="false"
-          :style="
-            childPlayer.powered != false || showSyncControls
-              ? 'opacity: 0.75'
-              : 'opacity: 0.4'
-          "
-          @click.stop
-        >
-          <template #prepend>
-            <v-icon
-              :size="30"
-              :icon="childPlayer.icon"
-              style="opacity: 0.6; margin-left: -4px; margin-right: 7px"
-            />
-          </template>
-          <template #default>
-            <h6>{{ truncateString(childPlayer.name, 27) }}</h6>
-          </template>
-          <template #append>
-            <v-checkbox
-              v-if="showSyncControls"
-              :ripple="false"
-              :disabled="
-                player.static_group_members.includes(childPlayer.player_id) &&
-                player.group_members.includes(childPlayer.player_id)
-              "
-              :model-value="
-                player.group_members.includes(childPlayer.player_id) ||
-                childPlayer.player_id == player.player_id
-              "
-              size="22"
-              class="checkbox"
-              @update:model-value="
-                syncCheckBoxChange(childPlayer.player_id, $event)
-              "
-            />
-          </template>
-        </v-list-item>
-        <!-- volume slider with integrated mute + level -->
-        <!-- only show if the child player is part of the group and has volume control -->
-        <div
-          v-if="
-            player.group_members.includes(childPlayer.player_id) &&
-            childPlayer.volume_control != PLAYER_CONTROL_NONE
-          "
-          class="volume-row child-volume-row"
-          :style="
-            childPlayer.powered == false ? 'opacity: 0.4' : 'opacity: 0.75'
-          "
-          @click.stop
-        >
-          <PlayerVolume
-            :player="childPlayer"
-            :allow-wheel="allowWheel"
-            width="100%"
-          />
-        </div>
-        <div style="height: 6px"></div>
-      </div>
+        <ChevronUp v-if="showChildVolumes" class="size-4" />
+        <ChevronDown v-else class="size-4" />
+      </Button>
     </div>
-  </v-list>
+
+    <PlayerChildVolumes
+      v-if="
+        showVolumeControl && showChildVolumes && childVolumePlayers.length > 0
+      "
+      :players="childVolumePlayers"
+      :allow-wheel="allowWheel"
+    />
+    <PlayerGroupMembers
+      v-if="showMemberControls"
+      :player="player"
+      :members="groupMembers"
+    />
+  </div>
 </template>
 
 <script setup lang="ts">
-import Button from "@/components/Button.vue";
-import {
-  getPlayerName,
-  groupMemberPickerVisible,
-  truncateString,
-} from "@/helpers/utils";
-import PlayerIcon from "@/components/PlayerIcon.vue";
+import PlayerChildVolumes from "@/components/PlayerChildVolumes.vue";
+import PlayerGroupMembers from "@/components/PlayerGroupMembers.vue";
+import { Button } from "@/components/ui/button";
 import PlayerVolume from "@/layouts/default/PlayerOSD/PlayerVolume.vue";
 import { api } from "@/plugins/api";
 import {
-  Player,
+  type Player,
   PLAYER_CONTROL_NONE,
-  PlayerFeature,
   PlayerType,
 } from "@/plugins/api/interfaces";
-import { computed, ref } from "vue";
+import { ChevronDown, ChevronUp } from "@lucide/vue";
+import { computed } from "vue";
 
 export interface Props {
   player: Player;
-  showSyncControls?: boolean;
-  showSubPlayers?: boolean;
-  showHeadingRow?: boolean;
+  showMemberControls?: boolean;
+  showChildVolumes?: boolean;
   showVolumeControl?: boolean;
   allowWheel?: boolean;
 }
-const compProps = defineProps<Props>();
-const playersToSync = ref<string[]>([]);
-const playersToUnSync = ref<string[]>([]);
-const timeOutId = ref<NodeJS.Timeout | undefined>(undefined);
 
-// emits
-defineEmits<{
-  (e: "toggle-expand", player: Player): void;
+const props = defineProps<Props>();
+const emit = defineEmits<{
+  (event: "toggle-child-volumes", player: Player): void;
 }>();
 
-const canExpand = computed(() => {
-  return compProps.player.group_members.length > 0;
+const volumePlayers = computed(() => {
+  const playerIds = new Set(props.player.group_members);
+  const hasGroupMembers =
+    props.player.type === PlayerType.GROUP
+      ? playerIds.size > 0
+      : [...playerIds].some((playerId) => playerId !== props.player.player_id);
+  if (props.player.type !== PlayerType.GROUP) {
+    if (hasGroupMembers) {
+      playerIds.add(props.player.player_id);
+    } else {
+      playerIds.delete(props.player.player_id);
+    }
+  }
+  const players = [...playerIds]
+    .map((playerId) => api.players[playerId])
+    .filter((player): player is Player => player?.available === true);
+  return players.sort((left, right) =>
+    left.name.localeCompare(right.name, undefined, {
+      sensitivity: "base",
+    }),
+  );
 });
 
-const getChildPlayers = function (player: Player) {
-  const items: Player[] = [];
-  // always include group_childs
-  for (const groupChildId of player.group_members) {
-    const groupChild = api?.players[groupChildId];
-    if (!groupChild) continue;
-    if (groupChild && groupChild.available && !items.includes(groupChild)) {
-      items.push(groupChild);
-    }
-  }
-  // when groupcontrols are enabled, show all groupable players
-  if (
-    compProps.showSyncControls &&
-    player.supported_features.includes(PlayerFeature.SET_MEMBERS)
-  ) {
-    for (const syncPlayer of Object.values(api?.players)) {
-      if (syncPlayer.player_id == player.player_id) continue;
-      if (
-        !(
-          player.can_group_with.includes(syncPlayer.player_id) ||
-          // also allow grouping with same provider players even if not explicitly listed
-          // this can be removed in a future version where the server handles this
-          player.can_group_with.includes(syncPlayer.provider)
-        )
-      ) {
-        continue;
-      }
-      // skip unavailable players
-      if (!syncPlayer.available) continue;
+const groupMembers = computed(() =>
+  volumePlayers.value.filter(
+    (player) => player.player_id !== props.player.player_id,
+  ),
+);
 
-      // skip players hidden from the picker; current group members above
-      // are always shown so they don't become invisible participants
-      if (!groupMemberPickerVisible(syncPlayer)) continue;
+const childVolumePlayers = computed(() =>
+  volumePlayers.value.filter(
+    (player) => player.volume_control !== PLAYER_CONTROL_NONE,
+  ),
+);
 
-      // skip for group players
-      if (syncPlayer.type == PlayerType.GROUP) continue;
-
-      // skip if player has (another) group active
-      if (
-        syncPlayer.active_group &&
-        syncPlayer.active_group != player.player_id
-      )
-        continue;
-
-      if (!items.includes(syncPlayer)) {
-        items.push(syncPlayer);
-      }
-    }
-  }
-  // Sort: by name
-  items.sort((a, b) => {
-    return a.name.toUpperCase() > b.name.toUpperCase() ? 1 : -1;
-  });
-  return items;
-};
-
-const syncCheckBoxChange = async function (
-  syncPlayerId: string,
-  value: boolean | null,
-) {
-  const parentPlayerId = compProps.player.player_id;
-
-  if (value) {
-    // add syncPlayerId to syncgroup
-    if (playersToUnSync.value.includes(syncPlayerId)) {
-      // remove syncPlayerId from the unSync list if needed
-      playersToUnSync.value = playersToUnSync.value.filter(
-        (x) => x != syncPlayerId,
-      );
-    }
-    if (!playersToSync.value.includes(syncPlayerId)) {
-      playersToSync.value.push(syncPlayerId);
-    }
-    // optimistically update player state
-    api.players[parentPlayerId].group_members.push(syncPlayerId);
-  } else {
-    // remove player from syncgroup
-    if (playersToSync.value.includes(syncPlayerId)) {
-      // remove syncPlayerId from the sync list if needed
-      playersToSync.value = playersToSync.value.filter(
-        (x) => x != syncPlayerId,
-      );
-    }
-    if (!playersToUnSync.value.includes(syncPlayerId)) {
-      playersToUnSync.value.push(syncPlayerId);
-    }
-    // optimistically update player state
-    api.players[parentPlayerId].group_members = api.players[
-      parentPlayerId
-    ].group_members.filter((x) => x != syncPlayerId);
-  }
-
-  // clear existing debounce timer
-  if (timeOutId.value != null) clearTimeout(timeOutId.value);
-
-  // execute (un)sync with a debounce timer to account for someone
-  // changing multiple checkboxes in quick succession
-
-  if (playersToSync.value.length == 0 && playersToUnSync.value.length == 0) {
-    // no changes to be made, so return
-    return;
-  }
-
-  timeOutId.value = setTimeout(async () => {
-    api
-      .playerCommandSetMembers(
-        parentPlayerId,
-        playersToSync.value.length ? playersToSync.value : undefined,
-        playersToUnSync.value.length ? playersToUnSync.value : undefined,
-      )
-      .catch(async () => {
-        // restore state if command failed
-        api.players[parentPlayerId] = await api.getPlayer(parentPlayerId);
-      })
-      .finally(() => {
-        playersToSync.value = [];
-        playersToUnSync.value = [];
-      });
-  }, 500);
-};
+const canExpandChildVolumes = computed(
+  () => childVolumePlayers.value.length > 0,
+);
 </script>
-
-<style scoped>
-.volumesliderrow {
-  margin-top: 0px;
-  padding-top: 0px;
-  padding-bottom: 0px;
-  height: 36px;
-  min-height: 36px;
-}
-
-.volumesliderrow :deep(.v-list-item__content) {
-  height: 36px;
-  min-height: 36px;
-  overflow: visible !important;
-  align-content: center;
-}
-
-.heading {
-  margin-bottom: 5px;
-  height: 35px;
-}
-
-.volume-row {
-  display: flex;
-  align-items: center;
-  padding: 0 2px;
-  margin-top: 0px;
-  min-height: 32px;
-}
-
-.volume-row :deep(.player-volume-container) {
-  flex: 1;
-  min-width: 0;
-}
-
-.child-volume-row {
-  padding-left: 2px;
-}
-
-.expandbtn {
-  flex-shrink: 0;
-  width: 36px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-}
-.powerbtn {
-  right: 8px;
-}
-
-.volumesliderrow :deep(.v-list-item__prepend) {
-  width: 36px;
-  margin-left: -12px;
-}
-.volumesliderrow :deep(.v-list-item__append) {
-  width: 20px;
-}
-
-.checkbox {
-  margin-right: -5px;
-  width: 25px;
-  margin-top: -30px;
-  height: 22px !important;
-  min-height: 22px !important;
-  display: unset;
-}
-
-.syncbtn {
-  margin-right: -32px;
-  height: 25px !important;
-  padding-bottom: 20px;
-}
-</style>

--- a/src/helpers/utils.ts
+++ b/src/helpers/utils.ts
@@ -857,8 +857,9 @@ export const isHiddenSendspinWebPlayer = function (
 export const getVolumeIconComponent = function (
   player: Player,
   displayVolume?: number,
+  muted = player.volume_muted ?? false,
 ) {
-  if (player.volume_muted) {
+  if (muted) {
     return VolumeX;
   }
 

--- a/src/layouts/default/PlayerOSD/PlayerFullscreen.vue
+++ b/src/layouts/default/PlayerOSD/PlayerFullscreen.vue
@@ -1171,7 +1171,12 @@ onMounted(() => {
 
 // Handle Escape key to close fullscreen player (since persistent disables default behavior)
 const onKeydown = (e: KeyboardEvent) => {
-  if (e.key === "Escape" && store.showFullscreenPlayer && !store.dialogActive) {
+  if (
+    e.key === "Escape" &&
+    store.showFullscreenPlayer &&
+    !store.dialogActive &&
+    !store.showPlayersMenu
+  ) {
     store.showFullscreenPlayer = false;
   }
 };

--- a/src/layouts/default/PlayerOSD/PlayerVolume.vue
+++ b/src/layouts/default/PlayerOSD/PlayerVolume.vue
@@ -70,6 +70,10 @@
       }"
       :style="{ width: width }"
       @click="onSliderClick"
+      @pointerdown.capture="onPointerDown"
+      @pointermove.capture="onPointerMove"
+      @pointerup="onPointerUp"
+      @pointercancel="onPointerCancel"
       @wheel.prevent="onWheel"
       @touchstart="onTouchStart"
       @touchmove="onTouchMove"
@@ -122,6 +126,7 @@ import {
   type Player,
   PLAYER_CONTROL_NONE,
   PlayerFeature,
+  PlayerType,
 } from "@/plugins/api/interfaces";
 import { store } from "@/plugins/store";
 import { computed, onUnmounted, ref, watch } from "vue";
@@ -138,6 +143,8 @@ export interface Props {
   preferGroupVolume?: boolean;
   /** Enable the Sonos-style group popout (set false when parent already shows child players) */
   enablePopout?: boolean;
+  /** Ask the parent to expand inline group controls when the slider is tapped */
+  requestExpandOnGroupTap?: boolean;
   width?: string;
   step?: number;
   allowWheel?: boolean;
@@ -151,6 +158,7 @@ const props = withDefaults(defineProps<Props>(), {
   disabled: false,
   preferGroupVolume: false,
   enablePopout: true,
+  requestExpandOnGroupTap: false,
   width: "100%",
   step: 2,
   allowWheel: false,
@@ -160,12 +168,17 @@ const props = withDefaults(defineProps<Props>(), {
 
 const emit = defineEmits<{
   (e: "update:local-value", value: number): void;
+  (e: "toggle-group-expansion"): void;
 }>();
 
 // --- Player-aware computed properties ---
 
-const isGroup = computed(
-  () => props.player && props.player.group_members.length > 0,
+const isGroup = computed(() =>
+  props.player.type === PlayerType.GROUP
+    ? props.player.group_members.length > 0
+    : props.player.group_members.some(
+        (playerId) => playerId !== props.player.player_id,
+      ),
 );
 
 const useGroupVolume = computed(() => isGroup.value && props.preferGroupVolume);
@@ -188,7 +201,9 @@ const isDisabled = computed(() => {
 });
 
 const isMuted = computed(() => {
-  return props.player.volume_muted ?? false;
+  return useGroupVolume.value
+    ? props.player.group_volume_muted === true
+    : (props.player.volume_muted ?? false);
 });
 
 const isSliderDisabled = computed(() => isDisabled.value || isMuted.value);
@@ -209,7 +224,11 @@ const muteDisabled = computed(() => {
 });
 
 const volumeIconComponent = computed(() => {
-  return getVolumeIconComponent(props.player, displayValue.value);
+  return getVolumeIconComponent(
+    props.player,
+    displayValue.value,
+    isMuted.value,
+  );
 });
 
 // --- Group popout ---
@@ -222,8 +241,12 @@ let lastPopoutToggleTime = 0;
 
 const childPlayers = computed(() => {
   if (!isGroup.value) return [];
+  const playerIds = new Set(props.player.group_members);
+  if (props.player.type !== PlayerType.GROUP) {
+    playerIds.add(props.player.player_id);
+  }
   const items: Player[] = [];
-  for (const childId of props.player.group_members) {
+  for (const childId of playerIds) {
     const child = api?.players[childId];
     if (
       child &&
@@ -240,6 +263,17 @@ const childPlayers = computed(() => {
 const hasGroupPopout = computed(
   () =>
     props.enablePopout && useGroupVolume.value && childPlayers.value.length > 0,
+);
+
+const requestsGroupExpansion = computed(
+  () =>
+    props.requestExpandOnGroupTap &&
+    useGroupVolume.value &&
+    childPlayers.value.length > 0,
+);
+
+const handlesGroupTap = computed(
+  () => hasGroupPopout.value || requestsGroupExpansion.value,
 );
 
 const POPOUT_MIN_WIDTH = 300;
@@ -287,6 +321,15 @@ const toggleGroupPopout = () => {
   }
   showGroupPopout.value = !showGroupPopout.value;
   lastPopoutToggleTime = Date.now();
+};
+
+const handleGroupTap = () => {
+  if (hasGroupPopout.value) {
+    toggleGroupPopout();
+  } else {
+    lastPopoutToggleTime = Date.now();
+    emit("toggle-group-expansion");
+  }
 };
 
 const closeGroupPopout = () => {
@@ -365,9 +408,13 @@ const isTouching = ref(false);
 // Dragging state: blocks server sync only while actively dragging the slider
 const isDragging = ref(false);
 let dragEndTimeout: ReturnType<typeof setTimeout> | null = null;
+let pointerStartX: number | null = null;
+let pointerStartValue = 0;
+let pointerMoved = false;
 
 let sliderUpdateDebounceTimeout: ReturnType<typeof setTimeout> | null = null;
 const SLIDER_UPDATE_DEBOUNCE_MS = 100;
+const POINTER_DRAG_THRESHOLD = 4;
 
 onUnmounted(() => {
   if (dragEndTimeout) clearTimeout(dragEndTimeout);
@@ -457,7 +504,7 @@ const getPercentageFromX = (clientX: number): number => {
 // --- Touch handlers ---
 
 const onTouchStart = (event: TouchEvent) => {
-  if (isSliderDisabled.value) return;
+  if (isSliderDisabled.value && !handlesGroupTap.value) return;
 
   isTouching.value = true;
   const touch = event.touches[0];
@@ -473,7 +520,9 @@ const onTouchStart = (event: TouchEvent) => {
 };
 
 const onTouchMove = (event: TouchEvent) => {
-  if (isSliderDisabled.value || isScrolling.value) return;
+  if ((isSliderDisabled.value && !handlesGroupTap.value) || isScrolling.value) {
+    return;
+  }
 
   const touch = event.touches[0];
   const deltaX = touch.clientX - touchStartX.value;
@@ -483,6 +532,15 @@ const onTouchMove = (event: TouchEvent) => {
 
   touchMoveCount.value++;
   maxMovement.value = Math.max(maxMovement.value, absDeltaX);
+
+  if (isSliderDisabled.value) {
+    if (absDeltaY > 10 && absDeltaY > absDeltaX * 2) {
+      isScrolling.value = true;
+    } else if (absDeltaX > 8) {
+      isDrag.value = true;
+    }
+    return;
+  }
 
   if (!isDrag.value && !isScrolling.value) {
     if (absDeltaY > 10 && absDeltaY > absDeltaX * 2) {
@@ -515,7 +573,7 @@ const onTouchMove = (event: TouchEvent) => {
 };
 
 const onTouchEnd = (event: TouchEvent) => {
-  if (isSliderDisabled.value) return;
+  if (isSliderDisabled.value && !handlesGroupTap.value) return;
 
   if (isScrolling.value) {
     isScrolling.value = false;
@@ -526,10 +584,15 @@ const onTouchEnd = (event: TouchEvent) => {
   const isTap = !isDrag.value;
 
   if (isTap) {
-    // Group player with popout: toggle the popout on tap
-    if (hasGroupPopout.value) {
-      toggleGroupPopout();
-    } else {
+    if (handlesGroupTap.value) {
+      if (sliderUpdateDebounceTimeout) {
+        clearTimeout(sliderUpdateDebounceTimeout);
+        sliderUpdateDebounceTimeout = null;
+      }
+      displayValue.value = touchStartValue.value;
+      emit("update:local-value", touchStartValue.value);
+      handleGroupTap();
+    } else if (!isSliderDisabled.value) {
       // Single player: tap before/after handle for volume up/down
       const touch = event.changedTouches[0];
       const thumb = sliderContainerRef.value?.querySelector("[role=slider]");
@@ -543,7 +606,7 @@ const onTouchEnd = (event: TouchEvent) => {
         }
       }
     }
-  } else {
+  } else if (!isSliderDisabled.value) {
     // Drag end: send the final absolute value to the server
     const touch = event.changedTouches[0];
     const finalValue = clamp(
@@ -561,6 +624,83 @@ const onTouchEnd = (event: TouchEvent) => {
   touchMoveCount.value = 0;
   maxMovement.value = 0;
   isTouching.value = false;
+};
+
+const onPointerDown = (event: PointerEvent) => {
+  const targetsSlider =
+    event.target instanceof Element &&
+    event.target.closest('[data-slot="slider"]');
+  if (event.pointerType === "touch") {
+    if (targetsSlider) isTouching.value = true;
+    return;
+  }
+  if (!handlesGroupTap.value || !targetsSlider) {
+    return;
+  }
+  pointerStartX = event.clientX;
+  pointerStartValue = displayValue.value;
+  pointerMoved = false;
+};
+
+const onPointerMove = (event: PointerEvent) => {
+  if (pointerStartX === null) return;
+  if (Math.abs(event.clientX - pointerStartX) > POINTER_DRAG_THRESHOLD) {
+    pointerMoved = true;
+  }
+};
+
+const onPointerUp = () => {
+  if (pointerStartX === null) return;
+  const shouldExpand = !pointerMoved;
+  resetPointerInteraction();
+  if (!shouldExpand) {
+    lastPopoutToggleTime = Date.now();
+    if (!sliderUpdateDebounceTimeout) {
+      if (isSliderDisabled.value) {
+        isDragging.value = false;
+        displayValue.value = pointerStartValue;
+        emit("update:local-value", pointerStartValue);
+      } else {
+        setVolume(displayValue.value);
+        stopDragging();
+      }
+    }
+    return;
+  }
+
+  if (sliderUpdateDebounceTimeout) {
+    clearTimeout(sliderUpdateDebounceTimeout);
+    sliderUpdateDebounceTimeout = null;
+  }
+  if (dragEndTimeout) {
+    clearTimeout(dragEndTimeout);
+    dragEndTimeout = null;
+  }
+  isDragging.value = false;
+  displayValue.value = pointerStartValue;
+  emit("update:local-value", pointerStartValue);
+  handleGroupTap();
+};
+
+const onPointerCancel = () => {
+  if (pointerStartX === null) return;
+  resetPointerInteraction();
+  if (sliderUpdateDebounceTimeout) {
+    clearTimeout(sliderUpdateDebounceTimeout);
+    sliderUpdateDebounceTimeout = null;
+  }
+  if (dragEndTimeout) {
+    clearTimeout(dragEndTimeout);
+    dragEndTimeout = null;
+  }
+  isDragging.value = false;
+  displayValue.value = pointerStartValue;
+  emit("update:local-value", pointerStartValue);
+};
+
+const resetPointerInteraction = () => {
+  pointerStartX = null;
+  pointerMoved = false;
 };
 
 const onTouchCancel = () => {
@@ -601,6 +741,8 @@ const onSliderUpdate = (values: number[] | undefined) => {
   displayValue.value = newValue;
   emit("update:local-value", newValue);
 
+  if (pointerStartX !== null && !pointerMoved) return;
+
   if (sliderUpdateDebounceTimeout) {
     clearTimeout(sliderUpdateDebounceTimeout);
     sliderUpdateDebounceTimeout = null;
@@ -613,13 +755,11 @@ const onSliderUpdate = (values: number[] | undefined) => {
   }, SLIDER_UPDATE_DEBOUNCE_MS);
 };
 
-// Desktop: click on slider area toggles popout for group players
+// Desktop clicks use the same group action as touch taps.
 const onSliderClick = () => {
-  // Only toggle for group players; skip if touch-driven, mid-drag,
-  // or within 500ms of a touch-driven toggle (prevents synthesized click)
-  if (!hasGroupPopout.value || isTouching.value || isDragging.value) return;
+  if (!handlesGroupTap.value || isTouching.value || isDragging.value) return;
   if (Date.now() - lastPopoutToggleTime < 500) return;
-  toggleGroupPopout();
+  handleGroupTap();
 };
 
 // Sync server volume to display when not actively dragging

--- a/src/layouts/default/PlayerSelect.vue
+++ b/src/layouts/default/PlayerSelect.vue
@@ -1,290 +1,252 @@
 <template>
-  <!-- Overlay scrim -->
-  <Transition name="player-scrim">
-    <div
-      v-if="store.showPlayersMenu"
-      class="player-panel-scrim"
-      @click="store.showPlayersMenu = false"
-    ></div>
-  </Transition>
+  <Teleport to="body">
+    <Transition
+      enter-active-class="transition-opacity duration-200"
+      enter-from-class="opacity-0"
+      leave-active-class="transition-opacity duration-200"
+      leave-to-class="opacity-0"
+    >
+      <button
+        v-if="store.showPlayersMenu"
+        type="button"
+        class="player-select-backdrop fixed inset-x-0 top-0 bottom-[60px] z-[99999] bg-black/60 backdrop-blur-sm md:bottom-0"
+        :aria-label="$t('close')"
+        @click="setMenuOpen(false)"
+      ></button>
+    </Transition>
+  </Teleport>
 
-  <!-- Panel: fixed position, slides in via transform -->
-  <div
-    class="player-panel player-panel--overlay"
-    :class="{
-      'player-panel--open': store.showPlayersMenu,
-    }"
+  <Sheet
+    :open="store.showPlayersMenu"
+    :modal="false"
+    @update:open="setMenuOpen"
   >
-    <div class="player-panel-inner">
-      <!-- header -->
-      <div class="player-header">
-        <Speaker class="player-header-icon" />
-        <span class="player-header-title">{{ $t("players") }}</span>
-      </div>
+    <SheetContent
+      data-testid="player-select-sheet"
+      side="right"
+      class="w-[90vw] gap-0 p-0 sm:max-w-[400px] max-md:bottom-[60px]"
+      @keydown="handleSheetKeydown"
+    >
+      <SheetHeader class="flex-row items-center gap-2 border-b pr-14">
+        <Speaker class="size-5 text-muted-foreground" />
+        <SheetTitle class="text-lg">{{ $t("players") }}</SheetTitle>
+        <SheetDescription class="sr-only">
+          {{ $t("tooltip.select_player") }}
+        </SheetDescription>
+      </SheetHeader>
 
-      <!-- scrollable content -->
-      <div class="player-content">
-        <!-- preferred/active players on top -->
-        <v-list flat style="margin: 0px 10px; padding: 0">
+      <div class="min-h-0 flex-1 overflow-y-auto pb-6">
+        <div
+          v-if="showSearch"
+          class="bg-background sticky top-0 z-10 px-3 pt-3 pb-2"
+        >
+          <SearchInput
+            v-model="playerSearchQuery"
+            :placeholder="$t('search')"
+            clearable
+          />
+        </div>
+
+        <div class="space-y-2 px-3 pt-3">
+          <p
+            v-if="filteredPlayers.length === 0"
+            class="text-muted-foreground px-3 py-8 text-center text-sm"
+          >
+            {{ playerSearchQuery ? $t("no_content_filter") : $t("no_content") }}
+          </p>
           <PlayerCard
-            v-for="player in preferredPlayers"
+            v-for="player in filteredPlayers"
             :id="player.player_id"
             :key="player.player_id"
-            style="margin: 10px 0px"
             :player="player"
             :show-volume-control="true"
             :show-menu-button="true"
-            :show-sub-players="
-              showSubPlayers && player.player_id == store.activePlayerId
+            :show-child-volumes="expandedVolumePlayerIds.has(player.player_id)"
+            :show-member-controls="
+              expandedMemberPlayerIds.has(player.player_id)
             "
-            :show-sync-controls="true"
+            :show-group-controls="true"
             :allow-power-control="true"
-            @click="playerClicked(player)"
-            @toggle-expand="toggleGroupExpand"
+            @click="selectPlayer"
+            @toggle-child-volumes="toggleChildVolumes"
+            @toggle-member-controls="toggleMemberControls"
           />
-        </v-list>
-
-        <!-- collapsible section with all players (only shown if more than 3 players) -->
-        <v-expansion-panels
-          v-if="allPlayers.length > 3"
-          v-model="allPlayersExpanded"
-          variant="accordion"
-          flat
-          class="expansion"
-        >
-          <v-expansion-panel style="padding: 0">
-            <v-expansion-panel-title>
-              <h3>{{ $t("all_players") }}</h3>
-            </v-expansion-panel-title>
-            <v-expansion-panel-text style="padding: 0">
-              <div style="margin: 0 8px 24px 8px">
-                <InputGroup>
-                  <InputGroupInput
-                    ref="playerSearchInput"
-                    v-model="playerSearchQuery"
-                    :placeholder="$t('search')"
-                  />
-                  <InputGroupAddon>
-                    <Search />
-                  </InputGroupAddon>
-                </InputGroup>
-              </div>
-              <v-list flat style="margin: -20px 3px 5px 3px">
-                <PlayerCard
-                  v-for="player in filteredPlayers"
-                  :id="player.player_id"
-                  :key="player.player_id"
-                  style="margin: 8px 0px"
-                  :player="player"
-                  :show-volume-control="true"
-                  :show-menu-button="true"
-                  :show-sub-players="
-                    showSubPlayers && player.player_id == store.activePlayerId
-                  "
-                  :show-sync-controls="
-                    player.supported_features.includes(
-                      PlayerFeature.SET_MEMBERS,
-                    )
-                  "
-                  :allow-power-control="true"
-                  @click="playerClicked(player)"
-                  @toggle-expand="toggleGroupExpand"
-                />
-              </v-list>
-            </v-expansion-panel-text>
-          </v-expansion-panel>
-        </v-expansion-panels>
+        </div>
       </div>
-    </div>
-  </div>
+    </SheetContent>
+  </Sheet>
 </template>
 
 <script setup lang="ts">
 import PlayerCard from "@/components/PlayerCard.vue";
+import { SearchInput } from "@/components/ui/search-input";
 import {
-  InputGroup,
-  InputGroupAddon,
-  InputGroupInput,
-} from "@/components/ui/input-group";
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
+} from "@/components/ui/sheet";
 import { useUserPreferences } from "@/composables/userPreferences";
-import { playerVisible } from "@/helpers/utils";
+import { isBuiltinPlayer, playerVisible } from "@/helpers/utils";
 import { api } from "@/plugins/api";
-import { Player, PlayerFeature } from "@/plugins/api/interfaces";
-
+import { PlaybackState, type Player } from "@/plugins/api/interfaces";
 import { store } from "@/plugins/store";
 import { webPlayer } from "@/plugins/web_player";
-import { Search, Speaker } from "@lucide/vue";
-import { computed, nextTick, onMounted, ref, watch } from "vue";
+import { Speaker } from "@lucide/vue";
+import { computed, nextTick, onMounted, reactive, ref, watch } from "vue";
 
-const showSubPlayers = ref(false);
-const recentlySelectedPlayerIds = ref<string[]>([]);
-const allPlayersExpanded = ref<number | undefined>(undefined);
+const SEARCH_PLAYER_THRESHOLD = 10;
+
 const playerSearchQuery = ref("");
-const playerSearchInput = ref<InstanceType<typeof InputGroupInput> | null>(
-  null,
-);
+const expandedVolumePlayerIds = reactive(new Set<string>());
+const expandedMemberPlayerIds = reactive(new Set<string>());
 const { getPreference, setPreference } = useUserPreferences();
+let menuTrigger: HTMLElement | null = null;
 
-const MAX_RECENT_PLAYERS = 3;
-
-// Load all players expanded state from user preferences
-const allPlayersExpandedPref = getPreference<boolean>("allPlayersExpanded");
-watch(
-  allPlayersExpandedPref,
-  (newVal) => {
-    // v-expansion-panels uses 0 for expanded, undefined for collapsed
-    allPlayersExpanded.value = newVal ? 0 : undefined;
-  },
-  { immediate: true },
+const players = computed(() =>
+  Object.values(api.players).filter((player) => playerVisible(player)),
 );
 
-// Save expanded state when it changes
-watch(allPlayersExpanded, (newVal) => {
-  setPreference("allPlayersExpanded", newVal === 0);
-});
+const orderedPlayers = computed(() =>
+  [...players.value].sort((left, right) => {
+    const leftPriority = getPlayerPriority(left);
+    const rightPriority = getPlayerPriority(right);
+    if (leftPriority !== rightPriority) {
+      return leftPriority - rightPriority;
+    }
+    return left.name.localeCompare(right.name, undefined, {
+      sensitivity: "base",
+    });
+  }),
+);
 
-// Load recently selected players from user preferences (only on initial load)
-const recentPlayersPref = getPreference<string[]>("recentlySelectedPlayerIds");
-if (recentPlayersPref.value) {
-  recentlySelectedPlayerIds.value = recentPlayersPref.value;
-}
+const showSearch = computed(
+  () => players.value.length > SEARCH_PLAYER_THRESHOLD,
+);
 
-// computed properties
-const allPlayers = computed(() => {
-  return Object.values(api.players)
-    .filter((x) => playerVisible(x))
-    .sort((a, b) => (a.name.toUpperCase() > b.name?.toUpperCase() ? 1 : -1));
-});
-
-// Filtered players based on search query
 const filteredPlayers = computed(() => {
-  if (playerSearchQuery.value) {
-    // When searching, show all matching players
-    const query = playerSearchQuery.value.toLowerCase();
-    return allPlayers.value.filter((p) => p.name.toLowerCase().includes(query));
-  }
-  // When not searching, exclude players already shown in preferred section
-  const preferredIds = preferredPlayers.value.map((p) => p.player_id);
-  return allPlayers.value.filter((p) => !preferredIds.includes(p.player_id));
+  if (!showSearch.value) return orderedPlayers.value;
+  const query = playerSearchQuery.value.trim().toLocaleLowerCase();
+  if (!query) return orderedPlayers.value;
+  return orderedPlayers.value.filter((player) =>
+    player.name.toLocaleLowerCase().includes(query),
+  );
 });
 
-// Preferred players shown at top (last 3 recently selected players)
-const preferredPlayers = computed(() => {
-  const players = Object.values(api.players).filter((x) => playerVisible(x));
-  if (players.length <= 3) {
-    // If 3 or fewer players, show all sorted alphabetically
-    return players.sort((a, b) =>
-      a.name.toUpperCase() > b.name.toUpperCase() ? 1 : -1,
-    );
-  }
-  // Show only recently selected players that still exist
-  const recentPlayers = recentlySelectedPlayerIds.value
-    .map((id) => players.find((p) => p.player_id === id))
-    .filter((p): p is Player => p !== undefined)
-    .slice(0, MAX_RECENT_PLAYERS);
-  return recentPlayers;
-});
-
-//watchers
 watch(
   () => store.showPlayersMenu,
-  (newVal) => {
-    if (newVal) {
-      showSubPlayers.value = true;
-    } else {
-      // Save preferences and reset state when menu closes
-      playerSearchQuery.value = "";
-      if (store.activePlayerId) {
-        setPreference("activePlayerId", store.activePlayerId);
-        localStorage.setItem("activePlayerId", store.activePlayerId);
-        // Update recently selected players list
-        const recent = recentlySelectedPlayerIds.value.filter(
-          (id) => id !== store.activePlayerId,
-        );
-        recent.unshift(store.activePlayerId);
-        recentlySelectedPlayerIds.value = recent.slice(0, MAX_RECENT_PLAYERS);
-      }
-      setPreference(
-        "recentlySelectedPlayerIds",
-        recentlySelectedPlayerIds.value,
-      );
+  (isOpen) => {
+    if (isOpen) {
+      const activeElement = document.activeElement;
+      menuTrigger =
+        activeElement instanceof HTMLElement && activeElement !== document.body
+          ? activeElement
+          : null;
+      return;
     }
+    resetPanelState();
+    nextTick(() => {
+      const focusTarget = menuTrigger?.isConnected
+        ? menuTrigger
+        : (document.getElementById("active-player-popover") ??
+          document.getElementById("extended-controls-speaker-button"));
+      focusTarget?.focus();
+      menuTrigger = null;
+    });
   },
 );
+
+watch(showSearch, (isVisible) => {
+  if (!isVisible) playerSearchQuery.value = "";
+});
+
+watch(
+  () => store.activePlayerId,
+  (playerId) => {
+    if (!playerId) return;
+    setPreference("activePlayerId", playerId);
+    localStorage.setItem("activePlayerId", playerId);
+  },
+);
+
 watch(
   () => api.players,
-  (newVal) => {
-    if (newVal) {
-      checkDefaultPlayer();
-    }
-  },
+  () => checkDefaultPlayer(),
   { deep: true },
 );
 
 watch(
   () => webPlayer.player_id,
-  (newVal) => {
-    if (newVal) {
-      checkDefaultPlayer();
-    }
-  },
+  () => checkDefaultPlayer(),
 );
-
-function playerClicked(player: Player, close: boolean = false) {
-  if (store.activePlayerId !== player.player_id) {
-    store.activePlayerId = player.player_id;
-  }
-  if (close) store.showPlayersMenu = false;
-  // Scroll the player card into view (use nearest to avoid hiding header)
-  nextTick(() => {
-    const element = document.getElementById(player.player_id);
-    if (element) {
-      element.scrollIntoView({ behavior: "smooth", block: "nearest" });
-    }
-  });
-}
-
-function toggleGroupExpand(player: Player) {
-  if (store.activePlayerId !== player.player_id) {
-    store.activePlayerId = player.player_id;
-    showSubPlayers.value = true;
-  } else {
-    showSubPlayers.value = !showSubPlayers.value;
-  }
-  // Scroll the player card into view when expanding (use nearest to avoid hiding header)
-  if (showSubPlayers.value) {
-    nextTick(() => {
-      const element = document.getElementById(player.player_id);
-      if (element) {
-        element.scrollIntoView({ behavior: "smooth", block: "nearest" });
-      }
-    });
-  }
-}
 
 onMounted(() => {
   checkDefaultPlayer();
 });
 
-const checkDefaultPlayer = function () {
-  if (store.activePlayer) return;
-  const newDefaultPlayerId = selectDefaultPlayer();
-  if (newDefaultPlayerId) {
-    store.activePlayerId = newDefaultPlayerId;
-  }
-};
+function setMenuOpen(isOpen: boolean) {
+  store.showPlayersMenu = isOpen;
+}
 
-const selectDefaultPlayer = function () {
-  // check if we have a player stored that was last used
-  // we prefer localStorage over user preferences to allow having a preferred
-  // player per device - especially useful in case of using the built-in web player
+function handleSheetKeydown(event: KeyboardEvent) {
+  event.stopPropagation();
+  if (event.key === "Escape") setMenuOpen(false);
+}
+
+function selectPlayer(player: Player) {
+  store.activePlayerId = player.player_id;
+  store.showPlayersMenu = false;
+}
+
+function toggleChildVolumes(player: Player) {
+  const playerId = player.player_id;
+  expandedMemberPlayerIds.delete(playerId);
+  toggleExpandedPlayer(expandedVolumePlayerIds, playerId);
+}
+
+function toggleMemberControls(player: Player) {
+  const playerId = player.player_id;
+  expandedVolumePlayerIds.delete(playerId);
+  toggleExpandedPlayer(expandedMemberPlayerIds, playerId);
+}
+
+function getPlayerPriority(player: Player) {
+  if (player.player_id === store.activePlayerId) return 0;
+  if (isBuiltinPlayer(player)) return 1;
+  if (player.playback_state === PlaybackState.PLAYING) return 2;
+  return 3;
+}
+
+function toggleExpandedPlayer(playerIds: Set<string>, playerId: string) {
+  if (playerIds.has(playerId)) {
+    playerIds.delete(playerId);
+  } else {
+    playerIds.add(playerId);
+  }
+}
+
+function resetPanelState() {
+  playerSearchQuery.value = "";
+  expandedVolumePlayerIds.clear();
+  expandedMemberPlayerIds.clear();
+}
+
+function checkDefaultPlayer() {
+  if (store.activePlayer) return;
+  const defaultPlayerId = selectDefaultPlayer();
+  if (defaultPlayerId) {
+    store.activePlayerId = defaultPlayerId;
+  }
+}
+
+function selectDefaultPlayer() {
   const lastPlayerId =
     localStorage.getItem("activePlayerId") ||
     getPreference<string>("activePlayerId").value;
   if (lastPlayerId && lastPlayerId in api.players) {
     return lastPlayerId;
   }
-  // select webPlayer if available (only if we do not have a previous player stored)
   if (
     !lastPlayerId &&
     webPlayer.player_id &&
@@ -292,7 +254,6 @@ const selectDefaultPlayer = function () {
   ) {
     return webPlayer.player_id;
   }
-  // select companionPlayer if available (only if we do not have a previous player stored)
   if (
     !lastPlayerId &&
     store.companionPlayerId &&
@@ -300,167 +261,5 @@ const selectDefaultPlayer = function () {
   ) {
     return store.companionPlayerId;
   }
-};
+}
 </script>
-
-<style scoped>
-/*
- * Panel: fixed position, slides via GPU-accelerated transform.
- */
-.player-panel {
-  position: fixed;
-  top: 0;
-  bottom: 0;
-  right: 0;
-  width: 400px;
-  z-index: 10;
-  transform: translateX(100%);
-  transition: transform 0.5s;
-  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
-  background: rgb(var(--v-theme-surface));
-  color: rgb(var(--v-theme-on-surface));
-  border-left: 1px solid rgba(var(--v-border-color), 0.12);
-  display: flex;
-  flex-direction: column;
-}
-
-.player-panel--open {
-  transform: translateX(0);
-}
-
-/* Overlay: higher z-index, rounded edges, shadow */
-.player-panel--overlay {
-  z-index: 99999;
-  top: 0px;
-  bottom: 0px;
-  border-left: none;
-  border-radius: 6px 0 0 6px;
-}
-
-.player-panel--overlay.player-panel--open {
-  box-shadow: -4px 0 24px rgba(0, 0, 0, 0.25);
-}
-
-@media (max-width: 769px) {
-  .player-panel--overlay {
-    width: 90vw;
-    max-width: 400px;
-    bottom: 60px;
-  }
-}
-
-/* Inner wrapper */
-.player-panel-inner {
-  width: 100%;
-  height: 100%;
-  display: flex;
-  flex-direction: column;
-  position: relative;
-}
-
-.player-panel-inner::after {
-  content: "";
-  position: absolute;
-  bottom: 0;
-  left: 0;
-  right: 0;
-  height: 20px;
-  background: linear-gradient(
-    to bottom,
-    transparent,
-    rgb(var(--v-theme-surface)) 80%
-  );
-  pointer-events: none;
-  z-index: 1;
-  border-radius: 0 0 0 6px;
-}
-
-/* Mobile scrim/overlay */
-.player-panel-scrim {
-  position: fixed;
-  inset: 0;
-  z-index: 1999;
-  background: rgba(0, 0, 0, 0.7);
-}
-
-.player-scrim-enter-active,
-.player-scrim-leave-active {
-  transition: opacity 0.2s ease;
-}
-
-.player-scrim-enter-from,
-.player-scrim-leave-to {
-  opacity: 0;
-}
-
-/* Header */
-.player-header {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  padding-top: 16px;
-  padding-bottom: 8px;
-  padding-left: 16px;
-  flex-shrink: 0;
-}
-
-.player-header-icon {
-  width: 20px;
-  height: 20px;
-  flex-shrink: 0;
-  opacity: 0.7;
-}
-
-.player-header-title {
-  font-size: 1.1rem;
-  font-weight: bold;
-  white-space: nowrap;
-  overflow: hidden;
-}
-
-/* Scrollable content */
-.player-content {
-  overflow-y: auto;
-  -webkit-overflow-scrolling: touch;
-  flex: 1;
-  min-height: 0;
-  padding-bottom: 100px;
-}
-
-/* Force Vuetify children to inherit the panel background */
-.player-content :deep(.v-list),
-.player-content :deep(.v-expansion-panels),
-.player-content :deep(.v-expansion-panel),
-.player-content :deep(.v-expansion-panel-title),
-.player-content :deep(.v-expansion-panel-text) {
-  background: transparent !important;
-}
-
-/* Decrease space above search bar */
-.player-content :deep(.v-expansion-panel .v-expansion-panel-title) {
-  padding-bottom: 0;
-}
-
-/* Prevent panel title from growing when opening */
-.player-content :deep(.v-expansion-panel--active > .v-expansion-panel-title) {
-  min-height: 48px;
-}
-
-/* Disable focus and hover color changes */
-.player-content
-  :deep(
-    .v-expansion-panel-title:focus-visible > .v-expansion-panel-title__overlay
-  ),
-.player-content
-  :deep(.v-expansion-panel-title:hover > .v-expansion-panel-title__overlay) {
-  opacity: 0;
-}
-
-.expansion :deep(.v-expansion-panel-title) {
-  padding: 10px 16px;
-}
-
-.expansion :deep(.v-expansion-panel-text__wrapper) {
-  padding: 10px 5px;
-}
-</style>

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -60,6 +60,7 @@
     "on": "On",
     "other_versions": "Other versions",
     "perform_action": "Perform action on {0} item(s)",
+    "pause": "Pause",
     "play": "Play",
     "play_album_from": "Play Album from here",
     "play_next": "Play Next",

--- a/tests/components/PlayerCard.test.ts
+++ b/tests/components/PlayerCard.test.ts
@@ -1,0 +1,302 @@
+import PlayerCard from "@/components/PlayerCard.vue";
+import {
+  IdentifierType,
+  MediaType,
+  PlaybackState,
+  type Player,
+  PlayerFeature,
+  PlayerType,
+} from "@/plugins/api/interfaces";
+import { mount } from "@vue/test-utils";
+import { describe, expect, it, vi } from "vitest";
+
+const { apiMock, emitContextMenu } = vi.hoisted(() => ({
+  apiMock: {
+    queues: {} as Record<
+      string,
+      {
+        extra_attributes?: {
+          play_action_in_progress?: boolean;
+        };
+        items?: number;
+      }
+    >,
+    playerCommandPlayPause: vi.fn(),
+    playerCommandPowerToggle: vi.fn(),
+  },
+  emitContextMenu: vi.fn(),
+}));
+
+vi.mock("@/plugins/api", () => ({
+  default: apiMock,
+}));
+
+vi.mock("@/plugins/store", () => ({
+  store: {
+    activePlayerId: "active",
+    deviceType: "desktop",
+  },
+}));
+
+vi.mock("@/plugins/eventbus", () => ({
+  eventbus: {
+    emit: emitContextMenu,
+  },
+}));
+
+vi.mock("@/composables/activeSource", () => ({
+  useActiveSource: () => ({
+    activeSource: {
+      value: {
+        can_play_pause: true,
+      },
+    },
+  }),
+}));
+
+vi.mock("@/composables/useHoldToOpenMenu", () => ({
+  getEventPosition: () => ({ x: 1, y: 2 }),
+  useHoldToOpenMenu: () => ({
+    onHold: vi.fn(),
+    onTouchStart: vi.fn(),
+    swallowClickAfterHold: vi.fn(),
+  }),
+}));
+
+vi.mock("@/helpers/player_menu_items", () => ({
+  getPlayerMenuItems: () => [],
+}));
+
+vi.mock("@/helpers/utils", () => ({
+  getMediaImageUrl: (url: string) => url,
+  getPlayerName: (player: Player) => player.name,
+  isBuiltinPlayer: () => false,
+}));
+
+const ButtonStub = {
+  template: "<button><slot /></button>",
+};
+
+const CardStub = {
+  template: "<div><slot /></div>",
+};
+
+const BadgeStub = {
+  template: "<span><slot /></span>",
+};
+
+const VolumeControlStub = {
+  emits: ["toggle-child-volumes"],
+  template: `
+    <button
+      class="volume-control"
+      @click="$emit('toggle-child-volumes')"
+    />
+  `,
+};
+
+function createPlayer(overrides: Partial<Player> = {}): Player {
+  return {
+    player_id: "player",
+    provider: "test",
+    type: PlayerType.PLAYER,
+    name: "Kitchen",
+    available: true,
+    device_info: {
+      model: "Test",
+      manufacturer: "Test",
+      identifiers: {
+        [IdentifierType.MAC_ADDRESS]: "",
+        [IdentifierType.SERIAL_NUMBER]: "",
+        [IdentifierType.UUID]: "",
+        [IdentifierType.IP_ADDRESS]: "",
+        [IdentifierType.UNKNOWN]: "",
+      },
+    },
+    supported_features: [PlayerFeature.SET_MEMBERS],
+    can_group_with: ["child"],
+    enabled: true,
+    playback_state: PlaybackState.IDLE,
+    powered: true,
+    volume_level: 25,
+    volume_muted: false,
+    group_members: [],
+    static_group_members: [],
+    source_list: [],
+    sound_mode_list: [],
+    options: [],
+    group_volume: null,
+    group_volume_muted: null,
+    hide_in_ui: false,
+    icon: "speaker",
+    power_control: "power",
+    volume_control: "volume",
+    mute_control: "mute",
+    needs_setup: false,
+    output_protocols: [],
+    active_output_protocol: null,
+    ...overrides,
+  };
+}
+
+function mountPlayerCard(player: Player) {
+  return mount(PlayerCard, {
+    props: {
+      player,
+      allowPowerControl: true,
+      showGroupControls: true,
+      showMenuButton: true,
+      showVolumeControl: true,
+    },
+    global: {
+      directives: {
+        hold: () => undefined,
+      },
+      mocks: {
+        $t: (key: string) => key,
+      },
+      stubs: {
+        Badge: BadgeStub,
+        Button: ButtonStub,
+        Card: CardStub,
+        PlayerIcon: {
+          template: '<span class="player-icon" />',
+        },
+        Spinner: {
+          template: '<span class="spinner" />',
+        },
+        VolumeControl: VolumeControlStub,
+      },
+    },
+  });
+}
+
+describe("PlayerCard", () => {
+  it("uses a primary border for the active player", () => {
+    const wrapper = mountPlayerCard(
+      createPlayer({
+        player_id: "active",
+      }),
+    );
+
+    expect(wrapper.classes()).toContain("border-primary");
+  });
+
+  it("keeps the player details in the selection action name", () => {
+    const wrapper = mountPlayerCard(createPlayer());
+    const action = wrapper.find(".player-select-action");
+
+    expect(action.attributes("aria-label")).toBeUndefined();
+    expect(action.text()).toContain("tooltip.select_player");
+    expect(action.text()).toContain("Kitchen");
+  });
+
+  it.each([PlaybackState.PLAYING, PlaybackState.PAUSED])(
+    "shows artwork while %s",
+    (playbackState) => {
+      const wrapper = mountPlayerCard(
+        createPlayer({
+          playback_state: playbackState,
+          current_media: {
+            uri: "test://track",
+            media_type: MediaType.TRACK,
+            image_url: "https://example.test/cover.jpg",
+          },
+        }),
+      );
+
+      expect(wrapper.find("img").attributes("src")).toBe(
+        "https://example.test/cover.jpg",
+      );
+    },
+  );
+
+  it("shows the player icon instead of idle artwork", () => {
+    const wrapper = mountPlayerCard(
+      createPlayer({
+        current_media: {
+          uri: "test://track",
+          media_type: MediaType.TRACK,
+          image_url: "https://example.test/cover.jpg",
+        },
+      }),
+    );
+
+    expect(wrapper.find("img").exists()).toBe(false);
+    expect(wrapper.find(".player-icon").exists()).toBe(true);
+  });
+
+  it("labels the pause control with its action", () => {
+    const wrapper = mountPlayerCard(
+      createPlayer({
+        playback_state: PlaybackState.PLAYING,
+      }),
+    );
+
+    expect(wrapper.find('[aria-label="pause"]').exists()).toBe(true);
+  });
+
+  it("keeps card controls separate from player selection", async () => {
+    vi.clearAllMocks();
+    const player = createPlayer({
+      powered: false,
+      group_members: ["player", "child"],
+    });
+    const wrapper = mountPlayerCard(player);
+
+    await wrapper.find(".player-select-action").trigger("click");
+    expect(wrapper.emitted("click")).toEqual([[player]]);
+
+    await wrapper.find('[aria-label="tooltip.toggle_power"]').trigger("click");
+    await wrapper
+      .find('[aria-label="tooltip.group_members: 2"]')
+      .trigger("click");
+    await wrapper.find('[aria-label="play"]').trigger("click");
+    await wrapper.find('[aria-label="tooltip.more_options"]').trigger("click");
+    await wrapper.find(".volume-control").trigger("click");
+
+    expect(wrapper.emitted("click")).toHaveLength(1);
+    expect(apiMock.playerCommandPowerToggle).toHaveBeenCalledWith(
+      player.player_id,
+    );
+    expect(apiMock.playerCommandPlayPause).toHaveBeenCalledWith(
+      player.player_id,
+    );
+    expect(wrapper.emitted("toggle-member-controls")).toEqual([[player]]);
+    expect(wrapper.emitted("toggle-child-volumes")).toEqual([[player]]);
+    expect(emitContextMenu).toHaveBeenCalledWith(
+      "contextmenu",
+      expect.objectContaining({
+        posX: 1,
+        posY: 2,
+      }),
+    );
+  });
+
+  it("disables every action for an unavailable player", async () => {
+    vi.clearAllMocks();
+    const player = createPlayer({
+      available: false,
+      powered: false,
+      group_members: ["player", "child"],
+    });
+    const wrapper = mountPlayerCard(player);
+    const actionSelectors = [
+      '[aria-label="tooltip.toggle_power"]',
+      '[aria-label="tooltip.group_members: 2"]',
+      '[aria-label="play"]',
+      '[aria-label="tooltip.more_options"]',
+    ];
+
+    for (const selector of actionSelectors) {
+      const action = wrapper.find(selector);
+      expect(action.attributes("disabled")).toBeDefined();
+      await action.trigger("click");
+    }
+
+    expect(apiMock.playerCommandPowerToggle).not.toHaveBeenCalled();
+    expect(apiMock.playerCommandPlayPause).not.toHaveBeenCalled();
+    expect(wrapper.emitted("toggle-member-controls")).toBeUndefined();
+    expect(emitContextMenu).not.toHaveBeenCalled();
+  });
+});

--- a/tests/components/PlayerGroupMembers.test.ts
+++ b/tests/components/PlayerGroupMembers.test.ts
@@ -166,6 +166,36 @@ describe("PlayerGroupMembers", () => {
     );
   });
 
+  it("sends pending group changes before unmounting", async () => {
+    vi.useFakeTimers();
+    const candidate = createPlayer({
+      player_id: "candidate",
+      name: "Office",
+    });
+    const parent = createPlayer({
+      can_group_with: [candidate.player_id],
+      group_members: ["parent"],
+    });
+    api.players = {
+      [parent.player_id]: parent,
+      [candidate.player_id]: candidate,
+    };
+    const wrapper = mountGroupMembers(parent, []);
+
+    await wrapper.find(".member-checkbox").trigger("click");
+    expect(api.playerCommandSetMembers).not.toHaveBeenCalled();
+
+    wrapper.unmount();
+
+    expect(api.playerCommandSetMembers).toHaveBeenCalledWith(
+      parent.player_id,
+      [candidate.player_id],
+      undefined,
+    );
+    await vi.runAllTimersAsync();
+    expect(api.playerCommandSetMembers).toHaveBeenCalledTimes(1);
+  });
+
   it("normalizes self-only membership after removing the final child", async () => {
     vi.useFakeTimers();
     const child = createPlayer({

--- a/tests/components/PlayerGroupMembers.test.ts
+++ b/tests/components/PlayerGroupMembers.test.ts
@@ -1,0 +1,195 @@
+import PlayerGroupMembers from "@/components/PlayerGroupMembers.vue";
+import { api } from "@/plugins/api";
+import {
+  IdentifierType,
+  PlaybackState,
+  type Player,
+  PlayerFeature,
+  PlayerType,
+} from "@/plugins/api/interfaces";
+import { mount } from "@vue/test-utils";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/plugins/api", async () => {
+  const { reactive } = await vi.importActual<typeof import("vue")>("vue");
+  const api = reactive({
+    players: {} as Record<string, Player>,
+    getPlayer: vi.fn(),
+    playerCommandSetMembers: vi.fn(() => Promise.resolve()),
+  });
+  return { api, default: api };
+});
+
+vi.mock("@/helpers/utils", () => ({
+  groupMemberPickerVisible: () => true,
+}));
+
+const CheckboxStub = {
+  props: ["modelValue"],
+  emits: ["update:modelValue"],
+  template: `
+    <button
+      class="member-checkbox"
+      @click="$emit('update:modelValue', !modelValue)"
+    />
+  `,
+};
+
+function createPlayer(overrides: Partial<Player> = {}): Player {
+  return {
+    player_id: "parent",
+    provider: "test",
+    type: PlayerType.PLAYER,
+    name: "Kitchen",
+    available: true,
+    device_info: {
+      model: "Test",
+      manufacturer: "Test",
+      identifiers: {
+        [IdentifierType.MAC_ADDRESS]: "",
+        [IdentifierType.SERIAL_NUMBER]: "",
+        [IdentifierType.UUID]: "",
+        [IdentifierType.IP_ADDRESS]: "",
+        [IdentifierType.UNKNOWN]: "",
+      },
+    },
+    supported_features: [PlayerFeature.SET_MEMBERS],
+    can_group_with: [],
+    enabled: true,
+    playback_state: PlaybackState.IDLE,
+    powered: true,
+    volume_level: 25,
+    volume_muted: false,
+    group_members: [],
+    static_group_members: [],
+    source_list: [],
+    sound_mode_list: [],
+    options: [],
+    group_volume: null,
+    group_volume_muted: null,
+    hide_in_ui: false,
+    icon: "speaker",
+    power_control: "power",
+    volume_control: "volume",
+    mute_control: "mute",
+    needs_setup: false,
+    output_protocols: [],
+    active_output_protocol: null,
+    ...overrides,
+  };
+}
+
+function mountGroupMembers(player: Player, members: Player[]) {
+  return mount(PlayerGroupMembers, {
+    props: {
+      player,
+      members,
+    },
+    global: {
+      mocks: {
+        $t: (key: string) => key,
+      },
+      stubs: {
+        Checkbox: CheckboxStub,
+        PlayerIcon: {
+          template: "<span />",
+        },
+        Separator: {
+          template: "<hr />",
+        },
+      },
+    },
+  });
+}
+
+describe("PlayerGroupMembers", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useRealTimers();
+    api.players = {};
+  });
+
+  it("uses aligned icon slots and prominent checkboxes", () => {
+    const child = createPlayer({
+      player_id: "child",
+      name: "Office",
+      powered: false,
+    });
+    const parent = createPlayer({
+      can_group_with: [child.player_id],
+      group_members: ["parent", child.player_id],
+    });
+    api.players = {
+      [parent.player_id]: parent,
+      [child.player_id]: child,
+    };
+    const wrapper = mountGroupMembers(parent, [child]);
+
+    expect(wrapper.find(".player-group-member-icon").classes()).toEqual(
+      expect.arrayContaining(["h-6", "w-[30px]"]),
+    );
+    expect(wrapper.find(".player-group-member").classes()).not.toContain(
+      "opacity-50",
+    );
+    expect(wrapper.find(".player-group-member-icon").html()).toContain(
+      "opacity-50",
+    );
+    expect(wrapper.find(".member-checkbox").classes()).toEqual(
+      expect.arrayContaining(["size-5", "border-2"]),
+    );
+  });
+
+  it("optimistically joins a player and sends the grouped update", async () => {
+    vi.useFakeTimers();
+    const candidate = createPlayer({
+      player_id: "candidate",
+      name: "Office",
+    });
+    const parent = createPlayer({
+      can_group_with: [candidate.player_id],
+      group_members: ["parent"],
+    });
+    api.players = {
+      [parent.player_id]: parent,
+      [candidate.player_id]: candidate,
+    };
+    const wrapper = mountGroupMembers(parent, []);
+
+    await wrapper.find(".member-checkbox").trigger("click");
+    expect(parent.group_members).toContain(candidate.player_id);
+
+    await vi.advanceTimersByTimeAsync(500);
+    expect(api.playerCommandSetMembers).toHaveBeenCalledWith(
+      parent.player_id,
+      [candidate.player_id],
+      undefined,
+    );
+  });
+
+  it("normalizes self-only membership after removing the final child", async () => {
+    vi.useFakeTimers();
+    const child = createPlayer({
+      player_id: "child",
+      name: "Office",
+    });
+    const parent = createPlayer({
+      can_group_with: [child.player_id],
+      group_members: ["parent", child.player_id],
+    });
+    api.players = {
+      [parent.player_id]: parent,
+      [child.player_id]: child,
+    };
+    const wrapper = mountGroupMembers(parent, [child]);
+
+    await wrapper.find(".member-checkbox").trigger("click");
+
+    expect(parent.group_members).toEqual([]);
+    await vi.advanceTimersByTimeAsync(500);
+    expect(api.playerCommandSetMembers).toHaveBeenCalledWith(
+      parent.player_id,
+      undefined,
+      [child.player_id],
+    );
+  });
+});

--- a/tests/components/PlayerIcon.test.ts
+++ b/tests/components/PlayerIcon.test.ts
@@ -1,0 +1,20 @@
+import PlayerIcon from "@/components/PlayerIcon.vue";
+import { mount } from "@vue/test-utils";
+import { describe, expect, it } from "vitest";
+
+describe("PlayerIcon", () => {
+  it("renders saved MDI icons without a Vuetify component", () => {
+    const wrapper = mount(PlayerIcon, {
+      props: {
+        icon: "mdi-speaker",
+        size: 20,
+      },
+    });
+
+    const icon = wrapper.find("i");
+    expect(icon.classes()).toEqual(
+      expect.arrayContaining(["mdi", "mdi-speaker"]),
+    );
+    expect(icon.attributes("style")).toContain("font-size: 20px");
+  });
+});

--- a/tests/components/VolumeControl.test.ts
+++ b/tests/components/VolumeControl.test.ts
@@ -1,0 +1,234 @@
+import VolumeControl from "@/components/VolumeControl.vue";
+import { api } from "@/plugins/api";
+import {
+  IdentifierType,
+  PlaybackState,
+  type Player,
+  PlayerFeature,
+  PlayerType,
+} from "@/plugins/api/interfaces";
+import { mount } from "@vue/test-utils";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/plugins/api", async () => {
+  const { reactive } = await vi.importActual<typeof import("vue")>("vue");
+  const api = reactive({
+    players: {} as Record<string, Player>,
+    getPlayer: vi.fn(),
+    playerCommandSetMembers: vi.fn(() => Promise.resolve()),
+  });
+  return { api, default: api };
+});
+
+vi.mock("@/helpers/utils", () => ({
+  groupMemberPickerVisible: () => true,
+}));
+
+vi.mock("@/layouts/default/PlayerOSD/PlayerVolume.vue", () => ({
+  default: {
+    props: ["player"],
+    emits: ["toggle-group-expansion"],
+    template: `
+      <button
+        class="player-volume"
+        :data-player-id="player.player_id"
+        @click="$emit('toggle-group-expansion')"
+      />
+    `,
+  },
+}));
+
+const CheckboxStub = {
+  props: ["modelValue"],
+  emits: ["update:modelValue"],
+  template: '<button class="member-checkbox" />',
+};
+
+function createPlayer(overrides: Partial<Player> = {}): Player {
+  return {
+    player_id: "parent",
+    provider: "test",
+    type: PlayerType.PLAYER,
+    name: "Kitchen",
+    available: true,
+    device_info: {
+      model: "Test",
+      manufacturer: "Test",
+      identifiers: {
+        [IdentifierType.MAC_ADDRESS]: "",
+        [IdentifierType.SERIAL_NUMBER]: "",
+        [IdentifierType.UUID]: "",
+        [IdentifierType.IP_ADDRESS]: "",
+        [IdentifierType.UNKNOWN]: "",
+      },
+    },
+    supported_features: [PlayerFeature.SET_MEMBERS, PlayerFeature.VOLUME_SET],
+    can_group_with: [],
+    enabled: true,
+    playback_state: PlaybackState.PLAYING,
+    powered: true,
+    volume_level: 25,
+    volume_muted: false,
+    group_members: [],
+    static_group_members: [],
+    source_list: [],
+    sound_mode_list: [],
+    options: [],
+    group_volume: 25,
+    group_volume_muted: false,
+    hide_in_ui: false,
+    icon: "speaker",
+    power_control: "power",
+    volume_control: "volume",
+    mute_control: "mute",
+    needs_setup: false,
+    output_protocols: [],
+    active_output_protocol: null,
+    ...overrides,
+  };
+}
+
+function mountVolumeControl(
+  player: Player,
+  props: {
+    showChildVolumes?: boolean;
+    showMemberControls?: boolean;
+    showVolumeControl?: boolean;
+  },
+) {
+  return mount(VolumeControl, {
+    props: {
+      player,
+      showVolumeControl: props.showVolumeControl ?? true,
+      ...props,
+    },
+    global: {
+      mocks: {
+        $t: (key: string) => key,
+      },
+      stubs: {
+        Button: {
+          template: "<button><slot /></button>",
+        },
+        Checkbox: CheckboxStub,
+        PlayerIcon: {
+          template: "<span />",
+        },
+        Separator: {
+          template: "<hr />",
+        },
+      },
+    },
+  });
+}
+
+describe("VolumeControl", () => {
+  beforeEach(() => {
+    api.players = {};
+  });
+
+  it("shows child sliders without group-member checkboxes", () => {
+    const child = createPlayer({
+      player_id: "child",
+      name: "Office",
+    });
+    const parent = createPlayer({
+      can_group_with: [child.player_id],
+      group_members: ["parent", child.player_id],
+    });
+    api.players = {
+      [parent.player_id]: parent,
+      [child.player_id]: child,
+    };
+
+    const wrapper = mountVolumeControl(parent, {
+      showChildVolumes: true,
+      showMemberControls: false,
+    });
+
+    expect(
+      wrapper
+        .findAll(".player-volume")
+        .map((volume) => volume.attributes("data-player-id")),
+    ).toEqual(["parent", "parent", "child"]);
+    expect(wrapper.find(".member-checkbox").exists()).toBe(false);
+  });
+
+  it("does not show child-volume expansion for a standalone player", () => {
+    const player = createPlayer({
+      group_members: ["parent"],
+    });
+    api.players = { [player.player_id]: player };
+
+    const wrapper = mountVolumeControl(player, {});
+
+    expect(wrapper.findAll(".player-volume")).toHaveLength(1);
+    expect(
+      wrapper.find('[aria-label="tooltip.toggle_subplayers"]').exists(),
+    ).toBe(false);
+  });
+
+  it("hides expanded child volumes when the parent is powered off", () => {
+    const child = createPlayer({
+      player_id: "child",
+      name: "Office",
+    });
+    const parent = createPlayer({
+      group_members: ["parent", child.player_id],
+      powered: false,
+    });
+    api.players = {
+      [parent.player_id]: parent,
+      [child.player_id]: child,
+    };
+
+    const wrapper = mountVolumeControl(parent, {
+      showChildVolumes: true,
+      showVolumeControl: false,
+    });
+
+    expect(wrapper.find(".player-volume").exists()).toBe(false);
+  });
+
+  it("shows member checkboxes without child sliders", () => {
+    const child = createPlayer({
+      player_id: "child",
+      name: "Office",
+    });
+    const parent = createPlayer({
+      can_group_with: [child.player_id],
+      group_members: ["parent", child.player_id],
+    });
+    api.players = {
+      [parent.player_id]: parent,
+      [child.player_id]: child,
+    };
+
+    const wrapper = mountVolumeControl(parent, {
+      showChildVolumes: false,
+      showMemberControls: true,
+    });
+
+    expect(wrapper.findAll(".player-volume")).toHaveLength(1);
+    expect(wrapper.findAll(".member-checkbox")).toHaveLength(1);
+  });
+
+  it("forwards group slider taps as child-volume toggles", async () => {
+    const child = createPlayer({
+      player_id: "child",
+      name: "Office",
+    });
+    const parent = createPlayer({
+      group_members: ["parent", child.player_id],
+    });
+    api.players = {
+      [parent.player_id]: parent,
+      [child.player_id]: child,
+    };
+    const wrapper = mountVolumeControl(parent, {});
+
+    await wrapper.find(".player-volume").trigger("click");
+
+    expect(wrapper.emitted("toggle-child-volumes")).toEqual([[parent]]);
+  });
+});

--- a/tests/layouts/PlayerSelect.test.ts
+++ b/tests/layouts/PlayerSelect.test.ts
@@ -1,0 +1,366 @@
+import PlayerSelect from "@/layouts/default/PlayerSelect.vue";
+import { api } from "@/plugins/api";
+import {
+  IdentifierType,
+  PlaybackState,
+  type Player,
+  PlayerType,
+} from "@/plugins/api/interfaces";
+import { store } from "@/plugins/store";
+import { webPlayer } from "@/plugins/web_player";
+import { mount } from "@vue/test-utils";
+import { nextTick } from "vue";
+import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { getPreference, setPreference, storage } = vi.hoisted(() => {
+  const values = new Map<string, string>();
+  const storage = {
+    clear: () => values.clear(),
+    getItem: (key: string) => values.get(key) ?? null,
+    removeItem: (key: string) => {
+      values.delete(key);
+    },
+    setItem: (key: string, value: string) => {
+      values.set(key, value);
+    },
+  };
+  vi.stubGlobal("localStorage", storage);
+  return {
+    getPreference: vi.fn(() => ({ value: undefined })),
+    setPreference: vi.fn(),
+    storage,
+  };
+});
+
+vi.mock("@/plugins/api", async () => {
+  const { reactive } = await vi.importActual<typeof import("vue")>("vue");
+  const api = reactive({
+    players: {} as Record<string, Player>,
+  });
+  return { api, default: api };
+});
+
+vi.mock("@/plugins/store", async () => {
+  const { reactive } = await vi.importActual<typeof import("vue")>("vue");
+  return {
+    store: reactive({
+      activePlayer: undefined as Player | undefined,
+      activePlayerId: undefined as string | undefined,
+      companionPlayerId: undefined as string | undefined,
+      showPlayersMenu: true,
+    }),
+  };
+});
+
+vi.mock("@/plugins/web_player", async () => {
+  const { reactive } = await vi.importActual<typeof import("vue")>("vue");
+  return {
+    webPlayer: reactive({
+      player_id: undefined as string | undefined,
+    }),
+  };
+});
+
+vi.mock("@/composables/userPreferences", () => ({
+  useUserPreferences: () => ({
+    getPreference,
+    setPreference,
+  }),
+}));
+
+vi.mock("@/helpers/utils", () => ({
+  isBuiltinPlayer: (player: Player) => player.player_id === "builtin",
+  playerVisible: () => true,
+}));
+
+const PlayerCardStub = {
+  props: [
+    "player",
+    "showChildVolumes",
+    "showMemberControls",
+    "showGroupControls",
+  ],
+  emits: ["click", "toggle-child-volumes", "toggle-member-controls"],
+  template: `
+    <article
+      class="player-card"
+      :data-player-id="player.player_id"
+      :data-child-volumes="showChildVolumes ? 'true' : 'false'"
+      :data-member-controls="showMemberControls ? 'true' : 'false'"
+    >
+      <button class="select-player" @click="$emit('click', player)">
+        {{ player.name }}
+      </button>
+      <button
+        class="volume-toggle"
+        @click="$emit('toggle-child-volumes', player)"
+      />
+      <button
+        class="member-toggle"
+        @click="$emit('toggle-member-controls', player)"
+      />
+    </article>
+  `,
+};
+
+const SearchInputStub = {
+  props: ["modelValue"],
+  emits: ["update:modelValue"],
+  template: `
+    <input
+      class="player-search"
+      :value="modelValue"
+      @input="$emit('update:modelValue', $event.target.value)"
+    />
+  `,
+};
+
+const passthroughStub = { template: "<div><slot /></div>" };
+
+function createPlayer(
+  playerId: string,
+  name: string,
+  playbackState = PlaybackState.IDLE,
+): Player {
+  return {
+    player_id: playerId,
+    provider: "test",
+    type: PlayerType.PLAYER,
+    name,
+    available: true,
+    device_info: {
+      model: "Test",
+      manufacturer: "Test",
+      identifiers: {
+        [IdentifierType.MAC_ADDRESS]: "",
+        [IdentifierType.SERIAL_NUMBER]: "",
+        [IdentifierType.UUID]: "",
+        [IdentifierType.IP_ADDRESS]: "",
+        [IdentifierType.UNKNOWN]: "",
+      },
+    },
+    supported_features: [],
+    can_group_with: [],
+    enabled: true,
+    playback_state: playbackState,
+    powered: true,
+    volume_level: 25,
+    volume_muted: false,
+    group_members: [],
+    static_group_members: [],
+    source_list: [],
+    sound_mode_list: [],
+    options: [],
+    group_volume: null,
+    group_volume_muted: null,
+    hide_in_ui: false,
+    icon: "speaker",
+    power_control: "power",
+    volume_control: "volume",
+    mute_control: "mute",
+    needs_setup: false,
+    output_protocols: [],
+    active_output_protocol: null,
+  };
+}
+
+function mountPlayerSelect() {
+  return mount(PlayerSelect, {
+    global: {
+      mocks: {
+        $t: (key: string) => key,
+      },
+      stubs: {
+        PlayerCard: PlayerCardStub,
+        SearchInput: SearchInputStub,
+        Sheet: passthroughStub,
+        SheetContent: passthroughStub,
+        SheetDescription: passthroughStub,
+        SheetHeader: passthroughStub,
+        SheetTitle: passthroughStub,
+        Teleport: true,
+      },
+    },
+  });
+}
+
+describe("PlayerSelect", () => {
+  afterAll(() => {
+    vi.unstubAllGlobals();
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    api.players = {};
+    store.activePlayer = undefined;
+    store.activePlayerId = undefined;
+    store.companionPlayerId = undefined;
+    store.showPlayersMenu = true;
+    webPlayer.player_id = null;
+    storage.clear();
+  });
+
+  it("orders the active player first, then playing players", () => {
+    const activePlayer = createPlayer("active", "Kitchen");
+    api.players = {
+      office: createPlayer("office", "Office"),
+      bedroom: createPlayer("bedroom", "Bedroom", PlaybackState.PLAYING),
+      active: activePlayer,
+      builtin: createPlayer("builtin", "This device"),
+      attic: createPlayer("attic", "Attic", PlaybackState.PLAYING),
+      lounge: createPlayer("lounge", "Lounge"),
+    };
+    store.activePlayer = activePlayer;
+    store.activePlayerId = activePlayer.player_id;
+
+    const wrapper = mountPlayerSelect();
+
+    expect(
+      wrapper
+        .findAll(".player-card")
+        .map((card) => card.attributes("data-player-id")),
+    ).toEqual(["active", "builtin", "attic", "bedroom", "lounge", "office"]);
+  });
+
+  it("waits for a remembered player instead of selecting the web player", async () => {
+    const web = createPlayer("web", "This device");
+    const remembered = createPlayer("remembered", "Living room");
+    storage.setItem("activePlayerId", remembered.player_id);
+    webPlayer.player_id = web.player_id;
+    api.players = {
+      [web.player_id]: web,
+    };
+
+    mountPlayerSelect();
+    expect(store.activePlayerId).toBeUndefined();
+
+    api.players[remembered.player_id] = remembered;
+    await nextTick();
+
+    expect(store.activePlayerId).toBe(remembered.player_id);
+  });
+
+  it("shows search only when more than ten players are visible", () => {
+    api.players = Object.fromEntries(
+      Array.from({ length: 10 }, (_, index) => {
+        const player = createPlayer(`player-${index}`, `Player ${index}`);
+        return [player.player_id, player];
+      }),
+    );
+
+    const tenPlayers = mountPlayerSelect();
+    expect(tenPlayers.find(".player-search").exists()).toBe(false);
+    tenPlayers.unmount();
+
+    const extraPlayer = createPlayer("player-10", "Player 10");
+    api.players[extraPlayer.player_id] = extraPlayer;
+
+    const elevenPlayers = mountPlayerSelect();
+    expect(elevenPlayers.find(".player-search").exists()).toBe(true);
+  });
+
+  it("filters the ordered list by player name", async () => {
+    api.players = Object.fromEntries(
+      Array.from({ length: 11 }, (_, index) => {
+        const name = index === 7 ? "Living room" : `Player ${index}`;
+        const player = createPlayer(`player-${index}`, name);
+        return [player.player_id, player];
+      }),
+    );
+    const wrapper = mountPlayerSelect();
+
+    await wrapper.find(".player-search").setValue("living");
+
+    expect(
+      wrapper
+        .findAll(".player-card")
+        .map((card) => card.attributes("data-player-id")),
+    ).toEqual(["player-7"]);
+  });
+
+  it("selects a player and closes the sheet from the card action", async () => {
+    const player = createPlayer("kitchen", "Kitchen");
+    api.players = { [player.player_id]: player };
+    const wrapper = mountPlayerSelect();
+
+    await wrapper.find(".select-player").trigger("click");
+
+    expect(store.activePlayerId).toBe(player.player_id);
+    expect(store.showPlayersMenu).toBe(false);
+  });
+
+  it("closes from the blurred backdrop", async () => {
+    const player = createPlayer("kitchen", "Kitchen");
+    api.players = { [player.player_id]: player };
+    const wrapper = mountPlayerSelect();
+
+    await wrapper.find(".player-select-backdrop").trigger("click");
+
+    expect(store.showPlayersMenu).toBe(false);
+  });
+
+  it("restores focus to the menu trigger after closing", async () => {
+    store.showPlayersMenu = false;
+    const wrapper = mountPlayerSelect();
+    const trigger = document.createElement("button");
+    document.body.appendChild(trigger);
+    trigger.focus();
+
+    store.showPlayersMenu = true;
+    await nextTick();
+    await wrapper.find(".player-select-backdrop").trigger("click");
+    await nextTick();
+
+    expect(document.activeElement).toBe(trigger);
+    trigger.remove();
+  });
+
+  it("uses a stable focus fallback when the trigger was removed", async () => {
+    store.showPlayersMenu = false;
+    const wrapper = mountPlayerSelect();
+    const trigger = document.createElement("button");
+    const fallback = document.createElement("button");
+    fallback.id = "active-player-popover";
+    document.body.append(trigger, fallback);
+    trigger.focus();
+
+    store.showPlayersMenu = true;
+    await nextTick();
+    trigger.remove();
+    await wrapper.find(".player-select-backdrop").trigger("click");
+    await nextTick();
+
+    expect(document.activeElement).toBe(fallback);
+    fallback.remove();
+  });
+
+  it("handles Escape inside the sheet without reaching the page", async () => {
+    const player = createPlayer("kitchen", "Kitchen");
+    api.players = { [player.player_id]: player };
+    const wrapper = mountPlayerSelect();
+
+    await wrapper
+      .find('[data-testid="player-select-sheet"]')
+      .trigger("keydown", { key: "Escape" });
+
+    expect(store.showPlayersMenu).toBe(false);
+  });
+
+  it("keeps member and child-volume controls mutually exclusive", async () => {
+    const player = createPlayer("group", "Everywhere");
+    api.players = { [player.player_id]: player };
+    const wrapper = mountPlayerSelect();
+    const card = () => wrapper.find(".player-card");
+
+    expect(card().attributes("data-child-volumes")).toBe("false");
+    expect(card().attributes("data-member-controls")).toBe("false");
+
+    await wrapper.find(".member-toggle").trigger("click");
+    expect(card().attributes("data-member-controls")).toBe("true");
+    expect(card().attributes("data-child-volumes")).toBe("false");
+
+    await wrapper.find(".volume-toggle").trigger("click");
+    expect(card().attributes("data-member-controls")).toBe("false");
+    expect(card().attributes("data-child-volumes")).toBe("true");
+  });
+});

--- a/tests/layouts/PlayerSelect.test.ts
+++ b/tests/layouts/PlayerSelect.test.ts
@@ -56,7 +56,7 @@ vi.mock("@/plugins/web_player", async () => {
   const { reactive } = await vi.importActual<typeof import("vue")>("vue");
   return {
     webPlayer: reactive({
-      player_id: undefined as string | undefined,
+      player_id: null as string | null,
     }),
   };
 });

--- a/tests/layouts/PlayerVolume.test.ts
+++ b/tests/layouts/PlayerVolume.test.ts
@@ -1,0 +1,326 @@
+import PlayerVolume from "@/layouts/default/PlayerOSD/PlayerVolume.vue";
+import { api } from "@/plugins/api";
+import {
+  IdentifierType,
+  PlaybackState,
+  type Player,
+  PlayerFeature,
+  PlayerType,
+} from "@/plugins/api/interfaces";
+import { mount } from "@vue/test-utils";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { getVolumeIconComponent } = vi.hoisted(() => ({
+  getVolumeIconComponent: vi.fn(() => "span"),
+}));
+
+vi.mock("@/plugins/api", async () => {
+  const { reactive } = await vi.importActual<typeof import("vue")>("vue");
+  const api = reactive({
+    players: {} as Record<string, Player>,
+    playerCommandGroupVolume: vi.fn(),
+    playerCommandGroupVolumeDown: vi.fn(),
+    playerCommandGroupVolumeMute: vi.fn(),
+    playerCommandGroupVolumeUp: vi.fn(),
+    playerCommandMuteToggle: vi.fn(),
+    playerCommandVolumeDown: vi.fn(),
+    playerCommandVolumeSet: vi.fn(),
+    playerCommandVolumeUp: vi.fn(),
+  });
+  return { api, default: api };
+});
+
+vi.mock("@/plugins/store", () => ({
+  store: {
+    isTouchscreen: false,
+    mobileLayout: false,
+  },
+}));
+
+vi.mock("@/helpers/utils", () => ({
+  getVolumeIconComponent,
+  truncateString: (value: string) => value,
+}));
+
+function createPlayer(overrides: Partial<Player> = {}): Player {
+  return {
+    player_id: "parent",
+    provider: "test",
+    type: PlayerType.PLAYER,
+    name: "Kitchen",
+    available: true,
+    device_info: {
+      model: "Test",
+      manufacturer: "Test",
+      identifiers: {
+        [IdentifierType.MAC_ADDRESS]: "",
+        [IdentifierType.SERIAL_NUMBER]: "",
+        [IdentifierType.UUID]: "",
+        [IdentifierType.IP_ADDRESS]: "",
+        [IdentifierType.UNKNOWN]: "",
+      },
+    },
+    supported_features: [PlayerFeature.VOLUME_SET],
+    can_group_with: [],
+    enabled: true,
+    playback_state: PlaybackState.PLAYING,
+    powered: true,
+    volume_level: 25,
+    volume_muted: false,
+    group_members: [],
+    static_group_members: [],
+    source_list: [],
+    sound_mode_list: [],
+    options: [],
+    group_volume: 25,
+    group_volume_muted: false,
+    hide_in_ui: false,
+    icon: "speaker",
+    power_control: "power",
+    volume_control: "volume",
+    mute_control: "mute",
+    needs_setup: false,
+    output_protocols: [],
+    active_output_protocol: null,
+    ...overrides,
+  };
+}
+
+function mountGroupVolume(player: Player) {
+  return mount(PlayerVolume, {
+    props: {
+      player,
+      preferGroupVolume: true,
+      enablePopout: false,
+      requestExpandOnGroupTap: true,
+    },
+    global: {
+      stubs: {
+        Slider: {
+          emits: ["update:modelValue"],
+          template: `
+            <div
+              data-slot="slider"
+              role="slider"
+              @pointerdown="$emit('update:modelValue', [80])"
+            />
+          `,
+        },
+      },
+    },
+  });
+}
+
+describe("PlayerVolume group expansion", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useRealTimers();
+    api.players = {};
+  });
+
+  it("requests inline expansion when a group slider is clicked", async () => {
+    const child = createPlayer({
+      player_id: "child",
+      name: "Office",
+    });
+    const parent = createPlayer({
+      group_members: ["parent", child.player_id],
+    });
+    api.players = {
+      [parent.player_id]: parent,
+      [child.player_id]: child,
+    };
+    const wrapper = mountGroupVolume(parent);
+
+    await wrapper.find(".player-volume-container").trigger("click");
+
+    expect(wrapper.emitted("toggle-group-expansion")).toHaveLength(1);
+  });
+
+  it("does not treat self-only membership as a group", async () => {
+    const player = createPlayer({
+      group_members: ["parent"],
+    });
+    api.players = {
+      [player.player_id]: player,
+    };
+    const wrapper = mountGroupVolume(player);
+
+    await wrapper.find(".player-volume-container").trigger("click");
+
+    expect(wrapper.emitted("toggle-group-expansion")).toBeUndefined();
+  });
+
+  it("treats a group slider track click as expansion, not a volume change", async () => {
+    const child = createPlayer({
+      player_id: "child",
+      name: "Office",
+    });
+    const parent = createPlayer({
+      group_members: ["parent", child.player_id],
+    });
+    api.players = {
+      [parent.player_id]: parent,
+      [child.player_id]: child,
+    };
+    const wrapper = mountGroupVolume(parent);
+    const slider = wrapper.find('[data-slot="slider"]');
+
+    await slider.trigger("pointerdown", {
+      clientX: 80,
+      pointerType: "mouse",
+    });
+    await slider.trigger("pointerup", {
+      clientX: 80,
+      pointerType: "mouse",
+    });
+
+    expect(wrapper.emitted("toggle-group-expansion")).toHaveLength(1);
+    expect(api.playerCommandGroupVolume).not.toHaveBeenCalled();
+  });
+
+  it("expands on a touch tap without changing group volume", async () => {
+    vi.useFakeTimers();
+    const child = createPlayer({
+      player_id: "child",
+      name: "Office",
+    });
+    const parent = createPlayer({
+      group_members: ["parent", child.player_id],
+    });
+    api.players = {
+      [parent.player_id]: parent,
+      [child.player_id]: child,
+    };
+    const wrapper = mountGroupVolume(parent);
+    const slider = wrapper.find('[data-slot="slider"]');
+    const container = wrapper.find(".player-volume-container");
+
+    await slider.trigger("pointerdown", {
+      clientX: 50,
+      pointerType: "touch",
+    });
+    await container.trigger("touchstart", {
+      touches: [{ clientX: 50, clientY: 10 }],
+    });
+    await container.trigger("touchend", {
+      changedTouches: [{ clientX: 50, clientY: 10 }],
+    });
+    await vi.advanceTimersByTimeAsync(200);
+
+    expect(wrapper.emitted("toggle-group-expansion")).toHaveLength(1);
+    expect(api.playerCommandGroupVolume).not.toHaveBeenCalled();
+  });
+
+  it("commits a moved group slider when no debounced update was created", async () => {
+    const child = createPlayer({
+      player_id: "child",
+      name: "Office",
+    });
+    const parent = createPlayer({
+      group_members: ["parent", child.player_id],
+    });
+    api.players = {
+      [parent.player_id]: parent,
+      [child.player_id]: child,
+    };
+    const wrapper = mountGroupVolume(parent);
+    const slider = wrapper.find('[data-slot="slider"]');
+
+    await slider.trigger("pointerdown", {
+      clientX: 80,
+      pointerType: "mouse",
+    });
+    await slider.trigger("pointermove", {
+      clientX: 85,
+      pointerType: "mouse",
+    });
+    await slider.trigger("pointerup", {
+      clientX: 85,
+      pointerType: "mouse",
+    });
+
+    expect(api.playerCommandGroupVolume).toHaveBeenCalledWith(
+      parent.player_id,
+      80,
+    );
+    expect(wrapper.emitted("toggle-group-expansion")).toBeUndefined();
+  });
+
+  it("uses group mute state for the group volume icon", () => {
+    const child = createPlayer({
+      player_id: "child",
+      name: "Office",
+    });
+    const parent = createPlayer({
+      group_members: ["parent", child.player_id],
+      group_volume_muted: false,
+      volume_muted: true,
+    });
+    api.players = {
+      [parent.player_id]: parent,
+      [child.player_id]: child,
+    };
+
+    mountGroupVolume(parent);
+
+    expect(getVolumeIconComponent).toHaveBeenCalledWith(parent, 25, false);
+  });
+
+  it("allows a muted group slider tap to expand child volumes", async () => {
+    const child = createPlayer({
+      player_id: "child",
+      name: "Office",
+    });
+    const parent = createPlayer({
+      group_members: ["parent", child.player_id],
+      group_volume_muted: true,
+    });
+    api.players = {
+      [parent.player_id]: parent,
+      [child.player_id]: child,
+    };
+    const wrapper = mountGroupVolume(parent);
+    const slider = wrapper.find(".player-volume-container");
+
+    await slider.trigger("touchstart", {
+      touches: [{ clientX: 50, clientY: 10 }],
+    });
+    await slider.trigger("touchend", {
+      changedTouches: [{ clientX: 50, clientY: 10 }],
+    });
+
+    expect(wrapper.emitted("toggle-group-expansion")).toHaveLength(1);
+    expect(api.playerCommandGroupVolume).not.toHaveBeenCalled();
+  });
+
+  it("ignores horizontal swipes on a muted group slider", async () => {
+    const child = createPlayer({
+      player_id: "child",
+      name: "Office",
+    });
+    const parent = createPlayer({
+      group_members: ["parent", child.player_id],
+      group_volume_muted: true,
+    });
+    api.players = {
+      [parent.player_id]: parent,
+      [child.player_id]: child,
+    };
+    const wrapper = mountGroupVolume(parent);
+    const slider = wrapper.find(".player-volume-container");
+
+    await slider.trigger("touchstart", {
+      touches: [{ clientX: 50, clientY: 10 }],
+    });
+    await slider.trigger("touchmove", {
+      touches: [{ clientX: 75, clientY: 10 }],
+    });
+    await slider.trigger("touchend", {
+      changedTouches: [{ clientX: 75, clientY: 10 }],
+    });
+
+    expect(wrapper.emitted("toggle-group-expansion")).toBeUndefined();
+    expect(api.playerCommandGroupVolume).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
The player selector had become difficult to scan and mixed player selection, grouping, and volume actions.

- Prioritize the active, this-device, and playing players
- Separate player selection, grouping, and group volume controls
- Refresh the menu with clearer controls, states, and mobile interactions
- Improve keyboard and screen-reader accessibility

Intermediate step into reaching this goal https://github.com/music-assistant/backlog/issues/52
This first step here is not a complete revamp of the player drawer just yet but splits the ux actions of grouping and child volume control.