### PR TITLE
Register transport listeners before connecting

### DIFF
--- a/src/plugins/api/index.ts
+++ b/src/plugins/api/index.ts
@@ -166,7 +166,6 @@ export class MusicAssistantApi {
       }
 
       transport = new WebSocketTransport({ url: wsUrl });
-      await transport.connect();
       baseUrl = httpBaseUrl;
     } else {
       // Transport instance provided (WebRTC)
@@ -239,6 +238,8 @@ export class MusicAssistantApi {
         }, 0);
       }
     });
+
+    await transport.connect();
 
     // Wait for initial ServerInfo message
     await this.waitForServerInfo();

--- a/src/plugins/remote/connection-manager.ts
+++ b/src/plugins/remote/connection-manager.ts
@@ -172,9 +172,6 @@ class RemoteConnectionManager {
 
       this.transport = transport;
       this.setupTransportHandlers();
-      await transport.connect();
-
-      this.state.value = RemoteConnectionState.CONNECTED;
 
       // Set up HTTP proxy bridge for remote connections
       // This must be awaited to ensure SW has remote mode set before images load
@@ -286,6 +283,10 @@ class RemoteConnectionManager {
 
   private setupTransportHandlers(): void {
     if (!this.transport) return;
+
+    this.transport.on("open", () => {
+      this.state.value = RemoteConnectionState.CONNECTED;
+    });
 
     this.transport.on("close", () => {
       this.state.value = RemoteConnectionState.DISCONNECTED;


### PR DESCRIPTION
Remote connections can receive the initial server information before the API registers its message listener, leaving cast dashboards stuck while connecting.

- Register API transport listeners before starting WebRTC or WebSocket connections
- Update remote connection state from the transport open event