### PR TITLE
Match fullscreen player text sizing to the now-playing dashboard

### DIFF
--- a/src/layouts/default/PlayerOSD/PlayerFullscreen.vue
+++ b/src/layouts/default/PlayerOSD/PlayerFullscreen.vue
@@ -81,14 +81,14 @@
             <!-- player name as title if its powered off-->
             <v-card-title
               v-if="store.activePlayer?.powered == false"
-              :style="`font-size: ${titleFontSize};font-weight:600;`"
+              class="now-playing-title"
             >
               {{ store.activePlayer?.name }}
             </v-card-title>
             <!-- current media title -->
             <v-card-title
               v-else-if="store.activePlayer?.current_media?.title"
-              :style="`font-size: ${titleFontSize};font-weight:600;cursor:pointer;`"
+              class="now-playing-title clickable"
               @click="onTitleClick"
             >
               <MarqueeText :sync="playerMarqueeSync">
@@ -98,7 +98,7 @@
             <!-- no player selected message -->
             <v-card-title
               v-else
-              :style="`font-size: ${titleFontSize};font-weight:600;cursor:pointer;`"
+              class="now-playing-title clickable"
               @click="store.showPlayersMenu = true"
             >
               <MarqueeText :sync="playerMarqueeSync">
@@ -121,7 +121,7 @@
               v-else-if="
                 store.activePlayer?.current_media?.album && showAlbumSubtitle
               "
-              :style="`font-size: ${subTitleFontSize};cursor:pointer;`"
+              class="now-playing-subtitle clickable"
               @click="onAlbumClick"
             >
               <MarqueeText :sync="playerMarqueeSync">
@@ -132,7 +132,7 @@
             <!-- subtitle: artist -->
             <v-card-subtitle
               v-if="store.activePlayer?.current_media?.artist"
-              :style="`font-size: ${subTitleFontSize};cursor:pointer;`"
+              class="now-playing-subtitle clickable"
               @click="onArtistClick"
             >
               <MarqueeText :sync="playerMarqueeSync">
@@ -503,7 +503,7 @@ import QueueBtn from "./PlayerControlBtn/QueueBtn.vue";
 import PlayerTimeline from "./PlayerTimeline.vue";
 import { useActiveTrackWaveform } from "@/composables/useActiveTrackWaveform";
 
-const { name, mdAndUp } = useDisplay();
+const { mdAndUp } = useDisplay();
 
 const MIN_HEIGHT_SHOW_FULL_DETAILS = 750;
 // The player select button is important enough to keep pinned at the bottom in
@@ -748,31 +748,6 @@ watch(
 const { waveformBins: waveformData } = useActiveTrackWaveform();
 const { getPreference, setPreference } = useUserPreferences();
 const showWaveformPref = getPreference("show_waveform", true);
-
-const titleFontSize = computed(() => {
-  switch (name.value) {
-    case "xs":
-      return "1.3em";
-    case "sm":
-      return "1.6em";
-    case "md":
-      return "1.8em";
-    case "lg":
-      return store.showQueueItems ? "1.7em" : "2.1em";
-    case "xl":
-      return store.showQueueItems ? "1.8em" : "2.3em";
-    case "xxl":
-      return store.showQueueItems ? "1.9em" : "2.5em";
-    default:
-      return "1.0em";
-  }
-});
-
-const subTitleFontSize = computed(() => {
-  // Anchor album/artist size to the track title using the EditorialMediaCard
-  // tile ratio (subtitle 12px / title 14px).
-  return `${(parseFloat(titleFontSize.value) * (12 / 14)).toFixed(3)}em`;
-});
 
 const showExpandedPlayerSelectButton = computed(() => {
   // Always show the player select button at the bottom; only hide it on very
@@ -1510,10 +1485,26 @@ watchEffect(() => {
   text-align: center;
   padding: min(5%, 5vh) 0 10px;
   overflow: hidden;
+  container-type: inline-size; /* anchor for the cqw sizing below */
 }
 
 .main-media-details-track-info > * {
   max-width: 100%;
+}
+
+/* Ratios mirror the cast dashboard; cqw trims the text when the queue halves this column. */
+.now-playing-title {
+  font-size: clamp(1.125rem, min(2.1vw, 3.4cqw), 1.75rem);
+  font-weight: 600;
+}
+
+.now-playing-subtitle {
+  font-size: clamp(0.8rem, min(1.5vw, 2.4cqw), 1.25rem);
+  opacity: 0.8;
+}
+
+.clickable {
+  cursor: pointer;
 }
 
 .player-bottom {


### PR DESCRIPTION
The title and artist text in the fullscreen player were noticeably larger than
the now-playing dashboard, which sizes its text with `clamp()` on the viewport
width. The player instead used a per-breakpoint `em` switch, with a separate
smaller variant for when the queue list is open. That gave a weaker
title/artist hierarchy (1.17x vs the dashboard's 1.40x) and a different
rendered size on every screen.

This aligns the player with the dashboard so both screens render the same type.

- Replace the `titleFontSize` / `subTitleFontSize` breakpoint switch with the
  dashboard's `clamp()` ratios, reusing the same class names
  (`.now-playing-title` / `.now-playing-subtitle`).
- Add `container-type: inline-size` to the details column and size the text
  with `min(vw, cqw)`, so it steps down on its own when the queue list halves
  the column instead of needing an explicit `showQueueItems` branch.
- Keep `font-weight: 600` on the title and set the artist to `opacity: 0.8`,
  matching the dashboard (Vuetify's card default was 0.6).
- Floor the title at `1.125rem` rather than the dashboard's `1rem`, so phone
  screens stay legible up close. This also holds the 1.4x hierarchy at the
  floor, where the old code fell to 1.17x.

Rendered sizes (title / artist, px):

| Viewport | Before | After, queue closed | After, queue open |
| --- | --- | --- | --- |
| 375 | 20.8 / 17.8 | 18 / 12.8 | - |
| 600 | 25.6 / 21.9 | 18 / 12.8 | - |
| 960 | 28.8 / 24.7 | 20.16 / 14.4 | - |
| 1100 | 33.6 / 28.8 | 23.1 / 16.5 | 18.7 / 13.2 |
| 1280 | 33.6 / 28.8 | 26.88 / 19.2 | 21.76 / 15.36 |
| 1920 | 36.8 / 31.5 | 28 / 20 | 28 / 20 |
| 2560 | 40 / 34.3 | 28 / 20 | 28 / 20 |

960px with the queue closed lands on 20.16 / 14.4, identical to the dashboard.
Queue-open is blank below 1100 because the details column is hidden entirely at
that width (`bp7`).
