### PR TITLE
Fix sleep timer menu alignment

### DIFF
--- a/src/layouts/default/ItemContextMenu.vue
+++ b/src/layouts/default/ItemContextMenu.vue
@@ -145,7 +145,7 @@ const MenuItemIcon = (props: { icon?: string | Component; size?: number }) => {
         size: props.size ?? 20,
         class: "shrink-0",
       })
-    : h(props.icon, { class: "size-5 shrink-0" });
+    : h(props.icon, { class: "size-5 shrink-0 scale-90" });
 };
 
 const playerSubItems = computed<ContextMenuItem[]>(() => {

--- a/src/layouts/default/ItemContextMenu.vue
+++ b/src/layouts/default/ItemContextMenu.vue
@@ -145,7 +145,7 @@ const MenuItemIcon = (props: { icon?: string | Component; size?: number }) => {
         size: props.size ?? 20,
         class: "shrink-0",
       })
-    : h(props.icon, { class: "size-4 shrink-0" });
+    : h(props.icon, { class: "size-5 shrink-0" });
 };
 
 const playerSubItems = computed<ContextMenuItem[]>(() => {


### PR DESCRIPTION
The sleep timer used a 16px Lucide icon slot while MDI menu icons used 20px, shifting its label out of alignment.

- Keep component-based icons in a 20px layout slot so labels align
- Render the Lucide glyph at a balanced 18px visual size

### Before and after

![Sleep timer menu alignment before and after](https://gist.githubusercontent.com/MarvinSchenkel/ea9f7dd77a7858ad50ea6689d47bb88e/raw/377e0b4b317bd72e06d63135ec2959c8e20eeea0/sleep-timer-before-after.svg)