### PR TITLE
Show when a Music Quiz game is restarting

### DIFF
--- a/src/components/music-quiz/MusicQuizHostControlsMenu.vue
+++ b/src/components/music-quiz/MusicQuizHostControlsMenu.vue
@@ -8,10 +8,12 @@
           size="sm"
           class="px-2"
           data-testid="guest-host-controls"
+          :aria-busy="busy"
           :aria-label="$t('providers.music_quiz.host_controls')"
           :title="$t('providers.music_quiz.host_controls')"
         >
-          <SlidersHorizontal class="size-4" aria-hidden="true" />
+          <Spinner v-if="busy" class="size-4" />
+          <SlidersHorizontal v-else class="size-4" aria-hidden="true" />
           <span class="hidden sm:inline">
             {{ $t("providers.music_quiz.host_controls") }}
           </span>
@@ -102,6 +104,7 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
+import { Spinner } from "@/components/ui/spinner";
 import {
   isSupportedMusicQuiz,
   type MusicQuizSupportedHostState,

--- a/src/components/music-quiz/MusicQuizPlayerStage.vue
+++ b/src/components/music-quiz/MusicQuizPlayerStage.vue
@@ -1,5 +1,10 @@
 <template>
-  <section v-if="state.phase === 'lobby'" class="flex flex-col gap-3">
+  <MusicQuizPreparingState
+    v-if="state.preparing"
+    class="rounded-xl border shadow-sm"
+  />
+
+  <section v-else-if="state.phase === 'lobby'" class="flex flex-col gap-3">
     <MusicQuizAutoStartStatus
       v-if="state.auto_start_at != null"
       :state="state"
@@ -63,6 +68,7 @@ import MusicQuizLeaderboard, {
   type MusicQuizLeaderboardRow,
 } from "@/components/music-quiz/MusicQuizLeaderboard.vue";
 import MusicQuizPodium from "@/components/music-quiz/MusicQuizPodium.vue";
+import MusicQuizPreparingState from "@/components/music-quiz/MusicQuizPreparingState.vue";
 import type {
   MusicQuizAnswerSubmission,
   MusicQuizCurrentRound,

--- a/src/components/music-quiz/MusicQuizPreparingState.vue
+++ b/src/components/music-quiz/MusicQuizPreparingState.vue
@@ -25,9 +25,15 @@ import { $t } from "@/plugins/i18n";
 import { LoaderCircle } from "@lucide/vue";
 import { onMounted, ref } from "vue";
 
+// The status region announces itself through aria-live, so moving focus is only
+// appropriate when this client just triggered the action it reports on.
+const props = withDefaults(defineProps<{ autofocus?: boolean }>(), {
+  autofocus: false,
+});
+
 const statusElement = ref<HTMLElement | null>(null);
 
 onMounted(() => {
-  statusElement.value?.focus({ preventScroll: true });
+  if (props.autofocus) statusElement.value?.focus({ preventScroll: true });
 });
 </script>

--- a/src/components/music-quiz/MusicQuizPresentStage.vue
+++ b/src/components/music-quiz/MusicQuizPresentStage.vue
@@ -23,9 +23,11 @@
     <MusicQuizConnectionBanners :degraded="isConnectionDegraded" />
 
     <div class="flex min-h-0 flex-1 flex-col gap-4">
+      <MusicQuizPreparingState v-if="state.preparing" class="min-h-0 flex-1" />
+
       <component
         :is="game.adapters.presentBody"
-        v-if="
+        v-else-if="
           game.adapters.presentBody &&
           currentRound &&
           (state.phase === 'answering' || state.phase === 'reveal')
@@ -154,6 +156,7 @@ import MusicQuizLeaderboard, {
 } from "@/components/music-quiz/MusicQuizLeaderboard.vue";
 import MusicQuizPodium from "@/components/music-quiz/MusicQuizPodium.vue";
 import MusicQuizPlayerTile from "@/components/music-quiz/MusicQuizPlayerTile.vue";
+import MusicQuizPreparingState from "@/components/music-quiz/MusicQuizPreparingState.vue";
 import MusicQuizQrCard from "@/components/music-quiz/MusicQuizQrCard.vue";
 import type { MusicQuizGameDefinition } from "@/components/music-quiz/game_types";
 import MusicQuizSessionHeader from "@/components/music-quiz/MusicQuizSessionHeader.vue";

--- a/src/components/music-quiz/MusicQuizSetupWizard.vue
+++ b/src/components/music-quiz/MusicQuizSetupWizard.vue
@@ -2,6 +2,7 @@
   <div class="relative flex flex-col gap-5" :class="{ 'min-h-64': busy }">
     <MusicQuizPreparingState
       v-if="busy"
+      autofocus
       class="absolute inset-0 z-10 rounded-lg"
     />
 

--- a/src/composables/music-quiz/useMusicQuiz.ts
+++ b/src/composables/music-quiz/useMusicQuiz.ts
@@ -112,6 +112,7 @@ interface MusicQuizGuessTheSongStateBase extends MusicQuizStateIdentity {
   mode: MusicQuizMode;
   players: MusicQuizMultipleChoicePlayer[];
   current_round?: MusicQuizGuessTheSongRound | null;
+  preparing?: boolean;
 }
 
 export type MusicQuizGuessTheSongPublicState = MusicQuizGuessTheSongStateBase;
@@ -126,6 +127,7 @@ interface MusicQuizTimelineStateBase extends MusicQuizStateIdentity {
   mode: MusicQuizMode;
   players: MusicQuizTimelinePlayer[];
   current_round: MusicQuizTimelineRound | null;
+  preparing?: boolean;
 }
 
 export type MusicQuizTimelinePublicState = MusicQuizTimelineStateBase;
@@ -141,6 +143,7 @@ interface MusicQuizTriviaStateBase extends MusicQuizStateIdentity {
   mode: MusicQuizMode;
   players: MusicQuizMultipleChoicePlayer[];
   current_round: MusicQuizTriviaRound | null;
+  preparing?: boolean;
 }
 
 export type MusicQuizTriviaPublicState = MusicQuizTriviaStateBase;

--- a/src/views/MusicQuizDashboardView.vue
+++ b/src/views/MusicQuizDashboardView.vue
@@ -94,7 +94,8 @@
       />
 
       <MusicQuizPreparingState
-        v-else-if="starting && activeState"
+        v-else-if="isPreparing && activeState"
+        :autofocus="starting"
         class="rounded-xl border shadow-sm"
       />
 
@@ -333,6 +334,12 @@ const statusText = computed(() => {
   if (state.value) return $t("providers.music_quiz.unsupported_title");
   return $t("providers.music_quiz.no_active_game");
 });
+
+// The local flag covers the gap between issuing a host action and the server
+// reporting that round preparation is underway.
+const isPreparing = computed(
+  () => starting.value || activeState.value?.preparing === true,
+);
 
 const isActiveRound = computed(
   () =>

--- a/tests/components/music-quiz/MusicQuizHostControlsMenu.test.ts
+++ b/tests/components/music-quiz/MusicQuizHostControlsMenu.test.ts
@@ -181,6 +181,17 @@ describe("MusicQuizHostControlsMenu", () => {
     ).toBeDefined();
   });
 
+  it("keeps a pending indicator on the trigger after the menu closes", () => {
+    const idleTrigger = mountMenu().get('[data-testid="guest-host-controls"]');
+    expect(idleTrigger.find('[role="status"]').exists()).toBe(false);
+
+    busy.value = true;
+    const trigger = mountMenu().get('[data-testid="guest-host-controls"]');
+
+    expect(trigger.attributes("aria-busy")).toBe("true");
+    expect(trigger.find('[role="status"]').exists()).toBe(true);
+  });
+
   it("loads only the host state needed by the menu", () => {
     mountMenu();
 

--- a/tests/components/music-quiz/MusicQuizPreparingState.test.ts
+++ b/tests/components/music-quiz/MusicQuizPreparingState.test.ts
@@ -1,0 +1,36 @@
+import MusicQuizPreparingState from "@/components/music-quiz/MusicQuizPreparingState.vue";
+import { mount } from "@vue/test-utils";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@/plugins/i18n", () => ({
+  $t: (key: string) => key,
+}));
+
+describe("MusicQuizPreparingState", () => {
+  it("announces without taking focus away from the participant", () => {
+    const wrapper = mount(MusicQuizPreparingState, {
+      attachTo: document.body,
+    });
+
+    const status = wrapper.get('[data-testid="music-quiz-preparing"]');
+    expect(status.attributes("role")).toBe("status");
+    expect(status.attributes("aria-live")).toBe("polite");
+    expect(document.activeElement).not.toBe(status.element);
+    expect(document.activeElement).toBe(document.body);
+
+    wrapper.unmount();
+  });
+
+  it("focuses the status region for the client that triggered the action", () => {
+    const wrapper = mount(MusicQuizPreparingState, {
+      attachTo: document.body,
+      props: { autofocus: true },
+    });
+
+    const status = wrapper.get('[data-testid="music-quiz-preparing"]');
+    expect(status.attributes("aria-live")).toBe("polite");
+    expect(document.activeElement).toBe(status.element);
+
+    wrapper.unmount();
+  });
+});

--- a/tests/components/music-quiz/MusicQuizStages.test.ts
+++ b/tests/components/music-quiz/MusicQuizStages.test.ts
@@ -304,6 +304,88 @@ describe("Music Quiz shared stages", () => {
     ).toBe("false");
   });
 
+  it("replaces the player podium while the server prepares a restart", async () => {
+    const state = {
+      ...playerState,
+      phase: "finished",
+      current_round: null,
+      preparing: true,
+    } satisfies MusicQuizGuessTheSongPersonalizedState;
+    const wrapper = mount(MusicQuizPlayerStage, {
+      props: {
+        state,
+        currentRound: null,
+        busy: false,
+        leaderboardRows,
+        winnerText: "Player wins",
+        gameComponent: gameAdapter,
+        answerComponent: answerAdapter,
+      },
+      global: {
+        stubs: {
+          MusicQuizLeaderboard: leaderboardStub,
+          MusicQuizPodium: true,
+        },
+      },
+    });
+
+    expect(wrapper.find('[data-testid="music-quiz-preparing"]').exists()).toBe(
+      true,
+    );
+    expect(wrapper.findComponent(MusicQuizPodium).exists()).toBe(false);
+    expect(wrapper.find('[data-testid="leaderboard"]').exists()).toBe(false);
+
+    await wrapper.setProps({ state: { ...state, preparing: false } });
+
+    expect(wrapper.find('[data-testid="music-quiz-preparing"]').exists()).toBe(
+      false,
+    );
+    expect(wrapper.find('[data-testid="leaderboard"]').exists()).toBe(true);
+  });
+
+  it("replaces the present podium while the server prepares a restart", () => {
+    const state = {
+      ...hostState,
+      phase: "finished",
+      current_round: null,
+      preparing: true,
+    } satisfies MusicQuizGuessTheSongHostState;
+    const wrapper = mount(MusicQuizPresentStage, {
+      props: {
+        state,
+        game: gameDefinition,
+        currentRound: null,
+        leaderboardRows,
+        winnerText: "Player wins",
+        phaseLabel: "Finished",
+        roundLabel: "",
+        joinLink: "https://example.test/join",
+        isConnectionDegraded: false,
+        gameComponent: gameAdapter,
+        answerComponent: answerAdapter,
+      },
+      global: {
+        stubs: {
+          Button: true,
+          MusicQuizConnectionBanners: true,
+          MusicQuizLeaderboard: true,
+          MusicQuizPodium: true,
+          MusicQuizQrCard: true,
+        },
+      },
+    });
+
+    expect(wrapper.find('[data-testid="music-quiz-preparing"]').exists()).toBe(
+      true,
+    );
+    expect(
+      wrapper.find('[data-testid="music-quiz-present-finished"]').exists(),
+    ).toBe(false);
+    expect(
+      wrapper.find('[data-testid="music-quiz-present-lobby"]').exists(),
+    ).toBe(false);
+  });
+
   it("shows joined guests the remaining server time and handles cancellation", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-01-01T00:00:18Z"));

--- a/tests/views/MusicQuizDashboardHostActions.test.ts
+++ b/tests/views/MusicQuizDashboardHostActions.test.ts
@@ -1,3 +1,4 @@
+import MusicQuizPreparingState from "@/components/music-quiz/MusicQuizPreparingState.vue";
 import MusicQuizDashboardView from "@/views/MusicQuizDashboardView.vue";
 import type {
   MusicQuizSupportedHostState,
@@ -230,6 +231,9 @@ describe("MusicQuizDashboardView host actions", () => {
     const status = wrapper.get('[data-testid="music-quiz-preparing"]');
     expect(status.attributes("role")).toBe("status");
     expect(status.text()).toContain("providers.music_quiz.preparing_game");
+    expect(
+      wrapper.findComponent(MusicQuizPreparingState).props("autofocus"),
+    ).toBe(true);
     expect(wrapper.find('[data-testid="start-now"]').exists()).toBe(false);
 
     finishStart();
@@ -238,6 +242,28 @@ describe("MusicQuizDashboardView host actions", () => {
     expect(wrapper.find('[data-testid="music-quiz-preparing"]').exists()).toBe(
       false,
     );
+  });
+
+  it("shows preparation progress when the server reports preparing", async () => {
+    state.value = { ...HOST_STATE, preparing: true };
+    const wrapper = mountDashboard();
+
+    expect(
+      wrapper.get('[data-testid="music-quiz-preparing"]').text(),
+    ).toContain("providers.music_quiz.preparing_game");
+    // A host tab that did not issue the action must not have focus pulled away.
+    expect(
+      wrapper.findComponent(MusicQuizPreparingState).props("autofocus"),
+    ).toBe(false);
+    expect(wrapper.find('[data-testid="play-again"]').exists()).toBe(false);
+
+    state.value = { ...HOST_STATE, preparing: false };
+    await nextTick();
+
+    expect(wrapper.find('[data-testid="music-quiz-preparing"]').exists()).toBe(
+      false,
+    );
+    expect(wrapper.find('[data-testid="play-again"]').exists()).toBe(true);
   });
 
   it("deletes the finished game before opening fresh setup", async () => {


### PR DESCRIPTION
Restarting a Music Quiz game looked broken. The host clicked "Play again", the menu closed, and nothing happened for several seconds until the game suddenly restarted. Everyone else kept staring at the final scoreboard until the new game appeared out of nowhere.

The server now reports that it is preparing the next round (music-assistant/server#5214). This shows it.

## Changes

- Show the existing "preparing" screen to players, on the big screen, and on the host dashboard while the next game is being prepared
- Show a spinner on the host controls button, so starting, revealing, skipping and ending a game no longer look like nothing happened
- Only move keyboard focus to the preparing message for the person who pressed the button, instead of for everyone
