### PR TITLE
Keep player menu above mobile navigation

### DIFF
--- a/src/layouts/default/PlayerSelect.vue
+++ b/src/layouts/default/PlayerSelect.vue
@@ -9,7 +9,10 @@
       <button
         v-if="store.showPlayersMenu"
         type="button"
-        class="player-select-backdrop fixed inset-x-0 top-0 bottom-[60px] z-[99999] bg-black/60 backdrop-blur-sm md:bottom-0"
+        :class="[
+          'player-select-backdrop fixed inset-x-0 top-0 z-[99999] bg-black/60 backdrop-blur-sm',
+          store.mobileLayout ? 'bottom-[60px]' : 'bottom-0',
+        ]"
         :aria-label="$t('close')"
         @click="setMenuOpen(false)"
       ></button>
@@ -24,7 +27,10 @@
     <SheetContent
       data-testid="player-select-sheet"
       side="right"
-      class="w-[90vw] gap-0 p-0 sm:max-w-[400px] max-md:bottom-[60px]"
+      :class="[
+        'w-[90vw] gap-0 p-0 sm:max-w-[400px]',
+        store.mobileLayout ? 'bottom-[60px]' : 'bottom-0',
+      ]"
       @keydown="handleSheetKeydown"
       @interact-outside="handleSheetInteractOutside"
     >

--- a/tests/layouts/PlayerSelect.test.ts
+++ b/tests/layouts/PlayerSelect.test.ts
@@ -48,6 +48,7 @@ vi.mock("@/plugins/store", async () => {
       activePlayerId: undefined as string | undefined,
       companionPlayerId: undefined as string | undefined,
       dialogActive: false,
+      mobileLayout: false,
       showPlayersMenu: true,
     }),
   };
@@ -206,6 +207,7 @@ describe("PlayerSelect", () => {
     store.activePlayerId = undefined;
     store.companionPlayerId = undefined;
     store.dialogActive = false;
+    store.mobileLayout = false;
     store.showPlayersMenu = true;
     webPlayer.player_id = null;
     storage.clear();
@@ -341,6 +343,19 @@ describe("PlayerSelect", () => {
     await wrapper.find(".player-select-backdrop").trigger("click");
 
     expect(store.showPlayersMenu).toBe(false);
+  });
+
+  it("stops above the bottom navigation in mobile layout", () => {
+    store.mobileLayout = true;
+
+    const wrapper = mountPlayerSelect();
+
+    expect(wrapper.find(".player-select-backdrop").classes()).toContain(
+      "bottom-[60px]",
+    );
+    expect(
+      wrapper.find('[data-testid="player-select-sheet"]').classes(),
+    ).toContain("bottom-[60px]");
   });
 
   it("restores focus to the menu trigger after closing", async () => {


### PR DESCRIPTION
On mobile, the player menu could cover the bottom navigation after the recent selector update.

- Keep the player menu and backdrop above the bottom navigation
- Apply the same behavior to forced mobile layouts
- Add regression coverage