### PR TITLE
Add CI check rejecting conventional-commit PR title prefixes

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,0 +1,46 @@
+---
+name: PR Title
+
+# Release notes are generated verbatim from PR titles
+# (.github/release-drafter.yml), so a title has to read as a
+# user-facing description of the change: "Fix Sonos hanging after
+# reconnect", not "fix: sonos reconnect".
+
+# yamllint disable-line rule:truthy
+on:
+  pull_request:
+    types:
+      - opened
+      - edited
+      - reopened
+      - ready_for_review
+    branches:
+      - main
+
+permissions: {}
+
+jobs:
+  check_title:
+    name: Verify
+    runs-on: ubuntu-latest
+    # GitHub-typed bots (Dependabot, musicassistant-bot[bot], etc.)
+    # generate their own titles, so failing here would only block
+    # their auto-merge.
+    if: github.event.pull_request.user.type != 'Bot'
+    steps:
+      - name: 📝 Reject conventional-commit title prefixes
+        env:
+          # Passed via env, never inlined into the script: the title
+          # is untrusted input.
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          types='build|chore|ci|deps|docs|feat|feature|fix|perf|refactor|revert|style|tests?'
+          prefix=$(printf '%s' "$PR_TITLE" |
+            grep -oiE "^[[:space:]]*($types)(\([^)]*\))?!?[[:space:]]*:" || true)
+
+          if [ -n "$prefix" ]; then
+            echo "::error title=PR title uses a conventional-commit prefix::Drop the '$(printf '%s' "$prefix" | tr -d '[:space:]')' prefix. Release notes are generated straight from PR titles, so write the title as the user-facing change instead, for example 'Fix Sonos hanging after reconnect'."
+            exit 1
+          fi
+
+          echo "Title OK: $PR_TITLE"


### PR DESCRIPTION
Release notes are generated verbatim from PR titles, so a conventional-commit style
title (`fix: playlist thumbnails`) ends up in the notes as-is and has to be rewritten by
hand. This adds a CI check that rejects those prefixes so the title is written as a
user-facing change description up front: `Fix playlist thumbnails not loading`.

Companion to music-assistant/server#5155, which adds the same check there.

## Changes

- New `.github/workflows/pr-title.yml`, running on PR open/edit/reopen/ready-for-review
  against `main`.
- Fails when the title starts with `build|chore|ci|deps|docs|feat|feature|fix|perf|refactor|revert|style|test(s)`,
  optionally scoped and/or `!`-marked, followed by a colon. The error names the prefix and
  shows the wanted form.
- Only that prefix is checked — no length, casing or wording rules — so titles like
  `Apple Music: signing in a second account no longer breaks the first` still pass.
- Bot PRs are skipped; their titles are generated and a failure would only block
  auto-merge.
- Read-only (`permissions: {}`), and the title is passed via env rather than inlined into
  the script.

Needs to be added as a required status check in branch protection to actually block a
merge.
