### PR TITLE
Improve Music Trivia reveal flow

### DIFF
--- a/src/components/music-quiz/MusicQuizHostPanel.vue
+++ b/src/components/music-quiz/MusicQuizHostPanel.vue
@@ -51,7 +51,7 @@
         </Button>
         <Button
           v-if="state.phase === 'reveal'"
-          :disabled="busy || revealCountdownElapsed"
+          :disabled="busy"
           data-testid="next-quiz"
           @click="emit('next')"
         >
@@ -171,14 +171,8 @@ const nextLabel = computed(() => {
   const defaultKey = props.isLastRound
     ? "providers.music_quiz.finish"
     : "providers.music_quiz.next";
-  if (!revealCountdownScheduled.value) return $t(defaultKey);
-  if (revealCountdownElapsed.value) {
-    return $t(
-      props.isLastRound
-        ? "providers.music_quiz.waiting_for_final_results"
-        : "providers.music_quiz.waiting_for_next",
-    );
-  }
+  if (!revealCountdownScheduled.value || revealCountdownElapsed.value)
+    return $t(defaultKey);
   return $t(
     props.isLastRound
       ? "providers.music_quiz.finish_quiz_countdown"

--- a/src/components/music-quiz/MusicQuizHostPanel.vue
+++ b/src/components/music-quiz/MusicQuizHostPanel.vue
@@ -51,15 +51,12 @@
         </Button>
         <Button
           v-if="state.phase === 'reveal'"
-          :disabled="busy"
+          :disabled="busy || revealCountdownElapsed"
+          data-testid="next-quiz"
           @click="emit('next')"
         >
           <SkipForward class="size-4" />
-          {{
-            isLastRound
-              ? $t("providers.music_quiz.finish")
-              : $t("providers.music_quiz.next")
-          }}
+          {{ nextLabel }}
         </Button>
         <ButtonGroup v-if="state.phase === 'finished'" class="w-full sm:w-fit">
           <Button
@@ -113,6 +110,7 @@ import {
 } from "@/components/ui/dropdown-menu";
 import type { MusicQuizSupportedHostState } from "@/composables/useMusicQuiz";
 import { useMusicQuizAutoStart } from "@/composables/useMusicQuizAutoStart";
+import { useMusicQuizRevealCountdown } from "@/composables/useMusicQuizRevealCountdown";
 import { $t } from "@/plugins/i18n";
 import {
   ChevronDown,
@@ -132,9 +130,11 @@ const props = withDefaults(
     busy: boolean;
     joinLink: string;
     isLastRound: boolean;
+    revealCountdown?: boolean;
     showActions?: boolean;
   }>(),
   {
+    revealCountdown: false,
     showActions: true,
   },
 );
@@ -158,5 +158,32 @@ const startLabel = computed(() => {
     return $t("providers.music_quiz.start_now_waiting");
   }
   return $t("providers.music_quiz.start_now_countdown", [remainingLabel.value]);
+});
+const {
+  hasElapsed: revealCountdownElapsed,
+  isScheduled: revealCountdownScheduled,
+  remainingLabel: revealCountdownLabel,
+} = useMusicQuizRevealCountdown({
+  active: () => props.revealCountdown && props.state.phase === "reveal",
+  autoAdvanceAt: () => props.state.current_round?.auto_advance_at,
+});
+const nextLabel = computed(() => {
+  const defaultKey = props.isLastRound
+    ? "providers.music_quiz.finish"
+    : "providers.music_quiz.next";
+  if (!revealCountdownScheduled.value) return $t(defaultKey);
+  if (revealCountdownElapsed.value) {
+    return $t(
+      props.isLastRound
+        ? "providers.music_quiz.waiting_for_final_results"
+        : "providers.music_quiz.waiting_for_next",
+    );
+  }
+  return $t(
+    props.isLastRound
+      ? "providers.music_quiz.finish_quiz_countdown"
+      : "providers.music_quiz.next_round_countdown",
+    [revealCountdownLabel.value],
+  );
 });
 </script>

--- a/src/components/music-quiz/MusicQuizPresentStage.vue
+++ b/src/components/music-quiz/MusicQuizPresentStage.vue
@@ -9,6 +9,7 @@
       :phase-label="phaseLabel"
       :round-label="roundLabel"
       :mode="state.mode"
+      :listen-in-enabled="listenInEnabled"
       present
     >
       <template #actions>
@@ -176,6 +177,7 @@ const props = defineProps<{
   roundLabel: string;
   joinLink: string;
   isConnectionDegraded: boolean;
+  listenInEnabled?: boolean;
   gameComponent: Component;
   answerComponent: Component;
 }>();

--- a/src/components/music-quiz/MusicQuizSessionHeader.vue
+++ b/src/components/music-quiz/MusicQuizSessionHeader.vue
@@ -72,18 +72,20 @@ const props = withDefaults(
     phaseLabel: string;
     roundLabel?: string;
     mode?: MusicQuizMode;
+    listenInEnabled?: boolean;
     present?: boolean;
   }>(),
   {
     name: null,
     roundLabel: "",
     mode: undefined,
+    listenInEnabled: false,
     present: false,
   },
 );
 
 const showMode = computed(
-  () => props.game.supportsListenIn && props.mode !== undefined,
+  () => props.listenInEnabled && props.mode !== undefined,
 );
 const modeLabel = computed(() =>
   props.mode === "remote"

--- a/src/components/music-quiz/game-types/music-timeline/MusicTimelineRound.vue
+++ b/src/components/music-quiz/game-types/music-timeline/MusicTimelineRound.vue
@@ -111,7 +111,7 @@ import type {
   MusicQuizTimelineRound,
   MusicQuizPhase,
 } from "@/composables/useMusicQuiz";
-import { useMusicQuizAnswerDeadline } from "@/composables/useMusicQuizAnswerDeadline";
+import { useMusicQuizRevealCountdown } from "@/composables/useMusicQuizRevealCountdown";
 import { getMediaImageUrl } from "@/helpers/utils";
 import { $t } from "@/plugins/i18n";
 import { AudioLines, Check, Clock3, Music2 } from "@lucide/vue";
@@ -142,11 +142,10 @@ const revealedEntry = computed(() => props.round.revealed_entry);
 const imageUrl = computed(() =>
   getMediaImageUrl(revealedEntry.value?.image_url ?? ""),
 );
-const { remainingLabel: autoAdvanceLabel } = useMusicQuizAnswerDeadline({
+const { remainingLabel: autoAdvanceLabel } = useMusicQuizRevealCountdown({
   active: () =>
     props.phase === "reveal" && props.round.auto_advance_at !== null,
-  deadline: () => props.round.auto_advance_at,
-  duration: () => null,
+  autoAdvanceAt: () => props.round.auto_advance_at,
 });
 const autoAdvanceText = computed(() =>
   autoAdvanceLabel.value

--- a/src/components/music-quiz/game-types/trivia/TriviaHostPanel.vue
+++ b/src/components/music-quiz/game-types/trivia/TriviaHostPanel.vue
@@ -9,6 +9,24 @@
       </span>
     </div>
 
+    <div
+      class="flex items-center justify-between gap-3 border-t px-4 py-3"
+      data-testid="trivia-reveal-audio"
+    >
+      <span class="font-medium">
+        {{ $t("providers.music_quiz.play_revealed_songs") }}
+      </span>
+      <span class="text-muted-foreground text-sm">
+        {{
+          $t(
+            state.play_reveal_audio === true
+              ? "providers.music_quiz.reveal_audio_on"
+              : "providers.music_quiz.reveal_audio_off",
+          )
+        }}
+      </span>
+    </div>
+
     <Accordion
       v-if="state.sources.length"
       type="multiple"

--- a/src/components/music-quiz/game-types/trivia/TriviaPlayerRound.vue
+++ b/src/components/music-quiz/game-types/trivia/TriviaPlayerRound.vue
@@ -48,22 +48,10 @@ const { hasElapsed, isScheduled, remainingLabel } = useMusicQuizRevealCountdown(
 );
 const readyRequested = ref(false);
 const readyDisabled = computed(
-  () =>
-    props.busy ||
-    props.state.you.ready ||
-    readyRequested.value ||
-    hasElapsed.value,
+  () => props.busy || props.state.you.ready || readyRequested.value,
 );
 const readyLabel = computed(() => {
-  if (hasElapsed.value) {
-    return $t(
-      isFinalRound.value
-        ? "providers.music_quiz.waiting_for_final_results"
-        : "providers.music_quiz.waiting_for_next",
-    );
-  }
-
-  if (isScheduled.value) {
+  if (isScheduled.value && !hasElapsed.value) {
     return $t(
       props.state.you.ready
         ? isFinalRound.value

--- a/src/components/music-quiz/game-types/trivia/TriviaPlayerRound.vue
+++ b/src/components/music-quiz/game-types/trivia/TriviaPlayerRound.vue
@@ -3,15 +3,12 @@
   <Button
     v-if="state.phase === 'reveal'"
     size="lg"
-    :disabled="busy || state.you.ready"
-    @click="emit('ready')"
+    :disabled="readyDisabled"
+    data-testid="trivia-ready"
+    @click="markReady"
   >
     <Check class="size-4" />
-    {{
-      state.you.ready
-        ? $t("providers.music_quiz.waiting_for_next")
-        : $t("providers.music_quiz.ready")
-    }}
+    {{ readyLabel }}
   </Button>
 </template>
 
@@ -26,14 +23,88 @@ import type {
   MusicQuizTriviaPersonalizedState,
   MusicQuizTriviaRound,
 } from "@/composables/useMusicQuiz";
+import { useMusicQuizRevealCountdown } from "@/composables/useMusicQuizRevealCountdown";
 import { $t } from "@/plugins/i18n";
 import { Check } from "@lucide/vue";
+import { computed, ref, watch } from "vue";
 
-defineProps<
-  MusicQuizPlayerGameAdapterProps<
-    MusicQuizTriviaPersonalizedState,
-    MusicQuizTriviaRound
-  >
->();
+const props =
+  defineProps<
+    MusicQuizPlayerGameAdapterProps<
+      MusicQuizTriviaPersonalizedState,
+      MusicQuizTriviaRound
+    >
+  >();
 const emit = defineEmits<MusicQuizPlayerGameAdapterEmits>();
+
+const isFinalRound = computed(
+  () => props.currentRound.round_index + 1 >= props.state.round_count,
+);
+const { hasElapsed, isScheduled, remainingLabel } = useMusicQuizRevealCountdown(
+  {
+    active: () => props.state.phase === "reveal",
+    autoAdvanceAt: () => props.currentRound.auto_advance_at,
+  },
+);
+const readyRequested = ref(false);
+const readyDisabled = computed(
+  () =>
+    props.busy ||
+    props.state.you.ready ||
+    readyRequested.value ||
+    hasElapsed.value,
+);
+const readyLabel = computed(() => {
+  if (hasElapsed.value) {
+    return $t(
+      isFinalRound.value
+        ? "providers.music_quiz.waiting_for_final_results"
+        : "providers.music_quiz.waiting_for_next",
+    );
+  }
+
+  if (isScheduled.value) {
+    return $t(
+      props.state.you.ready
+        ? isFinalRound.value
+          ? "providers.music_quiz.waiting_for_final_results_countdown"
+          : "providers.music_quiz.waiting_for_next_round_countdown"
+        : isFinalRound.value
+          ? "providers.music_quiz.ready_for_final_results_countdown"
+          : "providers.music_quiz.ready_for_next_round_countdown",
+      [remainingLabel.value],
+    );
+  }
+
+  return $t(
+    props.state.you.ready
+      ? isFinalRound.value
+        ? "providers.music_quiz.waiting_for_final_results"
+        : "providers.music_quiz.waiting_for_next"
+      : isFinalRound.value
+        ? "providers.music_quiz.ready_for_final_results"
+        : "providers.music_quiz.ready",
+  );
+});
+
+watch(
+  () => props.currentRound.round_index,
+  () => {
+    readyRequested.value = false;
+  },
+);
+watch(
+  () => props.busy,
+  (busy, wasBusy) => {
+    if (wasBusy && !busy && !props.state.you.ready) {
+      readyRequested.value = false;
+    }
+  },
+);
+
+function markReady() {
+  if (readyDisabled.value) return;
+  readyRequested.value = true;
+  emit("ready");
+}
 </script>

--- a/src/components/music-quiz/game-types/trivia/TriviaPresentRound.vue
+++ b/src/components/music-quiz/game-types/trivia/TriviaPresentRound.vue
@@ -1,5 +1,17 @@
 <template>
-  <TriviaQuestion class="flex-1" :round="currentRound" present />
+  <div class="flex min-h-0 flex-col gap-3">
+    <TriviaQuestion class="flex-1" :round="currentRound" present />
+    <div
+      v-if="countdownText"
+      class="bg-muted/40 text-muted-foreground flex items-center justify-center gap-2 rounded-lg border px-3 py-2 text-sm font-semibold tabular-nums"
+      role="timer"
+      :aria-label="countdownText"
+      data-testid="trivia-auto-advance"
+    >
+      <Clock3 class="size-4" aria-hidden="true" />
+      {{ countdownText }}
+    </div>
+  </div>
 </template>
 
 <script setup lang="ts">
@@ -9,11 +21,42 @@ import type {
   MusicQuizTriviaHostState,
   MusicQuizTriviaRound,
 } from "@/composables/useMusicQuiz";
+import { useMusicQuizRevealCountdown } from "@/composables/useMusicQuizRevealCountdown";
+import { $t } from "@/plugins/i18n";
+import { Clock3 } from "@lucide/vue";
+import { computed } from "vue";
 
-defineProps<
-  MusicQuizPresentGameAdapterProps<
-    MusicQuizTriviaHostState,
-    MusicQuizTriviaRound
-  >
->();
+const props =
+  defineProps<
+    MusicQuizPresentGameAdapterProps<
+      MusicQuizTriviaHostState,
+      MusicQuizTriviaRound
+    >
+  >();
+
+const isFinalRound = computed(
+  () => props.currentRound.round_index + 1 >= props.state.round_count,
+);
+const { hasElapsed, isScheduled, remainingLabel } = useMusicQuizRevealCountdown(
+  {
+    active: () => props.state.phase === "reveal",
+    autoAdvanceAt: () => props.currentRound.auto_advance_at,
+  },
+);
+const countdownText = computed(() => {
+  if (!isScheduled.value) return "";
+  if (hasElapsed.value) {
+    return $t(
+      isFinalRound.value
+        ? "providers.music_quiz.waiting_for_final_results"
+        : "providers.music_quiz.waiting_for_next",
+    );
+  }
+  return $t(
+    isFinalRound.value
+      ? "providers.music_quiz.final_results_in"
+      : "providers.music_quiz.next_round_in",
+    [remainingLabel.value],
+  );
+});
 </script>

--- a/src/components/music-quiz/game-types/trivia/TriviaSetup.vue
+++ b/src/components/music-quiz/game-types/trivia/TriviaSetup.vue
@@ -90,6 +90,25 @@
           </option>
         </NativeSelect>
       </Field>
+
+      <Field
+        orientation="horizontal"
+        class="items-center justify-between rounded-lg border p-4 sm:col-span-2"
+      >
+        <div class="flex flex-col gap-1">
+          <FieldLabel for="trivia-play-reveal-audio">
+            {{ $t("providers.music_quiz.play_revealed_songs") }}
+          </FieldLabel>
+          <FieldDescription>
+            {{ $t("providers.music_quiz.play_revealed_songs_help") }}
+          </FieldDescription>
+        </div>
+        <Switch
+          id="trivia-play-reveal-audio"
+          v-model="playRevealAudio"
+          data-testid="trivia-play-reveal-audio"
+        />
+      </Field>
     </div>
 
     <MusicQuizSourceSelector
@@ -111,7 +130,7 @@ import type {
   MusicQuizSetupAdapterProps,
 } from "@/components/music-quiz/adapter_contracts";
 import { Button } from "@/components/ui/button";
-import { Field, FieldLabel } from "@/components/ui/field";
+import { Field, FieldDescription, FieldLabel } from "@/components/ui/field";
 import { NativeSelect } from "@/components/ui/native-select";
 import {
   NumberField,
@@ -120,6 +139,7 @@ import {
   NumberFieldIncrement,
   NumberFieldInput,
 } from "@/components/ui/number-field";
+import { Switch } from "@/components/ui/switch";
 import type {
   MusicQuizDifficulty,
   MusicQuizTriviaConfig,
@@ -143,6 +163,7 @@ const suggestionCount = ref(4);
 const answerDuration = ref(30);
 const difficulty = ref<MusicQuizDifficulty>("normal");
 const language = ref(i18n.global.locale.value);
+const playRevealAudio = ref(true);
 const sourceUris = ref<string[]>([]);
 const canCreate = computed(() => sourceUris.value.length > 0);
 const languageOptions = computed(() =>
@@ -153,6 +174,7 @@ function create() {
   if (!canCreate.value) return;
   const config: MusicQuizTriviaConfig = {
     language: canonicalizeLocale(language.value),
+    play_reveal_audio: playRevealAudio.value,
     round_count: roundCount.value,
     suggestion_count: suggestionCount.value,
     answer_duration: answerDuration.value,

--- a/src/components/music-quiz/game_types.ts
+++ b/src/components/music-quiz/game_types.ts
@@ -21,12 +21,22 @@ import TriviaSetup from "@/components/music-quiz/game-types/trivia/TriviaSetup.v
 import type {
   MusicQuizGameAnswerTypeMap,
   MusicQuizPhase,
+  MusicQuizSupportedInfo,
+  MusicQuizSupportedPublicState,
   MusicQuizType,
 } from "@/composables/useMusicQuiz";
 import { Brain, Disc3, ListMusic } from "@lucide/vue";
 import { markRaw, type Component } from "vue";
 
 export const DEFAULT_MUSIC_QUIZ_GAME_TYPE: MusicQuizType = "guess_the_song";
+
+export type MusicQuizCapabilityState =
+  | MusicQuizSupportedInfo
+  | MusicQuizSupportedPublicState;
+
+export type MusicQuizStateCapability =
+  | boolean
+  | ((state: MusicQuizCapabilityState) => boolean);
 
 export interface MusicQuizGameDefinition<
   TGame extends MusicQuizType = MusicQuizType,
@@ -37,7 +47,8 @@ export interface MusicQuizGameDefinition<
   descriptionKey: string;
   icon: Component;
   requiresBackendAvailability: boolean;
-  supportsListenIn: boolean;
+  supportsListenIn: MusicQuizStateCapability;
+  usesRevealCountdown?: boolean;
   revealPhaseLabelKey: string;
   adapters: {
     setup: Component;
@@ -96,7 +107,9 @@ const MUSIC_QUIZ_GAME_TYPE_REGISTRY = {
     descriptionKey: "providers.music_quiz.game_type_trivia_description",
     icon: markRaw(Brain),
     requiresBackendAvailability: true,
-    supportsListenIn: false,
+    supportsListenIn: (state) =>
+      state.quiz_type === "trivia" && state.play_reveal_audio === true,
+    usesRevealCountdown: true,
     revealPhaseLabelKey: "providers.music_quiz.phase_answer_revealed",
     adapters: {
       setup: markRaw(TriviaSetup),
@@ -125,6 +138,15 @@ export function isMusicQuizGameAvailable(
   return (
     !game.requiresBackendAvailability || availableQuizTypes.includes(game.id)
   );
+}
+
+export function supportsMusicQuizListenIn(
+  game: MusicQuizGameDefinition,
+  state?: MusicQuizCapabilityState | null,
+) {
+  return typeof game.supportsListenIn === "boolean"
+    ? game.supportsListenIn
+    : state != null && game.supportsListenIn(state);
 }
 
 export function getMusicQuizPhaseLabelKey(

--- a/src/composables/useMusicQuiz.ts
+++ b/src/composables/useMusicQuiz.ts
@@ -116,6 +116,7 @@ interface MusicQuizTriviaStateBase extends MusicQuizStateIdentity {
   quiz_type: "trivia";
   answer_type: "multiple_choice";
   language: string;
+  play_reveal_audio?: boolean;
   round_count: number;
   suggestion_count: number;
   answer_duration: number;
@@ -237,6 +238,7 @@ export interface MusicQuizTriviaInfo extends MusicQuizStateIdentity {
   quiz_type: "trivia";
   answer_type: "multiple_choice";
   language: string;
+  play_reveal_audio?: boolean;
   player_count: number;
   round_count: number;
   mode: MusicQuizMode;
@@ -556,6 +558,7 @@ export interface MusicQuizTimelineCreateRequest {
 
 export interface MusicQuizTriviaConfig {
   language: string;
+  play_reveal_audio: boolean;
   round_count: number;
   suggestion_count: number;
   answer_duration: number;

--- a/src/composables/useMusicQuiz.ts
+++ b/src/composables/useMusicQuiz.ts
@@ -381,7 +381,7 @@ export interface MusicQuizGuessTheSongRound extends MusicQuizMultipleChoiceRound
 export interface MusicQuizTriviaRound extends MusicQuizMultipleChoiceRound {
   question: string;
   answer_label?: string;
-  track_uri?: null;
+  track_uri?: string | null;
   image_url?: null;
   duration?: null;
 }
@@ -494,7 +494,7 @@ export interface MusicQuizTriviaHostRound {
   answer_label: string;
   suggestions: MusicQuizSuggestion[];
   correct_suggestion_id: string;
-  track_uri: null;
+  track_uri: string | null;
   question: string;
   image_url: null;
   duration: null;

--- a/src/composables/useMusicQuizPlayer.ts
+++ b/src/composables/useMusicQuizPlayer.ts
@@ -170,6 +170,7 @@ export function useMusicQuizPlayer(options: UseMusicQuizPlayerOptions) {
   }
 
   async function ready() {
+    if (busy.value) return false;
     const currentPlayerId = playerId.value;
     if (!currentPlayerId) {
       notifyError($t("providers.music_quiz.error_not_joined"));

--- a/src/composables/useMusicQuizRevealCountdown.ts
+++ b/src/composables/useMusicQuizRevealCountdown.ts
@@ -1,0 +1,28 @@
+import { useMusicQuizAnswerDeadline } from "@/composables/useMusicQuizAnswerDeadline";
+import { computed, toValue, type MaybeRefOrGetter } from "vue";
+
+export interface MusicQuizRevealCountdownOptions {
+  active: MaybeRefOrGetter<boolean>;
+  autoAdvanceAt: MaybeRefOrGetter<number | null | undefined>;
+}
+
+export function useMusicQuizRevealCountdown(
+  options: MusicQuizRevealCountdownOptions,
+) {
+  const deadline = computed(() =>
+    toValue(options.active) ? (toValue(options.autoAdvanceAt) ?? null) : null,
+  );
+  const isScheduled = computed(() => deadline.value !== null);
+  const deadlineState = useMusicQuizAnswerDeadline({
+    active: isScheduled,
+    deadline,
+    duration: null,
+  });
+  const hasElapsed = computed(() => deadlineState.remainingSeconds.value === 0);
+
+  return {
+    ...deadlineState,
+    isScheduled,
+    hasElapsed,
+  };
+}

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1301,6 +1301,12 @@
             "game_ended_wait": "Ask the host to start a new game when everyone is ready.",
             "ready_for_final_results": "Ready for final results",
             "waiting_for_final_results": "Waiting for final results...",
+            "ready_for_next_round_countdown": "Ready for next round · {0}",
+            "waiting_for_next_round_countdown": "Waiting for next round · {0}",
+            "ready_for_final_results_countdown": "Ready for final results · {0}",
+            "waiting_for_final_results_countdown": "Waiting for final results · {0}",
+            "next_round_countdown": "Next Round · {0}",
+            "finish_quiz_countdown": "Finish Quiz · {0}",
             "next_round_in": "Next round in {0}",
             "final_results_in": "Final results in {0}",
             "timeline_skip_remaining_bonuses": "Skip remaining bonuses",
@@ -1316,7 +1322,11 @@
             "start_now_waiting": "Start now · Waiting…",
             "game_starts_in": "Game starts in {0}",
             "waiting_for_game_start": "Waiting for game to start…",
-            "question_language": "Question language"
+            "question_language": "Question language",
+            "play_revealed_songs": "Play revealed songs",
+            "play_revealed_songs_help": "Music plays only after the answer is revealed.",
+            "reveal_audio_on": "On",
+            "reveal_audio_off": "Off"
         }
     },
     "no_lyrics_available": "No lyrics available",

--- a/src/views/MusicQuizDashboardView.vue
+++ b/src/views/MusicQuizDashboardView.vue
@@ -19,6 +19,7 @@
       :round-label="roundLabel"
       :join-link="joinLink"
       :is-connection-degraded="isConnectionDegraded"
+      :listen-in-enabled="listenInEnabled"
       :game-component="resolvedDefinition.game.adapters.present"
       :answer-component="resolvedDefinition.answer.adapters.present"
       @exit="exitPresentMode"
@@ -94,6 +95,7 @@
           :phase-label="phaseLabel"
           :round-label="roundLabel"
           :mode="activeState.mode"
+          :listen-in-enabled="listenInEnabled"
         />
 
         <MusicQuizHostPanel
@@ -101,6 +103,7 @@
           :busy="busy"
           :join-link="joinLink"
           :is-last-round="!!isLastRound"
+          :reveal-countdown="resolvedDefinition.game.usesRevealCountdown"
           @end-game="showEndGameDialog = true"
           @present="enterPresentMode"
           @start="host.start"
@@ -193,6 +196,7 @@ import MusicQuizConnectionBanners from "@/components/music-quiz/MusicQuizConnect
 import {
   getMusicQuizPhaseLabelKey,
   resolveMusicQuizDefinition,
+  supportsMusicQuizListenIn,
 } from "@/components/music-quiz/game_types";
 import MusicQuizHostPanel from "@/components/music-quiz/MusicQuizHostPanel.vue";
 import MusicQuizLeaderboard, {
@@ -267,6 +271,15 @@ const activeState = computed(() => {
     isSupportedMusicQuiz(currentState)
     ? currentState
     : null;
+});
+const listenInEnabled = computed(() => {
+  const definition = resolvedDefinition.value;
+  const currentState = activeState.value;
+  return !!(
+    definition &&
+    currentState &&
+    supportsMusicQuizListenIn(definition.game, currentState)
+  );
 });
 
 const rankedPlayers = computed(() =>

--- a/src/views/MusicQuizPlayerView.vue
+++ b/src/views/MusicQuizPlayerView.vue
@@ -28,6 +28,7 @@
           $t('providers.music_quiz.rounds_count', [activeInfo.round_count])
         "
         :mode="activeInfo.mode"
+        :listen-in-enabled="listenInEnabled"
       />
       <Card>
         <CardContent>
@@ -54,6 +55,7 @@
         :phase-label="phaseText"
         :round-label="roundProgress"
         :mode="activeState.mode"
+        :listen-in-enabled="listenInEnabled"
       />
 
       <MusicQuizPlayerHeader
@@ -64,7 +66,7 @@
       />
 
       <ListenIn
-        v-if="resolvedDefinition.game.supportsListenIn"
+        v-if="listenInEnabled"
         domain="music_quiz"
         :mode="mode"
         :labels="listenInLabels"
@@ -110,6 +112,7 @@ import MusicQuizConnectionBanners from "@/components/music-quiz/MusicQuizConnect
 import {
   getMusicQuizPhaseLabelKey,
   resolveMusicQuizDefinition,
+  supportsMusicQuizListenIn,
 } from "@/components/music-quiz/game_types";
 import MusicQuizJoinForm from "@/components/music-quiz/MusicQuizJoinForm.vue";
 import { type MusicQuizLeaderboardRow } from "@/components/music-quiz/MusicQuizLeaderboard.vue";
@@ -179,6 +182,15 @@ const activeInfo = computed(() => {
     isSupportedMusicQuiz(currentInfo)
     ? currentInfo
     : null;
+});
+const listenInEnabled = computed(() => {
+  const definition = resolvedDefinition.value;
+  const currentState = activeState.value ?? activeInfo.value;
+  return !!(
+    definition &&
+    currentState &&
+    supportsMusicQuizListenIn(definition.game, currentState)
+  );
 });
 const unsupportedGame = computed(() => {
   const activeGame = state.value ?? info.value;

--- a/tests/components/music-quiz/MusicQuizHostPanel.test.ts
+++ b/tests/components/music-quiz/MusicQuizHostPanel.test.ts
@@ -212,31 +212,53 @@ describe("MusicQuizHostPanel", () => {
     },
   );
 
-  it("waits without advancing at an elapsed Trivia reveal deadline", async () => {
-    vi.useFakeTimers();
-    vi.setSystemTime(new Date("2026-01-01T00:00:00Z"));
-    const wrapper = mountPanel("reveal", false, {
-      revealCountdown: true,
-      autoAdvanceAt: Date.now() / 1000 + 1,
-    });
-    const nextButton = wrapper.get('[data-testid="next-quiz"]');
+  it.each([
+    [false, "Next Round"],
+    [true, "Finish Quiz"],
+  ] as const)(
+    "keeps elapsed Trivia recovery actionable for final=%s",
+    async (isLastRound, expectedLabel) => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date("2026-01-01T00:00:00Z"));
+      const wrapper = mountPanel("reveal", false, {
+        revealCountdown: true,
+        autoAdvanceAt: Date.now() / 1000 + 1,
+        isLastRound,
+      });
+      const nextButton = wrapper.get('[data-testid="next-quiz"]');
 
-    await vi.advanceTimersByTimeAsync(1_000);
+      await vi.advanceTimersByTimeAsync(1_000);
 
-    expect(nextButton.text()).toContain("Waiting for next round...");
-    expect(nextButton.text()).not.toContain("0s");
-    expect(nextButton.attributes("disabled")).toBeDefined();
-    expect(wrapper.emitted("next")).toBeUndefined();
-    await nextButton.trigger("click");
-    expect(wrapper.emitted("next")).toBeUndefined();
-  });
+      expect(nextButton.text()).toContain(expectedLabel);
+      expect(nextButton.text()).not.toContain("0s");
+      expect(nextButton.attributes("disabled")).toBeUndefined();
+      expect(wrapper.emitted("next")).toBeUndefined();
+
+      await nextButton.trigger("click");
+
+      expect(wrapper.emitted("next")).toEqual([[]]);
+    },
+  );
 
   it("keeps a null Trivia reveal deadline manual", async () => {
     const wrapper = mountPanel("reveal", false, {
       revealCountdown: true,
-      autoAdvanceAt: null,
+      autoAdvanceAt: Date.now() / 1000 + 15,
     });
     const nextButton = wrapper.get('[data-testid="next-quiz"]');
+
+    expect(nextButton.text()).toContain("·");
+
+    await wrapper.setProps({
+      state: {
+        ...HOST_STATE,
+        phase: "reveal",
+        current_round: {
+          ...HOST_ROUND,
+          auto_advance_at: null,
+        },
+      },
+    });
 
     expect(nextButton.text()).toContain("Next Round");
     expect(nextButton.text()).not.toContain("·");

--- a/tests/components/music-quiz/MusicQuizHostPanel.test.ts
+++ b/tests/components/music-quiz/MusicQuizHostPanel.test.ts
@@ -1,7 +1,8 @@
 import MusicQuizHostPanel from "@/components/music-quiz/MusicQuizHostPanel.vue";
 import type {
+  MusicQuizGuessTheSongHostState,
+  MusicQuizGuessTheSongRound,
   MusicQuizPhase,
-  MusicQuizSupportedHostState,
 } from "@/composables/useMusicQuiz";
 import { flushPromises, mount } from "@vue/test-utils";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -15,6 +16,13 @@ vi.mock("@/plugins/i18n", () => ({
           "providers.music_quiz.start_now_countdown": "Start now · {0}",
           "providers.music_quiz.start_now_waiting": "Start now · Waiting…",
           "providers.music_quiz.end_game": "End game",
+          "providers.music_quiz.next": "Next Round",
+          "providers.music_quiz.finish": "Finish Quiz",
+          "providers.music_quiz.next_round_countdown": "Next Round · {0}",
+          "providers.music_quiz.finish_quiz_countdown": "Finish Quiz · {0}",
+          "providers.music_quiz.waiting_for_next": "Waiting for next round...",
+          "providers.music_quiz.waiting_for_final_results":
+            "Waiting for final results...",
           "providers.music_quiz.play_again": "Play again",
           "providers.music_quiz.set_up_new_game": "Set up new game…",
         } as Record<string, string>
@@ -31,7 +39,7 @@ afterEach(() => {
   vi.useRealTimers();
 });
 
-const HOST_STATE: MusicQuizSupportedHostState = {
+const HOST_STATE = {
   quiz_type: "guess_the_song",
   answer_type: "multiple_choice",
   phase: "lobby",
@@ -46,7 +54,15 @@ const HOST_STATE: MusicQuizSupportedHostState = {
   join_url: "http://join",
   rounds: [],
   current_round: null,
-};
+} satisfies MusicQuizGuessTheSongHostState;
+const HOST_ROUND = {
+  question: "Which song is playing?",
+  round_index: 0,
+  started_at: 1,
+  deadline: 31,
+  auto_advance_at: null,
+  suggestions: [],
+} satisfies MusicQuizGuessTheSongRound;
 
 describe("MusicQuizHostPanel", () => {
   it("keeps Present mode and End game available", async () => {
@@ -73,7 +89,7 @@ describe("MusicQuizHostPanel", () => {
   it.each([
     ["lobby", "Start Quiz"],
     ["answering", "providers.music_quiz.phase_reveal"],
-    ["reveal", "providers.music_quiz.next"],
+    ["reveal", "Next Round"],
     ["finished", "Play again"],
   ] as const)(
     "keeps the %s lifecycle action in the shared control bar",
@@ -137,7 +153,9 @@ describe("MusicQuizHostPanel", () => {
   it("uses the server deadline for replay and never starts on its own", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-01-01T00:00:00Z"));
-    const wrapper = mountPanel("lobby", false, Date.now() / 1000 + 12);
+    const wrapper = mountPanel("lobby", false, {
+      autoStartAt: Date.now() / 1000 + 12,
+    });
     const startButton = wrapper.get('[data-testid="start-quiz"]');
 
     expect(startButton.text()).toContain("Start now · 12s");
@@ -163,7 +181,7 @@ describe("MusicQuizHostPanel", () => {
   });
 
   it("keeps a no-player lobby manual and guards Start while busy", async () => {
-    const wrapper = mountPanel("lobby", true, null);
+    const wrapper = mountPanel("lobby", true, { autoStartAt: null });
     const startButton = wrapper.get('[data-testid="start-quiz"]');
 
     expect(startButton.text()).toContain("Start Quiz");
@@ -172,19 +190,91 @@ describe("MusicQuizHostPanel", () => {
     await startButton.trigger("click");
     expect(wrapper.emitted("start")).toBeUndefined();
   });
+
+  it.each([
+    [false, "Next Round · 15s"],
+    [true, "Finish Quiz · 15s"],
+  ] as const)(
+    "shows the authoritative Trivia reveal action for final=%s",
+    async (isLastRound, expectedLabel) => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date("2026-01-01T00:00:00Z"));
+      const wrapper = mountPanel("reveal", false, {
+        revealCountdown: true,
+        autoAdvanceAt: Date.now() / 1000 + 15,
+        isLastRound,
+      });
+      const nextButton = wrapper.get('[data-testid="next-quiz"]');
+
+      expect(nextButton.text()).toContain(expectedLabel);
+      await nextButton.trigger("click");
+      expect(wrapper.emitted("next")).toEqual([[]]);
+    },
+  );
+
+  it("waits without advancing at an elapsed Trivia reveal deadline", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-01-01T00:00:00Z"));
+    const wrapper = mountPanel("reveal", false, {
+      revealCountdown: true,
+      autoAdvanceAt: Date.now() / 1000 + 1,
+    });
+    const nextButton = wrapper.get('[data-testid="next-quiz"]');
+
+    await vi.advanceTimersByTimeAsync(1_000);
+
+    expect(nextButton.text()).toContain("Waiting for next round...");
+    expect(nextButton.text()).not.toContain("0s");
+    expect(nextButton.attributes("disabled")).toBeDefined();
+    expect(wrapper.emitted("next")).toBeUndefined();
+    await nextButton.trigger("click");
+    expect(wrapper.emitted("next")).toBeUndefined();
+  });
+
+  it("keeps a null Trivia reveal deadline manual", async () => {
+    const wrapper = mountPanel("reveal", false, {
+      revealCountdown: true,
+      autoAdvanceAt: null,
+    });
+    const nextButton = wrapper.get('[data-testid="next-quiz"]');
+
+    expect(nextButton.text()).toContain("Next Round");
+    expect(nextButton.text()).not.toContain("·");
+    expect(nextButton.attributes("disabled")).toBeUndefined();
+
+    await nextButton.trigger("click");
+    expect(wrapper.emitted("next")).toEqual([[]]);
+  });
 });
 
 function mountPanel(
   phase: MusicQuizPhase,
   busy = false,
-  autoStartAt?: number | null,
+  options: {
+    autoStartAt?: number | null;
+    revealCountdown?: boolean;
+    autoAdvanceAt?: number | null;
+    isLastRound?: boolean;
+  } = {},
 ) {
   return mount(MusicQuizHostPanel, {
     props: {
-      state: { ...HOST_STATE, phase, auto_start_at: autoStartAt },
+      state: {
+        ...HOST_STATE,
+        phase,
+        auto_start_at: options.autoStartAt,
+        current_round:
+          phase === "answering" || phase === "reveal"
+            ? {
+                ...HOST_ROUND,
+                auto_advance_at: options.autoAdvanceAt ?? null,
+              }
+            : null,
+      },
       busy,
       joinLink: HOST_STATE.join_url,
-      isLastRound: false,
+      isLastRound: options.isLastRound ?? false,
+      revealCountdown: options.revealCountdown ?? false,
     },
     slots: {
       game: "<div />",

--- a/tests/components/music-quiz/MusicQuizSessionHeader.test.ts
+++ b/tests/components/music-quiz/MusicQuizSessionHeader.test.ts
@@ -42,6 +42,7 @@ describe("MusicQuizSessionHeader", () => {
         phaseLabel: "Answers open",
         roundLabel: "Round 2 / 5",
         mode: "remote",
+        listenInEnabled: true,
       },
     });
 
@@ -70,6 +71,7 @@ describe("MusicQuizSessionHeader", () => {
         game: game("trivia", false),
         phaseLabel: "Answers open",
         mode: "venue",
+        listenInEnabled: false,
       },
     });
 
@@ -87,6 +89,7 @@ describe("MusicQuizSessionHeader", () => {
       phaseLabel: "Answers open",
       roundLabel: "Round 2 / 5",
       mode: "venue" as const,
+      listenInEnabled: true,
     };
     const regular = mount(MusicQuizSessionHeader, { props });
     const present = mount(MusicQuizSessionHeader, {

--- a/tests/components/music-quiz/TriviaAdapters.test.ts
+++ b/tests/components/music-quiz/TriviaAdapters.test.ts
@@ -398,7 +398,7 @@ describe("Trivia adapters", () => {
     ).toBe(false);
   });
 
-  it("emits Ready once and never emits when the countdown reaches zero", async () => {
+  it("emits Ready once and keeps manual recovery at zero", async () => {
     const round = scheduledRevealRound(1);
     const wrapper = mount(TriviaPlayerRound, {
       props: {
@@ -425,13 +425,15 @@ describe("Trivia adapters", () => {
 
     await vi.advanceTimersByTimeAsync(1_000);
 
-    expect(elapsedButton.text()).toContain(
-      "providers.music_quiz.waiting_for_next",
-    );
+    expect(elapsedButton.text()).toContain("providers.music_quiz.ready");
     expect(elapsedButton.text()).not.toContain("0s");
-    expect(elapsedButton.attributes("disabled")).toBeDefined();
-    await elapsedButton.trigger("click");
+    expect(elapsedButton.attributes("disabled")).toBeUndefined();
     expect(elapsedWrapper.emitted("ready")).toBeUndefined();
+
+    await elapsedButton.trigger("click");
+    await elapsedButton.trigger("click");
+
+    expect(elapsedWrapper.emitted("ready")).toEqual([[]]);
 
     const presentWrapper = mount(TriviaPresentRound, {
       props: {
@@ -452,6 +454,59 @@ describe("Trivia adapters", () => {
       "providers.music_quiz.waiting_for_next",
     );
     expect(presentCountdown.text()).not.toContain("0s");
+  });
+
+  it("keeps an elapsed ready player disabled", () => {
+    const round = scheduledRevealRound(-1);
+    const wrapper = mount(TriviaPlayerRound, {
+      props: {
+        state: revealPlayerState(round, {
+          ready: true,
+          roundCount: 2,
+        }),
+        currentRound: round,
+        busy: false,
+      },
+    });
+    const button = wrapper.get('[data-testid="trivia-ready"]');
+
+    expect(button.text()).toContain("providers.music_quiz.waiting_for_next");
+    expect(button.text()).not.toContain("0s");
+    expect(button.attributes("disabled")).toBeDefined();
+  });
+
+  it("lets a successful server round replace an elapsed Ready request", async () => {
+    const elapsedRound = scheduledRevealRound(-1);
+    const wrapper = mount(TriviaPlayerRound, {
+      props: {
+        state: revealPlayerState(elapsedRound, { roundCount: 2 }),
+        currentRound: elapsedRound,
+        busy: false,
+      },
+    });
+
+    await wrapper.get('[data-testid="trivia-ready"]').trigger("click");
+    expect(wrapper.emitted("ready")).toEqual([[]]);
+
+    const nextRound = {
+      ...revealRound,
+      round_index: 1,
+      auto_advance_at: Date.now() / 1000 + 15,
+    } satisfies MusicQuizTriviaRound;
+    await wrapper.setProps({
+      state: revealPlayerState(nextRound, { roundCount: 2 }),
+      currentRound: nextRound,
+    });
+    const nextButton = wrapper.get('[data-testid="trivia-ready"]');
+
+    expect(nextButton.text()).toContain(
+      "providers.music_quiz.ready_for_final_results_countdown",
+    );
+    expect(nextButton.attributes("disabled")).toBeUndefined();
+
+    await nextButton.trigger("click");
+
+    expect(wrapper.emitted("ready")).toEqual([[], []]);
   });
 });
 

--- a/tests/components/music-quiz/TriviaAdapters.test.ts
+++ b/tests/components/music-quiz/TriviaAdapters.test.ts
@@ -5,6 +5,7 @@ import TriviaHostRound from "@/components/music-quiz/game-types/trivia/TriviaHos
 import TriviaPlayerRound from "@/components/music-quiz/game-types/trivia/TriviaPlayerRound.vue";
 import TriviaPresentRound from "@/components/music-quiz/game-types/trivia/TriviaPresentRound.vue";
 import type {
+  MusicQuizTriviaHostRound,
   MusicQuizTriviaHostState,
   MusicQuizTriviaPersonalizedState,
   MusicQuizTriviaRound,
@@ -40,11 +41,25 @@ const revealRound = {
   ...answeringRound,
   answer_label: "Daft Punk",
   correct_suggestion_id: "daft-punk",
-  track_uri: null,
+  track_uri: "library://track/daft-punk",
   image_url: null,
   duration: null,
   ended_at: 20,
 } satisfies MusicQuizTriviaRound;
+
+const protectedHostRound = {
+  round_index: 0,
+  answer_label: "Daft Punk",
+  suggestions: answeringRound.suggestions,
+  correct_suggestion_id: "daft-punk",
+  track_uri: "library://track/daft-punk",
+  question: answeringRound.question,
+  image_url: null,
+  duration: null,
+  started_at: 1,
+  ended_at: null,
+  auto_advance_at: null,
+} satisfies MusicQuizTriviaHostRound;
 
 const playerState = {
   quiz_type: "trivia",
@@ -72,7 +87,7 @@ const hostState = {
   created_at: 1,
   sources: [],
   join_url: "https://example.test/join",
-  rounds: [],
+  rounds: [protectedHostRound],
 } satisfies MusicQuizTriviaHostState;
 
 const triviaSurfaces: Array<{
@@ -189,9 +204,34 @@ describe("Trivia adapters", () => {
       expect(wrapper.get('[data-testid="trivia-answer"]').text()).toBe(
         revealRound.answer_label,
       );
+      expect(wrapper.find("audio").exists()).toBe(false);
+      expect(wrapper.html()).not.toContain(revealRound.track_uri);
       wrapper.unmount();
     },
   );
+
+  it("matches answering redaction and reveal audio round fields", () => {
+    const disabledRevealRound = {
+      ...revealRound,
+      track_uri: null,
+    } satisfies MusicQuizTriviaRound;
+    const disabledRound = {
+      ...protectedHostRound,
+      track_uri: null,
+    } satisfies MusicQuizTriviaHostRound;
+
+    expect("track_uri" in answeringRound).toBe(false);
+    expect("image_url" in answeringRound).toBe(false);
+    expect("duration" in answeringRound).toBe(false);
+    expect("ended_at" in answeringRound).toBe(false);
+    expect(revealRound.track_uri).toBe("library://track/daft-punk");
+    expect(disabledRevealRound.track_uri).toBeNull();
+    expect(revealRound.image_url).toBeNull();
+    expect(revealRound.duration).toBeNull();
+    expect(revealRound.ended_at).toBe(20);
+    expect(protectedHostRound.track_uri).toBe("library://track/daft-punk");
+    expect(disabledRound.track_uri).toBeNull();
+  });
 
   it("uses the shared multiple-choice submission and reveal result", () => {
     const answerWrapper = shallowMount(MultipleChoicePlayerAnswer, {

--- a/tests/components/music-quiz/TriviaAdapters.test.ts
+++ b/tests/components/music-quiz/TriviaAdapters.test.ts
@@ -11,11 +11,12 @@ import type {
 } from "@/composables/useMusicQuiz";
 import { mount, shallowMount } from "@vue/test-utils";
 import type { Component } from "vue";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@/plugins/i18n", async (importOriginal) => ({
   ...(await importOriginal<typeof import("@/plugins/i18n")>()),
-  $t: (key: string) => key,
+  $t: (key: string, values?: Array<string | number>) =>
+    values?.length ? `${key} ${values.join(" ")}` : key,
   i18n: {
     global: {
       locale: { value: "en" },
@@ -49,6 +50,7 @@ const playerState = {
   quiz_type: "trivia",
   answer_type: "multiple_choice",
   language: "en",
+  play_reveal_audio: true,
   phase: "answering",
   name: "Music Trivia",
   round_count: 1,
@@ -84,6 +86,15 @@ const triviaSurfaces: Array<{
 ];
 
 describe("Trivia adapters", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-01-01T00:00:00Z"));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   it("shows the canonical server language after a host state refresh", async () => {
     const displayNames = new Intl.DisplayNames(["en"], {
       type: "language",
@@ -108,6 +119,29 @@ describe("Trivia adapters", () => {
       displayNames.of("sr-Latn"),
     );
   });
+
+  it.each([
+    [true, "providers.music_quiz.reveal_audio_on"],
+    [false, "providers.music_quiz.reveal_audio_off"],
+    [undefined, "providers.music_quiz.reveal_audio_off"],
+  ] as const)(
+    "shows the reveal-audio setting after reconnect when set to %s",
+    (playRevealAudio, expectedLabel) => {
+      const wrapper = mount(TriviaHostPanel, {
+        props: {
+          state: {
+            ...hostState,
+            play_reveal_audio: playRevealAudio,
+          },
+          currentRound: hostState.current_round,
+        },
+      });
+
+      expect(
+        wrapper.get('[data-testid="trivia-reveal-audio"]').text(),
+      ).toContain(expectedLabel);
+    },
+  );
 
   it.each(triviaSurfaces)(
     "shows the server question in the $name state",
@@ -205,4 +239,201 @@ describe("Trivia adapters", () => {
     expect(revealWrapper.text()).toContain("providers.music_quiz.correct");
     expect(revealWrapper.text()).toContain("+10");
   });
+
+  it.each([
+    {
+      name: "intermediate Ready",
+      isFinal: false,
+      ready: false,
+      label: "providers.music_quiz.ready_for_next_round_countdown",
+    },
+    {
+      name: "intermediate waiting",
+      isFinal: false,
+      ready: true,
+      label: "providers.music_quiz.waiting_for_next_round_countdown",
+    },
+    {
+      name: "final Ready",
+      isFinal: true,
+      ready: false,
+      label: "providers.music_quiz.ready_for_final_results_countdown",
+    },
+    {
+      name: "final waiting",
+      isFinal: true,
+      ready: true,
+      label: "providers.music_quiz.waiting_for_final_results_countdown",
+    },
+  ])("shows the authoritative 15s $name label", ({ isFinal, ready, label }) => {
+    const round = scheduledRevealRound();
+    const wrapper = mount(TriviaPlayerRound, {
+      props: {
+        state: revealPlayerState(round, {
+          ready,
+          roundCount: isFinal ? 1 : 2,
+        }),
+        currentRound: round,
+        busy: false,
+      },
+    });
+    const button = wrapper.get('[data-testid="trivia-ready"]');
+
+    expect(button.text()).toContain(label);
+    expect(button.text()).toContain("15s");
+    expect(button.attributes("disabled") !== undefined).toBe(ready);
+  });
+
+  it.each([
+    [false, "providers.music_quiz.next_round_in"],
+    [true, "providers.music_quiz.final_results_in"],
+  ] as const)(
+    "shows the authoritative 15s %s present countdown",
+    (isFinal, label) => {
+      const round = scheduledRevealRound();
+      const wrapper = mount(TriviaPresentRound, {
+        props: {
+          state: {
+            ...hostState,
+            phase: "reveal",
+            round_count: isFinal ? 1 : 2,
+            current_round: round,
+          },
+          currentRound: round,
+        },
+      });
+      const countdown = wrapper.get('[data-testid="trivia-auto-advance"]');
+
+      expect(countdown.text()).toContain(label);
+      expect(countdown.text()).toContain("15s");
+      expect(countdown.attributes("role")).toBe("timer");
+    },
+  );
+
+  it("derives a reconnected countdown only from auto_advance_at", () => {
+    const round = scheduledRevealRound();
+    vi.advanceTimersByTime(6_000);
+
+    const wrapper = mount(TriviaPlayerRound, {
+      props: {
+        state: revealPlayerState(round, { roundCount: 2 }),
+        currentRound: round,
+        busy: false,
+      },
+    });
+
+    expect(wrapper.get('[data-testid="trivia-ready"]').text()).toContain("9s");
+  });
+
+  it("keeps null auto_advance_at manual on player and present surfaces", () => {
+    const round = {
+      ...revealRound,
+      auto_advance_at: null,
+    } satisfies MusicQuizTriviaRound;
+    const playerWrapper = mount(TriviaPlayerRound, {
+      props: {
+        state: revealPlayerState(round, { roundCount: 2 }),
+        currentRound: round,
+        busy: false,
+      },
+    });
+    const presentWrapper = mount(TriviaPresentRound, {
+      props: {
+        state: {
+          ...hostState,
+          phase: "reveal",
+          round_count: 2,
+          current_round: round,
+        },
+        currentRound: round,
+      },
+    });
+
+    expect(playerWrapper.get('[data-testid="trivia-ready"]').text()).toContain(
+      "providers.music_quiz.ready",
+    );
+    expect(playerWrapper.text()).not.toContain("_countdown");
+    expect(
+      presentWrapper.find('[data-testid="trivia-auto-advance"]').exists(),
+    ).toBe(false);
+  });
+
+  it("emits Ready once and never emits when the countdown reaches zero", async () => {
+    const round = scheduledRevealRound(1);
+    const wrapper = mount(TriviaPlayerRound, {
+      props: {
+        state: revealPlayerState(round, { roundCount: 2 }),
+        currentRound: round,
+        busy: false,
+      },
+    });
+    const button = wrapper.get('[data-testid="trivia-ready"]');
+
+    await button.trigger("click");
+    await button.trigger("click");
+    expect(wrapper.emitted("ready")).toEqual([[]]);
+
+    const elapsedRound = scheduledRevealRound(1);
+    const elapsedWrapper = mount(TriviaPlayerRound, {
+      props: {
+        state: revealPlayerState(elapsedRound, { roundCount: 2 }),
+        currentRound: elapsedRound,
+        busy: false,
+      },
+    });
+    const elapsedButton = elapsedWrapper.get('[data-testid="trivia-ready"]');
+
+    await vi.advanceTimersByTimeAsync(1_000);
+
+    expect(elapsedButton.text()).toContain(
+      "providers.music_quiz.waiting_for_next",
+    );
+    expect(elapsedButton.text()).not.toContain("0s");
+    expect(elapsedButton.attributes("disabled")).toBeDefined();
+    await elapsedButton.trigger("click");
+    expect(elapsedWrapper.emitted("ready")).toBeUndefined();
+
+    const presentWrapper = mount(TriviaPresentRound, {
+      props: {
+        state: {
+          ...hostState,
+          phase: "reveal",
+          round_count: 2,
+          current_round: elapsedRound,
+        },
+        currentRound: elapsedRound,
+      },
+    });
+    const presentCountdown = presentWrapper.get(
+      '[data-testid="trivia-auto-advance"]',
+    );
+
+    expect(presentCountdown.text()).toContain(
+      "providers.music_quiz.waiting_for_next",
+    );
+    expect(presentCountdown.text()).not.toContain("0s");
+  });
 });
+
+function scheduledRevealRound(seconds = 15) {
+  return {
+    ...revealRound,
+    auto_advance_at: Date.now() / 1000 + seconds,
+  } satisfies MusicQuizTriviaRound;
+}
+
+function revealPlayerState(
+  round: MusicQuizTriviaRound,
+  options: { ready?: boolean; roundCount?: number } = {},
+) {
+  return {
+    ...playerState,
+    phase: "reveal",
+    round_count: options.roundCount ?? 2,
+    current_round: round,
+    you: {
+      ...playerState.you,
+      ready: options.ready ?? false,
+    },
+  } satisfies MusicQuizTriviaPersonalizedState;
+}

--- a/tests/components/music-quiz/TriviaSetup.test.ts
+++ b/tests/components/music-quiz/TriviaSetup.test.ts
@@ -66,6 +66,7 @@ describe("TriviaSetup", () => {
           answer_type: "multiple_choice",
           config: {
             language: "sr-Latn",
+            play_reveal_audio: true,
             round_count: 5,
             suggestion_count: 4,
             answer_duration: 30,
@@ -93,11 +94,35 @@ describe("TriviaSetup", () => {
       answer_type: "multiple_choice",
       config: {
         language: "en",
+        play_reveal_audio: true,
         round_count: 5,
         suggestion_count: 4,
         answer_duration: 30,
         difficulty: "normal",
         source_uris: ["library://playlist/1", "library://genre/rock"],
+      },
+    });
+  });
+
+  it("defaults reveal audio on and emits an explicit disabled value", async () => {
+    const wrapper = mountSetup();
+    const toggle = wrapper.get('[data-testid="trivia-play-reveal-audio"]');
+
+    expect(toggle.attributes("data-state")).toBe("checked");
+
+    await toggle.trigger("click");
+    await wrapper.get('[data-testid="select-sources"]').trigger("click");
+    await nextTick();
+    await wrapper
+      .findAll("button")
+      .find((button) => button.text().includes("create"))
+      ?.trigger("click");
+
+    expect(toggle.attributes("data-state")).toBe("unchecked");
+    expect(wrapper.emitted("create")?.[0]?.[0]).toMatchObject({
+      quiz_type: "trivia",
+      config: {
+        play_reveal_audio: false,
       },
     });
   });

--- a/tests/components/music-quiz/registry.test.ts
+++ b/tests/components/music-quiz/registry.test.ts
@@ -4,6 +4,7 @@ import {
   MUSIC_QUIZ_GAME_TYPES,
   isMusicQuizGameAvailable,
   resolveMusicQuizDefinition,
+  supportsMusicQuizListenIn,
 } from "@/components/music-quiz/game_types";
 import type {
   MusicQuizAnswerType,
@@ -177,6 +178,7 @@ const triviaPlayerState = {
   quiz_type: "trivia",
   answer_type: "multiple_choice",
   language: "en",
+  play_reveal_audio: true,
   phase: "answering",
   name: "Trivia",
   round_count: 5,
@@ -290,13 +292,30 @@ describe("Music Quiz registries", () => {
 
     expect(mapping).toEqual(expected);
     expect(
-      MUSIC_QUIZ_GAME_TYPES.find((game) => game.id === "music_timeline")
-        ?.supportsListenIn,
+      supportsMusicQuizListenIn(
+        MUSIC_QUIZ_GAME_TYPES.find((game) => game.id === "music_timeline")!,
+        musicTimelinePlayerState,
+      ),
     ).toBe(true);
+    const trivia = MUSIC_QUIZ_GAME_TYPES.find((game) => game.id === "trivia")!;
+    expect(supportsMusicQuizListenIn(trivia, triviaPlayerState)).toBe(true);
     expect(
-      MUSIC_QUIZ_GAME_TYPES.find((game) => game.id === "trivia")
-        ?.supportsListenIn,
+      supportsMusicQuizListenIn(trivia, {
+        ...triviaPlayerState,
+        play_reveal_audio: false,
+      }),
     ).toBe(false);
+    const legacyTriviaState = {
+      ...triviaPlayerState,
+      play_reveal_audio: undefined,
+    };
+    expect(supportsMusicQuizListenIn(trivia, legacyTriviaState)).toBe(false);
+    expect(supportsMusicQuizListenIn(trivia)).toBe(false);
+    expect(
+      supportsMusicQuizListenIn(
+        MUSIC_QUIZ_GAME_TYPES.find((game) => game.id === "guess_the_song")!,
+      ),
+    ).toBe(true);
     expect(
       MUSIC_QUIZ_GAME_TYPES.find((game) => game.id === "music_timeline")
         ?.adapters.presentBody,

--- a/tests/composables/useMusicQuiz.test.ts
+++ b/tests/composables/useMusicQuiz.test.ts
@@ -23,6 +23,7 @@ import {
   submitMusicQuizAnswer,
   type MusicQuizProviderEvent,
   type MusicQuizPublicState,
+  type MusicQuizTriviaInfo,
 } from "@/composables/useMusicQuiz";
 
 function unsupportedQuizType(value: string) {
@@ -120,6 +121,7 @@ describe("useMusicQuiz commands", () => {
       answer_type: "multiple_choice",
       config: {
         language: "sr-Latn",
+        play_reveal_audio: true,
         round_count: 8,
         suggestion_count: 6,
         answer_duration: 45,
@@ -132,6 +134,7 @@ describe("useMusicQuiz commands", () => {
     expect(mockSendCommand).toHaveBeenCalledWith("music_quiz/create", {
       quiz_type: "trivia",
       language: "sr-Latn",
+      play_reveal_audio: true,
       round_count: 8,
       suggestion_count: 6,
       answer_duration: 45,
@@ -293,6 +296,62 @@ describe("useMusicQuiz commands", () => {
     expect(isSupportedMusicQuiz(unsupported)).toBe(false);
     expect(isSupportedMusicQuiz(unsupportedAnswer)).toBe(false);
     expect(isSupportedMusicQuiz(mismatched)).toBe(false);
+  });
+
+  it("types Trivia reveal audio in state and info while allowing legacy payloads", () => {
+    const state = {
+      quiz_type: "trivia",
+      answer_type: "multiple_choice",
+      language: "en",
+      play_reveal_audio: true,
+      phase: "lobby",
+      name: "Trivia",
+      round_count: 5,
+      suggestion_count: 4,
+      answer_duration: 30,
+      mode: "venue",
+      players: [],
+      current_round: null,
+    } satisfies MusicQuizPublicState;
+    const legacyState = {
+      quiz_type: "trivia",
+      answer_type: "multiple_choice",
+      language: "en",
+      phase: "lobby",
+      name: "Trivia",
+      round_count: 5,
+      suggestion_count: 4,
+      answer_duration: 30,
+      mode: "venue",
+      players: [],
+      current_round: null,
+    } satisfies MusicQuizPublicState;
+    const info = {
+      quiz_type: "trivia",
+      answer_type: "multiple_choice",
+      language: "en",
+      play_reveal_audio: false,
+      phase: "lobby",
+      name: "Trivia",
+      player_count: 2,
+      round_count: 5,
+      mode: "venue",
+    } satisfies MusicQuizTriviaInfo;
+    const legacyInfo = {
+      quiz_type: "trivia",
+      answer_type: "multiple_choice",
+      language: "en",
+      phase: "lobby",
+      name: "Trivia",
+      player_count: 2,
+      round_count: 5,
+      mode: "venue",
+    } satisfies MusicQuizTriviaInfo;
+
+    expect(state.play_reveal_audio).toBe(true);
+    expect("play_reveal_audio" in legacyState).toBe(false);
+    expect(info.play_reveal_audio).toBe(false);
+    expect("play_reveal_audio" in legacyInfo).toBe(false);
   });
 
   it("preserves nullable server fields in supported state", () => {

--- a/tests/composables/useMusicQuizPlayer.test.ts
+++ b/tests/composables/useMusicQuizPlayer.test.ts
@@ -1386,6 +1386,24 @@ describe("useMusicQuizPlayer", () => {
     expect(player.busy.value).toBe(false);
   });
 
+  it("sends Ready only once while the first request is in flight", async () => {
+    storedPlayerId.value = "stored-player";
+    const delayedReady = deferred<typeof TIMELINE_REVEAL_STATE>();
+    mockGetMusicQuizState.mockResolvedValue(TIMELINE_REVEAL_STATE);
+    mockReadyMusicQuiz.mockReturnValueOnce(delayedReady.promise);
+    const player = useMusicQuizPlayer({ notifyError: vi.fn() });
+    await flushPromises();
+
+    const firstReady = player.ready();
+    await expect(player.ready()).resolves.toBe(false);
+
+    expect(mockReadyMusicQuiz).toHaveBeenCalledOnce();
+    expect(mockReadyMusicQuiz).toHaveBeenCalledWith("stored-player");
+
+    delayedReady.resolve(TIMELINE_REVEAL_STATE);
+    await expect(firstReady).resolves.toBe(true);
+  });
+
   it("does not expose guess-the-song fields for an unknown game type", async () => {
     mockGetMusicQuizInfo.mockResolvedValue({
       quiz_type: "future_game",

--- a/tests/composables/useMusicQuizPlayer.test.ts
+++ b/tests/composables/useMusicQuizPlayer.test.ts
@@ -1358,7 +1358,7 @@ describe("useMusicQuizPlayer", () => {
     expect(player.state.value).toEqual(TIMELINE_REVEAL_STATE);
   });
 
-  it("keeps the next round authoritative over a delayed ready response", async () => {
+  it("keeps a successful next-round event authoritative over delayed Ready", async () => {
     storedPlayerId.value = "stored-player";
     const delayedReady = deferred<typeof TIMELINE_REVEAL_STATE>();
     const eventRefresh = deferred<typeof TIMELINE_REVEAL_STATE>();

--- a/tests/views/MusicQuizDashboardHostActions.test.ts
+++ b/tests/views/MusicQuizDashboardHostActions.test.ts
@@ -1,4 +1,8 @@
 import MusicQuizDashboardView from "@/views/MusicQuizDashboardView.vue";
+import type {
+  MusicQuizSupportedHostState,
+  MusicQuizTriviaHostState,
+} from "@/composables/useMusicQuiz";
 import { flushPromises, mount } from "@vue/test-utils";
 import { nextTick, ref, type Ref } from "vue";
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -25,6 +29,10 @@ vi.mock("@/components/music-quiz/game_types", () => ({
   getMusicQuizPhaseLabelKey: () =>
     "providers.music_quiz.phase_waiting_for_players",
   resolveMusicQuizDefinition: mockResolveMusicQuizDefinition,
+  supportsMusicQuizListenIn: (
+    _game: unknown,
+    state: { quiz_type: string; play_reveal_audio?: boolean },
+  ) => state.quiz_type !== "trivia" || state.play_reveal_audio === true,
 }));
 
 vi.mock("@/helpers/music_quiz", () => ({
@@ -78,9 +86,16 @@ const HOST_STATE = {
   join_url: "http://join",
   rounds: [],
   current_round: null,
-} as const;
+} satisfies MusicQuizSupportedHostState;
+const TRIVIA_HOST_STATE = {
+  ...HOST_STATE,
+  quiz_type: "trivia",
+  language: "en",
+  play_reveal_audio: true,
+  rounds: [],
+} satisfies MusicQuizTriviaHostState;
 
-let state: Ref<typeof HOST_STATE | null>;
+let state: Ref<MusicQuizSupportedHostState | null>;
 let busy: Ref<boolean>;
 
 describe("MusicQuizDashboardView host actions", () => {
@@ -247,6 +262,45 @@ describe("MusicQuizDashboardView host actions", () => {
     expect(root.classes()).not.toContain("p-4");
   });
 
+  it("shows the host playback badge only for reveal-audio Trivia", async () => {
+    state.value = {
+      ...TRIVIA_HOST_STATE,
+      play_reveal_audio: false,
+    };
+    const wrapper = mountDashboard();
+    await nextTick();
+
+    expect(
+      wrapper
+        .get('[data-testid="session-header"]')
+        .attributes("data-listen-in-enabled"),
+    ).toBe("false");
+
+    state.value = {
+      ...TRIVIA_HOST_STATE,
+      play_reveal_audio: true,
+    };
+    await nextTick();
+
+    expect(
+      wrapper
+        .get('[data-testid="session-header"]')
+        .attributes("data-listen-in-enabled"),
+    ).toBe("true");
+
+    state.value = {
+      ...TRIVIA_HOST_STATE,
+      play_reveal_audio: undefined,
+    };
+    await nextTick();
+
+    expect(
+      wrapper
+        .get('[data-testid="session-header"]')
+        .attributes("data-listen-in-enabled"),
+    ).toBe("false");
+  });
+
   it("returns to the compact empty state when the host state is cleared", async () => {
     const wrapper = mountDashboard();
 
@@ -298,7 +352,11 @@ function mountDashboard() {
           template: "<h2><slot /></h2>",
         },
         MusicQuizConnectionBanners: true,
-        MusicQuizSessionHeader: true,
+        MusicQuizSessionHeader: {
+          props: ["listenInEnabled"],
+          template:
+            '<div data-testid="session-header" :data-listen-in-enabled="String(listenInEnabled)" />',
+        },
         MusicQuizHostPanel: {
           props: ["busy"],
           emits: ["endGame", "present", "reset", "setUpNewGame", "start"],

--- a/tests/views/MusicQuizDashboardView.test.ts
+++ b/tests/views/MusicQuizDashboardView.test.ts
@@ -11,6 +11,7 @@ const { mockSendCommand, mockSubscribe, mockToastError } = vi.hoisted(() => ({
 vi.mock("@/components/music-quiz/game_types", () => ({
   MUSIC_QUIZ_GAME_TYPES: [],
   resolveMusicQuizDefinition: vi.fn(),
+  supportsMusicQuizListenIn: vi.fn(() => false),
 }));
 
 vi.mock("@/plugins/api", () => {

--- a/tests/views/MusicQuizPlayerView.test.ts
+++ b/tests/views/MusicQuizPlayerView.test.ts
@@ -33,6 +33,15 @@ vi.mock("@/components/ListenIn.vue", async () => {
 vi.mock("@/components/music-quiz/game_types", () => ({
   getMusicQuizPhaseLabelKey: () => "providers.music_quiz.phase_answers_open",
   resolveMusicQuizDefinition: mockResolveMusicQuizDefinition,
+  supportsMusicQuizListenIn: (
+    game: {
+      supportsListenIn: boolean | ((state: Record<string, unknown>) => boolean);
+    },
+    state: Record<string, unknown>,
+  ) =>
+    typeof game.supportsListenIn === "boolean"
+      ? game.supportsListenIn
+      : game.supportsListenIn(state),
 }));
 
 vi.mock("@/composables/useMusicQuizPlayer", () => ({
@@ -174,6 +183,8 @@ const triviaState = {
     active_from_round: 0,
   },
 };
+const triviaListenInCapability = (state: Record<string, unknown>) =>
+  state.play_reveal_audio === true;
 
 describe("MusicQuizPlayerView routing", () => {
   afterEach(() => {
@@ -200,11 +211,46 @@ describe("MusicQuizPlayerView routing", () => {
     });
   });
 
-  it("never initializes ListenIn or lyrics for Trivia", () => {
-    mockResolveMusicQuizDefinition.mockReturnValue(createDefinition(false));
+  it.each([
+    ["legacy", triviaState],
+    ["disabled", { ...triviaState, play_reveal_audio: false }],
+  ])(
+    "never initializes ListenIn or lyrics for %s Trivia state",
+    (_case, state) => {
+      mockResolveMusicQuizDefinition.mockReturnValue(
+        createDefinition(triviaListenInCapability),
+      );
+      mockUseMusicQuizPlayer.mockReturnValue({
+        info: ref(null),
+        state: ref(state),
+        playerId: ref("player-id"),
+        gameRemoved: ref(false),
+        busy: ref(false),
+        loading: ref(false),
+        currentRound: ref(triviaRound),
+        join: vi.fn(),
+        submitAnswer: vi.fn(),
+        ready: vi.fn(),
+      });
+
+      const wrapper = mountView();
+
+      expect(mockGameAdapterSetup).toHaveBeenCalledOnce();
+      expect(mockListenInSetup).not.toHaveBeenCalled();
+      expect(wrapper.find('[data-testid="listen-in"]').exists()).toBe(false);
+      expect(wrapper.text()).not.toContain("providers.music_quiz.mode_venue");
+      expect(mockGetTrackLyrics).not.toHaveBeenCalled();
+      wrapper.unmount();
+    },
+  );
+
+  it("initializes ListenIn for reveal-audio Trivia during answering", () => {
+    mockResolveMusicQuizDefinition.mockReturnValue(
+      createDefinition(triviaListenInCapability),
+    );
     mockUseMusicQuizPlayer.mockReturnValue({
       info: ref(null),
-      state: ref(triviaState),
+      state: ref({ ...triviaState, play_reveal_audio: true }),
       playerId: ref("player-id"),
       gameRemoved: ref(false),
       busy: ref(false),
@@ -218,9 +264,40 @@ describe("MusicQuizPlayerView routing", () => {
     const wrapper = mountView();
 
     expect(mockGameAdapterSetup).toHaveBeenCalledOnce();
-    expect(mockListenInSetup).not.toHaveBeenCalled();
-    expect(wrapper.find('[data-testid="listen-in"]').exists()).toBe(false);
+    expect(mockListenInSetup).toHaveBeenCalledOnce();
+    expect(wrapper.find('[data-testid="listen-in"]').exists()).toBe(true);
+    expect(wrapper.text()).toContain("providers.music_quiz.mode_venue");
     expect(mockGetTrackLyrics).not.toHaveBeenCalled();
+    wrapper.unmount();
+  });
+
+  it("allows reveal-audio Trivia ListenIn to be armed in the lobby", () => {
+    mockResolveMusicQuizDefinition.mockReturnValue(
+      createDefinition(triviaListenInCapability),
+    );
+    mockUseMusicQuizPlayer.mockReturnValue({
+      info: ref(null),
+      state: ref({
+        ...triviaState,
+        play_reveal_audio: true,
+        phase: "lobby",
+        current_round: null,
+      }),
+      playerId: ref("player-id"),
+      gameRemoved: ref(false),
+      busy: ref(false),
+      loading: ref(false),
+      currentRound: ref(null),
+      join: vi.fn(),
+      submitAnswer: vi.fn(),
+      ready: vi.fn(),
+    });
+
+    const wrapper = mountView();
+
+    expect(mockListenInSetup).toHaveBeenCalledOnce();
+    expect(wrapper.find('[data-testid="listen-in"]').exists()).toBe(true);
+    expect(wrapper.text()).toContain("providers.music_quiz.mode_venue");
     wrapper.unmount();
   });
 
@@ -300,12 +377,15 @@ describe("MusicQuizPlayerView routing", () => {
   });
 
   it("hides the mode label before joining Trivia", () => {
-    mockResolveMusicQuizDefinition.mockReturnValue(createDefinition(false));
+    mockResolveMusicQuizDefinition.mockReturnValue(
+      createDefinition(triviaListenInCapability),
+    );
     mockUseMusicQuizPlayer.mockReturnValue({
       info: ref({
         quiz_type: "trivia",
         answer_type: "multiple_choice",
         language: "en",
+        play_reveal_audio: false,
         phase: "lobby",
         name: "Trivia",
         player_count: 2,
@@ -326,6 +406,40 @@ describe("MusicQuizPlayerView routing", () => {
     const wrapper = mountView();
 
     expect(wrapper.text()).not.toContain("providers.music_quiz.mode_venue");
+    wrapper.unmount();
+  });
+
+  it("shows the mode label before joining reveal-audio Trivia", () => {
+    mockResolveMusicQuizDefinition.mockReturnValue(
+      createDefinition(triviaListenInCapability),
+    );
+    mockUseMusicQuizPlayer.mockReturnValue({
+      info: ref({
+        quiz_type: "trivia",
+        answer_type: "multiple_choice",
+        language: "en",
+        play_reveal_audio: true,
+        phase: "lobby",
+        name: "Trivia",
+        player_count: 2,
+        round_count: 5,
+        mode: "venue",
+      }),
+      state: ref(null),
+      playerId: ref(null),
+      gameRemoved: ref(false),
+      busy: ref(false),
+      loading: ref(false),
+      currentRound: ref(null),
+      join: vi.fn(),
+      submitAnswer: vi.fn(),
+      ready: vi.fn(),
+    });
+
+    const wrapper = mountView();
+
+    expect(wrapper.text()).toContain("providers.music_quiz.mode_venue");
+    expect(mockListenInSetup).not.toHaveBeenCalled();
     wrapper.unmount();
   });
 
@@ -492,7 +606,9 @@ describe("MusicQuizPlayerView routing", () => {
   });
 });
 
-function createDefinition(supportsListenIn: boolean) {
+function createDefinition(
+  supportsListenIn: boolean | ((state: Record<string, unknown>) => boolean),
+) {
   const gameAdapter = {
     name: "TestGameAdapter",
     props: {
@@ -539,9 +655,9 @@ function mountView() {
         MusicQuizLeaderboard: true,
         MusicQuizPlayerHeader: true,
         MusicQuizSessionHeader: {
-          props: ["game", "mode", "roundLabel"],
+          props: ["listenInEnabled", "mode", "roundLabel"],
           template:
-            '<div data-testid="music-quiz-session-header" :data-round-label="roundLabel"><span v-if="game.supportsListenIn">providers.music_quiz.mode_{{ mode }}</span></div>',
+            '<div data-testid="music-quiz-session-header" :data-round-label="roundLabel"><span v-if="listenInEnabled">providers.music_quiz.mode_{{ mode }}</span></div>',
         },
         MusicQuizPodium: true,
         MusicQuizUnsupportedGame: {


### PR DESCRIPTION
## Summary

Adds the frontend for the Music Trivia reveal flow, paired with music-assistant/server#4758.

- adds a revealed-song playback toggle and reconnect summary
- enables Listen in only when reveal audio is enabled
- shows server-authoritative Ready and Next countdowns without client auto-advance

Draft until the server and frontend changes can land together.