### PR TITLE
Keep setup-required players readable

### DIFF
--- a/src/components/PlayerCard.vue
+++ b/src/components/PlayerCard.vue
@@ -4,9 +4,10 @@
     class="gap-0 rounded-lg p-2 shadow-none transition-colors"
     :class="{
       'border-primary bg-primary/15': player.player_id === store.activePlayerId,
-      'opacity-80': player.playback_state === PlaybackState.IDLE,
-      'opacity-60': player.powered === false,
-      'opacity-40': !player.available,
+      'opacity-80':
+        !player.needs_setup && player.playback_state === PlaybackState.IDLE,
+      'opacity-60': !player.needs_setup && player.powered === false,
+      'opacity-40': !player.available && !player.needs_setup,
     }"
     @click.capture="swallowClickAfterHold"
     @contextmenu.prevent.stop="openPlayerMenu"

--- a/tests/components/PlayerCard.test.ts
+++ b/tests/components/PlayerCard.test.ts
@@ -213,6 +213,26 @@ describe("PlayerCard", () => {
     expect(action.text()).toContain("Kitchen");
   });
 
+  it("keeps setup-required player details at full opacity", () => {
+    const wrapper = mountPlayerCard(
+      createPlayer({
+        available: false,
+        needs_setup: true,
+        powered: false,
+      }),
+    );
+
+    expect(wrapper.classes()).not.toContain("opacity-80");
+    expect(wrapper.classes()).not.toContain("opacity-60");
+    expect(wrapper.classes()).not.toContain("opacity-40");
+    expect(wrapper.find(".player-card-name").text()).toBe("Kitchen");
+    expect(wrapper.text()).toContain("settings.setup_required");
+    expect(
+      wrapper.find(".player-select-action").attributes("disabled"),
+    ).toBeUndefined();
+    expect(wrapper.find('[aria-label="play"]').attributes("disabled")).toBe("");
+  });
+
   it("lists every player name in a manual group", () => {
     const office = createPlayer({
       player_id: "office",


### PR DESCRIPTION
Players awaiting setup were dimmed so heavily that their name and setup status were difficult to read.

- Keep the player name and setup badge at normal opacity
- Keep unavailable playback controls visibly disabled