### PR TITLE
Fix Android TV dashboard rendering and tidy the now-playing layout

### DIFF
--- a/src/components/LyricsViewer.vue
+++ b/src/components/LyricsViewer.vue
@@ -142,11 +142,17 @@ const props = withDefaults(defineProps<Props>(), {
   offset: 0,
 });
 
-// Older Cast and Android TV runtimes have no color-mix(); an unsupported stop
-// invalidates the whole gradient, which would blank the note entirely.
-const unsungNoteColor = computed(() =>
-  Color(props.textColor).alpha(0.35).string(),
-);
+// Older Cast and Android TV runtimes have no color-mix(), and an unsupported
+// stop invalidates the whole gradient, which would blank the note entirely.
+// Keywords and var() references can only be resolved by the browser, so those
+// keep the color-mix() form.
+const unsungNoteColor = computed(() => {
+  try {
+    return Color(props.textColor).alpha(0.35).string();
+  } catch {
+    return `color-mix(in srgb, ${props.textColor} 35%, transparent)`;
+  }
+});
 
 // Core state
 const displayLines = ref<DisplayLine[]>([]);

--- a/src/components/LyricsViewer.vue
+++ b/src/components/LyricsViewer.vue
@@ -69,7 +69,7 @@
               :style="
                 activeLyricIndex === index && n === filledNoteCount + 1
                   ? {
-                      backgroundImage: `linear-gradient(to right, ${textColor} ${currentNoteFillPercent}%, color-mix(in srgb, ${textColor} 35%, transparent) ${currentNoteFillPercent}%)`,
+                      backgroundImage: `linear-gradient(to right, ${textColor} ${currentNoteFillPercent}%, ${unsungNoteColor} ${currentNoteFillPercent}%)`,
                       backgroundClip: 'text',
                       '-webkit-background-clip': 'text',
                       '-webkit-text-fill-color': 'transparent',
@@ -106,6 +106,7 @@ import { Spinner } from "@/components/ui/spinner";
 import { parseLrcLine } from "@/helpers/lrcParser";
 import { MediaItemType, StreamDetails, Track } from "@/plugins/api/interfaces";
 import { $t } from "@/plugins/i18n";
+import Color from "color";
 import { computed, nextTick, onBeforeUnmount, ref, watch } from "vue";
 
 interface DisplayLine {
@@ -140,6 +141,12 @@ const props = withDefaults(defineProps<Props>(), {
   highlightAhead: true,
   offset: 0,
 });
+
+// Older Cast and Android TV runtimes have no color-mix(); an unsupported stop
+// invalidates the whole gradient, which would blank the note entirely.
+const unsungNoteColor = computed(() =>
+  Color(props.textColor).alpha(0.35).string(),
+);
 
 // Core state
 const displayLines = ref<DisplayLine[]>([]);

--- a/src/components/party/PartyQR.vue
+++ b/src/components/party/PartyQR.vue
@@ -17,7 +17,17 @@
         :aria-label="$t('providers.party.copy_link')"
         @click="copyUrlToClipboard"
       >
-        <canvas ref="qrCanvas"></canvas>
+        <svg
+          class="qr-code"
+          :viewBox="`0 0 ${qrExtent} ${qrExtent}`"
+          :width="qrSize"
+          :height="qrSize"
+          shape-rendering="crispEdges"
+          role="img"
+        >
+          <rect :width="qrExtent" :height="qrExtent" :fill="qrLight" />
+          <path :d="qrModulesPath" :fill="qrDark" />
+        </svg>
         <Transition name="copy-toast">
           <div
             v-if="copyFeedback"
@@ -69,7 +79,7 @@ import { EventType } from "@/plugins/api/interfaces";
 import { $t } from "@/plugins/i18n";
 import { AlertCircle, Check } from "@lucide/vue";
 import QRCode from "qrcode";
-import { computed, onBeforeUnmount, onMounted, ref, watch } from "vue";
+import { computed, onBeforeUnmount, onMounted, ref } from "vue";
 
 const props = withDefaults(
   defineProps<{
@@ -102,7 +112,6 @@ const shareDescription = computed(
     $t("providers.party.share_description"),
 );
 
-const qrCanvas = ref<HTMLCanvasElement | null>(null);
 const qrContainer = ref<HTMLElement | null>(null);
 const shareActions = ref<InstanceType<typeof InvitationShareActions> | null>(
   null,
@@ -119,6 +128,34 @@ let unsubProviders: (() => void) | undefined;
 let unsubCoreState: (() => void) | undefined;
 let unmounted = false;
 
+// Quiet zone around the symbol, in modules.
+const QR_MARGIN = 2;
+
+const qrModules = computed(() =>
+  qrCodeUrl.value ? QRCode.create(qrCodeUrl.value, {}).modules : null,
+);
+
+const qrExtent = computed(() =>
+  qrModules.value ? qrModules.value.size + QR_MARGIN * 2 : 1,
+);
+
+// One 1x1 module square per dark bit; the viewBox scales it to any size, so
+// resizing and recolouring stay pure attribute updates.
+const qrModulesPath = computed(() => {
+  const modules = qrModules.value;
+  if (!modules) return "";
+  const { size, data } = modules;
+  let path = "";
+  for (let y = 0; y < size; y++) {
+    for (let x = 0; x < size; x++) {
+      if (data[y * size + x]) {
+        path += `M${x + QR_MARGIN} ${y + QR_MARGIN}h1v1h-1z`;
+      }
+    }
+  }
+  return path;
+});
+
 function copyUrlToClipboard() {
   void shareActions.value?.copyLink();
 }
@@ -134,19 +171,6 @@ function handleCopyResult(success: boolean) {
   }, 2000);
 }
 
-// Render QR code when canvas mounts (after v-if switches to the qr-display branch)
-watch(qrCanvas, (canvas) => {
-  if (canvas) renderQRToCanvas();
-});
-
-// Re-render when colors change (e.g., empty-state vs album-art mode)
-watch(
-  () => [props.qrDark, props.qrLight],
-  () => {
-    if (qrCanvas.value && qrCodeUrl.value) renderQRToCanvas();
-  },
-);
-
 onMounted(async () => {
   await generateQRCode();
   if (unmounted) return;
@@ -154,12 +178,7 @@ onMounted(async () => {
   // Set up ResizeObserver to regenerate QR code when container size changes
   if (qrContainer.value) {
     resizeObserver = new ResizeObserver(() => {
-      if (qrCodeUrl.value && qrCanvas.value) {
-        const newSize = calculateQRSize();
-        if (newSize !== qrSize.value) {
-          renderQRToCanvas();
-        }
-      }
+      qrSize.value = calculateQRSize();
     });
     resizeObserver.observe(qrContainer.value);
   }
@@ -208,19 +227,6 @@ function calculateQRSize() {
   return Math.max(160, Math.min(1024, availableSize));
 }
 
-async function renderQRToCanvas() {
-  if (!qrCanvas.value || !qrCodeUrl.value) return;
-  qrSize.value = calculateQRSize();
-  await QRCode.toCanvas(qrCanvas.value, qrCodeUrl.value, {
-    width: qrSize.value,
-    margin: 2,
-    color: {
-      dark: props.qrDark,
-      light: props.qrLight,
-    },
-  });
-}
-
 async function generateQRCode() {
   loading.value = true;
   try {
@@ -233,13 +239,8 @@ async function generateQRCode() {
       return;
     }
 
-    // Set URL — the watch on qrCanvas handles initial mount rendering
+    // Setting the URL is enough — the symbol is derived from it.
     qrCodeUrl.value = url;
-
-    // If canvas is already mounted (e.g., re-generating after config change), render now
-    if (qrCanvas.value) {
-      await renderQRToCanvas();
-    }
   } catch (error) {
     console.error("Failed to generate QR code:", error);
     guestAccessEnabled.value = false;
@@ -353,7 +354,7 @@ async function generateQRCode() {
   transform: translate(-50%, -50%) scale(0.8);
 }
 
-.qr-display canvas {
+.qr-display .qr-code {
   display: block;
   border-radius: 8px;
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.2);

--- a/src/components/party/PartyQR.vue
+++ b/src/components/party/PartyQR.vue
@@ -23,7 +23,7 @@
           :width="qrSize"
           :height="qrSize"
           shape-rendering="crispEdges"
-          role="img"
+          aria-hidden="true"
         >
           <rect :width="qrExtent" :height="qrExtent" :fill="qrLight" />
           <path :d="qrModulesPath" :fill="qrDark" />
@@ -132,7 +132,7 @@ let unmounted = false;
 const QR_MARGIN = 2;
 
 const qrModules = computed(() =>
-  qrCodeUrl.value ? QRCode.create(qrCodeUrl.value, {}).modules : null,
+  qrCodeUrl.value ? QRCode.create(qrCodeUrl.value).modules : null,
 );
 
 const qrExtent = computed(() =>

--- a/src/components/party/PartyQR.vue
+++ b/src/components/party/PartyQR.vue
@@ -25,7 +25,6 @@
           shape-rendering="crispEdges"
           aria-hidden="true"
         >
-          <rect :width="qrExtent" :height="qrExtent" :fill="qrLight" />
           <path :d="qrModulesPath" :fill="qrDark" />
         </svg>
         <Transition name="copy-toast">
@@ -84,11 +83,9 @@ import { computed, onBeforeUnmount, onMounted, ref } from "vue";
 const props = withDefaults(
   defineProps<{
     qrDark?: string;
-    qrLight?: string;
   }>(),
   {
     qrDark: "#FFFFFF",
-    qrLight: "#00000000",
   },
 );
 

--- a/src/composables/useActiveTrackWaveform.ts
+++ b/src/composables/useActiveTrackWaveform.ts
@@ -9,10 +9,8 @@ import { useUserPreferences } from "@/composables/userPreferences";
 // duplicate API calls.
 const waveformBins = ref<number[] | null>(null);
 const trackDurationSecs = ref<number>(0);
-const waveformLoading = ref(false);
 
 let lastFetchKey: string | undefined;
-let loadingTimeoutId: ReturnType<typeof setTimeout> | null = null;
 
 const { getPreference } = useUserPreferences();
 const showWaveformPref = getPreference("show_waveform", true);
@@ -31,30 +29,18 @@ watch(
     if (fetchKey === lastFetchKey) return;
     lastFetchKey = fetchKey;
 
-    if (loadingTimeoutId !== null) {
-      clearTimeout(loadingTimeoutId);
-      loadingTimeoutId = null;
-    }
-
     waveformBins.value = null;
-    waveformLoading.value = false;
     trackDurationSecs.value = store.curQueueItem?.duration ?? 0;
 
     const mediaItem = store.curQueueItem?.media_item;
     if (!mediaItem || mediaItem.media_type !== MediaType.TRACK) return;
     if (!showWaveform) return;
 
+    // Without streamdetails there is nothing to analyse yet; this refires once
+    // they arrive, because the watcher tracks their item id.
     const streamDetails = store.curQueueItem?.streamdetails;
-    if (!streamDetails) {
-      waveformLoading.value = true;
-      // Safety net: clear loading if streamdetails never arrive for this item.
-      loadingTimeoutId = setTimeout(() => {
-        if (lastFetchKey === fetchKey) waveformLoading.value = false;
-      }, 5000);
-      return;
-    }
+    if (!streamDetails) return;
 
-    waveformLoading.value = true;
     try {
       const bins = await api.getWaveForm(
         streamDetails.item_id,
@@ -65,14 +51,11 @@ watch(
       waveformBins.value = bins?.length ? bins : null;
     } catch {
       // No audio analysis available.
-    } finally {
-      const currentKey = `${showWaveformPref.value}:${store.curQueueItem?.queue_item_id}:${store.curQueueItem?.streamdetails?.item_id}`;
-      if (currentKey === fetchKey) waveformLoading.value = false;
     }
   },
   { immediate: true },
 );
 
 export function useActiveTrackWaveform() {
-  return { waveformBins, trackDurationSecs, waveformLoading };
+  return { waveformBins, trackDurationSecs };
 }

--- a/src/layouts/default/PlayerOSD/PlayerFullscreen.vue
+++ b/src/layouts/default/PlayerOSD/PlayerFullscreen.vue
@@ -328,7 +328,6 @@
             :show-labels="true"
             :color="sliderColor"
             :waveform="waveformData"
-            :waveform-loading="waveformLoading"
           />
         </div>
 
@@ -746,8 +745,7 @@ watch(
 );
 
 // Waveform for the current track — loaded centrally by useActiveTrackWaveform.
-const { waveformBins: waveformData, waveformLoading } =
-  useActiveTrackWaveform();
+const { waveformBins: waveformData } = useActiveTrackWaveform();
 const { getPreference, setPreference } = useUserPreferences();
 const showWaveformPref = getPreference("show_waveform", true);
 

--- a/src/layouts/default/PlayerOSD/PlayerTimeline.vue
+++ b/src/layouts/default/PlayerOSD/PlayerTimeline.vue
@@ -1,15 +1,12 @@
 <template>
-  <div
-    class="w-auto"
-    :class="usesWaveformLayout ? 'h-8 md:h-10 lg:h-12' : 'h-6'"
-  >
+  <div class="w-auto" :class="hasWaveform ? 'h-8 md:h-10 lg:h-12' : 'h-6'">
     <div v-if="store.activePlayer">
       <SliderRoot
         v-model="wrappedCurTimeValue"
         data-slot="slider"
         class="relative flex items-center select-none touch-none w-full"
         :class="[
-          usesWaveformLayout ? 'h-11 md:h-12 lg:h-14' : 'h-8',
+          hasWaveform ? 'h-11 md:h-12 lg:h-14' : 'h-8',
           hasWaveform && canSeek ? 'cursor-pointer' : '',
         ]"
         :disabled="!canSeek"
@@ -27,29 +24,27 @@
         <SliderTrack
           data-slot="slider-track"
           class="relative grow rounded-full"
-          :class="usesWaveformLayout ? 'h-8 md:h-10 lg:h-12' : 'h-1'"
+          :class="hasWaveform ? 'h-8 md:h-10 lg:h-12' : 'h-1'"
         >
           <div
-            v-if="!usesWaveformLayout"
+            v-if="!hasWaveform"
             class="absolute inset-0 rounded-full"
             :style="trackBackgroundStyle"
           />
           <WaveformTrack
-            v-if="hasWaveform"
+            v-else
             :data="waveform!"
             :color="color"
             :progress-percent="progressPercent"
             :hover-percent="hoverPercent"
           />
-          <div
-            v-else-if="waveformLoading"
-            class="absolute inset-x-0 top-1/2 h-1 -translate-y-1/2 rounded-full"
-            :style="trackBackgroundStyle"
-          />
+          <!-- Sized to the track instead of centred with -translate-y-1/2:
+               Tailwind emits the standalone `translate` property, which Android
+               TV's Chrome ignores, dropping the fill half a bar too low. -->
           <SliderRange
             v-if="!hasWaveform"
             data-slot="slider-range"
-            class="absolute rounded-full h-1 top-1/2 -translate-y-1/2"
+            class="absolute inset-y-0 rounded-full"
             :style="{ 'background-color': color }"
           />
           <!-- pointerdown.stop prevents reka's slider track tap action -->
@@ -141,14 +136,12 @@ export interface Props {
   color?: string;
   // Precomputed waveform bins (0.0-1.0); when set, replaces the flat track.
   waveform?: number[] | null;
-  waveformLoading?: boolean;
 }
 
 const props = withDefaults(defineProps<Props>(), {
   showLabels: false,
   color: "var(--foreground)",
   waveform: null,
-  waveformLoading: false,
 });
 
 const { activeSource } = useActiveSource(toRef(store, "activePlayer"));
@@ -368,9 +361,6 @@ const chapterTicks = computed(() =>
 );
 
 const hasWaveform = computed(() => !!props.waveform?.length);
-const usesWaveformLayout = computed(
-  () => hasWaveform.value || props.waveformLoading,
-);
 // Older Cast and Android TV runtimes need an opacity layer instead of color-mix().
 const trackBackgroundStyle = computed(() => ({
   backgroundColor: props.color,

--- a/src/layouts/default/PlayerOSD/PlayerTimeline.vue
+++ b/src/layouts/default/PlayerOSD/PlayerTimeline.vue
@@ -38,9 +38,9 @@
             :progress-percent="progressPercent"
             :hover-percent="hoverPercent"
           />
-          <!-- Sized to the track instead of centred with -translate-y-1/2:
-               Tailwind emits the standalone `translate` property, which Android
-               TV's Chrome ignores, dropping the fill half a bar too low. -->
+          <!-- Tailwind's translate utilities emit the standalone `translate`
+               property, which Android TV's Chrome ignores. Everything below
+               centres via the track box or an explicit transform instead. -->
           <SliderRange
             v-if="!hasWaveform"
             data-slot="slider-range"
@@ -52,8 +52,11 @@
             v-for="tick in chapterTicks"
             :key="tick.position"
             type="button"
-            class="absolute top-1/2 -translate-x-1/2 -translate-y-1/2 flex h-4 w-3 items-center justify-center"
-            :style="{ left: `${tick.percent}%` }"
+            class="absolute top-1/2 flex h-4 w-3 items-center justify-center"
+            :style="{
+              left: `${tick.percent}%`,
+              transform: 'translate(-50%, -50%)',
+            }"
             :aria-label="tick.name"
             @pointerdown.stop
             @click.stop="chapterClicked(tick)"
@@ -84,8 +87,8 @@
             v-for="tick in chapterTicks"
             :key="`label-${tick.position}`"
             type="button"
-            class="absolute bottom-full mb-1 -translate-x-1/2 appearance-none border-0 bg-transparent p-0 text-caption text-inherit cursor-pointer whitespace-nowrap"
-            :style="{ left: `${tick.percent}%` }"
+            class="absolute bottom-full mb-1 appearance-none border-0 bg-transparent p-0 text-caption text-inherit cursor-pointer whitespace-nowrap"
+            :style="{ left: `${tick.percent}%`, transform: 'translateX(-50%)' }"
             @pointerdown.stop
             @click="chapterClicked(tick)"
           >

--- a/src/layouts/default/PlayerOSD/WaveformTrack.vue
+++ b/src/layouts/default/PlayerOSD/WaveformTrack.vue
@@ -1,6 +1,6 @@
 <template>
   <div ref="containerEl" class="waveform-track">
-    <svg class="waveform-layer" :aria-hidden="true">
+    <svg class="waveform-layer" aria-hidden="true">
       <path
         :d="barsPath"
         :stroke="color"
@@ -12,7 +12,7 @@
     </svg>
     <svg
       class="waveform-layer"
-      :aria-hidden="true"
+      aria-hidden="true"
       :style="{ clipPath: `inset(0 ${100 - brightClipEnd}% 0 0)` }"
     >
       <path

--- a/src/layouts/default/PlayerOSD/WaveformTrack.vue
+++ b/src/layouts/default/PlayerOSD/WaveformTrack.vue
@@ -1,16 +1,33 @@
 <template>
   <div ref="containerEl" class="waveform-track">
-    <canvas ref="dimCanvasEl" class="waveform-canvas" />
-    <canvas
-      ref="brightCanvasEl"
-      class="waveform-canvas"
+    <svg class="waveform-layer" :aria-hidden="true">
+      <path
+        :d="barsPath"
+        :stroke="color"
+        :stroke-opacity="DIM_ALPHA"
+        :stroke-width="BAR_WIDTH"
+        stroke-linecap="round"
+        fill="none"
+      />
+    </svg>
+    <svg
+      class="waveform-layer"
+      :aria-hidden="true"
       :style="{ clipPath: `inset(0 ${100 - brightClipEnd}% 0 0)` }"
-    />
+    >
+      <path
+        :d="barsPath"
+        :stroke="color"
+        :stroke-width="BAR_WIDTH"
+        stroke-linecap="round"
+        fill="none"
+      />
+    </svg>
   </div>
 </template>
 
 <script setup lang="ts">
-import { computed, ref, watch } from "vue";
+import { computed, ref } from "vue";
 import { useElementSize } from "@vueuse/core";
 
 export interface Props {
@@ -33,12 +50,8 @@ const BAR_WIDTH = 2;
 // Keep silent sections visible as a thin baseline.
 const MIN_BAR_HEIGHT = 2;
 const DIM_ALPHA = 0.3;
-// A 1/255 fill prevents older Cast and Android TV compositors from dropping the canvas.
-const COMPOSITOR_BLEED_ALPHA = 1 / 255;
 
 const containerEl = ref<HTMLDivElement>();
-const dimCanvasEl = ref<HTMLCanvasElement>();
-const brightCanvasEl = ref<HTMLCanvasElement>();
 
 const { width, height } = useElementSize(containerEl);
 
@@ -73,78 +86,29 @@ const computePeaks = (bins: number[], barCount: number): number[] => {
   return peaks;
 };
 
-const drawBars = (
-  canvas: HTMLCanvasElement,
-  peaks: number[],
-  cssWidth: number,
-  cssHeight: number,
-  dpr: number,
-  color: string,
-  alpha: number,
-) => {
-  canvas.width = Math.round(cssWidth * dpr);
-  canvas.height = Math.round(cssHeight * dpr);
-  const ctx = canvas.getContext("2d");
-  if (!ctx) return;
-  ctx.scale(dpr, dpr);
-  ctx.clearRect(0, 0, cssWidth, cssHeight);
-  ctx.fillStyle = color;
-  ctx.globalAlpha = COMPOSITOR_BLEED_ALPHA;
-  ctx.fillRect(0, 0, cssWidth, cssHeight);
-  ctx.globalAlpha = alpha;
-  for (let i = 0; i < peaks.length; i++) {
-    const barHeight = Math.max(MIN_BAR_HEIGHT, peaks[i] * cssHeight);
-    const x = i * BAR_PITCH;
-    const y = (cssHeight - barHeight) / 2;
-    ctx.beginPath();
-    if (typeof (ctx as CanvasRenderingContext2D).roundRect === "function") {
-      ctx.roundRect(x, y, BAR_WIDTH, barHeight, BAR_WIDTH / 2);
-    } else {
-      ctx.rect(x, y, BAR_WIDTH, barHeight);
-    }
-    ctx.fill();
-  }
-};
-
-const draw = () => {
+// One vertical segment per bar. Round caps supply the rounded ends, so a bar is
+// inset by half the stroke on both sides and a silent bar collapses to a dot.
+const barsPath = computed(() => {
   const cssWidth = width.value;
   const cssHeight = height.value;
-  if (
-    !dimCanvasEl.value ||
-    !brightCanvasEl.value ||
-    !props.data.length ||
-    cssWidth <= 0 ||
-    cssHeight <= 0
-  )
-    return;
+  if (!props.data.length || cssWidth <= 0 || cssHeight <= 0) return "";
 
-  const dpr = window.devicePixelRatio || 1;
   const barCount = Math.ceil(cssWidth / BAR_PITCH);
   const peaks = computePeaks(props.data, barCount);
+  const inset = BAR_WIDTH / 2;
 
-  drawBars(
-    dimCanvasEl.value,
-    peaks,
-    cssWidth,
-    cssHeight,
-    dpr,
-    props.color,
-    DIM_ALPHA,
-  );
-  drawBars(
-    brightCanvasEl.value,
-    peaks,
-    cssWidth,
-    cssHeight,
-    dpr,
-    props.color,
-    1,
-  );
-};
-
-// Progress/hover only move clip-paths, so playback and pointer movement never redraw.
-watch([width, height, () => props.data, () => props.color], draw, {
-  flush: "post",
+  let path = "";
+  for (let i = 0; i < barCount; i++) {
+    const barHeight = Math.max(MIN_BAR_HEIGHT, peaks[i] * cssHeight);
+    const x = (i * BAR_PITCH + inset).toFixed(2);
+    const top = ((cssHeight - barHeight) / 2 + inset).toFixed(2);
+    const bottom = (
+      (cssHeight - barHeight) / 2 +
+      Math.max(inset, barHeight - inset)
+    ).toFixed(2);
+    path += `M${x} ${top}V${bottom}`;
+  }
+  return path;
 });
 </script>
 
@@ -155,10 +119,11 @@ watch([width, height, () => props.data, () => props.color], draw, {
   height: 100%;
   pointer-events: none;
 }
-.waveform-canvas {
+.waveform-layer {
   position: absolute;
   inset: 0;
   width: 100%;
   height: 100%;
+  overflow: visible;
 }
 </style>

--- a/src/views/DashboardNowPlayingView.vue
+++ b/src/views/DashboardNowPlayingView.vue
@@ -142,7 +142,6 @@ const backgroundGradient = computed(() => {
 .now-playing-artwork {
   flex: 0 0 auto;
   margin-top: auto;
-  min-height: 0;
   width: 100%;
   display: flex;
   align-items: center;

--- a/src/views/DashboardNowPlayingView.vue
+++ b/src/views/DashboardNowPlayingView.vue
@@ -44,7 +44,6 @@
           :show-labels="true"
           :color="timelineColor"
           :waveform="waveformData"
-          :waveform-loading="waveformLoading"
         />
       </div>
     </template>
@@ -83,8 +82,7 @@ onMounted(() => {
 const marqueeSync = new MarqueeTextSync();
 
 // Waveform is always on here: the guest session has no show_waveform preference, so it defaults on.
-const { waveformBins: waveformData, waveformLoading } =
-  useActiveTrackWaveform();
+const { waveformBins: waveformData } = useActiveTrackWaveform();
 
 const artworkUrl = computed(
   () => getMediaImageUrl(store.activePlayer?.current_media?.image_url) || null,
@@ -115,7 +113,6 @@ const backgroundGradient = computed(() => {
 .now-playing-view {
   width: 100%;
   height: 100vh;
-  height: 100dvh;
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -124,6 +121,14 @@ const backgroundGradient = computed(() => {
   padding: 5vh 5vw;
   box-sizing: border-box;
   color: var(--text-color, #fff);
+}
+
+/* Keep the vh fallback in a separate rule: the minifier collapses duplicate
+   declarations, which would drop it and leave Android TV without a height. */
+@supports (height: 100dvh) {
+  .now-playing-view {
+    height: 100dvh;
+  }
 }
 
 .now-playing-empty {

--- a/src/views/DashboardNowPlayingView.vue
+++ b/src/views/DashboardNowPlayingView.vue
@@ -118,7 +118,8 @@ const backgroundGradient = computed(() => {
   align-items: center;
   justify-content: center;
   gap: 3vh;
-  padding: 5vh 5vw;
+  /* Deeper bottom padding lifts the timeline clear of the screen edge. */
+  padding: 5vh 5vw 9vh;
   box-sizing: border-box;
   color: var(--text-color, #fff);
 }
@@ -136,8 +137,11 @@ const backgroundGradient = computed(() => {
   opacity: 0.7;
 }
 
+/* The row hugs the artwork rather than growing, so the leftover height is
+   shared with the auto margins below instead of pooling under the artwork. */
 .now-playing-artwork {
-  flex: 1 1 auto;
+  flex: 0 0 auto;
+  margin-top: auto;
   min-height: 0;
   width: 100%;
   display: flex;
@@ -170,6 +174,8 @@ const backgroundGradient = computed(() => {
 
 .now-playing-info {
   flex: 0 0 auto;
+  /* Centres the text between the artwork and the timeline. */
+  margin-block: auto;
   width: 100%;
   max-width: 900px;
   text-align: center;

--- a/src/views/DashboardNowPlayingView.vue
+++ b/src/views/DashboardNowPlayingView.vue
@@ -146,8 +146,10 @@ const backgroundGradient = computed(() => {
 }
 
 .now-playing-artwork-image {
-  width: min(62.5vh, 92vw);
-  height: min(62.5vh, 92vw);
+  /* flex-basis auto with no shrink: the square must never be squashed to fit */
+  flex: 0 0 auto;
+  width: min(52vh, 85vw);
+  height: min(52vh, 85vw);
   aspect-ratio: 1;
   object-fit: cover;
   border-radius: 12px;
@@ -155,8 +157,9 @@ const backgroundGradient = computed(() => {
 }
 
 .now-playing-artwork-fallback {
-  width: min(62.5vh, 92vw);
-  height: min(62.5vh, 92vw);
+  flex: 0 0 auto;
+  width: min(52vh, 85vw);
+  height: min(52vh, 85vw);
   aspect-ratio: 1;
   border-radius: 12px;
   display: flex;
@@ -174,14 +177,14 @@ const backgroundGradient = computed(() => {
 }
 
 .now-playing-title {
-  font-size: clamp(1.5rem, 3vw, 2.5rem);
+  font-size: clamp(1rem, 2.1vw, 1.75rem);
   font-weight: 600;
 }
 
 .now-playing-subtitle {
-  font-size: clamp(1rem, 2.5vw, 1.75rem);
+  font-size: clamp(0.8rem, 1.5vw, 1.25rem);
   opacity: 0.8;
-  margin-top: 0.5rem;
+  margin-top: 0.25rem;
 }
 
 .now-playing-timeline {

--- a/src/views/PartyDashboardView.vue
+++ b/src/views/PartyDashboardView.vue
@@ -107,11 +107,7 @@
           class="karaoke-qr"
           :style="swapped ? { left: 'auto', right: '2vw' } : undefined"
         >
-          <PartyQR
-            :qr-dark="qrDarkColor"
-            :qr-light="qrLightColor"
-            @available="qrAvailable = $event"
-          />
+          <PartyQR :qr-dark="qrDarkColor" @available="qrAvailable = $event" />
         </div>
 
         <div
@@ -188,11 +184,7 @@
             class="qr-wrapper"
             :style="swapped && displayLyrics ? { order: 1 } : undefined"
           >
-            <PartyQR
-              :qr-dark="qrDarkColor"
-              :qr-light="qrLightColor"
-              @available="qrAvailable = $event"
-            />
+            <PartyQR :qr-dark="qrDarkColor" @available="qrAvailable = $event" />
           </div>
           <div
             v-if="displayLyrics"
@@ -418,10 +410,6 @@ const maLogoSrc = computed(() =>
 );
 const qrDarkColor = computed(() =>
   useLightChrome.value ? "#FFFFFF" : "#000000",
-);
-// Transparent quiet zone, so the symbol sits on the dashboard background.
-const qrLightColor = computed(() =>
-  useLightChrome.value ? "#00000000" : "#FFFFFF00",
 );
 
 const partyName = computed(() => partyConfig.value?.party_name ?? null);

--- a/src/views/PartyDashboardView.vue
+++ b/src/views/PartyDashboardView.vue
@@ -419,9 +419,9 @@ const maLogoSrc = computed(() =>
 const qrDarkColor = computed(() =>
   useLightChrome.value ? "#FFFFFF" : "#000000",
 );
-// A 1/255 fill keeps the QR canvas visible on older Cast and Android TV compositors.
+// Transparent quiet zone, so the symbol sits on the dashboard background.
 const qrLightColor = computed(() =>
-  useLightChrome.value ? "#00000001" : "#FFFFFF01",
+  useLightChrome.value ? "#00000000" : "#FFFFFF00",
 );
 
 const partyName = computed(() => partyConfig.value?.party_name ?? null);
@@ -906,12 +906,19 @@ watch(
 .party-view {
   width: 100%;
   height: 100vh;
-  height: 100dvh;
   overflow: hidden;
   position: relative;
   display: flex;
   align-items: center;
   justify-content: center;
+}
+
+/* Keep the vh fallback in a separate rule: the minifier collapses duplicate
+   declarations, which would drop it and leave Android TV without a height. */
+@supports (height: 100dvh) {
+  .party-view {
+    height: 100dvh;
+  }
 }
 
 .background-image {

--- a/tests/components/party/PartyQR.test.ts
+++ b/tests/components/party/PartyQR.test.ts
@@ -11,7 +11,6 @@ const mocks = vi.hoisted(() => ({
   share: vi.fn(),
   subscribe: vi.fn(),
   toastError: vi.fn(),
-  toCanvas: vi.fn(),
 }));
 
 vi.mock("@/composables/usePartyConfig", () => ({
@@ -54,18 +53,6 @@ vi.mock("@/plugins/i18n", () => ({
   },
 }));
 
-// Only the canvas renderer needs stubbing; symbol generation is pure, so the
-// component renders a real QR here.
-vi.mock("qrcode", async () => {
-  const actual = await vi.importActual<typeof import("qrcode")>("qrcode");
-  return {
-    default: {
-      create: actual.create,
-      toCanvas: mocks.toCanvas,
-    },
-  };
-});
-
 vi.mock("vue-sonner", () => ({
   toast: {
     error: mocks.toastError,
@@ -104,7 +91,6 @@ describe("PartyQR", () => {
     mocks.share.mockReset().mockResolvedValue(undefined);
     mocks.subscribe.mockReset().mockReturnValue(vi.fn());
     mocks.toastError.mockReset();
-    mocks.toCanvas.mockReset().mockResolvedValue(undefined);
   });
 
   afterEach(() => {

--- a/tests/components/party/PartyQR.test.ts
+++ b/tests/components/party/PartyQR.test.ts
@@ -54,11 +54,17 @@ vi.mock("@/plugins/i18n", () => ({
   },
 }));
 
-vi.mock("qrcode", () => ({
-  default: {
-    toCanvas: mocks.toCanvas,
-  },
-}));
+// Only the canvas renderer needs stubbing; symbol generation is pure, so the
+// component renders a real QR here.
+vi.mock("qrcode", async () => {
+  const actual = await vi.importActual<typeof import("qrcode")>("qrcode");
+  return {
+    default: {
+      create: actual.default.create,
+      toCanvas: mocks.toCanvas,
+    },
+  };
+});
 
 vi.mock("vue-sonner", () => ({
   toast: {

--- a/tests/components/party/PartyQR.test.ts
+++ b/tests/components/party/PartyQR.test.ts
@@ -60,7 +60,7 @@ vi.mock("qrcode", async () => {
   const actual = await vi.importActual<typeof import("qrcode")>("qrcode");
   return {
     default: {
-      create: actual.default.create,
+      create: actual.create,
       toCanvas: mocks.toCanvas,
     },
   };


### PR DESCRIPTION
The party and now-playing dashboards were unusable on Android TV: both collapsed to a fraction of the screen (216px of a 540px viewport), and the waveform and the party join QR went blank after a track change. Android TV's Chrome silently drops several modern CSS features, and three separate ones were in play.

- The CSS minifier collapses `height: 100vh; height: 100dvh;` down to the `dvh` declaration alone, which Android TV cannot parse, so both dashboards fell back to auto height. The `dvh` upgrade now lives in an `@supports` block that survives minification. The same pattern in #2194 and #2196 never took effect in a production build.
- The waveform and the QR are drawn as SVG instead of canvas. A canvas is never repainted there after the page's first rasterisation, which is what left them blank; this also removes the earlier compositor workarounds.
- Tailwind's translate utilities emit the standalone `translate` property (Chrome 104+), which put the timeline fill half a bar below its track and knocked the chapter markers off-centre.
- The karaoke note fill built its gradient with `color-mix()`. An unsupported colour stop invalidates the whole gradient, and because the note is painted through `background-clip: text` it disappeared rather than degrading.
- The timeline shows a plain progress bar while waveform data is still loading, instead of holding a waveform-sized gap open.
- Now-playing: smaller square artwork, smaller title and artist with a clearer difference between them, and the text centred between the artwork and the timeline.

Verified on a SHIELD (Chrome 92) and in current Chrome.
