### PR TITLE
Fix guest api errors

### DIFF
--- a/src/composables/useGuestEntryResolver.ts
+++ b/src/composables/useGuestEntryResolver.ts
@@ -7,7 +7,8 @@ import {
   type GuestQuizAffinity,
 } from "@/helpers/guest_quiz_affinity";
 import { consumeMusicQuizJoinedGameEnded } from "@/helpers/music_quiz_guest_state";
-import api, { ConnectionState } from "@/plugins/api";
+import api from "@/plugins/api";
+import { waitForApiInitialization } from "@/plugins/api/helpers";
 import { authManager } from "@/plugins/auth";
 import { EventType, type EventMessage } from "@/plugins/api/interfaces";
 import {
@@ -200,21 +201,4 @@ function getGuestEntryPath(state: GuestEntryState): string | undefined {
   if (state === "party") return "/guest/party";
   if (state === "quiz-inactive" || state === "inactive") return "/guest";
   return undefined;
-}
-
-async function waitForApiInitialization() {
-  if (api.state.value === ConnectionState.INITIALIZED) return;
-
-  await new Promise<void>((resolve) => {
-    const unwatch = watch(
-      () => api.state.value,
-      (newState) => {
-        if (newState === ConnectionState.INITIALIZED) {
-          unwatch();
-          resolve();
-        }
-      },
-      { immediate: true },
-    );
-  });
 }

--- a/src/composables/useGuestEntryResolver.ts
+++ b/src/composables/useGuestEntryResolver.ts
@@ -184,7 +184,9 @@ async function resolveGuestEntryState(
   const hasMusicQuiz = providerDomains.has("music_quiz");
 
   if (hasMusicQuiz) {
-    const game = await getMusicQuizInfo();
+    // Best-effort: an info failure must not strand the resolver in its
+    // loading state, so treat it the same as "no active quiz".
+    const game = await getMusicQuizInfo().catch(() => null);
     if (game) return "quiz";
   }
   if (quizAffinity.active) return "quiz-inactive";

--- a/src/composables/useGuestEntryResolver.ts
+++ b/src/composables/useGuestEntryResolver.ts
@@ -24,6 +24,7 @@ import { useRoute, useRouter } from "vue-router";
 
 export type GuestEntryState =
   | "loading"
+  | "error"
   | "quiz"
   | "party"
   | "quiz-ended"
@@ -103,7 +104,22 @@ export function useGuestEntryResolver() {
     while (active) {
       const version = requestedVersion;
       const resolutionAffinity = getQuizAffinity();
-      const nextState = await resolveGuestEntryState(resolutionAffinity);
+      let nextState: GuestEntryState;
+      try {
+        nextState = await resolveGuestEntryState(resolutionAffinity);
+      } catch {
+        if (!active) return;
+        if (version !== requestedVersion) continue;
+        if (resolutionAffinity !== getQuizAffinity()) {
+          requestedVersion += 1;
+          continue;
+        }
+        if (state.value === "loading") {
+          state.value = "error";
+          await syncRoute();
+        }
+        return;
+      }
       if (!active) return;
       if (version !== requestedVersion) continue;
       if (resolutionAffinity !== getQuizAffinity()) {
@@ -185,9 +201,7 @@ async function resolveGuestEntryState(
   const hasMusicQuiz = providerDomains.has("music_quiz");
 
   if (hasMusicQuiz) {
-    // Best-effort: an info failure must not strand the resolver in its
-    // loading state, so treat it the same as "no active quiz".
-    const game = await getMusicQuizInfo().catch(() => null);
+    const game = await getMusicQuizInfo();
     if (game) return "quiz";
   }
   if (quizAffinity.active) return "quiz-inactive";
@@ -199,6 +213,7 @@ function getGuestEntryPath(state: GuestEntryState): string | undefined {
   if (state === "quiz") return "/guest/quiz";
   if (state === "quiz-ended") return "/guest/quiz";
   if (state === "party") return "/guest/party";
+  if (state === "error") return "/guest";
   if (state === "quiz-inactive" || state === "inactive") return "/guest";
   return undefined;
 }

--- a/src/composables/useListenIn.ts
+++ b/src/composables/useListenIn.ts
@@ -1,6 +1,7 @@
 import { computed, onBeforeUnmount, onMounted, ref, watch } from "vue";
 import api from "@/plugins/api";
 import { EventType } from "@/plugins/api/interfaces";
+import { authManager } from "@/plugins/auth";
 import { webPlayer } from "@/plugins/web_player";
 
 let nextListenInOperationId = 0;
@@ -80,10 +81,18 @@ export function useListenIn(options: UseListenInOptions) {
       canListenIn.value = false;
       return;
     }
+    // The server's can_listen_in endpoints are guest-only and reject any
+    // other role, so don't even ask outside a guest access session.
+    if (!authManager.isGuestAccessSession()) {
+      canListenIn.value = false;
+      return;
+    }
     try {
       const available = await api.sendCommand<boolean>(
         `${domain}/can_listen_in`,
         { web_player_id: playerId },
+        // Availability is best-effort; failures are handled below.
+        { suppressGlobalError: true },
       );
       if (
         disposed ||

--- a/src/composables/useListenIn.ts
+++ b/src/composables/useListenIn.ts
@@ -1,7 +1,6 @@
 import { computed, onBeforeUnmount, onMounted, ref, watch } from "vue";
 import api from "@/plugins/api";
 import { EventType } from "@/plugins/api/interfaces";
-import { authManager } from "@/plugins/auth";
 import { webPlayer } from "@/plugins/web_player";
 
 let nextListenInOperationId = 0;
@@ -78,12 +77,6 @@ export function useListenIn(options: UseListenInOptions) {
     const playerId = webPlayerId.value;
     const playerGeneration = webPlayerGeneration.value;
     if (!playerId) {
-      canListenIn.value = false;
-      return;
-    }
-    // The server's can_listen_in endpoints are guest-only and reject any
-    // other role, so don't even ask outside a guest access session.
-    if (!authManager.isGuestAccessSession()) {
       canListenIn.value = false;
       return;
     }

--- a/src/composables/useMusicQuiz.ts
+++ b/src/composables/useMusicQuiz.ts
@@ -714,7 +714,7 @@ export function deleteMusicQuiz() {
   return api.sendCommand<null>("music_quiz/delete");
 }
 
-// Guest commands (any authenticated user; server validates guest username)
+// Participant game commands (available to any authenticated user)
 export function getMusicQuizInfo(): Promise<MusicQuizInfo | null> {
   // Without the music_quiz provider loaded on the server, the command isn't
   // even registered ("Invalid or unsupported command") — and there can be no
@@ -770,7 +770,7 @@ export function readyMusicQuiz(player_id: string) {
   });
 }
 
-// Listen-in commands (Scope.PLAYERS_CONTROL + guest validation)
+// Listen-in commands (Scope.PLAYERS_CONTROL)
 export function listenInMusicQuiz(web_player_id: string) {
   return api.sendCommand<void>("music_quiz/listen_in", { web_player_id });
 }

--- a/src/composables/useMusicQuiz.ts
+++ b/src/composables/useMusicQuiz.ts
@@ -715,8 +715,19 @@ export function deleteMusicQuiz() {
 }
 
 // Guest commands (any authenticated user; server validates guest username)
-export function getMusicQuizInfo() {
-  return api.sendCommand<MusicQuizInfo | null>("music_quiz/info");
+export function getMusicQuizInfo(): Promise<MusicQuizInfo | null> {
+  // Without the music_quiz provider loaded on the server, the command isn't
+  // even registered ("Invalid or unsupported command") — and there can be no
+  // active quiz, so don't bother the server.
+  const hasMusicQuiz = Object.values(api.providers).some(
+    (provider) => provider.domain === "music_quiz",
+  );
+  if (!hasMusicQuiz) return Promise.resolve(null);
+  // Callers treat failures as "no quiz available" and surface their own
+  // messaging, so skip the global error toast.
+  return api.sendCommand<MusicQuizInfo | null>("music_quiz/info", undefined, {
+    suppressGlobalError: true,
+  });
 }
 
 export function joinMusicQuiz(name: string) {

--- a/src/composables/useMusicQuizPlayer.ts
+++ b/src/composables/useMusicQuizPlayer.ts
@@ -27,6 +27,7 @@ import {
 import { markMusicQuizJoinedGameEnded } from "@/helpers/music_quiz_guest_state";
 import { $t } from "@/plugins/i18n";
 import api from "@/plugins/api";
+import { waitForApiInitialization } from "@/plugins/api/helpers";
 import { EventType } from "@/plugins/api/interfaces";
 import { computed, onBeforeUnmount, onMounted, ref } from "vue";
 
@@ -201,7 +202,15 @@ export function useMusicQuizPlayer(options: UseMusicQuizPlayerOptions) {
   }
 
   onMounted(() => {
-    void fetchState();
+    void (async () => {
+      // Wait until server state (e.g. the provider registry) is available;
+      // on a hard page refresh this composable can mount before the API
+      // connection finishes initializing, and probing quiz state too early
+      // would briefly resolve to a wrong "no quiz" answer.
+      await waitForApiInitialization();
+      if (disposed) return;
+      await fetchState();
+    })();
     unsubscribeProviderEvent = api.subscribe(
       EventType.PROVIDER_EVENT,
       handleProviderEvent,

--- a/src/plugins/api/helpers.ts
+++ b/src/plugins/api/helpers.ts
@@ -1,6 +1,7 @@
 // several helpers for dealing with the api and its (media) items
 
-import api from ".";
+import { watch } from "vue";
+import api, { ConnectionState } from ".";
 import {
   AudioSource,
   MediaItemType,
@@ -9,6 +10,29 @@ import {
   Player,
   PlayerQueue,
 } from "./interfaces";
+
+/**
+ * Resolve once the API connection is fully initialized (server state such as
+ * providers and players has been fetched). Resolves immediately when already
+ * initialized. Use before commands whose result depends on that state being
+ * present (e.g. provider-presence checks).
+ */
+export async function waitForApiInitialization(): Promise<void> {
+  if (api.state.value === ConnectionState.INITIALIZED) return;
+
+  await new Promise<void>((resolve) => {
+    const unwatch = watch(
+      () => api.state.value,
+      (newState) => {
+        if (newState === ConnectionState.INITIALIZED) {
+          unwatch();
+          resolve();
+        }
+      },
+      { immediate: true },
+    );
+  });
+}
 
 /**
  * Returns true when the queue's current item is an infinite stream

--- a/src/plugins/api/index.ts
+++ b/src/plugins/api/index.ts
@@ -106,6 +106,7 @@ export class MusicAssistantApi {
     {
       resolve: (result: unknown) => void;
       reject: (err: unknown) => void;
+      suppressGlobalError?: boolean;
     }
   >;
 
@@ -2434,20 +2435,26 @@ export class MusicAssistantApi {
     if ("error_code" in msg) {
       // always handle error (as we may be missing a resolve promise for this command)
       msg = msg as ErrorResultMessage;
-      console.error("[resultMessage]", msg);
+      if (resultPromise?.suppressGlobalError) {
+        // The caller opted out of global error handling (expected/best-effort
+        // failure); it still receives the rejection below.
+        console.debug("[resultMessage]", msg);
+      } else {
+        console.error("[resultMessage]", msg);
 
-      // Don't show toast for authentication errors - they're handled by the login UI
-      const errorMsg = msg.details || msg.error_code || "";
-      const isAuthError =
-        errorMsg.includes("Invalid credentials") ||
-        errorMsg.includes("Invalid username") ||
-        errorMsg.includes("Invalid password") ||
-        errorMsg.includes("Authentication failed") ||
-        errorMsg.includes("Authentication required") ||
-        errorMsg.toLowerCase().includes("unauthorized");
+        // Don't show toast for authentication errors - they're handled by the login UI
+        const errorMsg = msg.details || msg.error_code || "";
+        const isAuthError =
+          errorMsg.includes("Invalid credentials") ||
+          errorMsg.includes("Invalid username") ||
+          errorMsg.includes("Invalid password") ||
+          errorMsg.includes("Authentication failed") ||
+          errorMsg.includes("Authentication required") ||
+          errorMsg.toLowerCase().includes("unauthorized");
 
-      if (!isAuthError) {
-        toast.error(msg.details || msg.error_code);
+        if (!isAuthError) {
+          toast.error(msg.details || msg.error_code);
+        }
       }
     } else if (DEBUG) {
       console.log("[resultMessage]", msg);
@@ -2937,6 +2944,14 @@ export class MusicAssistantApi {
   public sendCommand<Result>(
     command: string,
     args?: Record<string, unknown>,
+    options?: {
+      /**
+       * Suppress the global console.error + error toast for an error result.
+       * Use for best-effort commands where the caller handles (or expects)
+       * failure itself; the returned promise still rejects as usual.
+       */
+      suppressGlobalError?: boolean;
+    },
   ): Promise<Result> {
     // send command to the server and return promise where the result can be returned
     const cmdId = this._genCmdId();
@@ -2944,6 +2959,7 @@ export class MusicAssistantApi {
       this.commands.set(cmdId, {
         resolve: resolve as (result: unknown) => void,
         reject,
+        suppressGlobalError: options?.suppressGlobalError,
       });
       this._sendCommand(command, args, cmdId);
     });

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1673,6 +1673,8 @@
     "guest": {
         "loading_title": "Finding the active experience",
         "loading_description": "Please wait...",
+        "error_title": "Unable to load the active experience",
+        "error_description": "Check your connection and try again.",
         "no_quiz_title": "No Quiz is currently active",
         "no_quiz_description": "Ask the host to start a Music Quiz.",
         "nothing_active_title": "Nothing is currently active",

--- a/src/views/GuestEntryView.vue
+++ b/src/views/GuestEntryView.vue
@@ -30,6 +30,12 @@ const copy = computed(() => {
       description: $t("guest.loading_description"),
     };
   }
+  if (state.value === "error") {
+    return {
+      title: $t("guest.error_title"),
+      description: $t("guest.error_description"),
+    };
+  }
   if (state.value === "quiz-inactive") {
     return {
       title: $t("guest.no_quiz_title"),

--- a/tests/composables/useGuestEntryResolver.test.ts
+++ b/tests/composables/useGuestEntryResolver.test.ts
@@ -69,11 +69,22 @@ describe("guest entry decisions", () => {
     apiMock.sendCommand.mockResolvedValue({ game_id: "active" });
 
     await expect(resolveGuestEntry()).resolves.toBe("quiz");
-    expect(apiMock.sendCommand).toHaveBeenCalledWith("music_quiz/info");
+    expect(apiMock.sendCommand).toHaveBeenCalledWith(
+      "music_quiz/info",
+      undefined,
+      { suppressGlobalError: true },
+    );
     expect(getStoredAffinity()).toEqual({
       version: 1,
       guestIdentity: "guest-token-1",
     });
+  });
+
+  it("treats a music quiz info failure as no active quiz", async () => {
+    setProviders("party", "music_quiz");
+    apiMock.sendCommand.mockRejectedValue(new Error("boom"));
+
+    await expect(resolveGuestEntry()).resolves.toBe("party");
   });
 
   it("keeps an entered Music Quiz ahead of Party after it disappears", async () => {

--- a/tests/composables/useGuestEntryResolver.test.ts
+++ b/tests/composables/useGuestEntryResolver.test.ts
@@ -80,11 +80,11 @@ describe("guest entry decisions", () => {
     });
   });
 
-  it("treats a music quiz info failure as no active quiz", async () => {
+  it("propagates a music quiz info failure", async () => {
     setProviders("party", "music_quiz");
     apiMock.sendCommand.mockRejectedValue(new Error("boom"));
 
-    await expect(resolveGuestEntry()).resolves.toBe("party");
+    await expect(resolveGuestEntry()).rejects.toThrow("boom");
   });
 
   it("keeps an entered Music Quiz ahead of Party after it disappears", async () => {
@@ -174,6 +174,54 @@ describe("guest entry transitions", () => {
 
   afterEach(() => {
     wrapper?.unmount();
+  });
+
+  it("shows an error state when the initial resolution fails", async () => {
+    setProviders("party", "music_quiz");
+    routeMock.path = "/guest/party";
+    apiMock.sendCommand.mockRejectedValue(new Error("boom"));
+    wrapper = mountResolver((state) => {
+      resolverState = state;
+    });
+
+    await expectState("error");
+
+    expect(routeMock.path).toBe("/guest");
+    expect(routerReplace).toHaveBeenCalledOnce();
+    expect(routerReplace).toHaveBeenCalledWith("/guest");
+  });
+
+  it("preserves the current Quiz state when a refresh fails", async () => {
+    setProviders("party", "music_quiz");
+    apiMock.sendCommand.mockResolvedValue({ game_id: "active" });
+    let resolveEntry!: () => Promise<void>;
+    wrapper = mountResolver((state, resolve) => {
+      resolverState = state;
+      resolveEntry = resolve;
+    });
+    await expectState("quiz");
+
+    apiMock.sendCommand.mockRejectedValue(new Error("boom"));
+    await resolveEntry();
+
+    expect(resolverState.value).toBe("quiz");
+    expect(routeMock.path).toBe("/guest/quiz");
+    expect(routerReplace).toHaveBeenCalledOnce();
+  });
+
+  it("recovers from an initial error on a later provider event", async () => {
+    setProviders("party", "music_quiz");
+    apiMock.sendCommand.mockRejectedValue(new Error("boom"));
+    wrapper = mountResolver((state) => {
+      resolverState = state;
+    });
+    await expectState("error");
+
+    apiMock.sendCommand.mockResolvedValue({ game_id: "active" });
+    signalProviderEvent({ event: "game_updated", state: {} });
+
+    await expectState("quiz");
+    expect(routeMock.path).toBe("/guest/quiz");
   });
 
   it("keeps a Party guest in Quiz context and returns to the next game", async () => {
@@ -443,13 +491,16 @@ describe("guest entry transitions", () => {
 });
 
 function mountResolver(
-  onSetup: (state: DeepReadonly<Ref<GuestEntryState>>) => void,
+  onSetup: (
+    state: DeepReadonly<Ref<GuestEntryState>>,
+    resolve: () => Promise<void>,
+  ) => void,
 ) {
   return mount(
     defineComponent({
       setup() {
-        const { state } = useGuestEntryResolver();
-        onSetup(state);
+        const { state, resolve } = useGuestEntryResolver();
+        onSetup(state, resolve);
         return () => h("div");
       },
     }),

--- a/tests/composables/useListenIn.test.ts
+++ b/tests/composables/useListenIn.test.ts
@@ -6,11 +6,13 @@ const {
   mockSendCommand,
   mockSubscribeMulti,
   mockPrimeAudio,
+  mockIsGuestAccessSession,
   unmountCallbacks,
 } = vi.hoisted(() => ({
   mockSendCommand: vi.fn(),
   mockSubscribeMulti: vi.fn(() => () => {}),
   mockPrimeAudio: vi.fn(),
+  mockIsGuestAccessSession: vi.fn(() => true),
   unmountCallbacks: [] as Array<() => void>,
 }));
 
@@ -30,6 +32,10 @@ vi.mock("@/plugins/api", () => ({
     sendCommand: mockSendCommand,
     subscribe_multi: mockSubscribeMulti,
   },
+}));
+
+vi.mock("@/plugins/auth", () => ({
+  authManager: { isGuestAccessSession: mockIsGuestAccessSession },
 }));
 
 vi.mock("@/plugins/web_player", async () => {
@@ -89,6 +95,8 @@ describe("useListenIn", () => {
     mockSubscribeMulti.mockReturnValue(() => {});
     mockPrimeAudio.mockReset();
     mockPrimeAudio.mockReturnValue(true);
+    mockIsGuestAccessSession.mockReset();
+    mockIsGuestAccessSession.mockReturnValue(true);
     unmountCallbacks.length = 0;
     webPlayer.player_id = "wp-1";
   });
@@ -100,10 +108,24 @@ describe("useListenIn", () => {
 
       await checkCanListenIn();
 
-      expect(mockSendCommand).toHaveBeenCalledWith("party/can_listen_in", {
-        web_player_id: "wp-1",
-      });
+      expect(mockSendCommand).toHaveBeenCalledWith(
+        "party/can_listen_in",
+        { web_player_id: "wp-1" },
+        { suppressGlobalError: true },
+      );
       expect(canListenIn.value).toBe(true);
+    });
+
+    it("stays unavailable and skips the command outside a guest session", async () => {
+      // can_listen_in is guest-only on the server; other roles get rejected.
+      mockIsGuestAccessSession.mockReturnValue(false);
+      mockSendCommand.mockResolvedValue(true);
+      const { canListenIn, checkCanListenIn } = create();
+
+      await checkCanListenIn();
+
+      expect(mockSendCommand).not.toHaveBeenCalled();
+      expect(canListenIn.value).toBe(false);
     });
 
     it("stays unavailable and skips the command without a web player", async () => {
@@ -442,9 +464,11 @@ describe("useListenIn", () => {
       await nextTick();
 
       expect(isListeningIn.value).toBe(false);
-      expect(mockSendCommand).toHaveBeenCalledWith("party/can_listen_in", {
-        web_player_id: "wp-2",
-      });
+      expect(mockSendCommand).toHaveBeenCalledWith(
+        "party/can_listen_in",
+        { web_player_id: "wp-2" },
+        { suppressGlobalError: true },
+      );
     });
 
     it("ignores a stale enable completion after player replacement", async () => {

--- a/tests/composables/useListenIn.test.ts
+++ b/tests/composables/useListenIn.test.ts
@@ -6,13 +6,11 @@ const {
   mockSendCommand,
   mockSubscribeMulti,
   mockPrimeAudio,
-  mockIsGuestAccessSession,
   unmountCallbacks,
 } = vi.hoisted(() => ({
   mockSendCommand: vi.fn(),
   mockSubscribeMulti: vi.fn(() => () => {}),
   mockPrimeAudio: vi.fn(),
-  mockIsGuestAccessSession: vi.fn(() => true),
   unmountCallbacks: [] as Array<() => void>,
 }));
 
@@ -32,10 +30,6 @@ vi.mock("@/plugins/api", () => ({
     sendCommand: mockSendCommand,
     subscribe_multi: mockSubscribeMulti,
   },
-}));
-
-vi.mock("@/plugins/auth", () => ({
-  authManager: { isGuestAccessSession: mockIsGuestAccessSession },
 }));
 
 vi.mock("@/plugins/web_player", async () => {
@@ -95,8 +89,6 @@ describe("useListenIn", () => {
     mockSubscribeMulti.mockReturnValue(() => {});
     mockPrimeAudio.mockReset();
     mockPrimeAudio.mockReturnValue(true);
-    mockIsGuestAccessSession.mockReset();
-    mockIsGuestAccessSession.mockReturnValue(true);
     unmountCallbacks.length = 0;
     webPlayer.player_id = "wp-1";
   });
@@ -114,18 +106,6 @@ describe("useListenIn", () => {
         { suppressGlobalError: true },
       );
       expect(canListenIn.value).toBe(true);
-    });
-
-    it("stays unavailable and skips the command outside a guest session", async () => {
-      // can_listen_in is guest-only on the server; other roles get rejected.
-      mockIsGuestAccessSession.mockReturnValue(false);
-      mockSendCommand.mockResolvedValue(true);
-      const { canListenIn, checkCanListenIn } = create();
-
-      await checkCanListenIn();
-
-      expect(mockSendCommand).not.toHaveBeenCalled();
-      expect(canListenIn.value).toBe(false);
     });
 
     it("stays unavailable and skips the command without a web player", async () => {

--- a/tests/composables/useMusicQuiz.test.ts
+++ b/tests/composables/useMusicQuiz.test.ts
@@ -1,12 +1,14 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const { mockSendCommand } = vi.hoisted(() => ({
+const { mockSendCommand, mockProviders } = vi.hoisted(() => ({
   mockSendCommand: vi.fn(),
+  mockProviders: {} as Record<string, { domain: string }>,
 }));
 
 vi.mock("@/plugins/api", () => ({
   default: {
     sendCommand: mockSendCommand,
+    providers: mockProviders,
   },
 }));
 
@@ -14,6 +16,7 @@ import {
   answerMusicQuiz,
   createMusicQuiz,
   getAvailableMusicQuizTypes,
+  getMusicQuizInfo,
   getMusicQuizPlaybackOptions,
   heartbeatMusicQuiz,
   isMusicQuizProviderEvent,
@@ -54,6 +57,27 @@ describe("useMusicQuiz commands", () => {
   beforeEach(() => {
     mockSendCommand.mockReset();
     mockSendCommand.mockResolvedValue(undefined);
+    Object.keys(mockProviders).forEach((key) => delete mockProviders[key]);
+  });
+
+  describe("getMusicQuizInfo", () => {
+    it("resolves null without a server round-trip when the provider is absent", async () => {
+      await expect(getMusicQuizInfo()).resolves.toBeNull();
+      expect(mockSendCommand).not.toHaveBeenCalled();
+    });
+
+    it("queries the server as a best-effort command when the provider is loaded", async () => {
+      mockProviders.music_quiz = { domain: "music_quiz" };
+      const info = { game_id: "game-1" };
+      mockSendCommand.mockResolvedValue(info);
+
+      await expect(getMusicQuizInfo()).resolves.toBe(info);
+      expect(mockSendCommand).toHaveBeenCalledWith(
+        "music_quiz/info",
+        undefined,
+        { suppressGlobalError: true },
+      );
+    });
   });
 
   it("sends difficulty in the create payload", async () => {

--- a/tests/composables/useMusicQuizPlayer.test.ts
+++ b/tests/composables/useMusicQuizPlayer.test.ts
@@ -16,6 +16,7 @@ const {
   mockClearStoredPlayerId,
   mockGetMusicQuizErrorMessage,
   mockMarkJoinedGameEnded,
+  mockWaitForApiInitialization,
   storedPlayerId,
   storedPlayerName,
   providerHandlers,
@@ -36,6 +37,7 @@ const {
   mockClearStoredPlayerId: vi.fn(),
   mockGetMusicQuizErrorMessage: vi.fn(),
   mockMarkJoinedGameEnded: vi.fn(),
+  mockWaitForApiInitialization: vi.fn(),
   storedPlayerId: { value: null as string | null },
   storedPlayerName: { value: "" },
   providerHandlers: [] as Array<
@@ -79,6 +81,10 @@ vi.mock("@/plugins/api", () => ({
   default: {
     subscribe: mockSubscribe,
   },
+}));
+
+vi.mock("@/plugins/api/helpers", () => ({
+  waitForApiInitialization: mockWaitForApiInitialization,
 }));
 
 vi.mock("@/helpers/music_quiz", () => ({
@@ -341,6 +347,8 @@ describe("useMusicQuizPlayer", () => {
     mockClearStoredPlayerId.mockReset();
     mockGetMusicQuizErrorMessage.mockReset();
     mockMarkJoinedGameEnded.mockReset();
+    mockWaitForApiInitialization.mockReset();
+    mockWaitForApiInitialization.mockResolvedValue(undefined);
     mockHeartbeatMusicQuiz.mockResolvedValue(true);
     mockGetStoredPlayerId.mockImplementation(() => storedPlayerId.value);
     mockGetStoredPlayerName.mockImplementation(() => storedPlayerName.value);
@@ -385,6 +393,25 @@ describe("useMusicQuizPlayer", () => {
     }
     vi.clearAllTimers();
     vi.useRealTimers();
+  });
+
+  it("defers the initial fetch until the API connection is initialized", async () => {
+    // On a hard page refresh the composable can mount before the API has
+    // fetched server state (providers); probing too early would resolve to
+    // a wrong "no quiz" answer.
+    const initialization = deferred<void>();
+    mockWaitForApiInitialization.mockReturnValue(initialization.promise);
+    mockGetMusicQuizInfo.mockResolvedValue(QUIZ_INFO);
+
+    useMusicQuizPlayer({ notifyError: vi.fn() });
+    await flushPromises();
+
+    expect(mockGetMusicQuizInfo).not.toHaveBeenCalled();
+
+    initialization.resolve(undefined);
+    await flushPromises();
+
+    expect(mockGetMusicQuizInfo).toHaveBeenCalled();
   });
 
   it("validates a stored player before fetching personalized state", async () => {

--- a/tests/plugins/api/index.test.ts
+++ b/tests/plugins/api/index.test.ts
@@ -1,0 +1,143 @@
+import {
+  type CommandMessage,
+  type ErrorResultMessage,
+  type ServerInfoMessage,
+} from "@/plugins/api/interfaces";
+import { BaseTransport, TransportState } from "@/plugins/remote/transport";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockToastError } = vi.hoisted(() => ({
+  mockToastError: vi.fn(),
+}));
+
+vi.mock("vue-sonner", () => ({
+  toast: {
+    error: mockToastError,
+  },
+}));
+
+vi.mock("@/plugins/i18n", () => ({
+  $t: (key: string) => key,
+  i18n: {
+    global: {
+      locale: { value: "en" },
+    },
+  },
+}));
+
+vi.mock("@/plugins/store", () => ({
+  store: {},
+}));
+
+import { ConnectionState, MusicAssistantApi } from "@/plugins/api";
+
+const SERVER_INFO: ServerInfoMessage = {
+  server_id: "test-server",
+  server_version: "0.0.0",
+  schema_version: 0,
+  min_supported_schema_version: 0,
+  base_url: "http://test.local",
+  homeassistant_addon: false,
+  onboard_done: true,
+};
+
+class TestTransport extends BaseTransport {
+  readonly sentCommands: CommandMessage[] = [];
+
+  connect(): Promise<void> {
+    this.setState(TransportState.CONNECTED);
+    return Promise.resolve();
+  }
+
+  disconnect(): void {
+    this.setState(TransportState.DISCONNECTED);
+  }
+
+  send(data: string): void {
+    this.sentCommands.push(JSON.parse(data) as CommandMessage);
+  }
+
+  receive(message: ServerInfoMessage | ErrorResultMessage): void {
+    this.emit("message", JSON.stringify(message));
+  }
+
+  get lastCommand(): CommandMessage {
+    const command = this.sentCommands.at(-1);
+    if (!command) throw new Error("No command was sent");
+    return command;
+  }
+}
+
+describe("MusicAssistantApi error handling", () => {
+  let api: MusicAssistantApi;
+  let transport: TestTransport;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    api = new MusicAssistantApi();
+    transport = new TestTransport();
+    const initialization = api.initialize(transport);
+    transport.receive(SERVER_INFO);
+    await initialization;
+    expect(api.state.value).toBe(ConnectionState.CONNECTED);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("rejects suppressed errors without global logging or a toast", async () => {
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    const consoleDebug = vi
+      .spyOn(console, "debug")
+      .mockImplementation(() => {});
+    const command = api.sendCommand("test/suppressed", undefined, {
+      suppressGlobalError: true,
+    });
+    const error = createErrorResult(
+      transport.lastCommand,
+      "Suppressed failure",
+    );
+    const rejection = expect(command).rejects.toBe("Suppressed failure");
+
+    transport.receive(error);
+
+    await rejection;
+    expect(consoleError).not.toHaveBeenCalled();
+    expect(mockToastError).not.toHaveBeenCalled();
+    expect(consoleDebug).toHaveBeenCalledWith("[resultMessage]", error);
+  });
+
+  it("keeps global logging and the toast for ordinary errors", async () => {
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    const consoleDebug = vi
+      .spyOn(console, "debug")
+      .mockImplementation(() => {});
+    const command = api.sendCommand("test/ordinary");
+    const error = createErrorResult(transport.lastCommand, "Visible failure");
+    const rejection = expect(command).rejects.toBe("Visible failure");
+
+    transport.receive(error);
+
+    await rejection;
+    expect(consoleError).toHaveBeenCalledWith("[resultMessage]", error);
+    expect(mockToastError).toHaveBeenCalledWith("Visible failure");
+    expect(consoleDebug).not.toHaveBeenCalled();
+  });
+});
+
+function createErrorResult(
+  command: CommandMessage,
+  details: string,
+): ErrorResultMessage {
+  if (!command.message_id) throw new Error("Command has no message ID");
+  return {
+    message_id: command.message_id,
+    error_code: "test_error",
+    details,
+  };
+}

--- a/tests/views/GuestEntryView.test.ts
+++ b/tests/views/GuestEntryView.test.ts
@@ -18,6 +18,7 @@ vi.mock("@/plugins/i18n", () => ({
 describe("GuestEntryView", () => {
   it.each([
     ["loading", "guest.loading_title", "guest.loading_description"],
+    ["error", "guest.error_title", "guest.error_description"],
     ["quiz-inactive", "guest.no_quiz_title", "guest.no_quiz_description"],
     [
       "inactive",


### PR DESCRIPTION
More playwright / automated testing findings. Split into three commits for reviewability but they're all conceptually tied together. I can open separate stacked PRs if that's preferred though.

Visiting the guest routes (`#/guest`, `#/guest/quiz`) produced console errors and raw server-error toasts for API failures that are entirely expected: the guest-only `can_listen_in` endpoints reject any non-guest session, and `music_quiz/info` isn't even registered when the music_quiz provider isn't loaded. This branch adds a `suppressGlobalError` option to `sendCommand` so best-effort commands can opt out of the global console.error + toast (the promise still rejects for the caller to handle), skips the listen-in availability probe outside guest access sessions, resolves `getMusicQuizInfo` to `null` without a server round-trip when the provider is absent, hardens the guest entry resolver against an info failure stranding it in its loading state, and gates `useMusicQuizPlayer`'s mount-time fetch on API initialization so a hard refresh of the guest quiz page won't briefly show a wrong "no quiz" state while the provider registry is still loading.