### PR TITLE
Explain why joining a party or quiz failed

### DIFF
--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1089,6 +1089,7 @@
         "error_unknown": "Unknown error occurred",
         "error_login_failed": "Login failed. Please check your credentials.",
         "error_oauth_failed": "Failed to authenticate with Home Assistant.",
+        "error_party_auth_failed": "Couldn't join the party",
         "scan_qr": "Scan QR",
         "scan_qr_code": "Scan QR Code",
         "scan_qr_hint": "Point your camera at the QR code shown in your Music Assistant server settings.",

--- a/src/views/Login.vue
+++ b/src/views/Login.vue
@@ -292,10 +292,22 @@
                     >mdi-alert-circle</v-icon
                   >
                   <p class="text-h6 mb-2">
-                    {{ $t("login.connection_failed", "Connection Failed") }}
+                    {{
+                      connectionErrorTitle ??
+                      $t("login.connection_failed", "Connection Failed")
+                    }}
                   </p>
-                  <p class="text-body-2 text-medium-emphasis">
+                  <p
+                    v-if="connectionError"
+                    class="text-body-2 text-medium-emphasis"
+                  >
                     {{ connectionError }}
+                  </p>
+                  <p
+                    v-if="connectionErrorDetail"
+                    class="text-caption text-medium-emphasis mt-2"
+                  >
+                    {{ connectionErrorDetail }}
                   </p>
                 </div>
                 <v-btn color="primary" block rounded="lg" @click="retry">
@@ -550,6 +562,10 @@ const showQrScanner = ref(false);
 const qrScannerError = ref<string | null>(null);
 const isConnecting = ref(false);
 const connectionError = ref<string | null>(null);
+// Overrides the error step's headline when the failure isn't a connection failure.
+const connectionErrorTitle = ref<string | null>(null);
+// Verbatim server-supplied reason shown under connectionError; not localized.
+const connectionErrorDetail = ref<string | null>(null);
 const connectionStatusMessage = ref("");
 const isRemoteConnection = ref(false);
 const connectedServerName = ref<string | null>(null);
@@ -691,10 +707,16 @@ const tryStoredTokenAuth = async (token?: string): Promise<boolean> => {
 /**
  * Try to authenticate with a guest code (exchange for JWT)
  * This is the new short code system for party guest access
+ *
+ * The `error` of a rejected exchange is the server's plain-English reason
+ * (rate limited, invalid or expired code); callers surface it as detail
+ * alongside their own localized message.
  */
-const tryGuestCodeAuth = async (code: string): Promise<boolean> => {
+const tryGuestCodeAuth = async (
+  code: string,
+): Promise<{ authenticated: boolean; error?: string }> => {
   if (!code) {
-    return false;
+    return { authenticated: false };
   }
 
   try {
@@ -713,7 +735,7 @@ const tryGuestCodeAuth = async (code: string): Promise<boolean> => {
 
     if (!result.success || !result.access_token) {
       console.error("[Login] Guest code exchange failed:", result.error);
-      return false;
+      return { authenticated: false, error: result.error };
     }
 
     authManager.setToken(result.access_token);
@@ -726,11 +748,14 @@ const tryGuestCodeAuth = async (code: string): Promise<boolean> => {
       token: result.access_token,
       user: authResult.user,
     });
-    return true;
+    return { authenticated: true };
   } catch (error) {
     console.error("[Login] Guest code authentication failed:", error);
     authManager.clearGuestSession();
-    return false;
+    return {
+      authenticated: false,
+      error: error instanceof Error ? error.message : undefined,
+    };
   }
 };
 
@@ -743,7 +768,7 @@ const completeDashboardAuth = async (
   rawPath: string | null,
 ): Promise<boolean> => {
   const path = sanitizeDashboardViewerPath(rawPath);
-  if (!(await tryGuestCodeAuth(dashboardCode))) {
+  if (!(await tryGuestCodeAuth(dashboardCode)).authenticated) {
     return false;
   }
 
@@ -867,17 +892,22 @@ const tryPendingGuestAuth = async (): Promise<PendingGuestAuthResult> => {
     return "authenticated";
   }
 
-  if (await tryGuestCodeAuth(code)) {
+  const codeAuth = await tryGuestCodeAuth(code);
+  if (codeAuth.authenticated) {
     clearPendingGuestAuth();
     return "authenticated";
   }
 
   clearPendingGuestAuth();
   authManager.clearGuestSession();
-  connectionError.value = t(
+  // The code was rejected, not the connection: headline the join failure and
+  // let the server's reason stand as the only detail.
+  connectionErrorTitle.value = t(
     "login.error_party_auth_failed",
-    "Failed to join party. The code may have expired.",
+    "Couldn't join the party",
   );
+  connectionError.value = null;
+  connectionErrorDetail.value = codeAuth.error ?? null;
   step.value = "error";
   return "failed";
 };
@@ -1265,10 +1295,11 @@ const autoConnect = async () => {
         }
 
         clearPendingGuestAuth();
-        connectionError.value = t(
+        connectionErrorTitle.value = t(
           "login.error_party_auth_failed",
-          "Failed to join party. The code may have expired.",
+          "Couldn't join the party",
         );
+        connectionError.value = null;
         step.value = "error";
         return;
       } catch (error) {
@@ -1658,6 +1689,8 @@ const setRemoteIdFromString = (value: string) => {
 const performLocalConnect = async (address: string) => {
   isConnecting.value = true;
   connectionError.value = null;
+  connectionErrorTitle.value = null;
+  connectionErrorDetail.value = null;
   isRemoteConnection.value = false;
   step.value = "connecting";
   connectionStatusMessage.value = t(
@@ -1735,6 +1768,8 @@ const connectToRemote = async () => {
 
   isConnecting.value = true;
   connectionError.value = null;
+  connectionErrorTitle.value = null;
+  connectionErrorDetail.value = null;
   isRemoteConnection.value = true;
   step.value = "connecting";
   connectionStatusMessage.value = t(
@@ -1970,6 +2005,8 @@ const cancelConnection = () => {
 
 const retry = () => {
   connectionError.value = null;
+  connectionErrorTitle.value = null;
+  connectionErrorDetail.value = null;
   remoteConnectionManager.disconnect();
   api.disconnect();
   step.value = "select-mode";

--- a/tests/views/Login.test.ts
+++ b/tests/views/Login.test.ts
@@ -421,21 +421,48 @@ describe("guest join login", () => {
     );
     mocks.sendCommand.mockResolvedValue({
       success: false,
-      error: "expired",
+      error: "Invalid or expired join code",
     });
 
     const wrapper = mountLogin();
 
     await vi.waitFor(() => {
-      expect(wrapper.text()).toContain(
-        "Failed to join party. The code may have expired.",
-      );
+      expect(wrapper.text()).toContain("Couldn't join the party");
     });
+    expect(wrapper.get(".text-h6").text()).toBe("Couldn't join the party");
+    expect(wrapper.text()).toContain("Invalid or expired join code");
+    expect(wrapper.text()).not.toContain("Connection Failed");
     expect(sessionStorage.getItem("ma_pending_join_code")).toBeNull();
     expect(sessionStorage.getItem("ma_pending_join_type")).toBeNull();
     expect(sessionStorage.getItem("ma_guest_server_address")).toBeNull();
     expect(localStorage.getItem("ma_access_token")).toBe("admin-token");
     expect(sessionStorage.getItem("ma_guest_access_token")).toBeNull();
+    expect(wrapper.emitted("authenticated")).toBeUndefined();
+  });
+
+  it("shows the server reason when the join code exchange is rate limited", async () => {
+    setLocation("?join=abcd1234");
+    mockStandaloneFrontend();
+    localStorage.setItem(
+      "mass_server_address",
+      "http://music-assistant.local:8095",
+    );
+    mocks.sendCommand.mockResolvedValue({
+      success: false,
+      error: "Too many failed attempts. Please try again in 120 seconds.",
+    });
+
+    const wrapper = mountLogin();
+
+    await vi.waitFor(() => {
+      expect(wrapper.text()).toContain("Couldn't join the party");
+    });
+    expect(wrapper.get(".text-h6").text()).toBe("Couldn't join the party");
+    expect(wrapper.text()).toContain(
+      "Too many failed attempts. Please try again in 120 seconds.",
+    );
+    expect(wrapper.text()).not.toContain("expired");
+    expect(wrapper.text()).not.toContain("Connection Failed");
     expect(wrapper.emitted("authenticated")).toBeUndefined();
   });
 


### PR DESCRIPTION
A guest who couldn't join a party or quiz was always told "Failed to join party. The code may have expired." - even when the code was fine and the real reason was something else, such as the server temporarily refusing further attempts. The server does say what actually went wrong, but that message was logged to the browser console and thrown away, so the guest and the host had no way to tell the two apart.

That message was also missing from the translations file, so everyone saw the hardcoded English text regardless of their language.

## Changes

- Show the reason the server gave underneath the message, instead of discarding it
- Stop claiming the code expired when that is not known
- Add the missing message to the translations so it can be translated
