### PR TITLE
Start audio faster on web players

### DIFF
--- a/src/components/SendspinPlayer.vue
+++ b/src/components/SendspinPlayer.vue
@@ -309,9 +309,10 @@ onMounted(() => {
           codecs,
           syncDelay,
           requiredLeadTimeMs: 250,
-          // Ask for a larger buffer when we are being routed through WebRTC.
-          // This increases latency for live streams, but improves stability
-          minBufferMs: isDirectConnection() ? 2500 : 6000,
+          // Startup lead the server uses to schedule the first chunk, so it
+          // directly delays first audio and must stay small. Once playback is
+          // running the buffer grows well beyond this on its own.
+          minBufferMs: 500,
           onStateChange: (state) => {
             // Update reactive state when player state changes
             isPlaying.value = state.isPlaying;


### PR DESCRIPTION
Audio took several seconds to start on a web player - around 7 seconds over a remote connection, and about 2.5 seconds on the local network. It was most obvious in the Music Quiz, where every question starts a new song, but it affected all playback to a browser, including radio.

The web player asks the server for a minimum buffer. That value is used as the delay before the first audio is scheduled to play, so asking for a big buffer directly delays the start. It does not make playback more stable: the buffer grows well past that on its own within the first second.

Verified on both a local network connection and a remote one: audio now starts almost immediately, with no stuttering.

## Changes

- Ask for a 500ms buffer instead of 2.5 seconds locally and 6 seconds remotely
