### PR TITLE
Config action buttons use the dedicated invoke_action commands

### DIFF
--- a/src/helpers/openActionUrlEntries.test.ts
+++ b/src/helpers/openActionUrlEntries.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, afterEach } from "vitest";
 import { openActionUrlEntries } from "./utils";
-import { ConfigEntry, ConfigEntryType } from "@/plugins/api/interfaces";
+import { type ConfigEntry, ConfigEntryType } from "@/plugins/api/interfaces";
 
 const urlEntry = (value: unknown, key = "wizard"): ConfigEntry =>
   ({

--- a/src/helpers/openActionUrlEntries.test.ts
+++ b/src/helpers/openActionUrlEntries.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { openActionUrlEntries } from "./utils";
+import { ConfigEntry, ConfigEntryType } from "@/plugins/api/interfaces";
+
+const urlEntry = (value: unknown, key = "wizard"): ConfigEntry =>
+  ({
+    key,
+    type: ConfigEntryType.URL,
+    label: key,
+    value,
+  }) as ConfigEntry;
+
+const stringEntry = (key = "server_url"): ConfigEntry =>
+  ({
+    key,
+    type: ConfigEntryType.STRING,
+    label: key,
+    value: "abc",
+  }) as ConfigEntry;
+
+describe("openActionUrlEntries", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("opens http(s) url entries via an anchor click and drops them", () => {
+    const click = vi
+      .spyOn(HTMLAnchorElement.prototype, "click")
+      .mockImplementation(() => undefined);
+    const entries = [urlEntry("https://example.com/connect"), stringEntry()];
+    const result = openActionUrlEntries(entries);
+    expect(click).toHaveBeenCalledTimes(1);
+    expect(result).toHaveLength(1);
+    expect(result[0].key).toBe("server_url");
+  });
+
+  it("never opens non-web schemes but still drops the entries", () => {
+    const click = vi
+      .spyOn(HTMLAnchorElement.prototype, "click")
+      .mockImplementation(() => undefined);
+    const entries = [
+      // eslint-disable-next-line no-script-url
+      urlEntry("javascript:alert(1)", "xss"),
+      urlEntry("data:text/html,hi", "data"),
+      urlEntry("not a url at all", "junk"),
+      urlEntry(1234, "notstring"),
+      stringEntry(),
+    ];
+    const result = openActionUrlEntries(entries);
+    expect(click).not.toHaveBeenCalled();
+    // every URL-type entry is removed from the rendered form, opened or not
+    expect(result.map((e) => e.key)).toEqual(["server_url"]);
+  });
+
+  it("leaves entry lists without url entries untouched", () => {
+    const click = vi
+      .spyOn(HTMLAnchorElement.prototype, "click")
+      .mockImplementation(() => undefined);
+    const entries = [stringEntry("a"), stringEntry("b")];
+    expect(openActionUrlEntries(entries)).toEqual(entries);
+    expect(click).not.toHaveBeenCalled();
+  });
+});

--- a/src/helpers/openActionUrlEntries.test.ts
+++ b/src/helpers/openActionUrlEntries.test.ts
@@ -52,6 +52,21 @@ describe("openActionUrlEntries", () => {
     expect(result.map((e) => e.key)).toEqual(["server_url"]);
   });
 
+  it("falls back to default_value when value is unset", () => {
+    const click = vi
+      .spyOn(HTMLAnchorElement.prototype, "click")
+      .mockImplementation(() => undefined);
+    const entry = {
+      key: "wizard",
+      type: ConfigEntryType.URL,
+      label: "wizard",
+      default_value: "https://example.com/from-default",
+    } as ConfigEntry;
+    const result = openActionUrlEntries([entry, stringEntry()]);
+    expect(click).toHaveBeenCalledTimes(1);
+    expect(result.map((e) => e.key)).toEqual(["server_url"]);
+  });
+
   it("leaves entry lists without url entries untouched", () => {
     const click = vi
       .spyOn(HTMLAnchorElement.prototype, "click")

--- a/src/helpers/utils.ts
+++ b/src/helpers/utils.ts
@@ -2,6 +2,8 @@ import { api } from "@/plugins/api";
 import {
   Artist,
   BrowseFolder,
+  ConfigEntry,
+  ConfigEntryType,
   ImageType,
   ItemMapping,
   MediaItemImage,
@@ -44,6 +46,24 @@ export const openLinkInNewTab = function (url: string) {
     url = url.replace("://music-assistant.io", "://beta.music-assistant.io");
   }
   window.open(url, "_blank");
+};
+
+export const openActionUrlEntries = (entries: ConfigEntry[]): ConfigEntry[] => {
+  // Open URL-type entries returned by a config invoke_action response (one-shot):
+  // a programmatic anchor click keeps the user-gesture chain so mobile browsers
+  // don't popup-block it. Opened entries are dropped from the rendered form.
+  const urlEntries = entries.filter(
+    (e) =>
+      e.type === ConfigEntryType.URL && typeof e.value === "string" && e.value,
+  );
+  for (const entry of urlEntries) {
+    const a = document.createElement("a");
+    a.setAttribute("href", String(entry.value));
+    a.setAttribute("target", "_blank");
+    a.setAttribute("rel", "noopener");
+    a.click();
+  }
+  return entries.filter((e) => !urlEntries.includes(e));
 };
 
 export const parseBool = (val: string | boolean | undefined | null) => {

--- a/src/helpers/utils.ts
+++ b/src/helpers/utils.ts
@@ -49,21 +49,29 @@ export const openLinkInNewTab = function (url: string) {
 };
 
 export const openActionUrlEntries = (entries: ConfigEntry[]): ConfigEntry[] => {
-  // Open URL-type entries returned by a config invoke_action response (one-shot):
-  // a programmatic anchor click keeps the user-gesture chain so mobile browsers
-  // don't popup-block it. Opened entries are dropped from the rendered form.
-  const urlEntries = entries.filter(
-    (e) =>
-      e.type === ConfigEntryType.URL && typeof e.value === "string" && e.value,
-  );
+  // Open URL-type entries returned by a config invoke_action response (one-shot)
+  // via an anchor click, which browsers treat more leniently than window.open
+  // when the triggering user gesture has just expired. Only web URLs are
+  // opened, and all URL entries are dropped from the rendered form.
+  const urlEntries = entries.filter((e) => {
+    if (e.type !== ConfigEntryType.URL || typeof e.value !== "string")
+      return false;
+    try {
+      return ["http:", "https:"].includes(new URL(e.value).protocol);
+    } catch {
+      return false;
+    }
+  });
   for (const entry of urlEntries) {
     const a = document.createElement("a");
     a.setAttribute("href", String(entry.value));
     a.setAttribute("target", "_blank");
     a.setAttribute("rel", "noopener");
+    document.body.appendChild(a);
     a.click();
+    a.remove();
   }
-  return entries.filter((e) => !urlEntries.includes(e));
+  return entries.filter((e) => e.type !== ConfigEntryType.URL);
 };
 
 export const parseBool = (val: string | boolean | undefined | null) => {

--- a/src/helpers/utils.ts
+++ b/src/helpers/utils.ts
@@ -2,7 +2,7 @@ import { api } from "@/plugins/api";
 import {
   Artist,
   BrowseFolder,
-  ConfigEntry,
+  type ConfigEntry,
   ConfigEntryType,
   ImageType,
   ItemMapping,

--- a/src/helpers/utils.ts
+++ b/src/helpers/utils.ts
@@ -53,18 +53,22 @@ export const openActionUrlEntries = (entries: ConfigEntry[]): ConfigEntry[] => {
   // via an anchor click, which browsers treat more leniently than window.open
   // when the triggering user gesture has just expired. Only web URLs are
   // opened, and all URL entries are dropped from the rendered form.
-  const urlEntries = entries.filter((e) => {
-    if (e.type !== ConfigEntryType.URL || typeof e.value !== "string")
-      return false;
+  const urls: string[] = [];
+  for (const entry of entries) {
+    if (entry.type !== ConfigEntryType.URL) continue;
+    const target = entry.value ?? entry.default_value;
+    if (typeof target !== "string") continue;
     try {
-      return ["http:", "https:"].includes(new URL(e.value).protocol);
+      if (["http:", "https:"].includes(new URL(target).protocol)) {
+        urls.push(target);
+      }
     } catch {
-      return false;
+      // not a parseable url: drop silently
     }
-  });
-  for (const entry of urlEntries) {
+  }
+  for (const url of urls) {
     const a = document.createElement("a");
-    a.setAttribute("href", String(entry.value));
+    a.setAttribute("href", url);
     a.setAttribute("target", "_blank");
     a.setAttribute("rel", "noopener");
     document.body.appendChild(a);

--- a/src/plugins/api/index.ts
+++ b/src/plugins/api/index.ts
@@ -2000,21 +2000,23 @@ export class MusicAssistantApi {
   }
 
   public async getProviderConfigEntries(
-    provider_domain: string,
-    instance_id?: string,
-    action?: string,
-    values?: Record<string, ConfigValueType>,
+    instance_id: string,
   ): Promise<ConfigEntry[]> {
-    // Return Config entries to setup/configure a provider.
-    // provider_domain: (mandatory) domain of the provider.
-    // instance_id: id of an existing provider instance (None for new instance setup).
-    // action: [optional] action key called from config entries UI.
-    // values: the (intermediate) raw values for config entries sent with the action.
+    // Return the config (options) entries for an existing provider instance.
     return this.sendCommand("config/providers/get_entries", {
-      provider_domain,
+      instance_id,
+    });
+  }
+
+  public async invokeProviderConfigAction(
+    instance_id: string,
+    action: string,
+  ): Promise<ConfigEntry[]> {
+    // Run a one-shot action button from a provider's options
+    // and return the (re-rendered) config entries.
+    return this.sendCommand("config/providers/invoke_action", {
       instance_id,
       action,
-      values,
     });
   }
 
@@ -2073,17 +2075,22 @@ export class MusicAssistantApi {
 
   public async getPlayerConfigEntries(
     player_id: string,
-    action?: string,
-    values?: Record<string, ConfigValueType>,
   ): Promise<ConfigEntry[]> {
-    // Return Config entries to setup/configure a player.
-    // player_id: (mandatory) id of the player.
-    // action: [optional] action key called from config entries UI.
-    // values: the (intermediate) raw values for config entries sent with the action.
+    // Return the config entries to configure a player.
     return this.sendCommand("config/players/get_entries", {
       player_id,
+    });
+  }
+
+  public async invokePlayerConfigAction(
+    player_id: string,
+    action: string,
+  ): Promise<ConfigEntry[]> {
+    // Run a one-shot action button from a player's config
+    // and return the (re-rendered) config entries.
+    return this.sendCommand("config/players/invoke_action", {
+      player_id,
       action,
-      values,
     });
   }
 

--- a/src/plugins/api/interfaces.ts
+++ b/src/plugins/api/interfaces.ts
@@ -423,6 +423,8 @@ export enum ConfigEntryType {
   ALERT = "alert",
   // image: presentational entry whose value/default_value is a data-URI image
   IMAGE = "image",
+  // url: clickable link; in an invoke_action response the frontend opens it (one-shot)
+  URL = "url",
 
   // Only used in the frontend
   DSP_SETTINGS = "dsp_settings",

--- a/src/views/settings/EditPlayer.vue
+++ b/src/views/settings/EditPlayer.vue
@@ -264,7 +264,7 @@ import {
   UI_ENTRY_TYPE,
   isInjected,
 } from "@/helpers/config_entry_ui";
-import { openLinkInNewTab } from "@/helpers/utils";
+import { openActionUrlEntries, openLinkInNewTab } from "@/helpers/utils";
 import { eventbus } from "@/plugins/eventbus";
 import { $t } from "@/plugins/i18n";
 // global refs
@@ -466,6 +466,7 @@ const onAction = async function (
   api
     .invokePlayerConfigAction(config.value!.player_id, action)
     .then(async (entries) => {
+      entries = openActionUrlEntries(entries);
       config.value!.values = {};
       for (const entry of entries) {
         config.value!.values[entry.key] = entry;

--- a/src/views/settings/EditPlayer.vue
+++ b/src/views/settings/EditPlayer.vue
@@ -259,7 +259,6 @@ import ProviderIcon from "@/components/ProviderIcon.vue";
 import PlayerIcon from "@/components/PlayerIcon.vue";
 import { watch } from "vue";
 
-import { nanoid } from "nanoid";
 import {
   ConfigEntryUI,
   UI_ENTRY_TYPE,
@@ -271,7 +270,6 @@ import { $t } from "@/plugins/i18n";
 // global refs
 const router = useRouter();
 const config = ref<PlayerConfig>();
-const sessionId = nanoid(11);
 const loading = ref(false);
 const showRenameDialog = ref(false);
 const editName = ref<string | null>(null);
@@ -461,21 +459,12 @@ const onImmediateApply = async function (
 
 const onAction = async function (
   action: string,
-  values: Record<string, ConfigValueType>,
+  _values: Record<string, ConfigValueType>,
   immediateApply: boolean,
 ) {
   loading.value = true;
-  // append existing ConfigEntry values to allow
-  // values be passed between flow steps
-  for (const entry of Object.values(config.value!.values)) {
-    if (entry.value !== undefined && values[entry.key] == undefined) {
-      values[entry.key] = entry.value;
-    }
-  }
-  // ensure the session id is passed along (for auth actions)
-  values["session_id"] = sessionId;
   api
-    .getPlayerConfigEntries(config.value!.player_id, action, values)
+    .invokePlayerConfigAction(config.value!.player_id, action)
     .then(async (entries) => {
       config.value!.values = {};
       for (const entry of entries) {

--- a/src/views/settings/EditProvider.vue
+++ b/src/views/settings/EditProvider.vue
@@ -351,24 +351,12 @@ const onImmediateApply = async function (
 
 const onAction = async function (
   action: string,
-  values: Record<string, ConfigValueType>,
+  _values: Record<string, ConfigValueType>,
   immediateApply: boolean,
 ) {
   loading.value = true;
-  // append existing ConfigEntry values to allow
-  // values be passed between flow steps
-  for (const entry of Object.values(config.value!.values)) {
-    if (entry.value !== undefined && values[entry.key] == undefined) {
-      values[entry.key] = entry.value;
-    }
-  }
   api
-    .getProviderConfigEntries(
-      config.value!.domain,
-      config.value!.instance_id,
-      action,
-      values,
-    )
+    .invokeProviderConfigAction(config.value!.instance_id, action)
     .then(async (entries) => {
       config.value!.values = {};
       for (const entry of entries) {

--- a/src/views/settings/EditProvider.vue
+++ b/src/views/settings/EditProvider.vue
@@ -201,7 +201,7 @@
 import ProviderIcon from "@/components/ProviderIcon.vue";
 import ProviderSaveErrorDialog from "@/components/ProviderSaveErrorDialog.vue";
 import { Button } from "@/components/ui/button";
-import { markdownToHtml } from "@/helpers/utils";
+import { markdownToHtml, openActionUrlEntries } from "@/helpers/utils";
 import { api } from "@/plugins/api";
 import {
   ConfigValueType,
@@ -358,6 +358,7 @@ const onAction = async function (
   api
     .invokeProviderConfigAction(config.value!.instance_id, action)
     .then(async (entries) => {
+      entries = openActionUrlEntries(entries);
       config.value!.values = {};
       for (const entry of entries) {
         config.value!.values[entry.key] = entry;


### PR DESCRIPTION
Counterpart to music-assistant/server#5017 (the options-contract cleanup).

- Action buttons on provider and player config screens now call the dedicated `config/providers/invoke_action` / `config/players/invoke_action` commands instead of tunneling the action through `get_entries`.
- `getProviderConfigEntries` / `getPlayerConfigEntries` simplified to the new server signatures (options read only).
- Dropped the values/session_id plumbing from the provider/player action path — auth-style multi-step actions live in setup flows now. Core-module config is untouched (server still uses the old contract there).
- New: `ConfigEntryType.URL` handling — when an action response contains a URL entry, it is opened one-shot via a programmatic anchor click (mobile-safe) and dropped from the rendered form. This is the replacement channel for the MCP server's Connect Wizard, whose old `AUTH_SESSION` listener was removed with the setup-flow dialog.