### PR TITLE
Add a shuffle toggle to AI Radio shows

### DIFF
--- a/src/components/ai-radio/CreateShowDialog.vue
+++ b/src/components/ai-radio/CreateShowDialog.vue
@@ -214,6 +214,7 @@ function buildDraft(): ShowDraft {
       targetPlaylistProvider: "builtin",
       defaultPlayerId: "",
       maxDurationMinutes: 0,
+      shuffleSourceTracks: true,
       dynamicBatchSize: 3,
       dynamicPollSeconds: 5,
       dynamicPrefetchRemainingTracks: 2,

--- a/src/components/ai-radio/CustomizeShow.vue
+++ b/src/components/ai-radio/CustomizeShow.vue
@@ -200,7 +200,23 @@
               </NumberField>
             </div>
 
-            <div class="flex items-center gap-3 md:col-span-2">
+            <div class="flex items-center gap-3">
+              <FieldLabel
+                html-for="customize-shuffle-source-tracks"
+                :label="$t('providers.ai_radio.fields.shuffle_playlist_tracks')"
+                :description="
+                  $t(
+                    'providers.ai_radio.field_descriptions.shuffle_playlist_tracks',
+                  )
+                "
+              />
+              <Switch
+                id="customize-shuffle-source-tracks"
+                v-model="draft.basics.shuffleSourceTracks"
+              />
+            </div>
+
+            <div class="flex items-center gap-3">
               <FieldLabel
                 html-for="customize-clear-queue"
                 :label="

--- a/src/helpers/ai_radio.ts
+++ b/src/helpers/ai_radio.ts
@@ -133,6 +133,7 @@ export interface ShowBasics {
   targetPlaylistProvider: string;
   defaultPlayerId: string;
   maxDurationMinutes: number;
+  shuffleSourceTracks: boolean;
   dynamicBatchSize: number;
   dynamicPollSeconds: number;
   dynamicPrefetchRemainingTracks: number;
@@ -491,6 +492,7 @@ export const compileShow = (draft: ShowDraft): AIRadioStation => {
     target_playlist_provider: draft.basics.targetPlaylistProvider || "builtin",
     default_player_id: draft.basics.defaultPlayerId || "",
     max_duration_minutes: draft.basics.maxDurationMinutes,
+    shuffle_source_tracks: draft.basics.shuffleSourceTracks,
     dynamic_batch_size: draft.basics.dynamicBatchSize,
     dynamic_poll_seconds: draft.basics.dynamicPollSeconds,
     dynamic_prefetch_remaining_tracks:
@@ -632,6 +634,7 @@ export const decompileStation = (
     targetPlaylistProvider: station.target_playlist_provider || "builtin",
     defaultPlayerId: station.default_player_id || "",
     maxDurationMinutes: station.max_duration_minutes || 0,
+    shuffleSourceTracks: station.shuffle_source_tracks !== false,
     dynamicBatchSize: station.dynamic_batch_size || 3,
     dynamicPollSeconds: station.dynamic_poll_seconds || 5,
     dynamicPrefetchRemainingTracks:

--- a/src/plugins/api/interfaces.ts
+++ b/src/plugins/api/interfaces.ts
@@ -1632,6 +1632,7 @@ export interface AIRadioStation {
   target_playlist_provider?: string;
   default_player_id?: string;
   max_duration_minutes?: number;
+  shuffle_source_tracks?: boolean;
   dynamic_batch_size?: number;
   dynamic_poll_seconds?: number;
   dynamic_prefetch_remaining_tracks?: number;

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1200,6 +1200,7 @@
             },
             "fields": {
                 "source_playtime_cap": "Source Playtime Cap (minutes)",
+                "shuffle_playlist_tracks": "Shuffle Playlist Tracks",
                 "default_playback_device": "Default Playback Device (optional)",
                 "web_search_mode": "Web Search Mode",
                 "character_limit": "Character Limit",
@@ -1209,7 +1210,8 @@
                 "instructions": "Host and Program Instructions"
             },
             "field_descriptions": {
-                "source_playtime_cap": "Maximum total playing time of the source music, in minutes. Tracks are picked at random until the cap is reached, so you get a random selection of the playlist rather than the first part of it. Leave at 0 for no limit.",
+                "source_playtime_cap": "Maximum total playing time of the source music, in minutes. Tracks are taken in the order the show plays them until the cap is reached. Leave at 0 for no limit.",
+                "shuffle_playlist_tracks": "Play the source playlist in random order. Turn this off to follow the playlist's own order.",
                 "clear_queue_on_dynamic_start": "Replace whatever is in the queue when the show starts. Turn this off to append the show to the queue instead and keep the current track playing.",
                 "dynamic_batch_size": "How many tracks the host prepares at a time. Larger batches mean fewer pauses while the next segment is generated, but a longer wait before the show starts playing.",
                 "instructions": "Describes the host's personality and how segments should be written. This is sent to the AI with every segment."

--- a/tests/helpers/ai_radio.test.ts
+++ b/tests/helpers/ai_radio.test.ts
@@ -1,4 +1,12 @@
-import { errorMessage, relativeTimeFromIso, slugify } from "@/helpers/ai_radio";
+import {
+  asGeneralDefaults,
+  compileShow,
+  decompileStation,
+  errorMessage,
+  relativeTimeFromIso,
+  slugify,
+} from "@/helpers/ai_radio";
+import type { ShowDraft } from "@/helpers/ai_radio";
 import type { AIRadioSection, AIRadioStation } from "@/plugins/api/interfaces";
 import { describe, expect, it, vi } from "vitest";
 
@@ -19,6 +27,27 @@ const makeSection = (
   type: "ai_text",
   prompt: "Say hello",
   ...overrides,
+});
+
+const makeDraft = (
+  overrides: Partial<ShowDraft["basics"]> = {},
+): ShowDraft => ({
+  basics: {
+    name: "My Show",
+    sourcePlaylistId: "42",
+    sourcePlaylistProvider: "library",
+    targetPlaylistProvider: "builtin",
+    defaultPlayerId: "",
+    maxDurationMinutes: 0,
+    shuffleSourceTracks: true,
+    dynamicBatchSize: 3,
+    dynamicPollSeconds: 5,
+    dynamicPrefetchRemainingTracks: 2,
+    clearQueueOnStart: true,
+    general: asGeneralDefaults(undefined),
+    ...overrides,
+  },
+  segments: [],
 });
 
 const makeStation = (
@@ -70,5 +99,19 @@ describe("relativeTimeFromIso", () => {
     expect(at("2026-07-16T11:45:00Z")).toBe("15m ago");
     expect(at("2026-07-16T10:00:00Z")).toBe("2h ago");
     expect(at("2026-07-13T12:00:00Z")).toBe("3d ago");
+  });
+});
+
+describe("compileShow", () => {
+  it("writes shuffle_source_tracks from the draft", () => {
+    const draft = makeDraft({ shuffleSourceTracks: false });
+    expect(compileShow(draft).shuffle_source_tracks).toBe(false);
+  });
+});
+
+describe("decompileStation", () => {
+  it("defaults shuffleSourceTracks to true when absent from the station", () => {
+    const { basics } = decompileStation(makeStation(), [makeSection()]);
+    expect(basics.shuffleSourceTracks).toBe(true);
   });
 });


### PR DESCRIPTION
Shuffling a show's source playlist used to be a hidden side effect of setting a source playtime cap: the cap picked tracks at random, so capping a show was the only way to get a random selection, and there was no way to shuffle a playlist without capping it. The server splits the two apart, so this exposes the new station option.

- Add a "shuffle playlist tracks" switch to Customize → Advanced, sharing a row with the existing "clear queue on dynamic start" switch
- Carry `shuffle_source_tracks` through the station interface, the compile/decompile helpers and the create-show defaults, treating an absent value as on to match the server default
- Rewrite the playtime cap's description, which documented the random-selection behaviour that has now moved to the toggle

Companion server PR: music-assistant/server#5106