### PR TITLE
Prevent duplicate Quiz actions

### DIFF
--- a/src/composables/useListenIn.ts
+++ b/src/composables/useListenIn.ts
@@ -81,6 +81,7 @@ export function useListenIn(options: UseListenInOptions) {
   }
 
   async function enableListenIn() {
+    if (busy.value) return false;
     const playerId = webPlayerId.value;
     if (!playerId) {
       notifyError(errorMessages.noWebPlayer);
@@ -105,6 +106,7 @@ export function useListenIn(options: UseListenInOptions) {
   }
 
   async function disableListenIn() {
+    if (busy.value) return false;
     const playerId = webPlayerId.value;
     if (!playerId) return false;
     busy.value = true;

--- a/src/composables/useMusicQuizHost.ts
+++ b/src/composables/useMusicQuizHost.ts
@@ -111,6 +111,7 @@ export function useMusicQuizHost(options: UseMusicQuizHostOptions) {
   }
 
   async function create(request: MusicQuizCreateRequest) {
+    if (busy.value) return false;
     busy.value = true;
     try {
       const nextState = await createMusicQuiz(request);
@@ -127,6 +128,7 @@ export function useMusicQuizHost(options: UseMusicQuizHostOptions) {
   }
 
   async function start() {
+    if (busy.value) return false;
     busy.value = true;
     try {
       const nextState = await startMusicQuiz();
@@ -143,6 +145,7 @@ export function useMusicQuizHost(options: UseMusicQuizHostOptions) {
   }
 
   async function reveal() {
+    if (busy.value) return false;
     busy.value = true;
     try {
       const nextState = await revealMusicQuiz();
@@ -159,6 +162,7 @@ export function useMusicQuizHost(options: UseMusicQuizHostOptions) {
   }
 
   async function next() {
+    if (busy.value) return false;
     busy.value = true;
     try {
       const nextState = await nextMusicQuiz();
@@ -175,6 +179,7 @@ export function useMusicQuizHost(options: UseMusicQuizHostOptions) {
   }
 
   async function reset(autoStart = false) {
+    if (busy.value) return false;
     busy.value = true;
     try {
       const nextState = await resetMusicQuiz(autoStart);
@@ -191,6 +196,7 @@ export function useMusicQuizHost(options: UseMusicQuizHostOptions) {
   }
 
   async function deleteGame() {
+    if (busy.value) return false;
     busy.value = true;
     try {
       await deleteMusicQuiz();

--- a/src/composables/useMusicQuizPlayer.ts
+++ b/src/composables/useMusicQuizPlayer.ts
@@ -132,6 +132,7 @@ export function useMusicQuizPlayer(options: UseMusicQuizPlayerOptions) {
   }
 
   async function join(name: string) {
+    if (busy.value) return false;
     const trimmedName = name.trim();
     if (!trimmedName) return false;
     const joined = await performJoin(trimmedName, true, gameGeneration);
@@ -144,6 +145,7 @@ export function useMusicQuizPlayer(options: UseMusicQuizPlayerOptions) {
   }
 
   async function submitAnswer(submission: MusicQuizAnswerSubmission) {
+    if (busy.value) return false;
     const currentPlayerId = playerId.value;
     if (!currentPlayerId) {
       notifyError($t("providers.music_quiz.error_not_joined"));

--- a/src/composables/useMusicQuizPlayer.ts
+++ b/src/composables/useMusicQuizPlayer.ts
@@ -462,6 +462,7 @@ export function useMusicQuizPlayer(options: UseMusicQuizPlayerOptions) {
     if (
       !name ||
       disposed ||
+      busy.value ||
       playerId.value ||
       autoJoinAttemptedGeneration === requestGeneration
     ) {

--- a/tests/composables/useListenIn.test.ts
+++ b/tests/composables/useListenIn.test.ts
@@ -59,6 +59,20 @@ function create(mode: ListenInMode | undefined = "venue") {
   return { ...composable, notifyError };
 }
 
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((promiseResolve) => {
+    resolve = promiseResolve;
+  });
+  return { promise, resolve };
+}
+
+function getCommandCallCount(command: string) {
+  return mockSendCommand.mock.calls.filter(
+    ([sentCommand]) => sentCommand === command,
+  ).length;
+}
+
 describe("useListenIn", () => {
   beforeEach(() => {
     mockSendCommand.mockReset();
@@ -196,6 +210,35 @@ describe("useListenIn", () => {
       expect(primedBeforeCommand).toBe(true);
     });
 
+    it("serializes concurrent starts and allows a later retry", async () => {
+      const pendingStart = deferred<void>();
+      const { busy, enableListenIn } = create();
+      let startCalls = 0;
+      mockPrimeAudio.mockClear();
+      mockSendCommand.mockImplementation((command: string) => {
+        if (command !== "party/listen_in") return Promise.resolve(true);
+        startCalls += 1;
+        return startCalls === 1
+          ? pendingStart.promise
+          : Promise.resolve(undefined);
+      });
+
+      const firstStart = enableListenIn();
+      await expect(enableListenIn()).resolves.toBe(false);
+
+      expect(getCommandCallCount("party/listen_in")).toBe(1);
+      expect(mockPrimeAudio).toHaveBeenCalledOnce();
+      expect(busy.value).toBe(true);
+
+      pendingStart.resolve();
+      await expect(firstStart).resolves.toBe(true);
+      expect(busy.value).toBe(false);
+
+      await expect(enableListenIn()).resolves.toBe(true);
+      expect(getCommandCallCount("party/listen_in")).toBe(2);
+      expect(mockPrimeAudio).toHaveBeenCalledTimes(2);
+    });
+
     it("does not prime the audio output without a web player", async () => {
       webPlayer.player_id = null;
       const { enableListenIn } = create();
@@ -246,6 +289,32 @@ describe("useListenIn", () => {
         web_player_id: "wp-1",
       });
       expect(isListeningIn.value).toBe(false);
+    });
+
+    it("serializes concurrent stops and allows a later retry", async () => {
+      const pendingStop = deferred<void>();
+      const { busy, disableListenIn } = create();
+      let stopCalls = 0;
+      mockSendCommand.mockImplementation((command: string) => {
+        if (command !== "party/stop_listen_in") return Promise.resolve(true);
+        stopCalls += 1;
+        return stopCalls === 1
+          ? pendingStop.promise
+          : Promise.resolve(undefined);
+      });
+
+      const firstStop = disableListenIn();
+      await expect(disableListenIn()).resolves.toBe(false);
+
+      expect(getCommandCallCount("party/stop_listen_in")).toBe(1);
+      expect(busy.value).toBe(true);
+
+      pendingStop.resolve();
+      await expect(firstStop).resolves.toBe(true);
+      expect(busy.value).toBe(false);
+
+      await expect(disableListenIn()).resolves.toBe(true);
+      expect(getCommandCallCount("party/stop_listen_in")).toBe(2);
     });
 
     it("silently bails out without a web player", async () => {

--- a/tests/composables/useMusicQuizHost.test.ts
+++ b/tests/composables/useMusicQuizHost.test.ts
@@ -1,17 +1,25 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, type Mock, vi } from "vitest";
 
 const {
+  mockCreateMusicQuiz,
   mockDeleteMusicQuiz,
   mockGetAvailableMusicQuizTypes,
   mockGetMusicQuiz,
+  mockNextMusicQuiz,
+  mockRevealMusicQuiz,
   mockResetMusicQuiz,
+  mockStartMusicQuiz,
   mockSubscribe,
   providerHandlers,
 } = vi.hoisted(() => ({
+  mockCreateMusicQuiz: vi.fn(),
   mockDeleteMusicQuiz: vi.fn(),
   mockGetAvailableMusicQuizTypes: vi.fn(),
   mockGetMusicQuiz: vi.fn(),
+  mockNextMusicQuiz: vi.fn(),
+  mockRevealMusicQuiz: vi.fn(),
   mockResetMusicQuiz: vi.fn(),
+  mockStartMusicQuiz: vi.fn(),
   mockSubscribe: vi.fn(),
   providerHandlers: [] as Array<
     (event: { object_id?: string; data?: unknown }) => void
@@ -30,10 +38,10 @@ vi.mock("vue", async () => {
 vi.mock("@/composables/useMusicQuiz", () => ({
   getMusicQuiz: mockGetMusicQuiz,
   getAvailableMusicQuizTypes: mockGetAvailableMusicQuizTypes,
-  createMusicQuiz: vi.fn(),
-  startMusicQuiz: vi.fn(),
-  revealMusicQuiz: vi.fn(),
-  nextMusicQuiz: vi.fn(),
+  createMusicQuiz: mockCreateMusicQuiz,
+  startMusicQuiz: mockStartMusicQuiz,
+  revealMusicQuiz: mockRevealMusicQuiz,
+  nextMusicQuiz: mockNextMusicQuiz,
   resetMusicQuiz: mockResetMusicQuiz,
   deleteMusicQuiz: mockDeleteMusicQuiz,
   isSupportedMusicQuiz: (value: { quiz_type?: string; answer_type?: string }) =>
@@ -60,6 +68,7 @@ vi.mock("@/plugins/i18n", () => ({
 }));
 
 import { EventType } from "@/plugins/api/interfaces";
+import type { MusicQuizCreateRequest } from "@/composables/useMusicQuiz";
 import { useMusicQuizHost } from "@/composables/useMusicQuizHost";
 
 const HOST_STATE = {
@@ -79,26 +88,101 @@ const HOST_STATE = {
   current_round: null,
 } as const;
 
+const CREATE_REQUEST: MusicQuizCreateRequest = {
+  quiz_type: "guess_the_song",
+  answer_type: "multiple_choice",
+  config: {
+    round_count: 5,
+    suggestion_count: 4,
+    answer_duration: 30,
+    difficulty: "normal",
+    source_uris: [],
+    include_similar_music: false,
+  },
+};
+
+type Host = ReturnType<typeof useMusicQuizHost>;
+
+const HOST_ACTIONS = [
+  {
+    name: "create",
+    command: mockCreateMusicQuiz,
+    invoke: (host: Host) => host.create(CREATE_REQUEST),
+    result: HOST_STATE,
+  },
+  {
+    name: "start",
+    command: mockStartMusicQuiz,
+    invoke: (host: Host) => host.start(),
+    result: HOST_STATE,
+  },
+  {
+    name: "reveal",
+    command: mockRevealMusicQuiz,
+    invoke: (host: Host) => host.reveal(),
+    result: HOST_STATE,
+  },
+  {
+    name: "next",
+    command: mockNextMusicQuiz,
+    invoke: (host: Host) => host.next(),
+    result: HOST_STATE,
+  },
+  {
+    name: "reset",
+    command: mockResetMusicQuiz,
+    invoke: (host: Host) => host.reset(),
+    result: HOST_STATE,
+  },
+  {
+    name: "delete",
+    command: mockDeleteMusicQuiz,
+    invoke: (host: Host) => host.deleteGame(),
+    result: undefined,
+  },
+] satisfies Array<{
+  name: string;
+  command: Mock;
+  invoke: (host: Host) => Promise<boolean>;
+  result: typeof HOST_STATE | undefined;
+}>;
+
 async function flushPromises() {
   await Promise.resolve();
   await Promise.resolve();
 }
 
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((promiseResolve) => {
+    resolve = promiseResolve;
+  });
+  return { promise, resolve };
+}
+
 describe("useMusicQuizHost", () => {
   beforeEach(() => {
     providerHandlers.length = 0;
+    mockCreateMusicQuiz.mockReset();
     mockDeleteMusicQuiz.mockReset();
     mockGetAvailableMusicQuizTypes.mockReset();
     mockGetMusicQuiz.mockReset();
+    mockNextMusicQuiz.mockReset();
+    mockRevealMusicQuiz.mockReset();
     mockResetMusicQuiz.mockReset();
+    mockStartMusicQuiz.mockReset();
     mockSubscribe.mockReset();
+    mockCreateMusicQuiz.mockResolvedValue({ ...HOST_STATE });
     mockDeleteMusicQuiz.mockResolvedValue(undefined);
     mockGetAvailableMusicQuizTypes.mockResolvedValue([
       "guess_the_song",
       "music_timeline",
     ]);
     mockGetMusicQuiz.mockResolvedValue({ ...HOST_STATE });
+    mockNextMusicQuiz.mockResolvedValue({ ...HOST_STATE });
+    mockRevealMusicQuiz.mockResolvedValue({ ...HOST_STATE });
     mockResetMusicQuiz.mockResolvedValue({ ...HOST_STATE });
+    mockStartMusicQuiz.mockResolvedValue({ ...HOST_STATE });
     mockSubscribe.mockImplementation(
       (
         _event: EventType,
@@ -196,6 +280,29 @@ describe("useMusicQuizHost", () => {
     expect(mockResetMusicQuiz).toHaveBeenNthCalledWith(1, false);
     expect(mockResetMusicQuiz).toHaveBeenNthCalledWith(2, true);
   });
+
+  it.each(HOST_ACTIONS)(
+    "serializes concurrent $name commands",
+    async ({ command, invoke, result }) => {
+      const pending = deferred<typeof result>();
+      command.mockReturnValueOnce(pending.promise);
+      const host = useMusicQuizHost({ notifyError: vi.fn() });
+      await flushPromises();
+
+      const firstAction = invoke(host);
+      await expect(invoke(host)).resolves.toBe(false);
+
+      expect(command).toHaveBeenCalledOnce();
+      expect(host.busy.value).toBe(true);
+
+      pending.resolve(result);
+      await expect(firstAction).resolves.toBe(true);
+      expect(host.busy.value).toBe(false);
+
+      await expect(invoke(host)).resolves.toBe(true);
+      expect(command).toHaveBeenCalledTimes(2);
+    },
+  );
 
   it("treats a no-active-game string as an empty state without a toast", async () => {
     mockGetMusicQuiz.mockRejectedValue("There is no active Music Quiz game");

--- a/tests/composables/useMusicQuizPlayer.test.ts
+++ b/tests/composables/useMusicQuizPlayer.test.ts
@@ -958,6 +958,33 @@ describe("useMusicQuizPlayer", () => {
     expect(mockJoinMusicQuiz).toHaveBeenCalledTimes(2);
   });
 
+  it("does not auto-join while a manual join is pending", async () => {
+    storedPlayerName.value = "Remembered Player";
+    const pendingInfo = deferred<typeof QUIZ_INFO>();
+    const pendingJoin = deferred<{
+      player_id: string;
+      state: typeof PLAYER_STATE;
+    }>();
+    mockGetMusicQuizInfo.mockReturnValue(pendingInfo.promise);
+    mockJoinMusicQuiz.mockReturnValue(pendingJoin.promise);
+    const player = useMusicQuizPlayer({ notifyError: vi.fn() });
+    await flushPromises();
+
+    const manualJoin = player.join("Manual Player");
+    pendingInfo.resolve(QUIZ_INFO);
+    await flushPromises();
+
+    expect(mockJoinMusicQuiz).toHaveBeenCalledOnce();
+    expect(mockJoinMusicQuiz).toHaveBeenCalledWith("Manual Player");
+
+    pendingJoin.resolve({
+      player_id: "manual-player",
+      state: PLAYER_STATE,
+    });
+    await expect(manualJoin).resolves.toBe(true);
+    expect(player.busy.value).toBe(false);
+  });
+
   it("automatically joins an active game once with the remembered name", async () => {
     storedPlayerName.value = "Player";
     mockGetMusicQuizInfo.mockResolvedValue(QUIZ_INFO);

--- a/tests/composables/useMusicQuizPlayer.test.ts
+++ b/tests/composables/useMusicQuizPlayer.test.ts
@@ -925,6 +925,39 @@ describe("useMusicQuizPlayer", () => {
     expect(player.rememberedName.value).toBe("Player One");
   });
 
+  it("serializes concurrent manual joins and allows a later retry", async () => {
+    mockGetMusicQuizInfo.mockResolvedValue(QUIZ_INFO);
+    const pendingJoin = deferred<{
+      player_id: string;
+      state: typeof PLAYER_STATE;
+    }>();
+    mockJoinMusicQuiz
+      .mockReturnValueOnce(pendingJoin.promise)
+      .mockResolvedValue({
+        player_id: "next-player",
+        state: PLAYER_STATE,
+      });
+    const player = useMusicQuizPlayer({ notifyError: vi.fn() });
+    await flushPromises();
+
+    const firstJoin = player.join("Player");
+    await expect(player.join("Player")).resolves.toBe(false);
+
+    expect(mockJoinMusicQuiz).toHaveBeenCalledOnce();
+    expect(player.busy.value).toBe(true);
+
+    pendingJoin.resolve({
+      player_id: "first-player",
+      state: PLAYER_STATE,
+    });
+    await expect(firstJoin).resolves.toBe(true);
+    expect(player.busy.value).toBe(false);
+
+    await player.leave();
+    await expect(player.join("Player")).resolves.toBe(true);
+    expect(mockJoinMusicQuiz).toHaveBeenCalledTimes(2);
+  });
+
   it("automatically joins an active game once with the remembered name", async () => {
     storedPlayerName.value = "Player";
     mockGetMusicQuizInfo.mockResolvedValue(QUIZ_INFO);
@@ -1027,6 +1060,8 @@ describe("useMusicQuizPlayer", () => {
     });
     await flushPromises();
 
+    expect(mockJoinMusicQuiz).toHaveBeenCalledTimes(2);
+    expect(mockJoinMusicQuiz).toHaveBeenNthCalledWith(2, "Player");
     expect(player.playerId.value).toBe("next-player");
     expect(player.busy.value).toBe(false);
 
@@ -1218,6 +1253,34 @@ describe("useMusicQuizPlayer", () => {
       "suggestion-1",
     );
     expect(player.state.value).toEqual(answeredState);
+  });
+
+  it("serializes concurrent answers and allows a later retry", async () => {
+    storedPlayerId.value = "stored-player";
+    const pendingAnswer = deferred<typeof PLAYER_STATE>();
+    mockGetMusicQuizState.mockResolvedValue(PLAYER_STATE);
+    mockAnswerMusicQuiz
+      .mockReturnValueOnce(pendingAnswer.promise)
+      .mockResolvedValue(PLAYER_STATE);
+    const player = useMusicQuizPlayer({ notifyError: vi.fn() });
+    await flushPromises();
+    const submission = {
+      answer_type: "multiple_choice",
+      suggestion_id: "suggestion-1",
+    } as const;
+
+    const firstAnswer = player.submitAnswer(submission);
+    await expect(player.submitAnswer(submission)).resolves.toBe(false);
+
+    expect(mockAnswerMusicQuiz).toHaveBeenCalledOnce();
+    expect(player.busy.value).toBe(true);
+
+    pendingAnswer.resolve(PLAYER_STATE);
+    await expect(firstAnswer).resolves.toBe(true);
+    expect(player.busy.value).toBe(false);
+
+    await expect(player.submitAnswer(submission)).resolves.toBe(true);
+    expect(mockAnswerMusicQuiz).toHaveBeenCalledTimes(2);
   });
 
   it("does not re-enable stale controls when action refresh fails", async () => {


### PR DESCRIPTION
Rapid repeated actions could send the same Quiz or Listen-in command more than once before the interface updated.

- Serialize host and player Quiz actions while one is already running
- Prevent duplicate Listen-in start/stop commands and audio priming
- Preserve automatic guest joining across new Quiz games