### PR TITLE
Fix missing cover art in fullscreen player on older browsers

### DIFF
--- a/src/layouts/default/PlayerOSD/PlayerFullscreen.vue
+++ b/src/layouts/default/PlayerOSD/PlayerFullscreen.vue
@@ -1487,6 +1487,9 @@ watchEffect(() => {
   container-type: size;
 }
 .main-media-details-image .v-img {
+  /* Fallback for engines without container query units; they drop the pair below and collapse the image to 0x0. */
+  width: 100%;
+  height: auto;
   width: min(100cqi, 100cqh);
   height: min(100cqi, 100cqh);
   flex: 0 0 auto;


### PR DESCRIPTION
The album cover is invisible on the fullscreen player in the Home Assistant companion app on older Android devices, while the rest of the screen renders fine. The same device shows the cover correctly in Chrome.

`.main-media-details-image .v-img` is sized with container query units (`min(100cqi, 100cqh)`), which need Chromium 105+. Older engines discard those declarations at parse time, leaving `width`/`height` at `auto`. Vuetify's `v-img` has no intrinsic width, so it collapses to 0x0 and the cover disappears.

Adds a plain fallback ahead of the container query pair. Modern browsers still use the container query sizing, older ones get a usable image instead of nothing.

- Fall back to `width: 100%` / `height: auto` so the image stays visible when container query units are unsupported; `height: auto` lets Vuetify's 1:1 sizer keep it square

Fixes music-assistant/support#5717
