### PR TITLE
Keep settings pages up to date when other providers are added or removed

### DIFF
--- a/src/helpers/config_entry_ui.ts
+++ b/src/helpers/config_entry_ui.ts
@@ -44,6 +44,9 @@ export const isDspLinkEntry = (
  * read_only, whether it exists at all), since that's what the server just
  * told us is current. `current` wins for `value`, so a refresh never
  * discards something the user typed but hasn't saved yet.
+ *
+ * Every returned entry is a fresh object, so the form is free to keep editing
+ * them in place without reaching back into either argument.
  */
 export const mergeConfigEntries = (
   current: Record<string, ConfigEntry>,
@@ -54,7 +57,7 @@ export const mergeConfigEntries = (
     const currentEntry = current[key];
     merged[key] = currentEntry
       ? { ...incomingEntry, value: currentEntry.value }
-      : incomingEntry;
+      : { ...incomingEntry };
   }
   return merged;
 };

--- a/src/helpers/config_entry_ui.ts
+++ b/src/helpers/config_entry_ui.ts
@@ -35,3 +35,26 @@ export const isDspLinkEntry = (
 ): e is InjectedConfigEntry & {
   type: typeof UI_ENTRY_TYPE.DSP_SETTINGS_LINK;
 } => isInjected(e) && e.type === UI_ENTRY_TYPE.DSP_SETTINGS_LINK;
+
+/**
+ * Merges a freshly fetched set of config entries into the entries currently
+ * on screen after a PROVIDERS_UPDATED refresh.
+ *
+ * `incoming` wins for everything about an entry's definition (options,
+ * read_only, whether it exists at all), since that's what the server just
+ * told us is current. `current` wins for `value`, so a refresh never
+ * discards something the user typed but hasn't saved yet.
+ */
+export const mergeConfigEntries = (
+  current: Record<string, ConfigEntry>,
+  incoming: Record<string, ConfigEntry>,
+): Record<string, ConfigEntry> => {
+  const merged: Record<string, ConfigEntry> = {};
+  for (const [key, incomingEntry] of Object.entries(incoming)) {
+    const currentEntry = current[key];
+    merged[key] = currentEntry
+      ? { ...incomingEntry, value: currentEntry.value }
+      : incomingEntry;
+  }
+  return merged;
+};

--- a/src/views/settings/EditPlayer.vue
+++ b/src/views/settings/EditPlayer.vue
@@ -263,6 +263,7 @@ import {
   ConfigEntryUI,
   UI_ENTRY_TYPE,
   isInjected,
+  mergeConfigEntries,
 } from "@/helpers/config_entry_ui";
 import { openActionUrlEntries, openLinkInNewTab } from "@/helpers/utils";
 import { eventbus } from "@/plugins/eventbus";
@@ -273,6 +274,8 @@ const config = ref<PlayerConfig>();
 const loading = ref(false);
 const showRenameDialog = ref(false);
 const editName = ref<string | null>(null);
+let configLoadRequestId = 0;
+let configRefreshRequestId = 0;
 
 // props
 const props = defineProps<{
@@ -299,6 +302,11 @@ const unsub = api.subscribe(
   },
 );
 onBeforeUnmount(unsub);
+
+const unsubProvidersUpdated = api.subscribe(EventType.PROVIDERS_UPDATED, () => {
+  if (props.playerId) void refreshPlayerConfig(props.playerId);
+});
+onBeforeUnmount(unsubProvidersUpdated);
 
 // computed properties
 const config_entries = computed(() => {
@@ -375,10 +383,8 @@ const config_entries = computed(() => {
 
 watch(
   () => props.playerId,
-  async (val) => {
-    if (val) {
-      config.value = await api.getPlayerConfig(val);
-    }
+  (val) => {
+    if (val) void loadConfig(val);
   },
   { immediate: true },
 );
@@ -495,6 +501,42 @@ const onAction = async function (
       loading.value = false;
     });
 };
+
+async function loadConfig(playerId: string) {
+  const requestId = ++configLoadRequestId;
+  try {
+    const updatedConfig = await api.getPlayerConfig(playerId);
+    if (requestId === configLoadRequestId && props.playerId === playerId) {
+      config.value = updatedConfig;
+    }
+  } catch (err) {
+    if (requestId === configLoadRequestId) {
+      toast.error(String(err));
+    }
+  }
+}
+
+async function refreshPlayerConfig(playerId: string) {
+  if (config.value?.player_id !== playerId) return;
+  const requestId = ++configRefreshRequestId;
+  try {
+    const updatedConfig = await api.getPlayerConfig(playerId);
+    if (
+      requestId === configRefreshRequestId &&
+      props.playerId === playerId &&
+      config.value?.player_id === playerId
+    ) {
+      config.value.values = mergeConfigEntries(
+        config.value.values,
+        updatedConfig.values,
+      );
+    }
+  } catch (err) {
+    if (requestId === configRefreshRequestId) {
+      toast.error(String(err));
+    }
+  }
+}
 </script>
 
 <style scoped>

--- a/src/views/settings/EditProvider.vue
+++ b/src/views/settings/EditProvider.vue
@@ -201,6 +201,7 @@
 import ProviderIcon from "@/components/ProviderIcon.vue";
 import ProviderSaveErrorDialog from "@/components/ProviderSaveErrorDialog.vue";
 import { Button } from "@/components/ui/button";
+import { mergeConfigEntries } from "@/helpers/config_entry_ui";
 import { canReconfigureProvider } from "@/helpers/provider_config";
 import { markdownToHtml, openActionUrlEntries } from "@/helpers/utils";
 import { api } from "@/plugins/api";
@@ -229,7 +230,7 @@ const saveErrorOpen = ref(false);
 const saveErrorMessage = ref("");
 const lastSubmitValues = ref<Record<string, ConfigValueType>>();
 let configLoadRequestId = 0;
-let statusRefreshRequestId = 0;
+let configRefreshRequestId = 0;
 let unsubProvidersUpdated: (() => void) | undefined;
 
 // props
@@ -269,7 +270,7 @@ watch(showRenameDialog, (val) => {
 
 onMounted(() => {
   unsubProvidersUpdated = api.subscribe(EventType.PROVIDERS_UPDATED, () => {
-    if (props.instanceId) void refreshProviderStatus(props.instanceId);
+    if (props.instanceId) void refreshProviderConfig(props.instanceId);
   });
 });
 
@@ -301,7 +302,7 @@ const onReconfigure = function () {
     kind: "reconfigure",
     instanceId,
     onFlowEnded: () => {
-      void refreshProviderStatus(instanceId);
+      void refreshProviderConfig(instanceId);
     },
   });
 };
@@ -463,21 +464,25 @@ async function loadConfig(instanceId: string) {
   }
 }
 
-async function refreshProviderStatus(instanceId: string) {
+async function refreshProviderConfig(instanceId: string) {
   if (config.value?.instance_id !== instanceId) return;
-  const requestId = ++statusRefreshRequestId;
+  const requestId = ++configRefreshRequestId;
   try {
     const updatedConfig = await api.getProviderConfig(instanceId);
     if (
-      requestId === statusRefreshRequestId &&
+      requestId === configRefreshRequestId &&
       props.instanceId === instanceId &&
       config.value?.instance_id === instanceId
     ) {
       config.value.status = updatedConfig.status;
       config.value.last_error = updatedConfig.last_error;
+      config.value.values = mergeConfigEntries(
+        config.value.values,
+        updatedConfig.values,
+      );
     }
   } catch (err) {
-    if (requestId === statusRefreshRequestId) {
+    if (requestId === configRefreshRequestId) {
       toast.error(String(err));
     }
   }

--- a/tests/helpers/config_entry_ui.test.ts
+++ b/tests/helpers/config_entry_ui.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest";
+import { mergeConfigEntries } from "@/helpers/config_entry_ui";
+import { ConfigEntryType, type ConfigEntry } from "@/plugins/api/interfaces";
+
+function entry(overrides: Partial<ConfigEntry> = {}): ConfigEntry {
+  return {
+    key: "engine",
+    type: ConfigEntryType.STRING,
+    label: "Engine",
+    default_value: null,
+    required: false,
+    category: "generic",
+    ...overrides,
+  };
+}
+
+describe("mergeConfigEntries", () => {
+  it("adopts the fresh definition for an untouched key", () => {
+    const current = { engine: entry({ options: [], read_only: true }) };
+    const incoming = {
+      engine: entry({
+        options: [{ title: "Home Assistant", value: "ha" }],
+        read_only: false,
+      }),
+    };
+
+    const merged = mergeConfigEntries(current, incoming);
+
+    expect(merged.engine.options).toEqual([
+      { title: "Home Assistant", value: "ha" },
+    ]);
+    expect(merged.engine.read_only).toBe(false);
+  });
+
+  it("keeps a locally edited value while refreshing its definition", () => {
+    const current = {
+      name: entry({ key: "name", value: "typed but not saved" }),
+    };
+    const incoming = {
+      name: entry({ key: "name", options: [], read_only: true }),
+    };
+
+    const merged = mergeConfigEntries(current, incoming);
+
+    expect(merged.name.value).toBe("typed but not saved");
+    expect(merged.name.read_only).toBe(true);
+  });
+
+  it("drops a key that no longer exists in the incoming entries", () => {
+    const current = { stale: entry({ key: "stale" }) };
+    const incoming = {};
+
+    const merged = mergeConfigEntries(current, incoming);
+
+    expect(merged).toEqual({});
+  });
+
+  it("adds a key that only exists in the incoming entries", () => {
+    const current = {};
+    const incoming = { fresh: entry({ key: "fresh" }) };
+
+    const merged = mergeConfigEntries(current, incoming);
+
+    expect(merged.fresh).toEqual(incoming.fresh);
+  });
+
+  it("does not mutate either input", () => {
+    const current = { engine: entry({ value: "current value" }) };
+    const incoming = {
+      engine: entry({ options: [{ title: "A", value: "a" }] }),
+    };
+    const currentSnapshot = JSON.parse(JSON.stringify(current));
+    const incomingSnapshot = JSON.parse(JSON.stringify(incoming));
+
+    mergeConfigEntries(current, incoming);
+
+    expect(current).toEqual(currentSnapshot);
+    expect(incoming).toEqual(incomingSnapshot);
+  });
+});

--- a/tests/helpers/config_entry_ui.test.ts
+++ b/tests/helpers/config_entry_ui.test.ts
@@ -62,6 +62,8 @@ describe("mergeConfigEntries", () => {
     const merged = mergeConfigEntries(current, incoming);
 
     expect(merged.fresh).toEqual(incoming.fresh);
+    // the form edits entries in place, so a merged entry must never alias its input
+    expect(merged.fresh).not.toBe(incoming.fresh);
   });
 
   it("does not mutate either input", () => {

--- a/tests/views/EditProvider.test.ts
+++ b/tests/views/EditProvider.test.ts
@@ -132,6 +132,47 @@ describe("EditProvider", () => {
     expect(unsubscribeMock).toHaveBeenCalledOnce();
   });
 
+  it("merges fresh entry definitions while keeping a pending local edit", async () => {
+    apiMock.getProviderConfig
+      .mockResolvedValueOnce(
+        providerConfig(ProviderStatus.LOADED, "current value", []),
+      )
+      .mockResolvedValueOnce(
+        providerConfig(ProviderStatus.LOADED, "server refresh", [
+          { title: "Home Assistant", value: "ha" },
+        ]),
+      );
+
+    const wrapper = shallowMount(EditProvider, {
+      props: {
+        instanceId: "spotify--test",
+      },
+      global: {
+        mocks: {
+          $t: (key: string) => key,
+        },
+      },
+    });
+    await flushPromises();
+
+    // EditConfig edits the entry objects in place, so this is what a user
+    // typing into the form leaves behind
+    const editConfig = wrapper.findComponent({ name: "EditConfig" });
+    editConfig.props("configEntries")[0].value = "typed but not saved";
+
+    providersUpdated?.();
+    await flushPromises();
+
+    expect(apiMock.getProviderConfig).toHaveBeenCalledTimes(2);
+    expect(editConfig.props("configEntries")).toEqual([
+      expect.objectContaining({
+        key: "account",
+        value: "typed but not saved",
+        options: [{ title: "Home Assistant", value: "ha" }],
+      }),
+    ]);
+  });
+
   it("refreshes provider status when reconfiguration ends", async () => {
     apiMock.getProviderConfig
       .mockResolvedValueOnce(providerConfig(ProviderStatus.AUTH_REQUIRED))
@@ -167,6 +208,7 @@ describe("EditProvider", () => {
 function providerConfig(
   status: ProviderStatus,
   account: string = "current value",
+  accountOptions?: { title: string; value: string }[],
 ): ProviderConfig {
   return {
     domain: "spotify",
@@ -203,6 +245,7 @@ function providerConfig(
         default_value: null,
         key: "account",
         label: "Account",
+        options: accountOptions,
         required: false,
         type: ConfigEntryType.STRING,
         value: account,


### PR DESCRIPTION
A provider's settings page builds its form once, when you open it. Option lists that are filled in by *other* providers therefore go stale: set up the Home Assistant plugin in a second tab, go back to the Music Quiz or Smart Playlist settings, and the AI engine picker is still empty, read-only, and showing "no engine available" until you navigate away and back. Player settings had the same problem for protocol sections that appear when a provider loads.

Both pages now re-fetch their config when providers change. The fresh definitions (option lists, read-only state, which entries exist at all) are merged in, while anything you have typed but not saved is kept as-is.

- Added a `mergeConfigEntries` helper: the server decides which entries exist and what they look like, the form keeps its own values
- Provider settings now refresh their entries on a provider update, not just the status banner
- Player settings now listen for provider updates too, and got the same request-race guard and error handling the provider page already had
- Tests for the merge rules and for the provider page picking up a new option list without losing a pending edit