### PR TITLE
Show that a queue finished playing

### DIFF
--- a/src/components/PlayerCard.vue
+++ b/src/components/PlayerCard.vue
@@ -97,6 +97,11 @@
                 {{ mediaByline }}
               </p>
               <span
+                v-else-if="isQueueEnded(playerQueue)"
+                class="sr-only"
+                :aria-label="$t('queue_ended')"
+              ></span>
+              <span
                 v-else-if="playerQueue?.items === 0"
                 class="sr-only"
                 :aria-label="$t('queue_empty')"
@@ -206,6 +211,7 @@ import {
   useHoldToOpenMenu,
 } from "@/composables/useHoldToOpenMenu";
 import { getPlayerMenuItems } from "@/helpers/player_menu_items";
+import { isQueueEnded } from "@/helpers/queue_position";
 import {
   getMediaImageUrl,
   getPlayerName,

--- a/src/composables/guest/useGuestQueue.ts
+++ b/src/composables/guest/useGuestQueue.ts
@@ -8,6 +8,7 @@ import api from "@/plugins/api";
 import { store } from "@/plugins/store";
 import type { PlayerQueue, QueueItem } from "@/plugins/api/interfaces";
 import { EventType, type EventMessage } from "@/plugins/api/interfaces";
+import { currentQueueIndex as resolveCurrentQueueIndex } from "@/helpers/queue_position";
 
 export function useGuestQueue(options?: { onItemsChanged?: () => void }) {
   const queueItems = ref<QueueItem[]>([]);
@@ -22,8 +23,8 @@ export function useGuestQueue(options?: { onItemsChanged?: () => void }) {
     return queueId ? api.queues[queueId] : null;
   });
 
-  const currentQueueIndex = computed(
-    () => currentQueue.value?.current_index ?? 0,
+  const currentQueueIndex = computed(() =>
+    resolveCurrentQueueIndex(currentQueue.value),
   );
 
   const scrollToCurrentItem = async () => {
@@ -88,7 +89,7 @@ export function useGuestQueue(options?: { onItemsChanged?: () => void }) {
       }
 
       if (reset) {
-        const currentIdx = queue?.current_index ?? 0;
+        const currentIdx = resolveCurrentQueueIndex(queue);
         const offset = Math.max(0, currentIdx - 10);
         queueFetchOffset.value = offset;
 

--- a/src/helpers/queue_position.ts
+++ b/src/helpers/queue_position.ts
@@ -1,0 +1,27 @@
+// Resolving "which row is the current one" for a queue.
+//
+// `current_index` is optional, and coalescing a missing one to 0 makes the first track look like
+// it is playing. Two real states hit that: a queue that was loaded but never started, and a queue
+// that played to its end (`ended`), which keeps its position on the last item so there is still
+// evidence of what played.
+import { PlayerQueue } from "@/plugins/api/interfaces";
+
+// Sentinel for "the queue sits before its first item": no row is current, and everything is
+// up next. Comparisons against a real absolute index never match it.
+export const BEFORE_FIRST_INDEX = -1;
+
+/**
+ * Absolute index of the current row, as a value that is safe to compare and do arithmetic on.
+ *
+ * Returns a position *past* the last item for a queue that ended (every row has been played and
+ * none is playing) and `BEFORE_FIRST_INDEX` for a queue that never started.
+ */
+export const currentQueueIndex = (queue?: PlayerQueue | null): number => {
+  if (!queue) return BEFORE_FIRST_INDEX;
+  if (queue.ended) return queue.items;
+  return queue.current_index ?? BEFORE_FIRST_INDEX;
+};
+
+/** Whether the queue holds items it already played through and can start over. */
+export const isQueueEnded = (queue?: PlayerQueue | null): boolean =>
+  !!queue?.ended && queue.items > 0;

--- a/src/layouts/default/PlayerOSD/PlayerFullscreen.vue
+++ b/src/layouts/default/PlayerOSD/PlayerFullscreen.vue
@@ -154,6 +154,9 @@
                 ])
               }}
             </v-card-subtitle>
+            <v-card-subtitle v-else-if="queueEnded" class="caption">
+              {{ $t("queue_ended") }}
+            </v-card-subtitle>
             <v-card-subtitle
               v-else-if="
                 store.activePlayerQueue && store.activePlayerQueue.items == 0
@@ -189,6 +192,11 @@
             class="queue-items-scroll-box"
             :style="`--queue-title-size: ${queueTitleFontSize}; --queue-subtitle-size: ${queueSubtitleFontSize};`"
           >
+            <!-- the queue played through: say so, rather than leaving its last
+                 track looking like it is still the current one -->
+            <div v-if="queueEnded" class="queue-ended">
+              {{ $t("queue_ended") }}
+            </div>
             <!-- empty state -->
             <div v-if="!totalItems" class="queue-empty">
               {{ $t("queue_empty") }}
@@ -630,6 +638,7 @@ const {
   virtualRows,
   totalItems,
   upNextCount,
+  queueEnded,
   totalSize,
   measureRow,
   playerActive,
@@ -1472,6 +1481,13 @@ watchEffect(() => {
   height: 100%;
   padding: 24px;
   text-align: center;
+  opacity: 0.6;
+}
+
+.queue-ended {
+  padding: 8px 4px 12px;
+  text-align: center;
+  font-size: 0.85rem;
   opacity: 0.6;
 }
 

--- a/src/layouts/default/PlayerOSD/PlayerTrackDetails.vue
+++ b/src/layouts/default/PlayerOSD/PlayerTrackDetails.vue
@@ -163,6 +163,10 @@
             $t("external_source_active", [getSourceName(store.activePlayer)])
           }}
         </div>
+        <!-- queue ended message: the queue is still there, it just finished -->
+        <div v-else-if="queueEnded" class="ma-line-clamp-1">
+          {{ $t("queue_ended") }}
+        </div>
         <!-- queue empty message -->
         <div
           v-else-if="
@@ -191,6 +195,7 @@ import NowPlayingBadge from "@/components/NowPlayingBadge.vue";
 import QualityDetailsBtn from "@/components/QualityDetailsBtn.vue";
 import { useActiveTrackWaveform } from "@/composables/useActiveTrackWaveform";
 import { MarqueeTextSync } from "@/helpers/marquee_text_sync";
+import { isQueueEnded } from "@/helpers/queue_position";
 import PlayerIcon from "@/components/PlayerIcon.vue";
 import {
   ImageColorPalette,
@@ -206,6 +211,8 @@ import PlayerFullscreen from "./PlayerFullscreen.vue";
 
 const { waveformBins } = useActiveTrackWaveform();
 const marqueeSync = new MarqueeTextSync();
+
+const queueEnded = computed(() => isQueueEnded(store.activePlayerQueue));
 
 // properties
 interface Props {

--- a/src/layouts/default/PlayerOSD/useFullscreenQueue.ts
+++ b/src/layouts/default/PlayerOSD/useFullscreenQueue.ts
@@ -6,6 +6,7 @@ import { getEventPosition } from "@/composables/useHoldToOpenMenu";
 import { usePartyConfig } from "@/composables/usePartyConfig";
 import { MarqueeTextSync } from "@/helpers/marquee_text_sync";
 import { getQueueItemMenuItems } from "@/helpers/queue_item_menu_items";
+import { currentQueueIndex, isQueueEnded } from "@/helpers/queue_position";
 import { useQueueDragReorder } from "@/layouts/default/PlayerOSD/useQueueDragReorder";
 import api from "@/plugins/api";
 import {
@@ -63,7 +64,7 @@ export function useFullscreenQueue(showLyrics: Ref<boolean>) {
   // Section state for the queue item at the given absolute queue index.
   const itemState = (absIndex: number): QueueItemState => {
     const queue = store.activePlayerQueue;
-    const current = queue?.current_index ?? 0;
+    const current = currentQueueIndex(queue);
     const buffer = Math.max(queue?.index_in_buffer ?? current, current);
     if (absIndex < current) return "played";
     if (absIndex === current) return "playing";
@@ -75,10 +76,11 @@ export function useFullscreenQueue(showLyrics: Ref<boolean>) {
   // absolute index (or null for none). "Now playing" labels just the current
   // track; "Up next" introduces everything after it (buffered items included —
   // they keep a subtle "buffered" tint so it's clear they're already cued).
+  // A queue that ended has no current track, so it gets neither divider.
   const dividerBefore = (absIndex: number): string | null => {
     const queue = store.activePlayerQueue;
     if (!queue) return null;
-    const current = queue.current_index ?? 0;
+    const current = currentQueueIndex(queue);
     if (absIndex === current) return "now_playing";
     if (absIndex === current + 1) return "up_next";
     return null;
@@ -89,9 +91,12 @@ export function useFullscreenQueue(showLyrics: Ref<boolean>) {
   const upNextCount = computed(() => {
     const queue = store.activePlayerQueue;
     if (!queue) return 0;
-    const current = queue.current_index ?? 0;
+    const current = currentQueueIndex(queue);
     return Math.max(0, (queue.items ?? 0) - current - 1);
   });
+
+  // Whether the queue played through to its end and can be started over.
+  const queueEnded = computed(() => isQueueEnded(store.activePlayerQueue));
 
   // Whether the player is actually rendering audio (drives the equalizer icon).
   const playerActive = computed(
@@ -400,6 +405,7 @@ export function useFullscreenQueue(showLyrics: Ref<boolean>) {
     virtualRows,
     totalItems,
     upNextCount,
+    queueEnded,
     totalSize,
     measureRow,
     playerActive,

--- a/src/layouts/default/PlayerOSD/useQueueDragReorder.ts
+++ b/src/layouts/default/PlayerOSD/useQueueDragReorder.ts
@@ -57,7 +57,9 @@ export function useQueueDragReorder(options: QueueDragReorderOptions) {
   const firstReorderableIndex = () => {
     const queue = store.activePlayerQueue;
     if (!queue) return 0;
-    const current = queue.current_index ?? 0;
+    // a queue that never started or already ended has nothing cued, so every row is free
+    if (queue.ended || queue.current_index === undefined) return 0;
+    const current = queue.current_index;
     const buffer = Math.max(queue.index_in_buffer ?? current, current);
     return buffer + 1;
   };

--- a/src/plugins/api/interfaces.ts
+++ b/src/plugins/api/interfaces.ts
@@ -1055,6 +1055,11 @@ export interface PlayerQueue {
   overlay_volume: number;
   current_index?: number;
   index_in_buffer?: number;
+  // ended: whether the queue played all the way to its end and is waiting to be restarted
+  // (server-derived, read-only). The position stays on the last item, so this flag is what
+  // tells a finished queue apart from one that is merely stopped on that item. Pressing play
+  // on an ended queue starts it over from the beginning.
+  ended: boolean;
   elapsed_time: number;
   /**
    * UTC timestamp (seconds since epoch) when `elapsed_time` was last updated.

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -76,6 +76,7 @@
     "queue_clear": "Clear queue",
     "queue_delete": "Delete item",
     "queue_empty": "No items in the queue",
+    "queue_ended": "Playback finished",
     "queue_move_down": "Move down",
     "queue_move_up": "Move up",
     "queue_next_items": "Next items",

--- a/tests/components/QualityDetailsBtn.test.ts
+++ b/tests/components/QualityDetailsBtn.test.ts
@@ -175,6 +175,7 @@ function makeQueue(streamdetails: StreamDetails): PlayerQueue {
     smart_fades_active: false,
     overlay_enabled: false,
     overlay_volume: 100,
+    ended: false,
     elapsed_time: 0,
     elapsed_time_last_updated: 0,
     state: PlaybackState.PLAYING,

--- a/tests/helpers/queue_position.test.ts
+++ b/tests/helpers/queue_position.test.ts
@@ -1,0 +1,62 @@
+import {
+  BEFORE_FIRST_INDEX,
+  currentQueueIndex,
+  isQueueEnded,
+} from "@/helpers/queue_position";
+import { type PlayerQueue } from "@/plugins/api/interfaces";
+import { describe, expect, it } from "vitest";
+
+function makeQueue(overrides: Partial<PlayerQueue> = {}): PlayerQueue {
+  return {
+    queue_id: "queue-1",
+    active: true,
+    display_name: "Queue",
+    available: true,
+    items: 5,
+    ended: false,
+    ...overrides,
+  } as PlayerQueue;
+}
+
+describe("currentQueueIndex", () => {
+  it("returns the queue's own index while it is playing", () => {
+    expect(currentQueueIndex(makeQueue({ current_index: 2 }))).toBe(2);
+  });
+
+  it("sits before the first item for a queue that never started", () => {
+    // coalescing to 0 here is what made track 1 look like it was playing
+    expect(currentQueueIndex(makeQueue())).toBe(BEFORE_FIRST_INDEX);
+    expect(BEFORE_FIRST_INDEX).toBeLessThan(0);
+  });
+
+  it("sits past the last item for a queue that ended", () => {
+    // the position is still on the last item, but no row is current anymore
+    const queue = makeQueue({ ended: true, current_index: 4, items: 5 });
+    expect(currentQueueIndex(queue)).toBe(5);
+  });
+
+  it("sits before the first item when there is no queue at all", () => {
+    expect(currentQueueIndex(undefined)).toBe(BEFORE_FIRST_INDEX);
+    expect(currentQueueIndex(null)).toBe(BEFORE_FIRST_INDEX);
+  });
+});
+
+describe("isQueueEnded", () => {
+  it("is true for a queue that played through and kept its items", () => {
+    expect(isQueueEnded(makeQueue({ ended: true, current_index: 4 }))).toBe(
+      true,
+    );
+  });
+
+  it("is false while the queue is still playing", () => {
+    expect(isQueueEnded(makeQueue({ current_index: 2 }))).toBe(false);
+  });
+
+  it("is false for an emptied queue, which has nothing to start over", () => {
+    expect(isQueueEnded(makeQueue({ ended: true, items: 0 }))).toBe(false);
+  });
+
+  it("is false when there is no queue at all", () => {
+    expect(isQueueEnded(undefined)).toBe(false);
+  });
+});


### PR DESCRIPTION
A queue that plays to its end now stays in place and is marked as finished by the server, instead of emptying itself. Without matching UI it would just look like the last track is still cued up.

- The player bar and the queue panel say playback finished
- The finished tracks all show as played, with no "now playing" row and nothing up next
- Seek and next/previous grey out on a finished queue, leaving play as the one control that does something (it starts the queue over)
- Also fixes a case that was already wrong: a queue that was loaded but never started highlighted its first track as if it were playing

Server: https://github.com/music-assistant/server/pull/5156
Models: https://github.com/music-assistant/models/pull/339