### PR TITLE
Show quiz results without scrolling

### DIFF
--- a/src/helpers/music_quiz.ts
+++ b/src/helpers/music_quiz.ts
@@ -93,25 +93,30 @@ export function isMusicQuizWinner(
   );
 }
 
+export function getMusicQuizRoundScore(
+  state: MusicQuizSupportedPublicState,
+  playerName: string,
+) {
+  if (state.phase !== "reveal" || !state.current_round) return undefined;
+  const player = state.players.find((p) => p.name === playerName);
+  if (!player) return undefined;
+  if (player.active_from_round > state.current_round.round_index) {
+    return undefined;
+  }
+  if (!player.last_answer) return undefined;
+  return "placement" in player.last_answer
+    ? player.last_answer.placement.points +
+        (player.last_answer.artist?.points ?? 0) +
+        (player.last_answer.title?.points ?? 0)
+    : player.last_answer.points;
+}
+
 export function getMusicQuizRoundScoreLabel(
   state: MusicQuizSupportedPublicState,
   playerName: string,
 ) {
-  if (state.phase !== "reveal" || !state.current_round) return "";
-  const player = state.players.find((p) => p.name === playerName);
-  if (!player) return "";
-  if (player.active_from_round > state.current_round.round_index) {
-    return "";
-  }
-  if (!player.last_answer) return "";
-  const points =
-    "placement" in player.last_answer
-      ? player.last_answer.placement.points +
-        (player.last_answer.artist?.points ?? 0) +
-        (player.last_answer.title?.points ?? 0)
-      : player.last_answer.points;
-  if (points !== undefined) return `(+${points})`;
-  return "";
+  const points = getMusicQuizRoundScore(state, playerName);
+  return points === undefined ? "" : `(+${points})`;
 }
 
 export function getMusicQuizErrorMessage(err: unknown, fallback = "") {

--- a/src/views/MusicQuizPlayerView.vue
+++ b/src/views/MusicQuizPlayerView.vue
@@ -139,6 +139,7 @@ import {
 } from "@/composables/useMusicQuiz";
 import {
   getMusicQuizErrorMessage,
+  getMusicQuizRoundScore,
   getMusicQuizRoundScoreLabel,
   getMusicQuizWinnerText,
   rankMusicQuizPlayers,
@@ -262,6 +263,11 @@ const playerRoundScoreLabel = computed(() =>
     ? getMusicQuizRoundScoreLabel(activeState.value, activeState.value.you.name)
     : "",
 );
+const playerRoundScore = computed(() =>
+  activeState.value
+    ? getMusicQuizRoundScore(activeState.value, activeState.value.you.name)
+    : undefined,
+);
 
 const phaseText = computed(() => {
   const currentState = activeState.value;
@@ -296,14 +302,18 @@ watch(
     () => activeState.value?.phase,
     () => currentRound.value?.round_index,
     () => activeState.value?.you.answer?.correct,
+    () => playerRoundScore.value,
   ],
-  ([phase, , correct]) => {
-    if (phase !== "reveal" || correct === undefined) return;
-    const message = $t(
+  ([phase, , correct, points]) => {
+    if (phase !== "reveal" || correct === undefined || points === undefined) {
+      return;
+    }
+    const result = $t(
       correct
         ? "providers.music_quiz.correct"
         : "providers.music_quiz.incorrect",
     );
+    const message = `${result} +${points}`;
     if (correct) {
       toast.success(message);
     } else {

--- a/src/views/MusicQuizPlayerView.vue
+++ b/src/views/MusicQuizPlayerView.vue
@@ -291,6 +291,28 @@ watch(
   },
 );
 
+watch(
+  [
+    () => activeState.value?.phase,
+    () => currentRound.value?.round_index,
+    () => activeState.value?.you.answer?.correct,
+  ],
+  ([phase, , correct]) => {
+    if (phase !== "reveal" || correct === undefined) return;
+    const message = $t(
+      correct
+        ? "providers.music_quiz.correct"
+        : "providers.music_quiz.incorrect",
+    );
+    if (correct) {
+      toast.success(message);
+    } else {
+      toast.error(message);
+    }
+  },
+  { immediate: true },
+);
+
 async function handleJoin(name: string) {
   if (listenInEnabled.value) {
     listenInPrimedGeneration.value = webPlayer.primeAudio()

--- a/tests/helpers/musicQuiz.test.ts
+++ b/tests/helpers/musicQuiz.test.ts
@@ -2,7 +2,10 @@ import type {
   MusicQuizGuessTheSongPublicState,
   MusicQuizTimelinePublicState,
 } from "@/composables/useMusicQuiz";
-import { getMusicQuizRoundScoreLabel } from "@/helpers/music_quiz";
+import {
+  getMusicQuizRoundScore,
+  getMusicQuizRoundScoreLabel,
+} from "@/helpers/music_quiz";
 import { describe, expect, it, vi } from "vitest";
 
 vi.mock("@/plugins/i18n", () => ({
@@ -61,6 +64,7 @@ describe("Music Quiz round score labels", () => {
       current_round: currentRound,
     } satisfies MusicQuizTimelinePublicState;
 
+    expect(getMusicQuizRoundScore(state, "Player")).toBe(1250);
     expect(getMusicQuizRoundScoreLabel(state, "Player")).toBe("(+1250)");
   });
 
@@ -99,6 +103,7 @@ describe("Music Quiz round score labels", () => {
       },
     } satisfies MusicQuizGuessTheSongPublicState;
 
+    expect(getMusicQuizRoundScore(state, "Player")).toBe(1000);
     expect(getMusicQuizRoundScoreLabel(state, "Player")).toBe("(+1000)");
   });
 });

--- a/tests/views/MusicQuizPlayerView.test.ts
+++ b/tests/views/MusicQuizPlayerView.test.ts
@@ -7,6 +7,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const {
   mockGameAdapterSetup,
+  mockGetMusicQuizRoundScore,
   mockGetTrackLyrics,
   mockListenInSetup,
   mockPrimeAudio,
@@ -16,6 +17,7 @@ const {
   mockUseMusicQuizPlayer,
 } = vi.hoisted(() => ({
   mockGameAdapterSetup: vi.fn(),
+  mockGetMusicQuizRoundScore: vi.fn(),
   mockGetTrackLyrics: vi.fn(),
   mockListenInSetup: vi.fn(),
   mockPrimeAudio: vi.fn(),
@@ -68,6 +70,7 @@ vi.mock("@/composables/useMusicQuizCelebration", () => ({
 
 vi.mock("@/helpers/music_quiz", () => ({
   getMusicQuizErrorMessage: () => "",
+  getMusicQuizRoundScore: mockGetMusicQuizRoundScore,
   getMusicQuizRoundScoreLabel: () => "",
   getMusicQuizWinnerText: () => "",
   rankMusicQuizPlayers: () => [],
@@ -216,6 +219,7 @@ describe("MusicQuizPlayerView routing", () => {
 
   beforeEach(() => {
     mockGameAdapterSetup.mockReset();
+    mockGetMusicQuizRoundScore.mockReset();
     mockGetTrackLyrics.mockReset();
     mockListenInSetup.mockReset();
     mockPrimeAudio.mockReset();
@@ -413,6 +417,8 @@ describe("MusicQuizPlayerView routing", () => {
   ] as const)(
     "shows a toast for %s answers when the result is revealed",
     async (_result, correct) => {
+      const points = correct ? 7 : 0;
+      mockGetMusicQuizRoundScore.mockReturnValue(points);
       const state = ref({
         ...playerState,
         phase: "answering" as "answering" | "reveal",
@@ -449,7 +455,7 @@ describe("MusicQuizPlayerView routing", () => {
           answer: {
             ...state.value.you.answer,
             correct,
-            points: correct ? 7 : 0,
+            points,
           },
         },
       };
@@ -458,9 +464,11 @@ describe("MusicQuizPlayerView routing", () => {
       const expectedToast = correct ? mockToastSuccess : mockToastError;
       expect(expectedToast).toHaveBeenCalledOnce();
       expect(expectedToast).toHaveBeenCalledWith(
-        correct
-          ? "providers.music_quiz.correct"
-          : "providers.music_quiz.incorrect",
+        `${
+          correct
+            ? "providers.music_quiz.correct"
+            : "providers.music_quiz.incorrect"
+        } +${points}`,
       );
 
       state.value = { ...state.value };

--- a/tests/views/MusicQuizPlayerView.test.ts
+++ b/tests/views/MusicQuizPlayerView.test.ts
@@ -11,6 +11,8 @@ const {
   mockListenInSetup,
   mockPrimeAudio,
   mockResolveMusicQuizDefinition,
+  mockToastError,
+  mockToastSuccess,
   mockUseMusicQuizPlayer,
 } = vi.hoisted(() => ({
   mockGameAdapterSetup: vi.fn(),
@@ -18,6 +20,8 @@ const {
   mockListenInSetup: vi.fn(),
   mockPrimeAudio: vi.fn(),
   mockResolveMusicQuizDefinition: vi.fn(),
+  mockToastError: vi.fn(),
+  mockToastSuccess: vi.fn(),
   mockUseMusicQuizPlayer: vi.fn(),
 }));
 
@@ -105,7 +109,8 @@ vi.mock("@/plugins/web_player", async () => {
 
 vi.mock("vue-sonner", () => ({
   toast: {
-    error: vi.fn(),
+    error: mockToastError,
+    success: mockToastSuccess,
   },
 }));
 
@@ -217,6 +222,8 @@ describe("MusicQuizPlayerView routing", () => {
     mockPrimeAudio.mockReturnValue(true);
     webPlayer.player_generation = 0;
     mockResolveMusicQuizDefinition.mockReset();
+    mockToastError.mockReset();
+    mockToastSuccess.mockReset();
     mockUseMusicQuizPlayer.mockReset();
     mockUseMusicQuizPlayer.mockReturnValue({
       info: ref(null),
@@ -399,6 +406,69 @@ describe("MusicQuizPlayerView routing", () => {
     ).toBe("providers.music_quiz.round_label 1/1");
     wrapper.unmount();
   });
+
+  it.each([
+    ["correct", true],
+    ["incorrect", false],
+  ] as const)(
+    "shows a toast for %s answers when the result is revealed",
+    async (_result, correct) => {
+      const state = ref({
+        ...playerState,
+        phase: "answering" as "answering" | "reveal",
+        you: {
+          ...playerState.you,
+          answer: {
+            suggestion_id: "one",
+            answered_at: 1,
+            correct: undefined as boolean | undefined,
+            points: undefined as number | undefined,
+          },
+        },
+      });
+      mockResolveMusicQuizDefinition.mockReturnValue(createDefinition(true));
+      mockUseMusicQuizPlayer.mockReturnValue({
+        info: ref(null),
+        state,
+        playerId: ref("player-id"),
+        gameRemoved: ref(false),
+        busy: ref(false),
+        loading: ref(false),
+        currentRound: ref(currentRound),
+        join: vi.fn(),
+        submitAnswer: vi.fn(),
+        ready: vi.fn(),
+      });
+      const wrapper = mountView();
+
+      state.value = {
+        ...state.value,
+        phase: "reveal",
+        you: {
+          ...state.value.you,
+          answer: {
+            ...state.value.you.answer,
+            correct,
+            points: correct ? 7 : 0,
+          },
+        },
+      };
+      await nextTick();
+
+      const expectedToast = correct ? mockToastSuccess : mockToastError;
+      expect(expectedToast).toHaveBeenCalledOnce();
+      expect(expectedToast).toHaveBeenCalledWith(
+        correct
+          ? "providers.music_quiz.correct"
+          : "providers.music_quiz.incorrect",
+      );
+
+      state.value = { ...state.value };
+      await nextTick();
+      expect(expectedToast).toHaveBeenCalledOnce();
+      wrapper.unmount();
+    },
+  );
 
   it("enables Music Timeline ListenIn without fetching lyrics", () => {
     mockResolveMusicQuizDefinition.mockReturnValue(createDefinition(true));


### PR DESCRIPTION
Quiz guests on mobile could miss whether their answer was correct because the result appeared below the revealed content.

- Show a green or red result notification as soon as an answer is revealed
- Include total earned points, including Music Timeline bonuses
- Keep the existing inline result for full round details
- Avoid duplicate notifications during state updates

## Screenshot

![Mobile quiz result notification with earned points](https://raw.githubusercontent.com/music-assistant/frontend/e1fb04ebdd817c5a91a83fd1723e8d1a98a5ff1c/.github/pr-assets/2123/quiz-result-mobile.png)