### PR TITLE
Improve Music Quiz playback flow

### DIFF
--- a/src/components/ListenIn.vue
+++ b/src/components/ListenIn.vue
@@ -73,10 +73,8 @@ export interface ListenInProps {
   recheckEvents?: EventType[];
   /** Optional server-error extractor passed through to useListenIn. */
   getErrorMessage?: (err: unknown, fallback: string) => string;
-  /** Start listening when available unless a stored preference overrides it. */
+  /** Start listening when available until the guest explicitly opts out. */
   autoEnable?: boolean;
-  /** Local-storage key used to remember the explicit on/off choice. */
-  preferenceKey?: string;
 }
 </script>
 
@@ -85,11 +83,12 @@ import { Button } from "@/components/ui/button";
 import { Switch } from "@/components/ui/switch";
 import { useListenIn } from "@/composables/useListenIn";
 import { Headphones } from "@lucide/vue";
-import { computed, useId } from "vue";
+import { computed, ref, useId } from "vue";
 import { toast } from "vue-sonner";
 
 const props = defineProps<ListenInProps>();
 const attributionId = useId();
+const autoEnableSuppressed = ref(false);
 
 const {
   isListeningIn,
@@ -133,33 +132,18 @@ function onToggle(enabled: boolean) {
 
 async function enableListenIn() {
   if (!(await startListenIn())) return;
-  rememberPreference(true);
+  autoEnableSuppressed.value = false;
 }
 
 async function disableListenIn() {
-  rememberPreference(false);
+  autoEnableSuppressed.value = true;
   await stopListenIn();
 }
 
 function shouldAutoEnable() {
-  if (!props.autoEnable) return false;
-  if (!props.preferenceKey) return true;
-  try {
-    const preference = window.localStorage.getItem(props.preferenceKey);
-    return preference === null || preference === "true";
-  } catch (error) {
-    console.debug("Could not read Listen-in preference:", error);
-    return true;
-  }
-}
-
-function rememberPreference(enabled: boolean) {
-  if (!props.preferenceKey) return;
-  try {
-    window.localStorage.setItem(props.preferenceKey, String(enabled));
-  } catch (error) {
-    console.debug("Could not store Listen-in preference:", error);
-  }
+  return (
+    props.mode === "remote" && !!props.autoEnable && !autoEnableSuppressed.value
+  );
 }
 </script>
 

--- a/src/components/music-quiz/MusicQuizPreparingState.vue
+++ b/src/components/music-quiz/MusicQuizPreparingState.vue
@@ -1,0 +1,33 @@
+<template>
+  <div
+    ref="statusElement"
+    class="bg-background flex min-h-64 flex-col items-center justify-center gap-3 p-6 text-center"
+    role="status"
+    aria-live="polite"
+    aria-atomic="true"
+    tabindex="-1"
+    data-testid="music-quiz-preparing"
+  >
+    <LoaderCircle class="text-primary size-8 animate-spin" aria-hidden="true" />
+    <div class="flex flex-col gap-1">
+      <h2 class="text-lg font-semibold">
+        {{ $t("providers.music_quiz.preparing_game") }}
+      </h2>
+      <p class="text-muted-foreground max-w-md text-sm">
+        {{ $t("providers.music_quiz.preparing_game_help") }}
+      </p>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { $t } from "@/plugins/i18n";
+import { LoaderCircle } from "@lucide/vue";
+import { onMounted, ref } from "vue";
+
+const statusElement = ref<HTMLElement | null>(null);
+
+onMounted(() => {
+  statusElement.value?.focus({ preventScroll: true });
+});
+</script>

--- a/src/components/music-quiz/MusicQuizSetupWizard.vue
+++ b/src/components/music-quiz/MusicQuizSetupWizard.vue
@@ -1,28 +1,9 @@
 <template>
   <div class="relative flex flex-col gap-5" :class="{ 'min-h-64': busy }">
-    <div
+    <MusicQuizPreparingState
       v-if="busy"
-      ref="preparingStatus"
-      class="bg-background absolute inset-0 z-10 flex min-h-64 flex-col items-center justify-center gap-3 rounded-lg p-6 text-center"
-      role="status"
-      aria-live="polite"
-      aria-atomic="true"
-      tabindex="-1"
-      data-testid="music-quiz-preparing"
-    >
-      <LoaderCircle
-        class="text-primary size-8 animate-spin"
-        aria-hidden="true"
-      />
-      <div class="flex flex-col gap-1">
-        <h2 class="text-lg font-semibold">
-          {{ $t("providers.music_quiz.preparing_game") }}
-        </h2>
-        <p class="text-muted-foreground max-w-md text-sm">
-          {{ $t("providers.music_quiz.preparing_game_help") }}
-        </p>
-      </div>
-    </div>
+      class="absolute inset-0 z-10 rounded-lg"
+    />
 
     <div
       class="flex-col gap-2"
@@ -145,6 +126,7 @@ import {
   type MusicQuizGameDefinition,
 } from "@/components/music-quiz/game_types";
 import MusicQuizPlaybackControls from "@/components/music-quiz/MusicQuizPlaybackControls.vue";
+import MusicQuizPreparingState from "@/components/music-quiz/MusicQuizPreparingState.vue";
 import { Button } from "@/components/ui/button";
 import { Field, FieldDescription, FieldLabel } from "@/components/ui/field";
 import { Progress } from "@/components/ui/progress";
@@ -160,7 +142,7 @@ import {
   type MusicQuizPlaybackSelection,
 } from "@/helpers/music_quiz_playback";
 import { $t } from "@/plugins/i18n";
-import { ArrowLeft, LoaderCircle } from "@lucide/vue";
+import { ArrowLeft } from "@lucide/vue";
 import { computed, defineComponent, nextTick, ref, watch } from "vue";
 
 const TOTAL_STEPS = 2;
@@ -210,7 +192,6 @@ const selectedType = ref<MusicQuizGameDefinition | null>(null);
 const includeSimilarMusic = ref(false);
 const chooseHeading = ref<HTMLHeadingElement | null>(null);
 const configureHeading = ref<HTMLHeadingElement | null>(null);
-const preparingStatus = ref<HTMLElement | null>(null);
 const sharedConfigValid = computed(() => {
   if (props.playbackOptionsLoading) return false;
   if (props.playbackOptions) {
@@ -234,16 +215,6 @@ watch(
         playbackSelection.value = reconciled;
       }
     }
-  },
-  { immediate: true },
-);
-
-watch(
-  () => props.busy,
-  async (busy) => {
-    if (!busy) return;
-    await nextTick();
-    preparingStatus.value?.focus({ preventScroll: true });
   },
   { immediate: true },
 );

--- a/src/composables/useMusicQuizHost.ts
+++ b/src/composables/useMusicQuizHost.ts
@@ -39,6 +39,7 @@ export function useMusicQuizHost(options: UseMusicQuizHostOptions) {
 
   const state = ref<MusicQuizHostState | null>(null);
   const busy = ref(false);
+  const starting = ref(false);
   const loading = ref(false);
   const availableQuizTypes = ref<string[]>([]);
   const playbackOptions = ref<MusicQuizPlaybackOptions | null>(null);
@@ -162,6 +163,7 @@ export function useMusicQuizHost(options: UseMusicQuizHostOptions) {
   async function start() {
     if (busy.value) return false;
     busy.value = true;
+    starting.value = true;
     try {
       const nextState = await startMusicQuiz();
       applyState(nextState);
@@ -172,6 +174,7 @@ export function useMusicQuizHost(options: UseMusicQuizHostOptions) {
       );
       return false;
     } finally {
+      starting.value = false;
       busy.value = false;
     }
   }
@@ -294,6 +297,7 @@ export function useMusicQuizHost(options: UseMusicQuizHostOptions) {
   return {
     state,
     busy,
+    starting,
     loading,
     availableQuizTypes,
     playbackOptions,

--- a/src/views/MusicQuizDashboardView.vue
+++ b/src/views/MusicQuizDashboardView.vue
@@ -35,30 +35,18 @@
             {{ statusText }}
           </p>
         </div>
-        <div class="flex shrink-0 items-center gap-2">
-          <Button
-            v-if="isAdmin && musicQuizProviderInstanceId"
-            variant="ghost"
-            size="icon"
-            data-testid="music-quiz-settings"
-            :aria-label="$t('providers.music_quiz.settings')"
-            :title="$t('providers.music_quiz.settings')"
-            @click="goToMusicQuizSettings"
-          >
-            <Settings class="size-5" />
-          </Button>
-          <Button
-            v-if="!state && !loading"
-            variant="default"
-            size="sm"
-            data-testid="new-game"
-            :disabled="busy"
-            @click="openSetupDialog"
-          >
-            <Plus class="size-4" />
-            {{ $t("providers.music_quiz.new_game") }}
-          </Button>
-        </div>
+        <Button
+          v-if="isAdmin && musicQuizProviderInstanceId"
+          class="shrink-0"
+          variant="ghost"
+          size="icon"
+          data-testid="music-quiz-settings"
+          :aria-label="$t('providers.music_quiz.settings')"
+          :title="$t('providers.music_quiz.settings')"
+          @click="goToMusicQuizSettings"
+        >
+          <Settings class="size-5" />
+        </Button>
       </header>
 
       <MusicQuizConnectionBanners :degraded="isConnectionDegraded" />
@@ -96,6 +84,11 @@
         :busy="busy"
         :can-end-game="true"
         @end-game="showEndGameDialog = true"
+      />
+
+      <MusicQuizPreparingState
+        v-else-if="starting && activeState"
+        class="rounded-xl border shadow-sm"
       />
 
       <div
@@ -222,6 +215,7 @@ import MusicQuizLeaderboard, {
   type MusicQuizLeaderboardRow,
 } from "@/components/music-quiz/MusicQuizLeaderboard.vue";
 import MusicQuizPresentStage from "@/components/music-quiz/MusicQuizPresentStage.vue";
+import MusicQuizPreparingState from "@/components/music-quiz/MusicQuizPreparingState.vue";
 import MusicQuizSessionHeader from "@/components/music-quiz/MusicQuizSessionHeader.vue";
 import MusicQuizSessionPanels from "@/components/music-quiz/MusicQuizSessionPanels.vue";
 import MusicQuizSetupWizard from "@/components/music-quiz/MusicQuizSetupWizard.vue";
@@ -272,6 +266,7 @@ const host = useMusicQuizHost({
 const {
   state,
   busy,
+  starting,
   loading,
   availableQuizTypes,
   playbackOptions,

--- a/src/views/MusicQuizPlayerView.vue
+++ b/src/views/MusicQuizPlayerView.vue
@@ -76,7 +76,6 @@
           mode === 'remote' &&
           listenInPrimedGeneration === webPlayer.player_generation
         "
-        preference-key="music_quiz_listen_in_enabled"
       />
 
       <MusicQuizPlayerStage

--- a/tests/components/ListenIn.test.ts
+++ b/tests/components/ListenIn.test.ts
@@ -48,21 +48,6 @@ vi.mock("vue-sonner", () => ({
 
 const initialLocale = i18n.global.locale.value;
 i18n.global.locale.value = "en";
-const storageValues = new Map<string, string>();
-const mockLocalStorage: Storage = {
-  get length() {
-    return storageValues.size;
-  },
-  clear: () => storageValues.clear(),
-  getItem: (key) => storageValues.get(key) ?? null,
-  key: (index) => [...storageValues.keys()][index] ?? null,
-  removeItem: (key) => storageValues.delete(key),
-  setItem: (key, value) => storageValues.set(key, value),
-};
-Object.defineProperty(window, "localStorage", {
-  configurable: true,
-  value: mockLocalStorage,
-});
 
 const surfaces = [
   {
@@ -98,7 +83,6 @@ describe("ListenIn", () => {
     listenInMock.enableListenIn.mockResolvedValue(true);
     listenInMock.disableListenIn.mockResolvedValue(true);
     listenInMock.options = undefined;
-    window.localStorage.removeItem("test_listen_in_enabled");
   });
 
   it.each(renderCases)(
@@ -240,37 +224,43 @@ describe("ListenIn", () => {
     expect(listenInMock.disableListenIn).toHaveBeenCalledTimes(2);
   });
 
-  it("defaults on, remembers explicit choices, and restores the preference", async () => {
+  it("defaults remote listening on until the guest explicitly opts out", async () => {
     const wrapper = mount(ListenIn, {
       props: {
         domain: "music_quiz",
         mode: "remote",
         labels: surfaces[1].labels,
         autoEnable: true,
-        preferenceKey: "test_listen_in_enabled",
       },
     });
 
     expect(listenInMock.options?.autoEnable?.()).toBe(true);
 
-    await wrapper.get("button").trigger("click");
-    expect(window.localStorage.getItem("test_listen_in_enabled")).toBe("true");
-
     getMockState().isListeningIn.value = true;
     await nextTick();
     await wrapper.get("button").trigger("click");
-    expect(window.localStorage.getItem("test_listen_in_enabled")).toBe("false");
+
     expect(listenInMock.options?.autoEnable?.()).toBe(false);
+
+    wrapper.unmount();
+    mount(ListenIn, {
+      props: {
+        domain: "music_quiz",
+        mode: "remote",
+        labels: surfaces[1].labels,
+        autoEnable: true,
+      },
+    });
+    expect(listenInMock.options?.autoEnable?.()).toBe(true);
   });
 
-  it("remembers Stop before the async command completes", async () => {
+  it("applies remote opt-out before the stop command completes", async () => {
     let resolveStop!: (result: boolean) => void;
     listenInMock.disableListenIn.mockReturnValueOnce(
       new Promise<boolean>((resolve) => {
         resolveStop = resolve;
       }),
     );
-    window.localStorage.setItem("test_listen_in_enabled", "true");
     getMockState().isListeningIn.value = true;
     const wrapper = mount(ListenIn, {
       props: {
@@ -278,65 +268,27 @@ describe("ListenIn", () => {
         mode: "remote",
         labels: surfaces[1].labels,
         autoEnable: true,
-        preferenceKey: "test_listen_in_enabled",
       },
     });
 
     await wrapper.get("button").trigger("click");
 
-    expect(window.localStorage.getItem("test_listen_in_enabled")).toBe("false");
+    expect(listenInMock.options?.autoEnable?.()).toBe(false);
     resolveStop(false);
   });
 
-  it("never restores Remote opt-in while the current mode requires opt-in", () => {
-    window.localStorage.setItem("test_listen_in_enabled", "true");
+  it("never auto-enables venue listening", () => {
     mount(ListenIn, {
       props: {
         domain: "music_quiz",
         mode: "venue",
         labels: surfaces[1].labels,
-        autoEnable: false,
-        preferenceKey: "test_listen_in_enabled",
+        autoEnable: true,
       },
     });
 
     expect(listenInMock.options?.autoEnable?.()).toBe(false);
     expect(listenInMock.enableListenIn).not.toHaveBeenCalled();
-  });
-
-  it("keeps Listen-in usable when browser storage is blocked", async () => {
-    const consoleDebug = vi
-      .spyOn(console, "debug")
-      .mockImplementation(() => {});
-    const getItem = vi
-      .spyOn(mockLocalStorage, "getItem")
-      .mockImplementationOnce(() => {
-        throw new DOMException("Blocked");
-      });
-    const wrapper = mount(ListenIn, {
-      props: {
-        domain: "music_quiz",
-        mode: "remote",
-        labels: surfaces[1].labels,
-        autoEnable: true,
-        preferenceKey: "test_listen_in_enabled",
-      },
-    });
-
-    expect(listenInMock.options?.autoEnable?.()).toBe(true);
-    getItem.mockRestore();
-
-    const setItem = vi
-      .spyOn(mockLocalStorage, "setItem")
-      .mockImplementationOnce(() => {
-        throw new DOMException("Blocked");
-      });
-    await wrapper.get("button").trigger("click");
-
-    expect(listenInMock.enableListenIn).toHaveBeenCalledOnce();
-    expect(consoleDebug).toHaveBeenCalledTimes(2);
-    setItem.mockRestore();
-    consoleDebug.mockRestore();
   });
 
   it("renders enabled actions and disables both action types while busy", async () => {

--- a/tests/composables/useMusicQuizHost.test.ts
+++ b/tests/composables/useMusicQuizHost.test.ts
@@ -408,6 +408,35 @@ describe("useMusicQuizHost", () => {
     expect(mockResetMusicQuiz).toHaveBeenNthCalledWith(2, true);
   });
 
+  it("exposes preparation state while a game is starting", async () => {
+    const pending = deferred<typeof HOST_STATE>();
+    mockStartMusicQuiz.mockReturnValueOnce(pending.promise);
+    const host = useMusicQuizHost({ notifyError: vi.fn() });
+    await flushPromises();
+
+    const start = host.start();
+
+    expect(host.starting.value).toBe(true);
+    expect(host.busy.value).toBe(true);
+
+    pending.resolve(HOST_STATE);
+    await expect(start).resolves.toBe(true);
+
+    expect(host.starting.value).toBe(false);
+    expect(host.busy.value).toBe(false);
+  });
+
+  it("clears preparation state when starting fails", async () => {
+    mockStartMusicQuiz.mockRejectedValueOnce(new Error("Unavailable"));
+    const host = useMusicQuizHost({ notifyError: vi.fn() });
+    await flushPromises();
+
+    await expect(host.start()).resolves.toBe(false);
+
+    expect(host.starting.value).toBe(false);
+    expect(host.busy.value).toBe(false);
+  });
+
   it.each(HOST_ACTIONS)(
     "serializes concurrent $name commands",
     async ({ command, invoke, result }) => {

--- a/tests/views/MusicQuizDashboardHostActions.test.ts
+++ b/tests/views/MusicQuizDashboardHostActions.test.ts
@@ -112,11 +112,13 @@ const TRIVIA_HOST_STATE = {
 
 let state: Ref<MusicQuizSupportedHostState | null>;
 let busy: Ref<boolean>;
+let starting: Ref<boolean>;
 
 describe("MusicQuizDashboardView host actions", () => {
   beforeEach(() => {
     state = ref({ ...HOST_STATE });
     busy = ref(false);
+    starting = ref(false);
     mockDeleteGame.mockReset();
     mockDeleteGame.mockResolvedValue(true);
     mockFetchPlaybackOptions.mockReset();
@@ -148,6 +150,7 @@ describe("MusicQuizDashboardView host actions", () => {
       reset: mockReset,
       reveal: vi.fn(),
       start: mockStart,
+      starting,
       state,
       fetchPlaybackOptions: mockFetchPlaybackOptions,
     });
@@ -206,6 +209,36 @@ describe("MusicQuizDashboardView host actions", () => {
     await wrapper.get('[data-testid="start-now"]').trigger("click");
 
     expect(mockStart).toHaveBeenCalledOnce();
+  });
+
+  it("shows preparation progress while the game starts", async () => {
+    state.value = { ...HOST_STATE, phase: "lobby" };
+    let finishStart!: () => void;
+    mockStart.mockImplementation(
+      () =>
+        new Promise<boolean>((resolve) => {
+          starting.value = true;
+          finishStart = () => {
+            starting.value = false;
+            resolve(true);
+          };
+        }),
+    );
+    const wrapper = mountDashboard();
+
+    await wrapper.get('[data-testid="start-now"]').trigger("click");
+
+    const status = wrapper.get('[data-testid="music-quiz-preparing"]');
+    expect(status.attributes("role")).toBe("status");
+    expect(status.text()).toContain("providers.music_quiz.preparing_game");
+    expect(wrapper.find('[data-testid="start-now"]').exists()).toBe(false);
+
+    finishStart();
+    await flushPromises();
+
+    expect(wrapper.find('[data-testid="music-quiz-preparing"]').exists()).toBe(
+      false,
+    );
   });
 
   it("deletes the finished game before opening fresh setup", async () => {

--- a/tests/views/MusicQuizDashboardView.test.ts
+++ b/tests/views/MusicQuizDashboardView.test.ts
@@ -113,6 +113,8 @@ describe("MusicQuizDashboardView", () => {
       false,
     );
     expect(wrapper.text()).toContain("providers.music_quiz.no_active_game");
+    expect(wrapper.find('[data-testid="new-game"]').exists()).toBe(false);
+    expect(wrapper.findAll('[data-testid="new-game-empty"]')).toHaveLength(1);
     expect(wrapper.find('[data-testid="music-quiz-setup"]').exists()).toBe(
       false,
     );

--- a/tests/views/MusicQuizPlayerView.test.ts
+++ b/tests/views/MusicQuizPlayerView.test.ts
@@ -29,13 +29,8 @@ vi.mock("@/components/ListenIn.vue", async () => {
       props: {
         autoEnable: Boolean,
         mode: String,
-        preferenceKey: String,
       },
-      setup(props: {
-        autoEnable?: boolean;
-        mode?: string;
-        preferenceKey?: string;
-      }) {
+      setup(props: { autoEnable?: boolean; mode?: string }) {
         mockListenInSetup(props);
         return () => h("div", { "data-testid": "listen-in" });
       },
@@ -358,7 +353,6 @@ describe("MusicQuizPlayerView routing", () => {
       expect.objectContaining({
         autoEnable: false,
         mode: "remote",
-        preferenceKey: "music_quiz_listen_in_enabled",
       }),
     );
     wrapper.unmount();
@@ -579,6 +573,52 @@ describe("MusicQuizPlayerView routing", () => {
     expect(
       wrapper.findComponent({ name: "ListenIn" }).props("autoEnable"),
     ).toBe(false);
+  });
+
+  it("keeps venue listen-in opt-in when joining", async () => {
+    const info = ref({
+      quiz_type: "guess_the_song",
+      answer_type: "multiple_choice",
+      phase: "lobby",
+      name: "Quiz",
+      player_count: 0,
+      round_count: 5,
+      mode: "venue",
+    });
+    const state = ref<typeof playerState | null>(null);
+    const playerId = ref<string | null>(null);
+    const activeRound = ref<typeof currentRound | null>(null);
+    const join = vi.fn(async () => {
+      state.value = { ...playerState, mode: "venue" };
+      playerId.value = "player-id";
+      activeRound.value = currentRound;
+    });
+    mockResolveMusicQuizDefinition.mockReturnValue(createDefinition(true));
+    mockUseMusicQuizPlayer.mockReturnValue({
+      info,
+      state,
+      playerId,
+      rememberedName: ref(""),
+      gameRemoved: ref(false),
+      busy: ref(false),
+      loading: ref(false),
+      currentRound: activeRound,
+      join,
+      submitAnswer: vi.fn(),
+      ready: vi.fn(),
+    });
+    const wrapper = mountView();
+
+    wrapper.getComponent(MusicQuizJoinForm).vm.$emit("join", "Guest");
+    await flushPromises();
+
+    expect(mockPrimeAudio).toHaveBeenCalledOnce();
+    expect(mockListenInSetup).toHaveBeenCalledWith(
+      expect.objectContaining({
+        autoEnable: false,
+        mode: "venue",
+      }),
+    );
   });
 
   it("keeps Tap available when Join cannot prime audio yet", async () => {


### PR DESCRIPTION
Fixes inconsistent loading and audio behavior when starting Music Quiz games.

- Show a preparation screen while a game loads
- Start remote guests with listen-in enabled while keeping venue audio optional
- Remove the duplicate New Game button
- Keep playback selection with each game setup