### PR TITLE
Keep Music Quiz lyrics in step with the audio

### DIFF
--- a/src/components/music-quiz/game-types/guess-the-song/GuessTheSongPlayerRound.vue
+++ b/src/components/music-quiz/game-types/guess-the-song/GuessTheSongPlayerRound.vue
@@ -73,7 +73,8 @@ const showRevealLyrics = computed(() => revealLyricsStatus.value !== "error");
 const { position: lyricsPosition } = useGuessTheSongPlaybackPosition({
   active: () =>
     props.state.phase === "reveal" && !!props.currentRound.track_uri,
-  startedAt: () => props.currentRound.started_at,
+  startedAt: () =>
+    props.currentRound.audio_started_at ?? props.currentRound.started_at,
   duration: () => props.currentRound.duration,
 });
 

--- a/src/composables/music-quiz/useMusicQuiz.ts
+++ b/src/composables/music-quiz/useMusicQuiz.ts
@@ -386,6 +386,9 @@ export interface MusicQuizTimelineYourAnswer {
 export interface MusicQuizRoundBase {
   round_index: number;
   started_at: number | null;
+  // when the round's track became audible; anything that follows the audio
+  // (e.g. synced lyrics) should prefer this over started_at
+  audio_started_at?: number | null;
   deadline: number;
   auto_advance_at: number | null;
   ended_at?: number;

--- a/tests/components/music-quiz/GuessTheSongPlayerRound.test.ts
+++ b/tests/components/music-quiz/GuessTheSongPlayerRound.test.ts
@@ -114,7 +114,16 @@ describe("GuessTheSongPlayerRound", () => {
     wrapper.unmount();
   });
 
-  it("falls back to started_at when audio_started_at is absent", () => {
+  it("falls back to started_at when the round omits audio_started_at", () => {
+    mockGetItemByUri.mockReturnValue(new Promise(() => {}));
+    const wrapper = mountRound(createState("reveal"));
+
+    const options = mockUseGuessTheSongPlaybackPosition.mock.calls.at(-1)?.[0];
+    expect(options.startedAt()).toBe(currentRound.started_at);
+    wrapper.unmount();
+  });
+
+  it("falls back to started_at when audio_started_at is null", () => {
     mockGetItemByUri.mockReturnValue(new Promise(() => {}));
     const wrapper = mountRound(createState("reveal"), {
       ...currentRound,

--- a/tests/components/music-quiz/GuessTheSongPlayerRound.test.ts
+++ b/tests/components/music-quiz/GuessTheSongPlayerRound.test.ts
@@ -6,6 +6,7 @@ import type {
 } from "@/composables/music-quiz/useMusicQuiz";
 import { MediaType } from "@/plugins/api/interfaces";
 import { shallowMount } from "@vue/test-utils";
+import { ref } from "vue";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const {
@@ -13,11 +14,13 @@ const {
   mockGetItemByUri,
   mockGetTrackLyrics,
   mockToastError,
+  mockUseGuessTheSongPlaybackPosition,
 } = vi.hoisted(() => ({
   mockCopyToClipboard: vi.fn(),
   mockGetItemByUri: vi.fn(),
   mockGetTrackLyrics: vi.fn(),
   mockToastError: vi.fn(),
+  mockUseGuessTheSongPlaybackPosition: vi.fn(),
 }));
 
 vi.mock("@/plugins/api", () => ({
@@ -34,15 +37,9 @@ vi.mock("@/helpers/utils", () => ({
 
 vi.mock(
   "@/components/music-quiz/game-types/guess-the-song/useGuessTheSongPlaybackPosition",
-  async () => {
-    const { ref } = await import("vue");
-    return {
-      useGuessTheSongPlaybackPosition: () => ({
-        position: ref(12),
-        teardown: vi.fn(),
-      }),
-    };
-  },
+  () => ({
+    useGuessTheSongPlaybackPosition: mockUseGuessTheSongPlaybackPosition,
+  }),
 );
 
 vi.mock("@/plugins/i18n", () => ({
@@ -74,6 +71,11 @@ describe("GuessTheSongPlayerRound", () => {
     mockGetItemByUri.mockReset();
     mockGetTrackLyrics.mockReset();
     mockToastError.mockReset();
+    mockUseGuessTheSongPlaybackPosition.mockReset();
+    mockUseGuessTheSongPlaybackPosition.mockImplementation(() => ({
+      position: ref(12),
+      teardown: vi.fn(),
+    }));
   });
 
   it("does not initialize lyrics while answering", () => {
@@ -97,6 +99,30 @@ describe("GuessTheSongPlayerRound", () => {
     expect(reveal.props("lyrics")).toBe("Plain lyrics");
     expect(reveal.props("lrcLyrics")).toBe("Synced lyrics");
     expect(reveal.props("lyricsPosition")).toBe(12);
+    wrapper.unmount();
+  });
+
+  it("prefers audio_started_at as the playback anchor when present", () => {
+    mockGetItemByUri.mockReturnValue(new Promise(() => {}));
+    const wrapper = mountRound(createState("reveal"), {
+      ...currentRound,
+      audio_started_at: 55,
+    });
+
+    const options = mockUseGuessTheSongPlaybackPosition.mock.calls.at(-1)?.[0];
+    expect(options.startedAt()).toBe(55);
+    wrapper.unmount();
+  });
+
+  it("falls back to started_at when audio_started_at is absent", () => {
+    mockGetItemByUri.mockReturnValue(new Promise(() => {}));
+    const wrapper = mountRound(createState("reveal"), {
+      ...currentRound,
+      audio_started_at: null,
+    });
+
+    const options = mockUseGuessTheSongPlaybackPosition.mock.calls.at(-1)?.[0];
+    expect(options.startedAt()).toBe(currentRound.started_at);
     wrapper.unmount();
   });
 
@@ -184,11 +210,14 @@ function createState(
   };
 }
 
-function mountRound(state: MusicQuizGuessTheSongPersonalizedState) {
+function mountRound(
+  state: MusicQuizGuessTheSongPersonalizedState,
+  round: MusicQuizGuessTheSongRound = currentRound,
+) {
   return shallowMount(GuessTheSongPlayerRound, {
     props: {
       state,
-      currentRound,
+      currentRound: round,
       busy: false,
     },
   });


### PR DESCRIPTION
The synced lyrics in a Music Quiz reveal ran ahead of the song you actually hear: their position was derived from the moment the round opened, which is when the server commanded playback rather than when the track became audible.

The server now publishes when the track actually started sounding, so the lyrics follow that instead.

- Use the round's `audio_started_at` as the lyrics position anchor, falling back to the round start when it is not supplied

Companion PR: music-assistant/server#5263