### PR TITLE
Core config action buttons use the invoke_action command

### DIFF
--- a/src/plugins/api/index.ts
+++ b/src/plugins/api/index.ts
@@ -2285,20 +2285,18 @@ export class MusicAssistantApi {
     return this.sendCommand("config/core/get_value", { domain, key });
   }
 
-  public async getCoreConfigEntries(
-    domain: string,
-    action?: string,
-    values?: Record<string, ConfigValueType>,
-  ): Promise<ConfigEntry[]> {
+  public async getCoreConfigEntries(domain: string): Promise<ConfigEntry[]> {
     // Return Config entries to configure a core controller.
-    // domain: (mandatory) domain of the core module.
-    // action: [optional] action key called from config entries UI.
-    // values: the (intermediate) raw values for config entries sent with the action.
-    return this.sendCommand("config/core/get_entries", {
-      domain,
-      action,
-      values,
-    });
+    return this.sendCommand("config/core/get_entries", { domain });
+  }
+
+  public async invokeCoreConfigAction(
+    domain: string,
+    action: string,
+  ): Promise<ConfigEntry[]> {
+    // Run a one-shot action button from a core module's config
+    // and return the (re-rendered) config entries.
+    return this.sendCommand("config/core/invoke_action", { domain, action });
   }
 
   public async saveCoreConfig(

--- a/src/views/settings/EditCoreConfig.vue
+++ b/src/views/settings/EditCoreConfig.vue
@@ -42,9 +42,9 @@
 </template>
 
 <script setup lang="ts">
+import { openActionUrlEntries } from "@/helpers/utils";
 import { api } from "@/plugins/api";
 import { ConfigValueType, CoreConfig } from "@/plugins/api/interfaces";
-import { nanoid } from "nanoid";
 import { computed, ref, watch } from "vue";
 import { useI18n } from "vue-i18n";
 import { useRouter } from "vue-router";
@@ -55,7 +55,6 @@ import EditConfig from "./EditConfig.vue";
 const router = useRouter();
 const { t } = useI18n();
 const config = ref<CoreConfig>();
-const sessionId = nanoid(11);
 const loading = ref(false);
 
 // props
@@ -140,22 +139,14 @@ const onImmediateApply = async function (
 
 const onAction = async function (
   action: string,
-  values: Record<string, ConfigValueType>,
+  _values: Record<string, ConfigValueType>,
   immediateApply: boolean,
 ) {
   loading.value = true;
-  // append existing ConfigEntry values to allow
-  // values be passed between flow steps
-  for (const entry of Object.values(config.value!.values)) {
-    if (entry.value !== undefined && values[entry.key] == undefined) {
-      values[entry.key] = entry.value;
-    }
-  }
-  // ensure the session id is passed along
-  values["session_id"] = sessionId;
   api
-    .getCoreConfigEntries(config.value!.domain, action, values)
+    .invokeCoreConfigAction(config.value!.domain, action)
     .then(async (entries) => {
+      entries = openActionUrlEntries(entries);
       config.value!.values = {};
       for (const entry of entries) {
         config.value!.values[entry.key] = entry;


### PR DESCRIPTION
Counterpart to music-assistant/server#5035 — the core-module half of the invoke_action alignment started in #2204.

- Action buttons on the core-module settings screen now call the dedicated `config/core/invoke_action` command instead of tunneling the action through `get_entries`.
- `getCoreConfigEntries` simplified to the new server signature (domain only); new `invokeCoreConfigAction(domain, action)`.
- Dropped the values/session_id plumbing from the core action path, and URL entries in the response are now opened one-shot via `openActionUrlEntries`, same as provider/player.
