### PR TITLE
Neutral wording when a setup session ended during a disconnect

### DIFF
--- a/src/components/SetupFlowDialog.vue
+++ b/src/components/SetupFlowDialog.vue
@@ -202,12 +202,24 @@
             class="flex flex-col items-center justify-center gap-3 py-3 text-center"
           >
             <span
+              v-if="isSessionEnded"
+              class="bg-muted text-muted-foreground flex size-[72px] items-center justify-center rounded-full"
+            >
+              <Info :size="40" />
+            </span>
+            <span
+              v-else
               class="flex size-[72px] items-center justify-center rounded-full bg-yellow-500/15 text-yellow-600 dark:text-yellow-400"
             >
               <TriangleAlert :size="40" />
             </span>
             <h3 class="text-base font-semibold">
-              {{ step.title ?? $t("settings.setup_flow.aborted_title") }}
+              {{
+                step.title ??
+                (isSessionEnded
+                  ? $t("settings.setup_flow.session_ended_title")
+                  : $t("settings.setup_flow.aborted_title"))
+              }}
             </h3>
             <p
               class="text-muted-foreground text-sm leading-relaxed whitespace-pre-wrap"
@@ -315,6 +327,7 @@ import {
   CircleCheck,
   Clock,
   ExternalLink,
+  Info,
   Settings2,
   ShieldCheck,
   TriangleAlert,
@@ -349,6 +362,10 @@ let countdownTimer: ReturnType<typeof setInterval> | null = null;
 // one-shot guard so an expired step triggers a single reconcile fetch
 let expiryReconciledFor: string | null = null;
 
+// step_id of the abort step this dialog synthesizes when the flow is gone after a
+// reconnect; the double underscores keep it out of reach of server-sent slugs
+const SESSION_ENDED_STEP_ID = "__session_ended__";
+
 // terminal steps: closing them must not abort (the flow already ended server-side)
 const PRESENTATIONAL_TYPES = [
   ConfigEntryType.DIVIDER,
@@ -362,6 +379,14 @@ const isTerminal = computed(
   () =>
     step.value?.type === FlowStepType.FINISH ||
     step.value?.type === FlowStepType.ABORT,
+);
+
+// the synthesized abort is not a failure (the flow may well have completed while we
+// were disconnected), so it gets neutral wording and styling instead of a warning
+const isSessionEnded = computed(
+  () =>
+    step.value?.type === FlowStepType.ABORT &&
+    step.value?.step_id === SESSION_ENDED_STEP_ID,
 );
 
 // while awaiting a submit response the dialog can't be dismissed accidentally
@@ -636,7 +661,7 @@ function openInstanceSettings() {
 }
 
 function reconcileFlow() {
-  // re-fetch the current step; if the flow is gone server-side, show an abort
+  // re-fetch the current step; if the flow is gone server-side, end the dialog neutrally
   if (!open.value || !step.value || isTerminal.value) return;
   const flowId = step.value.flow_id;
   api
@@ -650,11 +675,11 @@ function reconcileFlow() {
       cleanupFlow();
       step.value = {
         flow_id: flowId,
-        step_id: "abort",
+        step_id: SESSION_ENDED_STEP_ID,
         type: FlowStepType.ABORT,
         entries: [],
         errors: {},
-        reason: $t("settings.setup_flow.flow_gone"),
+        reason: $t("settings.setup_flow.session_ended_text"),
       };
     });
 }

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -514,7 +514,8 @@
             "open_settings": "Open settings",
             "setup_player_title": "Set up player",
             "expires_in": "Expires in {0}",
-            "flow_gone": "This setup is no longer available. Please start again."
+            "session_ended_title": "Setup session ended",
+            "session_ended_text": "The setup session ended — it may have completed. Check your providers or players to confirm."
         },
         "add_music_provider": "Add a music source",
         "add_player_provider": "Add a player provider",


### PR DESCRIPTION
When the setup dialog reconnects and the flow is gone server-side, it synthesizes an
abort step. That path also fires when the flow simply *completed* while we were
disconnected, where "This setup is no longer available. Please start again." reads as a
scary failure.

Give that synthesized case neutral wording ("Setup session ended — it may have
completed") and a neutral icon instead of the warning triangle. Genuine server-sent
aborts keep the existing wording and styling.

Server side: https://github.com/music-assistant/server/pull/5033
