### PR TITLE
Add similar music to quizzes

### DIFF
--- a/src/components/music-quiz/MusicQuizSetupWizard.vue
+++ b/src/components/music-quiz/MusicQuizSetupWizard.vue
@@ -60,10 +60,30 @@
           {{ $t("providers.music_quiz.configure_game") }}
         </h2>
       </div>
+      <Field
+        orientation="horizontal"
+        class="items-center justify-between gap-4 rounded-lg border p-4"
+      >
+        <div class="flex flex-col gap-1">
+          <FieldLabel for="quiz-include-similar-music">
+            {{ $t("providers.music_quiz.include_similar_music") }}
+          </FieldLabel>
+          <FieldDescription>
+            {{ $t("providers.music_quiz.include_similar_music_help") }}
+          </FieldDescription>
+        </div>
+        <Switch
+          id="quiz-include-similar-music"
+          v-model="includeSimilarMusic"
+          data-testid="quiz-include-similar-music"
+          :disabled="busy"
+        />
+      </Field>
       <component
         :is="selectedType.adapters.setup"
         v-if="selectedType"
         :busy="busy"
+        :include-similar-music="includeSimilarMusic"
         @create="onConfigCreate"
       />
     </section>
@@ -77,7 +97,9 @@ import {
   type MusicQuizGameDefinition,
 } from "@/components/music-quiz/game_types";
 import { Button } from "@/components/ui/button";
+import { Field, FieldDescription, FieldLabel } from "@/components/ui/field";
 import { Progress } from "@/components/ui/progress";
+import { Switch } from "@/components/ui/switch";
 import type { MusicQuizCreateRequest } from "@/composables/useMusicQuiz";
 import { $t } from "@/plugins/i18n";
 import { ArrowLeft } from "@lucide/vue";
@@ -100,6 +122,7 @@ const availableGameTypes = computed(() =>
 );
 const step = ref<1 | 2>(1);
 const selectedType = ref<MusicQuizGameDefinition | null>(null);
+const includeSimilarMusic = ref(false);
 
 function selectType(type: MusicQuizGameDefinition) {
   selectedType.value = type;

--- a/src/components/music-quiz/adapter_contracts.ts
+++ b/src/components/music-quiz/adapter_contracts.ts
@@ -12,6 +12,7 @@ import type { VNode } from "vue";
 
 export interface MusicQuizSetupAdapterProps {
   busy: boolean;
+  includeSimilarMusic: boolean;
 }
 
 export interface MusicQuizSetupAdapterEmits {

--- a/src/components/music-quiz/game-types/guess-the-song/GuessTheSongSetup.vue
+++ b/src/components/music-quiz/game-types/guess-the-song/GuessTheSongSetup.vue
@@ -116,7 +116,7 @@ const MAX_CHOICES = 8;
 const MIN_SECONDS = 5;
 const MAX_SECONDS = 120;
 
-defineProps<MusicQuizSetupAdapterProps>();
+const props = defineProps<MusicQuizSetupAdapterProps>();
 const emit = defineEmits<MusicQuizSetupAdapterEmits>();
 
 const roundCount = ref(5);
@@ -134,6 +134,7 @@ function create() {
     answer_duration: answerDuration.value,
     difficulty: difficulty.value,
     source_uris: sourceUris.value,
+    include_similar_music: props.includeSimilarMusic,
   };
   emit("create", {
     quiz_type: "guess_the_song",

--- a/src/components/music-quiz/game-types/music-timeline/MusicTimelineSetup.vue
+++ b/src/components/music-quiz/game-types/music-timeline/MusicTimelineSetup.vue
@@ -117,7 +117,7 @@ const MAX_ROUNDS = 100;
 const MIN_SECONDS = 1;
 const MAX_SECONDS = 300;
 
-defineProps<MusicQuizSetupAdapterProps>();
+const props = defineProps<MusicQuizSetupAdapterProps>();
 const emit = defineEmits<MusicQuizSetupAdapterEmits>();
 
 const roundCount = ref(5);
@@ -147,6 +147,7 @@ function create() {
     round_count: roundCount.value,
     answer_duration: answerDuration.value,
     source_uris: sourceUris.value,
+    include_similar_music: props.includeSimilarMusic,
     artist_bonus_mode: artistBonusMode.value,
     title_bonus_mode: titleBonusMode.value,
   };

--- a/src/components/music-quiz/game-types/trivia/TriviaSetup.vue
+++ b/src/components/music-quiz/game-types/trivia/TriviaSetup.vue
@@ -155,7 +155,7 @@ const MAX_CHOICES = 8;
 const MIN_SECONDS = 1;
 const MAX_SECONDS = 300;
 
-defineProps<MusicQuizSetupAdapterProps>();
+const props = defineProps<MusicQuizSetupAdapterProps>();
 const emit = defineEmits<MusicQuizSetupAdapterEmits>();
 
 const roundCount = ref(5);
@@ -180,6 +180,7 @@ function create() {
     answer_duration: answerDuration.value,
     difficulty: difficulty.value,
     source_uris: sourceUris.value,
+    include_similar_music: props.includeSimilarMusic,
   };
   emit("create", {
     quiz_type: "trivia",

--- a/src/composables/useMusicQuiz.ts
+++ b/src/composables/useMusicQuiz.ts
@@ -82,6 +82,7 @@ interface MusicQuizStateIdentity<
   answer_type: TAnswerType;
   phase: MusicQuizPhase;
   name: string | null;
+  include_similar_music?: boolean;
   auto_start_at?: number | null;
 }
 
@@ -526,7 +527,11 @@ export interface MusicQuizJoinResult {
   state: MusicQuizPersonalizedState;
 }
 
-export interface MusicQuizGuessTheSongConfig {
+export interface MusicQuizSharedConfig {
+  include_similar_music: boolean;
+}
+
+export interface MusicQuizGuessTheSongConfig extends MusicQuizSharedConfig {
   round_count: number;
   suggestion_count: number;
   answer_duration: number;
@@ -541,7 +546,7 @@ export interface MusicQuizGuessTheSongCreateRequest {
   config: MusicQuizGuessTheSongConfig;
 }
 
-export interface MusicQuizTimelineConfig {
+export interface MusicQuizTimelineConfig extends MusicQuizSharedConfig {
   round_count: number;
   answer_duration: number;
   source_uris: string[];
@@ -556,7 +561,7 @@ export interface MusicQuizTimelineCreateRequest {
   config: MusicQuizTimelineConfig;
 }
 
-export interface MusicQuizTriviaConfig {
+export interface MusicQuizTriviaConfig extends MusicQuizSharedConfig {
   language: string;
   play_reveal_audio: boolean;
   round_count: number;

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1251,6 +1251,8 @@
             "setup_step": "Step {0} of {1}",
             "coming_soon": "Coming soon",
             "answer_choices": "Answer choices",
+            "include_similar_music": "Include similar music",
+            "include_similar_music_help": "Add recommended tracks beyond your selected sources for more variety.",
             "game_type_guess_the_song": "Guess the Song",
             "game_type_guess_the_song_description": "Play a track and be the first to pick its title from the options.",
             "waiting_for_answer": "Waiting for answer",

--- a/tests/components/music-quiz/GuessTheSongSetup.test.ts
+++ b/tests/components/music-quiz/GuessTheSongSetup.test.ts
@@ -67,9 +67,9 @@ async function flushPromises() {
   await nextTick();
 }
 
-function mountConfig() {
+function mountConfig(includeSimilarMusic = false) {
   return mount(GuessTheSongSetup, {
-    props: { busy: false },
+    props: { busy: false, includeSimilarMusic },
     global: {
       stubs: {
         Button: { template: "<button><slot /></button>" },
@@ -186,6 +186,7 @@ describe("GuessTheSongSetup", () => {
         answer_duration: 30,
         difficulty: "normal",
         source_uris: ["playlist:test"],
+        include_similar_music: false,
       },
     });
   });
@@ -236,7 +237,7 @@ describe("GuessTheSongSetup", () => {
         { uri: "genre:rock", name: "Rock", media_type: MediaType.GENRE },
       ],
     });
-    const wrapper = mountConfig();
+    const wrapper = mountConfig(true);
 
     const searchInput = wrapper.find(
       'input[placeholder="providers.music_quiz.search_music"]',
@@ -262,7 +263,10 @@ describe("GuessTheSongSetup", () => {
       ?.trigger("click");
 
     expect(wrapper.emitted("create")?.[0]?.[0]).toMatchObject({
-      config: { source_uris: ["playlist:test", "genre:rock"] },
+      config: {
+        source_uris: ["playlist:test", "genre:rock"],
+        include_similar_music: true,
+      },
     });
   });
 

--- a/tests/components/music-quiz/MusicQuizSetupWizard.test.ts
+++ b/tests/components/music-quiz/MusicQuizSetupWizard.test.ts
@@ -9,32 +9,35 @@ vi.mock("@/plugins/i18n", () => ({
 
 vi.mock("@/components/music-quiz/game_types", async () => {
   const { defineComponent, h } = await import("vue");
-  const configComponent = defineComponent({
-    emits: ["create"],
-    setup(_, { emit }) {
-      return () =>
-        h(
-          "button",
-          {
-            "data-testid": "create-game",
-            onClick: () =>
-              emit("create", {
-                quiz_type: "guess_the_song",
-                answer_type: "multiple_choice",
-                config: {
-                  round_count: 5,
-                  suggestion_count: 4,
-                  answer_duration: 30,
-                  difficulty: "normal",
-                  source_uris: ["track:test"],
-                  name: "Test Quiz",
-                },
-              }),
-          },
-          "Create",
-        );
-    },
-  });
+  const setupComponent = (quizType: string, answerType: string) =>
+    defineComponent({
+      props: {
+        includeSimilarMusic: {
+          type: Boolean,
+          required: true,
+        },
+      },
+      emits: ["create"],
+      setup(props, { emit }) {
+        return () =>
+          h(
+            "button",
+            {
+              "data-testid": `create-${quizType}`,
+              onClick: () =>
+                emit("create", {
+                  quiz_type: quizType,
+                  answer_type: answerType,
+                  config: {
+                    source_uris: ["track:test"],
+                    include_similar_music: props.includeSimilarMusic,
+                  },
+                }),
+            },
+            "Create",
+          );
+      },
+    });
 
   return {
     MUSIC_QUIZ_GAME_TYPES: [
@@ -48,7 +51,20 @@ vi.mock("@/components/music-quiz/game_types", async () => {
         supportsListenIn: true,
         revealPhaseLabelKey: "reveal",
         adapters: {
-          setup: configComponent,
+          setup: setupComponent("guess_the_song", "multiple_choice"),
+        },
+      },
+      {
+        id: "music_timeline",
+        answerType: "timeline",
+        labelKey: "timeline_type",
+        descriptionKey: "timeline_description",
+        icon: { template: "<span />" },
+        requiresBackendAvailability: false,
+        supportsListenIn: true,
+        revealPhaseLabelKey: "reveal",
+        adapters: {
+          setup: setupComponent("music_timeline", "timeline"),
         },
       },
       {
@@ -61,7 +77,7 @@ vi.mock("@/components/music-quiz/game_types", async () => {
         supportsListenIn: false,
         revealPhaseLabelKey: "reveal",
         adapters: {
-          setup: configComponent,
+          setup: setupComponent("trivia", "multiple_choice"),
         },
       },
     ],
@@ -73,18 +89,23 @@ vi.mock("@/components/music-quiz/game_types", async () => {
   };
 });
 
-const request = {
-  quiz_type: "guess_the_song",
-  answer_type: "multiple_choice",
-  config: {
-    round_count: 5,
-    suggestion_count: 4,
-    answer_duration: 30,
-    difficulty: "normal",
-    source_uris: ["track:test"],
-    name: "Test Quiz",
+const GAME_CASES = [
+  {
+    label: "game_type",
+    quizType: "guess_the_song",
+    answerType: "multiple_choice",
   },
-} as const;
+  {
+    label: "timeline_type",
+    quizType: "music_timeline",
+    answerType: "timeline",
+  },
+  {
+    label: "trivia_type",
+    quizType: "trivia",
+    answerType: "multiple_choice",
+  },
+] as const;
 
 describe("MusicQuizSetupWizard", () => {
   it("shows Trivia only when the backend reports it available", async () => {
@@ -99,20 +120,81 @@ describe("MusicQuizSetupWizard", () => {
     expect(wrapper.text()).toContain("trivia_type");
   });
 
-  it("forwards the selected game component's create request", async () => {
-    const wrapper = mountWizard();
+  it.each(GAME_CASES)(
+    "renders one shared, accessible setting for $quizType and serializes both values",
+    async ({ label, quizType, answerType }) => {
+      const wrapper = mountWizard({ availableQuizTypes: ["trivia"] });
 
-    await wrapper.find("section button").trigger("click");
-    await nextTick();
-    await wrapper.get('[data-testid="create-game"]').trigger("click");
+      await selectGame(wrapper, label);
+      const toggle = wrapper.get('[data-testid="quiz-include-similar-music"]');
 
-    expect(wrapper.emitted("create")).toEqual([[request]]);
+      expect(
+        wrapper.findAll('[data-testid="quiz-include-similar-music"]'),
+      ).toHaveLength(1);
+      expect(toggle.attributes("role")).toBe("switch");
+      expect(toggle.attributes("aria-checked")).toBe("false");
+      expect(
+        wrapper.get('label[for="quiz-include-similar-music"]').text(),
+      ).toBe("providers.music_quiz.include_similar_music");
+      expect(wrapper.text()).toContain(
+        "providers.music_quiz.include_similar_music_help",
+      );
+
+      await wrapper.get(`[data-testid="create-${quizType}"]`).trigger("click");
+      expect(wrapper.emitted("create")?.[0]?.[0]).toMatchObject({
+        quiz_type: quizType,
+        answer_type: answerType,
+        config: {
+          include_similar_music: false,
+        },
+      });
+
+      await toggle.trigger("click");
+      expect(toggle.attributes("aria-checked")).toBe("true");
+      await wrapper.get(`[data-testid="create-${quizType}"]`).trigger("click");
+      expect(wrapper.emitted("create")?.[1]?.[0]).toMatchObject({
+        quiz_type: quizType,
+        answer_type: answerType,
+        config: {
+          include_similar_music: true,
+        },
+      });
+    },
+  );
+
+  it("preserves the shared choice between game types and resets fresh setup", async () => {
+    const wrapper = mountWizard({ availableQuizTypes: ["trivia"] });
+
+    await selectGame(wrapper, "game_type");
+    await wrapper
+      .get('[data-testid="quiz-include-similar-music"]')
+      .trigger("click");
+    await wrapper
+      .findAll("button")
+      .find((button) => button.text().includes("back"))
+      ?.trigger("click");
+    await selectGame(wrapper, "trivia_type");
+
+    expect(
+      wrapper
+        .get('[data-testid="quiz-include-similar-music"]')
+        .attributes("aria-checked"),
+    ).toBe("true");
+
+    wrapper.unmount();
+    const freshWrapper = mountWizard({ availableQuizTypes: ["trivia"] });
+    await selectGame(freshWrapper, "timeline_type");
+    expect(
+      freshWrapper
+        .get('[data-testid="quiz-include-similar-music"]')
+        .attributes("aria-checked"),
+    ).toBe("false");
   });
 });
 
-function mountWizard() {
+function mountWizard(props: { availableQuizTypes?: string[] } = {}) {
   return mount(MusicQuizSetupWizard, {
-    props: { busy: false },
+    props: { busy: false, ...props },
     global: {
       stubs: {
         Button: {
@@ -122,4 +204,15 @@ function mountWizard() {
       },
     },
   });
+}
+
+async function selectGame(
+  wrapper: ReturnType<typeof mountWizard>,
+  label: string,
+) {
+  await wrapper
+    .findAll("section button")
+    .find((button) => button.text().includes(label))
+    ?.trigger("click");
+  await nextTick();
 }

--- a/tests/components/music-quiz/MusicTimelineSetup.test.ts
+++ b/tests/components/music-quiz/MusicTimelineSetup.test.ts
@@ -65,7 +65,7 @@ describe("MusicTimelineSetup", () => {
 
   it("emits only the Music Timeline configuration fields", async () => {
     const wrapper = mount(MusicTimelineSetup, {
-      props: { busy: false },
+      props: { busy: false, includeSimilarMusic: false },
       global: {
         stubs: {
           Button: { template: "<button><slot /></button>" },
@@ -97,6 +97,7 @@ describe("MusicTimelineSetup", () => {
         round_count: 5,
         answer_duration: 30,
         source_uris: ["playlist:test"],
+        include_similar_music: false,
         artist_bonus_mode: "off",
         title_bonus_mode: "off",
       },
@@ -105,7 +106,7 @@ describe("MusicTimelineSetup", () => {
 
   it("keeps bonus modes independent without adding a name", async () => {
     const wrapper = mount(MusicTimelineSetup, {
-      props: { busy: false },
+      props: { busy: false, includeSimilarMusic: true },
       global: {
         stubs: {
           Button: { template: "<button><slot /></button>" },
@@ -134,6 +135,7 @@ describe("MusicTimelineSetup", () => {
     const request = wrapper.emitted("create")?.[0]?.[0];
     expect(request).toMatchObject({
       config: {
+        include_similar_music: true,
         artist_bonus_mode: "free_text",
         title_bonus_mode: "multiple_choice",
       },
@@ -142,7 +144,9 @@ describe("MusicTimelineSetup", () => {
   });
 
   it("labels removable sources for keyboard and screen-reader users", async () => {
-    const wrapper = mount(MusicTimelineSetup, { props: { busy: false } });
+    const wrapper = mount(MusicTimelineSetup, {
+      props: { busy: false, includeSimilarMusic: false },
+    });
 
     await wrapper
       .find('input[placeholder="providers.music_quiz.search_music"]')

--- a/tests/components/music-quiz/TriviaSetup.test.ts
+++ b/tests/components/music-quiz/TriviaSetup.test.ts
@@ -48,7 +48,7 @@ describe("TriviaSetup", () => {
   });
 
   it("preserves selected sources, difficulty, and language in the create request", async () => {
-    const wrapper = mountSetup();
+    const wrapper = mountSetup(true);
 
     await wrapper.get('[data-testid="select-sources"]').trigger("click");
     await wrapper.get("#trivia-difficulty").setValue("hard");
@@ -72,6 +72,7 @@ describe("TriviaSetup", () => {
             answer_duration: 30,
             difficulty: "hard",
             source_uris: ["library://playlist/1", "library://genre/rock"],
+            include_similar_music: true,
           },
         },
       ],
@@ -100,6 +101,7 @@ describe("TriviaSetup", () => {
         answer_duration: 30,
         difficulty: "normal",
         source_uris: ["library://playlist/1", "library://genre/rock"],
+        include_similar_music: false,
       },
     });
   });
@@ -178,9 +180,9 @@ describe("TriviaSetup", () => {
   });
 });
 
-function mountSetup() {
+function mountSetup(includeSimilarMusic = false) {
   return mount(TriviaSetup, {
-    props: { busy: false },
+    props: { busy: false, includeSimilarMusic },
     global: {
       stubs: {
         MusicQuizSourceSelector: {

--- a/tests/components/music-quiz/registry.test.ts
+++ b/tests/components/music-quiz/registry.test.ts
@@ -348,7 +348,7 @@ describe("Music Quiz registries", () => {
     const fixture = GAME_MOUNT_FIXTURES[game.id];
     const wrappers = [
       shallowMount(game.adapters.setup, {
-        props: { busy: false },
+        props: { busy: false, includeSimilarMusic: false },
       }),
       shallowMount(game.adapters.player, {
         props: {

--- a/tests/composables/useMusicQuiz.test.ts
+++ b/tests/composables/useMusicQuiz.test.ts
@@ -21,6 +21,9 @@ import {
   parseMusicQuizType,
   resetMusicQuiz,
   submitMusicQuizAnswer,
+  type MusicQuizHostState,
+  type MusicQuizInfo,
+  type MusicQuizPersonalizedState,
   type MusicQuizProviderEvent,
   type MusicQuizPublicState,
   type MusicQuizTriviaInfo,
@@ -62,6 +65,7 @@ describe("useMusicQuiz commands", () => {
         answer_duration: 30,
         difficulty: "hard",
         source_uris: ["library://track/1"],
+        include_similar_music: false,
         name: "Test Quiz",
       },
     });
@@ -73,6 +77,7 @@ describe("useMusicQuiz commands", () => {
       answer_duration: 30,
       difficulty: "hard",
       source_uris: ["library://track/1"],
+      include_similar_music: false,
       name: "Test Quiz",
     });
   });
@@ -127,6 +132,7 @@ describe("useMusicQuiz commands", () => {
         answer_duration: 45,
         difficulty: "hard",
         source_uris: ["library://playlist/1", "library://genre/rock"],
+        include_similar_music: true,
         name: "Friday Trivia",
       },
     });
@@ -140,6 +146,7 @@ describe("useMusicQuiz commands", () => {
       answer_duration: 45,
       difficulty: "hard",
       source_uris: ["library://playlist/1", "library://genre/rock"],
+      include_similar_music: true,
       name: "Friday Trivia",
     });
   });
@@ -161,6 +168,7 @@ describe("useMusicQuiz commands", () => {
         round_count: 10,
         answer_duration: 45,
         source_uris: ["library://playlist/1"],
+        include_similar_music: false,
         name: "Friday Music Timeline",
         artist_bonus_mode: "free_text",
         title_bonus_mode: "multiple_choice",
@@ -172,6 +180,7 @@ describe("useMusicQuiz commands", () => {
       round_count: 10,
       answer_duration: 45,
       source_uris: ["library://playlist/1"],
+      include_similar_music: false,
       name: "Friday Music Timeline",
       artist_bonus_mode: "free_text",
       title_bonus_mode: "multiple_choice",
@@ -352,6 +361,63 @@ describe("useMusicQuiz commands", () => {
     expect("play_reveal_audio" in legacyState).toBe(false);
     expect(info.play_reveal_audio).toBe(false);
     expect("play_reveal_audio" in legacyInfo).toBe(false);
+  });
+
+  it("types similar music across server state while allowing legacy payloads", () => {
+    const publicState = {
+      quiz_type: "guess_the_song",
+      answer_type: "multiple_choice",
+      phase: "lobby",
+      name: "Quiz",
+      include_similar_music: true,
+      round_count: 5,
+      suggestion_count: 4,
+      answer_duration: 30,
+      mode: "venue",
+      players: [],
+      current_round: null,
+    } satisfies MusicQuizPublicState;
+    const personalizedState = {
+      ...publicState,
+      you: {
+        name: "Player",
+        score: 0,
+        ready: false,
+        active_from_round: 0,
+      },
+    } satisfies MusicQuizPersonalizedState;
+    const hostState = {
+      ...publicState,
+      created_at: 1,
+      sources: [],
+      join_url: "https://example.test/quiz",
+      rounds: [],
+    } satisfies MusicQuizHostState;
+    const info = {
+      quiz_type: "guess_the_song",
+      answer_type: "multiple_choice",
+      phase: "lobby",
+      name: "Quiz",
+      include_similar_music: false,
+      player_count: 1,
+      round_count: 5,
+      mode: "venue",
+    } satisfies MusicQuizInfo;
+    const legacyInfo = {
+      quiz_type: "guess_the_song",
+      answer_type: "multiple_choice",
+      phase: "lobby",
+      name: "Quiz",
+      player_count: 1,
+      round_count: 5,
+      mode: "venue",
+    } satisfies MusicQuizInfo;
+
+    expect(publicState.include_similar_music).toBe(true);
+    expect(personalizedState.include_similar_music).toBe(true);
+    expect(hostState.include_similar_music).toBe(true);
+    expect(info.include_similar_music).toBe(false);
+    expect("include_similar_music" in legacyInfo).toBe(false);
   });
 
   it("preserves nullable server fields in supported state", () => {


### PR DESCRIPTION
Adds optional recommended tracks beyond selected quiz sources, supported by music-assistant/server#4765.

- Add one shared **Include similar music** setting for all quiz types
- Preserve the choice while switching game types and send it explicitly for every new quiz
- Support the setting in quiz state types while remaining compatible with older servers