### PR TITLE
Use official Sendspin audio unlock

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
         "@lucide/vue": "^1.24.0",
         "@mdi/font": "7.4.47",
         "@scure/base": "^2.2.0",
-        "@sendspin/sendspin-js": "3.2.0",
+        "@sendspin/sendspin-js": "3.2.1",
         "@tabler/icons-vue": "^3.44.0",
         "@tailwindcss/vite": "^4.3.2",
         "@tanstack/form-core": "1.33.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,8 +27,8 @@ importers:
         specifier: ^2.2.0
         version: 2.2.0
       '@sendspin/sendspin-js':
-        specifier: 3.2.0
-        version: 3.2.0
+        specifier: 3.2.1
+        version: 3.2.1
       '@tabler/icons-vue':
         specifier: ^3.44.0
         version: 3.44.0(vue@3.5.39(typescript@6.0.3))
@@ -1880,8 +1880,8 @@ packages:
   '@scure/base@2.2.0':
     resolution: {integrity: sha512-b8XEupJibegiXV+tDUseI8oLQc8ei3d/4Jkb2RpbHh3MfE054ov3uIz2dhFkB3FI8iwYkEh0gGCApkrYggkPNg==}
 
-  '@sendspin/sendspin-js@3.2.0':
-    resolution: {integrity: sha512-sxMibcr9eiue5yT0viXxCruq8LTRSEzaz9epmhSp3Qe4gHcksE+JwFOTEJfgkY5kJBmPq22CkYlyvJXcHacK2g==}
+  '@sendspin/sendspin-js@3.2.1':
+    resolution: {integrity: sha512-FlnHUV2hppNg/W3yIvV0v9XmDkHE/tbmHkc2/wWDE9CMfqNdCkGhaTsd4cRa4n5FafS3wTDccceFtPvNiacKvg==}
     engines: {node: '>=16.0.0'}
 
   '@standard-schema/spec@1.1.0':
@@ -6232,7 +6232,7 @@ snapshots:
 
   '@scure/base@2.2.0': {}
 
-  '@sendspin/sendspin-js@3.2.0':
+  '@sendspin/sendspin-js@3.2.1':
     dependencies:
       opus-encdec: 0.1.1
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,5 +3,8 @@ allowBuilds:
   esbuild: true
   vue-demi: true
 
+minimumReleaseAgeExclude:
+  - '@sendspin/sendspin-js@3.2.1'
+
 overrides:
   "minimatch@9": "9.0.9"

--- a/src/components/SendspinPlayer.vue
+++ b/src/components/SendspinPlayer.vue
@@ -55,34 +55,16 @@ const isMobileOutput = isAndroid || isIOS;
 // Sendspin Player instance
 let player: SendspinPlayer | null = null;
 
-// Internal sendspin-js scheduler hooks used to unlock audio within a user
-// gesture; the pinned 3.2.0 release exposes no public equivalent.
-interface SendspinAudioUnlock {
-  initAudioContext?: () => void;
-  resumeAudioContext?: () => void | Promise<void>;
-}
-
 // iOS only lets audio start inside a user gesture, but listen-in audio starts
 // asynchronously (after the server groups this player), so the library would
-// create and resume its AudioContext outside the gesture and stay silent.
-// Create and resume that context now, while the gesture is still active, so the
-// stream plays reliably once it arrives.
+// otherwise unlock its audio outside the gesture and stay silent.
 const primeAudio = () => {
   if (!isIOS) return true;
-  try {
-    const scheduler = (
-      player as unknown as { scheduler?: SendspinAudioUnlock } | null
-    )?.scheduler;
-    if (!scheduler?.initAudioContext || !scheduler.resumeAudioContext) {
-      return false;
-    }
-    scheduler.initAudioContext();
-    void scheduler.resumeAudioContext();
-    return true;
-  } catch (error) {
+  if (!player) return false;
+  void player.unlock().catch((error) => {
     console.debug("Sendspin: failed to prime audio for listen-in", error);
-    return false;
-  }
+  });
+  return true;
 };
 
 // Reactive state

--- a/tests/components/SendspinPlayer.test.ts
+++ b/tests/components/SendspinPlayer.test.ts
@@ -2,13 +2,34 @@ import SendspinPlayer from "@/components/SendspinPlayer.vue";
 import { webPlayer, WebPlayerMode } from "@/plugins/web_player";
 import { flushPromises, mount } from "@vue/test-utils";
 import { nextTick } from "vue";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  afterAll,
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
 
-vi.hoisted(() => {
+const { originalUserAgentDescriptor } = vi.hoisted(() => {
+  const originalUserAgentDescriptor = Object.getOwnPropertyDescriptor(
+    navigator,
+    "userAgent",
+  );
   Object.defineProperty(navigator, "userAgent", {
     configurable: true,
     value: "iPhone",
   });
+  return { originalUserAgentDescriptor };
+});
+
+afterAll(() => {
+  if (originalUserAgentDescriptor) {
+    Object.defineProperty(navigator, "userAgent", originalUserAgentDescriptor);
+  } else {
+    Reflect.deleteProperty(navigator, "userAgent");
+  }
 });
 
 const {

--- a/tests/components/SendspinPlayer.test.ts
+++ b/tests/components/SendspinPlayer.test.ts
@@ -1,8 +1,15 @@
 import SendspinPlayer from "@/components/SendspinPlayer.vue";
 import { webPlayer, WebPlayerMode } from "@/plugins/web_player";
-import { mount } from "@vue/test-utils";
+import { flushPromises, mount } from "@vue/test-utils";
 import { nextTick } from "vue";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.hoisted(() => {
+  Object.defineProperty(navigator, "userAgent", {
+    configurable: true,
+    value: "iPhone",
+  });
+});
 
 const {
   authState,
@@ -12,6 +19,8 @@ const {
   mockPlayerCommandPrevious,
   mockPlayerCommandSeek,
   mockPrepareSendspinSession,
+  mockRegisterWebPlayerAudioUnlock,
+  mockSendspinUnlock,
   mockUseMediaBrowserMetaData,
   routeState,
 } = vi.hoisted(() => ({
@@ -24,6 +33,8 @@ const {
   mockPlayerCommandPrevious: vi.fn(),
   mockPlayerCommandSeek: vi.fn(),
   mockPrepareSendspinSession: vi.fn(),
+  mockRegisterWebPlayerAudioUnlock: vi.fn<(handler: () => boolean) => void>(),
+  mockSendspinUnlock: vi.fn<() => Promise<void>>(),
   mockUseMediaBrowserMetaData: vi.fn(() => vi.fn()),
   routeState: {
     current: null as { meta: Record<string, unknown> } | null,
@@ -94,7 +105,7 @@ vi.mock("@/plugins/web_player", async () => {
       SENDSPIN_WITH_CONTROLS: "sendspin_with_controls",
     },
     clearWebPlayerAudioUnlock: vi.fn(),
-    registerWebPlayerAudioUnlock: vi.fn(),
+    registerWebPlayerAudioUnlock: mockRegisterWebPlayerAudioUnlock,
     webPlayer: reactive({
       interacted: false,
       tabMode: "sendspin_only",
@@ -118,6 +129,7 @@ vi.mock("@sendspin/sendspin-js", () => ({
     setCorrectionMode = vi.fn();
     setMuted = vi.fn();
     setVolume = vi.fn();
+    unlock = mockSendspinUnlock;
   },
 }));
 
@@ -164,6 +176,9 @@ describe("SendspinPlayer MediaSession", () => {
     mockPlayerCommandPlay.mockReset();
     mockPlayerCommandPrevious.mockReset();
     mockPlayerCommandSeek.mockReset();
+    mockRegisterWebPlayerAudioUnlock.mockClear();
+    mockSendspinUnlock.mockReset();
+    mockSendspinUnlock.mockResolvedValue(undefined);
     webPlayer.interacted = false;
     webPlayer.tabMode = WebPlayerMode.SENDSPIN_ONLY;
     if (routeState.current) routeState.current.meta = {};
@@ -176,6 +191,7 @@ describe("SendspinPlayer MediaSession", () => {
 
   afterEach(() => {
     vi.useRealTimers();
+    vi.restoreAllMocks();
     vi.unstubAllGlobals();
   });
 
@@ -213,6 +229,49 @@ describe("SendspinPlayer MediaSession", () => {
     expect(
       audioElements.every((audio) => !("controls" in audio.attributes())),
     ).toBe(true);
+    wrapper.unmount();
+  });
+
+  it("unlocks iOS audio once the Sendspin player is ready", async () => {
+    let resolvePrepare!: () => void;
+    mockPrepareSendspinSession.mockReturnValue(
+      new Promise<void>((resolve) => {
+        resolvePrepare = resolve;
+      }),
+    );
+    const wrapper = mount(SendspinPlayer, {
+      props: { playerId: "web-player" },
+    });
+    const unlockAudio = getAudioUnlockHandler();
+
+    expect(unlockAudio()).toBe(false);
+    expect(mockSendspinUnlock).not.toHaveBeenCalled();
+
+    resolvePrepare();
+    await flushPromises();
+
+    expect(unlockAudio()).toBe(true);
+    expect(mockSendspinUnlock).toHaveBeenCalledOnce();
+    wrapper.unmount();
+  });
+
+  it("logs rejected iOS audio unlocks", async () => {
+    const error = new Error("unlock failed");
+    mockPrepareSendspinSession.mockResolvedValue(undefined);
+    mockSendspinUnlock.mockRejectedValue(error);
+    const debugSpy = vi.spyOn(console, "debug").mockImplementation(() => {});
+    const wrapper = mount(SendspinPlayer, {
+      props: { playerId: "web-player" },
+    });
+    await flushPromises();
+
+    expect(getAudioUnlockHandler()()).toBe(true);
+    await flushPromises();
+
+    expect(debugSpy).toHaveBeenCalledWith(
+      "Sendspin: failed to prime audio for listen-in",
+      error,
+    );
     wrapper.unmount();
   });
 
@@ -341,6 +400,12 @@ describe("SendspinPlayer MediaSession", () => {
     wrapper.unmount();
   });
 });
+
+function getAudioUnlockHandler(): () => boolean {
+  const handler = mockRegisterWebPlayerAudioUnlock.mock.calls.at(-1)?.[0];
+  if (!handler) throw new Error("Audio unlock handler was not registered");
+  return handler;
+}
 
 function seedStaleMediaSession(): void {
   mediaSession.metadata = {} as MediaMetadata;


### PR DESCRIPTION
Use the supported Sendspin API to prepare iOS audio during a user action without accessing library internals.

- update sendspin-js to 3.2.1
- switch listen-in audio setup to the public unlock API
- cover the updated audio unlock path