### PR TITLE
Reject in-flight API commands when the connection drops

### DIFF
--- a/src/plugins/api/index.ts
+++ b/src/plugins/api/index.ts
@@ -86,6 +86,14 @@ export enum ConnectionState {
   FAILED = "failed", // Connection failed permanently
 }
 
+/** Rejection for in-flight commands that can never be answered because the connection dropped. */
+export class ConnectionLostError extends Error {
+  constructor() {
+    super("Connection lost");
+    this.name = "ConnectionLostError";
+  }
+}
+
 export class MusicAssistantApi {
   private transport?: ITransport;
   private _throttleId?: ReturnType<typeof setTimeout>;
@@ -337,8 +345,12 @@ export class MusicAssistantApi {
 
       return result;
     } catch (error) {
-      // Token is invalid - require user authentication
-      this.state.value = ConnectionState.AUTH_REQUIRED;
+      // a dropped connection says nothing about the token; leave the
+      // reconnect flow intact so re-auth runs again after reconnect
+      if (!(error instanceof ConnectionLostError)) {
+        // Token is invalid - require user authentication
+        this.state.value = ConnectionState.AUTH_REQUIRED;
+      }
       throw error;
     }
   }
@@ -3267,7 +3279,7 @@ export class MusicAssistantApi {
     this.commands.clear();
     this.partialResult = {};
     for (const command of pending) {
-      command.reject(new Error("Connection lost"));
+      command.reject(new ConnectionLostError());
     }
   }
 

--- a/src/plugins/api/index.ts
+++ b/src/plugins/api/index.ts
@@ -3195,7 +3195,13 @@ export class MusicAssistantApi {
         reject,
         suppressGlobalError: options?.suppressGlobalError,
       });
-      this._sendCommand(command, args, cmdId);
+      try {
+        this._sendCommand(command, args, cmdId);
+      } catch (error) {
+        // a synchronous throw here rejects the promise but leaves the map entry behind
+        this.commands.delete(cmdId);
+        throw error;
+      }
     });
   }
 
@@ -3212,7 +3218,7 @@ export class MusicAssistantApi {
       this.state.value !== ConnectionState.AUTHENTICATED &&
       this.state.value !== ConnectionState.INITIALIZED
     ) {
-      throw new Error("Connection lost");
+      throw new ConnectionLostError();
     }
 
     if (!msgId) {
@@ -3232,10 +3238,15 @@ export class MusicAssistantApi {
     const msgStr = JSON.stringify(msg);
 
     if (!this.transport) {
-      throw new Error("No connection available");
+      throw new ConnectionLostError();
     }
 
-    this.transport.send(msgStr);
+    try {
+      this.transport.send(msgStr);
+    } catch {
+      // transport throws untyped errors; callers filter on ConnectionLostError
+      throw new ConnectionLostError();
+    }
   }
 
   public async fetchState() {

--- a/src/plugins/api/index.ts
+++ b/src/plugins/api/index.ts
@@ -208,50 +208,7 @@ export class MusicAssistantApi {
 
     // Listen for transport state changes (reconnecting, failed, etc.)
     transport.on("stateChange", (state) => {
-      console.log("[API] Transport state changed to:", state);
-      this.transportState.value = state;
-
-      // Handle specific state transitions
-      if (state === "reconnecting") {
-        // Transport is attempting to reconnect
-        this.state.value = ConnectionState.RECONNECTING;
-        // pause probing but keep the estimate: clock offsets don't change while the
-        // connection is down, and a slightly stale offset still beats no correction.
-        // A new ServerInfo message resumes it once the connection is back.
-        stopServerTimeSync();
-        this.signalEvent({
-          event: EventType.DISCONNECTED,
-          object_id: "",
-        });
-      } else if (state === "failed") {
-        // Failed could be transient (during reconnect) or permanent
-        // Wait to see if it transitions to reconnecting or stays failed
-        setTimeout(() => {
-          if (this.transportState.value === "failed") {
-            // Still failed after brief wait - this is permanent failure
-            this.state.value = ConnectionState.FAILED;
-            stopServerTimeSync();
-            this.signalEvent({
-              event: EventType.DISCONNECTED,
-              object_id: "",
-            });
-          }
-          // Otherwise it transitioned to reconnecting - ignore this transient failure
-        }, 50);
-      } else if (state === "disconnected") {
-        // Check if this is an intentional disconnect (not followed by reconnecting)
-        // Use nextTick to allow reconnecting state to be set first
-        setTimeout(() => {
-          if (this.transportState.value === "disconnected") {
-            this.state.value = ConnectionState.DISCONNECTED;
-            stopServerTimeSync();
-            this.signalEvent({
-              event: EventType.DISCONNECTED,
-              object_id: "",
-            });
-          }
-        }, 0);
-      }
+      this.handleTransportStateChange(state);
     });
 
     await transport.connect();
@@ -407,6 +364,7 @@ export class MusicAssistantApi {
     this.isRemoteConnection.value = false;
     // the next connection may be to a different server, whose clock offset is unrelated
     resetServerTime();
+    this._failPendingCommands();
 
     // Clear reactive state
     Object.keys(this.players).forEach((key) => delete this.players[key]);
@@ -2621,6 +2579,61 @@ export class MusicAssistantApi {
     this.signalEvent(msg);
   }
 
+  private handleTransportStateChange(state: string): void {
+    console.log("[API] Transport state changed to:", state);
+    this.transportState.value = state;
+
+    // the socket is already gone here, so nothing in flight can be answered
+    if (
+      state === "reconnecting" ||
+      state === "failed" ||
+      state === "disconnected"
+    ) {
+      this._failPendingCommands();
+    }
+
+    if (state === "reconnecting") {
+      // Transport is attempting to reconnect
+      this.state.value = ConnectionState.RECONNECTING;
+      // pause probing but keep the estimate: clock offsets don't change while the
+      // connection is down, and a slightly stale offset still beats no correction.
+      // A new ServerInfo message resumes it once the connection is back.
+      stopServerTimeSync();
+      this.signalEvent({
+        event: EventType.DISCONNECTED,
+        object_id: "",
+      });
+    } else if (state === "failed") {
+      // Failed could be transient (during reconnect) or permanent
+      // Wait to see if it transitions to reconnecting or stays failed
+      setTimeout(() => {
+        if (this.transportState.value === "failed") {
+          // Still failed after brief wait - this is permanent failure
+          this.state.value = ConnectionState.FAILED;
+          stopServerTimeSync();
+          this.signalEvent({
+            event: EventType.DISCONNECTED,
+            object_id: "",
+          });
+        }
+        // Otherwise it transitioned to reconnecting - ignore this transient failure
+      }, 50);
+    } else if (state === "disconnected") {
+      // Check if this is an intentional disconnect (not followed by reconnecting)
+      // Use nextTick to allow reconnecting state to be set first
+      setTimeout(() => {
+        if (this.transportState.value === "disconnected") {
+          this.state.value = ConnectionState.DISCONNECTED;
+          stopServerTimeSync();
+          this.signalEvent({
+            event: EventType.DISCONNECTED,
+            object_id: "",
+          });
+        }
+      }, 0);
+    }
+  }
+
   private handleResultMessage(msg: SuccessResultMessage | ErrorResultMessage) {
     // Handle result of a command
     const resultPromise = this.commands.get(msg.message_id);
@@ -3240,6 +3253,21 @@ export class MusicAssistantApi {
     Object.keys(this.providers).forEach((key) => delete this.providers[key]);
     for (const provider of providers) {
       this.providers[provider.instance_id] = provider;
+    }
+  }
+
+  /** Reject commands still awaiting a reply; a dropped socket can never answer them. */
+  private _failPendingCommands(): void {
+    if (this.commands.size === 0) {
+      this.partialResult = {};
+      return;
+    }
+    // clear first: a rejection handler may immediately send a new command
+    const pending = [...this.commands.values()];
+    this.commands.clear();
+    this.partialResult = {};
+    for (const command of pending) {
+      command.reject(new Error("Connection lost"));
     }
   }
 

--- a/src/plugins/api/pendingCommands.test.ts
+++ b/src/plugins/api/pendingCommands.test.ts
@@ -1,24 +1,19 @@
 import { describe, expect, it, vi } from "vitest";
-import { ConnectionState, MusicAssistantApi } from "./index";
+import {
+  ConnectionLostError,
+  ConnectionState,
+  MusicAssistantApi,
+} from "./index";
 
 type FakeTransport = {
   send: ReturnType<typeof vi.fn>;
   disconnect: ReturnType<typeof vi.fn>;
-  on: (event: string, handler: (payload: unknown) => void) => void;
-  emit: (event: string, payload: unknown) => void;
 };
 
-const makeTransport = (): FakeTransport => {
-  const handlers: Record<string, (payload: unknown) => void> = {};
-  return {
-    send: vi.fn(),
-    disconnect: vi.fn(),
-    on: (event, handler) => {
-      handlers[event] = handler;
-    },
-    emit: (event, payload) => handlers[event]?.(payload),
-  };
-};
+const makeTransport = (): FakeTransport => ({
+  send: vi.fn(),
+  disconnect: vi.fn(),
+});
 
 /** Resolves to "pending" when the promise has not settled within a tick. */
 const outcomeOf = (promise: Promise<unknown>) => {
@@ -48,7 +43,7 @@ describe("commands in flight when the connection drops", () => {
 
     api.disconnect();
 
-    expect(await outcomeOf(inFlight)).toBe("Connection lost");
+    await expect(inFlight).rejects.toBeInstanceOf(ConnectionLostError);
   });
 
   it.each(["reconnecting", "failed", "disconnected"])(
@@ -74,5 +69,20 @@ describe("commands in flight when the connection drops", () => {
     } as never);
 
     expect(await outcomeOf(inFlight)).toBe("resolved");
+  });
+
+  it("keeps a reconnecting session out of AUTH_REQUIRED when re-auth is cut off", async () => {
+    const { api } = connectedApi();
+    const reauth = api
+      .authenticateWithToken("stored-token")
+      .catch(() => undefined);
+
+    // the transport dies again before the auth reply arrives
+    api["handleTransportStateChange"]("disconnected");
+    api["handleTransportStateChange"]("reconnecting");
+    await reauth;
+
+    // AUTH_REQUIRED here would break App.vue's re-auth watch (CONNECTED <- RECONNECTING)
+    expect(api.state.value).toBe(ConnectionState.RECONNECTING);
   });
 });

--- a/src/plugins/api/pendingCommands.test.ts
+++ b/src/plugins/api/pendingCommands.test.ts
@@ -85,4 +85,41 @@ describe("commands in flight when the connection drops", () => {
     // AUTH_REQUIRED here would break App.vue's re-auth watch (CONNECTED <- RECONNECTING)
     expect(api.state.value).toBe(ConnectionState.RECONNECTING);
   });
+
+  it("rejects with ConnectionLostError and leaves no commands map entry when sent while disconnected", async () => {
+    const api = new MusicAssistantApi();
+    api.state.value = ConnectionState.DISCONNECTED;
+
+    await expect(
+      api.sendCommand("ai_radio/stations/list"),
+    ).rejects.toBeInstanceOf(ConnectionLostError);
+    expect(api["commands"].size).toBe(0);
+  });
+
+  it("rejects with ConnectionLostError and leaves no commands map entry when the transport's send throws", async () => {
+    const { api, transport } = connectedApi();
+    transport.send.mockImplementation(() => {
+      throw new Error("WebSocket is not connected");
+    });
+
+    await expect(
+      api.sendCommand("ai_radio/stations/list"),
+    ).rejects.toBeInstanceOf(ConnectionLostError);
+    expect(api["commands"].size).toBe(0);
+  });
+
+  it("does not fall back to AUTH_REQUIRED when a dropped connection blocks re-auth from even being sent", async () => {
+    const { api, transport } = connectedApi();
+    api.state.value = ConnectionState.RECONNECTING;
+    transport.send.mockImplementation(() => {
+      throw new Error("WebSocket is not connected");
+    });
+
+    await expect(
+      api.authenticateWithToken("stored-token"),
+    ).rejects.toBeInstanceOf(ConnectionLostError);
+
+    // AUTH_REQUIRED here would wipe the token before the reconnect flow gets to retry
+    expect(api.state.value).not.toBe(ConnectionState.AUTH_REQUIRED);
+  });
 });

--- a/src/plugins/api/pendingCommands.test.ts
+++ b/src/plugins/api/pendingCommands.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it, vi } from "vitest";
+import { ConnectionState, MusicAssistantApi } from "./index";
+
+type FakeTransport = {
+  send: ReturnType<typeof vi.fn>;
+  disconnect: ReturnType<typeof vi.fn>;
+  on: (event: string, handler: (payload: unknown) => void) => void;
+  emit: (event: string, payload: unknown) => void;
+};
+
+const makeTransport = (): FakeTransport => {
+  const handlers: Record<string, (payload: unknown) => void> = {};
+  return {
+    send: vi.fn(),
+    disconnect: vi.fn(),
+    on: (event, handler) => {
+      handlers[event] = handler;
+    },
+    emit: (event, payload) => handlers[event]?.(payload),
+  };
+};
+
+/** Resolves to "pending" when the promise has not settled within a tick. */
+const outcomeOf = (promise: Promise<unknown>) => {
+  const pending = Symbol("pending");
+  return Promise.race([
+    promise.then(
+      () => "resolved",
+      (err) => (err as Error)?.message ?? "rejected",
+    ),
+    new Promise((resolve) => setTimeout(() => resolve(pending), 20)),
+  ]).then((outcome) => (outcome === pending ? "pending" : outcome));
+};
+
+const connectedApi = () => {
+  const api = new MusicAssistantApi();
+  api.state.value = ConnectionState.CONNECTED;
+  const transport = makeTransport();
+  // @ts-expect-error - inject a transport that accepts sends but never replies
+  api.transport = transport;
+  return { api, transport };
+};
+
+describe("commands in flight when the connection drops", () => {
+  it("rejects them on an explicit disconnect", async () => {
+    const { api } = connectedApi();
+    const inFlight = api.sendCommand("ai_radio/stations/list");
+
+    api.disconnect();
+
+    expect(await outcomeOf(inFlight)).toBe("Connection lost");
+  });
+
+  it.each(["reconnecting", "failed", "disconnected"])(
+    "rejects them when the transport goes %s",
+    async (state) => {
+      const { api } = connectedApi();
+      const inFlight = api.sendCommand("ai_radio/stations/list");
+
+      api["handleTransportStateChange"](state);
+
+      expect(await outcomeOf(inFlight)).toBe("Connection lost");
+    },
+  );
+
+  it("still resolves a command whose reply arrives normally", async () => {
+    const { api } = connectedApi();
+    const inFlight = api.sendCommand("ai_radio/stations/list");
+    const messageId = [...api["commands"].keys()][0];
+
+    api["handleResultMessage"]({
+      message_id: messageId,
+      result: [{ id: "show", name: "Show" }],
+    } as never);
+
+    expect(await outcomeOf(inFlight)).toBe("resolved");
+  });
+});

--- a/src/views/Login.vue
+++ b/src/views/Login.vue
@@ -439,7 +439,7 @@
 </template>
 
 <script setup lang="ts">
-import { api, ConnectionState } from "@/plugins/api";
+import { api, ConnectionLostError, ConnectionState } from "@/plugins/api";
 import type {
   AuthProvider,
   ServerInfoMessage,
@@ -783,8 +783,9 @@ const tryStoredTokenAuth = async (
     const result = await api.authenticateWithToken(authToken);
     emit("authenticated", { token: authToken, user: result.user });
     return "authenticated";
-  } catch {
-    if (token) return "failed";
+  } catch (error) {
+    // a blip says nothing about token validity; reconnect flow will retry
+    if (token || error instanceof ConnectionLostError) return "failed";
 
     const ended = authManager.endRejectedGuestSession();
     switch (ended.outcome) {

--- a/tests/views/Login.test.ts
+++ b/tests/views/Login.test.ts
@@ -34,6 +34,7 @@ vi.mock("@/plugins/api", async () => {
   const { ref } = await vi.importActual<typeof import("vue")>("vue");
   mocks.apiState = ref(mocks.apiState.value);
   return {
+    ConnectionLostError: class ConnectionLostError extends Error {},
     ConnectionState: {
       AUTHENTICATED: "authenticated",
       AUTHENTICATING: "authenticating",


### PR DESCRIPTION
A command still awaiting its reply when the websocket goes away is never settled: `commands` is only drained when a matching result message arrives. The caller's promise hangs forever, so its `finally` never runs and any loading flag it set stays set — a view awaiting a command behind a loading flag is stuck there until a full page reload, including its own refresh button if that is disabled while loading.

- reject pending commands on explicit disconnect and on transport `reconnecting` / `failed` / `disconnected`, where the socket is already gone and no reply can arrive
- reject with a dedicated `ConnectionLostError` so callers can tell a dropped connection from a real command failure
- keep `authenticateWithToken` out of `AUTH_REQUIRED` when the failure was a dropped connection, so a blip mid-re-auth no longer bounces the user to the login screen
- clear the matching partial-result buffers, which leaked an entry per dropped command
- move the inline `stateChange` closure into a private method so the behaviour is reachable from tests

Callers now see a rejection where they previously saw silence, so a connection blip can surface an error in views that catch and report; `ConnectionLostError` gives any view that would rather stay quiet a way to filter it.