### PR TITLE
Fix media controls while playing along

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -17,7 +17,7 @@
     v-if="
       webPlayer.audioSource === WebPlayerMode.CONTROLS_ONLY &&
       webPlayer.interacted == true &&
-      !authManager.isGuestAccessSession()
+      !mediaSessionDisabled
     "
     :key="webPlayer.tabMode"
   />
@@ -40,6 +40,10 @@ import {
   createLocalConnectionIdentity,
   createRemoteConnectionIdentity,
 } from "@/helpers/connection_identity";
+import {
+  isMediaSessionDisabled,
+  resetMediaSession,
+} from "@/helpers/mediaSession";
 import { api, ConnectionState } from "@/plugins/api";
 import { CoreState, EventType, ProviderType } from "@/plugins/api/interfaces";
 import { toast } from "vue-sonner";
@@ -48,7 +52,7 @@ import authManager from "@/plugins/auth";
 import { i18n, resolveLocale } from "@/plugins/i18n";
 import { store } from "@/plugins/store";
 import { computed, onMounted, onUnmounted, ref, watch } from "vue";
-import { useRouter } from "vue-router";
+import { useRoute, useRouter } from "vue-router";
 import "vue-sonner/style.css";
 import SendspinPlayer from "./components/SendspinPlayer.vue";
 import PlayerBrowserMediaControls from "./layouts/default/PlayerOSD/PlayerBrowserMediaControls.vue";
@@ -72,7 +76,19 @@ import Login from "./views/Login.vue";
 import { useUserPreferences } from "@/composables/userPreferences";
 
 const router = useRouter();
+const route = useRoute();
 const { applyThemePreference: setTheme } = useThemePreference();
+const mediaSessionDisabled = computed(() =>
+  isMediaSessionDisabled(route, authManager.isGuestAccessSession()),
+);
+
+watch(
+  mediaSessionDisabled,
+  (disabled) => {
+    if (disabled) resetMediaSession();
+  },
+  { immediate: true },
+);
 
 const isConnected = ref(false);
 const loginComponent = ref<InstanceType<typeof Login> | null>(null);

--- a/src/components/SendspinPlayer.vue
+++ b/src/components/SendspinPlayer.vue
@@ -10,7 +10,10 @@
 
 <script setup lang="ts">
 import { useMediaBrowserMetaData } from "@/helpers/useMediaBrowserMetaData";
-import { resetMediaSession } from "@/helpers/mediaSession";
+import {
+  isMediaSessionDisabled,
+  resetMediaSession,
+} from "@/helpers/mediaSession";
 import { getDeviceName } from "@/plugins/api/helpers";
 import { SendspinPlayer, Codec } from "@sendspin/sendspin-js";
 
@@ -30,12 +33,14 @@ import {
   isDirectConnection,
 } from "@/plugins/sendspin-connection";
 import { computed, onBeforeUnmount, onMounted, ref, watch } from "vue";
+import { useRoute } from "vue-router";
 
 // Properties
 export interface Props {
   playerId: string;
 }
 const props = defineProps<Props>();
+const route = useRoute();
 
 const audioRef = ref<HTMLAudioElement>();
 const silentAudioRef = ref<HTMLAudioElement>();
@@ -128,6 +133,9 @@ const metadataPlayerId = computed(() => {
   }
   return undefined;
 });
+const mediaSessionDisabled = computed(() =>
+  isMediaSessionDisabled(route, authManager.isGuestAccessSession()),
+);
 
 const correctionMode = computed(() => {
   // Only do the more precise but distorting "full" correction when grouped
@@ -139,10 +147,10 @@ const correctionMode = computed(() => {
 
 // Subscribe to metadata immediately (doesn't require user interaction)
 watch(
-  metadataPlayerId,
-  (newPlayerId) => {
+  [metadataPlayerId, mediaSessionDisabled],
+  ([newPlayerId, disabled]) => {
     if (unsubMetadata) unsubMetadata();
-    if (isReceiveOnlyGuest()) {
+    if (disabled) {
       resetMediaSession();
       unsubMetadata = undefined;
       return;
@@ -155,12 +163,24 @@ watch(
 watch(
   () => webPlayer.tabMode,
   () => {
-    if (!isReceiveOnlyGuest()) return;
+    if (!mediaSessionDisabled.value) return;
     if (unsubMetadata) {
       unsubMetadata();
       unsubMetadata = undefined;
     }
     resetMediaSession();
+  },
+  { immediate: true },
+);
+
+watch(
+  mediaSessionDisabled,
+  (disabled) => {
+    if (disabled) {
+      resetMediaSession();
+    } else {
+      registerMediaSessionActionHandlers();
+    }
   },
   { immediate: true },
 );
@@ -181,11 +201,18 @@ watch(
 
 // Watch active player's playback state to control silent audio
 watch(
-  () => store.activePlayer?.playback_state,
-  (state) => {
+  [() => store.activePlayer?.playback_state, mediaSessionDisabled],
+  ([state, disabled]) => {
+    if (disabled) {
+      if (silentAudioInterval) {
+        clearInterval(silentAudioInterval);
+        silentAudioInterval = undefined;
+      }
+      silentAudioRef.value?.pause();
+      return;
+    }
     // Only control when showing active player metadata (not web player)
     if (metadataPlayerId.value !== undefined) return;
-    if (isReceiveOnlyGuest()) return;
     if (!silentAudioRef.value) return;
 
     // Clear existing interval
@@ -219,9 +246,10 @@ watch(
     () => store.activePlayer?.playback_state,
     metadataPlayerId,
     () => webPlayer.interacted,
+    mediaSessionDisabled,
   ],
-  ([, pState, , metaPlayerId, interacted]) => {
-    if (isReceiveOnlyGuest()) {
+  ([, pState, , metaPlayerId, interacted, disabled]) => {
+    if (disabled) {
       resetMediaSession();
       return;
     }
@@ -261,7 +289,7 @@ onMounted(() => {
   // If already showing active player metadata, play silent audio now that silentAudioRef exists
   if (
     metadataPlayerId.value === undefined &&
-    !isReceiveOnlyGuest() &&
+    !mediaSessionDisabled.value &&
     webPlayer.interacted &&
     silentAudioRef.value
   ) {
@@ -341,12 +369,6 @@ onMounted(() => {
       });
   }
 
-  if (isReceiveOnlyGuest()) {
-    resetMediaSession();
-  } else {
-    registerMediaSessionActionHandlers();
-  }
-
   // Audio element event listeners for mobile MediaSession resilience
   if (audioRef.value) {
     // Ensure audio element doesn't stay paused after interruptions while stream should play
@@ -383,16 +405,12 @@ onBeforeUnmount(() => {
   for (const timeout of pauseCommandTimeouts) clearTimeout(timeout);
   pauseCommandTimeouts.clear();
   if (
-    isReceiveOnlyGuest() ||
+    mediaSessionDisabled.value ||
     webPlayer.tabMode !== WebPlayerMode.CONTROLS_ONLY
   ) {
     resetMediaSession();
   }
 });
-
-function isReceiveOnlyGuest(): boolean {
-  return authManager.isPartyGuest() || authManager.isMusicQuizGuest();
-}
 
 function getTargetPlayerId(): string | undefined {
   if (metadataPlayerId.value !== undefined) return props.playerId;

--- a/src/helpers/mediaSession.ts
+++ b/src/helpers/mediaSession.ts
@@ -1,3 +1,5 @@
+import type { RouteLocationNormalizedLoaded } from "vue-router";
+
 const actions: MediaSessionAction[] = [
   "play",
   "pause",
@@ -7,6 +9,13 @@ const actions: MediaSessionAction[] = [
   "seekforward",
   "seekbackward",
 ];
+
+export function isMediaSessionDisabled(
+  route: Pick<RouteLocationNormalizedLoaded, "meta">,
+  isGuestAccessSession: boolean,
+): boolean {
+  return isGuestAccessSession || route.meta.disableMediaSession === true;
+}
 
 export function resetMediaSession(): void {
   const session = navigator.mediaSession;

--- a/src/helpers/mediaSession.ts
+++ b/src/helpers/mediaSession.ts
@@ -14,7 +14,11 @@ export function isMediaSessionDisabled(
   route: Pick<RouteLocationNormalizedLoaded, "meta">,
   isGuestAccessSession: boolean,
 ): boolean {
-  return isGuestAccessSession || route.meta.disableMediaSession === true;
+  return (
+    !navigator.mediaSession ||
+    isGuestAccessSession ||
+    route.meta.disableMediaSession === true
+  );
 }
 
 export function resetMediaSession(): void {

--- a/src/plugins/router.ts
+++ b/src/plugins/router.ts
@@ -25,12 +25,14 @@ export const routes: RouteRecordRaw[] = [
       {
         path: "party",
         name: "guest-party",
+        meta: { disableMediaSession: true },
         component: () =>
           import(/* webpackChunkName: "guest" */ "@/views/PartyGuestView.vue"),
       },
       {
         path: "quiz",
         name: "guest-quiz",
+        meta: { disableMediaSession: true },
         component: () =>
           import(
             /* webpackChunkName: "music-quiz" */ "@/views/MusicQuizPlayerView.vue"

--- a/tests/App.test.ts
+++ b/tests/App.test.ts
@@ -282,6 +282,10 @@ describe("App initialization", () => {
         matches: false,
       }),
     });
+    Object.defineProperty(navigator, "mediaSession", {
+      configurable: true,
+      value: undefined,
+    });
   });
 
   afterEach(() => {
@@ -372,6 +376,10 @@ describe("App initialization", () => {
   );
 
   it("keeps browser media controls for regular fallback tabs", async () => {
+    Object.defineProperty(navigator, "mediaSession", {
+      configurable: true,
+      value: {},
+    });
     webPlayerMock.audioSource = "controls_only";
     webPlayerMock.interacted = true;
     webPlayerMock.tabMode = "controls_only";

--- a/tests/App.test.ts
+++ b/tests/App.test.ts
@@ -1,5 +1,6 @@
 import { EventType, ProviderType } from "@/plugins/api/interfaces";
 import { shallowMount, type VueWrapper } from "@vue/test-utils";
+import { nextTick } from "vue";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const {
@@ -14,6 +15,7 @@ const {
   mockRememberCurrentRemoteConnection,
   mockRouterPush,
   mockSetPreference,
+  routeState,
   storeMock,
   webPlayerMock,
 } = vi.hoisted(() => {
@@ -69,6 +71,9 @@ const {
     mockRememberCurrentRemoteConnection: vi.fn(),
     mockRouterPush: vi.fn(),
     mockSetPreference: vi.fn(),
+    routeState: {
+      current: null as { meta: Record<string, unknown> } | null,
+    },
     storeMock: {
       currentUser: undefined as
         | {
@@ -181,11 +186,17 @@ vi.mock("vuetify", () => ({
   }),
 }));
 
-vi.mock("vue-router", () => ({
-  useRouter: () => ({
-    push: mockRouterPush,
-  }),
-}));
+vi.mock("vue-router", async () => {
+  const { shallowReactive } =
+    await vi.importActual<typeof import("vue")>("vue");
+  routeState.current = shallowReactive({ meta: {} });
+  return {
+    useRoute: () => routeState.current,
+    useRouter: () => ({
+      push: mockRouterPush,
+    }),
+  };
+});
 
 vi.mock("vue-sonner", () => ({
   toast: {
@@ -261,6 +272,7 @@ describe("App initialization", () => {
     webPlayerMock.interacted = false;
     webPlayerMock.player_id = null;
     webPlayerMock.tabMode = "disabled";
+    if (routeState.current) routeState.current.meta = {};
     vi.stubGlobal("localStorage", createStorage());
     localStorage.setItem("frontend.settings.theme", "dark");
     Object.defineProperty(window, "matchMedia", {
@@ -365,6 +377,43 @@ describe("App initialization", () => {
     webPlayerMock.tabMode = "controls_only";
 
     wrapper = await mountApp();
+
+    expect(
+      wrapper.findComponent({ name: "PlayerBrowserMediaControls" }).exists(),
+    ).toBe(true);
+  });
+
+  it("clears browser media controls on participant routes for regular users", async () => {
+    const mediaSession = {
+      metadata: {} as MediaMetadata | null,
+      playbackState: "playing" as MediaSessionPlaybackState,
+      setActionHandler: vi.fn(),
+      setPositionState: vi.fn(),
+    };
+    Object.defineProperty(navigator, "mediaSession", {
+      configurable: true,
+      value: mediaSession,
+    });
+    webPlayerMock.audioSource = "controls_only";
+    webPlayerMock.interacted = true;
+    webPlayerMock.tabMode = "controls_only";
+    wrapper = await mountApp();
+
+    if (routeState.current) {
+      routeState.current.meta = { disableMediaSession: true };
+    }
+    await nextTick();
+
+    expect(
+      wrapper.findComponent({ name: "PlayerBrowserMediaControls" }).exists(),
+    ).toBe(false);
+    expect(mediaSession.metadata).toBeNull();
+    expect(mediaSession.playbackState).toBe("none");
+    expect(mediaSession.setPositionState).toHaveBeenCalledWith();
+    expect(mediaSession.setActionHandler).toHaveBeenCalledTimes(7);
+
+    if (routeState.current) routeState.current.meta = {};
+    await nextTick();
 
     expect(
       wrapper.findComponent({ name: "PlayerBrowserMediaControls" }).exists(),

--- a/tests/components/SendspinPlayer.test.ts
+++ b/tests/components/SendspinPlayer.test.ts
@@ -260,6 +260,26 @@ describe("SendspinPlayer MediaSession", () => {
     wrapper.unmount();
   });
 
+  it("does not enable controls without MediaSession support", async () => {
+    if (routeState.current) {
+      routeState.current.meta = { disableMediaSession: true };
+    }
+    Object.defineProperty(navigator, "mediaSession", {
+      configurable: true,
+      value: undefined,
+    });
+    const wrapper = mount(SendspinPlayer, {
+      props: { playerId: "web-player" },
+    });
+
+    if (routeState.current) routeState.current.meta = {};
+    await nextTick();
+
+    expect(mockUseMediaBrowserMetaData).not.toHaveBeenCalled();
+    expectPlayerCommandsNotCalled();
+    wrapper.unmount();
+  });
+
   it.each(["party", "music_quiz"] as const)(
     "does not require MediaSession for %s guests",
     async (guest) => {

--- a/tests/components/SendspinPlayer.test.ts
+++ b/tests/components/SendspinPlayer.test.ts
@@ -13,6 +13,7 @@ const {
   mockPlayerCommandSeek,
   mockPrepareSendspinSession,
   mockUseMediaBrowserMetaData,
+  routeState,
 } = vi.hoisted(() => ({
   authState: {
     guest: null as "music_quiz" | "party" | null,
@@ -24,6 +25,9 @@ const {
   mockPlayerCommandSeek: vi.fn(),
   mockPrepareSendspinSession: vi.fn(),
   mockUseMediaBrowserMetaData: vi.fn(() => vi.fn()),
+  routeState: {
+    current: null as { meta: Record<string, unknown> } | null,
+  },
 }));
 
 vi.mock("@/helpers/useMediaBrowserMetaData", () => ({
@@ -32,10 +36,20 @@ vi.mock("@/helpers/useMediaBrowserMetaData", () => ({
 
 vi.mock("@/plugins/auth", () => ({
   default: {
+    isGuestAccessSession: () => authState.guest !== null,
     isMusicQuizGuest: () => authState.guest === "music_quiz",
     isPartyGuest: () => authState.guest === "party",
   },
 }));
+
+vi.mock("vue-router", async () => {
+  const { shallowReactive } =
+    await vi.importActual<typeof import("vue")>("vue");
+  routeState.current = shallowReactive({ meta: {} });
+  return {
+    useRoute: () => routeState.current,
+  };
+});
 
 vi.mock("@/plugins/api", () => ({
   default: {
@@ -152,6 +166,7 @@ describe("SendspinPlayer MediaSession", () => {
     mockPlayerCommandSeek.mockReset();
     webPlayer.interacted = false;
     webPlayer.tabMode = WebPlayerMode.SENDSPIN_ONLY;
+    if (routeState.current) routeState.current.meta = {};
     Object.defineProperty(navigator, "mediaSession", {
       configurable: true,
       value: mediaSession,
@@ -216,6 +231,32 @@ describe("SendspinPlayer MediaSession", () => {
     expect(actions.every((action) => handlers.get(action) === null)).toBe(true);
     invokeAllActions();
     expectPlayerCommandsNotCalled();
+    wrapper.unmount();
+  });
+
+  it("disables controls while a signed-in user plays along", async () => {
+    const wrapper = mount(SendspinPlayer, {
+      props: { playerId: "web-player" },
+    });
+    seedStaleMediaSession();
+
+    if (routeState.current) {
+      routeState.current.meta = { disableMediaSession: true };
+    }
+    await nextTick();
+
+    expect(mediaSession.metadata).toBeNull();
+    expect(mediaSession.playbackState).toBe("none");
+    expect(actions.every((action) => handlers.get(action) === null)).toBe(true);
+    invokeAllActions();
+    expectPlayerCommandsNotCalled();
+
+    if (routeState.current) routeState.current.meta = {};
+    await nextTick();
+
+    expect(mockUseMediaBrowserMetaData).toHaveBeenCalledTimes(2);
+    invokeAction("play");
+    expect(mockPlayerCommandPlay).toHaveBeenCalledWith("web-player");
     wrapper.unmount();
   });
 

--- a/tests/plugins/router.test.ts
+++ b/tests/plugins/router.test.ts
@@ -40,4 +40,17 @@ describe("guest routes", () => {
       "quiz",
     ]);
   });
+
+  it("disables media controls on participant routes", () => {
+    const guestRoute = routes.find((route) => route.path === "/guest");
+    const participantRoutes = guestRoute?.children?.filter(
+      (route) => route.path === "party" || route.path === "quiz",
+    );
+
+    expect(
+      participantRoutes?.every(
+        (route) => route.meta?.disableMediaSession === true,
+      ),
+    ).toBe(true);
+  });
 });


### PR DESCRIPTION
Signed-in users playing along in Music Quiz could still see current track details in iOS media controls.

- Disable browser media controls on Quiz and Party participant screens
- Clear stale track details when entering and restore normal controls after leaving