### PR TITLE
Remember Music Quiz playback choice

### DIFF
--- a/src/components/music-quiz/MusicQuizSetupWizard.vue
+++ b/src/components/music-quiz/MusicQuizSetupWizard.vue
@@ -24,7 +24,11 @@
       </div>
     </div>
 
-    <div v-show="!busy" class="flex flex-col gap-2">
+    <div
+      class="flex-col gap-2"
+      :class="busy ? 'hidden' : 'flex'"
+      data-testid="music-quiz-setup-progress"
+    >
       <div class="flex items-center justify-between gap-3">
         <Button
           v-if="step > 1"
@@ -73,7 +77,11 @@
       </div>
     </section>
 
-    <section v-show="!busy && step === 2" class="flex flex-col gap-4">
+    <section
+      class="flex-col gap-4"
+      :class="!busy && step === 2 ? 'flex' : 'hidden'"
+      data-testid="music-quiz-configure-step"
+    >
       <div class="flex items-center gap-2">
         <component
           :is="selectedType.icon"
@@ -93,25 +101,6 @@
         :disabled="busy"
         @retry="emit('retryPlaybackOptions')"
       />
-      <Field
-        orientation="horizontal"
-        class="items-center justify-between gap-4 rounded-lg border p-4"
-      >
-        <div class="flex flex-col gap-1">
-          <FieldLabel for="quiz-include-similar-music">
-            {{ $t("providers.music_quiz.include_similar_music") }}
-          </FieldLabel>
-          <FieldDescription>
-            {{ $t("providers.music_quiz.include_similar_music_help") }}
-          </FieldDescription>
-        </div>
-        <Switch
-          id="quiz-include-similar-music"
-          v-model="includeSimilarMusic"
-          data-testid="quiz-include-similar-music"
-          :disabled="busy"
-        />
-      </Field>
       <KeepAlive v-if="selectedType">
         <component
           :is="
@@ -121,7 +110,29 @@
           :include-similar-music="includeSimilarMusic"
           :shared-config-valid="sharedConfigValid"
           @create="onConfigCreate"
-        />
+        >
+          <template #before-sources>
+            <Field
+              orientation="horizontal"
+              class="items-center justify-between gap-4 rounded-lg border p-4"
+            >
+              <div class="flex flex-col gap-1">
+                <FieldLabel for="quiz-include-similar-music">
+                  {{ $t("providers.music_quiz.include_similar_music") }}
+                </FieldLabel>
+                <FieldDescription>
+                  {{ $t("providers.music_quiz.include_similar_music_help") }}
+                </FieldDescription>
+              </div>
+              <Switch
+                id="quiz-include-similar-music"
+                v-model="includeSimilarMusic"
+                data-testid="quiz-include-similar-music"
+                :disabled="busy"
+              />
+            </Field>
+          </template>
+        </component>
       </KeepAlive>
     </section>
   </div>

--- a/src/components/music-quiz/MusicQuizSetupWizard.vue
+++ b/src/components/music-quiz/MusicQuizSetupWizard.vue
@@ -154,9 +154,9 @@ import type {
   MusicQuizPlaybackOptions,
 } from "@/composables/useMusicQuiz";
 import {
-  getDefaultMusicQuizPlaybackSelection,
   getMusicQuizPlaybackCreateFields,
   isMusicQuizPlaybackSelectionValid,
+  reconcileMusicQuizPlaybackSelection,
   type MusicQuizPlaybackSelection,
 } from "@/helpers/music_quiz_playback";
 import { $t } from "@/plugins/i18n";
@@ -190,6 +190,15 @@ const emit = defineEmits<{
   create: [request: MusicQuizCreateRequest];
   retryPlaybackOptions: [];
 }>();
+const playbackSelection = defineModel<MusicQuizPlaybackSelection>(
+  "playbackSelection",
+  {
+    default: () => ({
+      mode: null,
+      venuePlayerId: null,
+    }),
+  },
+);
 
 const availableGameTypes = computed(() =>
   MUSIC_QUIZ_GAME_TYPES.filter((type) =>
@@ -199,10 +208,6 @@ const availableGameTypes = computed(() =>
 const step = ref<1 | 2>(1);
 const selectedType = ref<MusicQuizGameDefinition | null>(null);
 const includeSimilarMusic = ref(false);
-const playbackSelection = ref<MusicQuizPlaybackSelection>({
-  mode: null,
-  venuePlayerId: null,
-});
 const chooseHeading = ref<HTMLHeadingElement | null>(null);
 const configureHeading = ref<HTMLHeadingElement | null>(null);
 const preparingStatus = ref<HTMLElement | null>(null);
@@ -221,7 +226,13 @@ watch(
   () => props.playbackOptions,
   (options) => {
     if (options) {
-      playbackSelection.value = getDefaultMusicQuizPlaybackSelection(options);
+      const reconciled = reconcileMusicQuizPlaybackSelection(
+        playbackSelection.value,
+        options,
+      );
+      if (reconciled !== playbackSelection.value) {
+        playbackSelection.value = reconciled;
+      }
     }
   },
   { immediate: true },

--- a/src/components/music-quiz/MusicQuizSourceSelector.vue
+++ b/src/components/music-quiz/MusicQuizSourceSelector.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="grid gap-4 lg:grid-cols-2">
+  <div class="grid gap-4 md:grid-cols-2">
     <Field>
       <FieldLabel :for="inputId">
         {{ $t("providers.music_quiz.add_music_sources") }}

--- a/src/components/music-quiz/adapter_contracts.ts
+++ b/src/components/music-quiz/adapter_contracts.ts
@@ -20,6 +20,10 @@ export interface MusicQuizSetupAdapterEmits {
   create: [request: MusicQuizCreateRequest];
 }
 
+export interface MusicQuizSetupAdapterSlots {
+  "before-sources": () => VNode[];
+}
+
 export interface MusicQuizPlayerGameAdapterProps<
   TState extends MusicQuizSupportedPersonalizedState =
     MusicQuizSupportedPersonalizedState,

--- a/src/components/music-quiz/game-types/guess-the-song/GuessTheSongSetup.vue
+++ b/src/components/music-quiz/game-types/guess-the-song/GuessTheSongSetup.vue
@@ -73,6 +73,8 @@
       </Field>
     </div>
 
+    <slot name="before-sources" />
+
     <MusicQuizSourceSelector
       v-model="sourceUris"
       input-id="quiz-source-search"
@@ -94,6 +96,7 @@ import MusicQuizSourceSelector from "@/components/music-quiz/MusicQuizSourceSele
 import type {
   MusicQuizSetupAdapterEmits,
   MusicQuizSetupAdapterProps,
+  MusicQuizSetupAdapterSlots,
 } from "@/components/music-quiz/adapter_contracts";
 import { Button } from "@/components/ui/button";
 import { Field, FieldLabel } from "@/components/ui/field";
@@ -123,6 +126,7 @@ const MAX_SECONDS = 120;
 const props = withDefaults(defineProps<MusicQuizSetupAdapterProps>(), {
   sharedConfigValid: true,
 });
+defineSlots<MusicQuizSetupAdapterSlots>();
 const emit = defineEmits<MusicQuizSetupAdapterEmits>();
 
 const roundCount = ref(5);

--- a/src/components/music-quiz/game-types/music-timeline/MusicTimelineSetup.vue
+++ b/src/components/music-quiz/game-types/music-timeline/MusicTimelineSetup.vue
@@ -76,6 +76,8 @@
       </Field>
     </div>
 
+    <slot name="before-sources" />
+
     <MusicQuizSourceSelector
       v-model="sourceUris"
       input-id="music-timeline-source-search"
@@ -97,6 +99,7 @@ import MusicQuizSourceSelector from "@/components/music-quiz/MusicQuizSourceSele
 import type {
   MusicQuizSetupAdapterEmits,
   MusicQuizSetupAdapterProps,
+  MusicQuizSetupAdapterSlots,
 } from "@/components/music-quiz/adapter_contracts";
 import { Button } from "@/components/ui/button";
 import { Field, FieldLabel } from "@/components/ui/field";
@@ -124,6 +127,7 @@ const MAX_SECONDS = 300;
 const props = withDefaults(defineProps<MusicQuizSetupAdapterProps>(), {
   sharedConfigValid: true,
 });
+defineSlots<MusicQuizSetupAdapterSlots>();
 const emit = defineEmits<MusicQuizSetupAdapterEmits>();
 
 const roundCount = ref(5);

--- a/src/components/music-quiz/game-types/trivia/TriviaSetup.vue
+++ b/src/components/music-quiz/game-types/trivia/TriviaSetup.vue
@@ -111,6 +111,8 @@
       </Field>
     </div>
 
+    <slot name="before-sources" />
+
     <MusicQuizSourceSelector
       v-model="sourceUris"
       input-id="trivia-source-search"
@@ -132,6 +134,7 @@ import MusicQuizSourceSelector from "@/components/music-quiz/MusicQuizSourceSele
 import type {
   MusicQuizSetupAdapterEmits,
   MusicQuizSetupAdapterProps,
+  MusicQuizSetupAdapterSlots,
 } from "@/components/music-quiz/adapter_contracts";
 import { Button } from "@/components/ui/button";
 import { Field, FieldDescription, FieldLabel } from "@/components/ui/field";
@@ -162,6 +165,7 @@ const MAX_SECONDS = 300;
 const props = withDefaults(defineProps<MusicQuizSetupAdapterProps>(), {
   sharedConfigValid: true,
 });
+defineSlots<MusicQuizSetupAdapterSlots>();
 const emit = defineEmits<MusicQuizSetupAdapterEmits>();
 
 const roundCount = ref(5);

--- a/src/components/ui/field/FieldSet.vue
+++ b/src/components/ui/field/FieldSet.vue
@@ -12,7 +12,7 @@ const props = defineProps<{
     data-slot="field-set"
     :class="
       cn(
-        'flex flex-col gap-6',
+        'm-0 flex min-w-0 flex-col gap-6 border-0 p-0',
         'has-[>[data-slot=checkbox-group]]:gap-3 has-[>[data-slot=radio-group]]:gap-3',
         props.class,
       )

--- a/src/helpers/music_quiz_playback.ts
+++ b/src/helpers/music_quiz_playback.ts
@@ -23,8 +23,30 @@ export function getDefaultMusicQuizPlaybackSelection(
 ): MusicQuizPlaybackSelection {
   return {
     mode: options.default_playback_mode,
-    venuePlayerId: options.default_venue_player_id,
+    venuePlayerId: isVenuePlayerAvailable(
+      options.default_venue_player_id,
+      options,
+    )
+      ? options.default_venue_player_id
+      : null,
   };
+}
+
+export function reconcileMusicQuizPlaybackSelection(
+  selection: MusicQuizPlaybackSelection,
+  options: MusicQuizPlaybackOptions,
+): MusicQuizPlaybackSelection {
+  const defaults = getDefaultMusicQuizPlaybackSelection(options);
+  const mode = isPlaybackModeAvailable(selection.mode, options)
+    ? selection.mode
+    : defaults.mode;
+  const venuePlayerId = isVenuePlayerAvailable(selection.venuePlayerId, options)
+    ? selection.venuePlayerId
+    : defaults.venuePlayerId;
+
+  return mode === selection.mode && venuePlayerId === selection.venuePlayerId
+    ? selection
+    : { mode, venuePlayerId };
 }
 
 export function getMusicQuizPlaybackCreateFields(
@@ -59,4 +81,25 @@ export function isMusicQuizPlaybackSelectionValid(
   options: MusicQuizPlaybackOptions,
 ) {
   return getMusicQuizPlaybackCreateFields(selection, options) !== null;
+}
+
+function isPlaybackModeAvailable(
+  mode: MusicQuizMode | null,
+  options: MusicQuizPlaybackOptions,
+) {
+  if (mode === "remote") return options.remote_available;
+  if (mode === "venue") {
+    return options.venue_available && options.venue_players.length > 0;
+  }
+  return false;
+}
+
+function isVenuePlayerAvailable(
+  playerId: string | null,
+  options: MusicQuizPlaybackOptions,
+) {
+  return (
+    playerId !== null &&
+    options.venue_players.some((player) => player.player_id === playerId)
+  );
 }

--- a/src/views/MusicQuizDashboardView.vue
+++ b/src/views/MusicQuizDashboardView.vue
@@ -161,7 +161,7 @@
     <Dialog v-model:open="showSetupDialog">
       <DialogContent
         data-testid="setup-dialog"
-        class="max-h-[calc(100dvh-1rem)] overflow-y-auto p-4 sm:max-w-3xl sm:p-6"
+        class="max-h-[calc(100dvh-1rem)] overflow-y-auto p-4 sm:max-w-[calc(100%-2rem)] sm:p-6 lg:max-w-3xl"
       >
         <DialogHeader class="pr-8 text-left">
           <DialogTitle>{{ $t("providers.music_quiz.new_game") }}</DialogTitle>

--- a/src/views/MusicQuizDashboardView.vue
+++ b/src/views/MusicQuizDashboardView.vue
@@ -171,6 +171,7 @@
         </DialogHeader>
         <MusicQuizSetupWizard
           v-if="showSetupDialog"
+          v-model:playback-selection="playbackSelection"
           :busy="busy"
           :available-quiz-types="availableQuizTypes"
           :playback-options="playbackOptions"
@@ -253,6 +254,7 @@ import {
   getMusicQuizWinnerText,
   rankMusicQuizPlayers,
 } from "@/helpers/music_quiz";
+import type { MusicQuizPlaybackSelection } from "@/helpers/music_quiz_playback";
 import api, { ConnectionState } from "@/plugins/api";
 import { ProviderType } from "@/plugins/api/interfaces";
 import { authManager } from "@/plugins/auth";
@@ -359,6 +361,10 @@ const presentMode = ref(false);
 const presentRootRef = ref<HTMLElement | null>(null);
 const showEndGameDialog = ref(false);
 const showSetupDialog = ref(false);
+const playbackSelection = ref<MusicQuizPlaybackSelection>({
+  mode: null,
+  venuePlayerId: null,
+});
 const musicQuizProviderInstanceId = ref<string | null>(null);
 const isAdmin = computed(() => authManager.isAdmin());
 

--- a/tests/components/music-quiz/MusicQuizPlaybackControls.test.ts
+++ b/tests/components/music-quiz/MusicQuizPlaybackControls.test.ts
@@ -22,9 +22,13 @@ const PLAYBACK_OPTIONS = {
 describe("MusicQuizPlaybackControls", () => {
   it("provides responsive, labelled radio and speaker controls", () => {
     const wrapper = mountControls();
+    const fieldSet = wrapper.get('[data-slot="field-set"]');
     const radioGroup = wrapper.get('[data-slot="radio-group"]');
     const speaker = wrapper.get("#music-quiz-venue-player");
 
+    expect(fieldSet.classes()).toEqual(
+      expect.arrayContaining(["m-0", "min-w-0", "border-0", "p-0"]),
+    );
     expect(radioGroup.classes()).toEqual(
       expect.arrayContaining(["grid", "sm:grid-cols-2"]),
     );

--- a/tests/components/music-quiz/MusicQuizSetupSourcePlacement.test.ts
+++ b/tests/components/music-quiz/MusicQuizSetupSourcePlacement.test.ts
@@ -1,0 +1,59 @@
+import MusicQuizSourceSelector from "@/components/music-quiz/MusicQuizSourceSelector.vue";
+import GuessTheSongSetup from "@/components/music-quiz/game-types/guess-the-song/GuessTheSongSetup.vue";
+import MusicTimelineSetup from "@/components/music-quiz/game-types/music-timeline/MusicTimelineSetup.vue";
+import TriviaSetup from "@/components/music-quiz/game-types/trivia/TriviaSetup.vue";
+import { shallowMount } from "@vue/test-utils";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@/plugins/i18n", () => ({
+  $t: (key: string) => key,
+  canonicalizeLocale: (locale: string) => locale,
+  getLocaleOptions: () => [],
+  i18n: {
+    global: {
+      availableLocales: ["en"],
+      locale: { value: "en" },
+    },
+  },
+}));
+
+vi.mock("@/components/music-quiz/MusicQuizSourceSelector.vue", () => ({
+  default: {
+    name: "MusicQuizSourceSelector",
+    template: '<div data-testid="music-quiz-source-selector" />',
+  },
+}));
+
+const SETUP_COMPONENTS = [
+  { label: "Guess the Song", component: GuessTheSongSetup },
+  { label: "Music Timeline", component: MusicTimelineSetup },
+  { label: "Trivia", component: TriviaSetup },
+] as const;
+
+describe("Music Quiz setup source placement", () => {
+  it.each(SETUP_COMPONENTS)(
+    "renders the shared source option immediately before sources for $label",
+    ({ component }) => {
+      const wrapper = shallowMount(component, {
+        props: {
+          busy: false,
+          includeSimilarMusic: false,
+          sharedConfigValid: true,
+        },
+        slots: {
+          "before-sources":
+            '<div data-testid="include-similar-option">Include similar music</div>',
+        },
+      });
+
+      const includeSimilar = wrapper.get(
+        '[data-testid="include-similar-option"]',
+      );
+      const sourceSelector = wrapper.getComponent(MusicQuizSourceSelector);
+
+      expect(sourceSelector.element.previousElementSibling).toBe(
+        includeSimilar.element,
+      );
+    },
+  );
+});

--- a/tests/components/music-quiz/MusicQuizSetupWizard.test.ts
+++ b/tests/components/music-quiz/MusicQuizSetupWizard.test.ts
@@ -365,6 +365,24 @@ describe("MusicQuizSetupWizard", () => {
     ).toBe("kitchen");
   });
 
+  it("does not emit when refreshed options keep the selection unchanged", async () => {
+    const wrapper = mountWizard({ playbackOptions: PLAYBACK_OPTIONS });
+    await nextTick();
+    const initialUpdates =
+      wrapper.emitted("update:playbackSelection")?.length ?? 0;
+
+    await wrapper.setProps({
+      playbackOptions: {
+        ...PLAYBACK_OPTIONS,
+        venue_players: [...PLAYBACK_OPTIONS.venue_players],
+      },
+    });
+
+    expect(wrapper.emitted("update:playbackSelection")?.length ?? 0).toBe(
+      initialUpdates,
+    );
+  });
+
   it("hides playback controls and omits fields for a legacy server", async () => {
     const wrapper = mountWizard({ playbackOptionsLegacy: true });
     await selectGame(wrapper, "game_type");

--- a/tests/components/music-quiz/MusicQuizSetupWizard.test.ts
+++ b/tests/components/music-quiz/MusicQuizSetupWizard.test.ts
@@ -23,7 +23,7 @@ vi.mock("@/components/music-quiz/game_types", async () => {
         },
       },
       emits: ["create"],
-      setup(props, { emit }) {
+      setup(props, { emit, slots }) {
         const gameSetting = ref(0);
         return () =>
           h("div", [
@@ -35,6 +35,9 @@ vi.mock("@/components/music-quiz/game_types", async () => {
               },
               "Change setting",
             ),
+            h("div", { "data-testid": `options-${quizType}` }, "Game options"),
+            slots["before-sources"]?.(),
+            h("div", { "data-testid": `sources-${quizType}` }, "Music sources"),
             h(
               "span",
               { "data-testid": `setting-${quizType}` },
@@ -186,6 +189,50 @@ describe("MusicQuizSetupWizard", () => {
     expect(document.activeElement).toBe(chooseHeading?.element);
     wrapper.unmount();
   });
+
+  it("uses mutually exclusive display classes for wizard visibility", async () => {
+    const wrapper = mountWizard();
+    const progress = wrapper.get('[data-testid="music-quiz-setup-progress"]');
+    const configureStep = wrapper.get(
+      '[data-testid="music-quiz-configure-step"]',
+    );
+
+    expect(progress.classes()).toContain("flex");
+    expect(progress.classes()).not.toContain("hidden");
+    expect(configureStep.classes()).toContain("hidden");
+    expect(configureStep.classes()).not.toContain("flex");
+
+    await selectGame(wrapper, "game_type");
+
+    expect(configureStep.classes()).toContain("flex");
+    expect(configureStep.classes()).not.toContain("hidden");
+
+    await wrapper.setProps({ busy: true });
+
+    expect(progress.classes()).toContain("hidden");
+    expect(progress.classes()).not.toContain("flex");
+    expect(configureStep.classes()).toContain("hidden");
+    expect(configureStep.classes()).not.toContain("flex");
+  });
+
+  it.each(GAME_CASES)(
+    "places the shared source option next to $quizType music sources",
+    async ({ label, quizType }) => {
+      const wrapper = mountWizard({ availableQuizTypes: ["trivia"] });
+
+      await selectGame(wrapper, label);
+
+      const sourceSelector = wrapper.get(`[data-testid="sources-${quizType}"]`);
+      const includeSimilar = wrapper.get(
+        '[data-testid="quiz-include-similar-music"]',
+      );
+      expect(
+        sourceSelector.element.previousElementSibling?.contains(
+          includeSimilar.element,
+        ),
+      ).toBe(true);
+    },
+  );
 
   it.each(GAME_CASES)(
     "adds one shared playback payload without changing $quizType config",
@@ -402,9 +449,11 @@ describe("MusicQuizSetupWizard", () => {
     expect(status.text()).toContain("providers.music_quiz.preparing_game");
     expect(status.text()).toContain("providers.music_quiz.preparing_game_help");
     expect(document.activeElement).toBe(status.element);
-    expect(
-      wrapper.get('[data-testid="setting-guess_the_song"]').isVisible(),
-    ).toBe(false);
+    const configureStep = wrapper.get(
+      '[data-testid="music-quiz-configure-step"]',
+    );
+    expect(configureStep.classes()).toContain("hidden");
+    expect(configureStep.classes()).not.toContain("flex");
 
     await wrapper.setProps({ busy: false });
     expect(wrapper.get('[data-testid="setting-guess_the_song"]').text()).toBe(

--- a/tests/components/music-quiz/MusicQuizSourceSelector.test.ts
+++ b/tests/components/music-quiz/MusicQuizSourceSelector.test.ts
@@ -33,6 +33,13 @@ describe("MusicQuizSourceSelector", () => {
     document.body.replaceChildren();
   });
 
+  it("uses its available width for the tablet source layout", () => {
+    const wrapper = mountSelector();
+
+    expect(wrapper.classes()).toContain("md:grid-cols-2");
+    expect(wrapper.classes()).not.toContain("lg:grid-cols-2");
+  });
+
   it.each([
     { description: "middle", removedIndex: 1, expectedFocusIndex: 1 },
     { description: "first", removedIndex: 0, expectedFocusIndex: 0 },

--- a/tests/helpers/music_quiz_playback.test.ts
+++ b/tests/helpers/music_quiz_playback.test.ts
@@ -1,0 +1,94 @@
+import type { MusicQuizPlaybackOptions } from "@/composables/useMusicQuiz";
+import {
+  reconcileMusicQuizPlaybackSelection,
+  type MusicQuizPlaybackSelection,
+} from "@/helpers/music_quiz_playback";
+import { describe, expect, it } from "vitest";
+
+const PLAYBACK_OPTIONS = {
+  default_playback_mode: "venue",
+  default_venue_player_id: "living-room",
+  venue_available: true,
+  remote_available: true,
+  venue_players: [
+    { player_id: "living-room", name: "Living Room" },
+    { player_id: "kitchen", name: "Kitchen" },
+  ],
+} satisfies MusicQuizPlaybackOptions;
+
+describe("reconcileMusicQuizPlaybackSelection", () => {
+  it("initializes from server defaults", () => {
+    expect(reconcile({ mode: null, venuePlayerId: null })).toEqual({
+      mode: "venue",
+      venuePlayerId: "living-room",
+    });
+  });
+
+  it("retains an available remote mode", () => {
+    expect(reconcile({ mode: "remote", venuePlayerId: "living-room" })).toEqual(
+      {
+        mode: "remote",
+        venuePlayerId: "living-room",
+      },
+    );
+  });
+
+  it("retains an available venue speaker", () => {
+    expect(reconcile({ mode: "venue", venuePlayerId: "kitchen" })).toEqual({
+      mode: "venue",
+      venuePlayerId: "kitchen",
+    });
+  });
+
+  it("falls back from a stale venue speaker while remote is selected", () => {
+    expect(reconcile({ mode: "remote", venuePlayerId: "bedroom" })).toEqual({
+      mode: "remote",
+      venuePlayerId: "living-room",
+    });
+  });
+
+  it("falls back when the remembered mode is unavailable", () => {
+    expect(
+      reconcile(
+        { mode: "remote", venuePlayerId: "kitchen" },
+        { ...PLAYBACK_OPTIONS, remote_available: false },
+      ),
+    ).toEqual({
+      mode: "venue",
+      venuePlayerId: "kitchen",
+    });
+  });
+
+  it("falls back from Venue when no speakers remain", () => {
+    expect(
+      reconcile(
+        { mode: "venue", venuePlayerId: "kitchen" },
+        {
+          ...PLAYBACK_OPTIONS,
+          default_playback_mode: "remote",
+          default_venue_player_id: null,
+          venue_players: [],
+        },
+      ),
+    ).toEqual({
+      mode: "remote",
+      venuePlayerId: null,
+    });
+  });
+
+  it("returns the same selection when no reconciliation is needed", () => {
+    const selection: MusicQuizPlaybackSelection = {
+      mode: "venue",
+      venuePlayerId: "kitchen",
+    };
+
+    expect(reconcile(selection)).toBe(selection);
+  });
+});
+
+function reconcile(
+  selection: MusicQuizPlaybackSelection,
+  options: MusicQuizPlaybackOptions = PLAYBACK_OPTIONS,
+) {
+  return reconcileMusicQuizPlaybackSelection(selection, options);
+}

--- a/tests/views/MusicQuizDashboardView.test.ts
+++ b/tests/views/MusicQuizDashboardView.test.ts
@@ -119,7 +119,11 @@ describe("MusicQuizDashboardView", () => {
 
     await wrapper.get('[data-testid="new-game-empty"]').trigger("click");
 
-    expect(wrapper.find('[data-testid="setup-dialog"]').exists()).toBe(true);
+    const setupDialog = wrapper.get('[data-testid="setup-dialog"]');
+    expect(setupDialog.classes()).toEqual(
+      expect.arrayContaining(["sm:max-w-[calc(100%-2rem)]", "lg:max-w-3xl"]),
+    );
+    expect(setupDialog.classes()).not.toContain("sm:max-w-3xl");
     expect(wrapper.find('[data-testid="music-quiz-setup"]').exists()).toBe(
       true,
     );

--- a/tests/views/MusicQuizDashboardView.test.ts
+++ b/tests/views/MusicQuizDashboardView.test.ts
@@ -131,6 +131,27 @@ describe("MusicQuizDashboardView", () => {
     wrapper.unmount();
   });
 
+  it("retains playback changes when setup is cancelled and reopened", async () => {
+    const wrapper = mountDashboard();
+    await flushPromises();
+
+    await wrapper.get('[data-testid="new-game-empty"]').trigger("click");
+    await flushPromises();
+    await wrapper
+      .get('[data-testid="select-remote-playback"]')
+      .trigger("click");
+    await wrapper.get('[data-testid="cancel-setup"]').trigger("click");
+
+    expect(wrapper.find('[data-testid="music-quiz-setup"]').exists()).toBe(
+      false,
+    );
+
+    await wrapper.get('[data-testid="new-game-empty"]').trigger("click");
+    await flushPromises();
+
+    expect(wrapper.get('[data-testid="playback-mode"]').text()).toBe("remote");
+  });
+
   it("resolves the admin settings shortcut and routes to its provider config", async () => {
     if (mockAdminState.current) mockAdminState.current.value = true;
     mockGetProviderConfigs.mockResolvedValue([
@@ -203,7 +224,9 @@ function mountDashboard() {
         AlertDialog: true,
         Dialog: {
           props: ["open"],
-          template: '<div v-if="open"><slot /></div>',
+          emits: ["update:open"],
+          template:
+            '<div v-if="open"><slot /><button data-testid="cancel-setup" @click="$emit(\'update:open\', false)">Cancel</button></div>',
         },
         DialogContent: {
           template: '<div data-testid="setup-dialog"><slot /></div>',
@@ -223,7 +246,10 @@ function mountDashboard() {
         },
         MusicQuizConnectionBanners: true,
         MusicQuizSetupWizard: {
-          template: '<div data-testid="music-quiz-setup" />',
+          props: ["playbackSelection"],
+          emits: ["update:playbackSelection"],
+          template:
+            '<div data-testid="music-quiz-setup"><span data-testid="playback-mode">{{ playbackSelection.mode }}</span><button data-testid="select-remote-playback" @click="$emit(\'update:playbackSelection\', { mode: \'remote\', venuePlayerId: \'living-room\' })">Remote</button></div>',
         },
       },
     },


### PR DESCRIPTION
Playback choices reset whenever the New Game setup was closed or reopened.

- Remember the last valid playback mode and venue speaker for the dashboard session
- Reconcile unavailable choices with refreshed server defaults
- Keep legacy server behavior and fresh per-game setup fields unchanged

Depends on #2109.