### PR TITLE
Add transpose DSP filter

### DIFF
--- a/src/components/dsp/DSPTranspose.vue
+++ b/src/components/dsp/DSPTranspose.vue
@@ -1,0 +1,136 @@
+<template>
+  <div class="@container p-4">
+    <div class="flex flex-wrap items-center gap-4">
+      <div class="min-w-0 flex-1 px-1 pb-6">
+        <Slider
+          :model-value="[sliderValue]"
+          :min="MIN_SEMITONES"
+          :max="MAX_SEMITONES"
+          :step="1"
+          @update:model-value="onSlide"
+        />
+        <div class="mt-2 flex justify-between text-xs text-muted-foreground">
+          <span>{{ format(MIN_SEMITONES) }}</span>
+          <span>{{ $t("settings.dsp.transpose.original_key") }}</span>
+          <span>+{{ format(MAX_SEMITONES) }}</span>
+        </div>
+      </div>
+      <div class="order-last mb-6 w-full @sm:order-none @sm:w-auto">
+        <div class="flex items-center gap-4">
+          <Input
+            v-model="fieldValue"
+            type="number"
+            :min="MIN_SEMITONES"
+            :max="MAX_SEMITONES"
+            step="0.001"
+            class="max-w-[100px]"
+            :aria-label="$t('settings.dsp.types.transpose')"
+            @focus="isEditing = true"
+            @blur="isEditing = false"
+          />
+          <span class="min-w-[90px] text-muted-foreground">
+            {{ unitLabel }}
+          </span>
+        </div>
+        <TooltipProvider :delay-duration="200">
+          <Tooltip>
+            <TooltipTrigger as-child>
+              <Button
+                variant="outline"
+                size="sm"
+                class="mt-2 w-[100px]"
+                :class="isConcertPitch432 ? 'border-primary text-primary' : ''"
+                @click="setConcertPitch432"
+              >
+                {{ $t("settings.dsp.transpose.concert_pitch_432") }}
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent side="bottom">
+              {{ $t("settings.dsp.transpose.concert_pitch_432_hint") }}
+            </TooltipContent>
+          </Tooltip>
+        </TooltipProvider>
+      </div>
+    </div>
+
+    <Alert variant="info" class="mt-4">
+      <Info />
+      <AlertDescription>
+        {{ $t("settings.dsp.transpose.help") }}
+      </AlertDescription>
+    </Alert>
+    <Alert v-if="model.semitones !== 0" variant="warning" class="mt-2">
+      <TriangleAlert />
+      <AlertDescription>
+        {{ $t("settings.dsp.transpose.cpu_hint") }}
+      </AlertDescription>
+    </Alert>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, ref } from "vue";
+import { Info, TriangleAlert } from "@lucide/vue";
+import { $t } from "@/plugins/i18n";
+import { TransposeFilter } from "@/plugins/api/interfaces";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Slider } from "@/components/ui/slider";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+
+const MIN_SEMITONES = -6;
+const MAX_SEMITONES = 6;
+// A=432Hz instead of the usual A=440Hz, a fraction of a semitone down.
+const CONCERT_PITCH_432_SEMITONES = -0.318;
+
+const model = defineModel<TransposeFilter>({ required: true });
+const isEditing = ref(false);
+
+const clamp = (value: number): number =>
+  Math.min(MAX_SEMITONES, Math.max(MIN_SEMITONES, value));
+
+// Fractional values are meaningful here, so keep the decimals and only drop
+// trailing zeros.
+const format = (value: number): string => Number(value.toFixed(3)).toString();
+
+const unitLabel = computed(() => {
+  const semitones = model.value.semitones;
+  if (semitones === 0) return $t("settings.dsp.transpose.original_key");
+  return Math.abs(semitones) === 1
+    ? $t("settings.dsp.transpose.unit_singular")
+    : $t("settings.dsp.transpose.unit");
+});
+
+const sliderValue = computed(() => model.value.semitones);
+
+const onSlide = (value?: number[]) => {
+  if (!value?.length) return;
+  model.value.semitones = clamp(value[0]);
+};
+
+const fieldValue = computed({
+  get: () =>
+    isEditing.value
+      ? model.value.semitones.toString()
+      : format(model.value.semitones),
+  set: (value: string) => {
+    const semitones = Number(value);
+    if (!Number.isFinite(semitones)) return;
+    model.value.semitones = clamp(semitones);
+  },
+});
+
+const isConcertPitch432 = computed(
+  () => model.value.semitones === CONCERT_PITCH_432_SEMITONES,
+);
+
+const setConcertPitch432 = () => {
+  model.value.semitones = CONCERT_PITCH_432_SEMITONES;
+};
+</script>

--- a/src/components/dsp/DSPTranspose.vue
+++ b/src/components/dsp/DSPTranspose.vue
@@ -1,56 +1,51 @@
 <template>
-  <div class="@container p-4">
-    <div class="flex flex-wrap items-center gap-4">
-      <div class="min-w-0 flex-1 px-1 pb-6">
+  <div class="p-4">
+    <div class="flex items-center gap-4 pb-7">
+      <div class="relative min-w-0 flex-1 px-1">
         <Slider
+          class="dsp-slider"
           :model-value="[sliderValue]"
           :min="MIN_SEMITONES"
           :max="MAX_SEMITONES"
           :step="1"
           @update:model-value="onSlide"
         />
-        <div class="mt-2 flex justify-between text-xs text-muted-foreground">
+        <div
+          class="pointer-events-none absolute inset-x-1 top-full mt-2 flex justify-between text-xs text-muted-foreground"
+        >
           <span>{{ format(MIN_SEMITONES) }}</span>
           <span>{{ $t("settings.dsp.transpose.original_key") }}</span>
           <span>+{{ format(MAX_SEMITONES) }}</span>
         </div>
       </div>
-      <div class="order-last mb-6 w-full @sm:order-none @sm:w-auto">
-        <div class="flex items-center gap-4">
-          <Input
-            v-model="fieldValue"
-            type="number"
-            :min="MIN_SEMITONES"
-            :max="MAX_SEMITONES"
-            step="0.001"
-            class="max-w-[100px]"
-            :aria-label="$t('settings.dsp.types.transpose')"
-            @focus="isEditing = true"
-            @blur="isEditing = false"
-          />
-          <span class="min-w-[90px] text-muted-foreground">
-            {{ unitLabel }}
-          </span>
-        </div>
-        <TooltipProvider :delay-duration="200">
-          <Tooltip>
-            <TooltipTrigger as-child>
-              <Button
-                variant="outline"
-                size="sm"
-                class="mt-2 w-[100px]"
-                :class="isConcertPitch432 ? 'border-primary text-primary' : ''"
-                @click="setConcertPitch432"
-              >
-                {{ $t("settings.dsp.transpose.concert_pitch_432") }}
-              </Button>
-            </TooltipTrigger>
-            <TooltipContent side="bottom">
-              {{ $t("settings.dsp.transpose.concert_pitch_432_hint") }}
-            </TooltipContent>
-          </Tooltip>
-        </TooltipProvider>
-      </div>
+      <Input
+        v-model="fieldValue"
+        type="number"
+        :min="MIN_SEMITONES"
+        :max="MAX_SEMITONES"
+        step="0.001"
+        class="max-w-[100px]"
+        :aria-label="$t('settings.dsp.types.transpose')"
+        @focus="isEditing = true"
+        @blur="isEditing = false"
+      />
+      <span class="min-w-[90px] text-muted-foreground">
+        {{ unitLabel }}
+      </span>
+    </div>
+
+    <div class="flex flex-wrap items-center gap-3">
+      <Button
+        variant="outline"
+        size="sm"
+        :class="isConcertPitch432 ? 'border-primary text-primary' : ''"
+        @click="setConcertPitch432"
+      >
+        {{ $t("settings.dsp.transpose.concert_pitch_432") }}
+      </Button>
+      <span class="text-xs text-muted-foreground">
+        {{ $t("settings.dsp.transpose.concert_pitch_432_hint") }}
+      </span>
     </div>
 
     <Alert variant="info" class="mt-4">
@@ -69,20 +64,14 @@
 </template>
 
 <script setup lang="ts">
-import { computed, ref } from "vue";
-import { Info, TriangleAlert } from "@lucide/vue";
-import { $t } from "@/plugins/i18n";
-import { TransposeFilter } from "@/plugins/api/interfaces";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Slider } from "@/components/ui/slider";
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipProvider,
-  TooltipTrigger,
-} from "@/components/ui/tooltip";
+import { TransposeFilter } from "@/plugins/api/interfaces";
+import { $t } from "@/plugins/i18n";
+import { Info, TriangleAlert } from "@lucide/vue";
+import { computed, ref } from "vue";
 
 const MIN_SEMITONES = -6;
 const MAX_SEMITONES = 6;

--- a/src/helpers/audioProcessing.ts
+++ b/src/helpers/audioProcessing.ts
@@ -9,6 +9,7 @@ import {
   type ParametricEQBand,
   type ParametricEQFilter,
   type ToneControlFilter,
+  type TransposeFilter,
 } from "@/plugins/api/interfaces";
 
 export function sanitizeDSPPresetConfig(config: DSPConfig): DSPConfig {
@@ -73,6 +74,12 @@ function areDspFilterEqual(left: DSPFilter, right: DSPFilter): boolean {
   ) {
     return areBalanceFiltersEqual(left, right);
   }
+  if (
+    left.type === DSPFilterType.TRANSPOSE &&
+    right.type === DSPFilterType.TRANSPOSE
+  ) {
+    return areTransposeFiltersEqual(left, right);
+  }
   return false;
 }
 
@@ -110,6 +117,13 @@ function areBalanceFiltersEqual(
   right: BalanceFilter,
 ): boolean {
   return left.balance === right.balance;
+}
+
+function areTransposeFiltersEqual(
+  left: TransposeFilter,
+  right: TransposeFilter,
+): boolean {
+  return left.semitones === right.semitones;
 }
 
 function areParametricEqBandsEqual(

--- a/src/plugins/api/interfaces.ts
+++ b/src/plugins/api/interfaces.ts
@@ -16,6 +16,7 @@ export enum DSPFilterType {
   TONE_CONTROL = "tone_control",
   GAIN = "gain",
   BALANCE = "balance",
+  TRANSPOSE = "transpose",
 }
 
 export enum ParametricEQBandType {
@@ -67,12 +68,19 @@ export interface BalanceFilter extends DSPFilterBase {
   balance: number;
 }
 
+export interface TransposeFilter extends DSPFilterBase {
+  type: DSPFilterType.TRANSPOSE;
+  // Key shift in semitones, -12.0 to +12.0. Fractional values are valid.
+  semitones: number;
+}
+
 // Union type for all possible filters
 export type DSPFilter =
   | ParametricEQFilter
   | ToneControlFilter
   | GainFilter
-  | BalanceFilter;
+  | BalanceFilter
+  | TransposeFilter;
 
 // Main DSP chain configuration
 export interface DSPConfig {

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -233,6 +233,15 @@
                 "mid_level": "Mid Level",
                 "treble_level": "Treble Level"
             },
+            "transpose": {
+                "help": "Shifts the music up or down in key without changing the tempo. Useful for playing along in a more comfortable key.",
+                "cpu_hint": "Transposing uses more CPU than the other filters. On low powered hardware, prefer using it on a single player.",
+                "original_key": "Original key",
+                "unit": "semitones",
+                "unit_singular": "semitone",
+                "concert_pitch_432": "A = 432 Hz",
+                "concert_pitch_432_hint": "Set the concert pitch so A is tuned to 432 Hz"
+            },
             "parameter": {
                 "frequency": "Frequency",
                 "gain": "Gain",
@@ -243,7 +252,8 @@
                 "parametric_eq": "Parametric EQ",
                 "tone_control": "Tone Control",
                 "gain": "Gain",
-                "balance": "Balance"
+                "balance": "Balance",
+                "transpose": "Transpose"
             },
             "channels": {
                 "ALL": "All",

--- a/src/views/settings/EditPlayerDsp.vue
+++ b/src/views/settings/EditPlayerDsp.vue
@@ -194,6 +194,12 @@
                 is_log: false,
               }"
             />
+            <DSPTranspose
+              v-else-if="
+                dsp.filters[selectedStage].type === DSPFilterType.TRANSPOSE
+              "
+              v-model="dsp.filters[selectedStage] as TransposeFilter"
+            />
           </v-card>
         </v-col>
       </v-row>
@@ -263,6 +269,7 @@ import {
   DSPFilterType,
   type GainFilter,
   type BalanceFilter,
+  type TransposeFilter,
   ParametricEQFilter,
   ToneControlFilter,
   EventType,
@@ -272,6 +279,7 @@ import DSPPipeline from "@/components/dsp/DSPPipeline.vue";
 import DSPSlider from "@/components/dsp/DSPSlider.vue";
 import DSPParametricEQ from "@/components/dsp/DSPParametricEQ.vue";
 import DSPToneControl from "@/components/dsp/DSPToneControl.vue";
+import DSPTranspose from "@/components/dsp/DSPTranspose.vue";
 import { Badge } from "@/components/ui/badge";
 import { useDSPPresets } from "@/composables/useDSPPresets";
 import {
@@ -324,12 +332,14 @@ let pendingPresetApply: PresetApplyContext | undefined;
 
 let unsubPlayerDSP: (() => void) | undefined = undefined;
 
-const filterTypes = Object.values(DSPFilterType).map((value) => {
-  return {
-    value: value,
-    title: t(`settings.dsp.types.${value}`),
-  };
-});
+const filterTypes = Object.values(DSPFilterType)
+  .map((value) => {
+    return {
+      value: value,
+      title: t(`settings.dsp.types.${value}`),
+    };
+  })
+  .sort((a, b) => a.title.localeCompare(b.title));
 const selectedPresetLabel = computed(() => {
   const presetId = dsp.value?.preset_id;
   if (!presetId) return undefined;
@@ -391,6 +401,13 @@ const addFilter = () => {
         enabled: true,
         type: DSPFilterType.BALANCE,
         balance: 0,
+      };
+      break;
+    case DSPFilterType.TRANSPOSE:
+      filter = {
+        enabled: true,
+        type: DSPFilterType.TRANSPOSE,
+        semitones: 0,
       };
       break;
     default:


### PR DESCRIPTION
Adds a transpose filter with a semitone slider (min / original key / max scale) and a numeric readout, plus an A=432Hz preset button with a hover hint. Built with shadcn components.

<img width="1393" height="285" alt="image" src="https://github.com/user-attachments/assets/6fadb06a-ae5a-4159-9670-51a404c4b560" />
