### PR TITLE
Clarify the bit-perfect playback label

### DIFF
--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -872,7 +872,7 @@
             "dsp_title": "DSP",
             "bit_perfect": "Bit-perfect output",
             "bit_perfect_badge": "Bit-perfect",
-            "bit_perfect_detail": "Bit-perfect: audio samples are unchanged from the source.",
+            "bit_perfect_detail": "Bit-perfect: decoded source samples reach the output unchanged.",
             "samples_changed_detail": "Audio processing or lossless format conversion changed the audio samples. This is not bit-perfect, but should not cause an audible loss of quality.",
             "lossy_output_detail": "The output is encoded with a lossy codec. This is not bit-perfect and may reduce sound quality.",
             "bit_perfect_unknown_detail": "Bit-perfect status is unavailable.",

--- a/tests/components/AudioProcessingDetails.test.ts
+++ b/tests/components/AudioProcessingDetails.test.ts
@@ -228,7 +228,9 @@ describe("AudioProcessingDetails", () => {
         .find('[data-stage="output-format-0"]')
         .findAll("li")
         .map((detail) => detail.text()),
-    ).toContain("Bit-perfect: audio samples are unchanged from the source.");
+    ).toContain(
+      "Bit-perfect: decoded source samples reach the output unchanged.",
+    );
     expect(text).not.toContain("Processed output");
   });
 

--- a/tests/components/AudioProcessingStage.test.ts
+++ b/tests/components/AudioProcessingStage.test.ts
@@ -102,7 +102,7 @@ describe("AudioProcessingStage", () => {
       badge: "Bit-perfect",
       details: [
         "Container: FLAC",
-        "Bit-perfect: audio samples are unchanged from the source.",
+        "Bit-perfect: decoded source samples reach the output unchanged.",
       ],
     });
 
@@ -112,7 +112,7 @@ describe("AudioProcessingStage", () => {
     expect(wrapper.find(".audio-processing-stage-info").exists()).toBe(true);
     expect(wrapper.findAll("li").map((detail) => detail.text())).toEqual([
       "Container: FLAC",
-      "Bit-perfect: audio samples are unchanged from the source.",
+      "Bit-perfect: decoded source samples reach the output unchanged.",
     ]);
   });
 


### PR DESCRIPTION
Clarifies that bit-perfect playback describes the signal after source decoding, not whether the original source was lossless.

- Explain that decoded source samples reach the output unchanged
- Update the related UI coverage

Companion server change: music-assistant/server#5087