### PR TITLE
Remove JWT claims the server never mints

### DIFF
--- a/src/plugins/auth.ts
+++ b/src/plugins/auth.ts
@@ -16,7 +16,9 @@ const TOKEN_STORAGE_KEY = "ma_access_token";
 const TOKEN_CONNECTION_STORAGE_KEY = "ma_access_token_connection";
 
 /**
- * JWT claims structure from Music Assistant tokens
+ * JWT claims structure from Music Assistant tokens, mirroring the server's
+ * token payload. Mutable per-user data (permissions, player/provider filters)
+ * lives on `User`, not on the token, since tokens can be long-lived.
  */
 interface JWTClaims {
   sub: string; // user_id
@@ -25,9 +27,6 @@ interface JWTClaims {
   exp: number; // expiration
   username: string;
   role: string;
-  permissions: string[];
-  player_filter: string[];
-  provider_filter: string[];
   token_name: string;
   is_long_lived: boolean;
 }

--- a/src/plugins/auth.ts
+++ b/src/plugins/auth.ts
@@ -16,9 +16,9 @@ const TOKEN_STORAGE_KEY = "ma_access_token";
 const TOKEN_CONNECTION_STORAGE_KEY = "ma_access_token_connection";
 
 /**
- * JWT claims structure from Music Assistant tokens, mirroring the server's
- * token payload. Mutable per-user data (permissions, player/provider filters)
- * lives on `User`, not on the token, since tokens can be long-lived.
+ * JWT claims from Music Assistant tokens, mirroring the server's token payload.
+ * Mutable per-user data (player/provider filters) stays on `User`, not the token —
+ * tokens can be long-lived and would serve stale filters after an admin edit.
  */
 interface JWTClaims {
   sub: string; // user_id


### PR DESCRIPTION
`JWTClaims` in `src/plugins/auth.ts` declared three fields that are not part of the token payload:

```ts
permissions: string[];
player_filter: string[];
provider_filter: string[];
```

## Where they came from

These are leftovers from the claims-based auth design proposed in server#2891 / server#2892. That design was redirected in review — mutable per-user data was kept off the token precisely because it goes stale ([#2891 review comment](https://github.com/music-assistant/server/pull/2891#discussion_r2690387976): *"it can dynamically be updated and then the token still has the old info"*), and `permission` was renamed to `scope`. The landed design keeps the filters on the `users` row and derives scopes from role, so these three were never part of the shipped payload. The frontend interface was written against the proposal and never updated.

`permissions` in particular never had anywhere to come from: there is no `permissions` field on `User` in either repo — scopes are derived from role via `ROLE_SCOPES` in `controllers/webserver/helpers/auth_middleware.py`.

The same commit that introduced this interface also added a fourth phantom claim, `provider_name?: string`, which was already cleaned up in "fix: Use User in favor of provider_name". This finishes that job.

## Why remove rather than add them to the token

Filters are mutable per-user data, and a token can be `is_long_lived` — a token-carried filter would keep serving the old value after an admin edits the user. That is the objection the leads raised on the original design, and it applies just as much to the client reading filters off the token. They are already available on the `User` object, refreshed per request.

## Why it is worth fixing

`getClaim<K extends keyof JWTClaims>` is a generic accessor keyed off this interface, and `decodeJWT` ends in an unvalidated `return decoded as JWTClaims` — so the interface is the only contract. `getClaim("permissions")` type-checked cleanly and returned `string[] | undefined`, meaning TypeScript vouched for a value that can never arrive. This interface is the first place someone reaching for per-user filters on the client would look.

## No behaviour or security impact

Filter enforcement is server-side and authoritative, resolved from the DB user row per request — e.g. `controllers/players/helpers.py` and `controllers/player_queues/controller.py` raise `InsufficientPermissions`, with further gates in the players, music and provider controllers. The frontend's `store.currentUser.provider_filter` / `player_filter` reads only hide UI affordances on top of that. Nothing read the removed claims (the only `getClaim` callers ask for `"jti"`).

Type-only change: no runtime change, no server-side change, no new claims. `vue-tsc --noEmit` clean; 1129 tests pass.
