### PR TITLE
Make provider reconfiguration easier

### DIFF
--- a/src/components/SetupFlowDialog.vue
+++ b/src/components/SetupFlowDialog.vue
@@ -359,6 +359,7 @@ const formRef = ref<HTMLFormElement | null>(null);
 
 // monotonically increasing launch token; guards async step application
 let launchSeq = 0;
+let completionNotified = false;
 
 let unsubscribeFlow: (() => void) | null = null;
 let countdownTimer: ReturnType<typeof setInterval> | null = null;
@@ -519,6 +520,7 @@ async function onLaunch(evt: SetupFlowDialogEvent) {
   // identity on launch.value cannot be used for staleness checks: the ref
   // proxy-wraps the stored event, so it never equals the raw evt again
   const seq = ++launchSeq;
+  completionNotified = false;
   launch.value = evt;
   step.value = null;
   busy.value = true;
@@ -560,6 +562,14 @@ function applyStep(newStep: SetupFlowStep) {
   if (isTerminal.value && unsubscribeFlow) {
     unsubscribeFlow();
     unsubscribeFlow = null;
+  }
+  if (
+    isTerminal.value &&
+    !completionNotified &&
+    launch.value?.kind === "reconfigure"
+  ) {
+    completionNotified = true;
+    launch.value.onFlowEnded?.();
   }
 
   if (newStep.type === FlowStepType.FORM) {
@@ -679,14 +689,14 @@ function reconcileFlow() {
     .catch(() => {
       if (!open.value || step.value?.flow_id !== flowId) return;
       cleanupFlow();
-      step.value = {
+      applyStep({
         flow_id: flowId,
         step_id: SESSION_ENDED_STEP_ID,
         type: FlowStepType.ABORT,
         entries: [],
         errors: {},
         reason: $t("settings.setup_flow.session_ended_text"),
-      };
+      });
     });
 }
 

--- a/src/helpers/provider_config.test.ts
+++ b/src/helpers/provider_config.test.ts
@@ -1,0 +1,40 @@
+import { ProviderStatus } from "@/plugins/api/interfaces";
+import { describe, expect, it } from "vitest";
+import {
+  canReconfigureProvider,
+  providerRequiresReconfiguration,
+} from "./provider_config";
+
+describe("provider configuration state", () => {
+  it.each([
+    [ProviderStatus.LOADED, true, true, true],
+    [ProviderStatus.ERROR, true, true, true],
+    [ProviderStatus.INCOMPATIBLE, true, true, false],
+    [ProviderStatus.LOADED, true, false, false],
+    [ProviderStatus.LOADED, false, true, false],
+    [ProviderStatus.LOADED, undefined, true, false],
+  ])(
+    "identifies reconfiguration support for status %s, setup flow %s, enabled %s",
+    (status, hasSetupFlow, enabled, expected) => {
+      expect(canReconfigureProvider(status, hasSetupFlow, enabled)).toBe(
+        expected,
+      );
+    },
+  );
+
+  it.each([
+    [ProviderStatus.AUTH_REQUIRED, true, true, true],
+    [ProviderStatus.AUTH_REQUIRED, true, false, false],
+    [ProviderStatus.AUTH_REQUIRED, false, true, false],
+    [ProviderStatus.ERROR, true, true, false],
+    [ProviderStatus.LOADED, true, true, false],
+    [undefined, true, true, false],
+  ])(
+    "identifies required reconfiguration for status %s, setup flow %s, enabled %s",
+    (status, hasSetupFlow, enabled, expected) => {
+      expect(
+        providerRequiresReconfiguration(status, hasSetupFlow, enabled),
+      ).toBe(expected);
+    },
+  );
+});

--- a/src/helpers/provider_config.ts
+++ b/src/helpers/provider_config.ts
@@ -1,0 +1,15 @@
+import { ProviderStatus } from "@/plugins/api/interfaces";
+
+export const canReconfigureProvider = (
+  status?: ProviderStatus,
+  hasSetupFlow?: boolean,
+  enabled: boolean = true,
+) => enabled && hasSetupFlow === true && status !== ProviderStatus.INCOMPATIBLE;
+
+export const providerRequiresReconfiguration = (
+  status?: ProviderStatus,
+  hasSetupFlow?: boolean,
+  enabled: boolean = true,
+) =>
+  status === ProviderStatus.AUTH_REQUIRED &&
+  canReconfigureProvider(status, hasSetupFlow, enabled);

--- a/src/plugins/api/interfaces.ts
+++ b/src/plugins/api/interfaces.ts
@@ -1249,6 +1249,8 @@ export interface ProviderManifest {
   builtin: boolean;
   // allow_disable: whether this provider can be disabled (used with builtin)
   allow_disable: boolean;
+  // has_setup_flow: whether setup can be run again to reconfigure the provider
+  has_setup_flow?: boolean;
   stage: ProviderStage;
   // icon: material design icon
   icon?: string;

--- a/src/plugins/eventbus.ts
+++ b/src/plugins/eventbus.ts
@@ -67,7 +67,11 @@ export type AudioOverlayDialogEvent = {
 // reconfiguring a provider instance, or setting up a player.
 export type SetupFlowDialogEvent =
   | { kind: "provider"; domain: string }
-  | { kind: "reconfigure"; instanceId: string }
+  | {
+      kind: "reconfigure";
+      instanceId: string;
+      onFlowEnded?: () => void;
+    }
   | { kind: "player"; playerId: string };
 
 export type Events = {

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -94,6 +94,7 @@
         "check_docs": "Check out the documentation",
         "config_player": "Configure player: {0}",
         "configure": "Configure",
+        "options": "Options",
         "delete": "Delete",
         "disable": "Disable",
         "documentation": "Documentation",

--- a/src/views/settings/EditProvider.vue
+++ b/src/views/settings/EditProvider.vue
@@ -201,16 +201,18 @@
 import ProviderIcon from "@/components/ProviderIcon.vue";
 import ProviderSaveErrorDialog from "@/components/ProviderSaveErrorDialog.vue";
 import { Button } from "@/components/ui/button";
+import { canReconfigureProvider } from "@/helpers/provider_config";
 import { markdownToHtml, openActionUrlEntries } from "@/helpers/utils";
 import { api } from "@/plugins/api";
 import {
   ConfigValueType,
+  EventType,
   ProviderConfig,
   ProviderStatus,
 } from "@/plugins/api/interfaces";
 import { eventbus } from "@/plugins/eventbus";
 import { RefreshCw, Trash2, TriangleAlert } from "@lucide/vue";
-import { computed, ref, watch } from "vue";
+import { computed, onBeforeUnmount, onMounted, ref, watch } from "vue";
 import { useI18n } from "vue-i18n";
 import { useRouter } from "vue-router";
 import { toast } from "vue-sonner";
@@ -226,6 +228,9 @@ const editName = ref<string | null>(null);
 const saveErrorOpen = ref(false);
 const saveErrorMessage = ref("");
 const lastSubmitValues = ref<Record<string, ConfigValueType>>();
+let configLoadRequestId = 0;
+let statusRefreshRequestId = 0;
+let unsubProvidersUpdated: (() => void) | undefined;
 
 // props
 const props = defineProps<{
@@ -239,19 +244,19 @@ const allConfigEntries = computed(() => {
 });
 
 // auth_required/error providers can relaunch their setup (reconfigure) flow
-const canReconfigure = computed(
-  () =>
-    config.value?.status === ProviderStatus.AUTH_REQUIRED ||
-    config.value?.status === ProviderStatus.ERROR,
+const canReconfigure = computed(() =>
+  canReconfigureProvider(
+    config.value?.status,
+    api.providerManifests[config.value?.domain ?? ""]?.has_setup_flow,
+    config.value?.enabled,
+  ),
 );
 
 // watchers
 watch(
   () => props.instanceId,
-  async (val) => {
-    if (val) {
-      config.value = await api.getProviderConfig(val);
-    }
+  (val) => {
+    if (val) void loadConfig(val);
   },
   { immediate: true },
 );
@@ -260,6 +265,16 @@ watch(showRenameDialog, (val) => {
   if (val && config.value) {
     editName.value = config.value.name || null;
   }
+});
+
+onMounted(() => {
+  unsubProvidersUpdated = api.subscribe(EventType.PROVIDERS_UPDATED, () => {
+    if (props.instanceId) void refreshProviderStatus(props.instanceId);
+  });
+});
+
+onBeforeUnmount(() => {
+  unsubProvidersUpdated?.();
 });
 
 // methods
@@ -281,9 +296,13 @@ const onReload = function () {
 
 const onReconfigure = function () {
   if (!config.value) return;
+  const instanceId = config.value.instance_id;
   eventbus.emit("setupFlowDialog", {
     kind: "reconfigure",
-    instanceId: config.value.instance_id,
+    instanceId,
+    onFlowEnded: () => {
+      void refreshProviderStatus(instanceId);
+    },
   });
 };
 
@@ -429,6 +448,40 @@ const saveRename = function () {
       showRenameDialog.value = false;
     });
 };
+
+async function loadConfig(instanceId: string) {
+  const requestId = ++configLoadRequestId;
+  try {
+    const updatedConfig = await api.getProviderConfig(instanceId);
+    if (requestId === configLoadRequestId && props.instanceId === instanceId) {
+      config.value = updatedConfig;
+    }
+  } catch (err) {
+    if (requestId === configLoadRequestId) {
+      toast.error(String(err));
+    }
+  }
+}
+
+async function refreshProviderStatus(instanceId: string) {
+  if (config.value?.instance_id !== instanceId) return;
+  const requestId = ++statusRefreshRequestId;
+  try {
+    const updatedConfig = await api.getProviderConfig(instanceId);
+    if (
+      requestId === statusRefreshRequestId &&
+      props.instanceId === instanceId &&
+      config.value?.instance_id === instanceId
+    ) {
+      config.value.status = updatedConfig.status;
+      config.value.last_error = updatedConfig.last_error;
+    }
+  } catch (err) {
+    if (requestId === statusRefreshRequestId) {
+      toast.error(String(err));
+    }
+  }
+}
 </script>
 
 <style scoped>

--- a/src/views/settings/Providers.vue
+++ b/src/views/settings/Providers.vue
@@ -28,7 +28,7 @@
         :class="{
           'provider-disabled': !item.enabled,
         }"
-        @click="editProvider(item.instance_id)"
+        @click="openProvider(item)"
         @menu="(evt) => onMenu(evt, item)"
       >
         <template #prepend>
@@ -59,12 +59,12 @@
               />
               <span class="provider-error-text">{{ getErrorText(item) }}</span>
               <v-btn
-                v-if="item.status !== ProviderStatus.INCOMPATIBLE"
+                v-if="canReconfigure(item)"
                 size="x-small"
                 color="error"
                 variant="tonal"
                 class="ml-2"
-                @click.stop="editProvider(item.instance_id)"
+                @click.stop="reconfigureProvider(item.instance_id)"
               >
                 {{ $t("settings.reconfigure") }}
               </v-btn>
@@ -136,7 +136,7 @@
           class="flex-fill rounded-lg provider-card d-flex flex-column"
           :class="{ 'player-provider-card': item.type === ProviderType.PLAYER }"
           min-height="200px"
-          @click="editProvider(item.instance_id)"
+          @click="openProvider(item)"
         >
           <template #prepend>
             <provider-icon
@@ -225,13 +225,13 @@
               {{ getErrorText(item) }}
             </div>
             <v-btn
-              v-if="item.status !== ProviderStatus.INCOMPATIBLE"
+              v-if="canReconfigure(item)"
               size="small"
               color="error"
               variant="tonal"
               class="mt-2"
               block
-              @click.stop="editProvider(item.instance_id)"
+              @click.stop="reconfigureProvider(item.instance_id)"
             >
               {{ $t("settings.reconfigure") }}
             </v-btn>
@@ -270,6 +270,11 @@ import ProviderFilters from "@/components/ProviderFilters.vue";
 import ProviderIcon from "@/components/ProviderIcon.vue";
 import { Button } from "@/components/ui/button";
 import { useBackgroundTasks } from "@/composables/useBackgroundTasks";
+import type { ContextMenuItem } from "@/helpers/context_menu_item";
+import {
+  canReconfigureProvider,
+  providerRequiresReconfiguration,
+} from "@/helpers/provider_config";
 import { openLinkInNewTab } from "@/helpers/utils";
 import { api } from "@/plugins/api";
 import {
@@ -354,8 +359,40 @@ const removeProvider = function (providerInstanceId: string) {
   );
 };
 
-const editProvider = function (providerInstanceId: string) {
+const openProviderOptions = function (providerInstanceId: string) {
   router.push(`/settings/editprovider/${providerInstanceId}`);
+};
+
+const reconfigureProvider = function (providerInstanceId: string) {
+  eventbus.emit("setupFlowDialog", {
+    kind: "reconfigure",
+    instanceId: providerInstanceId,
+    onFlowEnded: () => {
+      void loadItems();
+    },
+  });
+};
+
+const openProvider = function (provider: ProviderConfig) {
+  if (
+    providerRequiresReconfiguration(
+      provider.status,
+      api.providerManifests[provider.domain]?.has_setup_flow,
+      provider.enabled,
+    )
+  ) {
+    reconfigureProvider(provider.instance_id);
+    return;
+  }
+  openProviderOptions(provider.instance_id);
+};
+
+const canReconfigure = function (provider: ProviderConfig) {
+  return canReconfigureProvider(
+    provider.status,
+    api.providerManifests[provider.domain]?.has_setup_flow,
+    provider.enabled,
+  );
 };
 
 const shouldShowStageBadge = function (stage?: ProviderStage) {
@@ -399,12 +436,12 @@ const onMenu = function (evt: Event, item: ProviderConfig) {
     return;
   }
   const providerInstance = api.getProvider(item.instance_id);
-  const menuItems = [
+  const menuItems: ContextMenuItem[] = [
     {
-      label: "settings.configure",
+      label: "settings.options",
       labelArgs: [],
       action: () => {
-        editProvider(item.instance_id);
+        openProviderOptions(item.instance_id);
       },
       icon: "mdi-cog",
     },
@@ -453,6 +490,17 @@ const onMenu = function (evt: Event, item: ProviderConfig) {
       icon: "mdi-refresh",
     },
   ];
+
+  if (canReconfigure(item)) {
+    menuItems.unshift({
+      label: "settings.reconfigure",
+      labelArgs: [],
+      action: () => {
+        reconfigureProvider(item.instance_id);
+      },
+      icon: "mdi-cog-refresh",
+    });
+  }
 
   if (item.type === ProviderType.PLAYER && providerInstance) {
     menuItems.push({

--- a/tests/components/SetupFlowDialog.test.ts
+++ b/tests/components/SetupFlowDialog.test.ts
@@ -1,0 +1,125 @@
+import { flushPromises, shallowMount } from "@vue/test-utils";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { FlowStepType, type SetupFlowStep } from "@/plugins/api/interfaces";
+import SetupFlowDialog from "@/components/SetupFlowDialog.vue";
+
+const { apiMock, eventbusMock, routerMock, storeMock, toastMock } = vi.hoisted(
+  () => ({
+    apiMock: {
+      abortSetupFlow: vi.fn(),
+      players: {},
+      providerManifests: {},
+      providers: {
+        "spotify--test": {
+          domain: "spotify",
+        },
+      },
+      reconfigureProvider: vi.fn(),
+      state: {
+        value: "authenticated",
+      },
+      subscribeSetupFlow: vi.fn(),
+    },
+    eventbusMock: {
+      off: vi.fn(),
+      on: vi.fn(),
+    },
+    routerMock: {
+      push: vi.fn(),
+    },
+    storeMock: {
+      dialogActive: false,
+    },
+    toastMock: {
+      error: vi.fn(),
+    },
+  }),
+);
+
+let launchSetupFlow:
+  | ((event: {
+      kind: "reconfigure";
+      instanceId: string;
+      onFlowEnded: () => void;
+    }) => Promise<void>)
+  | undefined;
+
+vi.mock("@/plugins/api", () => ({
+  api: apiMock,
+  ConnectionState: {
+    AUTHENTICATED: "authenticated",
+  },
+}));
+
+vi.mock("@/plugins/eventbus", () => ({
+  eventbus: eventbusMock,
+}));
+
+vi.mock("@/plugins/i18n", () => ({
+  $t: (key: string) => key,
+}));
+
+vi.mock("@/plugins/store", () => ({
+  store: storeMock,
+}));
+
+vi.mock("@/views/settings/ConfigEntryRow.vue", () => ({
+  default: {
+    template: "<div />",
+  },
+}));
+
+vi.mock("vue-router", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("vue-router")>();
+  return {
+    ...actual,
+    useRouter: () => routerMock,
+  };
+});
+
+vi.mock("vue-sonner", () => ({
+  toast: toastMock,
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  launchSetupFlow = undefined;
+  apiMock.subscribeSetupFlow.mockReturnValue(vi.fn());
+  eventbusMock.on.mockImplementation(
+    (event: string, callback: typeof launchSetupFlow) => {
+      if (event === "setupFlowDialog") {
+        launchSetupFlow = callback;
+      }
+    },
+  );
+});
+
+describe("SetupFlowDialog", () => {
+  it.each([FlowStepType.FINISH, FlowStepType.ABORT])(
+    "notifies reconfigure callers when the flow ends with %s",
+    async (type) => {
+      apiMock.reconfigureProvider.mockResolvedValue(terminalStep(type));
+      const onFlowEnded = vi.fn();
+      shallowMount(SetupFlowDialog);
+
+      await launchSetupFlow?.({
+        kind: "reconfigure",
+        instanceId: "spotify--test",
+        onFlowEnded,
+      });
+      await flushPromises();
+
+      expect(onFlowEnded).toHaveBeenCalledOnce();
+    },
+  );
+});
+
+function terminalStep(type: FlowStepType): SetupFlowStep {
+  return {
+    entries: [],
+    errors: {},
+    flow_id: "flow-1",
+    step_id: type,
+    type,
+  };
+}

--- a/tests/views/EditProvider.test.ts
+++ b/tests/views/EditProvider.test.ts
@@ -1,0 +1,212 @@
+import { flushPromises, shallowMount } from "@vue/test-utils";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  ConfigEntryType,
+  EventType,
+  ProviderStage,
+  ProviderStatus,
+  ProviderType,
+  type ProviderConfig,
+} from "@/plugins/api/interfaces";
+import EditProvider from "@/views/settings/EditProvider.vue";
+
+const { apiMock, eventbusMock, routerMock, unsubscribeMock } = vi.hoisted(
+  () => ({
+    apiMock: {
+      getProvider: vi.fn(),
+      getProviderConfig: vi.fn(),
+      invokeProviderConfigAction: vi.fn(),
+      providerManifests: {
+        spotify: {
+          codeowners: [],
+          credits: [],
+          description: "Spotify music provider",
+          has_setup_flow: true,
+          name: "Spotify",
+        },
+      },
+      providers: {},
+      reloadProvider: vi.fn(),
+      removeProviderConfig: vi.fn(),
+      saveProviderConfig: vi.fn(),
+      subscribe: vi.fn(),
+    },
+    eventbusMock: {
+      emit: vi.fn(),
+    },
+    routerMock: {
+      push: vi.fn(),
+    },
+    unsubscribeMock: vi.fn(),
+  }),
+);
+
+let providersUpdated: (() => void) | undefined;
+
+vi.mock("@/plugins/api", () => ({
+  api: apiMock,
+  default: apiMock,
+}));
+
+vi.mock("@/plugins/eventbus", () => ({
+  eventbus: eventbusMock,
+}));
+
+vi.mock("@/helpers/utils", () => ({
+  markdownToHtml: (value: string) => value,
+  openActionUrlEntries: <T>(entries: T) => entries,
+}));
+
+vi.mock("vue-i18n", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("vue-i18n")>();
+  return {
+    ...actual,
+    useI18n: () => ({
+      t: (key: string) => key,
+    }),
+  };
+});
+
+vi.mock("vue-router", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("vue-router")>();
+  return {
+    ...actual,
+    useRouter: () => routerMock,
+  };
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  providersUpdated = undefined;
+  apiMock.getProvider.mockReturnValue(undefined);
+  apiMock.subscribe.mockImplementation(
+    (event: EventType, callback: () => void) => {
+      if (event === EventType.PROVIDERS_UPDATED) {
+        providersUpdated = callback;
+      }
+      return unsubscribeMock;
+    },
+  );
+});
+
+describe("EditProvider", () => {
+  it("refreshes provider state after a provider update", async () => {
+    apiMock.getProviderConfig
+      .mockResolvedValueOnce(
+        providerConfig(ProviderStatus.AUTH_REQUIRED, "current value"),
+      )
+      .mockResolvedValueOnce(
+        providerConfig(ProviderStatus.LOADED, "server refresh"),
+      );
+
+    const wrapper = shallowMount(EditProvider, {
+      props: {
+        instanceId: "spotify--test",
+      },
+      global: {
+        mocks: {
+          $t: (key: string) => key,
+        },
+      },
+    });
+    await flushPromises();
+    expect(wrapper.text()).toContain("settings.provider_requires_attention");
+
+    providersUpdated?.();
+    await flushPromises();
+
+    expect(apiMock.getProviderConfig).toHaveBeenCalledTimes(2);
+    expect(wrapper.text()).not.toContain(
+      "settings.provider_requires_attention",
+    );
+    expect(
+      wrapper.findComponent({ name: "EditConfig" }).props("configEntries"),
+    ).toEqual([
+      expect.objectContaining({
+        key: "account",
+        value: "current value",
+      }),
+    ]);
+
+    wrapper.unmount();
+    expect(unsubscribeMock).toHaveBeenCalledOnce();
+  });
+
+  it("refreshes provider status when reconfiguration ends", async () => {
+    apiMock.getProviderConfig
+      .mockResolvedValueOnce(providerConfig(ProviderStatus.AUTH_REQUIRED))
+      .mockResolvedValueOnce(providerConfig(ProviderStatus.LOADED));
+
+    const wrapper = shallowMount(EditProvider, {
+      props: {
+        instanceId: "spotify--test",
+      },
+      global: {
+        mocks: {
+          $t: (key: string) => key,
+        },
+      },
+    });
+    await flushPromises();
+
+    await wrapper.get("button-stub").trigger("click");
+
+    const setupFlowCall = eventbusMock.emit.mock.calls.find(
+      ([event]) => event === "setupFlowDialog",
+    );
+    setupFlowCall?.[1].onFlowEnded();
+    await flushPromises();
+
+    expect(apiMock.getProviderConfig).toHaveBeenCalledTimes(2);
+    expect(wrapper.text()).not.toContain(
+      "settings.provider_requires_attention",
+    );
+  });
+});
+
+function providerConfig(
+  status: ProviderStatus,
+  account: string = "current value",
+): ProviderConfig {
+  return {
+    domain: "spotify",
+    enabled: true,
+    instance_id: "spotify--test",
+    last_error:
+      status === ProviderStatus.AUTH_REQUIRED
+        ? {
+            error_code: 1,
+            message: "Authentication required",
+          }
+        : undefined,
+    manifest: {
+      allow_disable: true,
+      builtin: false,
+      codeowners: [],
+      credits: [],
+      description: "Spotify music provider",
+      domain: "spotify",
+      icon_images: [],
+      has_setup_flow: true,
+      multi_instance: true,
+      name: "Spotify",
+      requirements: [],
+      stage: ProviderStage.STABLE,
+      type: ProviderType.MUSIC,
+    },
+    name: "Spotify",
+    status,
+    type: ProviderType.MUSIC,
+    values: {
+      account: {
+        category: "generic",
+        default_value: null,
+        key: "account",
+        label: "Account",
+        required: false,
+        type: ConfigEntryType.STRING,
+        value: account,
+      },
+    },
+  };
+}

--- a/tests/views/Providers.test.ts
+++ b/tests/views/Providers.test.ts
@@ -1,0 +1,286 @@
+import { flushPromises, shallowMount } from "@vue/test-utils";
+import { ref } from "vue";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ProviderStatus, ProviderType } from "@/plugins/api/interfaces";
+import Providers from "@/views/settings/Providers.vue";
+
+const { apiMock, eventbusMock, routeMock, routerMock } = vi.hoisted(() => ({
+  apiMock: {
+    getProvider: vi.fn(),
+    getProviderConfigs: vi.fn(),
+    providerManifests: {
+      spotify: {
+        allow_disable: true,
+        builtin: false,
+        description: "Spotify music provider",
+        documentation: "https://example.com",
+        has_setup_flow: true,
+        name: "Spotify",
+        stage: "stable",
+      },
+    },
+    providers: {},
+    removeProviderConfig: vi.fn(),
+    saveProviderConfig: vi.fn(),
+    sendCommand: vi.fn(),
+    startSync: vi.fn(),
+    subscribe: vi.fn(),
+  },
+  eventbusMock: {
+    emit: vi.fn(),
+  },
+  routeMock: {
+    query: { types: "music" },
+  },
+  routerMock: {
+    push: vi.fn(),
+  },
+}));
+
+vi.mock("@/plugins/api", () => ({
+  api: apiMock,
+  default: apiMock,
+}));
+
+vi.mock("@/plugins/eventbus", () => ({
+  eventbus: eventbusMock,
+}));
+
+vi.mock("@/plugins/i18n", () => ({
+  $t: (key: string) => key,
+}));
+
+vi.mock("@/plugins/router", () => ({
+  default: routerMock,
+}));
+
+vi.mock("@/composables/useBackgroundTasks", () => ({
+  useBackgroundTasks: () => ({
+    isProviderSyncing: () => false,
+  }),
+}));
+
+vi.mock("@/helpers/utils", () => ({
+  openLinkInNewTab: vi.fn(),
+}));
+
+vi.mock("@/views/settings/AddProviderDialog.vue", () => ({
+  default: {
+    template: "<div />",
+  },
+}));
+
+vi.mock("vue-router", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("vue-router")>();
+  return {
+    ...actual,
+    useRoute: () => routeMock,
+    useRouter: () => routerMock,
+  };
+});
+
+const ListItemStub = {
+  name: "ListItem",
+  emits: ["click", "menu"],
+  template: `
+    <div data-testid="provider-row" @click="$emit('click')">
+      <slot name="subtitle" />
+    </div>
+  `,
+};
+
+const SlotStub = {
+  template: "<div><slot /></div>",
+};
+
+const ButtonStub = {
+  emits: ["click"],
+  template: `
+    <button data-testid="provider-action" @click="$emit('click', $event)">
+      <slot />
+    </button>
+  `,
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  apiMock.getProvider.mockReturnValue(undefined);
+  apiMock.subscribe.mockReturnValue(vi.fn());
+});
+
+describe("Providers", () => {
+  it("opens reconfiguration when an authentication-required provider is clicked", async () => {
+    const wrapper = await mountProviders(ProviderStatus.AUTH_REQUIRED);
+
+    await wrapper.get('[data-testid="provider-row"]').trigger("click");
+
+    expect(eventbusMock.emit).toHaveBeenCalledWith("setupFlowDialog", {
+      kind: "reconfigure",
+      instanceId: "spotify--test",
+      onFlowEnded: expect.any(Function),
+    });
+    expect(routerMock.push).not.toHaveBeenCalled();
+  });
+
+  it("opens options when a provider with a generic error is clicked", async () => {
+    const wrapper = await mountProviders(ProviderStatus.ERROR);
+
+    await wrapper.get('[data-testid="provider-row"]').trigger("click");
+
+    expect(routerMock.push).toHaveBeenCalledWith(
+      "/settings/editprovider/spotify--test",
+    );
+    expect(eventbusMock.emit).not.toHaveBeenCalledWith(
+      "setupFlowDialog",
+      expect.anything(),
+    );
+  });
+
+  it("opens options when an authentication-required provider has no setup flow", async () => {
+    const wrapper = await mountProviders(ProviderStatus.AUTH_REQUIRED, false);
+
+    await wrapper.get('[data-testid="provider-row"]').trigger("click");
+
+    expect(routerMock.push).toHaveBeenCalledWith(
+      "/settings/editprovider/spotify--test",
+    );
+    expect(wrapper.find('[data-testid="provider-action"]').exists()).toBe(
+      false,
+    );
+  });
+
+  it("starts reconfiguration from the provider warning action", async () => {
+    const wrapper = await mountProviders(ProviderStatus.ERROR);
+
+    await wrapper.get('[data-testid="provider-action"]').trigger("click");
+
+    expect(eventbusMock.emit).toHaveBeenCalledWith("setupFlowDialog", {
+      kind: "reconfigure",
+      instanceId: "spotify--test",
+      onFlowEnded: expect.any(Function),
+    });
+    expect(routerMock.push).not.toHaveBeenCalled();
+
+    const setupFlowCall = eventbusMock.emit.mock.calls.find(
+      ([event]) => event === "setupFlowDialog",
+    );
+    setupFlowCall?.[1].onFlowEnded();
+    await flushPromises();
+    expect(apiMock.getProviderConfigs).toHaveBeenCalledTimes(2);
+  });
+
+  it("offers separate reconfigure and options menu actions", async () => {
+    const wrapper = await mountProviders(ProviderStatus.LOADED);
+    const menuEvent = new Event("click");
+
+    wrapper.findComponent(ListItemStub).vm.$emit("menu", menuEvent);
+
+    const contextMenuCall = eventbusMock.emit.mock.calls.find(
+      ([event]) => event === "contextmenu",
+    );
+    const menuItems = contextMenuCall?.[1].items;
+    expect(
+      menuItems.slice(0, 2).map((item: { label: string }) => item.label),
+    ).toEqual(["settings.reconfigure", "settings.options"]);
+
+    menuItems[0].action();
+    expect(eventbusMock.emit).toHaveBeenCalledWith("setupFlowDialog", {
+      kind: "reconfigure",
+      instanceId: "spotify--test",
+      onFlowEnded: expect.any(Function),
+    });
+
+    menuItems[1].action();
+    expect(routerMock.push).toHaveBeenCalledWith(
+      "/settings/editprovider/spotify--test",
+    );
+  });
+
+  it("omits reconfigure from the menu when no setup flow exists", async () => {
+    const wrapper = await mountProviders(ProviderStatus.LOADED, false);
+
+    wrapper.findComponent(ListItemStub).vm.$emit("menu", new Event("click"));
+
+    const contextMenuCall = eventbusMock.emit.mock.calls.find(
+      ([event]) => event === "contextmenu",
+    );
+    const menuItems = contextMenuCall?.[1].items;
+    expect(
+      menuItems.map((item: { label: string }) => item.label),
+    ).not.toContain("settings.reconfigure");
+    expect(menuItems[0].label).toBe("settings.options");
+  });
+
+  it("omits reconfigure for disabled providers", async () => {
+    const wrapper = await mountProviders(ProviderStatus.DISABLED, true, false);
+
+    wrapper.findComponent(ListItemStub).vm.$emit("menu", new Event("click"));
+
+    const contextMenuCall = eventbusMock.emit.mock.calls.find(
+      ([event]) => event === "contextmenu",
+    );
+    const menuItems = contextMenuCall?.[1].items;
+    expect(
+      menuItems.map((item: { label: string }) => item.label),
+    ).not.toContain("settings.reconfigure");
+    expect(menuItems[0].label).toBe("settings.options");
+  });
+
+  it("omits reconfigure for incompatible providers", async () => {
+    const wrapper = await mountProviders(ProviderStatus.INCOMPATIBLE);
+
+    wrapper.findComponent(ListItemStub).vm.$emit("menu", new Event("click"));
+
+    const contextMenuCall = eventbusMock.emit.mock.calls.find(
+      ([event]) => event === "contextmenu",
+    );
+    const menuItems = contextMenuCall?.[1].items;
+    expect(
+      menuItems.map((item: { label: string }) => item.label),
+    ).not.toContain("settings.reconfigure");
+  });
+});
+
+async function mountProviders(
+  status: ProviderStatus,
+  hasSetupFlow: boolean = true,
+  enabled: boolean = true,
+) {
+  apiMock.providerManifests.spotify.has_setup_flow = hasSetupFlow;
+  apiMock.getProviderConfigs.mockResolvedValue([
+    {
+      domain: "spotify",
+      enabled,
+      instance_id: "spotify--test",
+      last_error: {
+        error_code: 1,
+        message: "Authentication required",
+      },
+      name: "Spotify",
+      status,
+      type: ProviderType.MUSIC,
+    },
+  ]);
+
+  const wrapper = shallowMount(Providers, {
+    global: {
+      mocks: {
+        $t: (key: string) => key,
+      },
+      provide: {
+        providersViewMode: {
+          toggleViewMode: vi.fn(),
+          viewMode: ref<"list" | "card">("list"),
+        },
+      },
+      stubs: {
+        Container: SlotStub,
+        ListItem: ListItemStub,
+        VBtn: ButtonStub,
+        VList: SlotStub,
+      },
+    },
+  });
+  await flushPromises();
+  return wrapper;
+}


### PR DESCRIPTION
Providers that need reauthentication currently open their regular options first, forcing an extra step and sometimes leaving stale status behind.

- Open required reconfiguration directly
- Separate **Options** and **Reconfigure** actions only when a setup flow exists
- Refresh provider status whenever reconfiguration finishes or stops

Uses the provider capability added in music-assistant/server#5061.