### PR TITLE
Support dashboards on older Cast runtimes

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -22,6 +22,15 @@ if (typeof AbortSignal !== "undefined" && !AbortSignal.timeout) {
   };
 }
 
+if (!Object.hasOwn) {
+  Object.defineProperty(Object, "hasOwn", {
+    configurable: true,
+    value: (object: object, property: PropertyKey): boolean =>
+      Object.prototype.hasOwnProperty.call(object, property),
+    writable: true,
+  });
+}
+
 // Global styles
 import "@/styles/global.css";
 import "@/styles/style.css";


### PR DESCRIPTION
Older Cast runtimes do not provide `Object.hasOwn`, which causes `color-string` to abort dashboard rendering after WebRTC auth succeeds.

- Add a standards-shaped fallback for `Object.hasOwn` in `src/main.ts`.
- Use `defineProperty` so the fallback stays non-enumerable like the native method.
- Leave modern runtimes untouched.