### PR TITLE
Fix setup wizard jumping back to a previous step

### DIFF
--- a/src/components/SetupFlowDialog.vue
+++ b/src/components/SetupFlowDialog.vue
@@ -359,6 +359,9 @@ const formRef = ref<HTMLFormElement | null>(null);
 
 // monotonically increasing launch token; guards async step application
 let launchSeq = 0;
+// bumped on every applied step; guards a late response from overwriting a newer
+// step that a push update already applied (flow_id alone never changes mid-flow)
+let stepSeq = 0;
 let completionNotified = false;
 
 let unsubscribeFlow: (() => void) | null = null;
@@ -549,6 +552,7 @@ function startFlow(evt: SetupFlowDialogEvent): Promise<SetupFlowStep> {
 function applyStep(newStep: SetupFlowStep) {
   const prevFlowId = step.value?.flow_id;
   const prevStepId = step.value?.step_id;
+  stepSeq++;
   step.value = newStep;
 
   // subscribe to push updates for non-terminal flows (external/progress advance this way)
@@ -628,10 +632,12 @@ async function submit() {
   }
   busy.value = true;
   const flowId = step.value.flow_id;
+  const seq = stepSeq;
   try {
     const nextStep = await api.submitSetupFlow(flowId, values);
-    // the dialog may have been closed (or a new flow started) while awaiting
-    if (!open.value || step.value?.flow_id !== flowId) return;
+    // the dialog may have been closed, a new flow started, or a pushed update
+    // already advanced us past this step while the request ran
+    if (!open.value || seq !== stepSeq) return;
     applyStep(nextStep);
   } catch (err) {
     toast.error(String(err));
@@ -680,14 +686,15 @@ function reconcileFlow() {
   // re-fetch the current step; if the flow is gone server-side, end the dialog neutrally
   if (!open.value || !step.value || isTerminal.value) return;
   const flowId = step.value.flow_id;
+  const seq = stepSeq;
   api
     .getSetupFlow(flowId)
     .then((current) => {
-      if (!open.value || step.value?.flow_id !== flowId) return;
+      if (!open.value || seq !== stepSeq) return;
       applyStep(current);
     })
     .catch(() => {
-      if (!open.value || step.value?.flow_id !== flowId) return;
+      if (!open.value || seq !== stepSeq) return;
       cleanupFlow();
       applyStep({
         flow_id: flowId,
@@ -736,6 +743,8 @@ function close(sendAbort = true) {
   open.value = false;
   store.dialogActive = false;
   cleanupFlow();
+  // invalidate any in-flight request so it can't apply a step onto a relaunch
+  stepSeq++;
   step.value = null;
   launch.value = null;
   formEntries.value = [];

--- a/src/components/SetupFlowDialog.vue
+++ b/src/components/SetupFlowDialog.vue
@@ -359,8 +359,9 @@ const formRef = ref<HTMLFormElement | null>(null);
 
 // monotonically increasing launch token; guards async step application
 let launchSeq = 0;
-// bumped on every applied step; guards a late response from overwriting a newer
-// step that a push update already applied (flow_id alone never changes mid-flow)
+// bumped whenever the dialog moves to another step; guards a late response from
+// overwriting a newer step that a push update already applied (flow_id alone
+// never changes mid-flow, so it can't be used for that)
 let stepSeq = 0;
 let completionNotified = false;
 
@@ -552,7 +553,11 @@ function startFlow(evt: SetupFlowDialogEvent): Promise<SetupFlowStep> {
 function applyStep(newStep: SetupFlowStep) {
   const prevFlowId = step.value?.flow_id;
   const prevStepId = step.value?.step_id;
-  stepSeq++;
+  // only a real step change invalidates in-flight requests: the same step being
+  // re-served (reconcile, validation errors) must not discard their responses
+  if (prevFlowId !== newStep.flow_id || prevStepId !== newStep.step_id) {
+    stepSeq++;
+  }
   step.value = newStep;
 
   // subscribe to push updates for non-terminal flows (external/progress advance this way)

--- a/tests/components/SetupFlowDialog.test.ts
+++ b/tests/components/SetupFlowDialog.test.ts
@@ -18,6 +18,7 @@ const { apiMock, eventbusMock, routerMock, storeMock, toastMock } = vi.hoisted(
       state: {
         value: "authenticated",
       },
+      submitSetupFlow: vi.fn(),
       subscribeSetupFlow: vi.fn(),
     },
     eventbusMock: {
@@ -112,6 +113,40 @@ describe("SetupFlowDialog", () => {
       expect(onFlowEnded).toHaveBeenCalledOnce();
     },
   );
+
+  it("keeps the pushed step when a stale submit response lands after it", async () => {
+    apiMock.reconfigureProvider.mockResolvedValue(formStep());
+    let resolveSubmit: (step: SetupFlowStep) => void = () => {};
+    apiMock.submitSetupFlow.mockReturnValue(
+      new Promise<SetupFlowStep>((resolve) => {
+        resolveSubmit = resolve;
+      }),
+    );
+    const wrapper = shallowMount(SetupFlowDialog, {
+      global: { renderStubDefaultSlot: true },
+    });
+
+    await launchSetupFlow?.({
+      kind: "reconfigure",
+      instanceId: "spotify--test",
+      onFlowEnded: vi.fn(),
+    });
+    await flushPromises();
+
+    const pushStep = apiMock.subscribeSetupFlow.mock.calls[0][1] as (
+      step: SetupFlowStep,
+    ) => void;
+    await wrapper.find("form").trigger("submit");
+
+    // the server pushes the follow-up step before the submit call comes back
+    pushStep(progressStep("pushed"));
+    await flushPromises();
+    resolveSubmit(progressStep("submitted"));
+    await flushPromises();
+
+    expect(wrapper.text()).toContain("pushed");
+    expect(wrapper.text()).not.toContain("submitted");
+  });
 });
 
 function terminalStep(type: FlowStepType): SetupFlowStep {
@@ -121,5 +156,26 @@ function terminalStep(type: FlowStepType): SetupFlowStep {
     flow_id: "flow-1",
     step_id: type,
     type,
+  };
+}
+
+function formStep(): SetupFlowStep {
+  return {
+    entries: [],
+    errors: {},
+    flow_id: "flow-1",
+    step_id: "form",
+    type: FlowStepType.FORM,
+  };
+}
+
+function progressStep(progressText: string): SetupFlowStep {
+  return {
+    entries: [],
+    errors: {},
+    flow_id: "flow-1",
+    progress_text: progressText,
+    step_id: progressText,
+    type: FlowStepType.PROGRESS,
   };
 }

--- a/tests/components/SetupFlowDialog.test.ts
+++ b/tests/components/SetupFlowDialog.test.ts
@@ -147,6 +147,39 @@ describe("SetupFlowDialog", () => {
     expect(wrapper.text()).toContain("pushed");
     expect(wrapper.text()).not.toContain("submitted");
   });
+
+  it("still applies the submit response when the same step is re-served", async () => {
+    apiMock.reconfigureProvider.mockResolvedValue(formStep());
+    let resolveSubmit: (step: SetupFlowStep) => void = () => {};
+    apiMock.submitSetupFlow.mockReturnValue(
+      new Promise<SetupFlowStep>((resolve) => {
+        resolveSubmit = resolve;
+      }),
+    );
+    const wrapper = shallowMount(SetupFlowDialog, {
+      global: { renderStubDefaultSlot: true },
+    });
+
+    await launchSetupFlow?.({
+      kind: "reconfigure",
+      instanceId: "spotify--test",
+      onFlowEnded: vi.fn(),
+    });
+    await flushPromises();
+
+    const pushStep = apiMock.subscribeSetupFlow.mock.calls[0][1] as (
+      step: SetupFlowStep,
+    ) => void;
+    await wrapper.find("form").trigger("submit");
+
+    // a reconcile re-serving the current step must not count as moving on
+    pushStep(formStep());
+    await flushPromises();
+    resolveSubmit(progressStep("submitted"));
+    await flushPromises();
+
+    expect(wrapper.text()).toContain("submitted");
+  });
 });
 
 function terminalStep(type: FlowStepType): SetupFlowStep {


### PR DESCRIPTION
While a setup/config wizard is open, the dialog gets its next step from two places: the reply to the step you just submitted, and live updates pushed by the server. If the server pushed a newer step while the reply was still on its way, the late reply would put the older step back on screen.

- Track the applied step with a counter so a late reply can no longer replace a newer step
- Same guard for the periodic re-check of the current step
- Added a test for this