### PR TITLE
Show artist life span in ArtistDetails InfoHeader

### DIFF
--- a/src/components/InfoHeader.vue
+++ b/src/components/InfoHeader.vue
@@ -136,6 +136,30 @@
               {{ new Date(item.metadata.release_date).getFullYear() }}
             </v-card-subtitle>
 
+            <!-- artist birth date -->
+            <v-card-subtitle
+              v-if="
+                item.media_type == MediaType.ARTIST &&
+                item.metadata?.life_span?.begin
+              "
+              class="title d-flex"
+            >
+              <component
+                :is="
+                  item.metadata?.artist_entity_type &&
+                  GROUP_TYPES.has(item.metadata.artist_entity_type)
+                    ? Users
+                    : Cake
+                "
+                :size="16"
+                style="margin-left: -1px; margin-right: 5px; flex-shrink: 0"
+              />
+              {{ formatLifeDate(item.metadata.life_span.begin) }}
+              <span v-if="item.metadata?.life_span?.end">
+                &nbsp;–&nbsp;{{ formatLifeDate(item.metadata.life_span.end) }}
+              </span>
+            </v-card-subtitle>
+
             <!-- item artists -->
             <v-card-subtitle
               v-if="'artists' in item && item.artists"
@@ -462,11 +486,16 @@ import type {
   ItemMapping,
   MediaItemType,
 } from "@/plugins/api/interfaces";
-import { ImageType, MediaType, Track } from "@/plugins/api/interfaces";
+import {
+  ArtistEntityType,
+  ImageType,
+  MediaType,
+  Track,
+} from "@/plugins/api/interfaces";
 import { authManager } from "@/plugins/auth";
 import { eventbus } from "@/plugins/eventbus";
 import { store } from "@/plugins/store";
-import { ArrowLeft, Merge, Trash2 } from "@lucide/vue";
+import { ArrowLeft, Cake, Merge, Trash2, Users } from "@lucide/vue";
 import { IconHeart, IconHeartFilled } from "@tabler/icons-vue";
 import { computed, ref, watch } from "vue";
 import { useRouter } from "vue-router";
@@ -483,6 +512,29 @@ export interface Props {
 }
 const compProps = defineProps<Props>();
 const showFullInfo = ref(false);
+
+const GROUP_TYPES = new Set([
+  ArtistEntityType.GROUP,
+  ArtistEntityType.ORCHESTRA,
+  ArtistEntityType.CHOIR,
+]);
+
+const formatLifeDate = (dateStr: string): string => {
+  const parts = dateStr.split("-").map(Number);
+  if (parts.length === 3 && parts[1] && parts[2]) {
+    return new Intl.DateTimeFormat(undefined, {
+      year: "numeric",
+      month: "short",
+      day: "numeric",
+    }).format(new Date(parts[0], parts[1] - 1, parts[2]));
+  } else if (parts.length >= 2 && parts[1]) {
+    return new Intl.DateTimeFormat(undefined, {
+      year: "numeric",
+      month: "short",
+    }).format(new Date(parts[0], parts[1] - 1, 1));
+  }
+  return String(parts[0]);
+};
 const fanartImage = ref();
 useDisplay();
 const menuItems = ref<ContextMenuItem[]>([]);


### PR DESCRIPTION
Displays the artist's birth/death date (persons) or founding/disbanding date (groups) in the `InfoHeader` on the ArtistDetails page, using the `life_span` and `artist_entity_type` metadata fields.

## What changed

- **`InfoHeader.vue`**: Added a new subtitle row for `MediaType.ARTIST` that renders the `life_span` dates when available.
  - Persons show a **Cake** icon; groups/orchestras/choirs show a **Users** icon.
  - Dates are formatted using `Intl.DateTimeFormat` (locale-aware, e.g. `Jul 8, 1958`).
  - If only a birth/founding date exists, only that is shown. If an end date exists too, it is rendered as a range: `Jul 8, 1958 – Jan 10, 2016`.
  - Partial dates (`YYYY` or `YYYY-MM`) are handled gracefully — only the available precision is shown.
  - The row is hidden entirely when no `life_span.begin` is present.

## Screenshots

<img width="1711" height="339" alt="ArtistDetails-LifeSpan" src="https://github.com/user-attachments/assets/fc8274cf-80cc-4ddb-ad99-6ceb3d15ddd6" />

<img width="1711" height="339" alt="ArtistDetails-LifeSpan-Group" src="https://github.com/user-attachments/assets/cdeae27e-4e4d-43a3-bb81-574a4c9c00f3" />

<img width="1711" height="339" alt="ArtistDetails-LifeSpan_startonly" src="https://github.com/user-attachments/assets/f035cb8f-9f79-40de-a5ae-8386a7a10f28" />

<img width="1711" height="339" alt="ArtistDetails-LifeSpan_startonly-Group" src="https://github.com/user-attachments/assets/87cec4a8-7d90-4ad4-bace-803f3af4d50b" />

## Dependencies

**Requires server PR [music-assistant/server#4687](https://github.com/music-assistant/server/pull/4687)** and a subsequent MusicBrainz metadata refresh on the artist, as `life_span` and `artist_entity_type` are populated by the MusicBrainz metadata provider during enrichment. Without the server PR merged, the fields will not be populated and the row will not appear.

**Requires frontend PR [#2042](https://github.com/music-assistant/frontend/pull/2042)** to be merged first, as `ArtistEntityType`, `LifeSpan` and the corresponding `MediaItemMetadata` fields are defined there. This PR will be rebased onto `main` once #2042 is merged. The CI failure on this PR is expected until then.

Also depends on **models PR [music-assistant/models#298](https://github.com/music-assistant/models/pull/298)** (`LifeSpan` + `ArtistEntityType`) which has already been merged as `music-assistant-models==1.1.164`.