### PR TITLE
Fix duplicate-ID console warnings from ListItem on settings pages

### DIFF
--- a/src/composables/useListItem.ts
+++ b/src/composables/useListItem.ts
@@ -52,10 +52,17 @@ export interface ListItemEmits {
 
 export const useListItem = (props: ListItemProps) => {
   const listItemProps = computed(() => {
-    const { variant, showMenuBtn, ...vuetifyProps } = props;
+    const { variant, showMenuBtn, link, value, ...vuetifyProps } = props;
 
     const baseProps = {
       ...vuetifyProps,
+      ...(link ? { link } : {}),
+      // value of false/null would register every item under the same ID in
+      // Vuetify's nested registry ("Multiple nodes with the same ID"); omit
+      // it so Vuetify falls back to a unique uid per item.
+      ...(value !== false && value !== undefined && value !== null
+        ? { value }
+        : {}),
       "aria-label": props["aria-label"],
     };
 
@@ -104,5 +111,4 @@ export const useListItem = (props: ListItemProps) => {
 export const defaultListItemProps = {
   variant: "default" as const,
   showMenuBtn: false,
-  link: false,
 };

--- a/tests/composables/useListItem.test.ts
+++ b/tests/composables/useListItem.test.ts
@@ -119,6 +119,46 @@ describe("useListItem", () => {
     expect(listItemProps.value).not.toHaveProperty("showMenuBtn");
   });
 
+  it("omits value when false so v-list-items don't share a nested ID", () => {
+    // Passing value: false to every v-list-item makes Vuetify's nested
+    // registry log "Multiple nodes with the same ID" for each collision.
+    const props: ListItemProps = { variant: "default", value: false };
+    const { listItemProps } = useListItem(props);
+
+    expect(listItemProps.value).not.toHaveProperty("value");
+  });
+
+  it("omits value when undefined", () => {
+    const props: ListItemProps = { variant: "default" };
+    const { listItemProps } = useListItem(props);
+
+    expect(listItemProps.value).not.toHaveProperty("value");
+  });
+
+  it("passes falsy-but-valid values through (0, empty string)", () => {
+    expect(
+      useListItem({ variant: "default", value: 0 }).listItemProps.value.value,
+    ).toBe(0);
+    expect(
+      useListItem({ variant: "default", value: "" }).listItemProps.value.value,
+    ).toBe("");
+  });
+
+  it("omits link when false or undefined", () => {
+    expect(
+      useListItem({ variant: "default", link: false }).listItemProps.value,
+    ).not.toHaveProperty("link");
+    expect(
+      useListItem({ variant: "default" }).listItemProps.value,
+    ).not.toHaveProperty("link");
+  });
+
+  it("passes link through when true", () => {
+    const { listItemProps } = useListItem({ variant: "default", link: true });
+
+    expect(listItemProps.value.link).toBe(true);
+  });
+
   it("handles object class correctly", () => {
     const props: ListItemProps = {
       variant: "default",


### PR DESCRIPTION
I've been going through and using playwright to do some automated testing, looking for JavaScript console errors. This is the next thing that I found. 

Commit message:

useListItem passed value (defaulting to false via prop passthrough) to every v-list-item, so all items without an explicit value registered in Vuetify's nested registry under the same ID 'false', flooding the console with 'Multiple nodes with the same ID' warnings on settings/players, system, and tasks.

- Omit value when false/null/undefined so Vuetify falls back to a unique uid per item; falsy-but-valid values (0, '') still pass through
- Only pass link when truthy and drop the link:false default, which matches Vuetify's own default (undefined) with no behavior change for existing consumers
- Add regression tests for the value/link passthrough contract