### PR TITLE
Fix TV dashboard rendering

### DIFF
--- a/src/components/party/PartyQueueItem.vue
+++ b/src/components/party/PartyQueueItem.vue
@@ -36,7 +36,7 @@
       <span
         v-if="item.extra_attributes?.party_guest === true"
         class="guest-request-badge"
-        :style="{ '--badge-color': badgeColor }"
+        :style="badgeStyle"
       >
         <component :is="badgeIconComponent" :size="10" />
         <span>{{ badgeLabel }}</span>
@@ -72,6 +72,7 @@ import { getMediaItemImageUrl } from "@/helpers/utils";
 import type { QueueItem } from "@/plugins/api/interfaces";
 import { $t } from "@/plugins/i18n";
 import { Music, Rocket, UserRound } from "@lucide/vue";
+import Color from "color";
 import { computed } from "vue";
 
 const props = defineProps<{
@@ -143,6 +144,16 @@ const isBoosted = computed(
 const badgeColor = computed(() =>
   isBoosted.value ? props.boostBadgeColor : props.requestBadgeColor,
 );
+
+// Older Cast and Android TV runtimes need precomputed alpha colors.
+const badgeStyle = computed(() => {
+  const color = Color(badgeColor.value);
+  return {
+    "--badge-color": badgeColor.value,
+    "--badge-background": color.alpha(0.2).string(),
+    "--badge-border": color.alpha(0.4).string(),
+  };
+});
 
 const badgeIconComponent = computed(() =>
   isBoosted.value ? Rocket : UserRound,
@@ -273,8 +284,8 @@ const badgeLabel = computed(() =>
   align-items: center;
   gap: 0.25rem;
   padding: 0.2rem 0.3rem;
-  background: color-mix(in srgb, var(--badge-color) 20%, transparent);
-  border: 1px solid color-mix(in srgb, var(--badge-color) 40%, transparent);
+  background: var(--badge-background);
+  border: 1px solid var(--badge-border);
   border-radius: 999px;
   font-size: 0.55rem;
   font-weight: 600;

--- a/src/components/party/PartyQueueItem.vue
+++ b/src/components/party/PartyQueueItem.vue
@@ -141,9 +141,13 @@ const isBoosted = computed(
   () => props.item.extra_attributes?.party_boosted === true,
 );
 
-const badgeColor = computed(() =>
-  isBoosted.value ? props.boostBadgeColor : props.requestBadgeColor,
-);
+const badgeColor = computed(() => {
+  const color = isBoosted.value
+    ? props.boostBadgeColor
+    : props.requestBadgeColor;
+  if (!color) return isBoosted.value ? "#FF5722" : "#2196F3";
+  return color;
+});
 
 // Older Cast and Android TV runtimes need precomputed alpha colors.
 const badgeStyle = computed(() => {

--- a/src/components/party/PartyTrackCard.vue
+++ b/src/components/party/PartyTrackCard.vue
@@ -6,7 +6,7 @@
       `position-${position}`,
       { 'guest-request': isGuestRequest, 'white-text': forceWhiteText },
     ]"
-    :style="isGuestRequest ? { '--guest-color': badgeColor } : {}"
+    :style="isGuestRequest ? guestRequestStyle : {}"
   >
     <div :class="['track-artwork', sizeClass]">
       <MediaItemThumb :item="queueItem" />
@@ -45,11 +45,7 @@
       ></div>
     </div>
     <!-- Guest request badge -->
-    <div
-      v-if="isGuestRequest"
-      class="guest-badge"
-      :style="{ '--badge-color': badgeColor }"
-    >
+    <div v-if="isGuestRequest" class="guest-badge" :style="guestBadgeStyle">
       <Rocket v-if="isBoost" class="badge-icon" />
       <UserRound v-else class="badge-icon" />
       <span v-if="position === 'current'">{{ badgeText }}</span>
@@ -68,6 +64,7 @@ import type { QueueItem } from "@/plugins/api/interfaces";
 import { $t } from "@/plugins/i18n";
 import { store } from "@/plugins/store";
 import { Rocket, UserRound } from "@lucide/vue";
+import Color from "color";
 import { computed, onMounted, onUnmounted, ref, watch } from "vue";
 
 const { config: partyConfig } = usePartyConfig();
@@ -150,6 +147,26 @@ const badgeColor = computed(() => {
   // Fallback to defaults if color is empty (before config loads)
   if (!color) return isBoost.value ? "#FF5722" : "#2196F3";
   return color;
+});
+
+// Older Cast and Android TV runtimes need precomputed alpha colors.
+const guestRequestStyle = computed(() => {
+  const color = Color(badgeColor.value);
+  return {
+    "--guest-background": color.alpha(0.2).string(),
+    "--guest-border": color.alpha(0.4).string(),
+    "--guest-current-background": color.alpha(0.25).string(),
+    "--guest-current-border": color.alpha(0.5).string(),
+    "--guest-shadow": color.alpha(0.3).string(),
+  };
+});
+
+const guestBadgeStyle = computed(() => {
+  const color = Color(badgeColor.value);
+  return {
+    "--badge-background": color.alpha(0.35).string(),
+    "--badge-border": color.alpha(0.55).string(),
+  };
 });
 
 // Get badge text based on queue option
@@ -327,16 +344,16 @@ watch(
 
 /* Guest request highlighting - color set via inline style from config */
 .track-card.guest-request {
-  background: color-mix(in srgb, var(--guest-color) 20%, transparent);
-  border: 2px solid color-mix(in srgb, var(--guest-color) 40%, transparent);
+  background: var(--guest-background);
+  border: 2px solid var(--guest-border);
 }
 
 .track-card.guest-request.position-current {
-  background: color-mix(in srgb, var(--guest-color) 25%, transparent);
-  border: 2px solid color-mix(in srgb, var(--guest-color) 50%, transparent);
+  background: var(--guest-current-background);
+  border: 2px solid var(--guest-current-border);
   box-shadow:
     0 0.8vh 3.2vh rgba(0, 0, 0, 0.3),
-    0 0 2vh color-mix(in srgb, var(--guest-color) 30%, transparent);
+    0 0 2vh var(--guest-shadow);
 }
 
 .guest-badge {
@@ -345,8 +362,8 @@ watch(
   align-items: center;
   gap: 0.6vh;
   padding: 0.5vh 1.2vh;
-  background: color-mix(in srgb, var(--badge-color) 35%, transparent);
-  border: 1px solid color-mix(in srgb, var(--badge-color) 55%, transparent);
+  background: var(--badge-background);
+  border: 1px solid var(--badge-border);
   border-radius: 999px;
   color: rgba(var(--v-theme-on-surface), 0.9);
   font-size: clamp(0.65rem, 1.2vh, 1.1rem);

--- a/src/layouts/default/PlayerOSD/PlayerTimeline.vue
+++ b/src/layouts/default/PlayerOSD/PlayerTimeline.vue
@@ -24,19 +24,16 @@
           hoverPercent = null;
         "
       >
-        <!-- color-mix is the same logic as tailwind's bg-color/30 -->
         <SliderTrack
           data-slot="slider-track"
           class="relative grow rounded-full"
           :class="usesWaveformLayout ? 'h-8 md:h-10 lg:h-12' : 'h-1'"
-          :style="
-            usesWaveformLayout
-              ? undefined
-              : {
-                  'background-color': `color-mix(in oklab, ${color} 30%, transparent)`,
-                }
-          "
         >
+          <div
+            v-if="!usesWaveformLayout"
+            class="absolute inset-0 rounded-full"
+            :style="trackBackgroundStyle"
+          />
           <WaveformTrack
             v-if="hasWaveform"
             :data="waveform!"
@@ -47,9 +44,7 @@
           <div
             v-else-if="waveformLoading"
             class="absolute inset-x-0 top-1/2 h-1 -translate-y-1/2 rounded-full"
-            :style="{
-              'background-color': `color-mix(in oklab, ${color} 30%, transparent)`,
-            }"
+            :style="trackBackgroundStyle"
           />
           <SliderRange
             v-if="!hasWaveform"
@@ -376,6 +371,10 @@ const hasWaveform = computed(() => !!props.waveform?.length);
 const usesWaveformLayout = computed(
   () => hasWaveform.value || props.waveformLoading,
 );
+const trackBackgroundStyle = computed(() => ({
+  backgroundColor: props.color,
+  opacity: 0.3,
+}));
 
 const progressPercent = computed(() => {
   const duration = store.activePlayer?.current_media?.duration;

--- a/src/layouts/default/PlayerOSD/PlayerTimeline.vue
+++ b/src/layouts/default/PlayerOSD/PlayerTimeline.vue
@@ -371,6 +371,7 @@ const hasWaveform = computed(() => !!props.waveform?.length);
 const usesWaveformLayout = computed(
   () => hasWaveform.value || props.waveformLoading,
 );
+// Older Cast and Android TV runtimes need an opacity layer instead of color-mix().
 const trackBackgroundStyle = computed(() => ({
   backgroundColor: props.color,
   opacity: 0.3,

--- a/src/layouts/default/PlayerOSD/WaveformTrack.vue
+++ b/src/layouts/default/PlayerOSD/WaveformTrack.vue
@@ -33,6 +33,7 @@ const BAR_WIDTH = 2;
 // Keep silent sections visible as a thin baseline.
 const MIN_BAR_HEIGHT = 2;
 const DIM_ALPHA = 0.3;
+// A 1/255 fill prevents older Cast and Android TV compositors from dropping the canvas.
 const COMPOSITOR_BLEED_ALPHA = 1 / 255;
 
 const containerEl = ref<HTMLDivElement>();

--- a/src/layouts/default/PlayerOSD/WaveformTrack.vue
+++ b/src/layouts/default/PlayerOSD/WaveformTrack.vue
@@ -33,6 +33,7 @@ const BAR_WIDTH = 2;
 // Keep silent sections visible as a thin baseline.
 const MIN_BAR_HEIGHT = 2;
 const DIM_ALPHA = 0.3;
+const COMPOSITOR_BLEED_ALPHA = 1 / 255;
 
 const containerEl = ref<HTMLDivElement>();
 const dimCanvasEl = ref<HTMLCanvasElement>();
@@ -87,6 +88,8 @@ const drawBars = (
   ctx.scale(dpr, dpr);
   ctx.clearRect(0, 0, cssWidth, cssHeight);
   ctx.fillStyle = color;
+  ctx.globalAlpha = COMPOSITOR_BLEED_ALPHA;
+  ctx.fillRect(0, 0, cssWidth, cssHeight);
   ctx.globalAlpha = alpha;
   for (let i = 0; i < peaks.length; i++) {
     const barHeight = Math.max(MIN_BAR_HEIGHT, peaks[i] * cssHeight);

--- a/src/views/DashboardNowPlayingView.vue
+++ b/src/views/DashboardNowPlayingView.vue
@@ -114,12 +114,13 @@ const backgroundGradient = computed(() => {
 <style scoped>
 .now-playing-view {
   width: 100%;
+  height: 100vh;
   height: 100dvh;
   display: flex;
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  gap: 5vh;
+  gap: 3vh;
   padding: 5vh 5vw;
   box-sizing: border-box;
   color: var(--text-color, #fff);
@@ -140,8 +141,8 @@ const backgroundGradient = computed(() => {
 }
 
 .now-playing-artwork-image {
-  max-width: min(70vh, 90%);
-  max-height: 100%;
+  width: min(62.5vh, 92vw);
+  height: min(62.5vh, 92vw);
   aspect-ratio: 1;
   object-fit: cover;
   border-radius: 12px;
@@ -149,7 +150,8 @@ const backgroundGradient = computed(() => {
 }
 
 .now-playing-artwork-fallback {
-  width: min(70vh, 90%);
+  width: min(62.5vh, 92vw);
+  height: min(62.5vh, 92vw);
   aspect-ratio: 1;
   border-radius: 12px;
   display: flex;
@@ -167,7 +169,7 @@ const backgroundGradient = computed(() => {
 }
 
 .now-playing-title {
-  font-size: clamp(1.5rem, 4vw, 3rem);
+  font-size: clamp(1.5rem, 3vw, 2.5rem);
   font-weight: 600;
 }
 

--- a/src/views/PartyDashboardView.vue
+++ b/src/views/PartyDashboardView.vue
@@ -419,6 +419,7 @@ const maLogoSrc = computed(() =>
 const qrDarkColor = computed(() =>
   useLightChrome.value ? "#FFFFFF" : "#000000",
 );
+// A 1/255 fill keeps the QR canvas visible on older Cast and Android TV compositors.
 const qrLightColor = computed(() =>
   useLightChrome.value ? "#00000001" : "#FFFFFF01",
 );

--- a/src/views/PartyDashboardView.vue
+++ b/src/views/PartyDashboardView.vue
@@ -107,7 +107,11 @@
           class="karaoke-qr"
           :style="swapped ? { left: 'auto', right: '2vw' } : undefined"
         >
-          <PartyQR :qr-dark="qrDarkColor" @available="qrAvailable = $event" />
+          <PartyQR
+            :qr-dark="qrDarkColor"
+            :qr-light="qrLightColor"
+            @available="qrAvailable = $event"
+          />
         </div>
 
         <div
@@ -184,7 +188,11 @@
             class="qr-wrapper"
             :style="swapped && displayLyrics ? { order: 1 } : undefined"
           >
-            <PartyQR :qr-dark="qrDarkColor" @available="qrAvailable = $event" />
+            <PartyQR
+              :qr-dark="qrDarkColor"
+              :qr-light="qrLightColor"
+              @available="qrAvailable = $event"
+            />
           </div>
           <div
             v-if="displayLyrics"
@@ -410,6 +418,9 @@ const maLogoSrc = computed(() =>
 );
 const qrDarkColor = computed(() =>
   useLightChrome.value ? "#FFFFFF" : "#000000",
+);
+const qrLightColor = computed(() =>
+  useLightChrome.value ? "#00000001" : "#FFFFFF01",
 );
 
 const partyName = computed(() => partyConfig.value?.party_name ?? null);
@@ -893,7 +904,7 @@ watch(
 <style scoped>
 .party-view {
   width: 100%;
-  height: 100dvh;
+  height: 100%;
   overflow: hidden;
   position: relative;
   display: flex;
@@ -1098,7 +1109,7 @@ watch(
   max-width: 60vw;
   display: flex;
   justify-content: center;
-  padding-bottom: 1rem;
+  padding-bottom: calc(1rem + var(--party-player-bottom, 0px));
 }
 
 .karaoke-track-stack :deep(.track-artwork) {


### PR DESCRIPTION
## Summary
- Fix Android TV/Cast viewport sizing on the dashboard views
- Harden party QR rendering and timeline backgrounds for older Chrome
- Tune the now-playing artwork sizing for SHIELD preview
