### PR TITLE
Use bot for automated releases

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -104,5 +104,4 @@ jobs:
       version: ${{ needs.check-and-release.outputs.version }}
     secrets:
       PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
-      TRIAGE_APP_ID: ${{ secrets.TRIAGE_APP_ID }}
-      TRIAGE_APP_PRIVATE_KEY: ${{ secrets.TRIAGE_APP_PRIVATE_KEY }}
+      MUSIC_ASSISTANT_BOT_PRIVATE_KEY: ${{ secrets.MUSIC_ASSISTANT_BOT_PRIVATE_KEY }}

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -23,7 +23,7 @@ jobs:
       should_release: ${{ steps.check_commits.outputs.has_commits }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0 # Fetch all history for proper comparison
 

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -104,4 +104,5 @@ jobs:
       version: ${{ needs.check-and-release.outputs.version }}
     secrets:
       PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
-      PRIVILEGED_GITHUB_TOKEN: ${{ secrets.PRIVILEGED_GITHUB_TOKEN }}
+      TRIAGE_APP_ID: ${{ secrets.TRIAGE_APP_ID }}
+      TRIAGE_APP_PRIVATE_KEY: ${{ secrets.TRIAGE_APP_PRIVATE_KEY }}

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -104,4 +104,5 @@ jobs:
       version: ${{ needs.check-and-release.outputs.version }}
     secrets:
       PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
-      MUSIC_ASSISTANT_BOT_PRIVATE_KEY: ${{ secrets.MUSIC_ASSISTANT_BOT_PRIVATE_KEY }}
+      TRIAGE_APP_ID: ${{ secrets.TRIAGE_APP_ID }}
+      TRIAGE_APP_PRIVATE_KEY: ${{ secrets.TRIAGE_APP_PRIVATE_KEY }}

--- a/.github/workflows/auto_approve_dependabot.yml
+++ b/.github/workflows/auto_approve_dependabot.yml
@@ -9,4 +9,4 @@ jobs:
       pull-requests: write
     if: github.actor == 'dependabot[bot]'
     steps:
-      - uses: hmarr/auto-approve-action@v4
+      - uses: hmarr/auto-approve-action@8f929096a962e83ccdfa8afcf855f39f12d4dac7 # v4

--- a/.github/workflows/dependency-security.yml
+++ b/.github/workflows/dependency-security.yml
@@ -22,13 +22,13 @@ jobs:
 
     steps:
       - name: Check out code from GitHub
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0 # Need full history for comparison
 
       # 1. GitHub's built-in vulnerability + license check
       - name: Dependency Review
-        uses: actions/dependency-review-action@v5
+        uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0
         with:
           fail-on-severity: high
           fail-on-scopes: runtime
@@ -99,12 +99,12 @@ jobs:
 
       # 5. Run pnpm audit for known vulnerabilities
       - name: Install pnpm
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
         with:
           version: 11.8.0
 
       - name: Use Node.js
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: ${{ env.NODE_VERSION }}
 

--- a/.github/workflows/lokalise-download.yml
+++ b/.github/workflows/lokalise-download.yml
@@ -6,9 +6,19 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
-      - name: Lokalise CLI
-        run: curl -sfL https://raw.githubusercontent.com/lokalise/lokalise-cli-2-go/master/install.sh | sh
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Install Lokalise CLI
+        env:
+          LOKALISE_VERSION: "3.1.7"
+          LOKALISE_SHA256: "3dc94825c6ff7b8300399d025a7bf8460463ac91d9bf92d08409ebdbc1baaea2"
+        run: |
+          ARCHIVE="$RUNNER_TEMP/lokalise2.tar.gz"
+          curl --fail --silent --show-error --location \
+            "https://github.com/lokalise/lokalise-cli-2-go/releases/download/v${LOKALISE_VERSION}/lokalise2_linux_x86_64.tar.gz" \
+            --output "$ARCHIVE"
+          echo "${LOKALISE_SHA256}  ${ARCHIVE}" | sha256sum --check
+          mkdir -p bin
+          tar -xzf "$ARCHIVE" -C bin lokalise2
       - name: Pull
         env: 
           VAR_LOKALISE_API_TOKEN: ${{ secrets.LOKALISE_RO_API_TOKEN }}

--- a/.github/workflows/pr-labels.yaml
+++ b/.github/workflows/pr-labels.yaml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 🏷 Verify PR has a valid label
-        uses: ludeeus/action-require-labels@2.0.0
+        uses: ludeeus/action-require-labels@be19cd7f04c6fad46a85336f9e9cebdf961807bb # 2.0.0
         with:
           labels: >-
             breaking-change, bugfix, refactor, new-feature, maintenance, ci, dependencies, documentation, new-provider, enhancement

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,7 +60,7 @@ jobs:
           client-id: ${{ vars.MUSIC_ASSISTANT_BOT_CLIENT_ID }}
           private-key: ${{ secrets.MUSIC_ASSISTANT_BOT_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
-          repositories: ${{ github.event.repository.name }}
+          repositories: ${{ github.repository }}
           permission-administration: read
 
       - name: Verify immutable releases are enabled
@@ -367,7 +367,7 @@ jobs:
           client-id: ${{ vars.MUSIC_ASSISTANT_BOT_CLIENT_ID }}
           private-key: ${{ secrets.MUSIC_ASSISTANT_BOT_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
-          repositories: ${{ github.event.repository.name }}
+          repositories: ${{ github.repository }}
           permission-administration: read
 
       - name: Recheck immutable releases are enabled

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -481,6 +481,7 @@ jobs:
           owner: ${{ github.repository_owner }}
           repositories: server
           permission-contents: write
+          permission-issues: write
           permission-pull-requests: write
 
       - name: Checkout server repository

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,9 +20,7 @@ on:
     secrets:
       PYPI_TOKEN:
         required: true
-      TRIAGE_APP_ID:
-        required: true
-      TRIAGE_APP_PRIVATE_KEY:
+      MUSIC_ASSISTANT_BOT_PRIVATE_KEY:
         required: true
 
 env:
@@ -59,8 +57,8 @@ jobs:
         id: immutable_settings_token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ secrets.TRIAGE_APP_ID }}
-          private-key: ${{ secrets.TRIAGE_APP_PRIVATE_KEY }}
+          client-id: ${{ vars.MUSIC_ASSISTANT_BOT_CLIENT_ID }}
+          private-key: ${{ secrets.MUSIC_ASSISTANT_BOT_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
           repositories: ${{ github.repository }}
           permission-administration: read
@@ -368,8 +366,8 @@ jobs:
         id: immutable_settings_token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ secrets.TRIAGE_APP_ID }}
-          private-key: ${{ secrets.TRIAGE_APP_PRIVATE_KEY }}
+          client-id: ${{ vars.MUSIC_ASSISTANT_BOT_CLIENT_ID }}
+          private-key: ${{ secrets.MUSIC_ASSISTANT_BOT_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
           repositories: ${{ github.repository }}
           permission-administration: read
@@ -478,8 +476,8 @@ jobs:
         id: server_repo_token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ secrets.TRIAGE_APP_ID }}
-          private-key: ${{ secrets.TRIAGE_APP_PRIVATE_KEY }}
+          client-id: ${{ vars.MUSIC_ASSISTANT_BOT_CLIENT_ID }}
+          private-key: ${{ secrets.MUSIC_ASSISTANT_BOT_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
           repositories: server
           permission-contents: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -481,7 +481,6 @@ jobs:
           owner: ${{ github.repository_owner }}
           repositories: server
           permission-contents: write
-          permission-issues: write
           permission-pull-requests: write
 
       - name: Checkout server repository

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,9 @@ on:
     secrets:
       PYPI_TOKEN:
         required: true
-      MUSIC_ASSISTANT_BOT_PRIVATE_KEY:
+      TRIAGE_APP_ID:
+        required: true
+      TRIAGE_APP_PRIVATE_KEY:
         required: true
 
 env:
@@ -57,8 +59,8 @@ jobs:
         id: immutable_settings_token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          client-id: ${{ vars.MUSIC_ASSISTANT_BOT_CLIENT_ID }}
-          private-key: ${{ secrets.MUSIC_ASSISTANT_BOT_PRIVATE_KEY }}
+          app-id: ${{ secrets.TRIAGE_APP_ID }}
+          private-key: ${{ secrets.TRIAGE_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
           repositories: ${{ github.repository }}
           permission-administration: read
@@ -366,8 +368,8 @@ jobs:
         id: immutable_settings_token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          client-id: ${{ vars.MUSIC_ASSISTANT_BOT_CLIENT_ID }}
-          private-key: ${{ secrets.MUSIC_ASSISTANT_BOT_PRIVATE_KEY }}
+          app-id: ${{ secrets.TRIAGE_APP_ID }}
+          private-key: ${{ secrets.TRIAGE_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
           repositories: ${{ github.repository }}
           permission-administration: read
@@ -476,8 +478,8 @@ jobs:
         id: server_repo_token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          client-id: ${{ vars.MUSIC_ASSISTANT_BOT_CLIENT_ID }}
-          private-key: ${{ secrets.MUSIC_ASSISTANT_BOT_PRIVATE_KEY }}
+          app-id: ${{ secrets.TRIAGE_APP_ID }}
+          private-key: ${{ secrets.TRIAGE_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
           repositories: server
           permission-contents: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -359,6 +359,8 @@ jobs:
     name: Verify Immutable Release
     needs: build-and-publish
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Create immutable settings token
         id: immutable_settings_token
@@ -480,6 +482,7 @@ jobs:
           repositories: server
           permission-contents: write
           permission-pull-requests: write
+          permission-issues: write
 
       - name: Checkout server repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -482,7 +482,6 @@ jobs:
           repositories: server
           permission-contents: write
           permission-pull-requests: write
-          permission-issues: write
 
       - name: Checkout server repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,9 +20,7 @@ on:
     secrets:
       PYPI_TOKEN:
         required: true
-      TRIAGE_APP_ID:
-        required: true
-      TRIAGE_APP_PRIVATE_KEY:
+      MUSIC_ASSISTANT_BOT_PRIVATE_KEY:
         required: true
 
 env:
@@ -50,25 +48,30 @@ jobs:
       release_id: ${{ steps.prepare_draft.outputs.release_id || steps.inspect_release.outputs.release_id }}
       already_published: ${{ steps.inspect_release.outputs.already_published }}
     steps:
-      - name: Create frontend administration token
-        id: frontend-admin-token
-        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
-        with:
-          app-id: ${{ secrets.TRIAGE_APP_ID }}
-          private-key: ${{ secrets.TRIAGE_APP_PRIVATE_KEY }}
-          owner: ${{ github.repository_owner }}
-          repositories: frontend
-          permission-administration: read
-
       - name: Checkout the repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
 
-      - name: Verify release credentials and settings
+      - name: Create immutable settings token
+        id: immutable_settings_token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ vars.MUSIC_ASSISTANT_BOT_CLIENT_ID }}
+          private-key: ${{ secrets.MUSIC_ASSISTANT_BOT_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }}
+          permission-administration: read
+
+      - name: Verify immutable releases are enabled
         run: |
+          if [[ "$APP_SLUG" != "musicassistant-bot" ]]; then
+            echo "::error::GitHub App slug is $APP_SLUG, expected musicassistant-bot."
+            exit 1
+          fi
+
           if ! SETTINGS=$(gh api "repos/$GITHUB_REPOSITORY/immutable-releases"); then
-            echo "::error::musicassistant-bot needs Administration read access to $GITHUB_REPOSITORY."
+            echo "::error::GitHub App needs administration read access to $GITHUB_REPOSITORY."
             exit 1
           fi
 
@@ -79,7 +82,8 @@ jobs:
             exit 1
           fi
         env:
-          GH_TOKEN: ${{ steps.frontend-admin-token.outputs.token }}
+          APP_SLUG: ${{ steps.immutable_settings_token.outputs.app-slug }}
+          GH_TOKEN: ${{ steps.immutable_settings_token.outputs.token }}
 
       - name: Inspect existing release
         id: inspect_release
@@ -356,20 +360,25 @@ jobs:
     needs: build-and-publish
     runs-on: ubuntu-latest
     steps:
-      - name: Create frontend administration token
-        id: frontend-admin-token
+      - name: Create immutable settings token
+        id: immutable_settings_token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ secrets.TRIAGE_APP_ID }}
-          private-key: ${{ secrets.TRIAGE_APP_PRIVATE_KEY }}
+          client-id: ${{ vars.MUSIC_ASSISTANT_BOT_CLIENT_ID }}
+          private-key: ${{ secrets.MUSIC_ASSISTANT_BOT_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
-          repositories: frontend
+          repositories: ${{ github.event.repository.name }}
           permission-administration: read
 
       - name: Recheck immutable releases are enabled
         run: |
+          if [[ "$APP_SLUG" != "musicassistant-bot" ]]; then
+            echo "::error::GitHub App slug is $APP_SLUG, expected musicassistant-bot."
+            exit 1
+          fi
+
           if ! SETTINGS=$(gh api "repos/$GITHUB_REPOSITORY/immutable-releases"); then
-            echo "::error::musicassistant-bot needs Administration read access to $GITHUB_REPOSITORY."
+            echo "::error::GitHub App needs administration read access to $GITHUB_REPOSITORY."
             exit 1
           fi
           if [[ $(jq -r '.enabled' <<< "$SETTINGS") != "true" ]]; then
@@ -377,7 +386,8 @@ jobs:
             exit 1
           fi
         env:
-          GH_TOKEN: ${{ steps.frontend-admin-token.outputs.token }}
+          APP_SLUG: ${{ steps.immutable_settings_token.outputs.app-slug }}
+          GH_TOKEN: ${{ steps.immutable_settings_token.outputs.token }}
 
       - name: Verify published release
         run: |
@@ -419,6 +429,8 @@ jobs:
     name: Server repo PR
     needs: verify-release
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Determine server target branch
         id: target
@@ -458,24 +470,23 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Create server update token
-        id: server-app-token
+      - name: Create server repository token
+        id: server_repo_token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ secrets.TRIAGE_APP_ID }}
-          private-key: ${{ secrets.TRIAGE_APP_PRIVATE_KEY }}
+          client-id: ${{ vars.MUSIC_ASSISTANT_BOT_CLIENT_ID }}
+          private-key: ${{ secrets.MUSIC_ASSISTANT_BOT_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
           repositories: server
           permission-contents: write
           permission-pull-requests: write
-          permission-issues: write
 
       - name: Checkout server repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: music-assistant/server
           ref: ${{ steps.target.outputs.branch }}
-          token: ${{ steps.server-app-token.outputs.token }}
+          token: ${{ steps.server_repo_token.outputs.token }}
           persist-credentials: false
           path: .
 
@@ -494,7 +505,7 @@ jobs:
         id: create_pr
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
-          token: ${{ steps.server-app-token.outputs.token }}
+          token: ${{ steps.server_repo_token.outputs.token }}
           commit-message: "⬆️ Update music-assistant-frontend to ${{ inputs.version }}"
           sign-commits: true
           branch: "auto-update-frontend-${{ inputs.version }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -482,6 +482,7 @@ jobs:
           repositories: server
           permission-contents: write
           permission-pull-requests: write
+          permission-issues: write
 
       - name: Checkout server repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,12 +49,22 @@ jobs:
       already_published: ${{ steps.inspect_release.outputs.already_published }}
     steps:
       - name: Checkout the repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
+          persist-credentials: false
 
-      - name: Verify immutable releases are enabled
+      - name: Verify release credentials and settings
         run: |
+          if ! TOKEN_LOGIN=$(gh api user --jq '.login'); then
+            echo "::error::PRIVILEGED_GITHUB_TOKEN must authenticate as music-assistant-machine."
+            exit 1
+          fi
+          if [[ "$TOKEN_LOGIN" != "music-assistant-machine" ]]; then
+            echo "::error::PRIVILEGED_GITHUB_TOKEN authenticates as $TOKEN_LOGIN, expected music-assistant-machine."
+            exit 1
+          fi
+
           if ! SETTINGS=$(gh api "repos/$GITHUB_REPOSITORY/immutable-releases"); then
             echo "::error::PRIVILEGED_GITHUB_TOKEN needs administration read access to $GITHUB_REPOSITORY."
             exit 1
@@ -119,19 +129,19 @@ jobs:
 
       - name: Set up Python ${{ env.PYTHON_VERSION }}
         if: steps.inspect_release.outputs.already_published != 'true'
-        uses: actions/setup-python@v7
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
       - name: Install pnpm
         if: steps.inspect_release.outputs.already_published != 'true'
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
         with:
           version: 11.8.0
 
       - name: Set up Node ${{ env.NODE_VERSION }}
         if: steps.inspect_release.outputs.already_published != 'true'
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: pnpm
@@ -184,18 +194,20 @@ jobs:
               exit 1
             fi
           else
-            git config user.name "github-actions[bot]"
-            git config user.email "github-actions[bot]@users.noreply.github.com"
+            git config user.name "music-assistant-machine"
+            git config user.email "141749843+music-assistant-machine@users.noreply.github.com"
             git tag -a "$RELEASE_VERSION" -m "Release $RELEASE_VERSION"
-            git push origin "refs/tags/$RELEASE_VERSION"
+            git push \
+              "https://x-access-token:${PRIVILEGED_GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" \
+              "refs/tags/$RELEASE_VERSION"
           fi
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PRIVILEGED_GITHUB_TOKEN: ${{ secrets.PRIVILEGED_GITHUB_TOKEN }}
 
       - name: Generate release notes with Release Drafter
         id: release_drafter
         if: steps.inspect_release.outputs.already_published != 'true'
-        uses: release-drafter/release-drafter@v7.6.0
+        uses: release-drafter/release-drafter@eada3c96a64734dd381cfbda23511034e328ddb0 # v7.6.0
         with:
           config-name: release-drafter.yml
           version: ${{ inputs.version }}
@@ -246,7 +258,7 @@ jobs:
           RELEASE_ID=$(gh api "${API_ARGS[@]}" --jq '.id')
           echo "release_id=$RELEASE_ID" >> "$GITHUB_OUTPUT"
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.PRIVILEGED_GITHUB_TOKEN }}
           RELEASE_NAME: ${{ steps.release_drafter.outputs.name }}
           RELEASE_NOTES: ${{ steps.release_drafter.outputs.body }}
 
@@ -311,11 +323,11 @@ jobs:
             exit 1
           fi
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.PRIVILEGED_GITHUB_TOKEN }}
 
       - name: Publish release to PyPI
         if: steps.inspect_release.outputs.already_published != 'true'
-        uses: pypa/gh-action-pypi-publish@v1.14.1
+        uses: pypa/gh-action-pypi-publish@ba38be9e461d3875417946c167d0b5f3d385a247 # v1.14.1
         with:
           user: __token__
           password: ${{ secrets.PYPI_TOKEN }}
@@ -337,7 +349,7 @@ jobs:
             -f make_latest=true \
             --jq '.html_url'
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.PRIVILEGED_GITHUB_TOKEN }}
 
   verify-release:
     name: Verify Immutable Release
@@ -424,11 +436,12 @@ jobs:
           GH_TOKEN: ${{ secrets.PRIVILEGED_GITHUB_TOKEN }}
 
       - name: Checkout server repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: music-assistant/server
           ref: ${{ steps.target.outputs.branch }}
           token: ${{ secrets.PRIVILEGED_GITHUB_TOKEN }}
+          persist-credentials: false
           path: .
 
       - name: Update frontend version
@@ -444,10 +457,12 @@ jobs:
 
       - name: Create Pull Request
         id: create_pr
-        uses: peter-evans/create-pull-request@v8
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
           token: ${{ secrets.PRIVILEGED_GITHUB_TOKEN }}
           commit-message: "⬆️ Update music-assistant-frontend to ${{ inputs.version }}"
+          committer: "music-assistant-machine <141749843+music-assistant-machine@users.noreply.github.com>"
+          author: "music-assistant-machine <141749843+music-assistant-machine@users.noreply.github.com>"
           branch: "auto-update-frontend-${{ inputs.version }}"
           base: ${{ steps.target.outputs.branch }}
           delete-branch: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,7 +52,6 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
-          persist-credentials: false
 
       - name: Verify release credentials and settings
         run: |
@@ -194,15 +193,13 @@ jobs:
               exit 1
             fi
           else
-            git config user.name "music-assistant-machine"
-            git config user.email "141749843+music-assistant-machine@users.noreply.github.com"
+            git config user.name "github-actions[bot]"
+            git config user.email "github-actions[bot]@users.noreply.github.com"
             git tag -a "$RELEASE_VERSION" -m "Release $RELEASE_VERSION"
-            git push \
-              "https://x-access-token:${PRIVILEGED_GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" \
-              "refs/tags/$RELEASE_VERSION"
+            git push origin "refs/tags/$RELEASE_VERSION"
           fi
         env:
-          PRIVILEGED_GITHUB_TOKEN: ${{ secrets.PRIVILEGED_GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Generate release notes with Release Drafter
         id: release_drafter
@@ -258,7 +255,7 @@ jobs:
           RELEASE_ID=$(gh api "${API_ARGS[@]}" --jq '.id')
           echo "release_id=$RELEASE_ID" >> "$GITHUB_OUTPUT"
         env:
-          GH_TOKEN: ${{ secrets.PRIVILEGED_GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RELEASE_NAME: ${{ steps.release_drafter.outputs.name }}
           RELEASE_NOTES: ${{ steps.release_drafter.outputs.body }}
 
@@ -323,7 +320,7 @@ jobs:
             exit 1
           fi
         env:
-          GH_TOKEN: ${{ secrets.PRIVILEGED_GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Publish release to PyPI
         if: steps.inspect_release.outputs.already_published != 'true'
@@ -349,7 +346,7 @@ jobs:
             -f make_latest=true \
             --jq '.html_url'
         env:
-          GH_TOKEN: ${{ secrets.PRIVILEGED_GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   verify-release:
     name: Verify Immutable Release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,9 @@ on:
     secrets:
       PYPI_TOKEN:
         required: true
-      PRIVILEGED_GITHUB_TOKEN:
+      TRIAGE_APP_ID:
+        required: true
+      TRIAGE_APP_PRIVATE_KEY:
         required: true
 
 env:
@@ -48,6 +50,16 @@ jobs:
       release_id: ${{ steps.prepare_draft.outputs.release_id || steps.inspect_release.outputs.release_id }}
       already_published: ${{ steps.inspect_release.outputs.already_published }}
     steps:
+      - name: Create frontend administration token
+        id: frontend-admin-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.TRIAGE_APP_ID }}
+          private-key: ${{ secrets.TRIAGE_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: frontend
+          permission-administration: read
+
       - name: Checkout the repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -55,17 +67,8 @@ jobs:
 
       - name: Verify release credentials and settings
         run: |
-          if ! TOKEN_LOGIN=$(gh api user --jq '.login'); then
-            echo "::error::PRIVILEGED_GITHUB_TOKEN must authenticate as music-assistant-machine."
-            exit 1
-          fi
-          if [[ "$TOKEN_LOGIN" != "music-assistant-machine" ]]; then
-            echo "::error::PRIVILEGED_GITHUB_TOKEN authenticates as $TOKEN_LOGIN, expected music-assistant-machine."
-            exit 1
-          fi
-
           if ! SETTINGS=$(gh api "repos/$GITHUB_REPOSITORY/immutable-releases"); then
-            echo "::error::PRIVILEGED_GITHUB_TOKEN needs administration read access to $GITHUB_REPOSITORY."
+            echo "::error::musicassistant-bot needs Administration read access to $GITHUB_REPOSITORY."
             exit 1
           fi
 
@@ -76,7 +79,7 @@ jobs:
             exit 1
           fi
         env:
-          GH_TOKEN: ${{ secrets.PRIVILEGED_GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.frontend-admin-token.outputs.token }}
 
       - name: Inspect existing release
         id: inspect_release
@@ -353,6 +356,29 @@ jobs:
     needs: build-and-publish
     runs-on: ubuntu-latest
     steps:
+      - name: Create frontend administration token
+        id: frontend-admin-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.TRIAGE_APP_ID }}
+          private-key: ${{ secrets.TRIAGE_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: frontend
+          permission-administration: read
+
+      - name: Recheck immutable releases are enabled
+        run: |
+          if ! SETTINGS=$(gh api "repos/$GITHUB_REPOSITORY/immutable-releases"); then
+            echo "::error::musicassistant-bot needs Administration read access to $GITHUB_REPOSITORY."
+            exit 1
+          fi
+          if [[ $(jq -r '.enabled' <<< "$SETTINGS") != "true" ]]; then
+            echo "::error::Immutable releases were disabled during publishing."
+            exit 1
+          fi
+        env:
+          GH_TOKEN: ${{ steps.frontend-admin-token.outputs.token }}
+
       - name: Verify published release
         run: |
           RELEASE_ID="${{ needs.build-and-publish.outputs.release_id }}"
@@ -430,14 +456,26 @@ jobs:
             echo EOF
           } >> $GITHUB_OUTPUT
         env:
-          GH_TOKEN: ${{ secrets.PRIVILEGED_GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create server update token
+        id: server-app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.TRIAGE_APP_ID }}
+          private-key: ${{ secrets.TRIAGE_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: server
+          permission-contents: write
+          permission-pull-requests: write
+          permission-issues: write
 
       - name: Checkout server repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: music-assistant/server
           ref: ${{ steps.target.outputs.branch }}
-          token: ${{ secrets.PRIVILEGED_GITHUB_TOKEN }}
+          token: ${{ steps.server-app-token.outputs.token }}
           persist-credentials: false
           path: .
 
@@ -456,10 +494,9 @@ jobs:
         id: create_pr
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
-          token: ${{ secrets.PRIVILEGED_GITHUB_TOKEN }}
+          token: ${{ steps.server-app-token.outputs.token }}
           commit-message: "⬆️ Update music-assistant-frontend to ${{ inputs.version }}"
-          committer: "music-assistant-machine <141749843+music-assistant-machine@users.noreply.github.com>"
-          author: "music-assistant-machine <141749843+music-assistant-machine@users.noreply.github.com>"
+          sign-commits: true
           branch: "auto-update-frontend-${{ inputs.version }}"
           base: ${{ steps.target.outputs.branch }}
           delete-branch: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,14 +12,14 @@ jobs:
     name: Test and Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
         with:
           version: 11.8.0
       - name: Use Node.js
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: pnpm


### PR DESCRIPTION
Automated releases need short-lived bot access instead of a personal token.

- Keep frontend tags and releases owned by GitHub Actions
- Use scoped bot tokens for release checks and server updates
- Pin external Actions and verify the Lokalise download

Requires the bot App on `frontend` and `server` with the requested permissions.