### PR TITLE
Show player setup actions consistently

### DIFF
--- a/src/components/PlayerCard.vue
+++ b/src/components/PlayerCard.vue
@@ -170,7 +170,7 @@
           variant="ghost"
           size="icon-sm"
           :class="{ '-ml-1': canPlayPause }"
-          :disabled="!player.available"
+          :disabled="!player.available && !player.needs_setup"
           :aria-label="$t('tooltip.more_options')"
           @click.stop="openPlayerMenu"
         >
@@ -351,7 +351,7 @@ watch(
 
 function openPlayerMenu(event: Event) {
   event.stopPropagation();
-  if (!props.player.available) return;
+  if (!props.player.available && !props.player.needs_setup) return;
   const position = getEventPosition(event);
   eventbus.emit("contextmenu", {
     items: getPlayerMenuItems(props.player, playerQueue.value, {

--- a/src/components/PlayerCard.vue
+++ b/src/components/PlayerCard.vue
@@ -170,7 +170,7 @@
           variant="ghost"
           size="icon-sm"
           :class="{ '-ml-1': canPlayPause }"
-          :disabled="!player.available && !player.needs_setup"
+          :disabled="!player.available"
           :aria-label="$t('tooltip.more_options')"
           @click.stop="openPlayerMenu"
         >
@@ -351,7 +351,7 @@ watch(
 
 function openPlayerMenu(event: Event) {
   event.stopPropagation();
-  if (!props.player.available && !props.player.needs_setup) return;
+  if (!props.player.available) return;
   const position = getEventPosition(event);
   eventbus.emit("contextmenu", {
     items: getPlayerMenuItems(props.player, playerQueue.value, {

--- a/src/helpers/player_menu_items.ts
+++ b/src/helpers/player_menu_items.ts
@@ -16,6 +16,26 @@ import router from "@/plugins/router";
 import { eventbus } from "@/plugins/eventbus";
 import { store } from "@/plugins/store";
 
+export const getPlayerSetupMenuItem = (
+  player: Pick<Player, "player_id" | "needs_setup" | "has_setup_flow">,
+): ContextMenuItem | undefined => {
+  if (!player.has_setup_flow && !player.needs_setup) return undefined;
+
+  return {
+    label: player.needs_setup ? "configure_player" : "reconfigure_player",
+    labelArgs: [],
+    action: () => {
+      store.showFullscreenPlayer = false;
+      store.showPlayersMenu = false;
+      eventbus.emit("setupFlowDialog", {
+        kind: "player",
+        playerId: player.player_id,
+      });
+    },
+    icon: "mdi-cog-refresh-outline",
+  };
+};
+
 export const getPlayerMenuItems = (
   player: Player,
   playerQueue: PlayerQueue | undefined,
@@ -279,21 +299,10 @@ export const getPlayerMenuItems = (
       });
     }
 
-    // re-run the player's setup flow (pairing etc.) on demand
-    if (isPlayer && player.has_setup_flow) {
-      menuItems.push({
-        label: "reconfigure_player",
-        labelArgs: [],
-        action: () => {
-          store.showFullscreenPlayer = false;
-          store.showPlayersMenu = false;
-          eventbus.emit("setupFlowDialog", {
-            kind: "player",
-            playerId: player.player_id,
-          });
-        },
-        icon: "mdi-cog-refresh-outline",
-      });
+    // configure the player or re-run its setup flow on demand
+    if (isPlayer) {
+      const setupMenuItem = getPlayerSetupMenuItem(player);
+      if (setupMenuItem) menuItems.push(setupMenuItem);
     }
 
     // open dsp settings (player menu only)

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1749,6 +1749,7 @@
     "autoplay_off_title": "Autoplay is disabled",
     "autoplay_off_desc": "Your music will stop once the queue has finished. Enable Autoplay to automatically keep it going with more content based on your preferences.",
     "open_player_settings": "Open player settings",
+    "configure_player": "Configure player",
     "reconfigure_player": "Reconfigure player",
     "sleep_timer": "Sleep timer",
     "sleep_timer_active": "Sleep timer · {0}",

--- a/src/views/settings/Players.vue
+++ b/src/views/settings/Players.vue
@@ -42,7 +42,7 @@
             'player-needs-setup':
               item.enabled && api.players[item.player_id]?.needs_setup,
           }"
-          @click="editPlayer(item.player_id, item.provider)"
+          @click="handlePlayerClick(item)"
           @menu="(evt) => onMenu(evt, item)"
         >
           <template #prepend>
@@ -154,7 +154,7 @@
         >
           <SettingsPlayerCard
             :player-config="item"
-            @click="(config) => editPlayer(config.player_id, config.provider)"
+            @click="handlePlayerClick"
             @menu="(evt, config) => onMenu(evt, config)"
             @setup="(config) => startPlayerSetup(config.player_id)"
           />
@@ -275,6 +275,14 @@ const editPlayer = function (playerId: string, provider: string) {
 
 const startPlayerSetup = function (playerId: string) {
   eventbus.emit("setupFlowDialog", { kind: "player", playerId });
+};
+
+const handlePlayerClick = function (playerConfig: PlayerConfig) {
+  if (api.players[playerConfig.player_id]?.needs_setup) {
+    startPlayerSetup(playerConfig.player_id);
+    return;
+  }
+  editPlayer(playerConfig.player_id, playerConfig.provider);
 };
 
 const editPlayerDsp = function (playerId: string) {

--- a/src/views/settings/Players.vue
+++ b/src/views/settings/Players.vue
@@ -192,6 +192,7 @@ import ProviderIcon from "@/components/ProviderIcon.vue";
 import PlayerIcon from "@/components/PlayerIcon.vue";
 import SettingsPlayerCard from "@/components/SettingsPlayerCard.vue";
 import { Button } from "@/components/ui/button";
+import { getPlayerSetupMenuItem } from "@/helpers/player_menu_items";
 import { isHiddenSendspinWebPlayer, openLinkInNewTab } from "@/helpers/utils";
 import type { ContextMenuItem } from "@/helpers/context_menu_item";
 import { api } from "@/plugins/api";
@@ -313,16 +314,21 @@ const getOutputProtocols = function (playerId: string) {
 };
 
 const onMenu = function (evt: Event, playerConfig: PlayerConfig) {
+  const player = api.players[playerConfig.player_id];
   const menuItems: ContextMenuItem[] = [
     {
-      label: "settings.configure",
+      label: "open_player_settings",
       labelArgs: [],
       action: () => {
         editPlayer(playerConfig.player_id, playerConfig.provider);
       },
-      icon: "mdi-cog",
+      icon: "mdi-cog-outline",
       disabled: !api.getProvider(playerConfig!.provider),
     },
+  ];
+  const setupMenuItem = player && getPlayerSetupMenuItem(player);
+  if (setupMenuItem) menuItems.push(setupMenuItem);
+  menuItems.push(
     {
       label: "open_dsp_settings",
       labelArgs: [],
@@ -361,7 +367,7 @@ const onMenu = function (evt: Event, playerConfig: PlayerConfig) {
       icon: "mdi-delete",
       hide: !playerCanBeDeleted(playerConfig.player_id),
     },
-  ];
+  );
   eventbus.emit("contextmenu", {
     items: menuItems,
     posX: (evt as PointerEvent).clientX,

--- a/src/views/settings/Players.vue
+++ b/src/views/settings/Players.vue
@@ -278,7 +278,10 @@ const startPlayerSetup = function (playerId: string) {
 };
 
 const handlePlayerClick = function (playerConfig: PlayerConfig) {
-  if (api.players[playerConfig.player_id]?.needs_setup) {
+  if (
+    playerConfig.enabled &&
+    api.players[playerConfig.player_id]?.needs_setup
+  ) {
     startPlayerSetup(playerConfig.player_id);
     return;
   }

--- a/tests/components/PlayerCard.test.ts
+++ b/tests/components/PlayerCard.test.ts
@@ -231,28 +231,11 @@ describe("PlayerCard", () => {
       wrapper.find(".player-select-action").attributes("disabled"),
     ).toBeUndefined();
     expect(wrapper.find('[aria-label="play"]').attributes("disabled")).toBe("");
-  });
-
-  it("keeps the menu available for a setup-required player", async () => {
-    vi.clearAllMocks();
-    const wrapper = mountPlayerCard(
-      createPlayer({
-        available: false,
-        needs_setup: true,
-      }),
-    );
-    const menu = wrapper.find('[aria-label="tooltip.more_options"]');
-
-    expect(menu.attributes("disabled")).toBeUndefined();
-    await menu.trigger("click");
-
-    expect(emitContextMenu).toHaveBeenCalledWith(
-      "contextmenu",
-      expect.objectContaining({
-        posX: 1,
-        posY: 2,
-      }),
-    );
+    expect(
+      wrapper
+        .find('[aria-label="tooltip.more_options"]')
+        .attributes("disabled"),
+    ).toBe("");
   });
 
   it("lists every player name in a manual group", () => {

--- a/tests/components/PlayerCard.test.ts
+++ b/tests/components/PlayerCard.test.ts
@@ -233,6 +233,28 @@ describe("PlayerCard", () => {
     expect(wrapper.find('[aria-label="play"]').attributes("disabled")).toBe("");
   });
 
+  it("keeps the menu available for a setup-required player", async () => {
+    vi.clearAllMocks();
+    const wrapper = mountPlayerCard(
+      createPlayer({
+        available: false,
+        needs_setup: true,
+      }),
+    );
+    const menu = wrapper.find('[aria-label="tooltip.more_options"]');
+
+    expect(menu.attributes("disabled")).toBeUndefined();
+    await menu.trigger("click");
+
+    expect(emitContextMenu).toHaveBeenCalledWith(
+      "contextmenu",
+      expect.objectContaining({
+        posX: 1,
+        posY: 2,
+      }),
+    );
+  });
+
   it("lists every player name in a manual group", () => {
     const office = createPlayer({
       player_id: "office",

--- a/tests/helpers/player_menu_items.test.ts
+++ b/tests/helpers/player_menu_items.test.ts
@@ -1,0 +1,91 @@
+import { getPlayerSetupMenuItem } from "@/helpers/player_menu_items";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { emitEvent, storeMock } = vi.hoisted(() => ({
+  emitEvent: vi.fn(),
+  storeMock: {
+    showFullscreenPlayer: true,
+    showPlayersMenu: true,
+  },
+}));
+
+vi.mock("@/plugins/api", () => ({
+  default: {},
+}));
+
+vi.mock("@/plugins/auth", () => ({
+  authManager: {
+    isAdmin: () => false,
+  },
+}));
+
+vi.mock("@/plugins/router", () => ({
+  default: {
+    push: vi.fn(),
+  },
+}));
+
+vi.mock("@/plugins/eventbus", () => ({
+  eventbus: {
+    emit: emitEvent,
+  },
+}));
+
+vi.mock("@/plugins/store", () => ({
+  store: storeMock,
+}));
+
+vi.mock("@/helpers/sleep_timer", () => ({
+  getSleepTimerMenuItem: vi.fn(),
+  sleepTimerActive: () => false,
+}));
+
+vi.mock("@/composables/useAudioOverlay", () => ({
+  useAudioOverlay: () => ({
+    openOverlayDialog: vi.fn(),
+    overlayAvailable: { value: false },
+  }),
+}));
+
+describe("getPlayerSetupMenuItem", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    storeMock.showFullscreenPlayer = true;
+    storeMock.showPlayersMenu = true;
+  });
+
+  it("omits players without a setup flow", () => {
+    expect(
+      getPlayerSetupMenuItem({
+        player_id: "kitchen",
+        needs_setup: false,
+      }),
+    ).toBeUndefined();
+  });
+
+  it("offers to reconfigure a configured player", () => {
+    const item = getPlayerSetupMenuItem({
+      player_id: "kitchen",
+      needs_setup: false,
+      has_setup_flow: true,
+    });
+
+    expect(item?.label).toBe("reconfigure_player");
+  });
+
+  it("offers to configure and starts the flow for a setup-required player", () => {
+    const item = getPlayerSetupMenuItem({
+      player_id: "kitchen",
+      needs_setup: true,
+    });
+
+    expect(item?.label).toBe("configure_player");
+    item?.action?.();
+    expect(storeMock.showFullscreenPlayer).toBe(false);
+    expect(storeMock.showPlayersMenu).toBe(false);
+    expect(emitEvent).toHaveBeenCalledWith("setupFlowDialog", {
+      kind: "player",
+      playerId: "kitchen",
+    });
+  });
+});

--- a/tests/layouts/PlayerSelect.test.ts
+++ b/tests/layouts/PlayerSelect.test.ts
@@ -12,7 +12,7 @@ import { mount } from "@vue/test-utils";
 import { nextTick } from "vue";
 import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
 
-const { getPreference, setPreference, storage } = vi.hoisted(() => {
+const { emitEvent, getPreference, setPreference, storage } = vi.hoisted(() => {
   const values = new Map<string, string>();
   const storage = {
     clear: () => values.clear(),
@@ -26,6 +26,7 @@ const { getPreference, setPreference, storage } = vi.hoisted(() => {
   };
   vi.stubGlobal("localStorage", storage);
   return {
+    emitEvent: vi.fn(),
     getPreference: vi.fn(() => ({ value: undefined })),
     setPreference: vi.fn(),
     storage,
@@ -62,6 +63,12 @@ vi.mock("@/plugins/web_player", async () => {
     }),
   };
 });
+
+vi.mock("@/plugins/eventbus", () => ({
+  eventbus: {
+    emit: emitEvent,
+  },
+}));
 
 vi.mock("@/composables/userPreferences", () => ({
   useUserPreferences: () => ({
@@ -326,6 +333,23 @@ describe("PlayerSelect", () => {
 
     expect(store.activePlayerId).toBe(player.player_id);
     expect(store.showPlayersMenu).toBe(false);
+  });
+
+  it("starts setup instead of selecting a setup-required player", async () => {
+    const player = createPlayer("kitchen", "Kitchen");
+    player.available = false;
+    player.needs_setup = true;
+    api.players = { [player.player_id]: player };
+    const wrapper = mountPlayerSelect();
+
+    await wrapper.find(".select-player").trigger("click");
+
+    expect(store.activePlayerId).toBeUndefined();
+    expect(store.showPlayersMenu).toBe(false);
+    expect(emitEvent).toHaveBeenCalledWith("setupFlowDialog", {
+      kind: "player",
+      playerId: player.player_id,
+    });
   });
 
   it("enables the detailed card layout only in the selector", () => {

--- a/tests/views/Players.test.ts
+++ b/tests/views/Players.test.ts
@@ -1,0 +1,173 @@
+import Players from "@/views/settings/Players.vue";
+import { flushPromises, mount } from "@vue/test-utils";
+import { ref } from "vue";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { apiMock, emitEvent, routerPush } = vi.hoisted(() => ({
+  apiMock: {
+    getPlayerConfigs: vi.fn(),
+    getProvider: vi.fn(),
+    getProviderManifest: vi.fn(),
+    playerManifests: {},
+    players: {} as Record<
+      string,
+      {
+        available: boolean;
+        needs_setup: boolean;
+        output_protocols: [];
+      }
+    >,
+    providerManifests: {},
+    providers: {},
+    subscribe_multi: vi.fn(),
+  },
+  emitEvent: vi.fn(),
+  routerPush: vi.fn(),
+}));
+
+vi.mock("@/plugins/api", () => ({
+  api: apiMock,
+  default: apiMock,
+}));
+
+vi.mock("@/plugins/eventbus", () => ({
+  eventbus: {
+    emit: emitEvent,
+  },
+}));
+
+vi.mock("@/helpers/player_menu_items", () => ({
+  getPlayerSetupMenuItem: () => undefined,
+}));
+
+vi.mock("@/helpers/utils", () => ({
+  isHiddenSendspinWebPlayer: () => false,
+  openLinkInNewTab: vi.fn(),
+}));
+
+vi.mock("@/views/settings/AddPlayerGroupDialog.vue", () => ({
+  default: {
+    template: "<div />",
+  },
+}));
+
+vi.mock("vue-router", () => ({
+  useRouter: () => ({
+    push: routerPush,
+  }),
+}));
+
+const playerConfig = {
+  enabled: true,
+  name: "Kitchen",
+  player_id: "kitchen",
+  provider: "test",
+  values: {},
+};
+
+const ListItemStub = {
+  emits: ["click", "menu"],
+  template: `<button class="player-list-item" @click="$emit('click')" />`,
+};
+
+const SettingsPlayerCardStub = {
+  props: ["playerConfig"],
+  emits: ["click", "menu", "setup"],
+  template: `
+    <button
+      class="settings-player-card"
+      @click="$emit('click', playerConfig)"
+    />
+  `,
+};
+
+const passthroughStub = {
+  template: "<div><slot /></div>",
+};
+
+describe("Players", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    apiMock.players = {
+      kitchen: {
+        available: false,
+        needs_setup: true,
+        output_protocols: [],
+      },
+    };
+    apiMock.getPlayerConfigs.mockResolvedValue([playerConfig]);
+    apiMock.getProvider.mockReturnValue({
+      domain: "test",
+      supported_features: [],
+    });
+    apiMock.getProviderManifest.mockReturnValue({
+      name: "Test",
+    });
+    apiMock.subscribe_multi.mockReturnValue(vi.fn());
+  });
+
+  it.each([
+    ["list", ".player-list-item"],
+    ["card", ".settings-player-card"],
+  ] as const)(
+    "starts setup when clicking a setup-required player in %s view",
+    async (viewMode, selector) => {
+      const wrapper = await mountPlayers(viewMode);
+
+      await wrapper.get(selector).trigger("click");
+
+      expect(routerPush).not.toHaveBeenCalled();
+      expect(emitEvent).toHaveBeenCalledWith("setupFlowDialog", {
+        kind: "player",
+        playerId: "kitchen",
+      });
+    },
+  );
+
+  it("opens settings when clicking a configured player", async () => {
+    apiMock.players.kitchen.needs_setup = false;
+    apiMock.players.kitchen.available = true;
+    const wrapper = await mountPlayers("list");
+
+    await wrapper.get(".player-list-item").trigger("click");
+
+    expect(emitEvent).not.toHaveBeenCalledWith(
+      "setupFlowDialog",
+      expect.anything(),
+    );
+    expect(routerPush).toHaveBeenCalledWith("/settings/editplayer/kitchen");
+  });
+});
+
+async function mountPlayers(viewMode: "list" | "card") {
+  const wrapper = mount(Players, {
+    global: {
+      mocks: {
+        $t: (key: string) => key,
+      },
+      provide: {
+        playersViewMode: {
+          toggleViewMode: vi.fn(),
+          viewMode: ref(viewMode),
+        },
+      },
+      stubs: {
+        AddPlayerGroupDialog: true,
+        Button: true,
+        Container: passthroughStub,
+        ListItem: ListItemStub,
+        PlayerFilters: true,
+        PlayerIcon: true,
+        ProviderIcon: true,
+        RouterLink: true,
+        SettingsPlayerCard: SettingsPlayerCardStub,
+        VCol: passthroughStub,
+        VIcon: true,
+        VList: passthroughStub,
+        VRow: passthroughStub,
+      },
+    },
+  });
+  await flushPromises();
+  return wrapper;
+}

--- a/tests/views/Players.test.ts
+++ b/tests/views/Players.test.ts
@@ -88,6 +88,7 @@ const passthroughStub = {
 describe("Players", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    playerConfig.enabled = true;
     apiMock.players = {
       kitchen: {
         available: false,
@@ -127,6 +128,19 @@ describe("Players", () => {
   it("opens settings when clicking a configured player", async () => {
     apiMock.players.kitchen.needs_setup = false;
     apiMock.players.kitchen.available = true;
+    const wrapper = await mountPlayers("list");
+
+    await wrapper.get(".player-list-item").trigger("click");
+
+    expect(emitEvent).not.toHaveBeenCalledWith(
+      "setupFlowDialog",
+      expect.anything(),
+    );
+    expect(routerPush).toHaveBeenCalledWith("/settings/editplayer/kitchen");
+  });
+
+  it("opens settings when a setup-required player is disabled", async () => {
+    playerConfig.enabled = false;
     const wrapper = await mountPlayers("list");
 
     await wrapper.get(".player-list-item").trigger("click");


### PR DESCRIPTION
Player setup actions were inconsistent between Player Select and Player Settings.

- Show Open player settings and Reconfigure player in both menus.
- Use Configure player when a player still needs setup.
- Open setup directly when selecting a player that still needs setup.