### PR TITLE
Use return values instead of deprecated next() in navigation guard

### DIFF
--- a/src/plugins/router.ts
+++ b/src/plugins/router.ts
@@ -583,16 +583,13 @@ router.onError((error, to) => {
 });
 
 // Navigation guard for admin-only routes and guest mode restrictions
-router.beforeEach(async (to, _from, next) => {
-  const currentUser = store.currentUser;
-
+router.beforeEach(async (to) => {
   const guestRedirect = getGuestNavigationRedirect(
     authManager.isGuestAccessSession(),
     to.path,
   );
   if (guestRedirect) {
-    next(guestRedirect);
-    return;
+    return guestRedirect;
   }
 
   // Check admin-only routes - check all matched routes for requiresAdmin meta
@@ -629,12 +626,9 @@ router.beforeEach(async (to, _from, next) => {
 
     if (!currentUser || currentUser.role !== "admin") {
       console.warn("Admin access required for", to.path);
-      next({ name: "discover" });
-      return;
+      return { name: "discover" };
     }
   }
-
-  next();
 });
 
 router.afterEach((to, from) => {


### PR DESCRIPTION
vue-router deprecated the next() callback in favor of returning the redirect target (or nothing) from the guard. Convert the global guest/admin guard accordingly and drop an unused variable.

BTW, the same deprecation warning is also emitted by Vuetify's internal useBackButton composable (vuetify/lib/composables/router.js), so a few occurrences will remain in the console until the Vuetify migration replaces that dependency.