### PR TITLE
Add MiniEqualizer: waveform-driven now-playing indicator

### DIFF
--- a/src/components/MiniEqualizer.vue
+++ b/src/components/MiniEqualizer.vue
@@ -102,7 +102,7 @@ function draw() {
   for (let i = 0; i < n; i++) {
     const binIdx = Math.max(0, Math.min(bins.length - 1, centerBin - half + i));
     const rms = bins[binIdx];
-    const barH = Math.max(2, rms * cssH);
+    const barH = Math.max(cssH * 0.25, rms * cssH);
     const x = startX + i * pitch;
     const y = (cssH - barH) / 2;
     const isCurrent = i === half;

--- a/src/components/MiniEqualizer.vue
+++ b/src/components/MiniEqualizer.vue
@@ -144,7 +144,7 @@ watch(waveformBins, () => draw());
 <style scoped>
 .mini-eq {
   display: block;
-  width: 100%;
+  width: v-bind("`${props.bars * (3 + 2) - 2}px`");
   height: v-bind("`${props.height}px`");
 }
 </style>

--- a/src/components/MiniEqualizer.vue
+++ b/src/components/MiniEqualizer.vue
@@ -1,5 +1,11 @@
 <template>
-  <canvas v-if="waveformBins" ref="canvasEl" class="mini-eq" />
+  <canvas
+    v-if="waveformBins"
+    ref="canvasEl"
+    class="mini-eq"
+    aria-hidden="true"
+    role="presentation"
+  />
 </template>
 
 <script setup lang="ts">
@@ -74,12 +80,16 @@ function draw() {
   const dpr = window.devicePixelRatio || 1;
   const cssW = canvas.clientWidth;
   const cssH = props.height;
-  canvas.width = Math.round(cssW * dpr);
-  canvas.height = Math.round(cssH * dpr);
+  const targetW = Math.round(cssW * dpr);
+  const targetH = Math.round(cssH * dpr);
+  if (canvas.width !== targetW || canvas.height !== targetH) {
+    canvas.width = targetW;
+    canvas.height = targetH;
+  }
   const ctx = canvas.getContext("2d");
   if (!ctx) return;
 
-  ctx.scale(dpr, dpr);
+  ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
   ctx.clearRect(0, 0, cssW, cssH);
 
   const duration = trackDurationSecs.value;
@@ -106,9 +116,8 @@ function draw() {
     const x = startX + i * pitch;
     const y = (cssH - barH) / 2;
     const isCurrent = i === half;
-    ctx.globalAlpha = isCurrent
-      ? 1
-      : 0.3 + 0.7 * (1 - Math.abs(i - half) / half) * rms;
+    const falloff = half > 0 ? 1 - Math.abs(i - half) / half : 1;
+    ctx.globalAlpha = isCurrent ? 1 : 0.3 + 0.7 * falloff * rms;
     ctx.beginPath();
     if (typeof ctx.roundRect === "function") {
       ctx.roundRect(x, y, barW, barH, 1);
@@ -131,14 +140,33 @@ function stopTimer() {
   }
 }
 
+function syncTimer() {
+  if (store.activePlayerQueue?.state === "playing" && waveformBins.value) {
+    startTimer();
+  } else {
+    stopTimer();
+  }
+}
+
 onMounted(() => {
-  startTimer();
   draw();
 });
 
 onUnmounted(stopTimer);
 
-watch(waveformBins, () => draw());
+watch(
+  () => store.activePlayerQueue?.state,
+  (state) => {
+    syncTimer();
+    if (state !== "playing") draw();
+  },
+  { immediate: true },
+);
+
+watch(waveformBins, () => {
+  syncTimer();
+  draw();
+});
 </script>
 
 <style scoped>

--- a/src/components/MiniEqualizer.vue
+++ b/src/components/MiniEqualizer.vue
@@ -1,0 +1,143 @@
+<template>
+  <canvas v-if="waveformBins" ref="canvasEl" class="mini-eq" />
+</template>
+
+<script setup lang="ts">
+import {
+  onMounted,
+  onUnmounted,
+  ref,
+  watch,
+} from "vue";
+import { useActiveTrackWaveform } from "@/composables/useActiveTrackWaveform";
+import { store } from "@/plugins/store";
+import api from "@/plugins/api";
+
+export interface Props {
+  color?: string;
+  // Number of bars to show in the scrolling window.
+  bars?: number;
+  // Height of the component in CSS pixels.
+  height?: number;
+}
+
+const props = withDefaults(defineProps<Props>(), {
+  color: "currentColor",
+  bars: 20,
+  height: 24,
+});
+
+const { waveformBins, trackDurationSecs } = useActiveTrackWaveform();
+const canvasEl = ref<HTMLCanvasElement>();
+let timerId: ReturnType<typeof setInterval> | null = null;
+
+function getElapsedSecs(): number {
+  const queueId = store.activePlayerQueue?.queue_id;
+  const queueTime = queueId ? api.queueElapsedTime[queueId] : undefined;
+  if (queueTime?.elapsed_time != null && queueTime?.elapsed_time_last_updated != null) {
+    const isPlaying = store.activePlayerQueue?.state === "playing";
+    const delta = isPlaying ? Date.now() / 1000 - queueTime.elapsed_time_last_updated : 0;
+    return queueTime.elapsed_time + delta;
+  }
+  const player = store.activePlayer;
+  if (player?.elapsed_time != null && player?.elapsed_time_last_updated != null) {
+    const isPlaying = player.playback_state === "playing";
+    const delta = isPlaying ? Date.now() / 1000 - player.elapsed_time_last_updated : 0;
+    return player.elapsed_time + delta;
+  }
+  return 0;
+}
+
+function resolveColor(color: string): string {
+  // Canvas fillStyle cannot resolve CSS variables — extract and resolve them.
+  const match = color.match(/var\(\s*(--[^)]+)\s*\)/);
+  if (match) {
+    const value = getComputedStyle(document.documentElement)
+      .getPropertyValue(match[1])
+      .trim();
+    // Vuetify exposes theme colors as bare "R, G, B" strings.
+    return value.includes(",") ? `rgb(${value})` : value || "#fff";
+  }
+  return color;
+}
+
+function draw() {
+  const canvas = canvasEl.value;
+  const bins = waveformBins.value;
+  if (!canvas || !bins) return;
+
+  const dpr = window.devicePixelRatio || 1;
+  const cssW = canvas.clientWidth;
+  const cssH = props.height;
+  canvas.width = Math.round(cssW * dpr);
+  canvas.height = Math.round(cssH * dpr);
+  const ctx = canvas.getContext("2d");
+  if (!ctx) return;
+
+  ctx.scale(dpr, dpr);
+  ctx.clearRect(0, 0, cssW, cssH);
+
+  const duration = trackDurationSecs.value;
+  if (!duration) return;
+
+  const elapsed = getElapsedSecs();
+  const progress = Math.min(1, Math.max(0, elapsed / duration));
+  const centerBin = Math.floor(progress * (bins.length - 1));
+
+  const n = props.bars;
+  const half = Math.floor(n / 2);
+  const barW = 3;
+  const gap = 2;
+  const pitch = barW + gap;
+  const totalW = n * pitch - gap;
+  const startX = (cssW - totalW) / 2;
+
+  ctx.fillStyle = resolveColor(props.color);
+
+  for (let i = 0; i < n; i++) {
+    const binIdx = Math.max(0, Math.min(bins.length - 1, centerBin - half + i));
+    const rms = bins[binIdx];
+    const barH = Math.max(2, rms * cssH);
+    const x = startX + i * pitch;
+    const y = (cssH - barH) / 2;
+    const isCurrent = i === half;
+    ctx.globalAlpha = isCurrent ? 1 : 0.3 + 0.7 * (1 - Math.abs(i - half) / half) * rms;
+    ctx.beginPath();
+    if (typeof ctx.roundRect === "function") {
+      ctx.roundRect(x, y, barW, barH, 1);
+    } else {
+      ctx.rect(x, y, barW, barH);
+    }
+    ctx.fill();
+  }
+}
+
+function startTimer() {
+  if (timerId !== null) return;
+  timerId = setInterval(draw, 100);
+}
+
+function stopTimer() {
+  if (timerId !== null) {
+    clearInterval(timerId);
+    timerId = null;
+  }
+}
+
+onMounted(() => {
+  startTimer();
+  draw();
+});
+
+onUnmounted(stopTimer);
+
+watch(waveformBins, () => draw());
+</script>
+
+<style scoped>
+.mini-eq {
+  display: block;
+  width: 100%;
+  height: v-bind("`${props.height}px`");
+}
+</style>

--- a/src/components/MiniEqualizer.vue
+++ b/src/components/MiniEqualizer.vue
@@ -3,12 +3,7 @@
 </template>
 
 <script setup lang="ts">
-import {
-  onMounted,
-  onUnmounted,
-  ref,
-  watch,
-} from "vue";
+import { onMounted, onUnmounted, ref, watch } from "vue";
 import { useActiveTrackWaveform } from "@/composables/useActiveTrackWaveform";
 import { store } from "@/plugins/store";
 import api from "@/plugins/api";
@@ -34,15 +29,25 @@ let timerId: ReturnType<typeof setInterval> | null = null;
 function getElapsedSecs(): number {
   const queueId = store.activePlayerQueue?.queue_id;
   const queueTime = queueId ? api.queueElapsedTime[queueId] : undefined;
-  if (queueTime?.elapsed_time != null && queueTime?.elapsed_time_last_updated != null) {
+  if (
+    queueTime?.elapsed_time != null &&
+    queueTime?.elapsed_time_last_updated != null
+  ) {
     const isPlaying = store.activePlayerQueue?.state === "playing";
-    const delta = isPlaying ? Date.now() / 1000 - queueTime.elapsed_time_last_updated : 0;
+    const delta = isPlaying
+      ? Date.now() / 1000 - queueTime.elapsed_time_last_updated
+      : 0;
     return queueTime.elapsed_time + delta;
   }
   const player = store.activePlayer;
-  if (player?.elapsed_time != null && player?.elapsed_time_last_updated != null) {
+  if (
+    player?.elapsed_time != null &&
+    player?.elapsed_time_last_updated != null
+  ) {
     const isPlaying = player.playback_state === "playing";
-    const delta = isPlaying ? Date.now() / 1000 - player.elapsed_time_last_updated : 0;
+    const delta = isPlaying
+      ? Date.now() / 1000 - player.elapsed_time_last_updated
+      : 0;
     return player.elapsed_time + delta;
   }
   return 0;
@@ -101,7 +106,9 @@ function draw() {
     const x = startX + i * pitch;
     const y = (cssH - barH) / 2;
     const isCurrent = i === half;
-    ctx.globalAlpha = isCurrent ? 1 : 0.3 + 0.7 * (1 - Math.abs(i - half) / half) * rms;
+    ctx.globalAlpha = isCurrent
+      ? 1
+      : 0.3 + 0.7 * (1 - Math.abs(i - half) / half) * rms;
     ctx.beginPath();
     if (typeof ctx.roundRect === "function") {
       ctx.roundRect(x, y, barW, barH, 1);

--- a/src/composables/useActiveTrackWaveform.ts
+++ b/src/composables/useActiveTrackWaveform.ts
@@ -12,33 +12,45 @@ const trackDurationSecs = ref<number>(0);
 const waveformLoading = ref(false);
 
 let lastFetchKey: string | undefined;
+let loadingTimeoutId: ReturnType<typeof setTimeout> | null = null;
 
 const { getPreference } = useUserPreferences();
 const showWaveformPref = getPreference("show_waveform", true);
 
-// Watch both queue_item_id and streamdetails.item_id because streamdetails
-// arrive asynchronously after the queue item switches.
+// Watch queue/stream IDs and the show_waveform preference together so that
+// toggling the preference re-triggers a fetch without a track change.
 watch(
   () =>
     [
       store.curQueueItem?.queue_item_id,
       store.curQueueItem?.streamdetails?.item_id,
+      showWaveformPref.value,
     ] as const,
-  async ([queueItemId, streamItemId]) => {
-    const fetchKey = `${queueItemId}:${streamItemId}`;
+  async ([queueItemId, streamItemId, showWaveform]) => {
+    const fetchKey = `${showWaveform}:${queueItemId}:${streamItemId}`;
     if (fetchKey === lastFetchKey) return;
     lastFetchKey = fetchKey;
 
+    if (loadingTimeoutId !== null) {
+      clearTimeout(loadingTimeoutId);
+      loadingTimeoutId = null;
+    }
+
     waveformBins.value = null;
+    waveformLoading.value = false;
     trackDurationSecs.value = store.curQueueItem?.duration ?? 0;
 
     const mediaItem = store.curQueueItem?.media_item;
     if (!mediaItem || mediaItem.media_type !== MediaType.TRACK) return;
-    if (!showWaveformPref.value) return;
+    if (!showWaveform) return;
 
     const streamDetails = store.curQueueItem?.streamdetails;
     if (!streamDetails) {
       waveformLoading.value = true;
+      // Safety net: clear loading if streamdetails never arrive for this item.
+      loadingTimeoutId = setTimeout(() => {
+        if (lastFetchKey === fetchKey) waveformLoading.value = false;
+      }, 5000);
       return;
     }
 
@@ -48,26 +60,18 @@ watch(
         streamDetails.item_id,
         streamDetails.provider,
       );
-      const currentKey = `${store.curQueueItem?.queue_item_id}:${store.curQueueItem?.streamdetails?.item_id}`;
+      const currentKey = `${showWaveformPref.value}:${store.curQueueItem?.queue_item_id}:${store.curQueueItem?.streamdetails?.item_id}`;
       if (currentKey !== fetchKey) return;
       waveformBins.value = bins?.length ? bins : null;
     } catch {
       // No audio analysis available.
     } finally {
-      const currentKey = `${store.curQueueItem?.queue_item_id}:${store.curQueueItem?.streamdetails?.item_id}`;
+      const currentKey = `${showWaveformPref.value}:${store.curQueueItem?.queue_item_id}:${store.curQueueItem?.streamdetails?.item_id}`;
       if (currentKey === fetchKey) waveformLoading.value = false;
     }
   },
   { immediate: true },
 );
-
-// React to show_waveform preference changes.
-watch(showWaveformPref, (show) => {
-  if (!show) {
-    waveformBins.value = null;
-    waveformLoading.value = false;
-  }
-});
 
 export function useActiveTrackWaveform() {
   return { waveformBins, trackDurationSecs, waveformLoading };

--- a/src/composables/useActiveTrackWaveform.ts
+++ b/src/composables/useActiveTrackWaveform.ts
@@ -19,10 +19,11 @@ const showWaveformPref = getPreference("show_waveform", true);
 // Watch both queue_item_id and streamdetails.item_id because streamdetails
 // arrive asynchronously after the queue item switches.
 watch(
-  () => [
-    store.curQueueItem?.queue_item_id,
-    store.curQueueItem?.streamdetails?.item_id,
-  ] as const,
+  () =>
+    [
+      store.curQueueItem?.queue_item_id,
+      store.curQueueItem?.streamdetails?.item_id,
+    ] as const,
   async ([queueItemId, streamItemId]) => {
     const fetchKey = `${queueItemId}:${streamItemId}`;
     if (fetchKey === lastFetchKey) return;

--- a/src/composables/useActiveTrackWaveform.ts
+++ b/src/composables/useActiveTrackWaveform.ts
@@ -1,0 +1,73 @@
+import { ref, watch } from "vue";
+import api from "@/plugins/api";
+import { store } from "@/plugins/store";
+import { MediaType } from "@/plugins/api/interfaces";
+import { useUserPreferences } from "@/composables/userPreferences";
+
+// Module-level shared state: waveform bins and track duration for the
+// currently playing track. Any component can read this without triggering
+// duplicate API calls.
+const waveformBins = ref<number[] | null>(null);
+const trackDurationSecs = ref<number>(0);
+const waveformLoading = ref(false);
+
+let lastFetchKey: string | undefined;
+
+const { getPreference } = useUserPreferences();
+const showWaveformPref = getPreference("show_waveform", true);
+
+// Watch both queue_item_id and streamdetails.item_id because streamdetails
+// arrive asynchronously after the queue item switches.
+watch(
+  () => [
+    store.curQueueItem?.queue_item_id,
+    store.curQueueItem?.streamdetails?.item_id,
+  ] as const,
+  async ([queueItemId, streamItemId]) => {
+    const fetchKey = `${queueItemId}:${streamItemId}`;
+    if (fetchKey === lastFetchKey) return;
+    lastFetchKey = fetchKey;
+
+    waveformBins.value = null;
+    trackDurationSecs.value = store.curQueueItem?.duration ?? 0;
+
+    const mediaItem = store.curQueueItem?.media_item;
+    if (!mediaItem || mediaItem.media_type !== MediaType.TRACK) return;
+    if (!showWaveformPref.value) return;
+
+    const streamDetails = store.curQueueItem?.streamdetails;
+    if (!streamDetails) {
+      waveformLoading.value = true;
+      return;
+    }
+
+    waveformLoading.value = true;
+    try {
+      const bins = await api.getWaveForm(
+        streamDetails.item_id,
+        streamDetails.provider,
+      );
+      const currentKey = `${store.curQueueItem?.queue_item_id}:${store.curQueueItem?.streamdetails?.item_id}`;
+      if (currentKey !== fetchKey) return;
+      waveformBins.value = bins?.length ? bins : null;
+    } catch {
+      // No audio analysis available.
+    } finally {
+      const currentKey = `${store.curQueueItem?.queue_item_id}:${store.curQueueItem?.streamdetails?.item_id}`;
+      if (currentKey === fetchKey) waveformLoading.value = false;
+    }
+  },
+  { immediate: true },
+);
+
+// React to show_waveform preference changes.
+watch(showWaveformPref, (show) => {
+  if (!show) {
+    waveformBins.value = null;
+    waveformLoading.value = false;
+  }
+});
+
+export function useActiveTrackWaveform() {
+  return { waveformBins, trackDurationSecs, waveformLoading };
+}

--- a/src/layouts/default/PlayerOSD/PlayerFullscreen.vue
+++ b/src/layouts/default/PlayerOSD/PlayerFullscreen.vue
@@ -502,6 +502,7 @@ import { useDisplay } from "vuetify";
 import type { ContextMenuItem } from "@/helpers/context_menu_item";
 import QueueBtn from "./PlayerControlBtn/QueueBtn.vue";
 import PlayerTimeline from "./PlayerTimeline.vue";
+import { useActiveTrackWaveform } from "@/composables/useActiveTrackWaveform";
 
 const { name, mdAndUp } = useDisplay();
 
@@ -744,95 +745,10 @@ watch(
   },
 );
 
-// Waveform for the current track, rendered by PlayerTimeline instead of the flat bar.
-const waveformData = ref<number[] | null>(null);
-const waveformLoading = ref(false);
+// Waveform for the current track — loaded centrally by useActiveTrackWaveform.
+const { waveformBins: waveformData, waveformLoading } = useActiveTrackWaveform();
 const { getPreference, setPreference } = useUserPreferences();
 const showWaveformPref = getPreference("show_waveform", true);
-let waveformLoadGeneration = 0;
-let waveformQueueItemId: string | undefined;
-let waveformDetailsTimer: ReturnType<typeof setTimeout> | null = null;
-const WAVEFORM_DETAILS_TIMEOUT_MS = 2000;
-const fetchWaveform = async () => {
-  const generation = ++waveformLoadGeneration;
-
-  const queueItemId = store.curQueueItem?.queue_item_id;
-  if (queueItemId !== waveformQueueItemId) {
-    waveformQueueItemId = queueItemId;
-    waveformData.value = null;
-  }
-
-  const mediaItem = store.curQueueItem?.media_item;
-  // Analysis is keyed by the provider-native (streaming) item id, not the library id.
-  const streamDetails = store.curQueueItem?.streamdetails;
-  if (
-    !showWaveformPref.value ||
-    !store.showFullscreenPlayer ||
-    mediaItem?.media_type !== MediaType.TRACK
-  ) {
-    waveformData.value = null;
-    waveformLoading.value = false;
-    clearWaveformDetailsTimer();
-    return;
-  }
-  if (!streamDetails) {
-    waveformLoading.value = true;
-    clearWaveformDetailsTimer();
-    waveformDetailsTimer = setTimeout(() => {
-      waveformDetailsTimer = null;
-      if (generation === waveformLoadGeneration) {
-        waveformLoading.value = false;
-      }
-    }, WAVEFORM_DETAILS_TIMEOUT_MS);
-    return;
-  }
-
-  clearWaveformDetailsTimer();
-  waveformLoading.value = true;
-  try {
-    const waveform = await api.getWaveForm(
-      streamDetails.item_id,
-      streamDetails.provider,
-    );
-    // a newer track change started while awaiting; this result is stale
-    if (generation !== waveformLoadGeneration) return;
-    waveformData.value = waveform?.length ? waveform : null;
-    waveformLoading.value = false;
-  } catch {
-    // No analysis available; PlayerTimeline falls back to the flat progress bar.
-    if (generation !== waveformLoadGeneration) return;
-    waveformData.value = null;
-    waveformLoading.value = false;
-  }
-};
-
-const clearWaveformDetailsTimer = () => {
-  if (waveformDetailsTimer === null) return;
-  clearTimeout(waveformDetailsTimer);
-  waveformDetailsTimer = null;
-};
-
-onBeforeUnmount(clearWaveformDetailsTimer);
-
-// Streamdetails can arrive after the queue item switches, so watch both ids.
-watch(
-  () => [
-    store.curQueueItem?.queue_item_id,
-    store.curQueueItem?.streamdetails?.item_id,
-  ],
-  fetchWaveform,
-  { immediate: true },
-);
-
-// FrontendConfig reloads the app on save, but react to live changes anyway (multi-tab sync).
-watch(showWaveformPref, fetchWaveform);
-
-watch(
-  () => store.showFullscreenPlayer,
-  (isOpen) => {
-    if (isOpen) fetchWaveform();
-  },
-);
 
 const titleFontSize = computed(() => {
   switch (name.value) {

--- a/src/layouts/default/PlayerOSD/PlayerFullscreen.vue
+++ b/src/layouts/default/PlayerOSD/PlayerFullscreen.vue
@@ -746,7 +746,8 @@ watch(
 );
 
 // Waveform for the current track — loaded centrally by useActiveTrackWaveform.
-const { waveformBins: waveformData, waveformLoading } = useActiveTrackWaveform();
+const { waveformBins: waveformData, waveformLoading } =
+  useActiveTrackWaveform();
 const { getPreference, setPreference } = useUserPreferences();
 const showWaveformPref = getPreference("show_waveform", true);
 

--- a/src/layouts/default/PlayerOSD/PlayerTrackDetails.vue
+++ b/src/layouts/default/PlayerOSD/PlayerTrackDetails.vue
@@ -89,7 +89,7 @@
           color="rgb(var(--v-theme-primary))"
           :bars="4"
           :height="16"
-          style="width: 18px; margin-left: 12px; margin-bottom: 4px;"
+          style="width: 18px; margin-left: 12px; margin-bottom: 4px"
         />
       </div>
     </template>

--- a/src/layouts/default/PlayerOSD/PlayerTrackDetails.vue
+++ b/src/layouts/default/PlayerOSD/PlayerTrackDetails.vue
@@ -89,7 +89,7 @@
           color="rgb(var(--v-theme-primary))"
           :bars="4"
           :height="16"
-          style="margin-left: 12px; margin-bottom: 4px;"
+          style="margin-left: 12px; margin-bottom: 4px"
         />
       </div>
     </template>

--- a/src/layouts/default/PlayerOSD/PlayerTrackDetails.vue
+++ b/src/layouts/default/PlayerOSD/PlayerTrackDetails.vue
@@ -212,7 +212,7 @@ interface Props {
   showOnlyArtist?: boolean;
   showQualityDetailsBtn?: boolean;
   colorPalette: ImageColorPalette;
-  primaryColor: string;
+  primaryColor?: string;
 }
 
 const props = withDefaults(defineProps<Props>(), {

--- a/src/layouts/default/PlayerOSD/PlayerTrackDetails.vue
+++ b/src/layouts/default/PlayerOSD/PlayerTrackDetails.vue
@@ -89,7 +89,7 @@
           color="rgb(var(--v-theme-primary))"
           :bars="4"
           :height="16"
-          style="width: 18px; margin-left: 12px; margin-bottom: 4px"
+          style="margin-left: 12px; margin-bottom: 4px;"
         />
       </div>
     </template>

--- a/src/layouts/default/PlayerOSD/PlayerTrackDetails.vue
+++ b/src/layouts/default/PlayerOSD/PlayerTrackDetails.vue
@@ -72,11 +72,24 @@
           v-if="
             store.activePlayer &&
             store.activePlayer?.powered != false &&
-            store.activePlayer?.playback_state != PlaybackState.IDLE
+            store.activePlayer?.playback_state != PlaybackState.IDLE &&
+            !waveformBins
           "
           :show-badge="false"
           :show-icon="true"
           icon-style="margin-left: 12px; margin-bottom: 4px;"
+        />
+        <MiniEqualizer
+          v-else-if="
+            store.activePlayer &&
+            store.activePlayer?.powered != false &&
+            store.activePlayer?.playback_state != PlaybackState.IDLE &&
+            waveformBins
+          "
+          color="rgb(var(--v-theme-primary))"
+          :bars="4"
+          :height="16"
+          style="width: 18px; margin-left: 12px; margin-bottom: 4px;"
         />
       </div>
     </template>
@@ -173,8 +186,10 @@
 
 <script setup lang="ts">
 import MarqueeText from "@/components/MarqueeText.vue";
+import MiniEqualizer from "@/components/MiniEqualizer.vue";
 import NowPlayingBadge from "@/components/NowPlayingBadge.vue";
 import QualityDetailsBtn from "@/components/QualityDetailsBtn.vue";
+import { useActiveTrackWaveform } from "@/composables/useActiveTrackWaveform";
 import { MarqueeTextSync } from "@/helpers/marquee_text_sync";
 import PlayerIcon from "@/components/PlayerIcon.vue";
 import {
@@ -189,6 +204,7 @@ import { store } from "@/plugins/store";
 import { computed } from "vue";
 import PlayerFullscreen from "./PlayerFullscreen.vue";
 
+const { waveformBins } = useActiveTrackWaveform();
 const marqueeSync = new MarqueeTextSync();
 
 // properties

--- a/src/layouts/default/PlayerOSD/QueueListItem.vue
+++ b/src/layouts/default/PlayerOSD/QueueListItem.vue
@@ -34,7 +34,14 @@
     <div class="qitem__thumb">
       <MediaItemThumb size="48" :item="item" />
       <div v-if="showEqualizer" class="qitem__eq" aria-hidden="true">
-        <NowPlayingBadge :show-badge="false" :show-icon="true" />
+        <MiniEqualizer
+          v-if="waveformBins"
+          color="rgb(var(--v-theme-primary))"
+          :bars="4"
+          :height="16"
+          style="width: 18px;"
+        />
+        <NowPlayingBadge v-else :show-badge="false" :show-icon="true" />
       </div>
     </div>
 
@@ -121,6 +128,7 @@
 <script setup lang="ts">
 import MarqueeText from "@/components/MarqueeText.vue";
 import MediaItemThumb from "@/components/MediaItemThumb.vue";
+import MiniEqualizer from "@/components/MiniEqualizer.vue";
 import NowPlayingBadge from "@/components/NowPlayingBadge.vue";
 import PartyPlayerBadge from "@/components/party/PartyPlayerBadge.vue";
 import { Button } from "@/components/ui/button";
@@ -131,6 +139,7 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { useHoldToOpenMenu } from "@/composables/useHoldToOpenMenu";
+import { useActiveTrackWaveform } from "@/composables/useActiveTrackWaveform";
 import { MarqueeTextSync } from "@/helpers/marquee_text_sync";
 import { formatDuration } from "@/helpers/utils";
 import { QueueItem } from "@/plugins/api/interfaces";
@@ -181,6 +190,8 @@ const hovered = ref(false);
 const { onHold, onTouchStart, swallowClickAfterHold } = useHoldToOpenMenu(
   (evt: Event) => emit("menu", evt),
 );
+
+const { waveformBins } = useActiveTrackWaveform();
 
 // Only animate the title/album marquee for the now-playing track, or while a
 // row is hovered — keeps the list calm and avoids dozens of scrolling rows.

--- a/src/layouts/default/PlayerOSD/QueueListItem.vue
+++ b/src/layouts/default/PlayerOSD/QueueListItem.vue
@@ -39,7 +39,7 @@
           color="rgb(var(--v-theme-primary))"
           :bars="4"
           :height="16"
-          style="width: 18px"
+
         />
         <NowPlayingBadge v-else :show-badge="false" :show-icon="true" />
       </div>

--- a/src/layouts/default/PlayerOSD/QueueListItem.vue
+++ b/src/layouts/default/PlayerOSD/QueueListItem.vue
@@ -39,7 +39,7 @@
           color="rgb(var(--v-theme-primary))"
           :bars="4"
           :height="16"
-          style="width: 18px;"
+          style="width: 18px"
         />
         <NowPlayingBadge v-else :show-badge="false" :show-icon="true" />
       </div>

--- a/src/layouts/default/PlayerOSD/QueueListItem.vue
+++ b/src/layouts/default/PlayerOSD/QueueListItem.vue
@@ -39,7 +39,6 @@
           color="rgb(var(--v-theme-primary))"
           :bars="4"
           :height="16"
-
         />
         <NowPlayingBadge v-else :show-badge="false" :show-icon="true" />
       </div>

--- a/tests/composables/useActiveTrackWaveform.test.ts
+++ b/tests/composables/useActiveTrackWaveform.test.ts
@@ -1,0 +1,190 @@
+import { nextTick, reactive } from "vue";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// ---------------------------------------------------------------------------
+// Hoisted mocks
+// ---------------------------------------------------------------------------
+
+const { mockGetWaveForm } = vi.hoisted(() => ({
+  mockGetWaveForm: vi.fn(),
+}));
+
+vi.mock("@/plugins/api", () => ({
+  default: { getWaveForm: mockGetWaveForm },
+}));
+
+// Reactive store mock so the module-level watch fires when we mutate it.
+const storeMock = reactive({
+  curQueueItem: null as unknown,
+});
+
+vi.mock("@/plugins/store", () => ({
+  store: storeMock,
+}));
+
+vi.mock("@/plugins/api/interfaces", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/plugins/api/interfaces")>();
+  return { ...actual };
+});
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeQueueItem(overrides: Record<string, unknown> = {}) {
+  return {
+    queue_item_id: "qi-1",
+    duration: 240,
+    media_item: {
+      item_id: "track-1",
+      provider: "spotify",
+      media_type: "track",
+    },
+    streamdetails: {
+      item_id: "stream-1",
+      provider: "spotify",
+    },
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("useActiveTrackWaveform", () => {
+  beforeEach(async () => {
+    mockGetWaveForm.mockReset();
+    storeMock.curQueueItem = null;
+    // Allow the immediate watch triggered by resetting to settle.
+    await nextTick();
+  });
+
+  it("fetches waveform and sets bins when track with streamdetails plays", async () => {
+    mockGetWaveForm.mockResolvedValueOnce([0.1, 0.5, 0.9]);
+
+    const { useActiveTrackWaveform } = await import(
+      "@/composables/useActiveTrackWaveform"
+    );
+    const { waveformBins, trackDurationSecs } = useActiveTrackWaveform();
+
+    storeMock.curQueueItem = makeQueueItem();
+    await nextTick();
+    await nextTick(); // await async watch body
+
+    expect(mockGetWaveForm).toHaveBeenCalledWith("stream-1", "spotify");
+    expect(waveformBins.value).toEqual([0.1, 0.5, 0.9]);
+    expect(trackDurationSecs.value).toBe(240);
+  });
+
+  it("does not fetch when media_type is not track", async () => {
+    const { useActiveTrackWaveform } = await import(
+      "@/composables/useActiveTrackWaveform"
+    );
+    const { waveformBins } = useActiveTrackWaveform();
+
+    storeMock.curQueueItem = makeQueueItem({
+      media_item: { item_id: "r-1", provider: "spotify", media_type: "radio" },
+    });
+    await nextTick();
+    await nextTick();
+
+    expect(mockGetWaveForm).not.toHaveBeenCalled();
+    expect(waveformBins.value).toBeNull();
+  });
+
+  it("does not fetch when streamdetails are absent", async () => {
+    const { useActiveTrackWaveform } = await import(
+      "@/composables/useActiveTrackWaveform"
+    );
+    const { waveformBins } = useActiveTrackWaveform();
+
+    storeMock.curQueueItem = makeQueueItem({ streamdetails: undefined });
+    await nextTick();
+    await nextTick();
+
+    expect(mockGetWaveForm).not.toHaveBeenCalled();
+    expect(waveformBins.value).toBeNull();
+  });
+
+  it("keeps waveformBins null when api throws", async () => {
+    mockGetWaveForm.mockRejectedValueOnce(new Error("no analysis"));
+
+    const { useActiveTrackWaveform } = await import(
+      "@/composables/useActiveTrackWaveform"
+    );
+    const { waveformBins } = useActiveTrackWaveform();
+
+    storeMock.curQueueItem = makeQueueItem();
+    await nextTick();
+    await nextTick();
+
+    expect(waveformBins.value).toBeNull();
+  });
+
+  it("keeps waveformBins null when api returns empty array", async () => {
+    mockGetWaveForm.mockResolvedValueOnce([]);
+
+    const { useActiveTrackWaveform } = await import(
+      "@/composables/useActiveTrackWaveform"
+    );
+    const { waveformBins } = useActiveTrackWaveform();
+
+    storeMock.curQueueItem = makeQueueItem();
+    await nextTick();
+    await nextTick();
+
+    expect(waveformBins.value).toBeNull();
+  });
+
+  it("ignores stale result when track changes before fetch resolves", async () => {
+    let resolve1!: (v: number[]) => void;
+    const promise1 = new Promise<number[]>((r) => (resolve1 = r));
+    mockGetWaveForm
+      .mockReturnValueOnce(promise1)
+      .mockResolvedValueOnce([0.8, 0.9]);
+
+    const { useActiveTrackWaveform } = await import(
+      "@/composables/useActiveTrackWaveform"
+    );
+    const { waveformBins } = useActiveTrackWaveform();
+
+    // Start first fetch.
+    storeMock.curQueueItem = makeQueueItem({ queue_item_id: "qi-1" });
+    await nextTick();
+
+    // Switch to second track before first resolves.
+    storeMock.curQueueItem = makeQueueItem({
+      queue_item_id: "qi-2",
+      streamdetails: { item_id: "stream-2", provider: "spotify" },
+    });
+    await nextTick();
+    await nextTick(); // second fetch resolves
+
+    // Now resolve the first (stale) fetch.
+    resolve1([0.1, 0.2]);
+    await nextTick();
+
+    // Only the second result should be stored.
+    expect(waveformBins.value).toEqual([0.8, 0.9]);
+  });
+
+  it("does not re-fetch when the same queue_item_id is set again", async () => {
+    mockGetWaveForm.mockResolvedValue([0.5]);
+
+    const { useActiveTrackWaveform } = await import(
+      "@/composables/useActiveTrackWaveform"
+    );
+    useActiveTrackWaveform();
+
+    storeMock.curQueueItem = makeQueueItem({ queue_item_id: "qi-same" });
+    await nextTick();
+    await nextTick();
+
+    storeMock.curQueueItem = { ...makeQueueItem({ queue_item_id: "qi-same" }) };
+    await nextTick();
+    await nextTick();
+
+    expect(mockGetWaveForm).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/composables/useActiveTrackWaveform.test.ts
+++ b/tests/composables/useActiveTrackWaveform.test.ts
@@ -23,7 +23,8 @@ vi.mock("@/plugins/store", () => ({
 }));
 
 vi.mock("@/plugins/api/interfaces", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("@/plugins/api/interfaces")>();
+  const actual =
+    await importOriginal<typeof import("@/plugins/api/interfaces")>();
   return { ...actual };
 });
 
@@ -63,9 +64,8 @@ describe("useActiveTrackWaveform", () => {
   it("fetches waveform and sets bins when track with streamdetails plays", async () => {
     mockGetWaveForm.mockResolvedValueOnce([0.1, 0.5, 0.9]);
 
-    const { useActiveTrackWaveform } = await import(
-      "@/composables/useActiveTrackWaveform"
-    );
+    const { useActiveTrackWaveform } =
+      await import("@/composables/useActiveTrackWaveform");
     const { waveformBins, trackDurationSecs } = useActiveTrackWaveform();
 
     storeMock.curQueueItem = makeQueueItem();
@@ -78,9 +78,8 @@ describe("useActiveTrackWaveform", () => {
   });
 
   it("does not fetch when media_type is not track", async () => {
-    const { useActiveTrackWaveform } = await import(
-      "@/composables/useActiveTrackWaveform"
-    );
+    const { useActiveTrackWaveform } =
+      await import("@/composables/useActiveTrackWaveform");
     const { waveformBins } = useActiveTrackWaveform();
 
     storeMock.curQueueItem = makeQueueItem({
@@ -94,9 +93,8 @@ describe("useActiveTrackWaveform", () => {
   });
 
   it("does not fetch when streamdetails are absent", async () => {
-    const { useActiveTrackWaveform } = await import(
-      "@/composables/useActiveTrackWaveform"
-    );
+    const { useActiveTrackWaveform } =
+      await import("@/composables/useActiveTrackWaveform");
     const { waveformBins } = useActiveTrackWaveform();
 
     storeMock.curQueueItem = makeQueueItem({ streamdetails: undefined });
@@ -110,9 +108,8 @@ describe("useActiveTrackWaveform", () => {
   it("keeps waveformBins null when api throws", async () => {
     mockGetWaveForm.mockRejectedValueOnce(new Error("no analysis"));
 
-    const { useActiveTrackWaveform } = await import(
-      "@/composables/useActiveTrackWaveform"
-    );
+    const { useActiveTrackWaveform } =
+      await import("@/composables/useActiveTrackWaveform");
     const { waveformBins } = useActiveTrackWaveform();
 
     storeMock.curQueueItem = makeQueueItem();
@@ -125,9 +122,8 @@ describe("useActiveTrackWaveform", () => {
   it("keeps waveformBins null when api returns empty array", async () => {
     mockGetWaveForm.mockResolvedValueOnce([]);
 
-    const { useActiveTrackWaveform } = await import(
-      "@/composables/useActiveTrackWaveform"
-    );
+    const { useActiveTrackWaveform } =
+      await import("@/composables/useActiveTrackWaveform");
     const { waveformBins } = useActiveTrackWaveform();
 
     storeMock.curQueueItem = makeQueueItem();
@@ -144,9 +140,8 @@ describe("useActiveTrackWaveform", () => {
       .mockReturnValueOnce(promise1)
       .mockResolvedValueOnce([0.8, 0.9]);
 
-    const { useActiveTrackWaveform } = await import(
-      "@/composables/useActiveTrackWaveform"
-    );
+    const { useActiveTrackWaveform } =
+      await import("@/composables/useActiveTrackWaveform");
     const { waveformBins } = useActiveTrackWaveform();
 
     // Start first fetch.
@@ -172,9 +167,8 @@ describe("useActiveTrackWaveform", () => {
   it("does not re-fetch when the same queue_item_id is set again", async () => {
     mockGetWaveForm.mockResolvedValue([0.5]);
 
-    const { useActiveTrackWaveform } = await import(
-      "@/composables/useActiveTrackWaveform"
-    );
+    const { useActiveTrackWaveform } =
+      await import("@/composables/useActiveTrackWaveform");
     useActiveTrackWaveform();
 
     storeMock.curQueueItem = makeQueueItem({ queue_item_id: "qi-same" });


### PR DESCRIPTION
Replaces the static CSS equalizer animation in the now-playing indicator with a `MiniEqualizer` component that displays actual waveform data from the audio analysis — scrolling a window of RMS energy bins centered on the current playback position.

## Changes

- **`MiniEqualizer.vue`** — new canvas component: 4 bars (3px wide, 2px gap, 16px tall — same footprint as `NowPlayingBadge`), scrolling window of waveform bins centered on current position, updates at 10fps
- **`useActiveTrackWaveform.ts`** — new composable: single shared waveform loader, watches both `queue_item_id` and `streamdetails.item_id`, respects the `show_waveform` user preference, handles race conditions on track changes
- **`PlayerFullscreen.vue`** — uses `useActiveTrackWaveform` instead of its own duplicate loading logic
- **`PlayerTrackDetails.vue`** — shows `MiniEqualizer` next to the track title in the bottom player bar when waveform data is available
- **`QueueListItem.vue`** — shows `MiniEqualizer` as the now-playing overlay on the queue item thumbnail

**Fallback:** When no audio analysis is available, the original `NowPlayingBadge` CSS animation shows unchanged.

**User preference:** The existing `show_waveform` setting (Frontend Settings) controls both the waveform timeline and this indicator.

## Videos

https://github.com/user-attachments/assets/fa1f7d07-4f83-425c-bac0-5fa3fc6eb4c9

https://github.com/user-attachments/assets/10f00b50-9d5b-4d7f-b889-d60014b30556
