### PR TITLE
Show per-provider search status in the search view

### DIFF
--- a/src/composables/useProgressiveSearch.ts
+++ b/src/composables/useProgressiveSearch.ts
@@ -3,6 +3,7 @@ import {
   Genre,
   MediaType,
   ProviderFeature,
+  ProviderSearchStatus,
   SearchResults,
 } from "@/plugins/api/interfaces";
 import { computed, onScopeDispose, ref, watch, type Ref } from "vue";
@@ -37,6 +38,40 @@ export interface SearchTarget {
   iconDomain: string;
 }
 
+// Per-target outcome as surfaced to consumers: "pending"/"retrying" while a
+// request or scheduled retry is in flight, "done"/"no_matches" once a target
+// has settled with or without contributing items, "failed" once retries (if
+// any) are exhausted for a hard server error.
+export type SearchTargetState =
+  | "pending"
+  | "done"
+  | "no_matches"
+  | "retrying"
+  | "failed";
+
+type SearchResultsArrayField =
+  | "artists"
+  | "albums"
+  | "tracks"
+  | "playlists"
+  | "radio"
+  | "podcasts"
+  | "audiobooks"
+  | "genres";
+
+// maps a media type to its SearchResults field, used to determine whether a
+// target contributed any items for the currently selected media types
+const MEDIA_TYPE_FIELDS: Partial<Record<MediaType, SearchResultsArrayField>> = {
+  [MediaType.TRACK]: "tracks",
+  [MediaType.ARTIST]: "artists",
+  [MediaType.ALBUM]: "albums",
+  [MediaType.PLAYLIST]: "playlists",
+  [MediaType.RADIO]: "radio",
+  [MediaType.PODCAST]: "podcasts",
+  [MediaType.AUDIOBOOK]: "audiobooks",
+  [MediaType.GENRE]: "genres",
+};
+
 export interface ProgressiveSearchOptions {
   // selected media types; an empty selection searches all allowed types
   mediaTypes: Ref<MediaType[]>;
@@ -70,6 +105,8 @@ export function useProgressiveSearch(options: ProgressiveSearchOptions) {
   const pendingTargets = ref(new Set<string>());
   const libraryGenresFallback = ref<Genre[]>([]);
   const retryTimers = new Map<string, ReturnType<typeof setTimeout>>();
+  // per-target outcome, surfaced to consumers for status reporting
+  const targetStates = ref<{ [targetId: string]: SearchTargetState }>({});
   // guards stale responses: bumped on every new search, responses for an
   // older search id are discarded
   let currentSearchId = 0;
@@ -187,12 +224,14 @@ export function useProgressiveSearch(options: ProgressiveSearchOptions) {
     providerResults.value = {};
     pendingTargets.value = new Set();
     libraryGenresFallback.value = [];
+    targetStates.value = {};
     activeSearchTerm.value = trimmedTerm;
     if (!trimmedTerm) return;
 
     if (genreOnly.value) {
       // Genre-only search: use library search directly
       pendingTargets.value.add(LIBRARY_SEARCH_TARGET);
+      targetStates.value[LIBRARY_SEARCH_TARGET] = "pending";
       try {
         const genres = await api.getLibraryGenres({
           search: trimmedTerm,
@@ -205,8 +244,12 @@ export function useProgressiveSearch(options: ProgressiveSearchOptions) {
           ...emptyResults(),
           genres,
         };
+        targetStates.value[LIBRARY_SEARCH_TARGET] = genres.length
+          ? "done"
+          : "no_matches";
       } catch (err) {
         console.error("Genre search failed", err);
+        targetStates.value[LIBRARY_SEARCH_TARGET] = "failed";
       }
       if (searchId === currentSearchId) {
         pendingTargets.value.delete(LIBRARY_SEARCH_TARGET);
@@ -258,46 +301,134 @@ export function useProgressiveSearch(options: ProgressiveSearchOptions) {
     }
   };
 
+  // Resolves a target's reported status from the response's provider_search_statuses
+  // map: a direct lookup for instance-id targets, or (for streaming domain
+  // targets) the best status across every instance of that domain - complete
+  // beats timeout beats failed. Returns undefined when the field is absent
+  // (old server) or no status could be resolved for this target, signalling
+  // the caller to fall back to the timing heuristic.
+  const resolveTargetStatus = function (
+    targetId: string,
+    statuses: Record<string, ProviderSearchStatus> | undefined,
+  ): ProviderSearchStatus | undefined {
+    if (!statuses) return undefined;
+    if (targetId in statuses) return statuses[targetId];
+    const instanceStatuses = Object.values(api.providers)
+      .filter((provider) => provider.domain === targetId)
+      .map((provider) => statuses[provider.instance_id])
+      .filter((status): status is ProviderSearchStatus => !!status);
+    if (!instanceStatuses.length) return undefined;
+    if (instanceStatuses.includes(ProviderSearchStatus.COMPLETE))
+      return ProviderSearchStatus.COMPLETE;
+    if (instanceStatuses.includes(ProviderSearchStatus.TIMEOUT))
+      return ProviderSearchStatus.TIMEOUT;
+    return ProviderSearchStatus.FAILED;
+  };
+
+  // Whether a target's result contributed any items for the currently
+  // selected media types (all allowed types when nothing is selected).
+  const resultHasSelectedItems = function (result: SearchResults): boolean {
+    const types = selectedMediaTypes.value.length
+      ? selectedMediaTypes.value
+      : allowedMediaTypes;
+    return types.some((type) => {
+      const field = MEDIA_TYPE_FIELDS[type];
+      return !!(field && result[field]?.length);
+    });
+  };
+
+  // Terminal step for a target: store its result, clear it from pending, and
+  // record whether it settled hard-failed, empty, or with items.
+  const settleTarget = function (
+    targetId: string,
+    result: SearchResults | undefined,
+    errored: boolean,
+  ) {
+    providerResults.value[targetId] = result || emptyResults();
+    pendingTargets.value.delete(targetId);
+    targetStates.value[targetId] = errored
+      ? "failed"
+      : resultHasSelectedItems(providerResults.value[targetId])
+        ? "done"
+        : "no_matches";
+  };
+
   // One search request for a single target (library or one provider); the
   // response is merged into the view as soon as it arrives.
   const searchTarget = async function (
     searchId: number,
     targetId: string,
     attempt = 0,
+    failedRetried = false,
   ) {
     if (searchId !== currentSearchId) return;
     const limit = singleType.value ? limits.single : limits.multi;
     const mediaTypes = effectiveMediaTypes.value;
     pendingTargets.value.add(targetId);
+    targetStates.value[targetId] = "pending";
     const started = Date.now();
     let result: SearchResults | undefined;
+    let errored = false;
     try {
       result = await api.search(activeSearchTerm.value, mediaTypes, limit, [
         targetId,
       ]);
     } catch (err) {
       console.error(`Search on ${targetId} failed`, err);
+      errored = true;
     }
     if (searchId !== currentSearchId) return;
+
+    const scheduleRetry = function (
+      nextAttempt: number,
+      nextFailedRetried: boolean,
+    ) {
+      targetStates.value[targetId] = "retrying";
+      retryTimers.set(
+        targetId,
+        setTimeout(() => {
+          retryTimers.delete(targetId);
+          searchTarget(searchId, targetId, nextAttempt, nextFailedRetried);
+        }, SOFT_TIMEOUT_RETRY_DELAY_MS),
+      );
+    };
+
+    const status = errored
+      ? undefined
+      : resolveTargetStatus(targetId, result?.provider_search_statuses);
+
+    if (status) {
+      // real per-target status reported by the server
+      if (
+        status === ProviderSearchStatus.TIMEOUT &&
+        attempt < MAX_SOFT_TIMEOUT_RETRIES
+      ) {
+        // soft timeout: the provider search continues in the background
+        // server-side, retry shortly to pick up the cached result
+        scheduleRetry(attempt + 1, failedRetried);
+        return;
+      }
+      if (status === ProviderSearchStatus.FAILED && !failedRetried) {
+        scheduleRetry(attempt, true);
+        return;
+      }
+      settleTarget(targetId, result, status === ProviderSearchStatus.FAILED);
+      return;
+    }
+
+    // field absent (old server) or unresolvable: fall back to the existing
+    // timing heuristic unchanged
     if (
+      !errored &&
       result &&
       isEmptyResult(result) &&
       Date.now() - started >= SOFT_TIMEOUT_MS &&
       attempt < MAX_SOFT_TIMEOUT_RETRIES
     ) {
-      // soft timeout: the provider search continues in the background
-      // server-side, retry shortly to pick up the cached result
-      retryTimers.set(
-        targetId,
-        setTimeout(() => {
-          retryTimers.delete(targetId);
-          searchTarget(searchId, targetId, attempt + 1);
-        }, SOFT_TIMEOUT_RETRY_DELAY_MS),
-      );
+      scheduleRetry(attempt + 1, failedRetried);
       return;
     }
-    providerResults.value[targetId] = result || emptyResults();
-    pendingTargets.value.delete(targetId);
+    settleTarget(targetId, result, errored);
   };
 
   // media type selection changes affect limits and per-request media types:
@@ -322,6 +453,7 @@ export function useProgressiveSearch(options: ProgressiveSearchOptions) {
     activeSearchTerm,
     loading,
     pendingTargets,
+    targetStates,
     searchResult,
     providerTargets,
     selectedProviders,

--- a/src/plugins/api/interfaces.ts
+++ b/src/plugins/api/interfaces.ts
@@ -853,6 +853,12 @@ export type PlayableMediaItemType =
   | PodcastEpisode;
 export type MediaItemTypeOrItemMapping = MediaItemType | ItemMapping;
 
+export enum ProviderSearchStatus {
+  COMPLETE = "complete",
+  TIMEOUT = "timeout",
+  FAILED = "failed",
+}
+
 export interface SearchResults {
   artists: Artist[];
   albums: Album[];
@@ -862,6 +868,9 @@ export interface SearchResults {
   podcasts: Podcast[];
   audiobooks: Audiobook[];
   genres: Genre[];
+  // keyed by provider instance_id, plus the special "library" key; absent
+  // on older servers that don't report per-provider search status
+  provider_search_statuses?: Record<string, ProviderSearchStatus>;
 }
 
 export interface AudioFormat {

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1058,6 +1058,8 @@
     "uri_copy_failed": "Failed to copy URI to clipboard",
     "search_all_providers": "Search all providers for matches",
     "search_all_providers_confirm": "Are you sure you want to search for matches on all providers? This can take some time to complete and will be executed in the background.",
+    "search_status_no_matches": "no matches",
+    "search_status_failed": "failed",
     "remove_provider_mapping": "Remove provider mapping",
     "remove_provider_mapping_confirm": "Are you sure you want to remove this provider mapping? This will unlink the item from the current item details. It may come back if you perform a rescan for all provider matches.",
     "map_provider_mapping": "Map this provider entry to the current item",

--- a/src/views/Search.vue
+++ b/src/views/Search.vue
@@ -99,6 +99,7 @@ import { MediaType } from "@/plugins/api/interfaces";
 import { $t } from "@/plugins/i18n";
 import { store } from "@/plugins/store";
 import { computed, onBeforeUnmount, onMounted, ref, watch } from "vue";
+import { toast } from "vue-sonner";
 
 // local refs
 const searchHasFocus = ref(false);
@@ -142,10 +143,57 @@ const {
   genreOnly,
   search,
   filteredItems,
+  targetStates,
 } = useProgressiveSearch({
   mediaTypes: selectedMediaTypes,
   providers: storedProviders,
 });
+
+// display name for a search target id, used by the noteworthy-outcome toasts
+const targetName = function (targetId: string) {
+  if (targetId === LIBRARY_SEARCH_TARGET) return $t("library");
+  return (
+    providerTargets.value.find((target) => target.id === targetId)?.name ||
+    targetId
+  );
+};
+
+const hasVisibleResults = computed(() =>
+  singleType.value ? singleTypeHasItems.value : searchSections.value.length > 0,
+);
+
+// label for a noteworthy target outcome, resolved at toast time so a locale
+// switch mid-search is reflected
+const noteworthyStatusLabel = function (state: "no_matches" | "failed") {
+  if (state === "no_matches") return $t("search_status_no_matches");
+  return $t("search_status_failed");
+};
+
+// Toast targets that reached a terminal outcome that didn't come back clean:
+// failed, or no_matches once other results are on screen. The transient
+// retrying state is not toasted since a toast can't be retracted when the
+// provider recovers. At most one toast per (search-run, target, outcome).
+const toastedOutcomes = new Set<string>();
+watch(
+  targetStates,
+  (states) => {
+    const entries = Object.entries(states);
+    if (!entries.length) {
+      // targetStates was reset to {}: a new search run started
+      toastedOutcomes.clear();
+      return;
+    }
+    for (const [targetId, state] of entries) {
+      if (state !== "failed" && state !== "no_matches") continue;
+      if (state === "no_matches" && !hasVisibleResults.value) continue;
+      const outcomeKey = `${targetId}:${state}`;
+      if (toastedOutcomes.has(outcomeKey)) continue;
+      toastedOutcomes.add(outcomeKey);
+      toast.info(`${targetName(targetId)}: ${noteworthyStatusLabel(state)}`);
+    }
+  },
+  { deep: true },
+);
 
 const selectedSearchProviders = computed<string[]>({
   // the composable drops stale ids of removed providers from the selection


### PR DESCRIPTION
Surfaces per-provider search status in the global search view, using the new
`provider_search_statuses` field from the search API.

- Replaces the timing heuristic for slow providers with the real reported
  status (`complete` / `timeout` / `failed`), falling back to the old heuristic
  when talking to a server that doesn't report it.
- Shows a brief info toast for terminal outcomes only: a provider that failed,
  or that returned no matches while others had results. Transient/retrying
  states aren't toasted.

Companion PRs:
https://github.com/music-assistant/models/pull/331
https://github.com/music-assistant/server/pull/5028

