### PR TITLE
Keep timings correct when a device clock is out of sync

### DIFF
--- a/src/components/AudioAnalysisFailures.vue
+++ b/src/components/AudioAnalysisFailures.vue
@@ -140,6 +140,7 @@ import {
   useAudioAnalysisFailures,
   type FailureRow,
 } from "@/composables/audio-analysis/useAudioAnalysisFailures";
+import { serverNow } from "@/composables/useServerTime";
 import { formatRelativeTime } from "@/helpers/utils";
 import { $t } from "@/plugins/i18n";
 import { api } from "@/plugins/api";
@@ -197,14 +198,14 @@ const pendingKey = ref<string | null>(null);
 const clearingAll = ref(false);
 
 function retryVariant(row: FailureRow): "warning" | "secondary" | "outline" {
-  const status = classifyRetry(row.nextRetry, Math.floor(Date.now() / 1000));
+  const status = classifyRetry(row.nextRetry, Math.floor(serverNow()));
   if (status.kind === "blocked") return "warning";
   if (status.kind === "eligible") return "secondary";
   return "outline";
 }
 
 function retryLabel(row: FailureRow): string {
-  const status = classifyRetry(row.nextRetry, Math.floor(Date.now() / 1000));
+  const status = classifyRetry(row.nextRetry, Math.floor(serverNow()));
   if (status.kind === "blocked")
     return $t("settings.audio_analysis_failures.retry_blocked");
   if (status.kind === "eligible")

--- a/src/components/MiniEqualizer.vue
+++ b/src/components/MiniEqualizer.vue
@@ -42,7 +42,7 @@ function getElapsedSecs(): number {
   ) {
     const isPlaying = store.activePlayerQueue?.state === "playing";
     const delta = isPlaying
-      ? serverNow() - queueTime.elapsed_time_last_updated
+      ? Math.max(0, serverNow() - queueTime.elapsed_time_last_updated)
       : 0;
     return queueTime.elapsed_time + delta;
   }
@@ -53,7 +53,7 @@ function getElapsedSecs(): number {
   ) {
     const isPlaying = player.playback_state === "playing";
     const delta = isPlaying
-      ? serverNow() - player.elapsed_time_last_updated
+      ? Math.max(0, serverNow() - player.elapsed_time_last_updated)
       : 0;
     return player.elapsed_time + delta;
   }

--- a/src/components/MiniEqualizer.vue
+++ b/src/components/MiniEqualizer.vue
@@ -11,6 +11,7 @@
 <script setup lang="ts">
 import { onMounted, onUnmounted, ref, watch } from "vue";
 import { useActiveTrackWaveform } from "@/composables/useActiveTrackWaveform";
+import { serverNow } from "@/composables/useServerTime";
 import { store } from "@/plugins/store";
 import api from "@/plugins/api";
 
@@ -41,7 +42,7 @@ function getElapsedSecs(): number {
   ) {
     const isPlaying = store.activePlayerQueue?.state === "playing";
     const delta = isPlaying
-      ? Date.now() / 1000 - queueTime.elapsed_time_last_updated
+      ? serverNow() - queueTime.elapsed_time_last_updated
       : 0;
     return queueTime.elapsed_time + delta;
   }
@@ -52,7 +53,7 @@ function getElapsedSecs(): number {
   ) {
     const isPlaying = player.playback_state === "playing";
     const delta = isPlaying
-      ? Date.now() / 1000 - player.elapsed_time_last_updated
+      ? serverNow() - player.elapsed_time_last_updated
       : 0;
     return player.elapsed_time + delta;
   }

--- a/src/components/SetupFlowDialog.vue
+++ b/src/components/SetupFlowDialog.vue
@@ -311,6 +311,7 @@ import {
 } from "@/components/ui/dialog";
 import { Progress } from "@/components/ui/progress";
 import { Spinner } from "@/components/ui/spinner";
+import { serverNow } from "@/composables/useServerTime";
 import { api, ConnectionState } from "@/plugins/api";
 import {
   type ConfigEntry,
@@ -353,7 +354,8 @@ const launch = ref<SetupFlowDialogEvent | null>(null);
 const formEntries = ref<ConfigEntry[]>([]);
 const showPasswordValues = ref(false);
 const helpEntry = ref<ConfigEntry | undefined>(undefined);
-const now = ref(Date.now() / 1000);
+// on the server's clock, since the step's `expires_at` is a server timestamp
+const now = ref(serverNow());
 
 const formRef = ref<HTMLFormElement | null>(null);
 
@@ -503,10 +505,10 @@ watch(countdownRemaining, (remaining) => {
 });
 
 function startCountdown() {
-  now.value = Date.now() / 1000;
+  now.value = serverNow();
   if (!countdownTimer) {
     countdownTimer = setInterval(() => {
-      now.value = Date.now() / 1000;
+      now.value = serverNow();
     }, 1000);
   }
 }

--- a/src/components/ai-radio/OnAirHero.vue
+++ b/src/components/ai-radio/OnAirHero.vue
@@ -79,6 +79,7 @@ import MediaItemThumb from "@/components/MediaItemThumb.vue";
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
 import { useShows } from "@/composables/ai-radio/useShows";
+import { serverNow } from "@/composables/useServerTime";
 import { errorMessage } from "@/helpers/ai_radio";
 import { formatDuration } from "@/helpers/utils";
 import api from "@/plugins/api";
@@ -145,7 +146,8 @@ const isStopping = computed(
     stoppingSessionId.value === onAirSession.value.session_id,
 );
 
-const nowMs = ref(Date.now());
+// on the server's clock, since the session start time comes from the server
+const nowMs = ref(serverNow() * 1000);
 let elapsedTimer: ReturnType<typeof setInterval> | null = null;
 
 const elapsedLabel = computed(() => {
@@ -173,7 +175,7 @@ async function onStop() {
 
 onMounted(() => {
   elapsedTimer = setInterval(() => {
-    nowMs.value = Date.now();
+    nowMs.value = serverNow() * 1000;
   }, 1000);
 });
 

--- a/src/components/music-quiz/game-types/guess-the-song/useGuessTheSongPlaybackPosition.ts
+++ b/src/components/music-quiz/game-types/guess-the-song/useGuessTheSongPlaybackPosition.ts
@@ -1,3 +1,4 @@
+import { serverNow } from "@/composables/useServerTime";
 import {
   onScopeDispose,
   ref,
@@ -57,7 +58,8 @@ export function useGuessTheSongPlaybackPosition(
       return;
     }
 
-    const elapsed = Math.max(0, Date.now() / 1000 - startedAt);
+    // `startedAt` is on the server's clock, so the position is measured against it too
+    const elapsed = Math.max(0, serverNow() - startedAt);
     const duration = toValue(options.duration);
     position.value =
       typeof duration === "number" && duration > 0

--- a/src/composables/music-quiz/useMusicQuizAnswerDeadline.ts
+++ b/src/composables/music-quiz/useMusicQuizAnswerDeadline.ts
@@ -1,3 +1,4 @@
+import { serverNow } from "@/composables/useServerTime";
 import {
   computed,
   onScopeDispose,
@@ -71,7 +72,9 @@ export function useMusicQuizAnswerDeadline(
       return;
     }
 
-    const remaining = deadline - Date.now() / 1000;
+    // the deadline is on the server's clock: a guest device whose own clock is off would
+    // otherwise count down to the wrong moment, by exactly that error
+    const remaining = deadline - serverNow();
     remainingSeconds.value = Math.max(0, Math.ceil(remaining));
 
     const duration = toValue(options.duration) ?? 0;

--- a/src/composables/useServerTime.ts
+++ b/src/composables/useServerTime.ts
@@ -1,0 +1,199 @@
+/**
+ * Server time.
+ *
+ * The server hands out absolute UTC timestamps (`elapsed_time_last_updated`,
+ * `auto_advance_at`, `audio_started_at`, ...) that a client turns into a position or a
+ * countdown by comparing them against its own clock. That comparison is only as good as
+ * the two clocks agree: a device (or server) whose clock is off by N seconds renders
+ * playback progress and quiz countdowns N seconds wrong, with no upper bound on N.
+ *
+ * `serverNow()` returns the current time on the *server's* clock, so those comparisons
+ * stay correct no matter which of the two clocks is off. Use it instead of
+ * `Date.now() / 1000` whenever the other operand is a server timestamp.
+ *
+ * The estimate comes from SNTP-style round trips of the `time` command: the server's
+ * reading is assumed to be taken halfway between sending the probe and receiving the
+ * reply, which makes the residual error half the round-trip time. Probes are sent in
+ * bursts and the fastest round trip of a burst wins, so a single slow reply cannot skew
+ * the result; the estimate is published from the first sample on and refined from there.
+ *
+ * The anchor is kept against `performance.now()` rather than `Date.now()`, so the
+ * estimate survives the device stepping its own clock (an NTP correction landing
+ * mid-playback) without the rendered position jumping.
+ */
+import { computed, readonly, ref } from "vue";
+
+/** Probes the server clock, resolving with its UTC timestamp in seconds. */
+export type ServerTimeProbe = () => Promise<number>;
+
+// Probes per burst. The first burst is larger because nothing is known yet; refreshes
+// only need enough samples to discard a transient network hiccup.
+const INITIAL_BURST_SIZE = 5;
+const REFRESH_BURST_SIZE = 3;
+const BURST_PROBE_SPACING_MS = 200;
+const REFRESH_INTERVAL_MS = 60_000;
+
+interface ServerTimeAnchor {
+  /** `performance.now()` reading the server timestamp is attributed to. */
+  perfMs: number;
+  /** Server clock reading (UTC seconds) at `perfMs`. */
+  serverSeconds: number;
+  /** Half the round trip of the accepted sample: the residual error of this anchor. */
+  uncertaintySeconds: number;
+}
+
+const anchor = ref<ServerTimeAnchor | undefined>();
+const supported = ref(true);
+let probe: ServerTimeProbe | undefined;
+let refreshTimer: ReturnType<typeof setInterval> | undefined;
+let burstInFlight = false;
+
+/**
+ * The current time on the server's clock, as a UTC timestamp in seconds.
+ *
+ * Falls back to the device clock while no estimate is available (before the first
+ * successful probe, or against a server that predates the `time` command).
+ */
+export function serverNow(): number {
+  const current = anchor.value;
+  if (!current) return Date.now() / 1000;
+  return current.serverSeconds + (performance.now() - current.perfMs) / 1000;
+}
+
+/**
+ * Start estimating the offset between the server clock and this device's clock.
+ *
+ * Safe to call again on every (re)connect: an in-flight burst is not duplicated and the
+ * previous estimate is kept until a new sample replaces it.
+ */
+export function startServerTimeSync(newProbe: ServerTimeProbe): void {
+  probe = newProbe;
+  supported.value = true;
+  if (refreshTimer === undefined) {
+    refreshTimer = setInterval(
+      () => void runBurst(REFRESH_BURST_SIZE),
+      REFRESH_INTERVAL_MS,
+    );
+  }
+  registerVisibilityListeners();
+  void runBurst(anchor.value ? REFRESH_BURST_SIZE : INITIAL_BURST_SIZE);
+}
+
+/**
+ * Stop probing, keeping the last estimate.
+ *
+ * Used while the connection is down: a slightly stale offset still beats no correction,
+ * and clock offsets do not meaningfully change over a reconnect.
+ */
+export function stopServerTimeSync(): void {
+  probe = undefined;
+  if (refreshTimer !== undefined) clearInterval(refreshTimer);
+  refreshTimer = undefined;
+  unregisterVisibilityListeners();
+}
+
+/**
+ * Drop the estimate and stop probing.
+ *
+ * Used when the connection cannot provide one (a server without the `time` command) or
+ * when connecting to a different server, whose clock offset is unrelated.
+ */
+export function resetServerTime(supportedByServer = true): void {
+  stopServerTimeSync();
+  anchor.value = undefined;
+  supported.value = supportedByServer;
+}
+
+/** Reactive view of the offset estimate, for diagnostics. */
+export function useServerTime() {
+  return {
+    serverNow,
+    /** Server clock minus device clock, in seconds. Positive: device is behind. */
+    offsetSeconds: computed(() =>
+      anchor.value ? serverNow() - Date.now() / 1000 : null,
+    ),
+    /** Residual error of the current estimate (half the accepted round trip). */
+    uncertaintySeconds: computed(
+      () => anchor.value?.uncertaintySeconds ?? null,
+    ),
+    isSynced: computed(() => anchor.value !== undefined),
+    /** Whether the connected server can report its clock at all. */
+    isSupported: readonly(supported),
+  };
+}
+
+async function runBurst(size: number): Promise<void> {
+  if (burstInFlight || !probe) return;
+  burstInFlight = true;
+  try {
+    let best: ServerTimeAnchor | undefined;
+    for (let index = 0; index < size; index++) {
+      if (!probe) break;
+      if (index > 0) await delay(BURST_PROBE_SPACING_MS);
+      const sample = await takeSample(probe);
+      if (!sample) continue;
+      if (!best || sample.uncertaintySeconds < best.uncertaintySeconds) {
+        // publish as the burst goes: the first sample already beats no correction, and
+        // each faster round trip refines it, so nothing waits for the burst to finish
+        best = sample;
+        anchor.value = sample;
+      }
+    }
+  } finally {
+    burstInFlight = false;
+  }
+}
+
+async function takeSample(
+  currentProbe: ServerTimeProbe,
+): Promise<ServerTimeAnchor | undefined> {
+  const sentAt = performance.now();
+  let serverSeconds: number;
+  try {
+    serverSeconds = await currentProbe();
+  } catch {
+    // Best-effort: a failed probe leaves the previous estimate in place.
+    return undefined;
+  }
+  const receivedAt = performance.now();
+  if (typeof serverSeconds !== "number" || !Number.isFinite(serverSeconds)) {
+    return undefined;
+  }
+  return {
+    // The server read its clock somewhere between sending and receiving; the midpoint
+    // is the best estimate, and is off by at most half the round trip.
+    perfMs: (sentAt + receivedAt) / 2,
+    serverSeconds,
+    uncertaintySeconds: (receivedAt - sentAt) / 2000,
+  };
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+// A device that was asleep may have resynced (or stepped) its own clock while the page
+// was hidden, and background timers are throttled, so resample as soon as it is back.
+function handleVisibilityChange() {
+  if (document.visibilityState === "visible") void runBurst(REFRESH_BURST_SIZE);
+}
+
+function handleFocus() {
+  void runBurst(REFRESH_BURST_SIZE);
+}
+
+let visibilityListenersRegistered = false;
+
+function registerVisibilityListeners() {
+  if (visibilityListenersRegistered || typeof document === "undefined") return;
+  document.addEventListener("visibilitychange", handleVisibilityChange);
+  window.addEventListener("focus", handleFocus);
+  visibilityListenersRegistered = true;
+}
+
+function unregisterVisibilityListeners() {
+  if (!visibilityListenersRegistered) return;
+  document.removeEventListener("visibilitychange", handleVisibilityChange);
+  window.removeEventListener("focus", handleFocus);
+  visibilityListenersRegistered = false;
+}

--- a/src/composables/useServerTime.ts
+++ b/src/composables/useServerTime.ts
@@ -128,9 +128,11 @@ async function runBurst(size: number): Promise<void> {
   try {
     let best: ServerTimeAnchor | undefined;
     for (let index = 0; index < size; index++) {
-      if (!probe) break;
       if (index > 0) await delay(BURST_PROBE_SPACING_MS);
-      const sample = await takeSample(probe);
+      // read after the delay: sync may have stopped while this burst was waiting
+      const currentProbe = probe;
+      if (!currentProbe) break;
+      const sample = await takeSample(currentProbe);
       if (!sample) continue;
       if (!best || sample.uncertaintySeconds < best.uncertaintySeconds) {
         // publish as the burst goes: the first sample already beats no correction, and

--- a/src/composables/useServerTime.ts
+++ b/src/composables/useServerTime.ts
@@ -21,7 +21,7 @@
  * estimate survives the device stepping its own clock (an NTP correction landing
  * mid-playback) without the rendered position jumping.
  */
-import { computed, readonly, ref } from "vue";
+import { computed, ref } from "vue";
 
 /** Probes the server clock, resolving with its UTC timestamp in seconds. */
 export type ServerTimeProbe = () => Promise<number>;
@@ -32,6 +32,9 @@ const INITIAL_BURST_SIZE = 5;
 const REFRESH_BURST_SIZE = 3;
 const BURST_PROBE_SPACING_MS = 200;
 const REFRESH_INTERVAL_MS = 60_000;
+// A command sent as the connection drops is never answered and never rejected, so a
+// probe needs its own deadline; without one it would stall every later refresh.
+const PROBE_TIMEOUT_MS = 2000;
 
 interface ServerTimeAnchor {
   /** `performance.now()` reading the server timestamp is attributed to. */
@@ -43,16 +46,18 @@ interface ServerTimeAnchor {
 }
 
 const anchor = ref<ServerTimeAnchor | undefined>();
-const supported = ref(true);
 let probe: ServerTimeProbe | undefined;
 let refreshTimer: ReturnType<typeof setInterval> | undefined;
-let burstInFlight = false;
+// bumped whenever probing stops, so a burst that is mid-flight abandons its remaining
+// probes instead of publishing samples taken across a reconnect
+let epoch = 0;
+let runningEpoch: number | undefined;
 
 /**
  * The current time on the server's clock, as a UTC timestamp in seconds.
  *
- * Falls back to the device clock while no estimate is available (before the first
- * successful probe, or against a server that predates the `time` command).
+ * Falls back to the device clock while no estimate is available: before the first
+ * probe lands, or when probing fails.
  */
 export function serverNow(): number {
   const current = anchor.value;
@@ -68,7 +73,6 @@ export function serverNow(): number {
  */
 export function startServerTimeSync(newProbe: ServerTimeProbe): void {
   probe = newProbe;
-  supported.value = true;
   if (refreshTimer === undefined) {
     refreshTimer = setInterval(
       () => void runBurst(REFRESH_BURST_SIZE),
@@ -87,6 +91,7 @@ export function startServerTimeSync(newProbe: ServerTimeProbe): void {
  */
 export function stopServerTimeSync(): void {
   probe = undefined;
+  epoch += 1;
   if (refreshTimer !== undefined) clearInterval(refreshTimer);
   refreshTimer = undefined;
   unregisterVisibilityListeners();
@@ -95,13 +100,12 @@ export function stopServerTimeSync(): void {
 /**
  * Drop the estimate and stop probing.
  *
- * Used when the connection cannot provide one (a server without the `time` command) or
- * when connecting to a different server, whose clock offset is unrelated.
+ * Used when disconnecting: the next connection may be to a different server, whose
+ * clock offset is unrelated to this one's.
  */
-export function resetServerTime(supportedByServer = true): void {
+export function resetServerTime(): void {
   stopServerTimeSync();
   anchor.value = undefined;
-  supported.value = supportedByServer;
 }
 
 /** Reactive view of the offset estimate, for diagnostics. */
@@ -117,22 +121,22 @@ export function useServerTime() {
       () => anchor.value?.uncertaintySeconds ?? null,
     ),
     isSynced: computed(() => anchor.value !== undefined),
-    /** Whether the connected server can report its clock at all. */
-    isSupported: readonly(supported),
   };
 }
 
 async function runBurst(size: number): Promise<void> {
-  if (burstInFlight || !probe) return;
-  burstInFlight = true;
+  if (runningEpoch === epoch || !probe) return;
+  const burstEpoch = epoch;
+  runningEpoch = burstEpoch;
   try {
     let best: ServerTimeAnchor | undefined;
     for (let index = 0; index < size; index++) {
       if (index > 0) await delay(BURST_PROBE_SPACING_MS);
-      // read after the delay: sync may have stopped while this burst was waiting
+      // re-read after the delay: probing may have stopped while this burst was waiting
       const currentProbe = probe;
-      if (!currentProbe) break;
+      if (burstEpoch !== epoch || !currentProbe) return;
       const sample = await takeSample(currentProbe);
+      if (burstEpoch !== epoch) return;
       if (!sample) continue;
       if (!best || sample.uncertaintySeconds < best.uncertaintySeconds) {
         // publish as the burst goes: the first sample already beats no correction, and
@@ -142,7 +146,7 @@ async function runBurst(size: number): Promise<void> {
       }
     }
   } finally {
-    burstInFlight = false;
+    if (runningEpoch === burstEpoch) runningEpoch = undefined;
   }
 }
 
@@ -150,13 +154,11 @@ async function takeSample(
   currentProbe: ServerTimeProbe,
 ): Promise<ServerTimeAnchor | undefined> {
   const sentAt = performance.now();
-  let serverSeconds: number;
-  try {
-    serverSeconds = await currentProbe();
-  } catch {
-    // Best-effort: a failed probe leaves the previous estimate in place.
-    return undefined;
-  }
+  // Best-effort: a probe that fails or never answers leaves the previous estimate in place.
+  const serverSeconds = await Promise.race([
+    currentProbe().catch(() => undefined),
+    delay(PROBE_TIMEOUT_MS).then(() => undefined),
+  ]);
   const receivedAt = performance.now();
   if (typeof serverSeconds !== "number" || !Number.isFinite(serverSeconds)) {
     return undefined;

--- a/src/helpers/elapsed.ts
+++ b/src/helpers/elapsed.ts
@@ -3,7 +3,7 @@
  *
  * Calculate the current elapsed playback time in seconds from a stored
  * `elapsed_time` value and the `elapsed_time_last_updated` UTC timestamp
- * (seconds since epoch). The function assumes:
+ * (seconds since epoch), on the server's clock. The function assumes:
  *  - elapsed_time: seconds (may be fractional)
  *  - elapsed_time_last_updated: seconds since epoch (UTC)
  *  - playback_speed: multiplier applied to the wall-clock delta (default 1)
@@ -12,6 +12,7 @@
  * `elapsed_time` without applying the time-delta. This avoids advancing the
  * position while paused/stopped.
  */
+import { serverNow } from "@/composables/useServerTime";
 import { PlaybackState } from "../plugins/api/interfaces";
 
 export function computeElapsedTime(
@@ -28,15 +29,12 @@ export function computeElapsedTime(
   if (playbackState !== undefined && playbackState !== PlaybackState.PLAYING) {
     return elapsed_time;
   }
-  // The server sends `elapsed_time_last_updated` in seconds since epoch.
-  // Convert to milliseconds for Date.now() math.
-  const lastUpdatedMs = elapsed_time_last_updated * 1000;
+  // `elapsed_time_last_updated` is on the server's clock, so the delta is measured
+  // against the server's clock too: on a device whose own clock is off, comparing the
+  // two directly would offset the position by exactly that error.
+  const delta = Math.max(0, serverNow() - elapsed_time_last_updated);
 
-  const nowMs = Date.now();
-  const deltaMs = Math.max(0, nowMs - lastUpdatedMs);
-  const deltaSeconds = (deltaMs / 1000) * playback_speed;
-
-  return elapsed_time + deltaSeconds;
+  return elapsed_time + delta * playback_speed;
 }
 
 export default computeElapsedTime;

--- a/src/layouts/default/PlayerOSD/PlayerControlBtn/SleepTimerBtn.vue
+++ b/src/layouts/default/PlayerOSD/PlayerControlBtn/SleepTimerBtn.vue
@@ -37,6 +37,7 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
+import { serverNow } from "@/composables/useServerTime";
 import { getSleepTimerMenuItems } from "@/helpers/sleep_timer";
 import { formatDuration } from "@/helpers/utils";
 import { eventbus } from "@/plugins/eventbus";
@@ -62,8 +63,9 @@ withDefaults(
 const pillClass = "relative";
 
 // Reactive clock that ticks every second while a timer is active, driving the
-// countdown and the auto-hide when it reaches zero.
-const now = ref(Date.now() / 1000);
+// countdown and the auto-hide when it reaches zero. On the server's clock, since
+// `sleep_timer_expires_at` is a server timestamp.
+const now = ref(serverNow());
 
 const expiresAt = computed(
   () => store.activePlayer?.sleep_timer_expires_at ?? null,
@@ -86,7 +88,7 @@ watch(
   active,
   (isActive) => {
     if (isActive && !ticker) {
-      ticker = setInterval(() => (now.value = Date.now() / 1000), 1000);
+      ticker = setInterval(() => (now.value = serverNow()), 1000);
     } else if (!isActive) {
       stopTicking();
     }

--- a/src/plugins/api/index.ts
+++ b/src/plugins/api/index.ts
@@ -2,6 +2,12 @@ import { store } from "../store";
 
 import { computed, reactive, ref } from "vue";
 import { toast } from "vue-sonner";
+import {
+  resetServerTime,
+  serverNow,
+  startServerTimeSync,
+  stopServerTimeSync,
+} from "@/composables/useServerTime";
 import { $t, i18n } from "../i18n";
 import type { ITransport } from "../remote/transport";
 import { WebSocketTransport } from "../remote/websocket-transport";
@@ -66,6 +72,9 @@ const DEBUG = process.env.NODE_ENV === "development";
 
 // Server-side string localization + the translations/set_locale command landed in API schema 32.
 const TRANSLATIONS_SCHEMA_VERSION = 32;
+
+// The `time` command (used to estimate the server/device clock offset) landed in schema 42.
+const SERVER_TIME_SCHEMA_VERSION = 42;
 
 export enum ConnectionState {
   DISCONNECTED = "disconnected", // Not connected
@@ -208,6 +217,9 @@ export class MusicAssistantApi {
       if (state === "reconnecting") {
         // Transport is attempting to reconnect
         this.state.value = ConnectionState.RECONNECTING;
+        // pause probing but keep the estimate: clock offsets don't change over a
+        // reconnect, and a slightly stale offset still beats no correction
+        stopServerTimeSync();
         this.signalEvent({
           event: EventType.DISCONNECTED,
           object_id: "",
@@ -392,6 +404,8 @@ export class MusicAssistantApi {
     }
     this.state.value = ConnectionState.DISCONNECTED;
     this.isRemoteConnection.value = false;
+    // the next connection may be to a different server, whose clock offset is unrelated
+    resetServerTime();
 
     // Clear reactive state
     Object.keys(this.players).forEach((key) => delete this.players[key]);
@@ -2536,7 +2550,10 @@ export class MusicAssistantApi {
     } else if (msg.event == EventType.QUEUE_TIME_UPDATED) {
       const queueId = msg.object_id as string;
       if (queueId in this.queues) {
-        const now = Date.now() / 1000;
+        // this event carries the elapsed time without a timestamp, so it is anchored
+        // here on arrival; in server time, to stay comparable with the timestamps that
+        // full queue updates carry.
+        const now = serverNow();
         const elapsed = msg.data as unknown as number;
         if (queueId in this.queueElapsedTime) {
           this.queueElapsedTime[queueId].elapsed_time = elapsed;
@@ -2648,10 +2665,37 @@ export class MusicAssistantApi {
     // so it also works on the Ingress path where the frontend skips the auth command.
     // best-effort, fire-and-forget: a transport failure here shouldn't break the connect flow
     void this.setLocale(i18n.global.locale.value).catch(() => undefined);
+    // (re)estimate the offset between the server clock and this device's clock, so
+    // server timestamps render correctly even when one of the two clocks is unsynced.
+    // The command needs no authentication, so this also covers the pre-auth phase.
+    if (this.supportsServerTime) {
+      startServerTimeSync(() => this.getServerTime());
+    } else {
+      resetServerTime(false);
+    }
     this.signalEvent({
       event: EventType.CONNECTED,
       object_id: "",
       data: msg,
+    });
+  }
+
+  /** Whether the connected server can report its own clock (schema >= 42). */
+  public get supportsServerTime(): boolean {
+    return (
+      (this.serverInfo.value?.schema_version ?? 0) >= SERVER_TIME_SCHEMA_VERSION
+    );
+  }
+
+  /**
+   * Read the server's clock (UTC timestamp in seconds).
+   *
+   * Prefer `serverNow()` from `useServerTime`, which keeps a corrected local estimate;
+   * this command is the probe that estimate is built from.
+   */
+  public async getServerTime(): Promise<number> {
+    return await this.sendCommand<number>("time", undefined, {
+      suppressGlobalError: true,
     });
   }
 

--- a/src/plugins/api/index.ts
+++ b/src/plugins/api/index.ts
@@ -214,8 +214,9 @@ export class MusicAssistantApi {
       if (state === "reconnecting") {
         // Transport is attempting to reconnect
         this.state.value = ConnectionState.RECONNECTING;
-        // pause probing but keep the estimate: clock offsets don't change over a
-        // reconnect, and a slightly stale offset still beats no correction
+        // pause probing but keep the estimate: clock offsets don't change while the
+        // connection is down, and a slightly stale offset still beats no correction.
+        // A new ServerInfo message resumes it once the connection is back.
         stopServerTimeSync();
         this.signalEvent({
           event: EventType.DISCONNECTED,
@@ -228,6 +229,7 @@ export class MusicAssistantApi {
           if (this.transportState.value === "failed") {
             // Still failed after brief wait - this is permanent failure
             this.state.value = ConnectionState.FAILED;
+            stopServerTimeSync();
             this.signalEvent({
               event: EventType.DISCONNECTED,
               object_id: "",
@@ -241,6 +243,7 @@ export class MusicAssistantApi {
         setTimeout(() => {
           if (this.transportState.value === "disconnected") {
             this.state.value = ConnectionState.DISCONNECTED;
+            stopServerTimeSync();
             this.signalEvent({
               event: EventType.DISCONNECTED,
               object_id: "",

--- a/src/plugins/api/index.ts
+++ b/src/plugins/api/index.ts
@@ -73,9 +73,6 @@ const DEBUG = process.env.NODE_ENV === "development";
 // Server-side string localization + the translations/set_locale command landed in API schema 32.
 const TRANSLATIONS_SCHEMA_VERSION = 32;
 
-// The `time` command (used to estimate the server/device clock offset) landed in schema 42.
-const SERVER_TIME_SCHEMA_VERSION = 42;
-
 export enum ConnectionState {
   DISCONNECTED = "disconnected", // Not connected
   CONNECTING = "connecting", // Establishing connection
@@ -2668,23 +2665,12 @@ export class MusicAssistantApi {
     // (re)estimate the offset between the server clock and this device's clock, so
     // server timestamps render correctly even when one of the two clocks is unsynced.
     // The command needs no authentication, so this also covers the pre-auth phase.
-    if (this.supportsServerTime) {
-      startServerTimeSync(() => this.getServerTime());
-    } else {
-      resetServerTime(false);
-    }
+    startServerTimeSync(() => this.getServerTime());
     this.signalEvent({
       event: EventType.CONNECTED,
       object_id: "",
       data: msg,
     });
-  }
-
-  /** Whether the connected server can report its own clock (schema >= 42). */
-  public get supportsServerTime(): boolean {
-    return (
-      (this.serverInfo.value?.schema_version ?? 0) >= SERVER_TIME_SCHEMA_VERSION
-    );
   }
 
   /**

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -137,6 +137,7 @@
         "server_version": "Server version",
         "server_base_url": "Base URL",
         "server_as_addon": "Home Assistant add-on",
+        "server_clock_offset": "Clock offset (server vs this device)",
         "artists_in_library": "Artists in library",
         "albums_in_library": "Albums in library",
         "tracks_in_library": "Tracks in library",

--- a/src/views/settings/About.vue
+++ b/src/views/settings/About.vue
@@ -36,12 +36,7 @@
           </ItemContent>
         </Item>
 
-        <Item
-          v-if="api.supportsServerTime"
-          variant="outline"
-          size="sm"
-          class="justify-between"
-        >
+        <Item variant="outline" size="sm" class="justify-between">
           <ItemContent>
             <ItemTitle>{{ $t("settings.server_clock_offset") }}</ItemTitle>
           </ItemContent>

--- a/src/views/settings/About.vue
+++ b/src/views/settings/About.vue
@@ -36,6 +36,25 @@
           </ItemContent>
         </Item>
 
+        <Item
+          v-if="api.supportsServerTime"
+          variant="outline"
+          size="sm"
+          class="justify-between"
+        >
+          <ItemContent>
+            <ItemTitle>{{ $t("settings.server_clock_offset") }}</ItemTitle>
+          </ItemContent>
+          <ItemContent class="flex-none text-right">
+            <Badge v-if="clockOffsetIsLarge" variant="destructive">
+              {{ clockOffsetLabel }}
+            </Badge>
+            <span v-else class="text-xs font-mono text-muted-foreground">
+              {{ clockOffsetLabel }}
+            </span>
+          </ItemContent>
+        </Item>
+
         <Item variant="outline" size="sm" class="justify-between">
           <ItemContent>
             <ItemTitle>{{ $t("settings.server_as_addon") }}</ItemTitle>
@@ -355,9 +374,33 @@ import {
   CardTitle,
 } from "@/components/ui/card";
 import { Item, ItemContent, ItemTitle } from "@/components/ui/item";
+import { useServerTime } from "@/composables/useServerTime";
 import { api } from "@/plugins/api";
 import { store } from "@/plugins/store";
 import { computed, onMounted } from "vue";
+
+// Above this, the offset is a real misconfiguration on one of the two machines rather
+// than measurement noise, and worth calling out: it also affects things the frontend
+// cannot correct for, such as token expiry and scheduled tasks.
+const LARGE_CLOCK_OFFSET_SECONDS = 10;
+
+const { offsetSeconds: clockOffsetSeconds } = useServerTime();
+
+const clockOffsetIsLarge = computed(
+  () =>
+    clockOffsetSeconds.value !== null &&
+    Math.abs(clockOffsetSeconds.value) >= LARGE_CLOCK_OFFSET_SECONDS,
+);
+
+const clockOffsetLabel = computed(() => {
+  const offset = clockOffsetSeconds.value;
+  if (offset === null) return "—";
+  const sign = offset < 0 ? "-" : "+";
+  const magnitude = Math.abs(offset);
+  return magnitude < 1
+    ? `${sign}${Math.round(magnitude * 1000)} ms`
+    : `${sign}${magnitude.toFixed(1)} s`;
+});
 
 const changelogUrl = computed(() => {
   return "https://github.com/music-assistant/server/releases";

--- a/tests/composables/useMusicQuizAnswerDeadline.test.ts
+++ b/tests/composables/useMusicQuizAnswerDeadline.test.ts
@@ -2,10 +2,20 @@ import { useMusicQuizAnswerDeadline } from "@/composables/music-quiz/useMusicQui
 import { effectScope, nextTick, ref, type Ref } from "vue";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+// Offset between the server clock and this device's, as useServerTime would estimate it.
+const { clockOffsetSeconds } = vi.hoisted(() => ({
+  clockOffsetSeconds: { value: 0 },
+}));
+
+vi.mock("@/composables/useServerTime", () => ({
+  serverNow: () => Date.now() / 1000 + clockOffsetSeconds.value,
+}));
+
 describe("useMusicQuizAnswerDeadline", () => {
   beforeEach(() => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-01-01T00:00:00Z"));
+    clockOffsetSeconds.value = 0;
   });
 
   afterEach(() => {
@@ -48,6 +58,24 @@ describe("useMusicQuizAnswerDeadline", () => {
     expect(clock.remainingSeconds.value).toBeNull();
     expect(clock.remainingFraction.value).toBeNull();
     expect(clock.remainingLabel.value).toBe("");
+    scope.stop();
+  });
+
+  it("counts down on the server clock, not the device clock", () => {
+    // this device's clock runs 20s behind the server's, so an uncorrected countdown
+    // would show 50s left on a 30s deadline
+    clockOffsetSeconds.value = 20;
+    const active = ref(true);
+    const deadline = ref(Date.now() / 1000 + 50);
+    const duration = ref(30);
+    const { clock, scope } = createClock(active, deadline, duration);
+
+    expect(clock.remainingSeconds.value).toBe(30);
+    expect(clock.remainingFraction.value).toBe(1);
+
+    vi.advanceTimersByTime(30_000);
+
+    expect(clock.remainingSeconds.value).toBe(0);
     scope.stop();
   });
 

--- a/tests/composables/useServerTime.test.ts
+++ b/tests/composables/useServerTime.test.ts
@@ -1,0 +1,137 @@
+import {
+  resetServerTime,
+  serverNow,
+  startServerTimeSync,
+  useServerTime,
+} from "@/composables/useServerTime";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const BURST_SPACING_MS = 200;
+const INITIAL_BURST_SIZE = 5;
+const REFRESH_INTERVAL_MS = 60_000;
+
+// The device clock runs 30 seconds ahead of the server's in these tests.
+const DEVICE_NOW_MS = Date.parse("2026-01-01T00:00:30Z");
+const DEVICE_CLOCK_ERROR_SECONDS = 30;
+
+describe("useServerTime", () => {
+  let perfNow: number;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(DEVICE_NOW_MS);
+    perfNow = 1000;
+    // vitest does not fake performance.now(), which the offset estimate is anchored on
+    vi.spyOn(performance, "now").mockImplementation(() => perfNow);
+  });
+
+  afterEach(() => {
+    resetServerTime();
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it("falls back to the device clock until a sample lands", () => {
+    expect(serverNow()).toBeCloseTo(DEVICE_NOW_MS / 1000, 6);
+    expect(useServerTime().isSynced.value).toBe(false);
+    expect(useServerTime().offsetSeconds.value).toBeNull();
+  });
+
+  it("anchors on the fastest round trip of the burst", async () => {
+    // round trips in ms per probe; the 40ms one should win
+    const roundTrips = [500, 300, 40, 260, 700];
+    const probe = vi.fn(() => {
+      const roundTrip = roundTrips[probe.mock.calls.length - 1];
+      // the server read its clock halfway through the round trip
+      const serverSeconds = serverClockNow() + roundTrip / 2000;
+      spendTime(roundTrip);
+      return Promise.resolve(serverSeconds);
+    });
+
+    startServerTimeSync(probe);
+    // the first sample already corrects the clock; the burst only refines it
+    await advanceTime(0);
+    expect(useServerTime().isSynced.value).toBe(true);
+    expect(useServerTime().uncertaintySeconds.value).toBeCloseTo(0.25, 6);
+
+    await flushBurst(INITIAL_BURST_SIZE);
+
+    const { offsetSeconds, uncertaintySeconds, isSynced } = useServerTime();
+    expect(probe).toHaveBeenCalledTimes(INITIAL_BURST_SIZE);
+    expect(isSynced.value).toBe(true);
+    // uncertainty is half of the accepted round trip
+    expect(uncertaintySeconds.value).toBeCloseTo(0.02, 6);
+    // the device clock runs ahead, so the correction is negative
+    expect(offsetSeconds.value).toBeCloseTo(-DEVICE_CLOCK_ERROR_SECONDS, 3);
+  });
+
+  it("advances with the monotonic clock, not the device clock", async () => {
+    startServerTimeSync(() => Promise.resolve(serverClockNow()));
+    await flushBurst(INITIAL_BURST_SIZE);
+
+    const before = serverNow();
+    // the device steps its own clock (an NTP correction landing mid-playback)
+    vi.setSystemTime(DEVICE_NOW_MS + 3_600_000);
+    perfNow += 5000;
+
+    expect(serverNow() - before).toBeCloseTo(5, 6);
+  });
+
+  it("keeps the previous estimate when probes start failing", async () => {
+    let failing = false;
+    startServerTimeSync(() =>
+      failing
+        ? Promise.reject(new Error("Connection lost"))
+        : Promise.resolve(serverClockNow()),
+    );
+    await flushBurst(INITIAL_BURST_SIZE);
+    const estimate = useServerTime().offsetSeconds.value;
+
+    failing = true;
+    await advanceTime(REFRESH_INTERVAL_MS);
+    await flushBurst(INITIAL_BURST_SIZE);
+
+    expect(useServerTime().isSynced.value).toBe(true);
+    expect(useServerTime().offsetSeconds.value).toBeCloseTo(estimate!, 6);
+  });
+
+  it("stops probing and drops the estimate on reset", async () => {
+    const probe = vi.fn(() => Promise.resolve(serverClockNow()));
+    startServerTimeSync(probe);
+    await flushBurst(INITIAL_BURST_SIZE);
+    expect(useServerTime().isSynced.value).toBe(true);
+
+    resetServerTime(false);
+    const callsAfterReset = probe.mock.calls.length;
+    await advanceTime(REFRESH_INTERVAL_MS * 2);
+
+    expect(probe).toHaveBeenCalledTimes(callsAfterReset);
+    expect(useServerTime().isSynced.value).toBe(false);
+    expect(useServerTime().isSupported.value).toBe(false);
+    expect(serverNow()).toBeCloseTo(Date.now() / 1000, 6);
+  });
+
+  /** The server's clock, which this device's clock runs ahead of. */
+  function serverClockNow() {
+    return Date.now() / 1000 - DEVICE_CLOCK_ERROR_SECONDS;
+  }
+
+  /** Burn wall-clock time without waiting on a timer (a round trip in flight). */
+  function spendTime(ms: number) {
+    perfNow += ms;
+    vi.setSystemTime(Date.now() + ms);
+  }
+
+  /** Advance time, keeping the monotonic and device clocks in step. */
+  async function advanceTime(ms: number) {
+    perfNow += ms;
+    await vi.advanceTimersByTimeAsync(ms);
+  }
+
+  /** Let a burst run to completion: each probe after the first waits out the spacing. */
+  async function flushBurst(size: number) {
+    for (let index = 0; index < size; index++) {
+      await advanceTime(BURST_SPACING_MS);
+    }
+  }
+});

--- a/tests/composables/useServerTime.test.ts
+++ b/tests/composables/useServerTime.test.ts
@@ -8,21 +8,27 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const BURST_SPACING_MS = 200;
 const INITIAL_BURST_SIZE = 5;
+const REFRESH_BURST_SIZE = 3;
 const REFRESH_INTERVAL_MS = 60_000;
+const PROBE_TIMEOUT_MS = 2000;
 
 // The device clock runs 30 seconds ahead of the server's in these tests.
 const DEVICE_NOW_MS = Date.parse("2026-01-01T00:00:30Z");
 const DEVICE_CLOCK_ERROR_SECONDS = 30;
 
 describe("useServerTime", () => {
-  let perfNow: number;
+  // offset of the monotonic clock against the (fake) device clock; only a device that
+  // steps its own clock makes the two diverge
+  let perfDrift: number;
 
   beforeEach(() => {
     vi.useFakeTimers();
     vi.setSystemTime(DEVICE_NOW_MS);
-    perfNow = 1000;
+    perfDrift = 0;
     // vitest does not fake performance.now(), which the offset estimate is anchored on
-    vi.spyOn(performance, "now").mockImplementation(() => perfNow);
+    vi.spyOn(performance, "now").mockImplementation(
+      () => Date.now() - DEVICE_NOW_MS + 1000 + perfDrift,
+    );
   });
 
   afterEach(() => {
@@ -70,9 +76,12 @@ describe("useServerTime", () => {
     await flushBurst(INITIAL_BURST_SIZE);
 
     const before = serverNow();
-    // the device steps its own clock (an NTP correction landing mid-playback)
-    vi.setSystemTime(DEVICE_NOW_MS + 3_600_000);
-    perfNow += 5000;
+    // the device steps its own clock an hour forward (an NTP correction landing
+    // mid-playback); the monotonic clock is untouched by that step
+    const stepMs = 3_600_000;
+    perfDrift -= stepMs;
+    vi.setSystemTime(Date.now() + stepMs);
+    await advanceTime(5000);
 
     expect(serverNow() - before).toBeCloseTo(5, 6);
   });
@@ -95,19 +104,42 @@ describe("useServerTime", () => {
     expect(useServerTime().offsetSeconds.value).toBeCloseTo(estimate!, 6);
   });
 
+  it("keeps refreshing after a probe that never answers", async () => {
+    // a command sent as the connection drops is never answered and never rejected
+    let stranded = true;
+    const probe = vi.fn(
+      () =>
+        new Promise<number>((resolve) => {
+          if (!stranded) resolve(serverClockNow());
+        }),
+    );
+    startServerTimeSync(probe);
+    await advanceTime(PROBE_TIMEOUT_MS + BURST_SPACING_MS);
+    expect(useServerTime().isSynced.value).toBe(false);
+
+    stranded = false;
+    await advanceTime(REFRESH_INTERVAL_MS);
+    await flushBurst(REFRESH_BURST_SIZE);
+
+    expect(useServerTime().isSynced.value).toBe(true);
+    expect(useServerTime().offsetSeconds.value).toBeCloseTo(
+      -DEVICE_CLOCK_ERROR_SECONDS,
+      3,
+    );
+  });
+
   it("stops probing and drops the estimate on reset", async () => {
     const probe = vi.fn(() => Promise.resolve(serverClockNow()));
     startServerTimeSync(probe);
     await flushBurst(INITIAL_BURST_SIZE);
     expect(useServerTime().isSynced.value).toBe(true);
 
-    resetServerTime(false);
+    resetServerTime();
     const callsAfterReset = probe.mock.calls.length;
     await advanceTime(REFRESH_INTERVAL_MS * 2);
 
     expect(probe).toHaveBeenCalledTimes(callsAfterReset);
     expect(useServerTime().isSynced.value).toBe(false);
-    expect(useServerTime().isSupported.value).toBe(false);
     expect(serverNow()).toBeCloseTo(Date.now() / 1000, 6);
   });
 
@@ -118,13 +150,11 @@ describe("useServerTime", () => {
 
   /** Burn wall-clock time without waiting on a timer (a round trip in flight). */
   function spendTime(ms: number) {
-    perfNow += ms;
     vi.setSystemTime(Date.now() + ms);
   }
 
-  /** Advance time, keeping the monotonic and device clocks in step. */
+  /** Advance time, letting any timer due in that window fire. */
   async function advanceTime(ms: number) {
-    perfNow += ms;
     await vi.advanceTimersByTimeAsync(ms);
   }
 

--- a/tests/plugins/api/server-time.test.ts
+++ b/tests/plugins/api/server-time.test.ts
@@ -54,6 +54,8 @@ describe("api server time sync", () => {
   beforeEach(() => {
     vi.useFakeTimers();
     vi.setSystemTime(DEVICE_NOW_MS);
+    // vitest does not fake performance.now(), which the offset estimate is anchored on
+    vi.spyOn(performance, "now").mockReturnValue(1000);
     api = new MusicAssistantApi();
   });
 
@@ -61,6 +63,7 @@ describe("api server time sync", () => {
     api.disconnect();
     resetServerTime();
     vi.useRealTimers();
+    vi.restoreAllMocks();
   });
 
   it("corrects the clock offset after connecting to a server that reports its time", async () => {

--- a/tests/plugins/api/server-time.test.ts
+++ b/tests/plugins/api/server-time.test.ts
@@ -7,11 +7,11 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 const DEVICE_NOW_MS = Date.parse("2026-01-01T00:00:45Z");
 const SERVER_CLOCK_ERROR_SECONDS = 45;
 
-/** Transport that replies to `time` and records every command the client sends. */
+/** Transport that answers `time` and records every command the client sends. */
 class FakeTransport extends BaseTransport {
   public commands: string[] = [];
 
-  constructor(private schemaVersion: number) {
+  constructor(private failsTimeCommand = false) {
     super();
   }
 
@@ -23,7 +23,7 @@ class FakeTransport extends BaseTransport {
       JSON.stringify({
         server_id: "test-server",
         server_version: "2.99.0",
-        schema_version: this.schemaVersion,
+        schema_version: 42,
         min_supported_schema_version: 28,
         base_url: "http://localhost:8095",
       }),
@@ -40,10 +40,18 @@ class FakeTransport extends BaseTransport {
     if (msg.command !== "time") return;
     this.emit(
       "message",
-      JSON.stringify({
-        message_id: msg.message_id,
-        result: Date.now() / 1000 - SERVER_CLOCK_ERROR_SECONDS,
-      }),
+      JSON.stringify(
+        this.failsTimeCommand
+          ? {
+              message_id: msg.message_id,
+              error_code: "invalid_command",
+              details: "Invalid command: time",
+            }
+          : {
+              message_id: msg.message_id,
+              result: Date.now() / 1000 - SERVER_CLOCK_ERROR_SECONDS,
+            },
+      ),
     );
   }
 }
@@ -66,12 +74,11 @@ describe("api server time sync", () => {
     vi.restoreAllMocks();
   });
 
-  it("corrects the clock offset after connecting to a server that reports its time", async () => {
-    const transport = new FakeTransport(42);
+  it("corrects the clock offset after connecting", async () => {
+    const transport = new FakeTransport();
     await api.initialize(transport);
     await vi.advanceTimersByTimeAsync(0);
 
-    expect(api.supportsServerTime).toBe(true);
     expect(transport.commands).toContain("time");
     expect(serverNow()).toBeCloseTo(
       Date.now() / 1000 - SERVER_CLOCK_ERROR_SECONDS,
@@ -79,13 +86,12 @@ describe("api server time sync", () => {
     );
   });
 
-  it("leaves the device clock alone on a server without the time command", async () => {
-    const transport = new FakeTransport(41);
+  it("leaves the device clock alone when the server cannot report its time", async () => {
+    const transport = new FakeTransport(true);
     await api.initialize(transport);
     await vi.advanceTimersByTimeAsync(0);
 
-    expect(api.supportsServerTime).toBe(false);
-    expect(transport.commands).not.toContain("time");
+    expect(transport.commands).toContain("time");
     expect(serverNow()).toBeCloseTo(Date.now() / 1000, 6);
   });
 });

--- a/tests/plugins/api/server-time.test.ts
+++ b/tests/plugins/api/server-time.test.ts
@@ -1,0 +1,88 @@
+import { resetServerTime, serverNow } from "@/composables/useServerTime";
+import { MusicAssistantApi } from "@/plugins/api";
+import { BaseTransport, TransportState } from "@/plugins/remote/transport";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// The server clock runs 45 seconds behind this device's.
+const DEVICE_NOW_MS = Date.parse("2026-01-01T00:00:45Z");
+const SERVER_CLOCK_ERROR_SECONDS = 45;
+
+/** Transport that replies to `time` and records every command the client sends. */
+class FakeTransport extends BaseTransport {
+  public commands: string[] = [];
+
+  constructor(private schemaVersion: number) {
+    super();
+  }
+
+  async connect(): Promise<void> {
+    this.setState(TransportState.CONNECTED);
+    this.emit("open");
+    this.emit(
+      "message",
+      JSON.stringify({
+        server_id: "test-server",
+        server_version: "2.99.0",
+        schema_version: this.schemaVersion,
+        min_supported_schema_version: 28,
+        base_url: "http://localhost:8095",
+      }),
+    );
+  }
+
+  disconnect(): void {
+    this.setState(TransportState.DISCONNECTED);
+  }
+
+  send(data: string): void {
+    const msg = JSON.parse(data) as { message_id: string; command: string };
+    this.commands.push(msg.command);
+    if (msg.command !== "time") return;
+    this.emit(
+      "message",
+      JSON.stringify({
+        message_id: msg.message_id,
+        result: Date.now() / 1000 - SERVER_CLOCK_ERROR_SECONDS,
+      }),
+    );
+  }
+}
+
+describe("api server time sync", () => {
+  let api: MusicAssistantApi;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(DEVICE_NOW_MS);
+    api = new MusicAssistantApi();
+  });
+
+  afterEach(() => {
+    api.disconnect();
+    resetServerTime();
+    vi.useRealTimers();
+  });
+
+  it("corrects the clock offset after connecting to a server that reports its time", async () => {
+    const transport = new FakeTransport(42);
+    await api.initialize(transport);
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(api.supportsServerTime).toBe(true);
+    expect(transport.commands).toContain("time");
+    expect(serverNow()).toBeCloseTo(
+      Date.now() / 1000 - SERVER_CLOCK_ERROR_SECONDS,
+      3,
+    );
+  });
+
+  it("leaves the device clock alone on a server without the time command", async () => {
+    const transport = new FakeTransport(41);
+    await api.initialize(transport);
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(api.supportsServerTime).toBe(false);
+    expect(transport.commands).not.toContain("time");
+    expect(serverNow()).toBeCloseTo(Date.now() / 1000, 6);
+  });
+});

--- a/tests/plugins/api/server-time.test.ts
+++ b/tests/plugins/api/server-time.test.ts
@@ -34,6 +34,10 @@ class FakeTransport extends BaseTransport {
     this.setState(TransportState.DISCONNECTED);
   }
 
+  fail(): void {
+    this.setState(TransportState.FAILED);
+  }
+
   send(data: string): void {
     const msg = JSON.parse(data) as { message_id: string; command: string };
     this.commands.push(msg.command);
@@ -84,6 +88,22 @@ describe("api server time sync", () => {
       Date.now() / 1000 - SERVER_CLOCK_ERROR_SECONDS,
       3,
     );
+  });
+
+  it("stops probing once the connection has failed for good", async () => {
+    const transport = new FakeTransport();
+    // a probe on a dead connection cannot succeed and leaves a pending command behind
+    const probe = vi.spyOn(api, "getServerTime");
+    await api.initialize(transport);
+    await vi.advanceTimersByTimeAsync(0);
+
+    transport.fail();
+    await vi.advanceTimersByTimeAsync(100);
+    const probesWhenFailed = probe.mock.calls.length;
+    // long enough for several refresh rounds, which would each probe again
+    await vi.advanceTimersByTimeAsync(5 * 60_000);
+
+    expect(probe).toHaveBeenCalledTimes(probesWhenFailed);
   });
 
   it("leaves the device clock alone when the server cannot report its time", async () => {


### PR DESCRIPTION
The server sends absolute timestamps and the frontend turns them into a position or a countdown by comparing them against the clock of the device it runs on. When one of the two clocks is off — a server that booted without internet, a phone that has not resynced yet — everything derived from those timestamps is off by the same amount: playback progress that jumps on a track change, synced lyrics that drift, a Music Quiz countdown that is unfair to a guest.

The frontend now measures the offset between the two clocks right after connecting (and refreshes it periodically) and renders every server timestamp against the server's clock, so those timings stay correct regardless of which clock has drifted.

- Added a `useServerTime` composable that estimates the offset and exposes a corrected `serverNow()`
- Playback progress, synced lyrics, the mini equaliser and the party view now use it
- Music Quiz countdowns, lyrics timing and the auto-start/reveal timers now use it
- Sleep timer, AI radio on-air duration, setup flow expiry and audio analysis retry labels now use it
- Settings > About shows the measured offset, highlighted when it is more than 10 seconds off

Companion to music-assistant/server#5266, which added the `time` command this uses.
