### PR TITLE
Cast the Music Quiz to a display

### DIFF
--- a/src/views/MusicQuizDashboardView.vue
+++ b/src/views/MusicQuizDashboardView.vue
@@ -35,18 +35,25 @@
             {{ statusText }}
           </p>
         </div>
-        <Button
-          v-if="isAdmin && musicQuizProviderInstanceId"
-          class="shrink-0"
-          variant="ghost"
-          size="icon"
-          data-testid="music-quiz-settings"
-          :aria-label="$t('providers.music_quiz.settings')"
-          :title="$t('providers.music_quiz.settings')"
-          @click="goToMusicQuizSettings"
-        >
-          <Settings class="size-5" />
-        </Button>
+        <div class="flex shrink-0 items-center gap-1">
+          <Button
+            v-if="isAdmin && musicQuizProviderInstanceId"
+            variant="ghost"
+            size="icon"
+            data-testid="music-quiz-settings"
+            :aria-label="$t('providers.music_quiz.settings')"
+            :title="$t('providers.music_quiz.settings')"
+            @click="goToMusicQuizSettings"
+          >
+            <Settings class="size-5" />
+          </Button>
+          <ShowDashboardButton
+            dashboard="music_quiz"
+            variant="ghost"
+            button-size="icon"
+            :icon-size="20"
+          />
+        </div>
       </header>
 
       <MusicQuizConnectionBanners :degraded="isConnectionDegraded" />
@@ -215,6 +222,7 @@ import MusicQuizSessionHeader from "@/components/music-quiz/MusicQuizSessionHead
 import MusicQuizSessionPanels from "@/components/music-quiz/MusicQuizSessionPanels.vue";
 import MusicQuizSetupWizard from "@/components/music-quiz/MusicQuizSetupWizard.vue";
 import MusicQuizUnsupportedGame from "@/components/music-quiz/MusicQuizUnsupportedGame.vue";
+import ShowDashboardButton from "@/components/ShowDashboardButton.vue";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import {

--- a/tests/views/MusicQuizDashboardHostActions.test.ts
+++ b/tests/views/MusicQuizDashboardHostActions.test.ts
@@ -301,10 +301,15 @@ describe("MusicQuizDashboardView host actions", () => {
       expect.arrayContaining(["mx-auto", "max-w-6xl", "p-4"]),
     );
     expect(root.classes()).not.toContain("lg:h-full");
+    expect(wrapper.find('[data-testid="music-quiz-cast"]').exists()).toBe(true);
 
     await wrapper.get('[data-testid="enter-present"]').trigger("click");
 
     expect(wrapper.find('[data-testid="present-stage"]').exists()).toBe(true);
+    // the header (and its cast button) gives way to the present stage
+    expect(wrapper.find('[data-testid="music-quiz-cast"]').exists()).toBe(
+      false,
+    );
     expect(root.classes()).toEqual(
       expect.arrayContaining([
         "w-full",
@@ -425,6 +430,9 @@ function mountDashboard() {
         MusicQuizSessionPanels: true,
         MusicQuizSetupWizard: {
           template: '<div data-testid="setup-wizard" />',
+        },
+        ShowDashboardButton: {
+          template: '<button data-testid="music-quiz-cast" />',
         },
         MusicQuizUnsupportedGame: true,
         Dialog: {

--- a/tests/views/MusicQuizDashboardView.test.ts
+++ b/tests/views/MusicQuizDashboardView.test.ts
@@ -138,6 +138,18 @@ describe("MusicQuizDashboardView", () => {
     wrapper.unmount();
   });
 
+  it("offers casting the quiz dashboard, also to non-admins", async () => {
+    const wrapper = mountDashboard();
+    await flushPromises();
+
+    const cast = wrapper.get('[data-testid="music-quiz-cast"]');
+    expect(cast.attributes("data-dashboard")).toBe("music_quiz");
+    // casting is a host action, unlike the admin-only provider settings shortcut
+    expect(wrapper.find('[data-testid="music-quiz-settings"]').exists()).toBe(
+      false,
+    );
+  });
+
   it("retains playback changes when setup is cancelled and reopened", async () => {
     const wrapper = mountDashboard();
     await flushPromises();
@@ -291,6 +303,11 @@ function mountDashboard() {
         MusicQuizConnectionBanners: true,
         MusicQuizHostPanel: {
           template: '<div><slot name="game" /></div>',
+        },
+        ShowDashboardButton: {
+          props: ["dashboard"],
+          template:
+            '<button data-testid="music-quiz-cast" :data-dashboard="dashboard" />',
         },
         MusicQuizSessionHeader: {
           template: '<header><slot name="actions" /></header>',


### PR DESCRIPTION
Party and the fullscreen player can already be cast to a display device (Chromecast, Apple TV), but the Music Quiz could not — the server offers it, there was just no button for it.

- Adds the cast button to the Music Quiz dashboard header, next to the settings shortcut.
- Available to anyone hosting the quiz, and hidden automatically when no display device supports it.
