### PR TITLE
Improve Music Quiz accessibility

### DIFF
--- a/src/components/music-quiz/MusicQuizCountdown.vue
+++ b/src/components/music-quiz/MusicQuizCountdown.vue
@@ -21,7 +21,7 @@
         :stroke-width="STROKE_WIDTH"
       />
       <circle
-        class="transition-[stroke-dashoffset] duration-200 ease-linear"
+        class="transition-[stroke-dashoffset] duration-200 ease-linear motion-reduce:transition-none"
         :class="isUrgent ? 'stroke-destructive' : 'stroke-primary'"
         fill="none"
         stroke-linecap="round"

--- a/src/components/music-quiz/MusicQuizPodium.vue
+++ b/src/components/music-quiz/MusicQuizPodium.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="flex items-end justify-center gap-3 sm:gap-5">
+  <div class="flex items-end justify-center gap-3 sm:gap-5" aria-hidden="true">
     <div
       v-for="spot in spots"
       :key="spot.row.name"

--- a/src/components/music-quiz/MusicQuizSetupWizard.vue
+++ b/src/components/music-quiz/MusicQuizSetupWizard.vue
@@ -21,7 +21,7 @@
     </div>
 
     <section v-if="step === 1" class="flex flex-col gap-3">
-      <h2 class="text-lg font-semibold">
+      <h2 ref="chooseHeading" class="text-lg font-semibold" tabindex="-1">
         {{ $t("providers.music_quiz.choose_game_type") }}
       </h2>
       <div class="grid gap-3 sm:grid-cols-2">
@@ -56,7 +56,7 @@
           v-if="selectedType"
           class="text-primary size-5"
         />
-        <h2 class="text-lg font-semibold">
+        <h2 ref="configureHeading" class="text-lg font-semibold" tabindex="-1">
           {{ $t("providers.music_quiz.configure_game") }}
         </h2>
       </div>
@@ -103,7 +103,7 @@ import { Switch } from "@/components/ui/switch";
 import type { MusicQuizCreateRequest } from "@/composables/useMusicQuiz";
 import { $t } from "@/plugins/i18n";
 import { ArrowLeft } from "@lucide/vue";
-import { computed, ref } from "vue";
+import { computed, nextTick, ref } from "vue";
 
 const TOTAL_STEPS = 2;
 
@@ -123,14 +123,20 @@ const availableGameTypes = computed(() =>
 const step = ref<1 | 2>(1);
 const selectedType = ref<MusicQuizGameDefinition | null>(null);
 const includeSimilarMusic = ref(false);
+const chooseHeading = ref<HTMLHeadingElement | null>(null);
+const configureHeading = ref<HTMLHeadingElement | null>(null);
 
-function selectType(type: MusicQuizGameDefinition) {
+async function selectType(type: MusicQuizGameDefinition) {
   selectedType.value = type;
   step.value = 2;
+  await nextTick();
+  configureHeading.value?.focus({ preventScroll: true });
 }
 
-function back() {
+async function back() {
   step.value = 1;
+  await nextTick();
+  chooseHeading.value?.focus({ preventScroll: true });
 }
 
 function onConfigCreate(request: MusicQuizCreateRequest) {

--- a/src/components/music-quiz/MusicQuizSourceSelector.vue
+++ b/src/components/music-quiz/MusicQuizSourceSelector.vue
@@ -26,6 +26,7 @@
       </div>
       <div
         v-if="selectedSources.length"
+        ref="selectedList"
         class="flex max-h-52 flex-col gap-2 overflow-y-auto overscroll-contain"
       >
         <button
@@ -36,7 +37,7 @@
           :aria-label="
             $t('providers.music_quiz.remove_music_source', [item.name])
           "
-          @click="removeSource(item.uri)"
+          @click="onSourceRemove(item.uri)"
         >
           <span class="flex min-w-0 flex-col">
             <strong class="truncate">{{ item.name }}</strong>
@@ -47,7 +48,13 @@
           <X class="text-muted-foreground size-4 shrink-0" />
         </button>
       </div>
-      <p v-else class="text-muted-foreground text-sm">
+      <p
+        v-else
+        ref="emptyState"
+        class="text-muted-foreground text-sm"
+        role="status"
+        tabindex="-1"
+      >
         {{ $t("providers.music_quiz.pick_at_least_one_source") }}
       </p>
     </Field>
@@ -73,7 +80,7 @@ import {
 } from "@/plugins/api/interfaces";
 import { $t } from "@/plugins/i18n";
 import { X } from "@lucide/vue";
-import { watch } from "vue";
+import { nextTick, ref, watch } from "vue";
 
 defineProps<{ inputId: string }>();
 const sourceUris = defineModel<string[]>({ required: true });
@@ -85,6 +92,8 @@ const {
   add: addSource,
   remove: removeSource,
 } = useMusicQuizSources();
+const selectedList = ref<HTMLDivElement | null>(null);
+const emptyState = ref<HTMLParagraphElement | null>(null);
 
 watch(selectedSourceUris, (uris) => {
   sourceUris.value = uris;
@@ -93,6 +102,25 @@ watch(selectedSourceUris, (uris) => {
 function onSourceSelect(item: MediaItemTypeOrItemMapping) {
   if (!isMusicQuizSourceItem(item)) return;
   addSource(item);
+}
+
+async function onSourceRemove(uri: string) {
+  const removedIndex = selectedSources.value.findIndex(
+    (source) => source.uri === uri,
+  );
+  removeSource(uri);
+  await nextTick();
+
+  if (!selectedSources.value.length) {
+    emptyState.value?.focus({ preventScroll: true });
+    return;
+  }
+
+  const removeButtons =
+    selectedList.value?.querySelectorAll<HTMLButtonElement>("button");
+  removeButtons?.[Math.min(removedIndex, removeButtons.length - 1)]?.focus({
+    preventScroll: true,
+  });
 }
 
 function sourceSubtitle(item: MusicQuizSourceItem) {

--- a/src/components/music-quiz/game-types/guess-the-song/GuessTheSongReveal.vue
+++ b/src/components/music-quiz/game-types/guess-the-song/GuessTheSongReveal.vue
@@ -38,6 +38,7 @@
               type="button"
               variant="outline"
               :title="$t('providers.music_quiz.copy_music_name')"
+              :aria-label="$t('providers.music_quiz.copy_music_name')"
               @click="emit('copy-title')"
             >
               <Copy class="size-4" />

--- a/tests/components/music-quiz/GuessTheSongReveal.test.ts
+++ b/tests/components/music-quiz/GuessTheSongReveal.test.ts
@@ -53,4 +53,16 @@ describe("GuessTheSongReveal", () => {
     expect(wrapper.text()).toContain("no_lyrics_available");
     expect(wrapper.text()).not.toContain("providers.music_quiz.loading_lyrics");
   });
+
+  it("uses the copy tooltip as the button's accessible name", () => {
+    const wrapper = mountReveal(false);
+    const copyButton = wrapper.get("button");
+
+    expect(copyButton.attributes("title")).toBe(
+      "providers.music_quiz.copy_music_name",
+    );
+    expect(copyButton.attributes("aria-label")).toBe(
+      "providers.music_quiz.copy_music_name",
+    );
+  });
 });

--- a/tests/components/music-quiz/MusicQuizCountdown.test.ts
+++ b/tests/components/music-quiz/MusicQuizCountdown.test.ts
@@ -1,0 +1,18 @@
+import MusicQuizCountdown from "@/components/music-quiz/MusicQuizCountdown.vue";
+import { mount } from "@vue/test-utils";
+import { describe, expect, it } from "vitest";
+
+describe("MusicQuizCountdown", () => {
+  it("disables the progress transition when reduced motion is requested", () => {
+    const wrapper = mount(MusicQuizCountdown, {
+      props: {
+        label: "10",
+        fraction: 0.5,
+      },
+    });
+
+    expect(wrapper.findAll("circle")[1].classes()).toContain(
+      "motion-reduce:transition-none",
+    );
+  });
+});

--- a/tests/components/music-quiz/MusicQuizCountdown.test.ts
+++ b/tests/components/music-quiz/MusicQuizCountdown.test.ts
@@ -3,7 +3,7 @@ import { mount } from "@vue/test-utils";
 import { describe, expect, it } from "vitest";
 
 describe("MusicQuizCountdown", () => {
-  it("disables the progress transition when reduced motion is requested", () => {
+  it("includes the reduced-motion transition override", () => {
     const wrapper = mount(MusicQuizCountdown, {
       props: {
         label: "10",

--- a/tests/components/music-quiz/MusicQuizSetupWizard.test.ts
+++ b/tests/components/music-quiz/MusicQuizSetupWizard.test.ts
@@ -120,6 +120,41 @@ describe("MusicQuizSetupWizard", () => {
     expect(wrapper.text()).toContain("trivia_type");
   });
 
+  it.each(["pointer", "keyboard"] as const)(
+    "moves focus between step headings after %s activation",
+    async (activation) => {
+      const wrapper = mountWizard({}, true);
+      const gameTypeButton = wrapper.get<HTMLButtonElement>("section button");
+
+      if (activation === "keyboard") {
+        gameTypeButton.element.focus();
+        await gameTypeButton.trigger("keydown", { key: "Enter" });
+      }
+      await gameTypeButton.trigger("click");
+      await nextTick();
+
+      const configureHeading = wrapper.get("h2");
+      expect(configureHeading.text()).toBe(
+        "providers.music_quiz.configure_game",
+      );
+      expect(configureHeading.attributes("tabindex")).toBe("-1");
+      expect(document.activeElement).toBe(configureHeading.element);
+
+      const backButton = wrapper.get("button");
+      backButton.element.focus();
+      await backButton.trigger("click");
+      await nextTick();
+
+      const chooseHeading = wrapper.get("h2");
+      expect(chooseHeading.text()).toBe(
+        "providers.music_quiz.choose_game_type",
+      );
+      expect(chooseHeading.attributes("tabindex")).toBe("-1");
+      expect(document.activeElement).toBe(chooseHeading.element);
+      wrapper.unmount();
+    },
+  );
+
   it.each(GAME_CASES)(
     "renders one shared, accessible setting for $quizType and serializes both values",
     async ({ label, quizType, answerType }) => {
@@ -192,9 +227,13 @@ describe("MusicQuizSetupWizard", () => {
   });
 });
 
-function mountWizard(props: { availableQuizTypes?: string[] } = {}) {
+function mountWizard(
+  props: { availableQuizTypes?: string[] } = {},
+  attachToDocument = false,
+) {
   return mount(MusicQuizSetupWizard, {
     props: { busy: false, ...props },
+    ...(attachToDocument ? { attachTo: document.body } : {}),
     global: {
       stubs: {
         Button: {

--- a/tests/components/music-quiz/MusicQuizSetupWizard.test.ts
+++ b/tests/components/music-quiz/MusicQuizSetupWizard.test.ts
@@ -120,40 +120,30 @@ describe("MusicQuizSetupWizard", () => {
     expect(wrapper.text()).toContain("trivia_type");
   });
 
-  it.each(["pointer", "keyboard"] as const)(
-    "moves focus between step headings after %s activation",
-    async (activation) => {
-      const wrapper = mountWizard({}, true);
-      const gameTypeButton = wrapper.get<HTMLButtonElement>("section button");
+  it("moves focus between step headings after navigation", async () => {
+    const wrapper = mountWizard({}, true);
+    const gameTypeButton = wrapper.get<HTMLButtonElement>("section button");
 
-      if (activation === "keyboard") {
-        gameTypeButton.element.focus();
-        await gameTypeButton.trigger("keydown", { key: "Enter" });
-      }
-      await gameTypeButton.trigger("click");
-      await nextTick();
+    gameTypeButton.element.focus();
+    await gameTypeButton.trigger("click");
+    await nextTick();
 
-      const configureHeading = wrapper.get("h2");
-      expect(configureHeading.text()).toBe(
-        "providers.music_quiz.configure_game",
-      );
-      expect(configureHeading.attributes("tabindex")).toBe("-1");
-      expect(document.activeElement).toBe(configureHeading.element);
+    const configureHeading = wrapper.get("h2");
+    expect(configureHeading.text()).toBe("providers.music_quiz.configure_game");
+    expect(configureHeading.attributes("tabindex")).toBe("-1");
+    expect(document.activeElement).toBe(configureHeading.element);
 
-      const backButton = wrapper.get("button");
-      backButton.element.focus();
-      await backButton.trigger("click");
-      await nextTick();
+    const backButton = wrapper.get("button");
+    backButton.element.focus();
+    await backButton.trigger("click");
+    await nextTick();
 
-      const chooseHeading = wrapper.get("h2");
-      expect(chooseHeading.text()).toBe(
-        "providers.music_quiz.choose_game_type",
-      );
-      expect(chooseHeading.attributes("tabindex")).toBe("-1");
-      expect(document.activeElement).toBe(chooseHeading.element);
-      wrapper.unmount();
-    },
-  );
+    const chooseHeading = wrapper.get("h2");
+    expect(chooseHeading.text()).toBe("providers.music_quiz.choose_game_type");
+    expect(chooseHeading.attributes("tabindex")).toBe("-1");
+    expect(document.activeElement).toBe(chooseHeading.element);
+    wrapper.unmount();
+  });
 
   it.each(GAME_CASES)(
     "renders one shared, accessible setting for $quizType and serializes both values",

--- a/tests/components/music-quiz/MusicQuizSourceSelector.test.ts
+++ b/tests/components/music-quiz/MusicQuizSourceSelector.test.ts
@@ -1,0 +1,144 @@
+import MediaSearch from "@/components/MediaSearch.vue";
+import MusicQuizSourceSelector from "@/components/music-quiz/MusicQuizSourceSelector.vue";
+import { MediaType, type Playlist } from "@/plugins/api/interfaces";
+import { flushPromises, mount } from "@vue/test-utils";
+import { nextTick } from "vue";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/components/MediaSearch.vue", async () => {
+  const { defineComponent } = await import("vue");
+  return {
+    default: defineComponent({
+      name: "MediaSearch",
+      inheritAttrs: false,
+      props: {
+        inputId: {
+          type: String,
+          required: true,
+        },
+      },
+      emits: ["select"],
+      template: '<input :id="inputId" data-testid="media-search-input" />',
+    }),
+  };
+});
+
+vi.mock("@/plugins/i18n", () => ({
+  $t: (key: string, values: unknown[] = []) =>
+    values.length ? `${key}:${values.join(",")}` : key,
+}));
+
+describe("MusicQuizSourceSelector", () => {
+  afterEach(() => {
+    document.body.replaceChildren();
+  });
+
+  it.each([
+    { description: "middle", removedIndex: 1, expectedFocusIndex: 1 },
+    { description: "first", removedIndex: 0, expectedFocusIndex: 0 },
+    { description: "final item", removedIndex: 2, expectedFocusIndex: 1 },
+  ])(
+    "focuses the adjacent source after removing the $description source",
+    async ({ removedIndex, expectedFocusIndex }) => {
+      const wrapper = mountSelector();
+      const sources = [
+        createPlaylist("First", 1),
+        createPlaylist("Second", 2),
+        createPlaylist("Third", 3),
+      ];
+      await selectSources(wrapper, sources);
+
+      const removeButton = getRemoveButtons(wrapper)[removedIndex];
+      removeButton.element.focus();
+      await removeButton.trigger("click");
+      await flushPromises();
+
+      const remainingButtons = getRemoveButtons(wrapper);
+      expect(
+        remainingButtons.map((button) => button.attributes("aria-label")),
+      ).toEqual(
+        sources
+          .filter((_, index) => index !== removedIndex)
+          .map(
+            (source) =>
+              `providers.music_quiz.remove_music_source:${source.name}`,
+          ),
+      );
+      expect(document.activeElement).toBe(
+        remainingButtons[expectedFocusIndex].element,
+      );
+      expect(document.activeElement).not.toBe(
+        wrapper.get('[data-testid="media-search-input"]').element,
+      );
+      wrapper.unmount();
+    },
+  );
+
+  it("focuses the empty status after removing the last source", async () => {
+    const wrapper = mountSelector();
+    await selectSources(wrapper, [createPlaylist("Only", 1)]);
+
+    const removeButton = getRemoveButtons(wrapper)[0];
+    removeButton.element.focus();
+    await removeButton.trigger("click");
+    await flushPromises();
+
+    const emptyStatus = wrapper.get('[role="status"]');
+    expect(emptyStatus.attributes("tabindex")).toBe("-1");
+    expect(emptyStatus.text()).toBe(
+      "providers.music_quiz.pick_at_least_one_source",
+    );
+    expect(document.activeElement).toBe(emptyStatus.element);
+    expect(document.activeElement).not.toBe(
+      wrapper.get('[data-testid="media-search-input"]').element,
+    );
+    wrapper.unmount();
+  });
+});
+
+function mountSelector() {
+  return mount(MusicQuizSourceSelector, {
+    attachTo: document.body,
+    props: {
+      inputId: "quiz-source-search",
+      modelValue: [],
+    },
+  });
+}
+
+async function selectSources(
+  wrapper: ReturnType<typeof mountSelector>,
+  sources: Playlist[],
+) {
+  const mediaSearch = wrapper.getComponent(MediaSearch);
+  for (const source of sources) {
+    mediaSearch.vm.$emit("select", source);
+    await nextTick();
+  }
+}
+
+function getRemoveButtons(wrapper: ReturnType<typeof mountSelector>) {
+  return wrapper.findAll<HTMLButtonElement>(
+    'button[aria-label^="providers.music_quiz.remove_music_source"]',
+  );
+}
+
+function createPlaylist(name: string, index: number): Playlist {
+  return {
+    item_id: String(index),
+    provider: "library",
+    name,
+    uri: `library://playlist/${index}`,
+    is_playable: true,
+    media_type: MediaType.PLAYLIST,
+    provider_mappings: [],
+    metadata: {},
+    favorite: false,
+    timestamp_added: 0,
+    timestamp_modified: 0,
+    owner: "",
+    is_editable: false,
+    supported_mediatypes: [MediaType.TRACK],
+    is_dynamic: false,
+  };
+}

--- a/tests/components/music-quiz/MusicQuizStages.test.ts
+++ b/tests/components/music-quiz/MusicQuizStages.test.ts
@@ -1,4 +1,6 @@
+import MusicQuizLeaderboard from "@/components/music-quiz/MusicQuizLeaderboard.vue";
 import MusicQuizPlayerStage from "@/components/music-quiz/MusicQuizPlayerStage.vue";
+import MusicQuizPodium from "@/components/music-quiz/MusicQuizPodium.vue";
 import MusicQuizPresentStage from "@/components/music-quiz/MusicQuizPresentStage.vue";
 import type { MusicQuizGameDefinition } from "@/components/music-quiz/game_types";
 import type {
@@ -577,15 +579,18 @@ describe("Music Quiz shared stages", () => {
         stubs: {
           Button: true,
           MusicQuizConnectionBanners: true,
-          MusicQuizLeaderboard: true,
-          MusicQuizPodium: {
-            template: '<div data-testid="podium" />',
-          },
         },
       },
     });
 
-    expect(wrapper.find('[data-testid="podium"]').exists()).toBe(true);
+    expect(
+      wrapper.getComponent(MusicQuizPodium).attributes("aria-hidden"),
+    ).toBe("true");
+    const leaderboard = wrapper.getComponent(MusicQuizLeaderboard);
+    expect(leaderboard.attributes("role")).toBe("region");
+    expect(leaderboard.attributes("aria-label")).toBe(
+      "providers.music_quiz.leaderboard",
+    );
     expect(wrapper.text()).toContain("Player wins");
     const finished = wrapper.get('[data-testid="music-quiz-present-finished"]');
     expect(finished.classes()).toEqual(


### PR DESCRIPTION
Some Music Quiz actions could leave keyboard and assistive-technology users without useful focus or duplicate final results.

- Keep focus on wizard steps and adjacent source controls
- Expose one semantic final leaderboard and label the copy action
- Respect reduced-motion preferences in the countdown