### PR TITLE
Stop the test suite picking up tests from nested git worktrees

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -16,8 +16,13 @@ export default mergeConfig(
         },
       },
       // Ignore nested git worktrees so a sibling branch's tests under
-      // ./.worktrees aren't picked up by this repo's suite.
-      exclude: [...configDefaults.exclude, "**/.worktrees/**"],
+      // ./.claude/worktrees (or the older ./.worktrees) aren't picked up by
+      // this repo's suite.
+      exclude: [
+        ...configDefaults.exclude,
+        "**/.claude/worktrees/**",
+        "**/.worktrees/**",
+      ],
     },
   }),
 );


### PR DESCRIPTION
`vitest.config.ts` excluded nested git worktrees with `**/.worktrees/**`, but worktrees actually live under `.claude/worktrees/`. The glob missed them, so a bare `pnpm test:run` globbed a sibling branch's test files into this repo's suite — 254 test files collected instead of 127, with failures attributed to paths like `.claude/worktrees/<branch>/tests/...`. That also broke the husky pre-commit hook, forcing `--no-verify` on every commit whenever a worktree existed.

- Widen the vitest `exclude` to `**/.claude/worktrees/**`, keeping `**/.worktrees/**` for the older layout
- Update the adjacent comment, which still referred to `./.worktrees`