### PR TITLE
Reduce PWA startup precache

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -30,14 +30,11 @@ export default defineConfig({
       srcDir: "public",
       filename: "sw.js",
       injectManifest: {
+        // MA requires a server, so only precache the web app manifest.
+        globPatterns: [],
         maximumFileSizeToCacheInBytes: 5 * 1024 * 1024, // 5 MiB
       },
-      includeAssets: [
-        "favicon.svg",
-        "favicon.ico",
-        "robots.txt",
-        "apple-touch-icon.png",
-      ],
+      includeManifestIcons: false,
       manifest: {
         name: "Music Assistant",
         short_name: "Music Assistant",


### PR DESCRIPTION
Remote startup waits for service-worker installation, and broad Workbox precaching delays cold connections.

- Limit generated precache assets so the frontend bundle is not eagerly cached.
- Keep the web manifest and PWA icons in the output.
- Preserve the existing Workbox cleanup and update behavior.