### PR TITLE
Party: return in-library tracks when a guest drills into an artist

### DIFF
--- a/src/composables/useGuestArtistTracks.ts
+++ b/src/composables/useGuestArtistTracks.ts
@@ -26,15 +26,8 @@ export function useGuestArtistTracks() {
     artistTracks.value = [];
 
     try {
-      const providerMapping = artist.provider_mappings?.[0];
-      if (!providerMapping) {
-        throw new Error("No provider mapping found for artist");
-      }
-
-      const tracks = await api.getArtistTracks(
-        providerMapping.item_id,
-        providerMapping.provider_instance,
-      );
+      // Use the artist's own identity so a library artist returns its in-library tracks.
+      const tracks = await api.getArtistTracks(artist.item_id, artist.provider);
       if (currentRequestId !== requestId) return;
       artistTracks.value = tracks;
     } catch (error) {

--- a/tests/composables/useGuestArtistTracks.test.ts
+++ b/tests/composables/useGuestArtistTracks.test.ts
@@ -40,8 +40,10 @@ describe("useGuestArtistTracks", () => {
       useGuestArtistTracks();
 
     const artist = {
+      item_id: "artist-id",
+      provider: "library",
       provider_mappings: [
-        { item_id: "artist-id", provider_instance: "provider-1" },
+        { item_id: "mapping-id", provider_instance: "provider-1" },
       ],
     } as unknown as Artist;
 
@@ -49,7 +51,7 @@ describe("useGuestArtistTracks", () => {
 
     expect(loadingArtistTracks.value).toBe(false);
     expect(selectedArtist.value).toStrictEqual(artist);
-    expect(mockGetArtistTracks).toHaveBeenCalledWith("artist-id", "provider-1");
+    expect(mockGetArtistTracks).toHaveBeenCalledWith("artist-id", "library");
     expect(artistTracks.value).toEqual(tracks);
   });
 


### PR DESCRIPTION
This issue was auto-triaged.

When a guest picks an artist in the party guest page, the drill-down showed "No tracks found for this artist" even though the artist had tracks in the library.

The drill-down queried `provider_mappings[0]`, which for a library artist points at an arbitrary music provider. When that provider doesn't support artist-tracks (e.g. the Filesystem/local-disk provider, which supports neither `ARTIST_TRACKS` nor `ARTIST_ALBUMS`), the server returns an empty list, so the guest sees an empty result. This is resolved by querying the artist's own identity instead: a library artist returns its in-library tracks, and a provider artist returns that provider's tracks.

Reproduced with a disposable server + local filesystem library: the old path (`provider_mappings[0]`) returned 0 tracks while the artist's own identity (`item_id` + `library`) returned all 4 library tracks. The reporter's log confirms the same cause — `Provider Filesystem (local disk) does not support fetching all artist albums` fired the moment the guest opened the artist.

Fixes music-assistant/support#5898

## Changes
- Resolve guest artist-track drill-down via the artist's own `item_id`/`provider` instead of `provider_mappings[0]`.