### PR TITLE
Show this device in group controls

### DIFF
--- a/src/helpers/utils.ts
+++ b/src/helpers/utils.ts
@@ -726,12 +726,12 @@ export const playerVisible = function (
   return true;
 };
 
-// Whether a player can be offered in the group/sync member picker. Honours
-// hide_in_ui, except for light/visualizer players which are hidden from the
-// normal player view but exist to be grouped (e.g. Hue lights synced to audio).
+// Keep hidden players out of group pickers unless they represent this device or
+// are player types intended to be grouped with audio players.
 export const groupMemberPickerVisible = function (player: Player): boolean {
   return (
     !player.hide_in_ui ||
+    isBuiltinPlayer(player) ||
     player.type === PlayerType.LIGHT ||
     player.type === PlayerType.VISUALIZER
   );

--- a/tests/helpers/utils.test.ts
+++ b/tests/helpers/utils.test.ts
@@ -2,6 +2,7 @@ import {
   formatAliasName,
   formatDuration,
   formatRelativeTime,
+  groupMemberPickerVisible,
   hexToRgb,
   kebabize,
   markdownToHtml,
@@ -12,8 +13,14 @@ import {
   sleep,
   truncateString,
 } from "@/helpers/utils";
-import type { MediaItemPalette } from "@/plugins/api/interfaces";
-import { describe, expect, it, vi } from "vitest";
+import {
+  IdentifierType,
+  type MediaItemPalette,
+  type Player,
+  PlayerType,
+} from "@/plugins/api/interfaces";
+import { webPlayer } from "@/plugins/web_player";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@/plugins/api", () => ({
   api: {
@@ -47,6 +54,72 @@ vi.mock("@/layouts/default/ItemContextMenu.vue", () => ({
 vi.mock("@/plugins/api/helpers", () => ({
   itemIsAvailable: vi.fn(),
 }));
+
+function createPlayer(overrides: Partial<Player> = {}): Player {
+  return {
+    player_id: "player",
+    provider: "test",
+    type: PlayerType.PLAYER,
+    name: "Player",
+    available: true,
+    device_info: {
+      model: "Test",
+      manufacturer: "Test",
+      identifiers: {
+        [IdentifierType.MAC_ADDRESS]: "",
+        [IdentifierType.SERIAL_NUMBER]: "",
+        [IdentifierType.UUID]: "",
+        [IdentifierType.IP_ADDRESS]: "",
+        [IdentifierType.UNKNOWN]: "",
+      },
+    },
+    supported_features: [],
+    can_group_with: [],
+    enabled: true,
+    group_members: [],
+    static_group_members: [],
+    source_list: [],
+    sound_mode_list: [],
+    options: [],
+    group_volume: null,
+    group_volume_muted: null,
+    hide_in_ui: false,
+    icon: "speaker",
+    power_control: "power",
+    volume_control: "volume",
+    mute_control: "mute",
+    needs_setup: false,
+    output_protocols: [],
+    active_output_protocol: null,
+    ...overrides,
+  };
+}
+
+describe("groupMemberPickerVisible", () => {
+  beforeEach(() => {
+    webPlayer.player_id = null;
+  });
+
+  it("shows the hidden web player owned by this browser", () => {
+    const player = createPlayer({
+      player_id: "local-web-player",
+      hide_in_ui: true,
+    });
+    webPlayer.player_id = player.player_id;
+
+    expect(groupMemberPickerVisible(player)).toBe(true);
+  });
+
+  it("keeps unrelated hidden players out of the picker", () => {
+    const player = createPlayer({
+      player_id: "remote-web-player",
+      hide_in_ui: true,
+    });
+    webPlayer.player_id = "local-web-player";
+
+    expect(groupMemberPickerVisible(player)).toBe(false);
+  });
+});
 
 describe("formatDuration", () => {
   it("formats seconds correctly", () => {

--- a/tests/helpers/utils.test.ts
+++ b/tests/helpers/utils.test.ts
@@ -19,6 +19,7 @@ import {
   type Player,
   PlayerType,
 } from "@/plugins/api/interfaces";
+import { store } from "@/plugins/store";
 import { webPlayer } from "@/plugins/web_player";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -30,7 +31,7 @@ vi.mock("@/plugins/api", () => ({
 }));
 
 vi.mock("@/plugins/store", () => ({
-  store: {},
+  store: { companionPlayerId: undefined },
 }));
 
 vi.mock("@/plugins/breakpoint", () => ({
@@ -97,6 +98,7 @@ function createPlayer(overrides: Partial<Player> = {}): Player {
 
 describe("groupMemberPickerVisible", () => {
   beforeEach(() => {
+    store.companionPlayerId = undefined;
     webPlayer.player_id = null;
   });
 
@@ -106,6 +108,16 @@ describe("groupMemberPickerVisible", () => {
       hide_in_ui: true,
     });
     webPlayer.player_id = player.player_id;
+
+    expect(groupMemberPickerVisible(player)).toBe(true);
+  });
+
+  it("shows the hidden companion player owned by this app", () => {
+    const player = createPlayer({
+      player_id: "local-companion-player",
+      hide_in_ui: true,
+    });
+    store.companionPlayerId = player.player_id;
 
     expect(groupMemberPickerVisible(player)).toBe(true);
   });


### PR DESCRIPTION
Hidden built-in players were omitted from group controls, even for the device currently running the UI.

- Show this device's web or mobile player as a group option
- Keep other hidden players excluded
- Add regression coverage