### PR TITLE
Remote access: reassemble chunked HTTP-proxy responses

### DIFF
--- a/src/plugins/remote/webrtc-transport.ts
+++ b/src/plugins/remote/webrtc-transport.ts
@@ -295,7 +295,11 @@ export class WebRTCTransport extends BaseTransport {
   }): void {
     let pending = this.chunkGroups.get(frame.id);
     if (!pending) {
-      pending = { count: frame.count, parts: new Array<string>(frame.count), received: 0 };
+      pending = {
+        count: frame.count,
+        parts: Array.from<string>({ length: frame.count }),
+        received: 0,
+      };
       this.chunkGroups.set(frame.id, pending);
     }
     if (pending.parts[frame.seq] === undefined) {

--- a/src/plugins/remote/webrtc-transport.ts
+++ b/src/plugins/remote/webrtc-transport.ts
@@ -73,16 +73,10 @@ export class WebRTCTransport extends BaseTransport {
       reject: (error: Error) => void;
     }
   >();
-  // Reassembly buffers for chunked HTTP proxy responses, keyed by request id.
-  private chunkedResponses = new Map<
-    string,
-    {
-      status: number;
-      headers: Record<string, string>;
-      chunks: number;
-      parts: string[];
-      received: number;
-    }
+  // Reassembly buffers for oversized messages the server splits into chunks, keyed by group id.
+  private chunkGroups = new Map<
+    number,
+    { count: number; parts: string[]; received: number }
   >();
   // ICE servers received from the signaling server (provided by MA server)
   private iceServers: IceServerConfig[] = [];
@@ -262,27 +256,74 @@ export class WebRTCTransport extends BaseTransport {
     };
 
     this.dataChannel.onmessage = (event) => {
-      // Check if this is an HTTP proxy response
-      try {
-        const data = JSON.parse(event.data);
-        if (data.type === "http-proxy-response") {
-          this.handleHttpProxyResponse(data);
-          return;
+      // The server splits oversized messages into "__chunk__" frames (see gateway
+      // _send_ma_api); reassemble them before dispatching. Everything else is a whole message.
+      if (typeof event.data === "string") {
+        try {
+          const frame = JSON.parse(event.data);
+          if (frame.type === "__chunk__") {
+            this.handleChunk(frame);
+            return;
+          }
+        } catch {
+          // not a JSON chunk frame; fall through to normal dispatch
         }
-        if (data.type === "http-proxy-response-start") {
-          this.handleHttpProxyResponseStart(data);
-          return;
-        }
-        if (data.type === "http-proxy-response-chunk") {
-          this.handleHttpProxyResponseChunk(data);
-          return;
-        }
-      } catch {
-        // Not JSON or not HTTP proxy response, treat as normal message
       }
-
-      this.emit("message", event.data);
+      this.dispatchMessage(event.data);
     };
+  }
+
+  private dispatchMessage(data: string): void {
+    // HTTP-proxy responses are consumed here; anything else is a normal API message.
+    try {
+      const parsed = JSON.parse(data);
+      if (parsed.type === "http-proxy-response") {
+        this.handleHttpProxyResponse(parsed);
+        return;
+      }
+    } catch {
+      // not JSON or not an HTTP proxy response
+    }
+    this.emit("message", data);
+  }
+
+  private handleChunk(frame: {
+    id: number;
+    seq: number;
+    count: number;
+    b64: string;
+  }): void {
+    let pending = this.chunkGroups.get(frame.id);
+    if (!pending) {
+      pending = { count: frame.count, parts: new Array<string>(frame.count), received: 0 };
+      this.chunkGroups.set(frame.id, pending);
+    }
+    if (pending.parts[frame.seq] === undefined) {
+      pending.received++;
+    }
+    pending.parts[frame.seq] = frame.b64;
+    if (pending.received < pending.count) return;
+
+    this.chunkGroups.delete(frame.id);
+    const bytes = this.base64PartsToBytes(pending.parts);
+    this.dispatchMessage(new TextDecoder().decode(bytes));
+  }
+
+  private base64PartsToBytes(parts: string[]): Uint8Array {
+    const chunks = parts.map((b64) => {
+      const binary = atob(b64);
+      const arr = new Uint8Array(binary.length);
+      for (let i = 0; i < binary.length; i++) arr[i] = binary.charCodeAt(i);
+      return arr;
+    });
+    const total = chunks.reduce((n, c) => n + c.length, 0);
+    const out = new Uint8Array(total);
+    let offset = 0;
+    for (const c of chunks) {
+      out.set(c, offset);
+      offset += c.length;
+    }
+    return out;
   }
 
   private async handleAnswer(answer: RTCSessionDescriptionInit): Promise<void> {
@@ -435,7 +476,6 @@ export class WebRTCTransport extends BaseTransport {
       setTimeout(() => {
         if (this.httpProxyCallbacks.has(requestId)) {
           this.httpProxyCallbacks.delete(requestId);
-          this.chunkedResponses.delete(requestId);
           reject(new Error("HTTP proxy request timeout"));
         }
       }, 30000);
@@ -487,52 +527,6 @@ export class WebRTCTransport extends BaseTransport {
         );
       }
     }
-  }
-
-  /**
-   * Begin buffering a chunked HTTP proxy response.
-   */
-  private handleHttpProxyResponseStart(data: {
-    id: string;
-    status: number;
-    headers: Record<string, string>;
-    chunks: number;
-  }): void {
-    this.chunkedResponses.set(data.id, {
-      status: data.status,
-      headers: data.headers,
-      chunks: data.chunks,
-      parts: new Array<string>(data.chunks),
-      received: 0,
-    });
-  }
-
-  /**
-   * Store one chunk of a chunked HTTP proxy response and, once all chunks have
-   * arrived, reassemble the body and resolve the pending request.
-   */
-  private handleHttpProxyResponseChunk(data: {
-    id: string;
-    index: number;
-    body: string;
-  }): void {
-    const pending = this.chunkedResponses.get(data.id);
-    if (!pending) return;
-
-    if (pending.parts[data.index] === undefined) {
-      pending.received++;
-    }
-    pending.parts[data.index] = data.body;
-
-    if (pending.received < pending.chunks) return;
-
-    this.chunkedResponses.delete(data.id);
-    this.handleHttpProxyResponse({
-      id: data.id,
-      status: pending.status,
-      headers: pending.headers,
-      body: pending.parts.join(""),
-    });
   }
 
   /**
@@ -650,7 +644,7 @@ export class WebRTCTransport extends BaseTransport {
       callbacks.reject(new Error("Transport closed"));
     }
     this.httpProxyCallbacks.clear();
-    this.chunkedResponses.clear();
+    this.chunkGroups.clear();
   }
 
   /**

--- a/src/plugins/remote/webrtc-transport.ts
+++ b/src/plugins/remote/webrtc-transport.ts
@@ -73,6 +73,17 @@ export class WebRTCTransport extends BaseTransport {
       reject: (error: Error) => void;
     }
   >();
+  // Reassembly buffers for chunked HTTP proxy responses, keyed by request id.
+  private chunkedResponses = new Map<
+    string,
+    {
+      status: number;
+      headers: Record<string, string>;
+      chunks: number;
+      parts: string[];
+      received: number;
+    }
+  >();
   // ICE servers received from the signaling server (provided by MA server)
   private iceServers: IceServerConfig[] = [];
 
@@ -258,6 +269,14 @@ export class WebRTCTransport extends BaseTransport {
           this.handleHttpProxyResponse(data);
           return;
         }
+        if (data.type === "http-proxy-response-start") {
+          this.handleHttpProxyResponseStart(data);
+          return;
+        }
+        if (data.type === "http-proxy-response-chunk") {
+          this.handleHttpProxyResponseChunk(data);
+          return;
+        }
       } catch {
         // Not JSON or not HTTP proxy response, treat as normal message
       }
@@ -416,6 +435,7 @@ export class WebRTCTransport extends BaseTransport {
       setTimeout(() => {
         if (this.httpProxyCallbacks.has(requestId)) {
           this.httpProxyCallbacks.delete(requestId);
+          this.chunkedResponses.delete(requestId);
           reject(new Error("HTTP proxy request timeout"));
         }
       }, 30000);
@@ -467,6 +487,52 @@ export class WebRTCTransport extends BaseTransport {
         );
       }
     }
+  }
+
+  /**
+   * Begin buffering a chunked HTTP proxy response.
+   */
+  private handleHttpProxyResponseStart(data: {
+    id: string;
+    status: number;
+    headers: Record<string, string>;
+    chunks: number;
+  }): void {
+    this.chunkedResponses.set(data.id, {
+      status: data.status,
+      headers: data.headers,
+      chunks: data.chunks,
+      parts: new Array<string>(data.chunks),
+      received: 0,
+    });
+  }
+
+  /**
+   * Store one chunk of a chunked HTTP proxy response and, once all chunks have
+   * arrived, reassemble the body and resolve the pending request.
+   */
+  private handleHttpProxyResponseChunk(data: {
+    id: string;
+    index: number;
+    body: string;
+  }): void {
+    const pending = this.chunkedResponses.get(data.id);
+    if (!pending) return;
+
+    if (pending.parts[data.index] === undefined) {
+      pending.received++;
+    }
+    pending.parts[data.index] = data.body;
+
+    if (pending.received < pending.chunks) return;
+
+    this.chunkedResponses.delete(data.id);
+    this.handleHttpProxyResponse({
+      id: data.id,
+      status: pending.status,
+      headers: pending.headers,
+      body: pending.parts.join(""),
+    });
   }
 
   /**
@@ -584,6 +650,7 @@ export class WebRTCTransport extends BaseTransport {
       callbacks.reject(new Error("Transport closed"));
     }
     this.httpProxyCallbacks.clear();
+    this.chunkedResponses.clear();
   }
 
   /**

--- a/tests/plugins/webrtc-transport-chunking.test.ts
+++ b/tests/plugins/webrtc-transport-chunking.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it } from "vitest";
+
+import { WebRTCTransport } from "../../src/plugins/remote/webrtc-transport";
+
+type ProxyResult = {
+  status: number;
+  headers: Record<string, string>;
+  body: Uint8Array;
+};
+
+// The chunk-reassembly logic lives on private methods; a thin cast keeps the test
+// focused on behaviour without exposing internals on the public API.
+type TransportInternals = {
+  httpProxyCallbacks: Map<
+    string,
+    { resolve: (value: ProxyResult) => void; reject: (error: Error) => void }
+  >;
+  handleHttpProxyResponse: (data: {
+    id: string;
+    status: number;
+    headers: Record<string, string>;
+    body: string;
+  }) => void;
+  handleHttpProxyResponseStart: (data: {
+    id: string;
+    status: number;
+    headers: Record<string, string>;
+    chunks: number;
+  }) => void;
+  handleHttpProxyResponseChunk: (data: {
+    id: string;
+    index: number;
+    body: string;
+  }) => void;
+};
+
+function makeTransport(): TransportInternals {
+  const transport = new WebRTCTransport({
+    signalingServerUrl: "wss://example.invalid/ws",
+    remoteId: "TEST-REMOTE-ID",
+  });
+  return transport as unknown as TransportInternals;
+}
+
+function pending(transport: TransportInternals, id: string): Promise<ProxyResult> {
+  return new Promise<ProxyResult>((resolve, reject) => {
+    transport.httpProxyCallbacks.set(id, { resolve, reject });
+  });
+}
+
+function toHex(bytes: number[]): string {
+  return bytes.map((b) => b.toString(16).padStart(2, "0")).join("");
+}
+
+describe("WebRTCTransport chunked http-proxy responses", () => {
+  it("resolves a legacy single-message response", async () => {
+    const transport = makeTransport();
+    const result = pending(transport, "req-legacy");
+
+    transport.handleHttpProxyResponse({
+      id: "req-legacy",
+      status: 200,
+      headers: { "content-type": "image/png" },
+      body: toHex([1, 2, 3, 4]),
+    });
+
+    const { status, headers, body } = await result;
+    expect(status).toBe(200);
+    expect(headers).toEqual({ "content-type": "image/png" });
+    expect(Array.from(body)).toEqual([1, 2, 3, 4]);
+  });
+
+  it("reassembles a chunked response into the original body", async () => {
+    const transport = makeTransport();
+    const result = pending(transport, "req-chunked");
+
+    transport.handleHttpProxyResponseStart({
+      id: "req-chunked",
+      status: 200,
+      headers: { "content-type": "image/jpeg" },
+      chunks: 3,
+    });
+    transport.handleHttpProxyResponseChunk({ id: "req-chunked", index: 0, body: toHex([10, 11]) });
+    transport.handleHttpProxyResponseChunk({ id: "req-chunked", index: 1, body: toHex([20, 21]) });
+    transport.handleHttpProxyResponseChunk({ id: "req-chunked", index: 2, body: toHex([30]) });
+
+    const { status, headers, body } = await result;
+    expect(status).toBe(200);
+    expect(headers).toEqual({ "content-type": "image/jpeg" });
+    expect(Array.from(body)).toEqual([10, 11, 20, 21, 30]);
+  });
+
+  it("reassembles correctly when chunks arrive out of order", async () => {
+    const transport = makeTransport();
+    const result = pending(transport, "req-ooo");
+
+    transport.handleHttpProxyResponseStart({
+      id: "req-ooo",
+      status: 200,
+      headers: {},
+      chunks: 3,
+    });
+    transport.handleHttpProxyResponseChunk({ id: "req-ooo", index: 2, body: toHex([3]) });
+    transport.handleHttpProxyResponseChunk({ id: "req-ooo", index: 0, body: toHex([1]) });
+    transport.handleHttpProxyResponseChunk({ id: "req-ooo", index: 1, body: toHex([2]) });
+
+    const { body } = await result;
+    expect(Array.from(body)).toEqual([1, 2, 3]);
+  });
+
+  it("ignores chunks for an unknown request id", () => {
+    const transport = makeTransport();
+    expect(() =>
+      transport.handleHttpProxyResponseChunk({ id: "nope", index: 0, body: toHex([1]) }),
+    ).not.toThrow();
+  });
+});

--- a/tests/plugins/webrtc-transport-chunking.test.ts
+++ b/tests/plugins/webrtc-transport-chunking.test.ts
@@ -16,7 +16,12 @@ type TransportInternals = {
     { resolve: (value: ProxyResult) => void; reject: (error: Error) => void }
   >;
   dispatchMessage: (data: string) => void;
-  handleChunk: (frame: { id: number; seq: number; count: number; b64: string }) => void;
+  handleChunk: (frame: {
+    id: number;
+    seq: number;
+    count: number;
+    b64: string;
+  }) => void;
   on: (event: string, cb: (...args: unknown[]) => void) => void;
 };
 
@@ -28,7 +33,10 @@ function makeTransport(): TransportInternals {
   return transport as unknown as TransportInternals;
 }
 
-function pending(transport: TransportInternals, id: string): Promise<ProxyResult> {
+function pending(
+  transport: TransportInternals,
+  id: string,
+): Promise<ProxyResult> {
   return new Promise<ProxyResult>((resolve, reject) => {
     transport.httpProxyCallbacks.set(id, { resolve, reject });
   });
@@ -42,7 +50,13 @@ function toHex(bytes: number[]): string {
 function makeChunks(text: string, id: number, pieceBytes = 8) {
   const bytes = new TextEncoder().encode(text);
   const count = Math.max(1, Math.ceil(bytes.length / pieceBytes));
-  const frames: { type: "__chunk__"; id: number; seq: number; count: number; b64: string }[] = [];
+  const frames: {
+    type: "__chunk__";
+    id: number;
+    seq: number;
+    count: number;
+    b64: string;
+  }[] = [];
   for (let seq = 0; seq < count; seq++) {
     const slice = bytes.slice(seq * pieceBytes, (seq + 1) * pieceBytes);
     let binary = "";
@@ -101,7 +115,8 @@ describe("WebRTCTransport chunk reassembly", () => {
       body: toHex([1, 2, 3, 4, 5, 6, 7, 8]),
     });
 
-    for (const frame of [...makeChunks(msg, 7)].reverse()) transport.handleChunk(frame);
+    for (const frame of [...makeChunks(msg, 7)].reverse())
+      transport.handleChunk(frame);
 
     const { body } = await result;
     expect(Array.from(body)).toEqual([1, 2, 3, 4, 5, 6, 7, 8]);

--- a/tests/plugins/webrtc-transport-chunking.test.ts
+++ b/tests/plugins/webrtc-transport-chunking.test.ts
@@ -8,30 +8,16 @@ type ProxyResult = {
   body: Uint8Array;
 };
 
-// The chunk-reassembly logic lives on private methods; a thin cast keeps the test
-// focused on behaviour without exposing internals on the public API.
+// The reassembly logic lives on private methods; a thin cast keeps the test focused on
+// behaviour without widening the public API.
 type TransportInternals = {
   httpProxyCallbacks: Map<
     string,
     { resolve: (value: ProxyResult) => void; reject: (error: Error) => void }
   >;
-  handleHttpProxyResponse: (data: {
-    id: string;
-    status: number;
-    headers: Record<string, string>;
-    body: string;
-  }) => void;
-  handleHttpProxyResponseStart: (data: {
-    id: string;
-    status: number;
-    headers: Record<string, string>;
-    chunks: number;
-  }) => void;
-  handleHttpProxyResponseChunk: (data: {
-    id: string;
-    index: number;
-    body: string;
-  }) => void;
+  dispatchMessage: (data: string) => void;
+  handleChunk: (frame: { id: number; seq: number; count: number; b64: string }) => void;
+  on: (event: string, cb: (...args: unknown[]) => void) => void;
 };
 
 function makeTransport(): TransportInternals {
@@ -52,17 +38,34 @@ function toHex(bytes: number[]): string {
   return bytes.map((b) => b.toString(16).padStart(2, "0")).join("");
 }
 
-describe("WebRTCTransport chunked http-proxy responses", () => {
-  it("resolves a legacy single-message response", async () => {
-    const transport = makeTransport();
-    const result = pending(transport, "req-legacy");
+// Build "__chunk__" frames exactly as the server does: UTF-8 bytes -> byte slices -> base64.
+function makeChunks(text: string, id: number, pieceBytes = 8) {
+  const bytes = new TextEncoder().encode(text);
+  const count = Math.max(1, Math.ceil(bytes.length / pieceBytes));
+  const frames: { type: "__chunk__"; id: number; seq: number; count: number; b64: string }[] = [];
+  for (let seq = 0; seq < count; seq++) {
+    const slice = bytes.slice(seq * pieceBytes, (seq + 1) * pieceBytes);
+    let binary = "";
+    slice.forEach((b) => (binary += String.fromCharCode(b)));
+    frames.push({ type: "__chunk__", id, seq, count, b64: btoa(binary) });
+  }
+  return frames;
+}
 
-    transport.handleHttpProxyResponse({
-      id: "req-legacy",
-      status: 200,
-      headers: { "content-type": "image/png" },
-      body: toHex([1, 2, 3, 4]),
-    });
+describe("WebRTCTransport chunk reassembly", () => {
+  it("resolves a whole (unchunked) http-proxy-response", async () => {
+    const transport = makeTransport();
+    const result = pending(transport, "req-1");
+
+    transport.dispatchMessage(
+      JSON.stringify({
+        type: "http-proxy-response",
+        id: "req-1",
+        status: 200,
+        headers: { "content-type": "image/png" },
+        body: toHex([1, 2, 3, 4]),
+      }),
+    );
 
     const { status, headers, body } = await result;
     expect(status).toBe(200);
@@ -70,48 +73,67 @@ describe("WebRTCTransport chunked http-proxy responses", () => {
     expect(Array.from(body)).toEqual([1, 2, 3, 4]);
   });
 
-  it("reassembles a chunked response into the original body", async () => {
+  it("reassembles a chunked http-proxy-response and resolves it", async () => {
     const transport = makeTransport();
-    const result = pending(transport, "req-chunked");
-
-    transport.handleHttpProxyResponseStart({
-      id: "req-chunked",
-      status: 200,
-      headers: { "content-type": "image/jpeg" },
-      chunks: 3,
-    });
-    transport.handleHttpProxyResponseChunk({ id: "req-chunked", index: 0, body: toHex([10, 11]) });
-    transport.handleHttpProxyResponseChunk({ id: "req-chunked", index: 1, body: toHex([20, 21]) });
-    transport.handleHttpProxyResponseChunk({ id: "req-chunked", index: 2, body: toHex([30]) });
-
-    const { status, headers, body } = await result;
-    expect(status).toBe(200);
-    expect(headers).toEqual({ "content-type": "image/jpeg" });
-    expect(Array.from(body)).toEqual([10, 11, 20, 21, 30]);
-  });
-
-  it("reassembles correctly when chunks arrive out of order", async () => {
-    const transport = makeTransport();
-    const result = pending(transport, "req-ooo");
-
-    transport.handleHttpProxyResponseStart({
-      id: "req-ooo",
+    const result = pending(transport, "req-2");
+    const msg = JSON.stringify({
+      type: "http-proxy-response",
+      id: "req-2",
       status: 200,
       headers: {},
-      chunks: 3,
+      body: toHex([9, 8, 7, 6, 5, 4, 3, 2, 1, 0]),
     });
-    transport.handleHttpProxyResponseChunk({ id: "req-ooo", index: 2, body: toHex([3]) });
-    transport.handleHttpProxyResponseChunk({ id: "req-ooo", index: 0, body: toHex([1]) });
-    transport.handleHttpProxyResponseChunk({ id: "req-ooo", index: 1, body: toHex([2]) });
+
+    for (const frame of makeChunks(msg, 42)) transport.handleChunk(frame);
 
     const { body } = await result;
-    expect(Array.from(body)).toEqual([1, 2, 3]);
+    expect(Array.from(body)).toEqual([9, 8, 7, 6, 5, 4, 3, 2, 1, 0]);
   });
 
-  it("ignores chunks for an unknown request id", () => {
+  it("reassembles chunks that arrive out of order", async () => {
+    const transport = makeTransport();
+    const result = pending(transport, "req-3");
+    const msg = JSON.stringify({
+      type: "http-proxy-response",
+      id: "req-3",
+      status: 200,
+      headers: {},
+      body: toHex([1, 2, 3, 4, 5, 6, 7, 8]),
+    });
+
+    for (const frame of [...makeChunks(msg, 7)].reverse()) transport.handleChunk(frame);
+
+    const { body } = await result;
+    expect(Array.from(body)).toEqual([1, 2, 3, 4, 5, 6, 7, 8]);
+  });
+
+  it("emits a reassembled non-proxy message as a normal message event", () => {
+    const transport = makeTransport();
+    const received: unknown[] = [];
+    transport.on("message", (m) => received.push(m));
+
+    const msg = JSON.stringify({ command: "players/all", message_id: 1 });
+    for (const frame of makeChunks(msg, 99)) transport.handleChunk(frame);
+
+    expect(received).toEqual([msg]);
+  });
+
+  it("reassembles multibyte payloads split across byte boundaries", () => {
+    const transport = makeTransport();
+    const received: unknown[] = [];
+    transport.on("message", (m) => received.push(m));
+
+    const msg = JSON.stringify({ name: "音楽ライブラリ".repeat(5) });
+    // pieceBytes = 5 forces slices to fall inside 3-byte characters
+    for (const frame of makeChunks(msg, 5, 5)) transport.handleChunk(frame);
+
+    expect(received).toEqual([msg]);
+  });
+
+  it("does not throw on an unknown/duplicate chunk", () => {
     const transport = makeTransport();
     expect(() =>
-      transport.handleHttpProxyResponseChunk({ id: "nope", index: 0, body: toHex([1]) }),
+      transport.handleChunk({ id: 123, seq: 0, count: 2, b64: btoa("x") }),
     ).not.toThrow();
   });
 });


### PR DESCRIPTION
## What

In remote mode, large proxied HTTP responses (album art) can exceed the 256 KiB WebRTC data-channel message limit that libdatachannel enforces. The server now splits those into an announce message plus fixed-size chunks, so the client must reassemble them before resolving the request.

## Changes

- Handle `http-proxy-response-start` and `http-proxy-response-chunk` in the WebRTC transport, reassembling the body by request id.
- Clear the reassembly buffer on request timeout and on transport cleanup.
- Backward compatible — the legacy single-message `http-proxy-response` path is unchanged.
- Unit tests: in-order, out-of-order, legacy single-message, and unknown-id chunks.

Companion to the server migration PR (aiolibdatachannel + chunking): https://github.com/music-assistant/server/pull/4930