### PR TITLE
Load provider icons on demand via the providers/icon command

### DIFF
--- a/src/components/ProviderIcon.vue
+++ b/src/components/ProviderIcon.vue
@@ -46,15 +46,9 @@ const providerName = computed(() => manifest.value?.name ?? "");
 // pick the best available variant for the current theme + monochrome request
 const variant = computed<ProviderIconVariant | undefined>(() => {
   const available = manifest.value?.icon_images ?? [];
-  if (
-    props.monochrome &&
-    available.includes(ProviderIconVariant.MONOCHROME)
-  )
+  if (props.monochrome && available.includes(ProviderIconVariant.MONOCHROME))
     return ProviderIconVariant.MONOCHROME;
-  if (
-    theme.current.value.dark &&
-    available.includes(ProviderIconVariant.DARK)
-  )
+  if (theme.current.value.dark && available.includes(ProviderIconVariant.DARK))
     return ProviderIconVariant.DARK;
   if (available.includes(ProviderIconVariant.DEFAULT))
     return ProviderIconVariant.DEFAULT;

--- a/src/components/ProviderIcon.vue
+++ b/src/components/ProviderIcon.vue
@@ -1,83 +1,24 @@
 <template>
-  <!-- eslint-disable vue/no-v-html -->
-  <!-- eslint-disable vue/no-v-text-v-html-on-component -->
   <div
     :style="`width:${size}px;margin-left:10px;margin-right:10px;content-align:center`"
   >
-    <!-- icon for library-->
-    <v-icon
-      v-if="domain && domain == 'library'"
-      :size="size"
-      icon="mdi-bookshelf"
-      :title="$t('item_in_library')"
-    />
-    <!-- monochrome icon-->
+    <!-- provider image (svg or png) served as data uri; blank when no variant exists -->
     <div
-      v-else-if="
-        props.monochrome &&
-        providerDomain &&
-        api.providerManifests[providerDomain].icon_svg_monochrome
-      "
+      v-if="iconDataUri"
       class="d-flex align-center justify-center align-content-center justify-content-center"
-      :style="`width: ${size}px;height: ${size}px;${$vuetify.theme.current.dark ? '' : 'filter: invert(1);'}`"
-      :title="api.providerManifests[providerDomain]!.name"
+      :style="`width: ${size}px;height: ${size}px;${applyInvert ? 'filter: invert(1);' : ''}`"
+      :title="providerName"
     >
-      <div
-        class="svg-wrapper"
-        v-html="api.providerManifests[providerDomain].icon_svg_monochrome"
-      ></div>
+      <img class="provider-img" :src="iconDataUri" :alt="providerName" />
     </div>
-    <!-- dark mode and dark svg icon-->
-    <div
-      v-else-if="
-        $vuetify.theme.current.dark &&
-        providerDomain &&
-        api.providerManifests[providerDomain].icon_svg_dark
-      "
-      class="d-flex align-center justify-center align-content-center justify-content-center"
-      :style="`width: ${size}px;height: ${size}px;`"
-      :title="api.providerManifests[providerDomain]!.name"
-    >
-      <div
-        class="svg-wrapper"
-        v-html="api.providerManifests[providerDomain].icon_svg_dark"
-      ></div>
-    </div>
-    <!-- regular svg icon -->
-    <div
-      v-else-if="
-        providerDomain && api.providerManifests[providerDomain].icon_svg
-      "
-      class="d-flex align-center justify-center align-content-center justify-content-center"
-      :style="`width: ${size}px;height: ${size}px;`"
-      :title="api.providerManifests[providerDomain]!.name"
-    >
-      <div
-        class="svg-wrapper"
-        v-html="api.providerManifests[providerDomain].icon_svg"
-      ></div>
-    </div>
-    <!-- material design icon -->
-    <v-icon
-      v-else-if="providerDomain && api.providerManifests[providerDomain].icon"
-      :size="size"
-      :icon="'mdi-' + api.providerManifests[providerDomain]!.icon"
-      :title="api.providerManifests[providerDomain]!.name"
-      :dark="$vuetify.theme.current.dark"
-    />
-    <!-- fallback icon -->
-    <v-icon
-      v-else
-      :size="size"
-      :dark="$vuetify.theme.current.dark"
-      icon="mdi-playlist-play"
-    />
   </div>
 </template>
 
 <script setup lang="ts">
-import { computed } from "vue";
+import { computed, ref, watchEffect } from "vue";
+import { useTheme } from "vuetify";
 import { api } from "@/plugins/api";
+import { ProviderIconVariant } from "@/plugins/api/interfaces";
 
 export interface Props {
   domain: string;
@@ -86,6 +27,7 @@ export interface Props {
   monochrome?: boolean;
 }
 const props = defineProps<Props>();
+const theme = useTheme();
 
 const providerDomain = computed(() => {
   // handle case where provider domain is provided as instance id.
@@ -93,9 +35,53 @@ const providerDomain = computed(() => {
   if (props.domain in api.providerManifests) return props.domain;
   return undefined;
 });
+
+const manifest = computed(() =>
+  providerDomain.value
+    ? api.providerManifests[providerDomain.value]
+    : undefined,
+);
+const providerName = computed(() => manifest.value?.name ?? "");
+
+// pick the best available variant for the current theme + monochrome request
+const variant = computed<ProviderIconVariant | undefined>(() => {
+  const available = manifest.value?.icon_images ?? [];
+  if (
+    props.monochrome &&
+    available.includes(ProviderIconVariant.MONOCHROME)
+  )
+    return ProviderIconVariant.MONOCHROME;
+  if (
+    theme.current.value.dark &&
+    available.includes(ProviderIconVariant.DARK)
+  )
+    return ProviderIconVariant.DARK;
+  if (available.includes(ProviderIconVariant.DEFAULT))
+    return ProviderIconVariant.DEFAULT;
+  return undefined;
+});
+
+// invert a monochrome icon in light mode (matches previous behaviour)
+const applyInvert = computed(
+  () =>
+    variant.value === ProviderIconVariant.MONOCHROME &&
+    !theme.current.value.dark,
+);
+
+const iconDataUri = ref<string | null>(null);
+watchEffect(async () => {
+  const dom = providerDomain.value;
+  const v = variant.value;
+  if (!dom || !v) {
+    iconDataUri.value = null;
+    return;
+  }
+  iconDataUri.value = await api.getProviderIcon(dom, v);
+});
 </script>
+
 <style>
-.svg-wrapper svg {
+.provider-img {
   width: 100%;
   height: 100%;
   display: block;

--- a/src/plugins/api/getProviderIcon.test.ts
+++ b/src/plugins/api/getProviderIcon.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { api } from "./index";
+import { ProviderIconVariant } from "./interfaces";
+
+describe("getProviderIcon", () => {
+  beforeEach(() => {
+    // reset cache between tests
+    Object.keys(api.providerIcons).forEach(
+      (k) => delete api.providerIcons[k],
+    );
+  });
+
+  afterEach(() => {
+    // restore spies so call counts don't accumulate across tests
+    vi.restoreAllMocks();
+  });
+
+  it("fetches, returns and caches a data uri", async () => {
+    const spy = vi
+      .spyOn(api, "sendCommand")
+      .mockResolvedValue("data:image/svg+xml;base64,PHN2Zy8+");
+    const first = await api.getProviderIcon(
+      "spotify",
+      ProviderIconVariant.DEFAULT,
+    );
+    const second = await api.getProviderIcon(
+      "spotify",
+      ProviderIconVariant.DEFAULT,
+    );
+    expect(first).toBe("data:image/svg+xml;base64,PHN2Zy8+");
+    expect(second).toBe(first);
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(spy).toHaveBeenCalledWith("providers/icon", {
+      provider: "spotify",
+      variant: ProviderIconVariant.DEFAULT,
+    });
+  });
+
+  it("dedups concurrent requests for the same key", async () => {
+    const spy = vi
+      .spyOn(api, "sendCommand")
+      .mockResolvedValue("data:image/png;base64,AAAA");
+    const [a, b] = await Promise.all([
+      api.getProviderIcon("tidal", ProviderIconVariant.DARK),
+      api.getProviderIcon("tidal", ProviderIconVariant.DARK),
+    ]);
+    expect(a).toBe(b);
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+
+  it("caches null for a missing icon", async () => {
+    const spy = vi.spyOn(api, "sendCommand").mockResolvedValue(null);
+    const first = await api.getProviderIcon(
+      "gone",
+      ProviderIconVariant.DEFAULT,
+    );
+    const second = await api.getProviderIcon(
+      "gone",
+      ProviderIconVariant.DEFAULT,
+    );
+    expect(first).toBeNull();
+    expect(second).toBeNull();
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/plugins/api/getProviderIcon.test.ts
+++ b/src/plugins/api/getProviderIcon.test.ts
@@ -5,9 +5,7 @@ import { ProviderIconVariant } from "./interfaces";
 describe("getProviderIcon", () => {
   beforeEach(() => {
     // reset cache between tests
-    Object.keys(api.providerIcons).forEach(
-      (k) => delete api.providerIcons[k],
-    );
+    Object.keys(api.providerIcons).forEach((k) => delete api.providerIcons[k]);
   });
 
   afterEach(() => {

--- a/src/plugins/api/index.ts
+++ b/src/plugins/api/index.ts
@@ -47,6 +47,7 @@ import {
   Podcast,
   PodcastEpisode,
   ProviderConfig,
+  ProviderIconVariant,
   ProviderManifest,
   ProviderType,
   QueueOption,
@@ -96,6 +97,8 @@ export class MusicAssistantApi {
   public providerManifests = reactive<{ [domain: string]: ProviderManifest }>(
     {},
   );
+  public providerIcons = reactive<{ [key: string]: string | null }>({});
+  private _providerIconRequests = new Map<string, Promise<string | null>>();
   public hasStreamingProviders = computed(() => {
     return Object.values(this.providers).some((p) => p.is_streaming_provider);
   });
@@ -397,6 +400,10 @@ export class MusicAssistantApi {
     Object.keys(this.providerManifests).forEach(
       (key) => delete this.providerManifests[key],
     );
+    Object.keys(this.providerIcons).forEach(
+      (key) => delete this.providerIcons[key],
+    );
+    this._providerIconRequests.clear();
     this.serverInfo.value = undefined;
   }
 
@@ -2382,6 +2389,30 @@ export class MusicAssistantApi {
       return this.providerManifests[prov.domain];
     }
     return undefined;
+  }
+
+  public async getProviderIcon(
+    domain: string,
+    variant: ProviderIconVariant,
+  ): Promise<string | null> {
+    const key = `${domain}:${variant}`;
+    if (key in this.providerIcons) return this.providerIcons[key];
+    let request = this._providerIconRequests.get(key);
+    if (!request) {
+      request = this.sendCommand<string | null>("providers/icon", {
+        provider: domain,
+        variant,
+      })
+        .then((dataUri) => {
+          this.providerIcons[key] = dataUri ?? null;
+          return this.providerIcons[key];
+        })
+        .finally(() => {
+          this._providerIconRequests.delete(key);
+        });
+      this._providerIconRequests.set(key, request);
+    }
+    return request;
   }
 
   private handleEventMessage(msg: EventMessage) {

--- a/src/plugins/api/interfaces.ts
+++ b/src/plugins/api/interfaces.ts
@@ -1154,6 +1154,12 @@ export interface Player {
 
 // provider
 
+export enum ProviderIconVariant {
+  DEFAULT = "default",
+  DARK = "dark",
+  MONOCHROME = "monochrome",
+}
+
 export interface ProviderManifest {
   // ProviderManifest, details of a provider.
   type: ProviderType;
@@ -1174,12 +1180,9 @@ export interface ProviderManifest {
   stage: ProviderStage;
   // icon: material design icon
   icon?: string;
-  // icon_svg: svg icon (full xml string)
-  icon_svg?: string;
-  // icon_svg_dark: optional separate dark svg icon (full xml string)
-  icon_svg_dark?: string;
-  // icon_svg_dark: optional separate monochrome svg icon (full xml string)
-  icon_svg_monochrome?: string;
+  // icon_images: which icon variants this provider supplies as image files.
+  // Fetch the bytes via api.getProviderIcon(domain, variant).
+  icon_images: ProviderIconVariant[];
   // depends on: domain of another provider that is required for this provider
   depends_on?: string;
 }

--- a/src/plugins/api/interfaces.ts
+++ b/src/plugins/api/interfaces.ts
@@ -1181,7 +1181,6 @@ export interface ProviderManifest {
   // icon: material design icon
   icon?: string;
   // icon_images: which icon variants this provider supplies as image files.
-  // Fetch the bytes via api.getProviderIcon(domain, variant).
   icon_images: ProviderIconVariant[];
   // depends on: domain of another provider that is required for this provider
   depends_on?: string;


### PR DESCRIPTION
## Problem

Provider icons were inlined in the `providers/manifests` payload (~1.6MB) and rendered with `v-html`. The oversized payload slows down and can crash the WebRTC connection.

## Changes

- Fetch each provider icon lazily via the new `providers/icon` API command, cached client-side (keyed `domain:variant`, with in-flight de-duplication).
- `ProviderIcon` renders `<img src="data:…">` instead of `v-html`, selecting the best available variant (`monochrome`/`dark`/`default`) from `icon_images`.
- Drop the removed `icon_svg*` fields and the mdi/fallback rendering; when a provider ships no image it renders blank.
- Add `ProviderIconVariant` and `icon_images` to the API types.

Companion PRs: music-assistant/server#4907 and music-assistant/models#322.

Known follow-up: the "in library" marker (`domain="library"`) has no image and renders blank.
