### PR TITLE
Add a Reconfigure entry to the player context menu

### DIFF
--- a/src/helpers/player_menu_items.ts
+++ b/src/helpers/player_menu_items.ts
@@ -279,6 +279,23 @@ export const getPlayerMenuItems = (
       });
     }
 
+    // re-run the player's setup flow (pairing etc.) on demand
+    if (isPlayer && player.has_setup_flow) {
+      menuItems.push({
+        label: "reconfigure_player",
+        labelArgs: [],
+        action: () => {
+          store.showFullscreenPlayer = false;
+          store.showPlayersMenu = false;
+          eventbus.emit("setupFlowDialog", {
+            kind: "player",
+            playerId: player.player_id,
+          });
+        },
+        icon: "mdi-cog-refresh-outline",
+      });
+    }
+
     // open dsp settings (player menu only)
     if (isPlayer && player.type !== PlayerType.GROUP) {
       menuItems.push({

--- a/src/plugins/api/interfaces.ts
+++ b/src/plugins/api/interfaces.ts
@@ -1205,6 +1205,8 @@ export interface Player {
   volume_control: string;
   mute_control: string;
   needs_setup: boolean;
+  // this player (or a wrapped protocol child) offers a setup flow that can be re-run on demand
+  has_setup_flow?: boolean;
 
   // output_protocols: all available output methods for this player
   // Includes native output (if PLAY_MEDIA supported) + protocol outputs

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1748,6 +1748,7 @@
     "autoplay_off_title": "Autoplay is disabled",
     "autoplay_off_desc": "Your music will stop once the queue has finished. Enable Autoplay to automatically keep it going with more content based on your preferences.",
     "open_player_settings": "Open player settings",
+    "reconfigure_player": "Reconfigure player",
     "sleep_timer": "Sleep timer",
     "sleep_timer_active": "Sleep timer · {0}",
     "sleep_timer_remaining": "Stops in {0}",


### PR DESCRIPTION
A player's setup flow (e.g. Apple TV pairing) could only be reached while the *Setup required* chip was showing — once setup completed, or an optional step like Companion pairing was dismissed, there was no way back to it from the UI.

- The player context menu now shows **Reconfigure player** (admin only) for players that offer a setup flow, re-launching the flow dialog on demand.
- Driven by the new `Player.has_setup_flow` flag (music-assistant/models#330); the entry stays hidden until the server populates it, so this is inert against older servers.