### PR TITLE
Maintain constant album art size on now playing view

### DIFF
--- a/src/layouts/default/PlayerOSD/PlayerFullscreen.vue
+++ b/src/layouts/default/PlayerOSD/PlayerFullscreen.vue
@@ -116,10 +116,8 @@
               {{ $t("off") }}
             </v-card-subtitle>
 
-            <!-- subtitle: album -->
-            <!-- keeps an empty placeholder line when the current media has no
-                 album, so the artwork above keeps a constant size when e.g.
-                 AI radio alternates between tracks and DJ announcements -->
+            <!-- subtitle: album; placeholder when empty so the artwork
+                 above keeps a constant size -->
             <v-card-subtitle
               v-else-if="store.activePlayer?.current_media && showAlbumSubtitle"
               :style="`font-size: ${subTitleFontSize};${
@@ -132,7 +130,7 @@
               </MarqueeText>
             </v-card-subtitle>
 
-            <!-- subtitle: artist (same placeholder treatment as the album) -->
+            <!-- subtitle: artist; placeholder when empty, as above -->
             <v-card-subtitle
               v-if="
                 store.activePlayer?.powered != false &&

--- a/src/layouts/default/PlayerOSD/PlayerFullscreen.vue
+++ b/src/layouts/default/PlayerOSD/PlayerFullscreen.vue
@@ -117,26 +117,34 @@
             </v-card-subtitle>
 
             <!-- subtitle: album -->
+            <!-- keeps an empty placeholder line when the current media has no
+                 album, so the artwork above keeps a constant size when e.g.
+                 AI radio alternates between tracks and DJ announcements -->
             <v-card-subtitle
-              v-else-if="
-                store.activePlayer?.current_media?.album && showAlbumSubtitle
-              "
-              :style="`font-size: ${subTitleFontSize};cursor:pointer;`"
+              v-else-if="store.activePlayer?.current_media && showAlbumSubtitle"
+              :style="`font-size: ${subTitleFontSize};${
+                store.activePlayer.current_media.album ? 'cursor:pointer;' : ''
+              }`"
               @click="onAlbumClick"
             >
               <MarqueeText :sync="playerMarqueeSync">
-                {{ store.activePlayer.current_media.album }}
+                {{ store.activePlayer.current_media.album || " " }}
               </MarqueeText>
             </v-card-subtitle>
 
-            <!-- subtitle: artist -->
+            <!-- subtitle: artist (same placeholder treatment as the album) -->
             <v-card-subtitle
-              v-if="store.activePlayer?.current_media?.artist"
-              :style="`font-size: ${subTitleFontSize};cursor:pointer;`"
+              v-if="
+                store.activePlayer?.powered != false &&
+                store.activePlayer?.current_media
+              "
+              :style="`font-size: ${subTitleFontSize};${
+                store.activePlayer.current_media.artist ? 'cursor:pointer;' : ''
+              }`"
               @click="onArtistClick"
             >
               <MarqueeText :sync="playerMarqueeSync">
-                {{ store.activePlayer.current_media.artist }}
+                {{ store.activePlayer.current_media.artist || " " }}
               </MarqueeText>
             </v-card-subtitle>
 

--- a/src/views/DashboardNowPlayingView.vue
+++ b/src/views/DashboardNowPlayingView.vue
@@ -29,12 +29,11 @@
               store.activePlayer.current_media?.title || store.activePlayer.name
             }}
           </MarqueeText>
-          <MarqueeText
-            v-if="store.activePlayer.current_media?.artist"
-            :sync="marqueeSync"
-            class="now-playing-subtitle"
-          >
-            {{ store.activePlayer.current_media.artist }}
+          <!-- keeps an empty placeholder line when the current media has no
+               artist, so the artwork keeps a fixed position when e.g. AI radio
+               alternates between tracks and DJ announcements -->
+          <MarqueeText :sync="marqueeSync" class="now-playing-subtitle">
+            {{ store.activePlayer.current_media?.artist || " " }}
           </MarqueeText>
         </template>
       </div>

--- a/src/views/DashboardNowPlayingView.vue
+++ b/src/views/DashboardNowPlayingView.vue
@@ -29,9 +29,7 @@
               store.activePlayer.current_media?.title || store.activePlayer.name
             }}
           </MarqueeText>
-          <!-- keeps an empty placeholder line when the current media has no
-               artist, so the artwork keeps a fixed position when e.g. AI radio
-               alternates between tracks and DJ announcements -->
+          <!-- placeholder when no artist, so the artwork position stays fixed -->
           <MarqueeText :sync="marqueeSync" class="now-playing-subtitle">
             {{ store.activePlayer.current_media?.artist || " " }}
           </MarqueeText>


### PR DESCRIPTION
While playing with the Audio AI plugin I noticed that the album art and text row were jumping in size and position.

This appears to be because the album and artist subtitles were removed entirely when empty and the artwork was sized to the remaining space. The subtitle rows now always render, using a non-breaking-space placeholder when the metadata is missing, so the text block height is constant and the artwork keeps a fixed size and position for a given view size