### PR TITLE
Remove output limiter from audio chain details

### DIFF
--- a/src/composables/useAudioProcessingDetails.ts
+++ b/src/composables/useAudioProcessingDetails.ts
@@ -343,13 +343,6 @@ function buildOutputDisplay(
       ]),
     });
   }
-  if (output.dsp?.output_limiter) {
-    stages.push({
-      key: `output-limiter-${index}`,
-      icon: Shield,
-      title: translate("streamdetails.output_limiter"),
-    });
-  }
   stages.push(finalOutputStage(output, index, translate, dependencies.locale));
 
   return {
@@ -757,9 +750,6 @@ function processingHeadroomReasons(
     if (!output.dsp) continue;
     if (hasActiveDSPTransform(output.dsp)) {
       reasons.add(translate("streamdetails.audio_processing.dsp_title"));
-    }
-    if (output.dsp.output_limiter) {
-      reasons.add(translate("streamdetails.output_limiter"));
     }
   }
   return [...reasons];

--- a/src/composables/useAudioProcessingDetails.ts
+++ b/src/composables/useAudioProcessingDetails.ts
@@ -5,7 +5,6 @@ import {
   File as FileIcon,
   FileAudio,
   Gauge,
-  Shield,
   SlidersHorizontal,
   Speaker,
   Split,

--- a/src/plugins/api/interfaces.ts
+++ b/src/plugins/api/interfaces.ts
@@ -887,7 +887,6 @@ export interface AudioDSPDetails {
   input_gain?: number;
   filters?: DSPFilter[];
   output_gain?: number;
-  output_limiter?: boolean;
   preset_id?: string | null;
 }
 

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -777,7 +777,6 @@
         "eq_band_count_singular": "1 band",
         "input_gain": "Input Gain ({0} dB)",
         "output_gain": "Output Gain ({0} dB)",
-        "output_limiter": "Output Limiter",
         "file_info": {
             "container": "Container: {0}",
             "codec": "Codec: {0}",

--- a/tests/components/AudioProcessingDetails.test.ts
+++ b/tests/components/AudioProcessingDetails.test.ts
@@ -143,7 +143,6 @@ describe("AudioProcessingDetails", () => {
         "dsp-filter-0-1",
         "dsp-filter-0-2",
         "dsp-output-gain-0",
-        "output-limiter-0",
         "output-format-0",
         "source-channel-0",
       ]),
@@ -175,7 +174,7 @@ describe("AudioProcessingDetails", () => {
       "32-bit float PCM",
     );
     expect(headroom.findAll("li").map((detail) => detail.text())).toContain(
-      "Floating-point headroom is available for: Volume normalization, Playback speed, Crossfade, Audio overlay, DSP, Output Limiter.",
+      "Floating-point headroom is available for: Volume normalization, Playback speed, Crossfade, Audio overlay, DSP.",
     );
     expect(
       wrapper
@@ -191,7 +190,6 @@ describe("AudioProcessingDetails", () => {
       "dsp-filter-0-2",
       "dsp-output-gain-0",
       "source-channel-0",
-      "output-limiter-0",
       "output-format-0",
       "destination",
     ]);
@@ -219,7 +217,6 @@ describe("AudioProcessingDetails", () => {
     expect(text).toContain("Gain");
     expect(text).toContain("Balance");
     expect(text).toContain("Source channel: Left");
-    expect(text).toContain("Output Limiter");
     expect(text).toContain("Lossless");
     expect(
       wrapper
@@ -677,7 +674,7 @@ describe("AudioProcessingDetails", () => {
     ).toBe("DSP unavailable for this group");
   });
 
-  it("hides disabled DSP while retaining limiter headroom context", () => {
+  it("hides disabled DSP and reports no headroom consumers", () => {
     const sourceFormat = makeFormat({
       sample_rate: 48000,
       bit_depth: 16,
@@ -697,7 +694,6 @@ describe("AudioProcessingDetails", () => {
             player_ids: ["player-1"],
             dsp: {
               state: DSPState.DISABLED,
-              output_limiter: true,
             },
             output_format: sourceFormat,
           },
@@ -707,13 +703,14 @@ describe("AudioProcessingDetails", () => {
     );
 
     expect(wrapper.find('[data-stage="dsp-state-0"]').exists()).toBe(false);
-    expect(wrapper.find('[data-stage="output-limiter-0"]').exists()).toBe(true);
     expect(
       wrapper
         .find('[data-stage="pcm-format"]')
         .findAll("li")
         .map((detail) => detail.text()),
-    ).toContain("Floating-point headroom is available for: Output Limiter.");
+    ).not.toContainEqual(
+      expect.stringContaining("Floating-point headroom is available for"),
+    );
   });
 
   it("keeps missing destination IDs visible in the grouped detail list", () => {
@@ -964,7 +961,6 @@ function makeFullChain(): AudioProcessingChain {
             },
           ],
           output_gain: 2,
-          output_limiter: true,
         },
         source_channel: AudioChannel.FL,
         output_format: makeFormat({


### PR DESCRIPTION
The output limiter is being removed from the player and replaced by a DSP filter.

Backend PR: https://github.com/music-assistant/server/pull/4901