### PR TITLE
Fix diagnostics settings breadcrumb

### DIFF
--- a/src/views/settings/Settings.vue
+++ b/src/views/settings/Settings.vue
@@ -657,6 +657,7 @@ const activeTab = computed(() => {
     name.includes("core") ||
     name.includes("serverlog") ||
     name === "backgroundtasks" ||
+    name === "diagnostics" ||
     name === "genremanagement" ||
     name === "audioanalysissettings"
   ) {


### PR DESCRIPTION
Diagnostics currently appears under Music sources because its route falls through to the default settings tab.

- Classify the `diagnostics` route as part of the System settings section.