### PR TITLE
Use the global i18n scope for the missing-players hint

### DIFF
--- a/src/views/settings/Players.vue
+++ b/src/views/settings/Players.vue
@@ -161,7 +161,7 @@
     </Container>
     <div class="missing-players-hint">
       <v-icon icon="mdi-information-outline" size="16" class="hint-icon" />
-      <i18n-t keypath="settings.missing_players_hint" tag="span">
+      <i18n-t keypath="settings.missing_players_hint" tag="span" scope="global">
         <router-link
           :to="{ name: 'providersettings', query: { types: 'player' } }"
           class="hint-link"


### PR DESCRIPTION
The i18n-t component defaults to the parent scope, but Players.vue has no local composer, so vue-i18n logged 'Not found parent scope' and fell back to the global scope anyway. Make the fallback explicit.