### PR TITLE
Fix login behind Home Assistant ingress

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -482,11 +482,7 @@ onMounted(async () => {
         initializationCompleted = false;
 
         const { authManager } = await import("@/plugins/auth");
-        // Check if we're in Ingress mode by examining the URL path
-        const isIngressMode =
-          window.location.pathname.includes("/hassio_ingress/");
-
-        if (isIngressMode) {
+        if (store.isIngressSession) {
           // In Ingress mode, authentication happens via HA proxy headers
           try {
             const user = await api.getCurrentUserInfo();

--- a/src/helpers/ingress.ts
+++ b/src/helpers/ingress.ts
@@ -1,0 +1,15 @@
+import type { ServerInfoMessage } from "@/plugins/api/interfaces";
+
+type IngressServerInfo = Pick<ServerInfoMessage, "homeassistant_addon">;
+
+export function hasHomeAssistantIngressPath(): boolean {
+  return window.location.pathname.includes("/hassio_ingress/");
+}
+
+export function isHomeAssistantIngressSession(
+  serverInfo?: IngressServerInfo | null,
+): boolean {
+  return (
+    hasHomeAssistantIngressPath() && serverInfo?.homeassistant_addon === true
+  );
+}

--- a/src/plugins/store.ts
+++ b/src/plugins/store.ts
@@ -9,6 +9,7 @@ import {
 } from "./api/interfaces";
 
 import { StoredState } from "@/components/ItemsListing.vue";
+import { isHomeAssistantIngressSession } from "@/helpers/ingress";
 import { isTouchscreenDevice, parseBool } from "@/helpers/utils";
 import api from "./api";
 
@@ -131,7 +132,9 @@ export const store: Store = reactive({
   }),
   currentUser: undefined,
   serverInfo: undefined,
-  isIngressSession: window.location.pathname.includes("/hassio_ingress/"),
+  isIngressSession: computed(() =>
+    isHomeAssistantIngressSession(api.serverInfo.value),
+  ),
   isOnboarding: false,
   enabledPlugins: new Set(),
   isPartyGuest: false,

--- a/src/views/Login.vue
+++ b/src/views/Login.vue
@@ -417,6 +417,10 @@ import {
   createLocalConnectionIdentity,
   createRemoteConnectionIdentity,
 } from "@/helpers/connection_identity";
+import {
+  hasHomeAssistantIngressPath,
+  isHomeAssistantIngressSession,
+} from "@/helpers/ingress";
 import type { ITransport } from "@/plugins/remote/transport";
 import { authManager } from "@/plugins/auth";
 import { remoteConnectionManager } from "@/plugins/remote";
@@ -465,10 +469,9 @@ const isRemoteOnlyMode = computed(() => {
   return urlParams.get("remote") === "1";
 });
 
-// Detect if running in Home Assistant Ingress mode
-const isIngressMode = computed(() => {
-  return window.location.pathname.includes("/hassio_ingress/");
-});
+const isIngressMode = computed(() =>
+  isHomeAssistantIngressSession(api.serverInfo.value),
+);
 
 const isHostedWithAPI = ref(false);
 
@@ -1213,8 +1216,8 @@ const autoConnect = async () => {
   // Check if we're hosted with the API
   isHostedWithAPI.value = await checkIfHostedWithAPI();
 
-  // Special handling for Home Assistant Ingress mode
-  if (isIngressMode.value) {
+  let currentHostConnected = false;
+  if (hasHomeAssistantIngressPath()) {
     connectionStatusMessage.value = t(
       "login.connecting_ingress",
       "Connecting via Home Assistant...",
@@ -1222,32 +1225,10 @@ const autoConnect = async () => {
 
     const address =
       window.location.origin + window.location.pathname.replace(/\/$/, "");
+    serverAddress.value = address;
 
-    try {
-      emit("local-connect", address);
-
-      if (await waitForApiConnection()) {
-        if (await tryIngressAuth()) {
-          return; // Success - App.vue will take over
-        }
-      }
-
-      console.error("[Login] Ingress authentication failed");
-      connectionError.value = t(
-        "login.error_ingress_failed",
-        "Failed to authenticate via Home Assistant Ingress",
-      );
-      step.value = "error";
-      return;
-    } catch (error) {
-      console.error("[Login] Ingress connection failed:", error);
-      connectionError.value =
-        error instanceof Error
-          ? error.message
-          : t("login.error_unknown", "Unknown error occurred");
-      step.value = "error";
-      return;
-    }
+    emit("local-connect", address);
+    currentHostConnected = await waitForApiConnection();
   }
 
   // If in remote-only mode, skip all local connection attempts
@@ -1352,7 +1333,7 @@ const autoConnect = async () => {
   }
 
   // 1. If hosted with API, try connecting to current host first
-  if (isHostedWithAPI.value) {
+  if (isHostedWithAPI.value || currentHostConnected) {
     connectionStatusMessage.value = t(
       "login.checking_local",
       "Checking local server...",
@@ -1361,15 +1342,34 @@ const autoConnect = async () => {
     const storedToken = authManager.getToken();
     const localWsUrl = getWebSocketUrlFromLocation();
 
-    if (await tryConnect(localWsUrl, 3000)) {
+    if (currentHostConnected || (await tryConnect(localWsUrl, 3000))) {
       const address =
         window.location.origin + window.location.pathname.replace(/\/$/, "");
       serverAddress.value = address;
 
-      emit("local-connect", address);
+      if (!currentHostConnected) {
+        emit("local-connect", address);
+      }
+
+      const apiConnected =
+        currentHostConnected || (await waitForApiConnection());
+      if (apiConnected && isIngressMode.value) {
+        if (await tryIngressAuth()) {
+          return; // Success - App.vue will take over
+        }
+
+        console.error("[Login] Ingress authentication failed");
+        connectionError.value = t(
+          "login.error_ingress_failed",
+          "Failed to authenticate via Home Assistant Ingress",
+        );
+        step.value = "error";
+        return;
+      }
+
       rememberServerAddress(address);
 
-      if (await waitForApiConnection()) {
+      if (apiConnected) {
         const pendingGuestAuthResult = await tryPendingGuestAuth();
         if (pendingGuestAuthResult !== "none") {
           return;

--- a/tests/views/Login.test.ts
+++ b/tests/views/Login.test.ts
@@ -16,7 +16,10 @@ const mocks = vi.hoisted(() => ({
   routerReplace: vi.fn(),
   sendCommand: vi.fn(),
   serverInfo: {
-    value: { server_id: "server-id" } as { server_id: string } | null,
+    value: {
+      homeassistant_addon: false,
+      server_id: "server-id",
+    } as { homeassistant_addon: boolean; server_id: string } | null,
   },
   setToken: vi.fn(),
 }));
@@ -249,7 +252,10 @@ beforeEach(() => {
     username: "ingress-user",
     role: "admin",
   });
-  mocks.serverInfo.value = { server_id: "server-id" };
+  mocks.serverInfo.value = {
+    homeassistant_addon: false,
+    server_id: "server-id",
+  };
   mocks.setToken.mockImplementation((token: string) => {
     sessionStorage.setItem("ma_guest_access_token", token);
   });
@@ -574,6 +580,10 @@ describe("guest join login", () => {
       "http://localhost:3000/hassio_ingress/server/?join=abcd1234#/guest",
     );
     mockHostedFrontend();
+    mocks.serverInfo.value = {
+      homeassistant_addon: true,
+      server_id: "server-id",
+    };
 
     const wrapper = mountLogin();
 
@@ -586,6 +596,7 @@ describe("guest join login", () => {
         },
       });
     });
+
     expect(mocks.getCurrentUserInfo).toHaveBeenCalledOnce();
     expect(mocks.sendCommand).not.toHaveBeenCalledWith(
       "auth/join_code/exchange",
@@ -619,5 +630,63 @@ describe("guest join login", () => {
     expect(mocks.clearAuth).not.toHaveBeenCalled();
     expect(localStorage.getItem("ma_access_token")).toBe("admin-token");
     expect(localStorage.getItem("mass_remote_id")).toBe(regularRemoteId);
+  });
+});
+
+describe("ingress login", () => {
+  it("uses ingress authentication for a Home Assistant add-on", async () => {
+    setLocation("hassio_ingress/server/");
+    mockHostedFrontend();
+    mocks.serverInfo.value = {
+      homeassistant_addon: true,
+      server_id: "server-id",
+    };
+
+    const wrapper = mountLogin();
+
+    await vi.waitFor(() => {
+      expect(wrapper.emitted("authenticated")?.[0]?.[0]).toEqual({
+        user: {
+          role: "admin",
+          user_id: "ingress-user",
+          username: "ingress-user",
+        },
+      });
+    });
+    expect(mocks.getCurrentUserInfo).toHaveBeenCalledOnce();
+    expect(mocks.authenticateWithToken).not.toHaveBeenCalled();
+  });
+
+  it("uses stored authentication for a standalone server behind ingress", async () => {
+    setLocation("hassio_ingress/server/");
+    mockHostedFrontend();
+    localStorage.setItem("ma_access_token", "admin-token");
+
+    const wrapper = mountLogin();
+
+    await vi.waitFor(() => {
+      expect(wrapper.emitted("authenticated")?.[0]?.[0]).toEqual({
+        token: "admin-token",
+        user: {
+          role: "admin",
+          user_id: "regular-id",
+          username: "regular-user",
+        },
+      });
+    });
+    expect(mocks.authenticateWithToken).toHaveBeenCalledWith("admin-token");
+    expect(mocks.getCurrentUserInfo).not.toHaveBeenCalled();
+  });
+
+  it("shows the normal login for a standalone server behind ingress", async () => {
+    setLocation("hassio_ingress/server/");
+    mockHostedFrontend();
+
+    const wrapper = mountLogin();
+
+    await vi.waitFor(() => {
+      expect(wrapper.text()).toContain("Username");
+    });
+    expect(mocks.getCurrentUserInfo).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
Fixes music-assistant/support#5907

Standalone servers hosted behind Home Assistant ingress were incorrectly forced into add-on ingress authentication.

- Confirm ingress sessions using both the URL path and server add-on status
- Use stored or normal login for standalone servers
- Preserve automatic login and reconnects for genuine add-on ingress