### PR TITLE
Handle unavailable browser storage safely

### DIFF
--- a/src/plugins/auth.ts
+++ b/src/plugins/auth.ts
@@ -38,6 +38,12 @@ export class AuthManager {
   private baseUrl: string = "";
 
   constructor() {
+    if (
+      typeof localStorage === "undefined" ||
+      typeof sessionStorage === "undefined"
+    ) {
+      return;
+    }
     this.loadStoredToken();
   }
 

--- a/src/plugins/auth.ts
+++ b/src/plugins/auth.ts
@@ -38,13 +38,17 @@ export class AuthManager {
   private baseUrl: string = "";
 
   constructor() {
-    if (
-      typeof localStorage === "undefined" ||
-      typeof sessionStorage === "undefined"
-    ) {
-      return;
+    try {
+      if (
+        typeof localStorage === "undefined" ||
+        typeof sessionStorage === "undefined"
+      ) {
+        return;
+      }
+      this.loadStoredToken();
+    } catch (error) {
+      console.warn("Unable to restore authentication token.", error);
     }
-    this.loadStoredToken();
   }
 
   /**

--- a/tests/plugins/auth.import.test.ts
+++ b/tests/plugins/auth.import.test.ts
@@ -1,7 +1,7 @@
 // @vitest-environment node
 
-import { authManager } from "@/plugins/auth";
-import { describe, expect, it, vi } from "vitest";
+import { AuthManager, authManager } from "@/plugins/auth";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@/plugins/store", () => ({
   store: {
@@ -10,7 +10,29 @@ vi.mock("@/plugins/store", () => ({
 }));
 
 describe("auth module", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
   it("imports without browser storage", () => {
     expect(authManager.getToken()).toBeNull();
+  });
+
+  it("constructs when browser storage access is blocked", () => {
+    const storageError = new DOMException("Access denied", "SecurityError");
+    vi.stubGlobal("sessionStorage", { getItem: () => null });
+    vi.stubGlobal("localStorage", {
+      getItem: () => {
+        throw storageError;
+      },
+    });
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+
+    expect(() => new AuthManager()).not.toThrow();
+    expect(warn).toHaveBeenCalledWith(
+      "Unable to restore authentication token.",
+      storageError,
+    );
   });
 });

--- a/tests/plugins/auth.import.test.ts
+++ b/tests/plugins/auth.import.test.ts
@@ -1,0 +1,16 @@
+// @vitest-environment node
+
+import { authManager } from "@/plugins/auth";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@/plugins/store", () => ({
+  store: {
+    currentUser: undefined,
+  },
+}));
+
+describe("auth module", () => {
+  it("imports without browser storage", () => {
+    expect(authManager.getToken()).toBeNull();
+  });
+});


### PR DESCRIPTION
Auth initialization could crash when browser storage was unavailable, causing intermittent frontend test failures.

- Skip stored-token loading when browser storage is unavailable
- Cover auth imports outside a browser environment