### PR TITLE
Fix waveform progress transitions and seeking

### DIFF
--- a/src/layouts/default/PlayerOSD/PlayerFullscreen.vue
+++ b/src/layouts/default/PlayerOSD/PlayerFullscreen.vue
@@ -750,7 +750,6 @@ const showWaveformPref = getPreference("show_waveform", true);
 let waveformLoadGeneration = 0;
 const fetchWaveform = async () => {
   const generation = ++waveformLoadGeneration;
-  waveformData.value = null;
 
   const mediaItem = store.curQueueItem?.media_item;
   // Analysis is keyed by the provider-native (streaming) item id, not the library id.
@@ -758,11 +757,13 @@ const fetchWaveform = async () => {
   if (
     !showWaveformPref.value ||
     !store.showFullscreenPlayer ||
-    mediaItem?.media_type !== MediaType.TRACK ||
-    !streamDetails
+    mediaItem?.media_type !== MediaType.TRACK
   ) {
+    waveformData.value = null;
     return;
   }
+  // Keep the current waveform mounted to prevent timeline collapse while loading.
+  if (!streamDetails) return;
 
   try {
     const waveform = await api.getWaveForm(

--- a/src/layouts/default/PlayerOSD/PlayerFullscreen.vue
+++ b/src/layouts/default/PlayerOSD/PlayerFullscreen.vue
@@ -328,6 +328,7 @@
             :show-labels="true"
             :color="sliderColor"
             :waveform="waveformData"
+            :waveform-loading="waveformLoading"
           />
         </div>
 
@@ -745,11 +746,21 @@ watch(
 
 // Waveform for the current track, rendered by PlayerTimeline instead of the flat bar.
 const waveformData = ref<number[] | null>(null);
+const waveformLoading = ref(false);
 const { getPreference, setPreference } = useUserPreferences();
 const showWaveformPref = getPreference("show_waveform", true);
 let waveformLoadGeneration = 0;
+let waveformQueueItemId: string | undefined;
+let waveformDetailsTimer: ReturnType<typeof setTimeout> | null = null;
+const WAVEFORM_DETAILS_TIMEOUT_MS = 2000;
 const fetchWaveform = async () => {
   const generation = ++waveformLoadGeneration;
+
+  const queueItemId = store.curQueueItem?.queue_item_id;
+  if (queueItemId !== waveformQueueItemId) {
+    waveformQueueItemId = queueItemId;
+    waveformData.value = null;
+  }
 
   const mediaItem = store.curQueueItem?.media_item;
   // Analysis is keyed by the provider-native (streaming) item id, not the library id.
@@ -760,11 +771,24 @@ const fetchWaveform = async () => {
     mediaItem?.media_type !== MediaType.TRACK
   ) {
     waveformData.value = null;
+    waveformLoading.value = false;
+    clearWaveformDetailsTimer();
     return;
   }
-  // Keep the current waveform mounted to prevent timeline collapse while loading.
-  if (!streamDetails) return;
+  if (!streamDetails) {
+    waveformLoading.value = true;
+    clearWaveformDetailsTimer();
+    waveformDetailsTimer = setTimeout(() => {
+      waveformDetailsTimer = null;
+      if (generation === waveformLoadGeneration) {
+        waveformLoading.value = false;
+      }
+    }, WAVEFORM_DETAILS_TIMEOUT_MS);
+    return;
+  }
 
+  clearWaveformDetailsTimer();
+  waveformLoading.value = true;
   try {
     const waveform = await api.getWaveForm(
       streamDetails.item_id,
@@ -773,12 +797,22 @@ const fetchWaveform = async () => {
     // a newer track change started while awaiting; this result is stale
     if (generation !== waveformLoadGeneration) return;
     waveformData.value = waveform?.length ? waveform : null;
+    waveformLoading.value = false;
   } catch {
     // No analysis available; PlayerTimeline falls back to the flat progress bar.
     if (generation !== waveformLoadGeneration) return;
     waveformData.value = null;
+    waveformLoading.value = false;
   }
 };
+
+const clearWaveformDetailsTimer = () => {
+  if (waveformDetailsTimer === null) return;
+  clearTimeout(waveformDetailsTimer);
+  waveformDetailsTimer = null;
+};
+
+onBeforeUnmount(clearWaveformDetailsTimer);
 
 // Streamdetails can arrive after the queue item switches, so watch both ids.
 watch(

--- a/src/layouts/default/PlayerOSD/PlayerTimeline.vue
+++ b/src/layouts/default/PlayerOSD/PlayerTimeline.vue
@@ -155,12 +155,16 @@ const isThumbHidden = ref(true);
 const isDragging = ref(false);
 const curTimeValue = ref(0);
 const tempTime = ref(0);
+const pendingSeekPosition = ref<number | null>(null);
 // ticking ref to force recompute of elapsed time (Date.now() is non-reactive)
 // rAF drives smooth 60fps slider movement; a 1s interval keeps text
 // labels up-to-date when the tab is backgrounded (rAF pauses).
 const nowTick = ref(0);
 let rafId: number | null = null;
 let fallbackTimer: ReturnType<typeof setInterval> | null = null;
+let pendingSeekTimer: ReturnType<typeof setTimeout> | null = null;
+const SEEK_CONFIRM_TOLERANCE_SECONDS = 1;
+const SEEK_CONFIRM_TIMEOUT_MS = 5000;
 
 // reka slider expects number[]
 const wrappedCurTimeValue = computed<number[]>({
@@ -204,6 +208,7 @@ const stopTick = () => {
 
 onUnmounted(() => {
   stopTick();
+  clearPendingSeek();
 });
 
 // computed properties
@@ -259,7 +264,53 @@ const playerTotalTimeStr = computed(() => {
   return formatDuration(duration);
 });
 
-const computedElapsedTime = computed(() => {
+const serverTiming = computed(() => {
+  // Prefer queue-level elapsed_time if available (from isolated reactive map)
+  const queue = store.activePlayerQueue;
+  const queueId = queue?.queue_id;
+  const queueTime = queueId ? api.queueElapsedTime[queueId] : undefined;
+  if (
+    queueTime?.elapsed_time != null &&
+    queueTime?.elapsed_time_last_updated != null
+  ) {
+    return {
+      elapsedTime: queueTime.elapsed_time,
+      lastUpdated: queueTime.elapsed_time_last_updated,
+      playbackState: queue!.state,
+    };
+  }
+
+  // Fallback to player-level elapsed_time. This is used for external/3rd-party
+  // sources currently playing on the player (not for Music Assistant queue
+  // playback). Use the player-level fields when no activePlayerQueue is set.
+  // Prefer current_media timing when available (external source playing on the player)
+  if (
+    store.activePlayer?.current_media?.elapsed_time != null &&
+    store.activePlayer?.current_media?.elapsed_time_last_updated != null
+  ) {
+    return {
+      elapsedTime: store.activePlayer.current_media.elapsed_time,
+      lastUpdated: store.activePlayer.current_media.elapsed_time_last_updated,
+      playbackState: store.activePlayer.playback_state,
+    };
+  }
+
+  // Fall back to player-level elapsed_time (legacy / provider-level value)
+  if (
+    store.activePlayer?.elapsed_time != null &&
+    store.activePlayer?.elapsed_time_last_updated != null
+  ) {
+    return {
+      elapsedTime: store.activePlayer.elapsed_time,
+      lastUpdated: store.activePlayer.elapsed_time_last_updated,
+      playbackState: store.activePlayer.playback_state,
+    };
+  }
+
+  return null;
+});
+
+const serverElapsedTime = computed(() => {
   // include nowTick.value so this computed re-evaluates periodically while mounted
   // and updates UI for fallback player-level current_media that relies on Date.now()
   void nowTick.value;
@@ -275,6 +326,21 @@ const computedElapsedTime = computed(() => {
   // Start ticking when playing and either using queue or external current_media
   if (isPlaying && (usingQueue || hasCurrentMedia)) startTick();
   else stopTick();
+
+  const timing = serverTiming.value;
+  if (!timing) return 0;
+
+  return (
+    computeElapsedTime(
+      timing.elapsedTime,
+      timing.lastUpdated,
+      timing.playbackState,
+      store.curQueueItem?.extra_attributes?.playback_speed ?? 1,
+    ) ?? 0
+  );
+});
+
+const displayedElapsedTime = computed(() => {
   if (isDragging.value) {
     // While dragging, mirror the live time into tempTime so the thumb tracks
     // the pointer. Intentional side effect in a computed (oxlint's vue plugin
@@ -284,55 +350,7 @@ const computedElapsedTime = computed(() => {
     return curTimeValue.value;
   }
 
-  // Prefer queue-level elapsed_time if available (from isolated reactive map)
-  const queue = store.activePlayerQueue;
-  const queueId = queue?.queue_id;
-  const queueTime = queueId ? api.queueElapsedTime[queueId] : undefined;
-  if (
-    queueTime?.elapsed_time != null &&
-    queueTime?.elapsed_time_last_updated != null
-  ) {
-    const computed = computeElapsedTime(
-      queueTime.elapsed_time,
-      queueTime.elapsed_time_last_updated,
-      queue!.state,
-      store.curQueueItem?.extra_attributes?.playback_speed ?? 1,
-    );
-    return computed ?? 0;
-  }
-
-  // Fallback to player-level elapsed_time. This is used for external/3rd-party
-  // sources currently playing on the player (not for Music Assistant queue
-  // playback). Use the player-level fields when no activePlayerQueue is set.
-  // Prefer current_media timing when available (external source playing on the player)
-  if (
-    store.activePlayer?.current_media?.elapsed_time != null &&
-    store.activePlayer?.current_media?.elapsed_time_last_updated != null
-  ) {
-    const computed = computeElapsedTime(
-      store.activePlayer.current_media.elapsed_time,
-      store.activePlayer.current_media.elapsed_time_last_updated,
-      store.activePlayer?.playback_state,
-      store.curQueueItem?.extra_attributes?.playback_speed ?? 1,
-    );
-    return computed ?? 0;
-  }
-
-  // Fall back to player-level elapsed_time (legacy / provider-level value)
-  if (
-    store.activePlayer?.elapsed_time != null &&
-    store.activePlayer?.elapsed_time_last_updated != null
-  ) {
-    const computed = computeElapsedTime(
-      store.activePlayer.elapsed_time,
-      store.activePlayer.elapsed_time_last_updated,
-      store.activePlayer?.playback_state,
-      store.curQueueItem?.extra_attributes?.playback_speed ?? 1,
-    );
-    return computed ?? 0;
-  }
-
-  return 0;
+  return pendingSeekPosition.value ?? serverElapsedTime.value;
 });
 
 const chapterTicks = computed(() =>
@@ -361,20 +379,40 @@ const onTrackPointerMove = (evt: PointerEvent) => {
 };
 
 //watch
-watch(computedElapsedTime, (newTime) => {
+watch(serverTiming, (timing) => {
+  const seekPosition = pendingSeekPosition.value;
+  if (
+    seekPosition != null &&
+    timing &&
+    Math.abs(timing.elapsedTime - seekPosition) <=
+      SEEK_CONFIRM_TOLERANCE_SECONDS
+  ) {
+    clearPendingSeek();
+  }
+});
+
+watch(displayedElapsedTime, (newTime) => {
   if (!isDragging.value) {
     curTimeValue.value = newTime;
   }
 });
 
+watch(
+  () => store.curQueueItem?.queue_item_id,
+  () => {
+    clearPendingSeek();
+    hoverPercent.value = null;
+  },
+);
+
 // methods
 const stopDragging = () => {
+  const seekPosition = Math.round(tempTime.value);
+  setPendingSeek(seekPosition);
+  curTimeValue.value = seekPosition;
   isDragging.value = false;
   if (store.activePlayer) {
-    api.playerCommandSeek(
-      store.activePlayer.player_id,
-      Math.round(tempTime.value),
-    );
+    api.playerCommandSeek(store.activePlayer.player_id, seekPosition);
   }
 };
 
@@ -385,6 +423,20 @@ const chapterClicked = function (chapter: MediaItemChapter) {
     undefined,
     chapter.position.toString(),
   );
+};
+
+const setPendingSeek = (position: number) => {
+  clearPendingSeek();
+  pendingSeekPosition.value = position;
+  pendingSeekTimer = setTimeout(clearPendingSeek, SEEK_CONFIRM_TIMEOUT_MS);
+};
+
+const clearPendingSeek = () => {
+  pendingSeekPosition.value = null;
+  if (pendingSeekTimer !== null) {
+    clearTimeout(pendingSeekTimer);
+    pendingSeekTimer = null;
+  }
 };
 </script>
 

--- a/src/layouts/default/PlayerOSD/PlayerTimeline.vue
+++ b/src/layouts/default/PlayerOSD/PlayerTimeline.vue
@@ -1,12 +1,15 @@
 <template>
-  <div class="w-auto" :class="hasWaveform ? 'h-8 md:h-10 lg:h-12' : 'h-6'">
+  <div
+    class="w-auto"
+    :class="usesWaveformLayout ? 'h-8 md:h-10 lg:h-12' : 'h-6'"
+  >
     <div v-if="store.activePlayer">
       <SliderRoot
         v-model="wrappedCurTimeValue"
         data-slot="slider"
         class="relative flex items-center select-none touch-none w-full"
         :class="[
-          hasWaveform ? 'h-11 md:h-12 lg:h-14' : 'h-8',
+          usesWaveformLayout ? 'h-11 md:h-12 lg:h-14' : 'h-8',
           hasWaveform && canSeek ? 'cursor-pointer' : '',
         ]"
         :disabled="!canSeek"
@@ -25,9 +28,9 @@
         <SliderTrack
           data-slot="slider-track"
           class="relative grow rounded-full"
-          :class="hasWaveform ? 'h-8 md:h-10 lg:h-12' : 'h-1'"
+          :class="usesWaveformLayout ? 'h-8 md:h-10 lg:h-12' : 'h-1'"
           :style="
-            hasWaveform
+            usesWaveformLayout
               ? undefined
               : {
                   'background-color': `color-mix(in oklab, ${color} 30%, transparent)`,
@@ -41,8 +44,15 @@
             :progress-percent="progressPercent"
             :hover-percent="hoverPercent"
           />
+          <div
+            v-else-if="waveformLoading"
+            class="absolute inset-x-0 top-1/2 h-1 -translate-y-1/2 rounded-full"
+            :style="{
+              'background-color': `color-mix(in oklab, ${color} 30%, transparent)`,
+            }"
+          />
           <SliderRange
-            v-else
+            v-if="!hasWaveform"
             data-slot="slider-range"
             class="absolute rounded-full h-1 top-1/2 -translate-y-1/2"
             :style="{ 'background-color': color }"
@@ -136,12 +146,14 @@ export interface Props {
   color?: string;
   // Precomputed waveform bins (0.0-1.0); when set, replaces the flat track.
   waveform?: number[] | null;
+  waveformLoading?: boolean;
 }
 
 const props = withDefaults(defineProps<Props>(), {
   showLabels: false,
   color: "var(--foreground)",
   waveform: null,
+  waveformLoading: false,
 });
 
 const { activeSource } = useActiveSource(toRef(store, "activePlayer"));
@@ -155,7 +167,7 @@ const isThumbHidden = ref(true);
 const isDragging = ref(false);
 const curTimeValue = ref(0);
 const tempTime = ref(0);
-const pendingSeekPosition = ref<number | null>(null);
+const pendingSeek = ref<{ position: number; origin: number } | null>(null);
 // ticking ref to force recompute of elapsed time (Date.now() is non-reactive)
 // rAF drives smooth 60fps slider movement; a 1s interval keeps text
 // labels up-to-date when the tab is backgrounded (rAF pauses).
@@ -350,7 +362,7 @@ const displayedElapsedTime = computed(() => {
     return curTimeValue.value;
   }
 
-  return pendingSeekPosition.value ?? serverElapsedTime.value;
+  return pendingSeek.value?.position ?? serverElapsedTime.value;
 });
 
 const chapterTicks = computed(() =>
@@ -361,6 +373,9 @@ const chapterTicks = computed(() =>
 );
 
 const hasWaveform = computed(() => !!props.waveform?.length);
+const usesWaveformLayout = computed(
+  () => hasWaveform.value || props.waveformLoading,
+);
 
 const progressPercent = computed(() => {
   const duration = store.activePlayer?.current_media?.duration;
@@ -380,13 +395,16 @@ const onTrackPointerMove = (evt: PointerEvent) => {
 
 //watch
 watch(serverTiming, (timing) => {
-  const seekPosition = pendingSeekPosition.value;
-  if (
-    seekPosition != null &&
-    timing &&
-    Math.abs(timing.elapsedTime - seekPosition) <=
-      SEEK_CONFIRM_TOLERANCE_SECONDS
-  ) {
+  const seek = pendingSeek.value;
+  if (!seek || !timing) return;
+
+  const difference = timing.elapsedTime - seek.position;
+  const direction = Math.sign(seek.position - seek.origin);
+  const reachedTarget =
+    Math.abs(difference) <= SEEK_CONFIRM_TOLERANCE_SECONDS ||
+    (direction > 0 && difference >= 0) ||
+    (direction < 0 && difference <= 0);
+  if (reachedTarget) {
     clearPendingSeek();
   }
 });
@@ -427,12 +445,15 @@ const chapterClicked = function (chapter: MediaItemChapter) {
 
 const setPendingSeek = (position: number) => {
   clearPendingSeek();
-  pendingSeekPosition.value = position;
+  pendingSeek.value = {
+    position,
+    origin: serverTiming.value?.elapsedTime ?? position,
+  };
   pendingSeekTimer = setTimeout(clearPendingSeek, SEEK_CONFIRM_TIMEOUT_MS);
 };
 
 const clearPendingSeek = () => {
-  pendingSeekPosition.value = null;
+  pendingSeek.value = null;
   if (pendingSeekTimer !== null) {
     clearTimeout(pendingSeekTimer);
     pendingSeekTimer = null;


### PR DESCRIPTION
Waveform progress could briefly collapse during track changes and jump back after seeking while waiting for updated server timing.

- Keep the current waveform mounted while the next waveform loads
- Hold the selected seek position until matching server timing arrives
- Separate raw server timing from the displayed elapsed position