### PR TITLE
Fix SHIELD dashboard routing and sizing

### DIFF
--- a/src/views/Login.vue
+++ b/src/views/Login.vue
@@ -745,7 +745,7 @@ const completeDashboardAuth = async (
   }
 
   sessionStorage.setItem(DASHBOARD_VIEWER_PATH_STORAGE_KEY, path);
-  void router.replace(path);
+  await router.replace(path);
 
   const urlParams = new URLSearchParams(window.location.search);
   urlParams.delete("remote_id");

--- a/src/views/PartyDashboardView.vue
+++ b/src/views/PartyDashboardView.vue
@@ -905,7 +905,8 @@ watch(
 <style scoped>
 .party-view {
   width: 100%;
-  height: 100%;
+  height: 100vh;
+  height: 100dvh;
   overflow: hidden;
   position: relative;
   display: flex;


### PR DESCRIPTION
Dashboard authentication could leave slower Cast and Android TV clients on the login route because URL cleanup raced dashboard navigation. Party dashboards also inherited a partial parent height instead of filling the viewport.

- Wait for dashboard navigation before removing authentication parameters
- Size Party dashboards with the progressive `100vh`/`100dvh` viewport fallback