### PR TITLE
Improve Music Quiz host controls

### DIFF
--- a/src/components/music-quiz/MusicQuizEndGameDialog.vue
+++ b/src/components/music-quiz/MusicQuizEndGameDialog.vue
@@ -1,0 +1,52 @@
+<template>
+  <AlertDialog v-model:open="open">
+    <AlertDialogContent class="gap-3 p-4 sm:max-w-sm sm:p-5">
+      <AlertDialogHeader class="gap-1 text-left">
+        <AlertDialogTitle>
+          {{ $t("providers.music_quiz.end_game") }}
+        </AlertDialogTitle>
+        <AlertDialogDescription>
+          {{ $t("providers.music_quiz.end_game_confirm") }}
+        </AlertDialogDescription>
+      </AlertDialogHeader>
+      <AlertDialogFooter class="flex-row justify-end">
+        <AlertDialogCancel class="mt-0">{{ $t("cancel") }}</AlertDialogCancel>
+        <Button
+          variant="destructive"
+          data-testid="confirm-end-game"
+          :disabled="busy"
+          @click="confirm"
+        >
+          {{ $t("providers.music_quiz.end_game") }}
+        </Button>
+      </AlertDialogFooter>
+    </AlertDialogContent>
+  </AlertDialog>
+</template>
+
+<script setup lang="ts">
+import {
+  AlertDialog,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import { Button } from "@/components/ui/button";
+import { $t } from "@/plugins/i18n";
+
+defineProps<{
+  busy: boolean;
+}>();
+const emit = defineEmits<{
+  confirm: [];
+}>();
+const open = defineModel<boolean>({ required: true });
+
+function confirm() {
+  open.value = false;
+  emit("confirm");
+}
+</script>

--- a/src/components/music-quiz/MusicQuizHostControlsMenu.vue
+++ b/src/components/music-quiz/MusicQuizHostControlsMenu.vue
@@ -1,0 +1,150 @@
+<template>
+  <div>
+    <DropdownMenu>
+      <DropdownMenuTrigger as-child>
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          class="px-2"
+          data-testid="guest-host-controls"
+          :aria-label="$t('providers.music_quiz.host_controls')"
+          :title="$t('providers.music_quiz.host_controls')"
+        >
+          <SlidersHorizontal class="size-4" aria-hidden="true" />
+          <span class="hidden sm:inline">
+            {{ $t("providers.music_quiz.host_controls") }}
+          </span>
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="start" class="w-56">
+        <DropdownMenuLabel>
+          {{ $t("providers.music_quiz.host_controls") }}
+        </DropdownMenuLabel>
+        <DropdownMenuSeparator />
+        <template v-if="activeState">
+          <DropdownMenuItem
+            v-if="activeState.phase === 'lobby'"
+            data-testid="quiz-host-start"
+            :disabled="busy"
+            @click="start"
+          >
+            <Play aria-hidden="true" />
+            {{ $t("providers.music_quiz.start") }}
+          </DropdownMenuItem>
+          <DropdownMenuItem
+            v-else-if="activeState.phase === 'answering'"
+            data-testid="quiz-host-reveal"
+            :disabled="busy"
+            @click="reveal"
+          >
+            <Eye aria-hidden="true" />
+            {{ $t("providers.music_quiz.phase_reveal") }}
+          </DropdownMenuItem>
+          <DropdownMenuItem
+            v-else-if="activeState.phase === 'reveal'"
+            data-testid="quiz-host-next"
+            :disabled="busy"
+            @click="next"
+          >
+            <SkipForward aria-hidden="true" />
+            {{ nextLabel }}
+          </DropdownMenuItem>
+          <DropdownMenuItem
+            v-else-if="activeState.phase === 'finished'"
+            data-testid="quiz-host-replay"
+            :disabled="busy"
+            @click="replay"
+          >
+            <RotateCcw aria-hidden="true" />
+            {{ $t("providers.music_quiz.play_again") }}
+          </DropdownMenuItem>
+          <DropdownMenuSeparator />
+        </template>
+        <DropdownMenuItem
+          data-testid="quiz-host-panel"
+          @click="emit('openHostPanel')"
+        >
+          <ArrowLeft aria-hidden="true" />
+          {{ $t("providers.music_quiz.return_to_host_panel") }}
+        </DropdownMenuItem>
+        <template v-if="state">
+          <DropdownMenuSeparator />
+          <DropdownMenuItem
+            variant="destructive"
+            data-testid="quiz-host-end"
+            :disabled="busy"
+            @click="showEndGameDialog = true"
+          >
+            <Square aria-hidden="true" />
+            {{ $t("providers.music_quiz.end_game") }}
+          </DropdownMenuItem>
+        </template>
+      </DropdownMenuContent>
+    </DropdownMenu>
+
+    <MusicQuizEndGameDialog
+      v-model="showEndGameDialog"
+      :busy="busy"
+      @confirm="confirmEndGame"
+    />
+  </div>
+</template>
+
+<script setup lang="ts">
+import MusicQuizEndGameDialog from "@/components/music-quiz/MusicQuizEndGameDialog.vue";
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import {
+  isSupportedMusicQuiz,
+  type MusicQuizSupportedHostState,
+} from "@/composables/useMusicQuiz";
+import { useMusicQuizHost } from "@/composables/useMusicQuizHost";
+import { $t } from "@/plugins/i18n";
+import {
+  ArrowLeft,
+  Eye,
+  Play,
+  RotateCcw,
+  SkipForward,
+  SlidersHorizontal,
+  Square,
+} from "@lucide/vue";
+import { computed, ref } from "vue";
+import { toast } from "vue-sonner";
+
+const emit = defineEmits<{
+  openHostPanel: [];
+}>();
+const host = useMusicQuizHost({
+  loadSetupData: false,
+  notifyError: (message) => toast.error(message),
+});
+const { state, busy, isLastRound, start, reveal, next, replay, deleteGame } =
+  host;
+const activeState = computed<MusicQuizSupportedHostState | null>(() => {
+  const currentState = state.value;
+  return currentState && isSupportedMusicQuiz(currentState)
+    ? currentState
+    : null;
+});
+const nextLabel = computed(() =>
+  $t(
+    isLastRound.value
+      ? "providers.music_quiz.finish"
+      : "providers.music_quiz.next",
+  ),
+);
+const showEndGameDialog = ref(false);
+
+async function confirmEndGame() {
+  await deleteGame();
+}
+</script>

--- a/src/composables/useMusicQuizHost.ts
+++ b/src/composables/useMusicQuizHost.ts
@@ -25,6 +25,7 @@ import {
 } from "@/helpers/music_quiz";
 
 export interface UseMusicQuizHostOptions {
+  loadSetupData?: boolean;
   notifyError: (message: string) => void;
 }
 
@@ -35,7 +36,7 @@ export interface UseMusicQuizHostOptions {
  * (game_updated -> re-fetch, game_removed -> clear), and wraps all host actions.
  */
 export function useMusicQuizHost(options: UseMusicQuizHostOptions) {
-  const { notifyError } = options;
+  const { loadSetupData = true, notifyError } = options;
 
   const state = ref<MusicQuizHostState | null>(null);
   const busy = ref(false);
@@ -230,6 +231,36 @@ export function useMusicQuizHost(options: UseMusicQuizHostOptions) {
     }
   }
 
+  async function replay() {
+    if (busy.value) return false;
+    busy.value = true;
+    starting.value = true;
+    let resetComplete = false;
+    try {
+      const lobbyState = await resetMusicQuiz(false);
+      applyState(lobbyState);
+      resetComplete = true;
+      const nextState = await startMusicQuiz();
+      applyState(nextState);
+      return true;
+    } catch (err) {
+      notifyError(
+        getMusicQuizErrorMessage(
+          err,
+          $t(
+            resetComplete
+              ? "providers.music_quiz.error_start"
+              : "providers.music_quiz.error_reset",
+          ),
+        ),
+      );
+      return false;
+    } finally {
+      starting.value = false;
+      busy.value = false;
+    }
+  }
+
   async function deleteGame() {
     if (busy.value) return false;
     busy.value = true;
@@ -282,8 +313,10 @@ export function useMusicQuizHost(options: UseMusicQuizHostOptions) {
 
   onMounted(() => {
     fetchState();
-    fetchAvailableQuizTypes();
-    fetchPlaybackOptions();
+    if (loadSetupData) {
+      fetchAvailableQuizTypes();
+      fetchPlaybackOptions();
+    }
     unsubscribeProviderEvent = api.subscribe(
       EventType.PROVIDER_EVENT,
       handleProviderEvent,
@@ -312,6 +345,7 @@ export function useMusicQuizHost(options: UseMusicQuizHostOptions) {
     reveal,
     next,
     reset,
+    replay,
     deleteGame,
     fetchState,
     fetchAvailableQuizTypes,

--- a/src/layouts/GuestLayout.vue
+++ b/src/layouts/GuestLayout.vue
@@ -1,24 +1,13 @@
 <template>
   <div class="bg-background flex h-dvh flex-col overflow-hidden">
     <header
-      class="grid h-12 shrink-0 grid-cols-[1fr_auto_1fr] items-center border-b px-2"
+      class="guest-layout-header grid shrink-0 grid-cols-[1fr_auto_1fr] items-center border-b"
     >
-      <Button
+      <MusicQuizHostControlsMenu
         v-if="showHostControls"
-        type="button"
-        variant="ghost"
-        size="sm"
-        class="justify-self-start px-2"
-        data-testid="guest-host-controls"
-        :aria-label="$t('providers.music_quiz.host_controls')"
-        :title="$t('providers.music_quiz.host_controls')"
-        @click="returnToHostControls"
-      >
-        <SlidersHorizontal class="size-4" aria-hidden="true" />
-        <span class="hidden sm:inline">
-          {{ $t("providers.music_quiz.host_controls") }}
-        </span>
-      </Button>
+        class="justify-self-start"
+        @open-host-panel="returnToHostPanel"
+      />
       <div v-else />
       <img
         :src="logoSrc"
@@ -94,6 +83,7 @@
 </template>
 
 <script setup lang="ts">
+import MusicQuizHostControlsMenu from "@/components/music-quiz/MusicQuizHostControlsMenu.vue";
 import { Avatar, AvatarFallback } from "@/components/ui/avatar";
 import { Button } from "@/components/ui/button";
 import {
@@ -121,13 +111,7 @@ import {
 import { authManager } from "@/plugins/auth";
 import { $t } from "@/plugins/i18n";
 import { store } from "@/plugins/store";
-import {
-  ArrowLeft,
-  LogOut,
-  Palette,
-  SlidersHorizontal,
-  UserRound,
-} from "@lucide/vue";
+import { ArrowLeft, LogOut, Palette, UserRound } from "@lucide/vue";
 import { computed, provide } from "vue";
 import { useRoute, useRouter } from "vue-router";
 import { useTheme } from "vuetify";
@@ -170,7 +154,16 @@ function returnToApp(): void {
   void router.push({ name: "discover" });
 }
 
-function returnToHostControls(): void {
+function returnToHostPanel(): void {
   void router.push({ name: "music-quiz" });
 }
 </script>
+
+<style scoped>
+.guest-layout-header {
+  height: calc(3rem + env(safe-area-inset-top, 0px));
+  padding: env(safe-area-inset-top, 0px)
+    calc(0.5rem + env(safe-area-inset-right, 0px)) 0
+    calc(0.5rem + env(safe-area-inset-left, 0px));
+}
+</style>

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1152,6 +1152,7 @@
             "title": "Music Quiz",
             "play_along": "Play along",
             "host_controls": "Host controls",
+            "return_to_host_panel": "Return to host panel",
             "create_intro": "Create a new quiz game to test your music knowledge!",
             "loading": "Loading...",
             "no_active_game": "No active game",

--- a/src/views/MusicQuizDashboardView.vue
+++ b/src/views/MusicQuizDashboardView.vue
@@ -189,34 +189,17 @@
       </DialogContent>
     </Dialog>
 
-    <AlertDialog v-model:open="showEndGameDialog">
-      <AlertDialogContent class="gap-3 p-4 sm:max-w-sm sm:p-5">
-        <AlertDialogHeader class="gap-1 text-left">
-          <AlertDialogTitle>
-            {{ $t("providers.music_quiz.end_game") }}
-          </AlertDialogTitle>
-          <AlertDialogDescription>
-            {{ $t("providers.music_quiz.end_game_confirm") }}
-          </AlertDialogDescription>
-        </AlertDialogHeader>
-        <AlertDialogFooter class="flex-row justify-end">
-          <AlertDialogCancel class="mt-0">{{ $t("cancel") }}</AlertDialogCancel>
-          <Button
-            variant="destructive"
-            data-testid="confirm-end-game"
-            :disabled="busy"
-            @click="confirmEndGame"
-          >
-            {{ $t("providers.music_quiz.end_game") }}
-          </Button>
-        </AlertDialogFooter>
-      </AlertDialogContent>
-    </AlertDialog>
+    <MusicQuizEndGameDialog
+      v-model="showEndGameDialog"
+      :busy="busy"
+      @confirm="confirmEndGame"
+    />
   </div>
 </template>
 
 <script setup lang="ts">
 import MusicQuizConnectionBanners from "@/components/music-quiz/MusicQuizConnectionBanners.vue";
+import MusicQuizEndGameDialog from "@/components/music-quiz/MusicQuizEndGameDialog.vue";
 import {
   getMusicQuizPhaseLabelKey,
   resolveMusicQuizDefinition,
@@ -232,15 +215,6 @@ import MusicQuizSessionHeader from "@/components/music-quiz/MusicQuizSessionHead
 import MusicQuizSessionPanels from "@/components/music-quiz/MusicQuizSessionPanels.vue";
 import MusicQuizSetupWizard from "@/components/music-quiz/MusicQuizSetupWizard.vue";
 import MusicQuizUnsupportedGame from "@/components/music-quiz/MusicQuizUnsupportedGame.vue";
-import {
-  AlertDialog,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-} from "@/components/ui/alert-dialog";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import {
@@ -408,7 +382,7 @@ async function handleCreate(request: MusicQuizCreateRequest) {
 
 async function handleReplay() {
   if (busy.value) return;
-  await host.reset(true);
+  await host.replay();
 }
 
 async function handleSetUpNewGame() {
@@ -453,7 +427,6 @@ watch(state, (nextState) => {
 });
 
 async function confirmEndGame() {
-  showEndGameDialog.value = false;
   await host.deleteGame();
 }
 

--- a/src/views/MusicQuizPlayerView.vue
+++ b/src/views/MusicQuizPlayerView.vue
@@ -344,15 +344,16 @@ async function handleReady() {
 <style scoped>
 .music-quiz-player {
   min-height: 100%;
-  padding: calc(0.75rem + env(safe-area-inset-top, 0px))
-    calc(0.75rem + env(safe-area-inset-right, 0px))
+  padding: 0.75rem calc(0.75rem + env(safe-area-inset-right, 0px))
     calc(1rem + env(safe-area-inset-bottom, 0px))
     calc(0.75rem + env(safe-area-inset-left, 0px));
 }
 
 @media (min-width: 768px) {
   .music-quiz-player {
-    padding: 1.25rem;
+    padding: 1.25rem calc(1.25rem + env(safe-area-inset-right, 0px))
+      calc(1.25rem + env(safe-area-inset-bottom, 0px))
+      calc(1.25rem + env(safe-area-inset-left, 0px));
   }
 }
 </style>

--- a/tests/components/music-quiz/MusicQuizHostControlsMenu.test.ts
+++ b/tests/components/music-quiz/MusicQuizHostControlsMenu.test.ts
@@ -28,10 +28,7 @@ vi.mock("@/composables/useMusicQuizHost", () => ({
 }));
 
 vi.mock("@/composables/useMusicQuiz", () => ({
-  isSupportedMusicQuiz: (state: {
-    answer_type?: string;
-    quiz_type?: string;
-  }) =>
+  isSupportedMusicQuiz: (state: { answer_type?: string; quiz_type?: string }) =>
     state.quiz_type === "guess_the_song" &&
     state.answer_type === "multiple_choice",
 }));

--- a/tests/components/music-quiz/MusicQuizHostControlsMenu.test.ts
+++ b/tests/components/music-quiz/MusicQuizHostControlsMenu.test.ts
@@ -1,0 +1,227 @@
+import MusicQuizHostControlsMenu from "@/components/music-quiz/MusicQuizHostControlsMenu.vue";
+import type {
+  MusicQuizHostState,
+  MusicQuizPhase,
+} from "@/composables/useMusicQuiz";
+import { mount } from "@vue/test-utils";
+import { nextTick, ref, type Ref } from "vue";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const {
+  mockDeleteGame,
+  mockNext,
+  mockReplay,
+  mockReveal,
+  mockStart,
+  mockUseMusicQuizHost,
+} = vi.hoisted(() => ({
+  mockDeleteGame: vi.fn(),
+  mockNext: vi.fn(),
+  mockReplay: vi.fn(),
+  mockReveal: vi.fn(),
+  mockStart: vi.fn(),
+  mockUseMusicQuizHost: vi.fn(),
+}));
+
+vi.mock("@/composables/useMusicQuizHost", () => ({
+  useMusicQuizHost: mockUseMusicQuizHost,
+}));
+
+vi.mock("@/composables/useMusicQuiz", () => ({
+  isSupportedMusicQuiz: (state: {
+    answer_type?: string;
+    quiz_type?: string;
+  }) =>
+    state.quiz_type === "guess_the_song" &&
+    state.answer_type === "multiple_choice",
+}));
+
+vi.mock("@/plugins/i18n", () => ({
+  $t: (key: string) =>
+    (
+      ({
+        "providers.music_quiz.end_game": "End game",
+        "providers.music_quiz.finish": "Finish Quiz",
+        "providers.music_quiz.host_controls": "Host controls",
+        "providers.music_quiz.next": "Next Round",
+        "providers.music_quiz.phase_reveal": "Reveal answer",
+        "providers.music_quiz.play_again": "Play again",
+        "providers.music_quiz.return_to_host_panel": "Return to host panel",
+        "providers.music_quiz.start": "Start Quiz",
+      }) as Record<string, string>
+    )[key] ?? key,
+}));
+
+vi.mock("vue-sonner", () => ({
+  toast: {
+    error: vi.fn(),
+  },
+}));
+
+const HOST_STATE = {
+  quiz_type: "guess_the_song",
+  answer_type: "multiple_choice",
+  phase: "lobby",
+  name: "Quiz",
+  round_count: 5,
+  suggestion_count: 4,
+  answer_duration: 30,
+  mode: "venue",
+  players: [],
+  created_at: 1,
+  sources: [],
+  join_url: "http://join",
+  rounds: [],
+  current_round: null,
+} satisfies MusicQuizHostState;
+
+let state: Ref<MusicQuizHostState | null>;
+let busy: Ref<boolean>;
+let isLastRound: Ref<boolean>;
+
+describe("MusicQuizHostControlsMenu", () => {
+  beforeEach(() => {
+    state = ref({ ...HOST_STATE });
+    busy = ref(false);
+    isLastRound = ref(false);
+    mockDeleteGame.mockReset();
+    mockDeleteGame.mockResolvedValue(true);
+    mockNext.mockReset();
+    mockNext.mockResolvedValue(true);
+    mockReplay.mockReset();
+    mockReplay.mockResolvedValue(true);
+    mockReveal.mockReset();
+    mockReveal.mockResolvedValue(true);
+    mockStart.mockReset();
+    mockStart.mockResolvedValue(true);
+    mockUseMusicQuizHost.mockReset();
+    mockUseMusicQuizHost.mockReturnValue({
+      state,
+      busy,
+      isLastRound,
+      start: mockStart,
+      reveal: mockReveal,
+      next: mockNext,
+      replay: mockReplay,
+      deleteGame: mockDeleteGame,
+    });
+  });
+
+  it.each([
+    ["lobby", "quiz-host-start", "Start Quiz", "start"],
+    ["answering", "quiz-host-reveal", "Reveal answer", "reveal"],
+    ["reveal", "quiz-host-next", "Next Round", "next"],
+    ["finished", "quiz-host-replay", "Play again", "replay"],
+  ] as const)(
+    "offers the %s host action",
+    async (phase, testId, label, action) => {
+      state.value = { ...HOST_STATE, phase };
+      const wrapper = mountMenu();
+
+      const button = wrapper.get(`[data-testid="${testId}"]`);
+      expect(button.text()).toContain(label);
+      await button.trigger("click");
+
+      expect(
+        {
+          start: mockStart,
+          reveal: mockReveal,
+          next: mockNext,
+          replay: mockReplay,
+        }[action],
+      ).toHaveBeenCalledOnce();
+    },
+  );
+
+  it("uses Finish Quiz for the final reveal", () => {
+    state.value = { ...HOST_STATE, phase: "reveal" };
+    isLastRound.value = true;
+    const wrapper = mountMenu();
+
+    expect(wrapper.get('[data-testid="quiz-host-next"]').text()).toContain(
+      "Finish Quiz",
+    );
+  });
+
+  it("confirms before ending the game", async () => {
+    const wrapper = mountMenu();
+
+    await wrapper.get('[data-testid="quiz-host-end"]').trigger("click");
+    await nextTick();
+    await wrapper.get('[data-testid="confirm-end-game"]').trigger("click");
+
+    expect(mockDeleteGame).toHaveBeenCalledOnce();
+  });
+
+  it("returns to the full host panel", async () => {
+    const wrapper = mountMenu();
+
+    await wrapper.get('[data-testid="quiz-host-panel"]').trigger("click");
+
+    expect(wrapper.emitted("openHostPanel")).toEqual([[]]);
+  });
+
+  it("only offers the host panel when no game is active", () => {
+    state.value = null;
+    const wrapper = mountMenu();
+
+    expect(wrapper.find('[data-testid="quiz-host-start"]').exists()).toBe(
+      false,
+    );
+    expect(wrapper.find('[data-testid="quiz-host-end"]').exists()).toBe(false);
+    expect(wrapper.find('[data-testid="quiz-host-panel"]').exists()).toBe(true);
+  });
+
+  it("keeps host actions disabled while another action is running", () => {
+    busy.value = true;
+    const wrapper = mountMenu();
+
+    expect(
+      wrapper.get('[data-testid="quiz-host-start"]').attributes("disabled"),
+    ).toBeDefined();
+    expect(
+      wrapper.get('[data-testid="quiz-host-end"]').attributes("disabled"),
+    ).toBeDefined();
+  });
+
+  it("loads only the host state needed by the menu", () => {
+    mountMenu();
+
+    expect(mockUseMusicQuizHost).toHaveBeenCalledWith({
+      loadSetupData: false,
+      notifyError: expect.any(Function),
+    });
+  });
+});
+
+function mountMenu() {
+  const passthroughStub = { template: "<div><slot /></div>" };
+  return mount(MusicQuizHostControlsMenu, {
+    global: {
+      stubs: {
+        Button: {
+          props: ["disabled"],
+          template:
+            '<button v-bind="$attrs" :disabled="disabled"><slot /></button>',
+        },
+        DropdownMenu: passthroughStub,
+        DropdownMenuContent: passthroughStub,
+        DropdownMenuItem: {
+          props: ["disabled", "variant"],
+          emits: ["click"],
+          template:
+            '<button v-bind="$attrs" :disabled="disabled" :data-variant="variant" @click="$emit(\'click\')"><slot /></button>',
+        },
+        DropdownMenuLabel: passthroughStub,
+        DropdownMenuSeparator: true,
+        DropdownMenuTrigger: passthroughStub,
+        MusicQuizEndGameDialog: {
+          props: ["modelValue", "busy"],
+          emits: ["update:modelValue", "confirm"],
+          template:
+            '<button v-if="modelValue" data-testid="confirm-end-game" @click="$emit(\'update:modelValue\', false); $emit(\'confirm\')" />',
+        },
+      },
+    },
+  });
+}

--- a/tests/composables/useMusicQuizHost.test.ts
+++ b/tests/composables/useMusicQuizHost.test.ts
@@ -271,6 +271,18 @@ describe("useMusicQuizHost", () => {
     expect(host.playbackOptionsError.value).toBe(false);
   });
 
+  it("skips setup data when only host controls are needed", async () => {
+    useMusicQuizHost({
+      loadSetupData: false,
+      notifyError: vi.fn(),
+    });
+    await flushPromises();
+
+    expect(mockGetMusicQuiz).toHaveBeenCalledOnce();
+    expect(mockGetAvailableMusicQuizTypes).not.toHaveBeenCalled();
+    expect(mockGetMusicQuizPlaybackOptions).not.toHaveBeenCalled();
+  });
+
   it("exposes playback discovery loading state", async () => {
     const pending = deferred<typeof PLAYBACK_OPTIONS>();
     mockGetMusicQuizPlaybackOptions.mockReturnValue(pending.promise);
@@ -406,6 +418,59 @@ describe("useMusicQuizHost", () => {
 
     expect(mockResetMusicQuiz).toHaveBeenNthCalledWith(1, false);
     expect(mockResetMusicQuiz).toHaveBeenNthCalledWith(2, true);
+  });
+
+  it("replays immediately without scheduling a new lobby", async () => {
+    const startedState = {
+      ...HOST_STATE,
+      phase: "answering",
+    } as const;
+    mockStartMusicQuiz.mockResolvedValueOnce(startedState);
+    const host = useMusicQuizHost({ notifyError: vi.fn() });
+    await flushPromises();
+
+    await expect(host.replay()).resolves.toBe(true);
+
+    expect(mockResetMusicQuiz).toHaveBeenCalledOnce();
+    expect(mockResetMusicQuiz).toHaveBeenCalledWith(false);
+    expect(mockStartMusicQuiz).toHaveBeenCalledOnce();
+    expect(mockResetMusicQuiz.mock.invocationCallOrder[0]).toBeLessThan(
+      mockStartMusicQuiz.mock.invocationCallOrder[0],
+    );
+    expect(host.state.value).toEqual(startedState);
+  });
+
+  it("keeps replay serialized across reset and start", async () => {
+    const pendingReset = deferred<typeof HOST_STATE>();
+    mockResetMusicQuiz.mockReturnValueOnce(pendingReset.promise);
+    const host = useMusicQuizHost({ notifyError: vi.fn() });
+    await flushPromises();
+
+    const replay = host.replay();
+
+    await expect(host.replay()).resolves.toBe(false);
+    expect(host.busy.value).toBe(true);
+    expect(host.starting.value).toBe(true);
+    expect(mockStartMusicQuiz).not.toHaveBeenCalled();
+
+    pendingReset.resolve(HOST_STATE);
+    await expect(replay).resolves.toBe(true);
+
+    expect(mockStartMusicQuiz).toHaveBeenCalledOnce();
+    expect(host.busy.value).toBe(false);
+    expect(host.starting.value).toBe(false);
+  });
+
+  it("stays in the lobby when immediate replay cannot start", async () => {
+    mockStartMusicQuiz.mockRejectedValueOnce(new Error("Unavailable"));
+    const host = useMusicQuizHost({ notifyError: vi.fn() });
+    await flushPromises();
+
+    await expect(host.replay()).resolves.toBe(false);
+
+    expect(host.state.value).toEqual(HOST_STATE);
+    expect(host.busy.value).toBe(false);
+    expect(host.starting.value).toBe(false);
   });
 
   it("exposes preparation state while a game is starting", async () => {

--- a/tests/layouts/GuestLayout.test.ts
+++ b/tests/layouts/GuestLayout.test.ts
@@ -85,6 +85,11 @@ function mountLayout() {
         DropdownMenuSubContent: passthroughStub,
         DropdownMenuSubTrigger: passthroughStub,
         DropdownMenuTrigger: passthroughStub,
+        MusicQuizHostControlsMenu: {
+          emits: ["openHostPanel"],
+          template:
+            '<button data-testid="guest-host-controls" @click="$emit(\'openHostPanel\')" />',
+        },
         RouterView: true,
       },
     },
@@ -103,6 +108,7 @@ describe("GuestLayout", () => {
 
     expect(wrapper.classes()).toContain("h-dvh");
     expect(wrapper.classes()).toContain("overflow-hidden");
+    expect(wrapper.get("header").classes()).toContain("guest-layout-header");
     expect(
       wrapper.get('img[alt="Music Assistant"]').attributes("src"),
     ).toContain("logo-dark.svg");

--- a/tests/views/MusicQuizDashboardHostActions.test.ts
+++ b/tests/views/MusicQuizDashboardHostActions.test.ts
@@ -10,14 +10,14 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 const {
   mockDeleteGame,
   mockFetchPlaybackOptions,
-  mockReset,
+  mockReplay,
   mockResolveMusicQuizDefinition,
   mockStart,
   mockUseMusicQuizHost,
 } = vi.hoisted(() => ({
   mockDeleteGame: vi.fn(),
   mockFetchPlaybackOptions: vi.fn(),
-  mockReset: vi.fn(),
+  mockReplay: vi.fn(),
   mockResolveMusicQuizDefinition: vi.fn(),
   mockStart: vi.fn(),
   mockUseMusicQuizHost: vi.fn(),
@@ -123,8 +123,8 @@ describe("MusicQuizDashboardView host actions", () => {
     mockDeleteGame.mockResolvedValue(true);
     mockFetchPlaybackOptions.mockReset();
     mockFetchPlaybackOptions.mockResolvedValue(undefined);
-    mockReset.mockReset();
-    mockReset.mockResolvedValue(true);
+    mockReplay.mockReset();
+    mockReplay.mockResolvedValue(true);
     mockStart.mockReset();
     mockStart.mockResolvedValue(true);
     mockResolveMusicQuizDefinition.mockReset();
@@ -147,7 +147,7 @@ describe("MusicQuizDashboardView host actions", () => {
       playbackOptionsLegacy: ref(false),
       playbackOptionsError: ref(false),
       next: vi.fn(),
-      reset: mockReset,
+      replay: mockReplay,
       reveal: vi.fn(),
       start: mockStart,
       starting,
@@ -179,20 +179,19 @@ describe("MusicQuizDashboardView host actions", () => {
     expect(mockDeleteGame).toHaveBeenCalledOnce();
   });
 
-  it("replays with auto-start without deleting or opening setup", async () => {
+  it("replays immediately without deleting or opening setup", async () => {
     const wrapper = mountDashboard();
 
     await wrapper.get('[data-testid="play-again"]').trigger("click");
     await flushPromises();
 
-    expect(mockReset).toHaveBeenCalledOnce();
-    expect(mockReset).toHaveBeenCalledWith(true);
+    expect(mockReplay).toHaveBeenCalledOnce();
     expect(mockDeleteGame).not.toHaveBeenCalled();
     expect(wrapper.find('[data-testid="setup-wizard"]').exists()).toBe(false);
   });
 
   it("keeps the finished game when replay reset fails", async () => {
-    mockReset.mockResolvedValue(false);
+    mockReplay.mockResolvedValue(false);
     const wrapper = mountDashboard();
 
     await wrapper.get('[data-testid="play-again"]').trigger("click");
@@ -278,7 +277,7 @@ describe("MusicQuizDashboardView host actions", () => {
   });
 
   it("prevents overlapping replay and fresh setup actions", async () => {
-    mockReset.mockImplementation(() => {
+    mockReplay.mockImplementation(() => {
       busy.value = true;
       return Promise.resolve(true);
     });
@@ -290,7 +289,7 @@ describe("MusicQuizDashboardView host actions", () => {
     await wrapper.get('[data-testid="set-up-new-game"]').trigger("click");
     await replayClick;
 
-    expect(mockReset).toHaveBeenCalledOnce();
+    expect(mockReplay).toHaveBeenCalledOnce();
     expect(mockDeleteGame).not.toHaveBeenCalled();
   });
 


### PR DESCRIPTION
Hosts playing along had to leave the quiz to control or replay it, while the guest header could overlap iPhone screen cutouts.

- Keep the guest header clear of iOS safe areas
- Add phase-aware host controls while playing along
- Replay completed quizzes immediately without the 30-second wait