### PR TITLE
Restore audio chain icons

### DIFF
--- a/src/components/AudioProcessingDetails.vue
+++ b/src/components/AudioProcessingDetails.vue
@@ -265,40 +265,26 @@ const {
   align-items: center;
   justify-content: center;
   width: 24px;
-  height: 16px;
-  margin-top: 4px;
+  height: 20px;
+  margin-top: 2px;
 }
 
 .audio-processing-details .audio-processing-stage-provider-icon {
-  width: 16px !important;
-  height: 16px !important;
-  margin: 0 !important;
-}
-
-.audio-processing-details .audio-processing-stage-codec-icon {
-  box-sizing: border-box;
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 24px;
-  height: 14px;
-  padding: 0 2px;
-  border: 1px solid currentColor;
-  border-radius: 3px;
-  color: var(--muted-foreground);
-  font-family:
-    ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono",
-    monospace;
-  font-size: 0.44rem;
-  font-weight: 700;
-  letter-spacing: -0.03em;
-  line-height: 1;
+  flex: 0 0 20px;
+  width: 20px !important;
+  height: 20px !important;
+  margin: 0 !important;
+  overflow: hidden;
 }
 
-.audio-processing-details .audio-processing-stage-codec-icon--dense {
-  padding: 0 1px;
-  font-size: 0.32rem;
-  letter-spacing: -0.05em;
+.audio-processing-details .audio-processing-stage-provider-icon :is(svg, img) {
+  display: block;
+  max-width: 100%;
+  max-height: 100%;
+  object-fit: contain;
 }
 
 .audio-processing-details .audio-processing-stage-copy {

--- a/src/components/AudioProcessingDetails.vue
+++ b/src/components/AudioProcessingDetails.vue
@@ -136,7 +136,7 @@ const {
 }
 
 .audio-processing-details .audio-processing-group + .audio-processing-group {
-  margin-top: 12px;
+  margin-top: 8px;
 }
 
 .audio-processing-details .audio-processing-header {
@@ -161,7 +161,7 @@ const {
   .audio-processing-group
   + .audio-processing-group
   .audio-processing-header::before {
-  top: -12px;
+  top: -8px;
 }
 
 .audio-processing-details .audio-processing-quality-dot {
@@ -273,9 +273,9 @@ const {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  flex: 0 0 20px;
-  width: 20px !important;
-  height: 20px !important;
+  flex: 0 0 18px;
+  width: 18px !important;
+  height: 18px !important;
   margin: 0 !important;
   overflow: hidden;
 }
@@ -298,7 +298,7 @@ const {
   min-width: 0;
   align-items: baseline;
   gap: 6px;
-  line-height: 1.25;
+  line-height: 1.35;
 }
 
 .audio-processing-details .audio-processing-stage-title {
@@ -319,10 +319,10 @@ const {
 }
 
 .audio-processing-details .audio-processing-stage-subtitle {
-  margin-top: 1px;
+  margin-top: 2px;
   color: var(--muted-foreground);
   font-size: 0.72rem;
-  line-height: 1.25;
+  line-height: 1.35;
   overflow-wrap: anywhere;
 }
 

--- a/src/components/AudioProcessingDetails.vue
+++ b/src/components/AudioProcessingDetails.vue
@@ -205,8 +205,8 @@ const {
 .audio-processing-details .audio-processing-stage {
   position: relative;
   display: grid;
-  grid-template-columns: 12px 16px minmax(0, 1fr) 24px;
-  column-gap: 7px;
+  grid-template-columns: 12px 24px minmax(0, 1fr) 24px;
+  column-gap: 4px;
   align-items: start;
   min-height: 24px;
 }
@@ -261,9 +261,44 @@ const {
 
 .audio-processing-details .audio-processing-stage-icon {
   grid-column: 2;
-  width: 16px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
   height: 16px;
   margin-top: 4px;
+}
+
+.audio-processing-details .audio-processing-stage-provider-icon {
+  width: 16px !important;
+  height: 16px !important;
+  margin: 0 !important;
+}
+
+.audio-processing-details .audio-processing-stage-codec-icon {
+  box-sizing: border-box;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 14px;
+  padding: 0 2px;
+  border: 1px solid currentColor;
+  border-radius: 3px;
+  color: var(--muted-foreground);
+  font-family:
+    ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono",
+    monospace;
+  font-size: 0.44rem;
+  font-weight: 700;
+  letter-spacing: -0.03em;
+  line-height: 1;
+}
+
+.audio-processing-details .audio-processing-stage-codec-icon--dense {
+  padding: 0 1px;
+  font-size: 0.32rem;
+  letter-spacing: -0.05em;
 }
 
 .audio-processing-details .audio-processing-stage-copy {

--- a/src/components/AudioProcessingStage.vue
+++ b/src/components/AudioProcessingStage.vue
@@ -5,11 +5,11 @@
       <ProviderIcon
         v-if="stage.providerIconDomain"
         :domain="stage.providerIconDomain"
-        :size="20"
+        :size="18"
         :monochrome="true"
         class="audio-processing-stage-provider-icon"
       />
-      <component :is="stage.icon" v-else :size="16" />
+      <component :is="stage.icon" v-else :size="18" />
     </span>
     <div class="audio-processing-stage-copy">
       <div class="audio-processing-stage-primary">

--- a/src/components/AudioProcessingStage.vue
+++ b/src/components/AudioProcessingStage.vue
@@ -5,20 +5,10 @@
       <ProviderIcon
         v-if="stage.providerIconDomain"
         :domain="stage.providerIconDomain"
-        :size="16"
+        :size="20"
         :monochrome="true"
         class="audio-processing-stage-provider-icon"
       />
-      <span
-        v-else-if="stage.codecIconLabel"
-        class="audio-processing-stage-codec-icon"
-        :class="{
-          'audio-processing-stage-codec-icon--dense':
-            stage.codecIconLabel.length > 4,
-        }"
-      >
-        {{ stage.codecIconLabel }}
-      </span>
       <component :is="stage.icon" v-else :size="16" />
     </span>
     <div class="audio-processing-stage-copy">

--- a/src/components/AudioProcessingStage.vue
+++ b/src/components/AudioProcessingStage.vue
@@ -1,11 +1,26 @@
 <template>
   <div class="audio-processing-stage" :data-stage="stage.key">
     <span class="audio-processing-stage-connector" aria-hidden="true"></span>
-    <component
-      :is="stage.icon"
-      :size="16"
-      class="audio-processing-stage-icon"
-    />
+    <span class="audio-processing-stage-icon" aria-hidden="true">
+      <ProviderIcon
+        v-if="stage.providerIconDomain"
+        :domain="stage.providerIconDomain"
+        :size="16"
+        :monochrome="true"
+        class="audio-processing-stage-provider-icon"
+      />
+      <span
+        v-else-if="stage.codecIconLabel"
+        class="audio-processing-stage-codec-icon"
+        :class="{
+          'audio-processing-stage-codec-icon--dense':
+            stage.codecIconLabel.length > 4,
+        }"
+      >
+        {{ stage.codecIconLabel }}
+      </span>
+      <component :is="stage.icon" v-else :size="16" />
+    </span>
     <div class="audio-processing-stage-copy">
       <div class="audio-processing-stage-primary">
         <span class="audio-processing-stage-title">{{ stage.title }}</span>
@@ -87,6 +102,7 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from "@/components/ui/popover";
+import ProviderIcon from "@/components/ProviderIcon.vue";
 import type { AudioProcessingDisplayStage } from "@/composables/useAudioProcessingDetails";
 import { $t } from "@/plugins/i18n";
 

--- a/src/composables/useAudioProcessingDetails.ts
+++ b/src/composables/useAudioProcessingDetails.ts
@@ -6,7 +6,6 @@ import {
   Gauge,
   GitMerge,
   Layers,
-  Radio,
   Shield,
   SlidersHorizontal,
   Speaker,
@@ -37,15 +36,33 @@ type TranslationValue = string | number;
 type Translate = (key: string, values?: TranslationValue[]) => string;
 type AudioDSPDetails = NonNullable<AudioOutputDetails["dsp"]>;
 
-export interface AudioProcessingDisplayStage {
+interface AudioProcessingDisplayStageBase {
   key: string;
-  icon: Component;
   title: string;
   subtitleParts?: string[];
   atomicSubtitleParts?: boolean;
   badge?: string;
   details?: string[];
 }
+
+export type AudioProcessingDisplayStage = AudioProcessingDisplayStageBase &
+  (
+    | {
+        icon: Component;
+        providerIconDomain?: never;
+        codecIconLabel?: never;
+      }
+    | {
+        icon?: never;
+        providerIconDomain: string;
+        codecIconLabel?: never;
+      }
+    | {
+        icon?: never;
+        providerIconDomain?: never;
+        codecIconLabel: string;
+      }
+  );
 
 export interface AudioProcessingOutputDisplay {
   key: string;
@@ -67,10 +84,12 @@ export interface AudioProcessingDetailsDisplay {
 export interface AudioProcessingDisplayPlayer {
   player_id: string;
   name: string;
+  provider: string;
   active_output_protocol?: string | null;
   output_protocols?: Array<{
     output_protocol_id: string;
     is_native: boolean;
+    protocol_domain?: string | null;
   }>;
 }
 
@@ -78,6 +97,7 @@ export interface AudioProcessingDetailsDependencies {
   translate: Translate;
   locale: string;
   getProviderName: (providerId: string) => string;
+  getProviderDomain: (providerId: string) => string | undefined;
   getPresetName: (presetId: string | null | undefined) => string | undefined;
   players: Record<string, AudioProcessingDisplayPlayer>;
 }
@@ -145,6 +165,8 @@ export function useAudioProcessingDetails(
         translate,
         locale: locale.value,
         getProviderName: (providerId) => api.getProviderName(providerId),
+        getProviderDomain: (providerId) =>
+          api.getProviderManifest(providerId)?.domain,
         getPresetName,
         players: api.players,
       },
@@ -186,7 +208,7 @@ function buildInputStages(
   return [
     {
       key: "provider",
-      icon: Radio,
+      providerIconDomain: streamDetails.provider,
       title: dependencies.getProviderName(streamDetails.provider),
     },
     formatStage(
@@ -363,9 +385,8 @@ function destinationStage(
   const destinations = resolveDestinations(playerIds, dependencies);
   const primary = destinations[0];
   const additionalDestinationCount = destinations.length - 1;
-  return {
+  const stage = {
     key: "destination",
-    icon: Speaker,
     title:
       additionalDestinationCount > 0
         ? `${primary.name} +${additionalDestinationCount}`
@@ -375,46 +396,112 @@ function destinationStage(
         ? destinations.map((destination) => destination.name)
         : undefined,
   };
+  const providerIconDomain = commonDestinationProviderDomain(destinations);
+  return providerIconDomain
+    ? { ...stage, providerIconDomain }
+    : { ...stage, icon: Speaker };
+}
+
+interface ResolvedDestination {
+  playerId: string;
+  name: string;
+  providerDomain?: string;
 }
 
 function resolveDestinations(
   playerIds: string[],
   dependencies: AudioProcessingDetailsDependencies,
-): Array<{ playerId: string; name: string }> {
-  const destinations: Array<{ playerId: string; name: string }> = [];
+): ResolvedDestination[] {
+  const destinations: ResolvedDestination[] = [];
   const seenPlayerIds = new Set<string>();
   for (const playerId of playerIds) {
-    const player = resolveDestinationPlayer(playerId, dependencies.players);
-    const resolvedPlayerId = player?.player_id ?? playerId;
+    const resolved = resolveDestination(playerId, dependencies);
+    const resolvedPlayerId = resolved?.player.player_id ?? playerId;
     if (seenPlayerIds.has(resolvedPlayerId)) continue;
     seenPlayerIds.add(resolvedPlayerId);
     destinations.push({
       playerId: resolvedPlayerId,
       name:
-        player?.name ??
+        resolved?.player.name ??
         dependencies.translate(
           "streamdetails.audio_processing.destination_unknown",
           [playerId],
         ),
+      providerDomain: resolved?.providerDomain,
     });
   }
   return destinations;
 }
 
-function resolveDestinationPlayer(
+interface DestinationResolution {
+  player: AudioProcessingDisplayPlayer;
+  providerDomain?: string;
+}
+
+function resolveDestination(
   playerId: string,
-  players: Record<string, AudioProcessingDisplayPlayer>,
-): AudioProcessingDisplayPlayer | undefined {
-  const protocolParent = Object.values(players).find(
-    (player) =>
-      player.player_id !== playerId &&
-      (player.active_output_protocol === playerId ||
-        player.output_protocols?.some(
-          (protocol) =>
-            !protocol.is_native && protocol.output_protocol_id === playerId,
-        )),
+  dependencies: AudioProcessingDetailsDependencies,
+): DestinationResolution | undefined {
+  for (const player of Object.values(dependencies.players)) {
+    if (player.player_id === playerId) continue;
+    const protocol = player.output_protocols?.find(
+      (outputProtocol) =>
+        !outputProtocol.is_native &&
+        outputProtocol.output_protocol_id === playerId,
+    );
+    if (!protocol) continue;
+    return {
+      player,
+      providerDomain:
+        protocol.protocol_domain ??
+        playerProviderDomain(dependencies.players[playerId], dependencies),
+    };
+  }
+
+  const player = dependencies.players[playerId];
+  if (!player) return undefined;
+  const activeProtocolId = player.active_output_protocol;
+  if (
+    !activeProtocolId ||
+    activeProtocolId === "native" ||
+    activeProtocolId === player.player_id
+  ) {
+    return {
+      player,
+      providerDomain: playerProviderDomain(player, dependencies),
+    };
+  }
+
+  const activeProtocol = player.output_protocols?.find(
+    (protocol) => protocol.output_protocol_id === activeProtocolId,
   );
-  return protocolParent ?? players[playerId];
+  return {
+    player,
+    providerDomain: activeProtocol
+      ? (activeProtocol.protocol_domain ??
+        playerProviderDomain(
+          dependencies.players[activeProtocolId],
+          dependencies,
+        ))
+      : undefined,
+  };
+}
+
+function playerProviderDomain(
+  player: AudioProcessingDisplayPlayer | undefined,
+  dependencies: AudioProcessingDetailsDependencies,
+): string | undefined {
+  return player ? dependencies.getProviderDomain(player.provider) : undefined;
+}
+
+function commonDestinationProviderDomain(
+  destinations: ResolvedDestination[],
+): string | undefined {
+  const domain = destinations[0]?.providerDomain;
+  return domain &&
+    destinations.every((destination) => destination.providerDomain === domain)
+    ? domain
+    : undefined;
 }
 
 function normalizationStage(
@@ -571,9 +658,8 @@ function finalOutputStage(
       translate,
     ),
   );
-  return {
+  const stage = {
     key: `output-format-${index}`,
-    icon: FileAudio,
     title: format
       ? audioFormatTitle(format, translate)
       : translate("streamdetails.audio_processing.unknown_format"),
@@ -587,6 +673,10 @@ function finalOutputStage(
         : undefined,
     details,
   };
+  const codecIconLabel = format ? codecBadgeLabel(format) : undefined;
+  return codecIconLabel
+    ? { ...stage, codecIconLabel }
+    : { ...stage, icon: FileAudio };
 }
 
 function formatStage(
@@ -595,14 +685,17 @@ function formatStage(
   translate: Translate,
   locale: string,
 ): AudioProcessingDisplayStage {
-  return {
+  const stage = {
     key,
-    icon: FileAudio,
     title: audioFormatTitle(format, translate),
     subtitleParts: audioFormatTechnicalParts(format, translate, locale),
     atomicSubtitleParts: true,
     details: audioFormatDetails(format, translate, locale),
   };
+  const codecIconLabel = codecBadgeLabel(format);
+  return codecIconLabel
+    ? { ...stage, codecIconLabel }
+    : { ...stage, icon: FileAudio };
 }
 
 function outputFidelityDetail(
@@ -806,6 +899,19 @@ function audioFormatCodec(format: AudioFormat): string {
   return format.codec_type && format.codec_type !== ContentType.UNKNOWN
     ? format.codec_type
     : format.content_type;
+}
+
+function codecBadgeLabel(format: AudioFormat): string | undefined {
+  const codec = audioFormatCodec(format);
+  if (codec === ContentType.UNKNOWN || !KNOWN_CONTENT_TYPES.has(codec)) {
+    return undefined;
+  }
+  if (codec === ContentType.PCM || PCM_CONTENT_TYPES.has(codec)) {
+    return "PCM";
+  }
+  if (codec.startsWith("adpcm_")) return "ADPCM";
+  if (codec.startsWith("dsd_")) return "DSD";
+  return codec.toUpperCase().replaceAll("_", "-");
 }
 
 function audioChannelCountLabel(

--- a/src/composables/useAudioProcessingDetails.ts
+++ b/src/composables/useAudioProcessingDetails.ts
@@ -2,17 +2,16 @@ import { computed, toValue, type Component, type MaybeRefOrGetter } from "vue";
 import { useI18n } from "vue-i18n";
 import {
   AudioLines,
-  Binary,
+  File as FileIcon,
   FileAudio,
   Gauge,
-  GitMerge,
-  Layers,
   Shield,
   SlidersHorizontal,
   Speaker,
   Split,
 } from "@lucide/vue";
 import { useDSPPresets } from "@/composables/useDSPPresets";
+import CrossfadeIcon from "@/layouts/default/PlayerOSD/PlayerControlBtn/CrossfadeIcon.vue";
 import {
   audioQualityToTier,
   type QualityTier,
@@ -252,7 +251,7 @@ function buildProcessingStages(
   ) {
     stages.push({
       key: "crossfade",
-      icon: GitMerge,
+      icon: CrossfadeIcon,
       title: translate("streamdetails.audio_processing.crossfade", [
         crossfadeModeLabel(processing.crossfade_mode, translate),
       ]),
@@ -261,7 +260,7 @@ function buildProcessingStages(
   if (processing?.overlay_active) {
     stages.push({
       key: "overlay",
-      icon: Layers,
+      icon: AudioLines,
       title: translate("streamdetails.audio_processing.overlay_active"),
     });
   }
@@ -571,7 +570,7 @@ function processingContextStage(
     }
     return {
       key: "pcm-format",
-      icon: FileAudio,
+      icon: Gauge,
       title: translate("streamdetails.audio_processing.processing_headroom"),
       subtitleParts: [contentTypeLabel(internalCodec, translate)],
       atomicSubtitleParts: true,
@@ -654,7 +653,7 @@ function finalOutputStage(
   );
   return {
     key: `output-format-${index}`,
-    icon: Binary,
+    icon: FileIcon,
     title: format
       ? audioFormatTitle(format, translate)
       : translate("streamdetails.audio_processing.unknown_format"),
@@ -678,7 +677,7 @@ function formatStage(
 ): AudioProcessingDisplayStage {
   return {
     key,
-    icon: Binary,
+    icon: FileIcon,
     title: audioFormatTitle(format, translate),
     subtitleParts: audioFormatTechnicalParts(format, translate, locale),
     atomicSubtitleParts: true,

--- a/src/composables/useAudioProcessingDetails.ts
+++ b/src/composables/useAudioProcessingDetails.ts
@@ -2,6 +2,7 @@ import { computed, toValue, type Component, type MaybeRefOrGetter } from "vue";
 import { useI18n } from "vue-i18n";
 import {
   AudioLines,
+  Binary,
   FileAudio,
   Gauge,
   GitMerge,
@@ -50,17 +51,10 @@ export type AudioProcessingDisplayStage = AudioProcessingDisplayStageBase &
     | {
         icon: Component;
         providerIconDomain?: never;
-        codecIconLabel?: never;
       }
     | {
         icon?: never;
         providerIconDomain: string;
-        codecIconLabel?: never;
-      }
-    | {
-        icon?: never;
-        providerIconDomain?: never;
-        codecIconLabel: string;
       }
   );
 
@@ -658,8 +652,9 @@ function finalOutputStage(
       translate,
     ),
   );
-  const stage = {
+  return {
     key: `output-format-${index}`,
+    icon: Binary,
     title: format
       ? audioFormatTitle(format, translate)
       : translate("streamdetails.audio_processing.unknown_format"),
@@ -673,10 +668,6 @@ function finalOutputStage(
         : undefined,
     details,
   };
-  const codecIconLabel = format ? codecBadgeLabel(format) : undefined;
-  return codecIconLabel
-    ? { ...stage, codecIconLabel }
-    : { ...stage, icon: FileAudio };
 }
 
 function formatStage(
@@ -685,17 +676,14 @@ function formatStage(
   translate: Translate,
   locale: string,
 ): AudioProcessingDisplayStage {
-  const stage = {
+  return {
     key,
+    icon: Binary,
     title: audioFormatTitle(format, translate),
     subtitleParts: audioFormatTechnicalParts(format, translate, locale),
     atomicSubtitleParts: true,
     details: audioFormatDetails(format, translate, locale),
   };
-  const codecIconLabel = codecBadgeLabel(format);
-  return codecIconLabel
-    ? { ...stage, codecIconLabel }
-    : { ...stage, icon: FileAudio };
 }
 
 function outputFidelityDetail(
@@ -899,19 +887,6 @@ function audioFormatCodec(format: AudioFormat): string {
   return format.codec_type && format.codec_type !== ContentType.UNKNOWN
     ? format.codec_type
     : format.content_type;
-}
-
-function codecBadgeLabel(format: AudioFormat): string | undefined {
-  const codec = audioFormatCodec(format);
-  if (codec === ContentType.UNKNOWN || !KNOWN_CONTENT_TYPES.has(codec)) {
-    return undefined;
-  }
-  if (codec === ContentType.PCM || PCM_CONTENT_TYPES.has(codec)) {
-    return "PCM";
-  }
-  if (codec.startsWith("adpcm_")) return "ADPCM";
-  if (codec.startsWith("dsd_")) return "DSD";
-  return codec.toUpperCase().replaceAll("_", "-");
 }
 
 function audioChannelCountLabel(

--- a/tests/components/AudioProcessingDetails.test.ts
+++ b/tests/components/AudioProcessingDetails.test.ts
@@ -115,9 +115,9 @@ describe("AudioProcessingDetails", () => {
     expect(
       wrapper
         .find('[data-stage="source-format"]')
-        .get(".audio-processing-stage-codec-icon")
-        .text(),
-    ).toBe("FLAC");
+        .find(".audio-processing-stage-icon svg")
+        .exists(),
+    ).toBe(true);
     expect(
       groupedDestination
         .get('[data-testid="provider-icon"]')

--- a/tests/components/AudioProcessingDetails.test.ts
+++ b/tests/components/AudioProcessingDetails.test.ts
@@ -21,15 +21,20 @@ import {
 interface PlayerDisplayMock {
   player_id: string;
   name: string;
+  provider: string;
   active_output_protocol?: string | null;
   output_protocols?: Array<{
     output_protocol_id: string;
     is_native: boolean;
+    protocol_domain?: string | null;
   }>;
 }
 
 const apiMock = vi.hoisted(() => ({
   getProviderName: vi.fn(() => "Test provider"),
+  getProviderManifest: vi.fn((providerId: string) => ({
+    domain: providerId.split("--", 1)[0],
+  })),
   players: {} as Record<string, PlayerDisplayMock>,
 }));
 const presetRegistryMock = vi.hoisted(() => ({
@@ -57,12 +62,14 @@ beforeEach(() => {
     "player-1": {
       player_id: "player-1",
       name: "Kitchen",
+      provider: "squeezelite--main",
       active_output_protocol: null,
       output_protocols: [],
     },
     "player-2": {
       player_id: "player-2",
       name: "Office",
+      provider: "squeezelite--main",
       active_output_protocol: null,
       output_protocols: [],
     },
@@ -99,6 +106,23 @@ describe("AudioProcessingDetails", () => {
         .find(".audio-processing-stage-info")
         .attributes("aria-label"),
     ).toBe("More information about Kitchen +1");
+    expect(
+      wrapper
+        .find('[data-stage="provider"]')
+        .get('[data-testid="provider-icon"]')
+        .attributes("data-domain"),
+    ).toBe("filesystem--music");
+    expect(
+      wrapper
+        .find('[data-stage="source-format"]')
+        .get(".audio-processing-stage-codec-icon")
+        .text(),
+    ).toBe("FLAC");
+    expect(
+      groupedDestination
+        .get('[data-testid="provider-icon"]')
+        .attributes("data-domain"),
+    ).toBe("squeezelite");
 
     const stageKeys = wrapper
       .findAll("[data-stage]")
@@ -718,6 +742,7 @@ describe("AudioProcessingDetails", () => {
       {
         output_protocol_id: "airplay-kitchen",
         is_native: false,
+        protocol_domain: "airplay",
       },
     ];
     const wrapper = mountDetails({
@@ -737,6 +762,35 @@ describe("AudioProcessingDetails", () => {
       "Kitchen",
       "Office",
     ]);
+    expect(destination.find('[data-testid="provider-icon"]').exists()).toBe(
+      false,
+    );
+  });
+
+  it("renders the active output protocol icon for a parent destination", () => {
+    apiMock.players["player-1"].active_output_protocol = "airplay-kitchen";
+    apiMock.players["player-1"].output_protocols = [
+      {
+        output_protocol_id: "airplay-kitchen",
+        is_native: false,
+        protocol_domain: "airplay",
+      },
+    ];
+    const wrapper = mountDetails({
+      outputs: [
+        {
+          player_ids: ["player-1"],
+          output_format: makeFormat(),
+        },
+      ],
+    });
+
+    const destination = wrapper.find('[data-stage="destination"]');
+    expect(
+      destination
+        .get('[data-testid="provider-icon"]')
+        .attributes("data-domain"),
+    ).toBe("airplay");
   });
 
   it("keeps large destination groups in one complete detail list", () => {
@@ -748,6 +802,7 @@ describe("AudioProcessingDetails", () => {
       apiMock.players[playerId] = {
         player_id: playerId,
         name: `Room ${index + 1}`,
+        provider: "squeezelite--main",
         active_output_protocol: null,
         output_protocols: [],
       };
@@ -821,6 +876,11 @@ function mountDetails(
         Popover: { template: "<div><slot /></div>" },
         PopoverContent: { template: "<div><slot /></div>" },
         PopoverTrigger: { template: "<div><slot /></div>" },
+        ProviderIcon: {
+          props: ["domain"],
+          template:
+            '<span data-testid="provider-icon" :data-domain="domain" />',
+        },
       },
     },
   });
@@ -848,7 +908,7 @@ function makeFormat(overrides: Partial<AudioFormat> = {}): AudioFormat {
 
 function makeStreamDetails(audioFormat = makeFormat()): StreamDetails {
   return {
-    provider: "test",
+    provider: "filesystem--music",
     item_id: "track-1",
     audio_format: audioFormat,
     media_type: MediaType.TRACK,

--- a/tests/components/AudioProcessingStage.test.ts
+++ b/tests/components/AudioProcessingStage.test.ts
@@ -1,8 +1,17 @@
 import { mount } from "@vue/test-utils";
 import { markRaw, nextTick } from "vue";
-import { beforeEach, describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import AudioProcessingStage from "@/components/AudioProcessingStage.vue";
+import type { AudioProcessingDisplayStage } from "@/composables/useAudioProcessingDetails";
 import { i18n } from "@/plugins/i18n";
+
+vi.mock("@/components/ProviderIcon.vue", () => ({
+  default: {
+    name: "ProviderIcon",
+    props: ["domain"],
+    template: '<span data-testid="provider-icon" :domain="domain" />',
+  },
+}));
 
 const TestIcon = markRaw({
   template: '<svg data-testid="stage-icon"></svg>',
@@ -57,6 +66,48 @@ describe("AudioProcessingStage", () => {
     expect(detail.classes("audio-processing-stage-subtitle-part--atomic")).toBe(
       false,
     );
+  });
+
+  it("renders provider icons as decorative stage content", () => {
+    const wrapper = mountStage({
+      key: "provider",
+      providerIconDomain: "filesystem--music",
+      title: "Filesystem",
+    });
+
+    expect(
+      wrapper.get('[data-testid="provider-icon"]').attributes("domain"),
+    ).toBe("filesystem--music");
+    expect(
+      wrapper.get(".audio-processing-stage-icon").attributes("aria-hidden"),
+    ).toBe("true");
+  });
+
+  it("renders compact and dense codec badges", () => {
+    const compact = mountStage({
+      key: "source-format",
+      codecIconLabel: "FLAC",
+      title: "FLAC",
+    });
+    expect(compact.get(".audio-processing-stage-codec-icon").text()).toBe(
+      "FLAC",
+    );
+    expect(
+      compact
+        .get(".audio-processing-stage-codec-icon")
+        .classes("audio-processing-stage-codec-icon--dense"),
+    ).toBe(false);
+
+    const dense = mountStage({
+      key: "source-format",
+      codecIconLabel: "WAVPACK",
+      title: "WAVPACK",
+    });
+    expect(
+      dense
+        .get(".audio-processing-stage-codec-icon")
+        .classes("audio-processing-stage-codec-icon--dense"),
+    ).toBe(true);
   });
 
   it("renders a badge and tooltip details in their dedicated columns", () => {
@@ -133,15 +184,7 @@ describe("AudioProcessingStage", () => {
   });
 });
 
-function mountStage(stage: {
-  key: string;
-  icon: typeof TestIcon;
-  title: string;
-  subtitleParts?: string[];
-  atomicSubtitleParts?: boolean;
-  badge?: string;
-  details?: string[];
-}) {
+function mountStage(stage: AudioProcessingDisplayStage) {
   return mount(AudioProcessingStage, {
     props: { stage },
     global: {

--- a/tests/components/AudioProcessingStage.test.ts
+++ b/tests/components/AudioProcessingStage.test.ts
@@ -8,8 +8,9 @@ import { i18n } from "@/plugins/i18n";
 vi.mock("@/components/ProviderIcon.vue", () => ({
   default: {
     name: "ProviderIcon",
-    props: ["domain"],
-    template: '<span data-testid="provider-icon" :domain="domain" />',
+    props: ["domain", "size", "monochrome"],
+    template:
+      '<span data-testid="provider-icon" :domain="domain" :data-size="size" :data-monochrome="monochrome" />',
   },
 }));
 
@@ -79,35 +80,16 @@ describe("AudioProcessingStage", () => {
       wrapper.get('[data-testid="provider-icon"]').attributes("domain"),
     ).toBe("filesystem--music");
     expect(
+      wrapper.get('[data-testid="provider-icon"]').attributes("data-size"),
+    ).toBe("20");
+    expect(
+      wrapper
+        .get('[data-testid="provider-icon"]')
+        .attributes("data-monochrome"),
+    ).toBe("true");
+    expect(
       wrapper.get(".audio-processing-stage-icon").attributes("aria-hidden"),
     ).toBe("true");
-  });
-
-  it("renders compact and dense codec badges", () => {
-    const compact = mountStage({
-      key: "source-format",
-      codecIconLabel: "FLAC",
-      title: "FLAC",
-    });
-    expect(compact.get(".audio-processing-stage-codec-icon").text()).toBe(
-      "FLAC",
-    );
-    expect(
-      compact
-        .get(".audio-processing-stage-codec-icon")
-        .classes("audio-processing-stage-codec-icon--dense"),
-    ).toBe(false);
-
-    const dense = mountStage({
-      key: "source-format",
-      codecIconLabel: "WAVPACK",
-      title: "WAVPACK",
-    });
-    expect(
-      dense
-        .get(".audio-processing-stage-codec-icon")
-        .classes("audio-processing-stage-codec-icon--dense"),
-    ).toBe(true);
   });
 
   it("renders a badge and tooltip details in their dedicated columns", () => {

--- a/tests/components/AudioProcessingStage.test.ts
+++ b/tests/components/AudioProcessingStage.test.ts
@@ -81,7 +81,7 @@ describe("AudioProcessingStage", () => {
     ).toBe("filesystem--music");
     expect(
       wrapper.get('[data-testid="provider-icon"]').attributes("data-size"),
-    ).toBe("20");
+    ).toBe("18");
     expect(
       wrapper
         .get('[data-testid="provider-icon"]')

--- a/tests/composables/useAudioProcessingDetails.test.ts
+++ b/tests/composables/useAudioProcessingDetails.test.ts
@@ -541,12 +541,12 @@ describe("buildAudioProcessingDetailsDisplay", () => {
     });
 
     expect(wrapper.get('[data-testid="playback-speed"]').text()).toBe(
-      "Playback speed: 1.25x",
+      $t("streamdetails.audio_processing.playback_speed", ["1.25"]),
     );
     i18n.global.locale.value = "de";
     await nextTick();
     expect(wrapper.get('[data-testid="playback-speed"]').text()).toBe(
-      "Playback speed: 1,25x",
+      $t("streamdetails.audio_processing.playback_speed", ["1,25"]),
     );
     wrapper.unmount();
   });

--- a/tests/composables/useAudioProcessingDetails.test.ts
+++ b/tests/composables/useAudioProcessingDetails.test.ts
@@ -54,7 +54,7 @@ beforeEach(() => {
 });
 
 describe("buildAudioProcessingDetailsDisplay", () => {
-  it("uses provider and codec icons for the input path", () => {
+  it("uses provider and file icons for the input path", () => {
     const display = buildDisplay({});
 
     expect(display.inputStages[0]).toMatchObject({
@@ -63,16 +63,17 @@ describe("buildAudioProcessingDetailsDisplay", () => {
     });
     expect(display.inputStages[1]).toMatchObject({
       title: "FLAC",
-      codecIconLabel: "FLAC",
+      icon: expect.any(Function),
     });
   });
 
   it.each([
-    [ContentType.PCM_F32LE, "PCM"],
-    [ContentType.ADPCM_IMA, "ADPCM"],
-    [ContentType.DSD_MSBF, "DSD"],
-    [ContentType.WAVPACK, "WAVPACK"],
-  ])("builds a compact %s codec label", (contentType, expectedLabel) => {
+    ContentType.FLAC,
+    ContentType.PCM_F32LE,
+    ContentType.ADPCM_IMA,
+    ContentType.DSD_MSBF,
+    ContentType.WAVPACK,
+  ])("uses the generic file icon for %s", (contentType) => {
     const format = makeFormat({
       content_type: contentType,
       codec_type: contentType,
@@ -84,23 +85,8 @@ describe("buildAudioProcessingDetailsDisplay", () => {
       format,
     );
 
-    expect(display.inputStages[1]).toMatchObject({
-      codecIconLabel: expectedLabel,
-    });
-    expect(display.outputPaths[0].stages.at(-1)).toMatchObject({
-      codecIconLabel: expectedLabel,
-    });
-  });
-
-  it("keeps the generic format icon when the codec is unknown", () => {
-    const format = makeFormat({
-      content_type: ContentType.UNKNOWN,
-      codec_type: ContentType.UNKNOWN,
-    });
-    const display = buildDisplay({}, format);
-
     expect(display.inputStages[1]).toHaveProperty("icon");
-    expect(display.inputStages[1]).not.toHaveProperty("codecIconLabel");
+    expect(display.outputPaths[0].stages.at(-1)).toHaveProperty("icon");
   });
 
   it("uses the native player provider for direct output", () => {

--- a/tests/composables/useAudioProcessingDetails.test.ts
+++ b/tests/composables/useAudioProcessingDetails.test.ts
@@ -22,6 +22,9 @@ import {
 vi.mock("@/plugins/api", () => ({
   default: {
     getProviderName: vi.fn(),
+    getProviderManifest: vi.fn((providerId: string) => ({
+      domain: providerId,
+    })),
     players: {},
   },
 }));
@@ -36,37 +39,273 @@ const dependencies: AudioProcessingDetailsDependencies = {
   translate: (key, values) => (values ? $t(key, values) : $t(key)),
   locale: "en-US",
   getProviderName: () => "Test provider",
+  getProviderDomain: (providerId) => providerId.split("--", 1)[0],
   getPresetName: (presetId) =>
     presetId ? presetNames.get(presetId) : undefined,
-  players: {
-    kitchen: {
-      player_id: "kitchen",
-      name: "Kitchen",
-      active_output_protocol: "airplay-kitchen",
-      output_protocols: [
-        {
-          output_protocol_id: "airplay-kitchen",
-          is_native: false,
-        },
-      ],
-    },
-    office: {
-      player_id: "office",
-      name: "Office",
-      active_output_protocol: null,
-      output_protocols: [],
-    },
-  },
+  players: makePlayers(),
 };
 
 beforeEach(() => {
   i18n.global.locale.value = "en";
   dependencies.locale = "en-US";
+  dependencies.players = makePlayers();
   presetNames.clear();
   presetNames.set("preset-1", "Living room");
 });
 
 describe("buildAudioProcessingDetailsDisplay", () => {
+  it("uses provider and codec icons for the input path", () => {
+    const display = buildDisplay({});
+
+    expect(display.inputStages[0]).toMatchObject({
+      title: "Test provider",
+      providerIconDomain: "test--instance",
+    });
+    expect(display.inputStages[1]).toMatchObject({
+      title: "FLAC",
+      codecIconLabel: "FLAC",
+    });
+  });
+
+  it.each([
+    [ContentType.PCM_F32LE, "PCM"],
+    [ContentType.ADPCM_IMA, "ADPCM"],
+    [ContentType.DSD_MSBF, "DSD"],
+    [ContentType.WAVPACK, "WAVPACK"],
+  ])("builds a compact %s codec label", (contentType, expectedLabel) => {
+    const format = makeFormat({
+      content_type: contentType,
+      codec_type: contentType,
+    });
+    const display = buildDisplay(
+      {
+        outputs: [{ player_ids: ["office"], output_format: format }],
+      },
+      format,
+    );
+
+    expect(display.inputStages[1]).toMatchObject({
+      codecIconLabel: expectedLabel,
+    });
+    expect(display.outputPaths[0].stages.at(-1)).toMatchObject({
+      codecIconLabel: expectedLabel,
+    });
+  });
+
+  it("keeps the generic format icon when the codec is unknown", () => {
+    const format = makeFormat({
+      content_type: ContentType.UNKNOWN,
+      codec_type: ContentType.UNKNOWN,
+    });
+    const display = buildDisplay({}, format);
+
+    expect(display.inputStages[1]).toHaveProperty("icon");
+    expect(display.inputStages[1]).not.toHaveProperty("codecIconLabel");
+  });
+
+  it("uses the native player provider for direct output", () => {
+    const destination = buildDisplay({
+      outputs: [{ player_ids: ["office"], output_format: makeFormat() }],
+    }).outputPaths[0].destination;
+
+    expect(destination).toMatchObject({
+      title: "Office",
+      providerIconDomain: "squeezelite",
+    });
+  });
+
+  it.each(["airplay", "sendspin", "snapcast", "msx_bridge"])(
+    "uses the exact active %s protocol domain",
+    (protocolDomain) => {
+      const protocolId = `${protocolDomain}-kitchen`;
+      dependencies.players.kitchen.active_output_protocol = protocolId;
+      dependencies.players.kitchen.output_protocols = [
+        {
+          output_protocol_id: protocolId,
+          is_native: false,
+          protocol_domain: protocolDomain,
+        },
+      ];
+
+      const destination = buildDisplay({
+        outputs: [{ player_ids: ["kitchen"], output_format: makeFormat() }],
+      }).outputPaths[0].destination;
+
+      expect(destination).toMatchObject({
+        title: "Kitchen",
+        providerIconDomain: protocolDomain,
+      });
+    },
+  );
+
+  it("resolves older protocol IDs to one visible parent", () => {
+    const destination = buildDisplay({
+      outputs: [
+        {
+          player_ids: ["airplay-kitchen", "kitchen"],
+          output_format: makeFormat(),
+        },
+      ],
+    }).outputPaths[0].destination;
+
+    expect(destination).toMatchObject({
+      title: "Kitchen",
+      providerIconDomain: "airplay",
+    });
+    expect(destination.details).toBeUndefined();
+  });
+
+  it("uses the protocol player provider when the active entry has no domain", () => {
+    dependencies.players.kitchen.active_output_protocol = "sendspin-kitchen";
+    dependencies.players.kitchen.output_protocols = [
+      {
+        output_protocol_id: "sendspin-kitchen",
+        is_native: false,
+        protocol_domain: null,
+      },
+    ];
+    dependencies.players["sendspin-kitchen"] = {
+      player_id: "sendspin-kitchen",
+      name: "Kitchen",
+      provider: "sendspin--bridge",
+      active_output_protocol: null,
+      output_protocols: [],
+    };
+
+    const destination = buildDisplay({
+      outputs: [{ player_ids: ["kitchen"], output_format: makeFormat() }],
+    }).outputPaths[0].destination;
+
+    expect(destination).toMatchObject({
+      title: "Kitchen",
+      providerIconDomain: "sendspin",
+    });
+  });
+
+  it("never falls back to the base provider for an unresolved active protocol", () => {
+    dependencies.players.kitchen.active_output_protocol = "missing-protocol";
+    dependencies.players.kitchen.output_protocols = [];
+    dependencies.players["missing-protocol"] = {
+      player_id: "missing-protocol",
+      name: "Unrelated protocol player",
+      provider: "snapcast--other",
+      active_output_protocol: null,
+      output_protocols: [],
+    };
+
+    const destination = buildDisplay({
+      outputs: [{ player_ids: ["kitchen"], output_format: makeFormat() }],
+    }).outputPaths[0].destination;
+
+    expect(destination).toHaveProperty("icon");
+    expect(destination).not.toHaveProperty("providerIconDomain");
+  });
+
+  it.each(["snapcast", "msx_bridge"])(
+    "uses a visible %s destination provider without a parent mapping",
+    (providerDomain) => {
+      const playerId = `${providerDomain}-room`;
+      dependencies.players.kitchen.output_protocols = [];
+      dependencies.players[playerId] = {
+        player_id: playerId,
+        name: "Visible destination",
+        provider: `${providerDomain}--main`,
+        active_output_protocol: null,
+        output_protocols: [],
+      };
+
+      const destination = buildDisplay({
+        outputs: [
+          {
+            player_ids: [playerId],
+            output_format: makeFormat(),
+          },
+        ],
+      }).outputPaths[0].destination;
+
+      expect(destination).toMatchObject({
+        title: "Visible destination",
+        providerIconDomain: providerDomain,
+      });
+    },
+  );
+
+  it("keeps a missing protocol ID generic without an exact parent mapping", () => {
+    dependencies.players.kitchen.output_protocols = [];
+
+    const destination = buildDisplay({
+      outputs: [
+        {
+          player_ids: ["airplay-kitchen"],
+          output_format: makeFormat(),
+        },
+      ],
+    }).outputPaths[0].destination;
+
+    expect(destination.title).toBe("Destination airplay-kitchen");
+    expect(destination).toHaveProperty("icon");
+    expect(destination).not.toHaveProperty("providerIconDomain");
+  });
+
+  it("uses a provider icon only for grouped destinations on one domain", () => {
+    dependencies.players.kitchen.active_output_protocol = "native";
+    dependencies.players.office.provider = "sonos--office";
+    let destination = buildDisplay({
+      outputs: [
+        {
+          player_ids: ["kitchen", "office"],
+          output_format: makeFormat(),
+        },
+      ],
+    }).outputPaths[0].destination;
+    expect(destination).toMatchObject({ providerIconDomain: "sonos" });
+
+    dependencies.players.office.provider = "squeezelite--office";
+    destination = buildDisplay({
+      outputs: [
+        {
+          player_ids: ["kitchen", "office"],
+          output_format: makeFormat(),
+        },
+      ],
+    }).outputPaths[0].destination;
+    expect(destination).toHaveProperty("icon");
+    expect(destination).not.toHaveProperty("providerIconDomain");
+  });
+
+  it("uses a shared active protocol icon for grouped output", () => {
+    dependencies.players.office.active_output_protocol = "airplay-office";
+    dependencies.players.office.output_protocols = [
+      {
+        output_protocol_id: "airplay-office",
+        is_native: false,
+        protocol_domain: "airplay",
+      },
+    ];
+    let destination = buildDisplay({
+      outputs: [
+        {
+          player_ids: ["kitchen", "office"],
+          output_format: makeFormat(),
+        },
+      ],
+    }).outputPaths[0].destination;
+    expect(destination).toMatchObject({ providerIconDomain: "airplay" });
+
+    dependencies.players.office.output_protocols[0].protocol_domain =
+      "snapcast";
+    destination = buildDisplay({
+      outputs: [
+        {
+          player_ids: ["kitchen", "office"],
+          output_format: makeFormat(),
+        },
+      ],
+    }).outputPaths[0].destination;
+    expect(destination).toHaveProperty("icon");
+    expect(destination).not.toHaveProperty("providerIconDomain");
+  });
+
   it("distinguishes direct paths from floating-point headroom", () => {
     const sourceFormat = makeFormat({
       sample_rate: 44100,
@@ -329,12 +568,37 @@ describe("buildAudioProcessingDetailsDisplay", () => {
 
 function buildDisplay(chain: AudioProcessingChain, audioFormat = makeFormat()) {
   const streamDetails: StreamDetails = {
-    provider: "test",
+    provider: "test--instance",
     item_id: "track-1",
     audio_format: audioFormat,
     media_type: MediaType.TRACK,
   };
   return buildAudioProcessingDetailsDisplay(chain, streamDetails, dependencies);
+}
+
+function makePlayers(): AudioProcessingDetailsDependencies["players"] {
+  return {
+    kitchen: {
+      player_id: "kitchen",
+      name: "Kitchen",
+      provider: "sonos--main",
+      active_output_protocol: "airplay-kitchen",
+      output_protocols: [
+        {
+          output_protocol_id: "airplay-kitchen",
+          is_native: false,
+          protocol_domain: "airplay",
+        },
+      ],
+    },
+    office: {
+      player_id: "office",
+      name: "Office",
+      provider: "squeezelite--main",
+      active_output_protocol: null,
+      output_protocols: [],
+    },
+  };
 }
 
 function makeFormat(overrides: Partial<AudioFormat> = {}): AudioFormat {

--- a/tests/composables/useAudioProcessingDetails.test.ts
+++ b/tests/composables/useAudioProcessingDetails.test.ts
@@ -1,4 +1,5 @@
 import { mount } from "@vue/test-utils";
+import { File as FileIcon } from "@lucide/vue";
 import { defineComponent, h, nextTick, ref } from "vue";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
@@ -63,7 +64,7 @@ describe("buildAudioProcessingDetailsDisplay", () => {
     });
     expect(display.inputStages[1]).toMatchObject({
       title: "FLAC",
-      icon: expect.any(Function),
+      icon: FileIcon,
     });
   });
 
@@ -85,8 +86,10 @@ describe("buildAudioProcessingDetailsDisplay", () => {
       format,
     );
 
-    expect(display.inputStages[1]).toHaveProperty("icon");
-    expect(display.outputPaths[0].stages.at(-1)).toHaveProperty("icon");
+    expect(display.inputStages[1]).toMatchObject({ icon: FileIcon });
+    expect(display.outputPaths[0].stages.at(-1)).toMatchObject({
+      icon: FileIcon,
+    });
   });
 
   it("uses the native player provider for direct output", () => {


### PR DESCRIPTION
The compact audio processing view lost useful provider and protocol identity.

- Restore readable source provider and actual output protocol icons
- Keep grouped, mixed, and missing destinations accurate without guessing IDs
- Use compact generic file icons for audio format stages