### PR TITLE
Skeleton placeholders for loading and hidden Discover rows

### DIFF
--- a/src/components/HomeWidgetRows.vue
+++ b/src/components/HomeWidgetRows.vue
@@ -196,15 +196,14 @@
                 <EyeOff v-else />
               </Button>
             </template>
-            <!-- Spinner only while a fetch is genuinely in flight. A hidden row
-                 (edit mode) is never fetched until unhidden, so it renders just
-                 its shell rather than spinning forever. -->
-            <template
-              v-if="rowItemsMap.get(row.id) === undefined && !row.hidden"
-            >
-              <div class="ed-row-loading">
-                <v-progress-circular indeterminate size="24" />
-              </div>
+            <!-- Skeleton tiles while a fetch is in flight - and for hidden rows
+                 in edit mode (never fetched until unhidden) - so every row
+                 reserves its final height and nothing shifts as items land. -->
+            <template v-if="rowItemsMap.get(row.id) === undefined">
+              <EditorialCardSkeleton
+                v-for="n in skeletonTileCount"
+                :key="`skeleton-${n}`"
+              />
             </template>
             <template v-else>
               <EditorialMediaCard
@@ -271,6 +270,7 @@
 </template>
 
 <script setup lang="ts">
+import EditorialCardSkeleton from "@/components/discover/EditorialCardSkeleton.vue";
 import EditorialGenreTile from "@/components/discover/EditorialGenreTile.vue";
 import EditorialHeroCard from "@/components/discover/EditorialHeroCard.vue";
 import EditorialMediaCard from "@/components/discover/EditorialMediaCard.vue";
@@ -343,6 +343,11 @@ const tilesPerView = computed(() => {
   const isPhone = getBreakpointValue({ breakpoint: "bp1", condition: "lt" });
   return isPhone ? 2.2 : panelViewItemResponsive(0) + 0.5;
 });
+
+// One skeleton per (partially) visible tile while a row's items load.
+const skeletonTileCount = computed(() =>
+  Math.max(2, Math.ceil(tilesPerView.value)),
+);
 
 const players = useOrderedPlayers();
 
@@ -829,11 +834,6 @@ onBeforeUnmount(() => {
   display: flex;
   justify-content: center;
   padding: 80px 0;
-}
-.ed-row-loading {
-  display: flex;
-  align-items: center;
-  padding: 24px 28px;
 }
 .ed-section {
   margin-bottom: 32px;

--- a/src/components/discover/EditorialCardSkeleton.vue
+++ b/src/components/discover/EditorialCardSkeleton.vue
@@ -1,0 +1,48 @@
+<template>
+  <div class="ed-card-skeleton" aria-hidden="true">
+    <Skeleton class="ed-card-skeleton__art" />
+    <Skeleton class="ed-card-skeleton__title" />
+    <Skeleton class="ed-card-skeleton__sub" />
+  </div>
+</template>
+
+<script setup lang="ts">
+import { Skeleton } from "@/components/ui/skeleton";
+</script>
+
+<style scoped>
+/* Mirrors .ed-card's sizing (EditorialMediaCard.vue) so a loading row reserves
+   exactly the height its resolved cards will occupy - no layout shift. */
+.ed-card-skeleton {
+  --ed-card-pad: 8px;
+  --ed-art-size: var(--ed-tile-art, 168px);
+  flex: 0 0 auto;
+  width: calc(var(--ed-art-size) + 2 * var(--ed-card-pad));
+  box-sizing: border-box;
+  padding: var(--ed-card-pad);
+}
+.ed-card-skeleton__art {
+  width: var(--ed-art-size);
+  height: var(--ed-art-size);
+  border-radius: var(--ed-card-pad);
+}
+.ed-card-skeleton__title {
+  width: 70%;
+  height: 16px;
+  margin-top: 13px;
+}
+.ed-card-skeleton__sub {
+  width: 45%;
+  height: 14px;
+  margin-top: 6px;
+}
+
+@media (max-width: 500px) {
+  .ed-card-skeleton {
+    --ed-card-pad: 4px;
+  }
+  .ed-card-skeleton__title {
+    margin-top: 7px;
+  }
+}
+</style>


### PR DESCRIPTION
Recommendation rows on the Discover page now show skeleton tiles (sized exactly like the real cards, one per visible tile) while their items load, so the page keeps its final layout instead of shifting as rows resolve one by one. Hidden rows in edit mode render the same dimmed skeleton shells instead of a bare header, as placeholders for what toggling them on will show.

Follow-up to #2141.