### PR TITLE
Also send updates when artist or title changes

### DIFF
--- a/src/plugins/companion.ts
+++ b/src/plugins/companion.ts
@@ -347,6 +347,8 @@ const startNowPlayingWatcher = (): void => {
   unwatchNowPlaying = watch(
     () => ({
       uri: store.activePlayer?.current_media?.uri,
+      title: store.activePlayer?.current_media?.title,
+      artist: store.activePlayer?.current_media?.artist,
       state: store.activePlayer?.playback_state,
       playerId: store.activePlayer?.player_id,
     }),
@@ -355,6 +357,8 @@ const startNowPlayingWatcher = (): void => {
       if (
         oldVal &&
         newVal.uri === oldVal.uri &&
+        newVal.title === oldVal.title &&
+        newVal.artist === oldVal.artist &&
         newVal.state === oldVal.state &&
         newVal.playerId === oldVal.playerId
       ) {


### PR DESCRIPTION
So when I am listening to a radio stream via Music Assistant, Discord rich presence doesn't update, as the uri, state and player don't change. So by adding the title and artist to the equation, we will trigger more updates and allow rich presence to work correctly again