### PR TITLE
Drop the AI Radio clear-queue-on-start option

### DIFF
--- a/src/components/ai-radio/CreateShowDialog.vue
+++ b/src/components/ai-radio/CreateShowDialog.vue
@@ -218,7 +218,6 @@ function buildDraft(): ShowDraft {
       dynamicBatchSize: 3,
       dynamicPollSeconds: 5,
       dynamicPrefetchRemainingTracks: 2,
-      clearQueueOnStart: true,
       general,
     },
     segments: applyTalkativeness(preset.segments, talkLevel.value),

--- a/src/components/ai-radio/CustomizeShow.vue
+++ b/src/components/ai-radio/CustomizeShow.vue
@@ -215,24 +215,6 @@
                 v-model="draft.basics.shuffleSourceTracks"
               />
             </div>
-
-            <div class="flex items-center gap-3">
-              <FieldLabel
-                html-for="customize-clear-queue"
-                :label="
-                  $t('providers.ai_radio.fields.clear_queue_on_dynamic_start')
-                "
-                :description="
-                  $t(
-                    'providers.ai_radio.field_descriptions.clear_queue_on_dynamic_start',
-                  )
-                "
-              />
-              <Switch
-                id="customize-clear-queue"
-                v-model="draft.basics.clearQueueOnStart"
-              />
-            </div>
           </AccordionContent>
         </AccordionItem>
       </Accordion>

--- a/src/helpers/ai_radio.ts
+++ b/src/helpers/ai_radio.ts
@@ -137,7 +137,6 @@ export interface ShowBasics {
   dynamicBatchSize: number;
   dynamicPollSeconds: number;
   dynamicPrefetchRemainingTracks: number;
-  clearQueueOnStart: boolean;
   general: AIRadioStationGeneral;
 }
 
@@ -497,7 +496,6 @@ export const compileShow = (draft: ShowDraft): AIRadioStation => {
     dynamic_poll_seconds: draft.basics.dynamicPollSeconds,
     dynamic_prefetch_remaining_tracks:
       draft.basics.dynamicPrefetchRemainingTracks,
-    clear_queue_on_start: draft.basics.clearQueueOnStart,
     merge_section_id: mergeSectionId,
     general: draft.basics.general,
     sections,
@@ -639,7 +637,6 @@ export const decompileStation = (
     dynamicPollSeconds: station.dynamic_poll_seconds || 5,
     dynamicPrefetchRemainingTracks:
       station.dynamic_prefetch_remaining_tracks || 2,
-    clearQueueOnStart: station.clear_queue_on_start !== false,
     general: asGeneralDefaults(station.general),
   };
 

--- a/src/plugins/api/interfaces.ts
+++ b/src/plugins/api/interfaces.ts
@@ -1636,7 +1636,6 @@ export interface AIRadioStation {
   dynamic_batch_size?: number;
   dynamic_poll_seconds?: number;
   dynamic_prefetch_remaining_tracks?: number;
-  clear_queue_on_start?: boolean;
   merge_section_id?: string;
   general?: AIRadioStationGeneral;
   section_ids?: string[];

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1215,14 +1215,12 @@
                 "web_search_mode": "Web Search Mode",
                 "character_limit": "Character Limit",
                 "prompt": "Prompt",
-                "clear_queue_on_dynamic_start": "Clear Queue on Dynamic Start",
                 "dynamic_batch_size": "Dynamic Batch Size",
                 "instructions": "Host and Program Instructions"
             },
             "field_descriptions": {
                 "source_playtime_cap": "Maximum total playing time of the source music, in minutes. Tracks are taken in the order the show plays them until the cap is reached. Leave at 0 for no limit.",
                 "shuffle_playlist_tracks": "Play the source playlist in random order. Turn this off to follow the playlist's own order.",
-                "clear_queue_on_dynamic_start": "Replace whatever is in the queue when the show starts. Turn this off to append the show to the queue instead and keep the current track playing.",
                 "dynamic_batch_size": "How many tracks the host prepares at a time. Larger batches mean fewer pauses while the next segment is generated, but a longer wait before the show starts playing.",
                 "instructions": "Describes the host's personality and how segments should be written. This is sent to the AI with every segment."
             },

--- a/tests/helpers/ai_radio.test.ts
+++ b/tests/helpers/ai_radio.test.ts
@@ -43,7 +43,6 @@ const makeDraft = (
     dynamicBatchSize: 3,
     dynamicPollSeconds: 5,
     dynamicPrefetchRemainingTracks: 2,
-    clearQueueOnStart: true,
     general: asGeneralDefaults(undefined),
     ...overrides,
   },


### PR DESCRIPTION
Companion to music-assistant/server#5130, which makes a dynamic AI Radio run always replace the target queue. The toggle no longer changes anything, so it comes out of the UI.

Appending a show after whatever was already queued was never useful in practice — the host intro landed behind unrelated music — and on a queue in smart-mix mode the generated clips were discarded outright.

- remove the toggle from the customize form, its draft field, and its compile/decompile mapping
- remove `clear_queue_on_start` from the station interface
- remove the two source translation keys; the already-translated copies in de/nl/sr_Latn/sv_SE are left for Lokalise to prune

A station saved earlier with the option off keeps working: the server drops the key on the next save, and nothing here reads it any more. The one behaviour change for those users is that starting a show now replaces the queue instead of appending to it.

Also removed the now-invalid `clearQueueOnStart` line from the `makeDraft` fixture in the existing helper tests — fixture only, no assertion touched.