### PR TITLE
Fix shows vanishing from the AI Radio gallery under a non-English locale

### DIFF
--- a/src/helpers/ai_radio.ts
+++ b/src/helpers/ai_radio.ts
@@ -8,7 +8,7 @@ import type {
   AIRadioStationGeneral,
   AIRadioWebSearchMode,
 } from "@/plugins/api/interfaces";
-import { $t, i18n } from "@/plugins/i18n";
+import { $t, canonicalizeLocale, i18n } from "@/plugins/i18n";
 
 // Sentinel for "no selection" in shadcn Select components, which do not
 // allow SelectItem values to be empty strings.
@@ -68,10 +68,13 @@ export const relativeTimeFromIso = (
   if (Number.isNaN(thenMs)) return "";
   const diffSeconds = Math.round((thenMs - nowMs) / 1000);
   const absSeconds = Math.abs(diffSeconds);
-  const rtf = new Intl.RelativeTimeFormat(i18n.global.locale.value, {
-    numeric: "auto",
-    style: "narrow",
-  });
+  const rtf = new Intl.RelativeTimeFormat(
+    canonicalizeLocale(i18n.global.locale.value),
+    {
+      numeric: "auto",
+      style: "narrow",
+    },
+  );
   if (absSeconds < 60) return rtf.format(0, "second");
   if (absSeconds < 3600)
     return rtf.format(Math.trunc(diffSeconds / 60), "minute");

--- a/src/helpers/music_quiz.ts
+++ b/src/helpers/music_quiz.ts
@@ -4,7 +4,7 @@ import type {
   MusicQuizSupportedPublicState,
 } from "@/composables/music-quiz/useMusicQuiz";
 import type { ConnectionIdentity } from "@/helpers/connection_identity";
-import { $t, i18n } from "@/plugins/i18n";
+import { $t, canonicalizeLocale, i18n } from "@/plugins/i18n";
 
 const MUSIC_QUIZ_PLAYER_ID_KEY = "music_quiz_player_id";
 const MUSIC_QUIZ_PLAYER_NAME_KEY = "music_quiz_player_name";
@@ -139,7 +139,7 @@ export function getMusicQuizRoundPlayers<T extends MusicQuizPlayer>(
 }
 
 export function formatNameList(names: string[]) {
-  return new Intl.ListFormat(i18n.global.locale.value, {
+  return new Intl.ListFormat(canonicalizeLocale(i18n.global.locale.value), {
     style: "long",
     type: "conjunction",
   }).format(names);

--- a/tests/components/ai-radio/ShowCard.test.ts
+++ b/tests/components/ai-radio/ShowCard.test.ts
@@ -1,0 +1,72 @@
+import ShowCard from "@/components/ai-radio/ShowCard.vue";
+import { useShows } from "@/composables/ai-radio/useShows";
+import { i18n } from "@/plugins/i18n";
+import type { AIRadioSession, AIRadioStation } from "@/plugins/api/interfaces";
+import { mount } from "@vue/test-utils";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/plugins/api", () => ({
+  default: {
+    players: {},
+    sendCommand: vi.fn(async () => []),
+    getLibraryPlaylists: vi.fn(async () => []),
+  },
+}));
+
+vi.mock("vue-router", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("vue-router")>()),
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn() }),
+}));
+
+const show = {
+  id: "party_host_pirates",
+  name: "Party host — Pirates",
+  source_playlist_id: "42",
+  source_playlist_provider: "library",
+} as AIRadioStation;
+
+const session = (status: string): AIRadioSession =>
+  ({
+    session_id: "s1",
+    station_id: show.id,
+    mode: "dynamic",
+    status,
+    created_at: "2026-07-29T11:00:00Z",
+    ended_at: status === "running" ? null : "2026-07-29T11:30:00Z",
+  }) as unknown as AIRadioSession;
+
+const renderCard = (locale: string, sessionStatus: string) => {
+  const previous = i18n.global.locale.value;
+  i18n.global.locale.value = locale;
+  useShows().sessions.value = [session(sessionStatus)];
+  try {
+    return mount(ShowCard, { props: { show }, shallow: true });
+  } finally {
+    i18n.global.locale.value = previous;
+  }
+};
+
+afterEach(() => {
+  useShows().sessions.value = [];
+});
+
+describe("ShowCard status chip", () => {
+  it("renders the last-on-air chip for a stopped show under an underscored locale", () => {
+    const wrapper = renderCard("en_GB", "stopped");
+
+    expect(wrapper.find(".show-card__status-chip").exists()).toBe(true);
+    expect(wrapper.text()).toContain("Last on air");
+  });
+
+  it("renders the chip under a hyphenated locale", () => {
+    const wrapper = renderCard("en-GB", "stopped");
+
+    expect(wrapper.text()).toContain("Last on air");
+  });
+
+  it("renders no relative-time chip while the show is on air", () => {
+    const wrapper = renderCard("en_GB", "running");
+
+    expect(wrapper.find(".show-card__status-chip").exists()).toBe(false);
+  });
+});

--- a/tests/helpers/ai_radio.test.ts
+++ b/tests/helpers/ai_radio.test.ts
@@ -12,6 +12,7 @@ import { describe, expect, it, vi } from "vitest";
 
 vi.mock("@/plugins/i18n", () => ({
   $t: (key: string) => key,
+  canonicalizeLocale: (locale: string) => locale.replaceAll("_", "-"),
   i18n: {
     global: {
       locale: { value: "en" },

--- a/tests/helpers/localeFormatters.test.ts
+++ b/tests/helpers/localeFormatters.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import { relativeTimeFromIso } from "@/helpers/ai_radio";
+import { formatNameList } from "@/helpers/music_quiz";
+import { i18n } from "@/plugins/i18n";
+
+/**
+ * Lokalise locales use underscores (en_GB), which Intl rejects as an invalid
+ * language tag. Thrown from a render function it takes the whole component out.
+ */
+describe("Intl formatters with an underscored locale", () => {
+  const withLocale = <T>(locale: string, fn: () => T): T => {
+    const previous = i18n.global.locale.value;
+    i18n.global.locale.value = locale;
+    try {
+      return fn();
+    } finally {
+      i18n.global.locale.value = previous;
+    }
+  };
+
+  it.each(["en_GB", "de_DE", "pt_BR"])(
+    "formats a relative time under %s",
+    (locale) => {
+      const now = Date.parse("2026-07-29T12:00:00Z");
+      const then = new Date(now - 2 * 3600 * 1000).toISOString();
+
+      const label = withLocale(locale, () => relativeTimeFromIso(then, now));
+
+      expect(label).not.toBe("");
+    },
+  );
+
+  it("formats a name list under en_GB", () => {
+    const label = withLocale("en_GB", () => formatNameList(["Ann", "Bo"]));
+
+    expect(label).toContain("Ann");
+    expect(label).toContain("Bo");
+  });
+
+  it("still formats a relative time under a hyphenated locale", () => {
+    const now = Date.parse("2026-07-29T12:00:00Z");
+    const then = new Date(now - 90 * 1000).toISOString();
+
+    expect(withLocale("en-GB", () => relativeTimeFromIso(then, now))).not.toBe(
+      "",
+    );
+  });
+});


### PR DESCRIPTION
Lokalise locale codes use underscores (`en_GB`), and `Intl` rejects those as invalid language tags. `relativeTimeFromIso` passed the raw locale straight to `Intl.RelativeTimeFormat`, so it threw `RangeError: Invalid language tag: en_GB`.

That throw happens inside a `ShowCard` render, but only once session data lands and the card's "last on air" / "failed" chip appears. So the gallery painted every show, then dropped each card that had an ended session a moment later — shows appeared to vanish, and the only survivor was one whose session was still running. Reported by a user on `en_GB`; invisible on an English install, which is why it never reproduced locally.

`Intl.ListFormat` in the music quiz name list has the same raw-locale bug and is fixed here too.

- canonicalize the locale before handing it to `Intl` in both formatters, via the existing `canonicalizeLocale` helper already used for `Intl.Collator` and `Intl.DisplayNames`
- cover both under `en_GB`, `de_DE` and `pt_BR`, against the real helper rather than a mock
- add the now-required `canonicalizeLocale` to the i18n mock in the existing `ai_radio` helper tests (mock completion only, no assertions touched)