### PR TITLE
Stop lint and formatting reaching into nested git worktrees

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -123,4 +123,7 @@ venv/*
 !.vscode/launch.json
 !.vscode/tasks.json
 .coverage
+
+# nested git worktrees
+/.claude/worktrees
 /.worktrees

--- a/.prettierignore
+++ b/.prettierignore
@@ -8,3 +8,7 @@ pnpm-lock.yaml
 
 # Lokalise-managed translation files use their own formatting
 src/translations
+
+# Nested git worktrees hold another branch's checkout
+.claude/worktrees
+.worktrees

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -10,7 +10,15 @@ export default defineConfigWithVueTs(
   // Replaces the old `ignorePatterns`. node_modules is ignored by default.
   {
     name: "app/ignores",
-    ignores: ["dist", "dev-dist", "coverage"],
+    ignores: [
+      "dist",
+      "dev-dist",
+      "coverage",
+      // Nested git worktrees hold another branch's checkout; linting them
+      // would report — and with `--fix`, rewrite — files outside this branch.
+      "**/.claude/worktrees/**",
+      "**/.worktrees/**",
+    ],
   },
   vueTsConfigs.eslintRecommended,
   pluginVue.configs["flat/recommended"],


### PR DESCRIPTION
Follow-up to #2232, which fixed the same blind spot in the vitest config. Nested git worktrees live under `.claude/worktrees/`, but only the older `/.worktrees` path was ignored — so `pnpm lint` globbed a sibling branch's checkout. Unlike the test run, this one *writes*: `eslint . --fix` and `prettier --write` rewrote files belonging to another branch.

- Ignore `**/.claude/worktrees/**` in the ESLint config (keeping `**/.worktrees/**` for the older layout)
- Add the same two paths to `.prettierignore`
- Add `/.claude/worktrees` to `.gitignore` — this is also what keeps Oxlint and Prettier out, since both honour `.gitignore` but not `.git/info/exclude`