### PR TITLE
Improve Music Timeline answers

### DIFF
--- a/src/components/music-quiz/answer-types/timeline/TimelineAudienceAnswer.vue
+++ b/src/components/music-quiz/answer-types/timeline/TimelineAudienceAnswer.vue
@@ -71,26 +71,32 @@
               <span
                 data-testid="timeline-result-score"
                 class="flex min-w-0 max-w-[45%] items-center gap-1 font-semibold tabular-nums"
-                :class="
-                  result.correct
-                    ? 'text-green-600 dark:text-green-400'
-                    : 'text-muted-foreground'
-                "
               >
                 <CircleCheck
-                  v-if="result.correct"
-                  class="size-4"
+                  v-if="result.placementCorrect"
+                  class="size-4 text-green-600 dark:text-green-400"
                   aria-hidden="true"
                 />
-                <CircleX v-else class="size-4" aria-hidden="true" />
+                <CircleX
+                  v-else
+                  class="text-muted-foreground size-4"
+                  aria-hidden="true"
+                />
                 <span class="sr-only">
                   {{
-                    result.correct
-                      ? $t("providers.music_quiz.correct")
-                      : $t("providers.music_quiz.incorrect")
+                    result.placementCorrect
+                      ? $t("providers.music_quiz.timeline_correct_placement")
+                      : $t("providers.music_quiz.timeline_incorrect_placement")
                   }}
                 </span>
-                <span class="min-w-0 flex-1 truncate">
+                <span
+                  class="min-w-0 flex-1 truncate"
+                  :class="
+                    result.points > 0
+                      ? 'text-green-600 dark:text-green-400'
+                      : 'text-muted-foreground'
+                  "
+                >
                   +{{ result.points }}
                 </span>
               </span>
@@ -147,7 +153,7 @@ const revealedResults = computed(() =>
     return [
       {
         name: player.name,
-        correct: answer.placement.correct,
+        placementCorrect: answer.placement.correct,
         points:
           answer.placement.points +
           (answer.artist?.points ?? 0) +

--- a/src/components/music-quiz/answer-types/timeline/TimelineDisplay.vue
+++ b/src/components/music-quiz/answer-types/timeline/TimelineDisplay.vue
@@ -35,15 +35,26 @@
         <template v-for="boundary in boundaries" :key="boundary.key">
           <li
             v-if="selectable && entries.length"
-            class="relative z-10 flex justify-center py-2"
+            class="relative z-10 flex flex-col items-center justify-center gap-3 py-2"
+            :class="horizontal ? 'w-52 shrink-0' : 'w-full'"
           >
             <Button
               type="button"
               size="sm"
+              :variant="
+                hasSelectedBoundary && !boundary.selected
+                  ? 'outline'
+                  : 'default'
+              "
               class="h-auto min-h-11 min-w-44 max-w-full rounded-full px-4 py-2 text-center whitespace-normal"
+              :class="{
+                'ring-primary/30 ring-4 disabled:opacity-100':
+                  boundary.selected,
+              }"
               :disabled="disabled"
               :aria-label="boundary.label"
               :aria-pressed="boundary.selected"
+              :data-selected="boundary.selected ? 'true' : undefined"
               :data-previous-entry-id="boundary.previousEntryId"
               :data-next-entry-id="boundary.nextEntryId"
               @click="
@@ -52,12 +63,29 @@
             >
               <Check v-if="boundary.selected" class="size-4" />
               <Plus v-else class="size-4" />
-              {{
-                boundary.selected
-                  ? $t("providers.music_quiz.timeline_placed_here")
-                  : boundary.actionLabel
-              }}
+              <span class="flex flex-col">
+                <span>
+                  {{
+                    boundary.selected
+                      ? $t("providers.music_quiz.timeline_placed_here")
+                      : boundary.actionLabel
+                  }}
+                </span>
+                <span
+                  v-if="boundary.selected"
+                  class="text-primary-foreground/80 text-xs"
+                >
+                  {{ boundary.actionLabel }}
+                </span>
+              </span>
             </Button>
+            <div
+              v-if="boundary.selected"
+              data-testid="timeline-selected-boundary"
+              class="w-full max-w-xl"
+            >
+              <slot name="selected-boundary" />
+            </div>
           </li>
           <li
             v-if="boundary.entry"
@@ -142,6 +170,9 @@ const boundaries = computed<TimelineBoundary[]>(() =>
         nextEntryId === props.selectedNextEntryId,
     };
   }),
+);
+const hasSelectedBoundary = computed(() =>
+  boundaries.value.some((boundary) => boundary.selected),
 );
 
 watch(

--- a/src/components/music-quiz/answer-types/timeline/TimelinePlayerAnswer.vue
+++ b/src/components/music-quiz/answer-types/timeline/TimelinePlayerAnswer.vue
@@ -9,96 +9,103 @@
         />
         <p class="text-center text-lg font-bold">
           {{
-            state.you.answer
+            placementLocked
               ? $t("providers.music_quiz.timeline_placement_locked")
               : $t("providers.music_quiz.timeline_choose_position")
           }}
         </p>
       </div>
 
-      <div
-        v-if="state.you.answer"
-        ref="postPlacementRef"
-        data-testid="timeline-post-placement"
-        class="scroll-mt-3"
-        tabindex="-1"
-        aria-live="polite"
-      >
-        <Card v-if="!state.you.answer.finished && activeBonus">
-          <CardContent class="flex flex-col gap-4">
-            <div>
-              <h2 class="font-semibold">{{ activeBonusLabel }}</h2>
-              <p class="text-muted-foreground text-sm">
-                {{ $t("providers.music_quiz.timeline_bonus_optional") }}
-              </p>
-            </div>
-
-            <form
-              v-if="activeBonus.mode === 'free_text'"
-              class="flex flex-col gap-3"
-              @submit.prevent="submitTextBonus"
-            >
-              <Label :for="`timeline-${activeBonus.bonus_type}-answer`">
-                {{ activeBonusLabel }}
-              </Label>
-              <Input
-                :id="`timeline-${activeBonus.bonus_type}-answer`"
-                v-model="bonusText"
-                :disabled="busy"
-                :maxlength="MAX_BONUS_TEXT_LENGTH"
-                autocomplete="off"
-              />
-              <Button type="submit" :disabled="busy || !bonusText.trim()">
-                <Send class="size-4" />
-                {{ $t("providers.music_quiz.timeline_submit_bonus") }}
-              </Button>
-            </form>
-
-            <div v-else class="grid gap-2 sm:grid-cols-2">
-              <Button
-                v-for="option in activeBonus.options"
-                :key="option.option_id"
-                type="button"
-                variant="outline"
-                class="h-auto min-h-14 justify-start whitespace-normal text-left"
-                :disabled="busy"
-                @click="submitChoiceBonus(option.option_id)"
-              >
-                {{ option.label }}
-              </Button>
-            </div>
-
-            <Button
-              type="button"
-              variant="outline"
-              :disabled="busy"
-              @click="skipRemainingBonuses"
-            >
-              <SkipForward class="size-4" />
-              {{ $t("providers.music_quiz.timeline_skip_remaining_bonuses") }}
-            </Button>
-          </CardContent>
-        </Card>
-
-        <p
-          v-else-if="state.you.answer.finished"
-          class="text-muted-foreground text-center"
-          role="status"
-        >
-          {{ $t("providers.music_quiz.answered") }}
-        </p>
-      </div>
-
       <TimelineDisplay
         :entries="currentRound.timeline"
         :selectable="true"
-        :disabled="busy || !!state.you.answer"
+        :disabled="busy || placementLocked"
         :selected-previous-entry-id="
-          state.you.answer?.previous_entry_id ?? undefined
+          selectedPlacement?.previousEntryId ?? undefined
         "
-        :selected-next-entry-id="state.you.answer?.next_entry_id ?? undefined"
+        :selected-next-entry-id="selectedPlacement?.nextEntryId ?? undefined"
         @select="place"
-      />
+      >
+        <template #selected-boundary>
+          <div
+            v-if="state.you.answer"
+            ref="postPlacementRef"
+            data-testid="timeline-post-placement"
+            class="scroll-mt-3"
+            tabindex="-1"
+            aria-live="polite"
+          >
+            <Card
+              v-if="!state.you.answer.finished && activeBonus"
+              class="border-primary/30 bg-primary/5"
+            >
+              <CardContent class="flex flex-col gap-4">
+                <div>
+                  <h2 class="font-semibold">{{ activeBonusLabel }}</h2>
+                  <p class="text-muted-foreground text-sm">
+                    {{ $t("providers.music_quiz.timeline_bonus_optional") }}
+                  </p>
+                </div>
+
+                <form
+                  v-if="activeBonus.mode === 'free_text'"
+                  class="flex flex-col gap-3"
+                  @submit.prevent="submitTextBonus"
+                >
+                  <Label :for="`timeline-${activeBonus.bonus_type}-answer`">
+                    {{ activeBonusLabel }}
+                  </Label>
+                  <Input
+                    :id="`timeline-${activeBonus.bonus_type}-answer`"
+                    v-model="bonusText"
+                    :disabled="busy"
+                    :maxlength="MAX_BONUS_TEXT_LENGTH"
+                    autocomplete="off"
+                  />
+                  <Button type="submit" :disabled="busy || !bonusText.trim()">
+                    <Send class="size-4" />
+                    {{ $t("providers.music_quiz.timeline_submit_bonus") }}
+                  </Button>
+                </form>
+
+                <div v-else class="grid gap-2 sm:grid-cols-2">
+                  <Button
+                    v-for="option in activeBonus.options"
+                    :key="option.option_id"
+                    type="button"
+                    variant="outline"
+                    class="h-auto min-h-14 justify-start whitespace-normal text-left"
+                    :disabled="busy"
+                    @click="submitChoiceBonus(option.option_id)"
+                  >
+                    {{ option.label }}
+                  </Button>
+                </div>
+
+                <Button
+                  type="button"
+                  variant="outline"
+                  :disabled="busy"
+                  @click="skipRemainingBonuses"
+                >
+                  <SkipForward class="size-4" />
+                  {{
+                    $t("providers.music_quiz.timeline_skip_remaining_bonuses")
+                  }}
+                </Button>
+              </CardContent>
+            </Card>
+
+            <p
+              v-else-if="state.you.answer.finished"
+              class="text-muted-foreground text-center"
+              role="status"
+            >
+              {{ $t("providers.music_quiz.answered") }}
+            </p>
+          </div>
+        </template>
+      </TimelineDisplay>
     </template>
 
     <p v-else class="text-muted-foreground text-center" role="status">
@@ -114,17 +121,16 @@
       :highlighted-entry-id="currentRound.revealed_entry?.entry_id"
     />
 
-    <div
-      v-if="state.you.answer"
-      class="flex flex-col gap-2 rounded-lg p-3"
-      :class="
-        state.you.answer.correct
-          ? 'bg-green-500/15 text-green-700 dark:text-green-400'
-          : 'bg-red-500/10 text-destructive'
-      "
-      role="status"
-    >
-      <div class="flex items-center justify-center gap-2 font-semibold">
+    <div v-if="state.you.answer" class="flex flex-col gap-2" role="status">
+      <div
+        data-testid="timeline-placement-result"
+        class="flex items-center justify-center gap-2 rounded-lg p-3 font-semibold"
+        :class="
+          state.you.answer.correct
+            ? 'bg-green-500/15 text-green-700 dark:text-green-400'
+            : 'bg-red-500/10 text-destructive'
+        "
+      >
         <CircleCheck
           v-if="state.you.answer.correct"
           class="size-5"
@@ -141,7 +147,13 @@
       <div
         v-for="result in state.you.answer.bonus_results"
         :key="result.bonus_type"
-        class="flex items-center justify-center gap-2 text-sm font-medium"
+        :data-testid="`timeline-${result.bonus_type}-result`"
+        class="flex items-center justify-center gap-2 rounded-lg p-2 text-sm font-medium"
+        :class="
+          result.correct
+            ? 'bg-green-500/15 text-green-700 dark:text-green-400'
+            : 'bg-red-500/10 text-destructive'
+        "
       >
         <CircleCheck v-if="result.correct" class="size-4" aria-hidden="true" />
         <CircleX v-else class="size-4" aria-hidden="true" />
@@ -195,6 +207,11 @@ import { computed, ref, watch } from "vue";
 
 const MAX_BONUS_TEXT_LENGTH = 200;
 
+interface TimelinePlacementSelection {
+  previousEntryId: string | null;
+  nextEntryId: string | null;
+}
+
 const props =
   defineProps<
     MusicQuizPlayerAnswerAdapterProps<
@@ -205,25 +222,36 @@ const props =
 const emit = defineEmits<MusicQuizPlayerAnswerAdapterEmits<"timeline">>();
 
 const bonusText = ref("");
-const { postPlacementRef } = useTimelinePostPlacementFocus(
-  () => !!props.state.you.answer,
-  () => props.busy,
-);
+const pendingPlacement = ref<TimelinePlacementSelection>();
 const answeredBonusTypes = computed(
   () =>
     new Set(
       props.state.you.answer?.bonuses.map((answer) => answer.bonus_type) ?? [],
     ),
 );
-const activeBonus = computed(() =>
-  props.state.you.answer?.finished
-    ? undefined
-    : props.currentRound.bonus_definitions.find(
-        (definition) => !answeredBonusTypes.value.has(definition.bonus_type),
-      ),
-);
+const activeBonus = computed(() => {
+  const answer = props.state.you.answer;
+  if (!answer || answer.finished) return undefined;
+  return props.currentRound.bonus_definitions.find(
+    (definition) => !answeredBonusTypes.value.has(definition.bonus_type),
+  );
+});
 const activeBonusLabel = computed(() =>
   activeBonus.value ? bonusTypeLabel(activeBonus.value.bonus_type) : "",
+);
+const placementLocked = computed(
+  () => !!props.state.you.answer || !!pendingPlacement.value,
+);
+const selectedPlacement = computed<TimelinePlacementSelection | undefined>(
+  () => {
+    const answer = props.state.you.answer;
+    return answer
+      ? {
+          previousEntryId: answer.previous_entry_id,
+          nextEntryId: answer.next_entry_id,
+        }
+      : pendingPlacement.value;
+  },
 );
 const canAnswerRound = computed(
   () => props.state.you.active_from_round <= props.currentRound.round_index,
@@ -236,6 +264,10 @@ const { remainingLabel, remainingFraction } = useMusicQuizAnswerDeadline({
   deadline: () => props.currentRound.deadline,
   duration: () => props.state.answer_duration,
 });
+const { postPlacementRef } = useTimelinePostPlacementFocus(
+  () => activeBonus.value?.bonus_type,
+  () => props.busy,
+);
 
 watch(
   () => activeBonus.value?.bonus_type,
@@ -243,8 +275,30 @@ watch(
     bonusText.value = "";
   },
 );
+watch(
+  () => props.state.you.answer,
+  (answer) => {
+    if (answer) pendingPlacement.value = undefined;
+  },
+);
+watch(
+  () => props.busy,
+  (busy, wasBusy) => {
+    if (wasBusy && !busy && !props.state.you.answer) {
+      pendingPlacement.value = undefined;
+    }
+  },
+);
+watch(
+  () => props.currentRound.round_index,
+  () => {
+    pendingPlacement.value = undefined;
+  },
+);
 
 function place(previousEntryId: string | null, nextEntryId: string | null) {
+  if (placementLocked.value) return;
+  pendingPlacement.value = { previousEntryId, nextEntryId };
   emit("submit", {
     answer_type: "timeline",
     action: "place",

--- a/src/components/music-quiz/answer-types/timeline/useTimelinePostPlacementFocus.ts
+++ b/src/components/music-quiz/answer-types/timeline/useTimelinePostPlacementFocus.ts
@@ -1,24 +1,23 @@
 import { nextTick, ref, watch } from "vue";
 
-/** Focus post-placement controls when a placement becomes locked. */
+/** Focus each newly available post-placement action. */
 export function useTimelinePostPlacementFocus(
-  hasPlacement: () => boolean,
+  actionKey: () => string | undefined,
   isBusy: () => boolean,
 ) {
   const postPlacementRef = ref<HTMLElement | null>(null);
   let focusPending = false;
 
-  watch(
-    [hasPlacement, isBusy],
-    ([hasLockedPlacement, busy], [hadLockedPlacement]) => {
-      if (hasLockedPlacement && !hadLockedPlacement) focusPending = true;
-      if (!hasLockedPlacement) focusPending = false;
-      if (focusPending && !busy) {
-        focusPending = false;
-        void focusPostPlacement();
-      }
-    },
-  );
+  watch([actionKey, isBusy], ([nextActionKey, busy], [previousActionKey]) => {
+    if (nextActionKey && nextActionKey !== previousActionKey) {
+      focusPending = true;
+    }
+    if (!nextActionKey) focusPending = false;
+    if (focusPending && !busy) {
+      focusPending = false;
+      void focusPostPlacement();
+    }
+  });
 
   return { postPlacementRef };
 

--- a/src/components/music-quiz/answer-types/timeline/useTimelinePostPlacementFocus.ts
+++ b/src/components/music-quiz/answer-types/timeline/useTimelinePostPlacementFocus.ts
@@ -25,12 +25,15 @@ export function useTimelinePostPlacementFocus(
     await nextTick();
     const container = postPlacementRef.value;
     if (!container) return;
-    const reducedMotion =
-      window.matchMedia?.("(prefers-reduced-motion: reduce)").matches ?? false;
-    container.scrollIntoView({
-      behavior: reducedMotion ? "auto" : "smooth",
-      block: "start",
-    });
+    if (typeof container.scrollIntoView === "function") {
+      const reducedMotion =
+        window.matchMedia?.("(prefers-reduced-motion: reduce)").matches ??
+        false;
+      container.scrollIntoView({
+        behavior: reducedMotion ? "auto" : "smooth",
+        block: "start",
+      });
+    }
     const target =
       container.querySelector<HTMLElement>(
         'input:not([disabled]), button:not([disabled]), [tabindex]:not([tabindex="-1"])',

--- a/tests/components/music-quiz/TimelineAudienceAdapters.test.ts
+++ b/tests/components/music-quiz/TimelineAudienceAdapters.test.ts
@@ -214,13 +214,13 @@ describe("timeline host and present answers", () => {
       players: [
         {
           ...hostState.players[1],
-          score: 1250,
+          score: 250,
           last_answer: {
             placement: {
               previous_entry_id: "anchor",
               next_entry_id: null,
-              correct: true,
-              points: 1000,
+              correct: false,
+              points: 0,
             },
             artist: {
               correct: true,
@@ -249,11 +249,16 @@ describe("timeline host and present answers", () => {
     });
 
     expect(wrapper.text()).toContain("Complete");
-    expect(wrapper.text()).toContain("+1250");
+    expect(wrapper.text()).toContain("+250");
     expect(wrapper.findComponent(TimelineProgress).exists()).toBe(false);
     expect(wrapper.find(".sr-only").text()).toContain(
-      "providers.music_quiz.correct",
+      "providers.music_quiz.timeline_incorrect_placement",
     );
+    expect(
+      wrapper
+        .get('[data-testid="timeline-result-score"] span.truncate')
+        .classes(),
+    ).toContain("text-green-600");
     expect(wrapper.find('[data-testid="leaderboard"]').exists()).toBe(true);
   });
 });

--- a/tests/components/music-quiz/TimelineDisplay.test.ts
+++ b/tests/components/music-quiz/TimelineDisplay.test.ts
@@ -188,20 +188,41 @@ describe("TimelineDisplay", () => {
         selectedPreviousEntryId: "same-a",
         selectedNextEntryId: "same-b",
       },
+      slots: {
+        "selected-boundary":
+          '<section data-testid="inline-follow-up">Follow-up</section>',
+      },
     });
     const buttons = wrapper.findAll("button");
     const selected = buttons[2];
+    const selectedItem = selected.element.closest("li");
 
     expect(selected.attributes("aria-pressed")).toBe("true");
+    expect(selected.attributes("data-selected")).toBe("true");
     expect(buttons.every((button) => "disabled" in button.attributes())).toBe(
       true,
     );
     expect(selected.classes()).toContain("min-h-11");
     expect(selected.classes()).toContain("bg-primary");
+    expect(selected.classes()).toContain("ring-4");
+    expect(selected.classes()).toContain("disabled:opacity-100");
     expect(selected.text()).toContain(
       "providers.music_quiz.timeline_placed_here",
     );
+    expect(selected.text()).toContain(
+      "providers.music_quiz.timeline_place_in_year:2000",
+    );
     expect(selected.find("svg").exists()).toBe(true);
+    expect(
+      buttons
+        .filter((button) => button !== selected)
+        .every((button) => button.classes().includes("bg-background")),
+    ).toBe(true);
+    expect(
+      selectedItem?.contains(
+        wrapper.get('[data-testid="inline-follow-up"]').element,
+      ),
+    ).toBe(true);
   });
 
   it("renders a read-only timeline without placement controls", () => {

--- a/tests/components/music-quiz/TimelinePlayerAnswer.test.ts
+++ b/tests/components/music-quiz/TimelinePlayerAnswer.test.ts
@@ -15,7 +15,38 @@ vi.mock("@/helpers/utils", () => ({
 }));
 
 describe("Timeline player placement", () => {
-  it("submits exact start and end placement boundaries", () => {
+  it.each([
+    ["start", null, "anchor"],
+    ["end", "anchor", null],
+  ] as const)(
+    "submits the exact %s placement boundary",
+    (_label, previousEntryId, nextEntryId) => {
+      const wrapper = shallowMount(TimelinePlayerAnswer, {
+        props: {
+          state: baseState,
+          currentRound: baseRound,
+          busy: false,
+        },
+      });
+
+      wrapper
+        .getComponent(TimelineDisplay)
+        .vm.$emit("select", previousEntryId, nextEntryId);
+
+      expect(wrapper.emitted("submit")).toEqual([
+        [
+          {
+            answer_type: "timeline",
+            action: "place",
+            previous_entry_id: previousEntryId,
+            next_entry_id: nextEntryId,
+          },
+        ],
+      ]);
+    },
+  );
+
+  it("shows and locks the chosen boundary while placement is pending", async () => {
     const wrapper = shallowMount(TimelinePlayerAnswer, {
       props: {
         state: baseState,
@@ -25,27 +56,29 @@ describe("Timeline player placement", () => {
     });
     const timeline = wrapper.getComponent(TimelineDisplay);
 
-    timeline.vm.$emit("select", null, "anchor");
     timeline.vm.$emit("select", "anchor", null);
+    await wrapper.vm.$nextTick();
 
-    expect(wrapper.emitted("submit")).toEqual([
-      [
-        {
-          answer_type: "timeline",
-          action: "place",
-          previous_entry_id: null,
-          next_entry_id: "anchor",
-        },
-      ],
-      [
-        {
-          answer_type: "timeline",
-          action: "place",
-          previous_entry_id: "anchor",
-          next_entry_id: null,
-        },
-      ],
-    ]);
+    expect(wrapper.text()).toContain(
+      "providers.music_quiz.timeline_placement_locked",
+    );
+    expect(timeline.props()).toMatchObject({
+      disabled: true,
+      selectedPreviousEntryId: "anchor",
+      selectedNextEntryId: null,
+    });
+
+    timeline.vm.$emit("select", null, "anchor");
+    expect(wrapper.emitted("submit")).toHaveLength(1);
+
+    await wrapper.setProps({ busy: true });
+    await wrapper.setProps({ busy: false });
+
+    expect(wrapper.getComponent(TimelineDisplay).props()).toMatchObject({
+      disabled: false,
+      selectedPreviousEntryId: null,
+      selectedNextEntryId: null,
+    });
   });
 
   it("keeps late joiners waiting until their active round", () => {

--- a/tests/components/music-quiz/TimelinePlayerBonusFlow.test.ts
+++ b/tests/components/music-quiz/TimelinePlayerBonusFlow.test.ts
@@ -7,7 +7,7 @@ import {
   player,
   stateWithAnswer,
 } from "./timelinePlayerFixtures";
-import { mount, shallowMount } from "@vue/test-utils";
+import { mount } from "@vue/test-utils";
 import { describe, expect, it, vi } from "vitest";
 
 vi.mock("@/plugins/i18n", () => ({
@@ -40,11 +40,17 @@ describe("Timeline player bonus flow", () => {
         },
       },
     } satisfies MusicQuizTimelinePersonalizedState;
-    const wrapper = shallowMount(TimelinePlayerAnswer, {
+    const wrapper = mount(TimelinePlayerAnswer, {
       props: {
         state,
         currentRound: baseRound,
         busy: false,
+      },
+      global: {
+        stubs: {
+          MusicQuizCountdown: true,
+          TimelineProgress: true,
+        },
       },
     });
 
@@ -65,11 +71,18 @@ describe("Timeline player bonus flow", () => {
       global: {
         stubs: {
           MusicQuizCountdown: true,
-          TimelineDisplay: true,
           TimelineProgress: true,
         },
       },
     });
+
+    const followUp = wrapper.get('[data-testid="timeline-post-placement"]');
+    expect(
+      wrapper
+        .get('button[data-selected="true"]')
+        .element.closest("li")
+        ?.contains(followUp.element),
+    ).toBe(true);
 
     await wrapper.get("input").setValue("  Massive Attack  ");
     await wrapper.get("form").trigger("submit");
@@ -129,7 +142,6 @@ describe("Timeline player bonus flow", () => {
       global: {
         stubs: {
           MusicQuizCountdown: true,
-          TimelineDisplay: true,
           TimelineProgress: true,
         },
       },
@@ -155,7 +167,6 @@ describe("Timeline player bonus flow", () => {
       global: {
         stubs: {
           MusicQuizCountdown: true,
-          TimelineDisplay: true,
           TimelineProgress: true,
         },
       },
@@ -191,7 +202,6 @@ describe("Timeline player bonus flow", () => {
       global: {
         stubs: {
           MusicQuizCountdown: true,
-          TimelineDisplay: true,
           TimelineProgress: true,
         },
       },

--- a/tests/components/music-quiz/TimelinePlayerFocus.test.ts
+++ b/tests/components/music-quiz/TimelinePlayerFocus.test.ts
@@ -43,7 +43,7 @@ describe("Timeline player focus", () => {
     expect(scrollIntoView).not.toHaveBeenCalled();
   });
 
-  it("moves and focuses bonus controls before a long timeline", async () => {
+  it("moves and focuses bonus controls at the chosen boundary", async () => {
     const longRound = {
       ...bonusRound,
       timeline: Array.from({ length: 100 }, (_, index) => ({
@@ -55,6 +55,9 @@ describe("Timeline player focus", () => {
         is_anchor: index === 0,
       })),
     } satisfies MusicQuizTimelineRound;
+    const answeredState = stateWithAnswer();
+    if (!answeredState.you.answer) throw new Error("Expected fixture answer");
+    answeredState.you.answer.previous_entry_id = "entry-99";
     const wrapper = mount(TimelinePlayerAnswer, {
       attachTo: document.body,
       props: {
@@ -71,7 +74,7 @@ describe("Timeline player focus", () => {
     });
 
     await wrapper.setProps({
-      state: stateWithAnswer(),
+      state: answeredState,
       busy: true,
     });
     await nextTick();
@@ -81,11 +84,11 @@ describe("Timeline player focus", () => {
     await nextTick();
 
     const controls = wrapper.get('[data-testid="timeline-post-placement"]');
-    const timeline = wrapper.get(
-      'ol[aria-label="providers.music_quiz.timeline_order"]',
-    );
+    const selectedButton = wrapper.get('button[data-selected="true"]');
+    const selectedBoundary = selectedButton.element.closest("li");
+    expect(selectedBoundary?.contains(controls.element)).toBe(true);
     expect(
-      controls.element.compareDocumentPosition(timeline.element) &
+      selectedButton.element.compareDocumentPosition(controls.element) &
         Node.DOCUMENT_POSITION_FOLLOWING,
     ).toBeTruthy();
     expect(document.activeElement).toBe(wrapper.get("input").element);
@@ -106,14 +109,13 @@ describe("Timeline player focus", () => {
     const wrapper = mount(TimelinePlayerAnswer, {
       attachTo: document.body,
       props: {
-        state: baseState,
+        state: stateWithAnswer(),
         currentRound: bonusRound,
         busy: false,
       },
       global: {
         stubs: {
           MusicQuizCountdown: true,
-          TimelineDisplay: true,
           TimelineProgress: true,
         },
       },
@@ -121,7 +123,12 @@ describe("Timeline player focus", () => {
 
     await wrapper.setProps({
       state: stateWithAnswer([artistAnswer]),
+      busy: true,
     });
+    await nextTick();
+    expect(scrollIntoView).not.toHaveBeenCalled();
+
+    await wrapper.setProps({ busy: false });
     await nextTick();
 
     expect((document.activeElement as HTMLElement).textContent).toContain(

--- a/tests/components/music-quiz/TimelinePlayerFocus.test.ts
+++ b/tests/components/music-quiz/TimelinePlayerFocus.test.ts
@@ -140,6 +140,33 @@ describe("Timeline player focus", () => {
     });
     wrapper.unmount();
   });
+
+  it("focuses bonus controls when scrolling is unavailable", async () => {
+    Object.defineProperty(HTMLElement.prototype, "scrollIntoView", {
+      configurable: true,
+      value: undefined,
+    });
+    const wrapper = mount(TimelinePlayerAnswer, {
+      attachTo: document.body,
+      props: {
+        state: baseState,
+        currentRound: bonusRound,
+        busy: false,
+      },
+      global: {
+        stubs: {
+          MusicQuizCountdown: true,
+          TimelineProgress: true,
+        },
+      },
+    });
+
+    await wrapper.setProps({ state: stateWithAnswer() });
+    await nextTick();
+
+    expect(document.activeElement).toBe(wrapper.get("input").element);
+    wrapper.unmount();
+  });
 });
 
 function setReducedMotion(matches: boolean) {

--- a/tests/components/music-quiz/TimelinePlayerReveal.test.ts
+++ b/tests/components/music-quiz/TimelinePlayerReveal.test.ts
@@ -22,7 +22,7 @@ vi.mock("@/helpers/utils", () => ({
 }));
 
 describe("Timeline player reveal", () => {
-  it("shows placement and bonus correctness with points", () => {
+  it("shows placement and bonus results independently", () => {
     const revealedEntry = {
       ...anchor,
       entry_id: "current",
@@ -48,13 +48,18 @@ describe("Timeline player reveal", () => {
         ...stateWithAnswer([], true).you,
         answer: {
           ...stateWithAnswer([], true).you.answer!,
-          correct: true,
-          points: 1000,
+          correct: false,
+          points: 0,
           bonus_results: [
             {
               bonus_type: "artist",
               correct: true,
               points: 250,
+            },
+            {
+              bonus_type: "title",
+              correct: false,
+              points: 0,
             },
           ],
         },
@@ -69,13 +74,32 @@ describe("Timeline player reveal", () => {
     });
 
     expect(wrapper.text()).toContain(
-      "providers.music_quiz.timeline_correct_placement",
+      "providers.music_quiz.timeline_incorrect_placement",
     );
-    expect(wrapper.text()).toContain("+1000");
+    expect(wrapper.text()).toContain("+0");
     expect(wrapper.text()).toContain("+250");
-    expect(wrapper.find(".sr-only").text()).toContain(
+    expect(
+      wrapper
+        .get('[data-testid="timeline-placement-result"]')
+        .classes()
+        .includes("text-destructive"),
+    ).toBe(true);
+    expect(
+      wrapper
+        .get('[data-testid="timeline-artist-result"]')
+        .classes()
+        .includes("text-green-700"),
+    ).toBe(true);
+    expect(
+      wrapper
+        .get('[data-testid="timeline-title-result"]')
+        .classes()
+        .includes("text-destructive"),
+    ).toBe(true);
+    expect(wrapper.findAll(".sr-only").map((result) => result.text())).toEqual([
       "providers.music_quiz.correct",
-    );
+      "providers.music_quiz.incorrect",
+    ]);
   });
 
   it("does not mark a late joiner as missing an answer", () => {


### PR DESCRIPTION
Music Timeline did not clearly show the chosen placement, and artist/title questions were easy to miss.

- Highlight the selected timeline position immediately
- Show configured artist and title questions inline below the choice
- Keep placement and bonus results visually distinct

Server support: https://github.com/music-assistant/server/pull/4830