### PR TITLE
Improve Music Timeline presentation layout

### DIFF
--- a/src/components/music-quiz/MusicQuizLeaderboard.vue
+++ b/src/components/music-quiz/MusicQuizLeaderboard.vue
@@ -59,12 +59,12 @@
             {{ row.name }}
           </span>
           <span
-            class="flex min-w-0 max-w-[45%] shrink-0 items-baseline gap-1 tabular-nums"
+            class="flex min-w-0 max-w-[45%] items-baseline gap-1 tabular-nums"
           >
-            <strong class="truncate">{{ row.score }}</strong>
+            <strong class="min-w-0 flex-1 truncate">{{ row.score }}</strong>
             <span
               v-if="row.roundScoreLabel"
-              class="text-primary quiz-score-pop truncate text-xs font-semibold"
+              class="text-primary quiz-score-pop min-w-0 flex-1 truncate text-xs font-semibold"
             >
               {{ row.roundScoreLabel }}
             </span>

--- a/src/components/music-quiz/MusicQuizLeaderboard.vue
+++ b/src/components/music-quiz/MusicQuizLeaderboard.vue
@@ -1,14 +1,28 @@
 <template>
-  <Card :class="compact ? 'gap-2 py-2' : 'gap-4 py-4'">
+  <Card
+    role="region"
+    :aria-label="title ?? $t('providers.music_quiz.leaderboard')"
+    :class="[
+      compact ? 'gap-2 py-2' : 'gap-4 py-4',
+      { 'min-h-0 overflow-hidden': scrollable },
+    ]"
+  >
     <CardHeader :class="compact ? 'px-3' : 'px-4'">
       <CardTitle :class="compact ? 'text-sm' : 'text-base'">
         {{ title ?? $t("providers.music_quiz.leaderboard") }}
       </CardTitle>
     </CardHeader>
     <CardContent
-      :class="
-        compact ? 'max-h-56 overflow-y-auto overscroll-contain px-2' : 'px-4'
-      "
+      :class="[
+        compact
+          ? scrollable
+            ? 'px-2'
+            : 'max-h-56 overflow-y-auto overscroll-contain px-2'
+          : 'px-4',
+        {
+          'min-h-0 flex-1 overflow-y-auto overscroll-contain': scrollable,
+        },
+      ]"
     >
       <TransitionGroup
         tag="ol"
@@ -44,11 +58,13 @@
           >
             {{ row.name }}
           </span>
-          <span class="flex shrink-0 items-baseline gap-1 tabular-nums">
-            <strong>{{ row.score }}</strong>
+          <span
+            class="flex min-w-0 max-w-[45%] shrink-0 items-baseline gap-1 tabular-nums"
+          >
+            <strong class="truncate">{{ row.score }}</strong>
             <span
               v-if="row.roundScoreLabel"
-              class="text-primary quiz-score-pop text-xs font-semibold"
+              class="text-primary quiz-score-pop truncate text-xs font-semibold"
             >
               {{ row.roundScoreLabel }}
             </span>
@@ -74,6 +90,7 @@ defineProps<{
   currentPlayerName?: string;
   title?: string;
   compact?: boolean;
+  scrollable?: boolean;
 }>();
 </script>
 

--- a/src/components/music-quiz/MusicQuizPresentStage.vue
+++ b/src/components/music-quiz/MusicQuizPresentStage.vue
@@ -1,6 +1,7 @@
 <template>
   <section
-    class="bg-background flex min-h-screen flex-col gap-4 p-5 sm:gap-6 sm:p-8"
+    data-testid="music-quiz-present-stage"
+    class="bg-background flex min-h-dvh flex-col gap-3 p-3 sm:gap-4 sm:p-5 lg:h-full lg:min-h-0 lg:overflow-hidden"
   >
     <MusicQuizSessionHeader
       :game="game"
@@ -11,8 +12,8 @@
       present
     >
       <template #actions>
-        <Button variant="ghost-outline" size="lg" @click="emit('exit')">
-          <Minimize2 class="size-5" />
+        <Button variant="ghost-outline" size="sm" @click="emit('exit')">
+          <Minimize2 class="size-4" />
           {{ $t("providers.music_quiz.exit_present_mode") }}
         </Button>
       </template>
@@ -21,7 +22,19 @@
     <MusicQuizConnectionBanners :degraded="isConnectionDegraded" />
 
     <div class="flex min-h-0 flex-1 flex-col gap-4">
-      <template v-if="state.phase === 'answering' && currentRound">
+      <component
+        :is="game.adapters.presentBody"
+        v-if="
+          game.adapters.presentBody &&
+          currentRound &&
+          (state.phase === 'answering' || state.phase === 'reveal')
+        "
+        :state="state"
+        :current-round="currentRound"
+        :leaderboard-rows="leaderboardRows"
+      />
+
+      <template v-else-if="state.phase === 'answering' && currentRound">
         <component
           :is="gameComponent"
           :state="state"
@@ -33,14 +46,18 @@
           :current-round="currentRound"
         >
           <template #leaderboard>
-            <MusicQuizLeaderboard :rows="leaderboardRows" />
+            <MusicQuizLeaderboard
+              class="min-h-0 flex-1"
+              :rows="leaderboardRows"
+              scrollable
+            />
           </template>
         </component>
       </template>
 
       <template v-else-if="state.phase === 'reveal' && currentRound">
         <div
-          class="grid flex-1 gap-4 lg:grid-cols-[minmax(0,1fr)_minmax(0,22rem)]"
+          class="grid min-h-0 flex-1 gap-4 lg:grid-cols-[minmax(0,1fr)_minmax(0,22rem)]"
         >
           <component
             :is="gameComponent"
@@ -53,14 +70,21 @@
             :current-round="currentRound"
           >
             <template #leaderboard>
-              <MusicQuizLeaderboard :rows="leaderboardRows" />
+              <MusicQuizLeaderboard
+                class="min-h-0 flex-1"
+                :rows="leaderboardRows"
+                scrollable
+              />
             </template>
           </component>
         </div>
       </template>
 
       <template v-else-if="state.phase === 'finished'">
-        <div class="flex flex-col gap-6">
+        <div
+          data-testid="music-quiz-present-finished"
+          class="flex min-h-0 flex-1 flex-col gap-6 lg:overflow-y-auto"
+        >
           <div class="flex flex-col items-center gap-1 text-center">
             <h2 class="text-2xl font-black sm:text-3xl lg:text-4xl">
               {{ $t("providers.music_quiz.final_leaderboard") }}
@@ -79,7 +103,8 @@
 
       <template v-else>
         <div
-          class="grid flex-1 items-start gap-6 lg:grid-cols-[auto_minmax(0,1fr)]"
+          data-testid="music-quiz-present-lobby"
+          class="grid min-h-0 flex-1 items-start gap-6 lg:grid-cols-[auto_minmax(0,1fr)] lg:overflow-y-auto"
         >
           <MusicQuizQrCard
             class="mx-auto w-full max-w-sm lg:w-80"

--- a/src/components/music-quiz/MusicQuizSessionHeader.vue
+++ b/src/components/music-quiz/MusicQuizSessionHeader.vue
@@ -1,17 +1,17 @@
 <template>
   <section
     data-testid="music-quiz-session-header"
-    class="bg-card flex min-w-0 flex-col gap-3 rounded-xl border p-4 shadow-sm sm:flex-row sm:items-center"
-    :class="{ 'p-5 sm:p-6': present }"
+    class="bg-card flex min-w-0 flex-col rounded-xl border shadow-sm sm:flex-row sm:items-center"
+    :class="present ? 'gap-2 p-3 sm:p-4' : 'gap-3 p-4'"
   >
     <div class="flex min-w-0 flex-1 items-center gap-3">
       <span
         class="bg-primary/10 text-primary grid shrink-0 place-items-center rounded-lg"
-        :class="present ? 'size-14' : 'size-11'"
+        :class="present ? 'size-11 sm:size-12' : 'size-11'"
       >
         <component
           :is="game.icon"
-          :class="present ? 'size-7' : 'size-5'"
+          :class="present ? 'size-5 sm:size-6' : 'size-5'"
           aria-hidden="true"
         />
       </span>
@@ -19,18 +19,20 @@
         <p
           v-if="name"
           class="text-primary text-xs font-bold tracking-wide uppercase"
-          :class="{ 'sm:text-sm': present }"
         >
           {{ $t(game.labelKey) }}
         </p>
         <component
           :is="present ? 'h1' : 'h2'"
           class="truncate font-bold"
-          :class="present ? 'text-2xl sm:text-4xl' : 'text-lg sm:text-xl'"
+          :class="present ? 'text-xl sm:text-2xl' : 'text-lg sm:text-xl'"
         >
           {{ name || $t(game.labelKey) }}
         </component>
-        <div class="mt-1 flex flex-wrap items-center gap-2">
+        <div
+          class="flex flex-wrap items-center"
+          :class="present ? 'mt-0.5 gap-1.5' : 'mt-1 gap-2'"
+        >
           <Badge
             variant="secondary"
             role="status"

--- a/src/components/music-quiz/adapter_contracts.ts
+++ b/src/components/music-quiz/adapter_contracts.ts
@@ -7,6 +7,7 @@ import type {
   MusicQuizSupportedPersonalizedState,
   MusicQuizSupportedRound,
 } from "@/composables/useMusicQuiz";
+import type { MusicQuizLeaderboardRow } from "@/components/music-quiz/MusicQuizLeaderboard.vue";
 import type { VNode } from "vue";
 
 export interface MusicQuizSetupAdapterProps {
@@ -51,6 +52,15 @@ export type MusicQuizPresentGameAdapterProps<
   TState extends MusicQuizSupportedHostState = MusicQuizSupportedHostState,
   TRound extends MusicQuizRoundBase = MusicQuizSupportedRound,
 > = MusicQuizHostGameAdapterProps<TState, TRound>;
+
+export interface MusicQuizPresentBodyAdapterProps<
+  TState extends MusicQuizSupportedHostState = MusicQuizSupportedHostState,
+  TRound extends MusicQuizRoundBase = MusicQuizSupportedRound,
+> {
+  state: TState;
+  currentRound: TRound;
+  leaderboardRows: MusicQuizLeaderboardRow[];
+}
 
 export interface MusicQuizPlayerAnswerAdapterProps<
   TState extends MusicQuizSupportedPersonalizedState =

--- a/src/components/music-quiz/answer-types/multiple-choice/MultipleChoicePresentAnswer.vue
+++ b/src/components/music-quiz/answer-types/multiple-choice/MultipleChoicePresentAnswer.vue
@@ -7,17 +7,23 @@
         :label="remainingLabel || '…'"
       />
     </div>
-    <div class="grid flex-1 gap-4 lg:grid-cols-[minmax(0,1fr)_minmax(0,22rem)]">
+    <div
+      class="grid min-h-0 flex-1 gap-4 lg:grid-cols-[minmax(0,1fr)_minmax(0,22rem)]"
+    >
       <MultipleChoiceGrid
         :suggestions="currentRound.suggestions"
         :disabled="true"
         :selected-suggestion-id="null"
         @select="noop"
       />
-      <div class="flex flex-col gap-4">
+      <div
+        data-testid="multiple-choice-present-panels"
+        class="flex flex-col gap-4 lg:grid lg:min-h-0 lg:grid-rows-[minmax(7rem,2fr)_minmax(9rem,3fr)] lg:overflow-hidden"
+      >
         <MultipleChoiceProgress
           :statuses="roundPlayerStatuses"
           :answered-count="answeredCount"
+          scrollable
         />
         <slot name="leaderboard" />
       </div>

--- a/src/components/music-quiz/answer-types/multiple-choice/MultipleChoiceProgress.vue
+++ b/src/components/music-quiz/answer-types/multiple-choice/MultipleChoiceProgress.vue
@@ -1,5 +1,5 @@
 <template>
-  <Card class="gap-4 py-4">
+  <Card class="gap-4 py-4" :class="{ 'min-h-0 overflow-hidden': scrollable }">
     <CardHeader class="px-4">
       <CardTitle class="text-base">
         {{ $t("providers.music_quiz.answers") }}
@@ -10,7 +10,12 @@
         >
       </CardAction>
     </CardHeader>
-    <CardContent class="px-4">
+    <CardContent
+      class="px-4"
+      :class="{
+        'min-h-0 flex-1 overflow-y-auto overscroll-contain': scrollable,
+      }"
+    >
       <ul class="grid grid-cols-[repeat(auto-fill,minmax(150px,1fr))] gap-2">
         <li v-for="player in statuses" :key="player.name">
           <MusicQuizPlayerTile :name="player.name">
@@ -52,7 +57,10 @@ import { Check, Clock } from "@lucide/vue";
 interface MultipleChoiceProgressProps {
   statuses: MusicQuizPlayer[];
   answeredCount: number;
+  scrollable?: boolean;
 }
 
-defineProps<MultipleChoiceProgressProps>();
+withDefaults(defineProps<MultipleChoiceProgressProps>(), {
+  scrollable: false,
+});
 </script>

--- a/src/components/music-quiz/answer-types/timeline/TimelineAudienceAnswer.vue
+++ b/src/components/music-quiz/answer-types/timeline/TimelineAudienceAnswer.vue
@@ -1,11 +1,8 @@
 <template>
   <div
+    data-testid="timeline-audience-answer"
     class="flex flex-col gap-4"
-    :class="
-      present && state.phase === 'reveal'
-        ? 'max-h-[calc(100dvh-8rem)] overflow-y-auto pr-1'
-        : ''
-    "
+    :class="{ 'lg:h-full lg:min-h-0 lg:overflow-hidden': present }"
   >
     <div
       v-if="state.phase === 'answering'"
@@ -19,41 +16,60 @@
     </div>
 
     <TimelineDisplay
+      v-if="showTimeline"
       :entries="currentRound.timeline"
       :highlighted-entry-id="currentRound.revealed_entry?.entry_id"
     />
 
     <div
       class="grid gap-4"
-      :class="
-        present && state.phase === 'answering'
-          ? 'lg:grid-cols-[minmax(0,1fr)_22rem]'
-          : !present
-            ? 'lg:grid-cols-2'
-            : ''
-      "
+      :class="{
+        'lg:min-h-0 lg:flex-1 lg:grid-cols-[minmax(0,1fr)_22rem] lg:overflow-hidden':
+          present && state.phase === 'answering',
+        'lg:min-h-0 lg:flex-1 lg:grid-rows-[minmax(7rem,2fr)_minmax(9rem,3fr)] lg:overflow-hidden':
+          present && state.phase === 'reveal' && revealedResults.length,
+        'lg:min-h-0 lg:flex-1 lg:grid-rows-[minmax(0,1fr)] lg:overflow-hidden':
+          present && state.phase === 'reveal' && !revealedResults.length,
+        'lg:grid-cols-2': !present,
+      }"
     >
       <TimelineProgress
         v-if="state.phase === 'answering'"
         :statuses="roundPlayerStatuses"
+        :scrollable="present"
       />
 
-      <Card v-if="state.phase === 'reveal' && revealedResults.length">
-        <CardHeader>
+      <Card
+        v-if="state.phase === 'reveal' && revealedResults.length"
+        data-testid="timeline-round-results"
+        role="region"
+        :aria-label="$t('providers.music_quiz.timeline_round_results')"
+        :class="{
+          'lg:min-h-0 lg:gap-3 lg:overflow-hidden lg:py-3': present,
+        }"
+      >
+        <CardHeader :class="{ 'lg:px-4': present }">
           <CardTitle class="text-base">
             {{ $t("providers.music_quiz.timeline_round_results") }}
           </CardTitle>
         </CardHeader>
-        <CardContent>
+        <CardContent
+          :class="{
+            'lg:min-h-0 lg:flex-1 lg:overflow-y-auto lg:overscroll-contain lg:px-4':
+              present,
+          }"
+        >
           <ul class="flex flex-col gap-2">
             <li
               v-for="result in revealedResults"
               :key="result.name"
               class="bg-muted flex items-center justify-between gap-3 rounded-md px-3 py-2"
             >
-              <span class="truncate font-medium">{{ result.name }}</span>
+              <span class="min-w-0 flex-1 truncate font-medium">
+                {{ result.name }}
+              </span>
               <span
-                class="flex shrink-0 items-center gap-1 font-semibold tabular-nums"
+                class="flex min-w-0 max-w-[45%] shrink-0 items-center gap-1 font-semibold tabular-nums"
                 :class="
                   result.correct
                     ? 'text-green-600 dark:text-green-400'
@@ -73,14 +89,21 @@
                       : $t("providers.music_quiz.incorrect")
                   }}
                 </span>
-                +{{ result.points }}
+                <span class="truncate">+{{ result.points }}</span>
               </span>
             </li>
           </ul>
         </CardContent>
       </Card>
 
-      <slot name="leaderboard" />
+      <div
+        v-if="present"
+        data-testid="timeline-leaderboard-region"
+        class="lg:min-h-0 lg:overflow-hidden"
+      >
+        <slot name="leaderboard" />
+      </div>
+      <slot v-else name="leaderboard" />
     </div>
   </div>
 </template>
@@ -105,9 +128,11 @@ const props = withDefaults(
     state: MusicQuizTimelineHostState;
     currentRound: MusicQuizTimelineRound;
     present?: boolean;
+    showTimeline?: boolean;
   }>(),
   {
     present: false,
+    showTimeline: true,
   },
 );
 defineSlots<{ leaderboard: () => VNode[] }>();

--- a/src/components/music-quiz/answer-types/timeline/TimelineAudienceAnswer.vue
+++ b/src/components/music-quiz/answer-types/timeline/TimelineAudienceAnswer.vue
@@ -69,7 +69,8 @@
                 {{ result.name }}
               </span>
               <span
-                class="flex min-w-0 max-w-[45%] shrink-0 items-center gap-1 font-semibold tabular-nums"
+                data-testid="timeline-result-score"
+                class="flex min-w-0 max-w-[45%] items-center gap-1 font-semibold tabular-nums"
                 :class="
                   result.correct
                     ? 'text-green-600 dark:text-green-400'
@@ -89,7 +90,9 @@
                       : $t("providers.music_quiz.incorrect")
                   }}
                 </span>
-                <span class="truncate">+{{ result.points }}</span>
+                <span class="min-w-0 flex-1 truncate">
+                  +{{ result.points }}
+                </span>
               </span>
             </li>
           </ul>

--- a/src/components/music-quiz/answer-types/timeline/TimelineDisplay.vue
+++ b/src/components/music-quiz/answer-types/timeline/TimelineDisplay.vue
@@ -1,5 +1,6 @@
 <template>
   <div
+    ref="containerRef"
     class="flex flex-col gap-2"
     :class="{
       'min-w-0 overflow-x-auto overscroll-x-contain pb-1': horizontal,
@@ -71,7 +72,7 @@ import { Button } from "@/components/ui/button";
 import type { MusicQuizTimelineEntry } from "@/composables/useMusicQuiz";
 import { $t } from "@/plugins/i18n";
 import { Check, Plus } from "@lucide/vue";
-import { computed } from "vue";
+import { computed, nextTick, ref, watch } from "vue";
 
 interface TimelineBoundary {
   key: string;
@@ -107,6 +108,7 @@ const emit = defineEmits<{
   select: [previousEntryId: string | null, nextEntryId: string | null];
 }>();
 
+const containerRef = ref<HTMLElement | null>(null);
 const boundaries = computed<TimelineBoundary[]>(() =>
   Array.from({ length: props.entries.length + 1 }, (_, index) => {
     const previous = props.entries[index - 1];
@@ -124,6 +126,20 @@ const boundaries = computed<TimelineBoundary[]>(() =>
         nextEntryId === props.selectedNextEntryId,
     };
   }),
+);
+
+watch(
+  () => ({
+    horizontal: props.horizontal,
+    highlightedEntryId: props.highlightedEntryId,
+    entryIds: props.entries.map((entry) => entry.entry_id).join("\0"),
+  }),
+  async ({ horizontal, highlightedEntryId }) => {
+    if (!horizontal || !highlightedEntryId) return;
+    await nextTick();
+    scrollEntryIntoView(highlightedEntryId);
+  },
+  { flush: "post", immediate: true },
 );
 
 function boundaryLabel(
@@ -151,5 +167,21 @@ function boundaryLabel(
     ]);
   }
   return $t("providers.music_quiz.timeline_place_here");
+}
+
+function scrollEntryIntoView(entryId: string) {
+  const entry = Array.from(
+    containerRef.value?.querySelectorAll<HTMLElement>("[data-entry-id]") ?? [],
+  ).find((element) => element.dataset.entryId === entryId);
+  if (!entry?.scrollIntoView) return;
+
+  const reduceMotion =
+    typeof window !== "undefined" &&
+    window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+  entry.scrollIntoView({
+    behavior: reduceMotion ? "auto" : "smooth",
+    block: "nearest",
+    inline: "center",
+  });
 }
 </script>

--- a/src/components/music-quiz/answer-types/timeline/TimelineDisplay.vue
+++ b/src/components/music-quiz/answer-types/timeline/TimelineDisplay.vue
@@ -177,7 +177,7 @@ function scrollEntryIntoView(entryId: string) {
 
   const reduceMotion =
     typeof window !== "undefined" &&
-    window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+    window.matchMedia?.("(prefers-reduced-motion: reduce)").matches === true;
   entry.scrollIntoView({
     behavior: reduceMotion ? "auto" : "smooth",
     block: "nearest",

--- a/src/components/music-quiz/answer-types/timeline/TimelineDisplay.vue
+++ b/src/components/music-quiz/answer-types/timeline/TimelineDisplay.vue
@@ -1,10 +1,21 @@
 <template>
-  <div class="flex flex-col gap-2">
+  <div
+    class="flex flex-col gap-2"
+    :class="{
+      'min-w-0 overflow-x-auto overscroll-x-contain pb-1': horizontal,
+    }"
+    :data-orientation="horizontal ? 'horizontal' : 'vertical'"
+  >
     <p v-if="selectable" class="text-muted-foreground text-center text-sm">
       {{ $t("providers.music_quiz.timeline_place_help") }}
     </p>
     <ol
-      class="mx-auto flex w-full max-w-2xl flex-col"
+      class="flex"
+      :class="
+        horizontal
+          ? 'w-max min-w-full flex-row items-stretch gap-2'
+          : 'mx-auto w-full max-w-2xl flex-col'
+      "
       :aria-label="$t('providers.music_quiz.timeline')"
     >
       <template v-for="boundary in boundaries" :key="boundary.key">
@@ -36,11 +47,17 @@
         </li>
         <li
           v-if="boundary.entry"
-          class="border-primary/25 border-l-2 py-2 pl-3"
+          class="border-primary/25"
+          :class="
+            horizontal
+              ? 'w-52 shrink-0 border-t-2 pt-2'
+              : 'border-l-2 py-2 pl-3'
+          "
         >
           <TimelineEntryCard
             :entry="boundary.entry"
             :highlighted="boundary.entry.entry_id === highlightedEntryId"
+            :compact="compact"
           />
         </li>
       </template>
@@ -73,6 +90,8 @@ const props = withDefaults(
     selectedPreviousEntryId?: string | null;
     selectedNextEntryId?: string | null;
     highlightedEntryId?: string | null;
+    horizontal?: boolean;
+    compact?: boolean;
   }>(),
   {
     selectable: false,
@@ -80,6 +99,8 @@ const props = withDefaults(
     selectedPreviousEntryId: null,
     selectedNextEntryId: null,
     highlightedEntryId: null,
+    horizontal: false,
+    compact: false,
   },
 );
 const emit = defineEmits<{

--- a/src/components/music-quiz/answer-types/timeline/TimelineEntryCard.vue
+++ b/src/components/music-quiz/answer-types/timeline/TimelineEntryCard.vue
@@ -1,41 +1,62 @@
 <template>
   <article
     :data-entry-id="entry.entry_id"
-    class="bg-card grid grid-cols-[4.25rem_minmax(0,1fr)] items-center gap-3 rounded-xl border p-3 shadow-sm transition-colors motion-reduce:transition-none sm:grid-cols-[5rem_minmax(0,1fr)]"
-    :class="
+    :data-compact="compact ? 'true' : undefined"
+    class="bg-card grid items-center border transition-colors motion-reduce:transition-none"
+    :class="[
+      compact
+        ? 'h-full grid-cols-[3rem_minmax(0,1fr)] gap-2 rounded-lg p-2 shadow-none'
+        : 'grid-cols-[4.25rem_minmax(0,1fr)] gap-3 rounded-xl p-3 shadow-sm sm:grid-cols-[5rem_minmax(0,1fr)]',
       highlighted
         ? 'border-primary bg-primary/5 ring-primary/20 ring-2'
-        : 'border-border'
-    "
+        : 'border-border',
+    ]"
   >
     <img
       v-if="imageUrl"
       :src="imageUrl"
       :alt="`${entry.title} - ${entry.artist}`"
-      class="bg-muted aspect-square w-full rounded-lg object-cover"
+      class="bg-muted aspect-square w-full object-cover"
+      :class="compact ? 'rounded-md' : 'rounded-lg'"
     />
     <div
       v-else
-      class="bg-muted text-muted-foreground grid aspect-square w-full place-items-center rounded-lg"
+      class="bg-muted text-muted-foreground grid aspect-square w-full place-items-center"
+      :class="compact ? 'rounded-md' : 'rounded-lg'"
       aria-hidden="true"
     >
-      <Music2 class="size-6" />
+      <Music2 :class="compact ? 'size-4' : 'size-6'" />
     </div>
 
-    <div class="flex min-w-0 flex-col gap-1">
+    <div class="flex min-w-0 flex-col" :class="compact ? 'gap-0.5' : 'gap-1'">
       <div class="flex flex-wrap items-center gap-2">
-        <strong class="text-primary text-xl leading-none tabular-nums">
+        <strong
+          class="text-primary leading-none tabular-nums"
+          :class="compact ? 'text-base' : 'text-xl'"
+        >
           {{ entry.release_year }}
         </strong>
-        <Badge v-if="entry.is_anchor" variant="secondary">
+        <Badge
+          v-if="entry.is_anchor"
+          variant="secondary"
+          :class="{ 'px-1.5 py-0 text-[0.625rem]': compact }"
+        >
           {{ $t("providers.music_quiz.timeline_anchor") }}
         </Badge>
-        <Badge v-if="highlighted">
+        <Badge
+          v-if="highlighted"
+          :class="{ 'px-1.5 py-0 text-[0.625rem]': compact }"
+        >
           {{ $t("providers.music_quiz.timeline_revealed") }}
         </Badge>
       </div>
-      <span class="truncate font-semibold">{{ entry.title }}</span>
-      <span class="text-muted-foreground truncate text-sm">
+      <span class="truncate font-semibold" :class="{ 'text-sm': compact }">
+        {{ entry.title }}
+      </span>
+      <span
+        class="text-muted-foreground truncate"
+        :class="compact ? 'text-xs' : 'text-sm'"
+      >
         {{ entry.artist }}
       </span>
     </div>
@@ -54,9 +75,11 @@ const props = withDefaults(
   defineProps<{
     entry: MusicQuizTimelineEntry;
     highlighted?: boolean;
+    compact?: boolean;
   }>(),
   {
     highlighted: false,
+    compact: false,
   },
 );
 

--- a/src/components/music-quiz/answer-types/timeline/TimelineProgress.vue
+++ b/src/components/music-quiz/answer-types/timeline/TimelineProgress.vue
@@ -1,5 +1,5 @@
 <template>
-  <Card class="gap-4 py-4">
+  <Card class="gap-4 py-4" :class="{ 'min-h-0 overflow-hidden': scrollable }">
     <CardHeader class="px-4">
       <CardTitle class="text-base">
         {{ $t("providers.music_quiz.timeline_progress") }}
@@ -13,7 +13,12 @@
         </Badge>
       </CardAction>
     </CardHeader>
-    <CardContent class="px-4">
+    <CardContent
+      class="px-4"
+      :class="{
+        'min-h-0 flex-1 overflow-y-auto overscroll-contain': scrollable,
+      }"
+    >
       <ul class="grid grid-cols-[repeat(auto-fill,minmax(150px,1fr))] gap-2">
         <li v-for="player in statuses" :key="player.name">
           <MusicQuizPlayerTile :name="player.name">
@@ -51,7 +56,15 @@ import { $t } from "@/plugins/i18n";
 import { CheckCircle2, Clock, ListChecks } from "@lucide/vue";
 import { computed } from "vue";
 
-const props = defineProps<{ statuses: MusicQuizTimelinePlayer[] }>();
+const props = withDefaults(
+  defineProps<{
+    statuses: MusicQuizTimelinePlayer[];
+    scrollable?: boolean;
+  }>(),
+  {
+    scrollable: false,
+  },
+);
 
 const placedCount = computed(
   () => props.statuses.filter((player) => player.placed).length,

--- a/src/components/music-quiz/game-types/music-timeline/MusicTimelinePresentBody.vue
+++ b/src/components/music-quiz/game-types/music-timeline/MusicTimelinePresentBody.vue
@@ -1,0 +1,57 @@
+<template>
+  <div
+    data-testid="music-timeline-present-body"
+    class="flex min-h-0 flex-col gap-3 lg:grid lg:flex-1 lg:grid-cols-[minmax(16rem,2fr)_minmax(22rem,3fr)] lg:grid-rows-[minmax(0,1fr)_auto] lg:gap-4 lg:overflow-hidden"
+  >
+    <MusicTimelinePresentRound
+      class="lg:self-start"
+      :state="state"
+      :current-round="currentRound"
+      compact
+    />
+
+    <TimelineAudienceAnswer
+      class="lg:h-full"
+      :state="state"
+      :current-round="currentRound"
+      :show-timeline="false"
+      present
+    >
+      <template #leaderboard>
+        <MusicQuizLeaderboard
+          class="lg:h-full"
+          :rows="leaderboardRows"
+          scrollable
+        />
+      </template>
+    </TimelineAudienceAnswer>
+
+    <TimelineDisplay
+      data-testid="music-timeline-history"
+      class="lg:col-span-2"
+      :entries="currentRound.timeline"
+      :highlighted-entry-id="currentRound.revealed_entry?.entry_id"
+      horizontal
+      compact
+    />
+  </div>
+</template>
+
+<script setup lang="ts">
+import TimelineAudienceAnswer from "@/components/music-quiz/answer-types/timeline/TimelineAudienceAnswer.vue";
+import TimelineDisplay from "@/components/music-quiz/answer-types/timeline/TimelineDisplay.vue";
+import type { MusicQuizPresentBodyAdapterProps } from "@/components/music-quiz/adapter_contracts";
+import MusicTimelinePresentRound from "@/components/music-quiz/game-types/music-timeline/MusicTimelinePresentRound.vue";
+import MusicQuizLeaderboard from "@/components/music-quiz/MusicQuizLeaderboard.vue";
+import type {
+  MusicQuizTimelineHostState,
+  MusicQuizTimelineRound,
+} from "@/composables/useMusicQuiz";
+
+defineProps<
+  MusicQuizPresentBodyAdapterProps<
+    MusicQuizTimelineHostState,
+    MusicQuizTimelineRound
+  >
+>();
+</script>

--- a/src/components/music-quiz/game-types/music-timeline/MusicTimelinePresentRound.vue
+++ b/src/components/music-quiz/game-types/music-timeline/MusicTimelinePresentRound.vue
@@ -3,6 +3,7 @@
     :phase="state.phase"
     :round="currentRound"
     :is-final-round="currentRound.round_index + 1 >= state.round_count"
+    :compact="compact"
   />
 </template>
 
@@ -14,10 +15,17 @@ import type {
   MusicQuizTimelineRound,
 } from "@/composables/useMusicQuiz";
 
-defineProps<
-  MusicQuizPresentGameAdapterProps<
-    MusicQuizTimelineHostState,
-    MusicQuizTimelineRound
-  >
->();
+withDefaults(
+  defineProps<
+    MusicQuizPresentGameAdapterProps<
+      MusicQuizTimelineHostState,
+      MusicQuizTimelineRound
+    > & {
+      compact?: boolean;
+    }
+  >(),
+  {
+    compact: false,
+  },
+);
 </script>

--- a/src/components/music-quiz/game-types/music-timeline/MusicTimelineRound.vue
+++ b/src/components/music-quiz/game-types/music-timeline/MusicTimelineRound.vue
@@ -1,14 +1,24 @@
 <template>
-  <Card class="overflow-hidden">
-    <CardContent class="flex flex-col gap-4">
+  <Card
+    data-testid="music-timeline-round"
+    :data-compact="compact ? 'true' : undefined"
+    class="overflow-hidden"
+    :class="{ 'gap-0 py-3': compact }"
+  >
+    <CardContent
+      class="flex flex-col"
+      :class="compact ? 'gap-3 px-3 sm:px-4' : 'gap-4'"
+    >
       <div
         v-if="phase === 'answering'"
-        class="flex flex-col items-center gap-3 py-4 text-center"
+        class="flex flex-col items-center text-center"
+        :class="compact ? 'gap-2 py-2' : 'gap-3 py-4'"
       >
         <span
-          class="bg-primary/10 text-primary grid size-16 place-items-center rounded-full"
+          class="bg-primary/10 text-primary grid place-items-center rounded-full"
+          :class="compact ? 'size-12' : 'size-16'"
         >
-          <AudioLines class="size-8" />
+          <AudioLines :class="compact ? 'size-6' : 'size-8'" />
         </span>
         <div>
           <h2 class="text-xl font-bold">
@@ -22,29 +32,45 @@
 
       <div
         v-else-if="phase === 'reveal' && revealedEntry"
-        class="grid items-center gap-4 sm:grid-cols-[minmax(8rem,14rem)_minmax(0,1fr)]"
+        class="grid items-center gap-4"
+        :class="
+          compact
+            ? 'sm:grid-cols-[minmax(5rem,8rem)_minmax(0,1fr)]'
+            : 'sm:grid-cols-[minmax(8rem,14rem)_minmax(0,1fr)]'
+        "
       >
         <img
           v-if="imageUrl"
           :src="imageUrl"
           :alt="`${revealedEntry.title} - ${revealedEntry.artist}`"
-          class="bg-muted mx-auto aspect-square w-full max-w-56 rounded-xl object-cover"
+          class="bg-muted mx-auto aspect-square w-full object-cover"
+          :class="compact ? 'max-w-32 rounded-lg' : 'max-w-56 rounded-xl'"
         />
         <div
           v-else
-          class="bg-muted text-muted-foreground mx-auto grid aspect-square w-full max-w-56 place-items-center rounded-xl"
+          class="bg-muted text-muted-foreground mx-auto grid aspect-square w-full place-items-center"
+          :class="compact ? 'max-w-32 rounded-lg' : 'max-w-56 rounded-xl'"
           aria-hidden="true"
         >
-          <Music2 class="size-12" />
+          <Music2 :class="compact ? 'size-8' : 'size-12'" />
         </div>
-        <div class="flex min-w-0 flex-col gap-2 text-center sm:text-left">
+        <div
+          class="flex min-w-0 flex-col text-center sm:text-left"
+          :class="compact ? 'gap-1' : 'gap-2'"
+        >
           <Badge class="w-fit self-center sm:self-start">
             {{ revealedEntry.release_year }}
           </Badge>
-          <h2 class="text-2xl font-black break-words sm:text-3xl">
+          <h2
+            class="font-black break-words"
+            :class="compact ? 'text-xl sm:text-2xl' : 'text-2xl sm:text-3xl'"
+          >
             {{ revealedEntry.title }}
           </h2>
-          <p class="text-muted-foreground text-lg break-words">
+          <p
+            class="text-muted-foreground break-words"
+            :class="{ 'text-lg': !compact }"
+          >
             {{ revealedEntry.artist }}
           </p>
         </div>
@@ -52,7 +78,8 @@
 
       <div
         v-if="autoAdvanceText"
-        class="bg-muted/40 text-muted-foreground flex items-center justify-center gap-2 rounded-lg border px-3 py-2 text-sm font-semibold tabular-nums"
+        class="bg-muted/40 text-muted-foreground flex items-center justify-center gap-2 rounded-lg border px-3 text-sm font-semibold tabular-nums"
+        :class="compact ? 'py-1.5' : 'py-2'"
         role="timer"
         :aria-label="autoAdvanceText"
         data-testid="music-timeline-auto-advance"
@@ -99,12 +126,14 @@ const props = withDefaults(
     isReady?: boolean;
     readyLabel?: string;
     showReadyButton?: boolean;
+    compact?: boolean;
   }>(),
   {
     busy: false,
     isReady: false,
     readyLabel: "",
     showReadyButton: false,
+    compact: false,
   },
 );
 const emit = defineEmits<{ ready: [] }>();

--- a/src/components/music-quiz/game_types.ts
+++ b/src/components/music-quiz/game_types.ts
@@ -10,6 +10,7 @@ import GuessTheSongSetup from "@/components/music-quiz/game-types/guess-the-song
 import MusicTimelineHostPanel from "@/components/music-quiz/game-types/music-timeline/MusicTimelineHostPanel.vue";
 import MusicTimelineHostRound from "@/components/music-quiz/game-types/music-timeline/MusicTimelineHostRound.vue";
 import MusicTimelinePlayerRound from "@/components/music-quiz/game-types/music-timeline/MusicTimelinePlayerRound.vue";
+import MusicTimelinePresentBody from "@/components/music-quiz/game-types/music-timeline/MusicTimelinePresentBody.vue";
 import MusicTimelinePresentRound from "@/components/music-quiz/game-types/music-timeline/MusicTimelinePresentRound.vue";
 import MusicTimelineSetup from "@/components/music-quiz/game-types/music-timeline/MusicTimelineSetup.vue";
 import TriviaHostPanel from "@/components/music-quiz/game-types/trivia/TriviaHostPanel.vue";
@@ -44,6 +45,7 @@ export interface MusicQuizGameDefinition<
     hostPanel: Component;
     host: Component;
     present: Component;
+    presentBody?: Component;
   };
 }
 
@@ -84,6 +86,7 @@ const MUSIC_QUIZ_GAME_TYPE_REGISTRY = {
       hostPanel: markRaw(MusicTimelineHostPanel),
       host: markRaw(MusicTimelineHostRound),
       present: markRaw(MusicTimelinePresentRound),
+      presentBody: markRaw(MusicTimelinePresentBody),
     },
   },
   trivia: {

--- a/src/views/MusicQuizDashboardView.vue
+++ b/src/views/MusicQuizDashboardView.vue
@@ -1,5 +1,13 @@
 <template>
-  <div ref="presentRootRef" class="mx-auto w-full max-w-6xl p-4 sm:p-5">
+  <div
+    ref="presentRootRef"
+    data-testid="music-quiz-dashboard-root"
+    :class="
+      presentMode
+        ? 'w-full lg:h-full lg:min-h-0 lg:overflow-hidden'
+        : 'mx-auto w-full max-w-6xl p-4 sm:p-5'
+    "
+  >
     <MusicQuizPresentStage
       v-if="presentMode && activeState && resolvedDefinition"
       :state="activeState"

--- a/tests/components/music-quiz/MultipleChoiceAdapters.test.ts
+++ b/tests/components/music-quiz/MultipleChoiceAdapters.test.ts
@@ -8,7 +8,7 @@ import type {
   MusicQuizGuessTheSongPersonalizedState,
   MusicQuizGuessTheSongRound,
 } from "@/composables/useMusicQuiz";
-import { shallowMount } from "@vue/test-utils";
+import { mount, shallowMount } from "@vue/test-utils";
 import { describe, expect, it, vi } from "vitest";
 
 vi.mock("@/plugins/i18n", () => ({
@@ -190,11 +190,48 @@ describe("multiple-choice adapters", () => {
       }),
     ];
 
-    for (const wrapper of wrappers) {
+    for (const [index, wrapper] of wrappers.entries()) {
       const progress = wrapper.getComponent(MultipleChoiceProgress);
       expect(progress.props("statuses")).toEqual([players[0]]);
       expect(progress.props("answeredCount")).toBe(1);
+      expect(progress.props("scrollable")).toBe(index === 2);
+      if (index === 2) {
+        const panels = wrapper.get(
+          '[data-testid="multiple-choice-present-panels"]',
+        );
+        expect(panels.classes()).toEqual(
+          expect.arrayContaining([
+            "lg:grid",
+            "lg:min-h-0",
+            "lg:grid-rows-[minmax(7rem,2fr)_minmax(9rem,3fr)]",
+            "lg:overflow-hidden",
+          ]),
+        );
+        expect(panels.classes()).not.toContain("overflow-hidden");
+      }
       wrapper.unmount();
     }
+  });
+
+  it("contains long present progress lists with internal scrolling", () => {
+    const wrapper = mount(MultipleChoiceProgress, {
+      props: {
+        statuses: playerState.players,
+        answeredCount: 0,
+        scrollable: true,
+      },
+    });
+
+    expect(wrapper.get('[data-slot="card"]').classes()).toEqual(
+      expect.arrayContaining(["min-h-0", "overflow-hidden"]),
+    );
+    expect(wrapper.get('[data-slot="card-content"]').classes()).toEqual(
+      expect.arrayContaining([
+        "min-h-0",
+        "flex-1",
+        "overflow-y-auto",
+        "overscroll-contain",
+      ]),
+    );
   });
 });

--- a/tests/components/music-quiz/MusicQuizLeaderboard.test.ts
+++ b/tests/components/music-quiz/MusicQuizLeaderboard.test.ts
@@ -101,8 +101,14 @@ describe("MusicQuizLeaderboard", () => {
     expect(wrapper.get("li span.min-w-0.flex-1").classes()).toContain(
       "truncate",
     );
-    expect(wrapper.get("li span.max-w-\\[45\\%\\]").classes()).toContain(
-      "max-w-[45%]",
+    const score = wrapper.get("li span.max-w-\\[45\\%\\]");
+    expect(score.classes()).toContain("max-w-[45%]");
+    expect(score.classes()).not.toContain("shrink-0");
+    expect(score.get("strong").classes()).toEqual(
+      expect.arrayContaining(["min-w-0", "flex-1", "truncate"]),
+    );
+    expect(score.get("span").classes()).toEqual(
+      expect.arrayContaining(["min-w-0", "flex-1", "truncate"]),
     );
   });
 });

--- a/tests/components/music-quiz/MusicQuizLeaderboard.test.ts
+++ b/tests/components/music-quiz/MusicQuizLeaderboard.test.ts
@@ -65,4 +65,44 @@ describe("MusicQuizLeaderboard", () => {
       renderedRows[1].findComponent({ name: "MusicQuizAvatar" }).classes(),
     ).toContain("size-6");
   });
+
+  it("fills a constrained region and scrolls long rankings internally", () => {
+    const manyRows = Array.from({ length: 30 }, (_, index) => ({
+      ...rows[0],
+      name: `Player ${index + 1} with a safely truncated long name`,
+      rank: index + 1,
+      score: Number.MAX_SAFE_INTEGER,
+    }));
+    const wrapper = mount(MusicQuizLeaderboard, {
+      props: {
+        rows: manyRows,
+        scrollable: true,
+      },
+    });
+    const card = wrapper.get('[data-slot="card"]');
+    const content = wrapper.get('[data-slot="card-content"]');
+
+    expect(card.attributes("role")).toBe("region");
+    expect(card.attributes("aria-label")).toBe(
+      "providers.music_quiz.leaderboard",
+    );
+    expect(card.classes()).toEqual(
+      expect.arrayContaining(["min-h-0", "overflow-hidden"]),
+    );
+    expect(content.classes()).toEqual(
+      expect.arrayContaining([
+        "min-h-0",
+        "flex-1",
+        "overflow-y-auto",
+        "overscroll-contain",
+      ]),
+    );
+    expect(wrapper.findAll("li")).toHaveLength(30);
+    expect(wrapper.get("li span.min-w-0.flex-1").classes()).toContain(
+      "truncate",
+    );
+    expect(wrapper.get("li span.max-w-\\[45\\%\\]").classes()).toContain(
+      "max-w-[45%]",
+    );
+  });
 });

--- a/tests/components/music-quiz/MusicQuizSessionHeader.test.ts
+++ b/tests/components/music-quiz/MusicQuizSessionHeader.test.ts
@@ -79,4 +79,40 @@ describe("MusicQuizSessionHeader", () => {
     );
     expect(wrapper.text()).not.toContain("providers.music_quiz.mode_venue");
   });
+
+  it("uses compact sizing only for present mode", () => {
+    const props = {
+      game: game("guess_the_song", true),
+      name: "Friday Quiz",
+      phaseLabel: "Answers open",
+      roundLabel: "Round 2 / 5",
+      mode: "venue" as const,
+    };
+    const regular = mount(MusicQuizSessionHeader, { props });
+    const present = mount(MusicQuizSessionHeader, {
+      props: {
+        ...props,
+        present: true,
+      },
+    });
+
+    expect(
+      regular.get('[data-testid="music-quiz-session-header"]').classes(),
+    ).toEqual(expect.arrayContaining(["gap-3", "p-4"]));
+    expect(regular.get("h2").classes()).toEqual(
+      expect.arrayContaining(["text-lg", "sm:text-xl"]),
+    );
+
+    expect(
+      present.get('[data-testid="music-quiz-session-header"]').classes(),
+    ).toEqual(expect.arrayContaining(["gap-2", "p-3", "sm:p-4"]));
+    expect(present.get("h1").classes()).toEqual(
+      expect.arrayContaining(["text-xl", "sm:text-2xl"]),
+    );
+    expect(
+      present.get('[data-testid="game-icon"]').element.parentElement?.classList,
+    ).toContain("size-11");
+    expect(regular.find("h1").exists()).toBe(false);
+    expect(present.find("h2").exists()).toBe(false);
+  });
 });

--- a/tests/components/music-quiz/MusicQuizStages.test.ts
+++ b/tests/components/music-quiz/MusicQuizStages.test.ts
@@ -1,10 +1,12 @@
 import MusicQuizPlayerStage from "@/components/music-quiz/MusicQuizPlayerStage.vue";
 import MusicQuizPresentStage from "@/components/music-quiz/MusicQuizPresentStage.vue";
+import type { MusicQuizGameDefinition } from "@/components/music-quiz/game_types";
 import type {
   MusicQuizGuessTheSongHostState,
   MusicQuizGuessTheSongPersonalizedState,
   MusicQuizGuessTheSongRound,
   MusicQuizTimelinePersonalizedState,
+  MusicQuizTriviaHostState,
 } from "@/composables/useMusicQuiz";
 import {
   baseRound as musicTimelineRound,
@@ -58,6 +60,15 @@ const answerAdapter = {
   template:
     "<button data-testid=\"answer-adapter\" @click=\"$emit('submit', { answer_type: 'multiple_choice', suggestion_id: 'one' })\">Answer<slot name=\"leaderboard\" /></button>",
 };
+const presentBodyAdapter = {
+  props: {
+    state: { type: Object, required: true },
+    currentRound: { type: Object, required: true },
+    leaderboardRows: { type: Array, required: true },
+  },
+  template:
+    '<div data-testid="present-body-adapter">{{ leaderboardRows.length }}</div>',
+};
 const timelineAnswerAdapter = {
   props: {
     state: { type: Object, required: true },
@@ -92,6 +103,13 @@ const gameDefinition = {
     present: gameAdapter,
   },
 } as const;
+const gameDefinitionWithPresentBody = {
+  ...gameDefinition,
+  adapters: {
+    ...gameDefinition.adapters,
+    presentBody: presentBodyAdapter,
+  },
+} satisfies MusicQuizGameDefinition<"guess_the_song">;
 
 const currentRound = {
   question: "Which song is playing?",
@@ -128,6 +146,18 @@ const hostState = {
   join_url: "https://example.test/join",
   rounds: [currentRound],
 } satisfies MusicQuizGuessTheSongHostState;
+const triviaHostState = {
+  ...hostState,
+  quiz_type: "trivia",
+  name: "Trivia",
+  language: "en",
+  rounds: [],
+} satisfies MusicQuizTriviaHostState;
+const triviaGameDefinition = {
+  ...gameDefinition,
+  id: "trivia",
+  supportsListenIn: false,
+} satisfies MusicQuizGameDefinition<"trivia">;
 
 const leaderboardRows = [
   {
@@ -359,6 +389,11 @@ describe("Music Quiz shared stages", () => {
     expect(wrapper.get('[data-testid="music-quiz-auto-start"]').text()).toBe(
       "Game starts in 9s",
     );
+    const lobby = wrapper.get('[data-testid="music-quiz-present-lobby"]');
+    expect(lobby.classes()).toEqual(
+      expect.arrayContaining(["min-h-0", "flex-1", "lg:overflow-y-auto"]),
+    );
+    expect(lobby.classes()).not.toContain("overflow-y-auto");
     wrapper.unmount();
   });
 
@@ -391,6 +426,17 @@ describe("Music Quiz shared stages", () => {
 
     expect(wrapper.find('[data-testid="answer-adapter"]').exists()).toBe(true);
     expect(wrapper.find('[data-testid="leaderboard"]').exists()).toBe(true);
+    const root = wrapper.get('[data-testid="music-quiz-present-stage"]');
+    expect(root.classes()).toEqual(
+      expect.arrayContaining([
+        "min-h-dvh",
+        "lg:h-full",
+        "lg:min-h-0",
+        "lg:overflow-hidden",
+      ]),
+    );
+    expect(root.classes()).not.toContain("overflow-hidden");
+    expect(wrapper.get("button-stub").attributes("size")).toBe("sm");
   });
 
   it("keeps reveal presentation routed through the answer adapter", () => {
@@ -429,6 +475,84 @@ describe("Music Quiz shared stages", () => {
     expect(wrapper.find('[data-testid="leaderboard"]').exists()).toBe(true);
   });
 
+  it("uses the default present layout for Trivia answering and reveal", () => {
+    for (const phase of ["answering", "reveal"] as const) {
+      const wrapper = mount(MusicQuizPresentStage, {
+        props: {
+          state: {
+            ...triviaHostState,
+            phase,
+          },
+          game: triviaGameDefinition,
+          currentRound,
+          leaderboardRows,
+          winnerText: "",
+          phaseLabel: phase,
+          roundLabel: "Round 1",
+          joinLink: "https://example.test/join",
+          isConnectionDegraded: false,
+          gameComponent: gameAdapter,
+          answerComponent: answerAdapter,
+        },
+        global: {
+          stubs: {
+            Button: true,
+            MusicQuizConnectionBanners: true,
+            MusicQuizLeaderboard: {
+              template: '<div data-testid="leaderboard" />',
+            },
+            MusicQuizPodium: true,
+          },
+        },
+      });
+
+      expect(
+        wrapper.find('[data-testid="present-body-adapter"]').exists(),
+      ).toBe(false);
+      expect(wrapper.find('[data-testid="game-adapter"]').exists()).toBe(true);
+      expect(wrapper.find('[data-testid="answer-adapter"]').exists()).toBe(
+        true,
+      );
+      expect(wrapper.find('[data-testid="leaderboard"]').exists()).toBe(true);
+      wrapper.unmount();
+    }
+  });
+
+  it("routes active rounds through an optional game present body", () => {
+    const wrapper = mount(MusicQuizPresentStage, {
+      props: {
+        state: {
+          ...hostState,
+          phase: "reveal",
+        },
+        game: gameDefinitionWithPresentBody,
+        currentRound,
+        leaderboardRows,
+        winnerText: "",
+        phaseLabel: "Reveal",
+        roundLabel: "Round 1",
+        joinLink: "https://example.test/join",
+        isConnectionDegraded: false,
+        gameComponent: gameAdapter,
+        answerComponent: answerAdapter,
+      },
+      global: {
+        stubs: {
+          Button: true,
+          MusicQuizConnectionBanners: true,
+          MusicQuizLeaderboard: true,
+          MusicQuizPodium: true,
+        },
+      },
+    });
+
+    expect(wrapper.get('[data-testid="present-body-adapter"]').text()).toBe(
+      "1",
+    );
+    expect(wrapper.find('[data-testid="game-adapter"]').exists()).toBe(false);
+    expect(wrapper.find('[data-testid="answer-adapter"]').exists()).toBe(false);
+  });
+
   it("keeps the podium in the shared finished presentation", () => {
     const state = {
       ...hostState,
@@ -463,5 +587,10 @@ describe("Music Quiz shared stages", () => {
 
     expect(wrapper.find('[data-testid="podium"]').exists()).toBe(true);
     expect(wrapper.text()).toContain("Player wins");
+    const finished = wrapper.get('[data-testid="music-quiz-present-finished"]');
+    expect(finished.classes()).toEqual(
+      expect.arrayContaining(["min-h-0", "flex-1", "lg:overflow-y-auto"]),
+    );
+    expect(finished.classes()).not.toContain("overflow-y-auto");
   });
 });

--- a/tests/components/music-quiz/MusicTimelinePresentBody.test.ts
+++ b/tests/components/music-quiz/MusicTimelinePresentBody.test.ts
@@ -152,6 +152,11 @@ describe("MusicTimelinePresentBody", () => {
     expect(resultsContent.classes()).toEqual(
       expect.arrayContaining(["lg:min-h-0", "lg:overflow-y-auto"]),
     );
+    const resultScore = results.get('[data-testid="timeline-result-score"]');
+    expect(resultScore.classes()).not.toContain("shrink-0");
+    expect(resultScore.get("span.truncate").classes()).toEqual(
+      expect.arrayContaining(["min-w-0", "flex-1"]),
+    );
     expect(leaderboardRegion.classes()).toEqual(
       expect.arrayContaining(["lg:min-h-0", "lg:overflow-hidden"]),
     );

--- a/tests/components/music-quiz/MusicTimelinePresentBody.test.ts
+++ b/tests/components/music-quiz/MusicTimelinePresentBody.test.ts
@@ -1,0 +1,202 @@
+import MusicTimelinePresentBody from "@/components/music-quiz/game-types/music-timeline/MusicTimelinePresentBody.vue";
+import type { MusicQuizLeaderboardRow } from "@/components/music-quiz/MusicQuizLeaderboard.vue";
+import type {
+  MusicQuizTimelineEntry,
+  MusicQuizTimelineHostState,
+  MusicQuizTimelineRound,
+} from "@/composables/useMusicQuiz";
+import { mount } from "@vue/test-utils";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@/plugins/i18n", () => ({
+  $t: (key: string) => key,
+}));
+
+vi.mock("@/helpers/utils", () => ({
+  getAvatarImage: () => "",
+  getMediaImageUrl: (url: string) => url,
+}));
+
+const entries = Array.from({ length: 12 }, (_, index) => ({
+  entry_id: `entry-${index}`,
+  release_year: 1980 + index,
+  title: `Song ${index}`,
+  artist: `Artist ${index}`,
+  track_uri: `library://track/${index}`,
+  image_url: null,
+  is_anchor: index === 0,
+})) satisfies MusicQuizTimelineEntry[];
+const revealedEntry = entries.at(-1)!;
+const currentRound = {
+  round_index: 0,
+  started_at: 1,
+  deadline: 31,
+  auto_advance_at: null,
+  question: null,
+  timeline: entries,
+  bonus_definitions: [],
+  revealed_entry: revealedEntry,
+  answer_label: `${revealedEntry.artist} - ${revealedEntry.title}`,
+  track_uri: revealedEntry.track_uri,
+  image_url: revealedEntry.image_url,
+  duration: 180,
+  ended_at: 20,
+} satisfies MusicQuizTimelineRound;
+const players = Array.from({ length: 24 }, (_, index) => ({
+  name: `Player ${index + 1} with a safely truncated long name`,
+  score: 24_000 - index * 100,
+  ready: false,
+  answered: true,
+  active_from_round: 0,
+  placed: true,
+  artist_bonus_answered: true,
+  title_bonus_answered: true,
+  last_answer: {
+    placement: {
+      previous_entry_id: entries.at(-2)!.entry_id,
+      next_entry_id: null,
+      correct: index % 2 === 0,
+      points: index % 2 === 0 ? 1_000 : 0,
+    },
+    artist: {
+      correct: true,
+      points: 250,
+    },
+    title: {
+      correct: true,
+      points: 250,
+    },
+  },
+}));
+const state = {
+  quiz_type: "music_timeline",
+  answer_type: "timeline",
+  phase: "reveal",
+  name: "Music Timeline",
+  round_count: 12,
+  answer_duration: 30,
+  artist_bonus_mode: "free_text",
+  title_bonus_mode: "free_text",
+  mode: "venue",
+  players,
+  current_round: currentRound,
+  created_at: 1,
+  sources: [],
+  join_url: "https://example.test/join",
+  rounds: [],
+} satisfies MusicQuizTimelineHostState;
+const leaderboardRows = players.map((player, index) => ({
+  ...player,
+  rank: index + 1,
+  roundScoreLabel: index === 0 ? "+1500" : "",
+})) satisfies MusicQuizLeaderboardRow[];
+
+describe("MusicTimelinePresentBody", () => {
+  it("keeps song and score panels before the bottom timeline", () => {
+    const wrapper = mount(MusicTimelinePresentBody, {
+      props: {
+        state,
+        currentRound,
+        leaderboardRows,
+      },
+    });
+    const body = wrapper.get('[data-testid="music-timeline-present-body"]');
+    const currentSong = wrapper.get('[data-testid="music-timeline-round"]');
+    const results = wrapper.get('[data-testid="timeline-round-results"]');
+    const leaderboard = wrapper.get(
+      '[aria-label="providers.music_quiz.leaderboard"]',
+    );
+    const history = wrapper.get('[data-testid="music-timeline-history"]');
+
+    expect(body.classes()).toEqual(
+      expect.arrayContaining([
+        "flex",
+        "flex-col",
+        "min-h-0",
+        "lg:grid",
+        "lg:flex-1",
+        "lg:overflow-hidden",
+      ]),
+    );
+    expect(body.classes()).not.toContain("overflow-hidden");
+    for (const panel of [currentSong, results, leaderboard]) {
+      expect(
+        panel.element.compareDocumentPosition(history.element) &
+          Node.DOCUMENT_POSITION_FOLLOWING,
+      ).toBeTruthy();
+    }
+    expect(currentSong.attributes("data-compact")).toBe("true");
+    expect(results.attributes("role")).toBe("region");
+    expect(leaderboard.attributes("role")).toBe("region");
+  });
+
+  it("bounds many-player results and gives the leaderboard internal scroll", () => {
+    const wrapper = mount(MusicTimelinePresentBody, {
+      props: {
+        state,
+        currentRound,
+        leaderboardRows,
+      },
+    });
+    const results = wrapper.get('[data-testid="timeline-round-results"]');
+    const resultsContent = results.get('[data-slot="card-content"]');
+    const leaderboardRegion = wrapper.get(
+      '[data-testid="timeline-leaderboard-region"]',
+    );
+    const leaderboard = leaderboardRegion.get('[data-slot="card"]');
+    const leaderboardContent = leaderboard.get('[data-slot="card-content"]');
+
+    expect(results.classes()).toEqual(
+      expect.arrayContaining(["lg:min-h-0", "lg:overflow-hidden"]),
+    );
+    expect(resultsContent.classes()).toEqual(
+      expect.arrayContaining(["lg:min-h-0", "lg:overflow-y-auto"]),
+    );
+    expect(leaderboardRegion.classes()).toEqual(
+      expect.arrayContaining(["lg:min-h-0", "lg:overflow-hidden"]),
+    );
+    expect(leaderboard.classes()).toEqual(
+      expect.arrayContaining(["min-h-0", "overflow-hidden", "lg:h-full"]),
+    );
+    expect(leaderboardContent.classes()).toEqual(
+      expect.arrayContaining(["min-h-0", "flex-1", "overflow-y-auto"]),
+    );
+    expect(results.findAll("li")).toHaveLength(players.length);
+    expect(leaderboard.findAll("li")).toHaveLength(players.length);
+  });
+
+  it("renders a small chronological highlighted strip without vertical growth", () => {
+    const wrapper = mount(MusicTimelinePresentBody, {
+      props: {
+        state,
+        currentRound,
+        leaderboardRows,
+      },
+    });
+    const history = wrapper.get('[data-testid="music-timeline-history"]');
+    const cards = history.findAll("article");
+
+    expect(history.attributes("data-orientation")).toBe("horizontal");
+    expect(history.classes()).toEqual(
+      expect.arrayContaining(["overflow-x-auto", "lg:col-span-2"]),
+    );
+    expect(history.get("ol").classes()).toEqual(
+      expect.arrayContaining(["w-max", "min-w-full", "flex-row"]),
+    );
+    expect(cards.map((card) => card.attributes("data-entry-id"))).toEqual(
+      entries.map((entry) => entry.entry_id),
+    );
+    expect(
+      cards.every((card) => card.attributes("data-compact") === "true"),
+    ).toBe(true);
+    expect(
+      history.get(`[data-entry-id="${revealedEntry.entry_id}"]`).classes(),
+    ).toContain("border-primary");
+    expect(
+      history
+        .findAll("li")
+        .filter((item) => item.find("article").exists())
+        .every((item) => item.classes().includes("shrink-0")),
+    ).toBe(true);
+  });
+});

--- a/tests/components/music-quiz/TimelineAudienceAdapters.test.ts
+++ b/tests/components/music-quiz/TimelineAudienceAdapters.test.ts
@@ -161,8 +161,32 @@ describe("timeline host and present answers", () => {
       expect(wrapper.getComponent(TimelineProgress).props("statuses")).toEqual(
         hostState.players.slice(0, 2),
       );
+      expect(wrapper.getComponent(TimelineProgress).props("scrollable")).toBe(
+        present,
+      );
       wrapper.unmount();
     }
+  });
+
+  it("contains long present progress lists with internal scrolling", () => {
+    const wrapper = mount(TimelineProgress, {
+      props: {
+        statuses: hostState.players,
+        scrollable: true,
+      },
+    });
+
+    expect(wrapper.get('[data-slot="card"]').classes()).toEqual(
+      expect.arrayContaining(["min-h-0", "overflow-hidden"]),
+    );
+    expect(wrapper.get('[data-slot="card-content"]').classes()).toEqual(
+      expect.arrayContaining([
+        "min-h-0",
+        "flex-1",
+        "overflow-y-auto",
+        "overscroll-contain",
+      ]),
+    );
   });
 
   it("shows aggregate reveal results and preserves the leaderboard slot", () => {

--- a/tests/components/music-quiz/TimelineDisplay.test.ts
+++ b/tests/components/music-quiz/TimelineDisplay.test.ts
@@ -1,7 +1,15 @@
 import TimelineDisplay from "@/components/music-quiz/answer-types/timeline/TimelineDisplay.vue";
 import type { MusicQuizTimelineEntry } from "@/composables/useMusicQuiz";
-import { mount } from "@vue/test-utils";
-import { describe, expect, it, vi } from "vitest";
+import { flushPromises, mount } from "@vue/test-utils";
+import {
+  afterAll,
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
 
 vi.mock("@/plugins/i18n", () => ({
   $t: (key: string, args: unknown[] = []) =>
@@ -41,8 +49,40 @@ const entries: MusicQuizTimelineEntry[] = [
     is_anchor: false,
   },
 ];
+const originalScrollIntoView = Object.getOwnPropertyDescriptor(
+  HTMLElement.prototype,
+  "scrollIntoView",
+);
+const scrollIntoView = vi.fn();
 
 describe("TimelineDisplay", () => {
+  beforeEach(() => {
+    scrollIntoView.mockReset();
+    Object.defineProperty(HTMLElement.prototype, "scrollIntoView", {
+      configurable: true,
+      value: scrollIntoView,
+    });
+    vi.spyOn(window, "matchMedia").mockImplementation((query) =>
+      mediaQueryList(query, false),
+    );
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  afterAll(() => {
+    if (originalScrollIntoView) {
+      Object.defineProperty(
+        HTMLElement.prototype,
+        "scrollIntoView",
+        originalScrollIntoView,
+      );
+    } else {
+      Reflect.deleteProperty(HTMLElement.prototype, "scrollIntoView");
+    }
+  });
+
   it("emits stable neighboring IDs for every boundary", async () => {
     const wrapper = mount(TimelineDisplay, {
       props: {
@@ -147,7 +187,7 @@ describe("TimelineDisplay", () => {
     ).toBe(true);
   });
 
-  it("renders a compact chronological strip with horizontal overflow", () => {
+  it("renders and centers an initially highlighted horizontal entry", async () => {
     const wrapper = mount(TimelineDisplay, {
       props: {
         entries,
@@ -159,6 +199,7 @@ describe("TimelineDisplay", () => {
     const display = wrapper.get('[data-orientation="horizontal"]');
     const list = display.get("ol");
     const cards = display.findAll("article");
+    await flushPromises();
 
     expect(display.classes()).toEqual(
       expect.arrayContaining([
@@ -195,6 +236,86 @@ describe("TimelineDisplay", () => {
         .filter((item) => item.find("article").exists())
         .every((item) => item.classes().includes("shrink-0")),
     ).toBe(true);
+    expect(scrollIntoView).toHaveBeenCalledOnce();
+    expect(scrollIntoView.mock.instances[0]).toBe(
+      display.get('article[data-entry-id="same-b"]').element,
+    );
+    expect(scrollIntoView).toHaveBeenCalledWith({
+      behavior: "smooth",
+      block: "nearest",
+      inline: "center",
+    });
+  });
+
+  it("centers the new entry when the horizontal highlight changes", async () => {
+    const wrapper = mount(TimelineDisplay, {
+      props: {
+        entries,
+        highlightedEntryId: "older",
+        horizontal: true,
+      },
+    });
+    await flushPromises();
+    scrollIntoView.mockReset();
+
+    await wrapper.setProps({ highlightedEntryId: "same-a" });
+    await flushPromises();
+
+    expect(scrollIntoView).toHaveBeenCalledOnce();
+    expect(scrollIntoView.mock.instances[0]).toBe(
+      wrapper.get('article[data-entry-id="same-a"]').element,
+    );
+  });
+
+  it("does nothing without a highlighted ID or matching entry", async () => {
+    const wrapper = mount(TimelineDisplay, {
+      props: {
+        entries,
+        horizontal: true,
+      },
+    });
+    await flushPromises();
+    expect(scrollIntoView).not.toHaveBeenCalled();
+
+    await wrapper.setProps({ highlightedEntryId: "missing" });
+    await flushPromises();
+    expect(scrollIntoView).not.toHaveBeenCalled();
+  });
+
+  it("never scrolls vertical timelines", async () => {
+    const wrapper = mount(TimelineDisplay, {
+      props: {
+        entries,
+        highlightedEntryId: "same-b",
+      },
+    });
+    await flushPromises();
+
+    await wrapper.setProps({ highlightedEntryId: "same-a" });
+    await flushPromises();
+
+    expect(scrollIntoView).not.toHaveBeenCalled();
+  });
+
+  it("avoids animated scrolling when reduced motion is preferred", async () => {
+    vi.mocked(window.matchMedia).mockImplementation((query) =>
+      mediaQueryList(query, true),
+    );
+
+    mount(TimelineDisplay, {
+      props: {
+        entries,
+        highlightedEntryId: "same-b",
+        horizontal: true,
+      },
+    });
+    await flushPromises();
+
+    expect(scrollIntoView).toHaveBeenCalledWith({
+      behavior: "auto",
+      block: "nearest",
+      inline: "center",
+    });
   });
 
   it("never offers the invalid null-to-null boundary", () => {
@@ -208,3 +329,16 @@ describe("TimelineDisplay", () => {
     expect(wrapper.find("button").exists()).toBe(false);
   });
 });
+
+function mediaQueryList(query: string, matches: boolean): MediaQueryList {
+  return {
+    matches,
+    media: query,
+    onchange: null,
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    dispatchEvent: vi.fn(() => false),
+  };
+}

--- a/tests/components/music-quiz/TimelineDisplay.test.ts
+++ b/tests/components/music-quiz/TimelineDisplay.test.ts
@@ -53,6 +53,10 @@ const originalScrollIntoView = Object.getOwnPropertyDescriptor(
   HTMLElement.prototype,
   "scrollIntoView",
 );
+const originalMatchMedia = Object.getOwnPropertyDescriptor(
+  window,
+  "matchMedia",
+);
 const scrollIntoView = vi.fn();
 
 describe("TimelineDisplay", () => {
@@ -62,13 +66,20 @@ describe("TimelineDisplay", () => {
       configurable: true,
       value: scrollIntoView,
     });
-    vi.spyOn(window, "matchMedia").mockImplementation((query) =>
-      mediaQueryList(query, false),
-    );
+    Object.defineProperty(window, "matchMedia", {
+      configurable: true,
+      value: vi.fn((query: string) => mediaQueryList(query, false)),
+      writable: true,
+    });
   });
 
   afterEach(() => {
     vi.restoreAllMocks();
+    if (originalMatchMedia) {
+      Object.defineProperty(window, "matchMedia", originalMatchMedia);
+    } else {
+      Reflect.deleteProperty(window, "matchMedia");
+    }
   });
 
   afterAll(() => {

--- a/tests/components/music-quiz/TimelineDisplay.test.ts
+++ b/tests/components/music-quiz/TimelineDisplay.test.ts
@@ -147,6 +147,56 @@ describe("TimelineDisplay", () => {
     ).toBe(true);
   });
 
+  it("renders a compact chronological strip with horizontal overflow", () => {
+    const wrapper = mount(TimelineDisplay, {
+      props: {
+        entries,
+        highlightedEntryId: "same-b",
+        horizontal: true,
+        compact: true,
+      },
+    });
+    const display = wrapper.get('[data-orientation="horizontal"]');
+    const list = display.get("ol");
+    const cards = display.findAll("article");
+
+    expect(display.classes()).toEqual(
+      expect.arrayContaining([
+        "min-w-0",
+        "overflow-x-auto",
+        "overscroll-x-contain",
+      ]),
+    );
+    expect(list.classes()).toEqual(
+      expect.arrayContaining(["w-max", "min-w-full", "flex-row"]),
+    );
+    expect(cards.map((card) => card.attributes("data-entry-id"))).toEqual([
+      "older",
+      "same-a",
+      "same-b",
+    ]);
+    expect(
+      cards.every((card) => card.attributes("data-compact") === "true"),
+    ).toBe(true);
+    expect(
+      cards.every((card) =>
+        card.classes().includes("grid-cols-[3rem_minmax(0,1fr)]"),
+      ),
+    ).toBe(true);
+    expect(
+      display
+        .find('article[data-entry-id="same-b"]')
+        .classes()
+        .includes("border-primary"),
+    ).toBe(true);
+    expect(
+      display
+        .findAll("li")
+        .filter((item) => item.find("article").exists())
+        .every((item) => item.classes().includes("shrink-0")),
+    ).toBe(true);
+  });
+
   it("never offers the invalid null-to-null boundary", () => {
     const wrapper = mount(TimelineDisplay, {
       props: {

--- a/tests/components/music-quiz/TimelineDisplay.test.ts
+++ b/tests/components/music-quiz/TimelineDisplay.test.ts
@@ -329,6 +329,29 @@ describe("TimelineDisplay", () => {
     });
   });
 
+  it("scrolls safely when matchMedia is unavailable", async () => {
+    Object.defineProperty(window, "matchMedia", {
+      configurable: true,
+      value: undefined,
+      writable: true,
+    });
+
+    mount(TimelineDisplay, {
+      props: {
+        entries,
+        highlightedEntryId: "same-b",
+        horizontal: true,
+      },
+    });
+    await flushPromises();
+
+    expect(scrollIntoView).toHaveBeenCalledWith({
+      behavior: "smooth",
+      block: "nearest",
+      inline: "center",
+    });
+  });
+
   it("never offers the invalid null-to-null boundary", () => {
     const wrapper = mount(TimelineDisplay, {
       props: {

--- a/tests/components/music-quiz/registry.test.ts
+++ b/tests/components/music-quiz/registry.test.ts
@@ -297,6 +297,15 @@ describe("Music Quiz registries", () => {
       MUSIC_QUIZ_GAME_TYPES.find((game) => game.id === "trivia")
         ?.supportsListenIn,
     ).toBe(false);
+    expect(
+      MUSIC_QUIZ_GAME_TYPES.find((game) => game.id === "music_timeline")
+        ?.adapters.presentBody,
+    ).toBeDefined();
+    expect(
+      MUSIC_QUIZ_GAME_TYPES.filter(
+        (game) => game.id !== "music_timeline",
+      ).every((game) => game.adapters.presentBody === undefined),
+    ).toBe(true);
   });
 
   it("gates only Trivia on backend availability", () => {

--- a/tests/views/MusicQuizDashboardHostActions.test.ts
+++ b/tests/views/MusicQuizDashboardHostActions.test.ts
@@ -225,10 +225,26 @@ describe("MusicQuizDashboardView host actions", () => {
 
   it("keeps Present mode available", async () => {
     const wrapper = mountDashboard();
+    const root = wrapper.get('[data-testid="music-quiz-dashboard-root"]');
+
+    expect(root.classes()).toEqual(
+      expect.arrayContaining(["mx-auto", "max-w-6xl", "p-4"]),
+    );
+    expect(root.classes()).not.toContain("lg:h-full");
 
     await wrapper.get('[data-testid="enter-present"]').trigger("click");
 
     expect(wrapper.find('[data-testid="present-stage"]').exists()).toBe(true);
+    expect(root.classes()).toEqual(
+      expect.arrayContaining([
+        "w-full",
+        "lg:h-full",
+        "lg:min-h-0",
+        "lg:overflow-hidden",
+      ]),
+    );
+    expect(root.classes()).not.toContain("mx-auto");
+    expect(root.classes()).not.toContain("p-4");
   });
 
   it("returns to the compact empty state when the host state is cleared", async () => {


### PR DESCRIPTION
Music Timeline's presenter view could push round results and the leaderboard below the screen.

- Keep the current song, round results, and leaderboard visible on TV-sized displays
- Move timeline history into a compact horizontally scrolling strip
- Use internal scrolling for long player lists and a compact present-mode header
- Keep smaller screens vertically scrollable