### PR TITLE
Add missing tests for reconnect, language switching and connection warnings

### DIFF
--- a/tests/App.test.ts
+++ b/tests/App.test.ts
@@ -1,6 +1,6 @@
 import { EventType, ProviderType } from "@/plugins/api/interfaces";
 import { shallowMount, type VueWrapper } from "@vue/test-utils";
-import { nextTick, ref } from "vue";
+import { nextTick } from "vue";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const {
@@ -115,9 +115,10 @@ const {
   };
 });
 
-vi.mock("@/plugins/api", () => {
+vi.mock("@/plugins/api", async () => {
   // App.vue watches api.state, so the mock has to carry a real ref: assignments
   // to a plain { value } would never reach the watcher.
+  const { ref } = await vi.importActual<typeof import("vue")>("vue");
   apiMock.state = ref(apiMock.state.value);
   return {
     api: apiMock,
@@ -186,9 +187,10 @@ vi.mock("@/plugins/remote/http-proxy", () => ({
   },
 }));
 
-vi.mock("@/plugins/i18n", () => {
+vi.mock("@/plugins/i18n", async () => {
   // App.vue watches the UI locale to push it to the server, so the mock has to
   // carry a real ref: assignments to a plain { value } never reach the watcher.
+  const { ref } = await vi.importActual<typeof import("vue")>("vue");
   i18nMock.global.locale = ref(i18nMock.global.locale.value);
   return { i18n: i18nMock };
 });

--- a/tests/App.test.ts
+++ b/tests/App.test.ts
@@ -7,6 +7,7 @@ const {
   apiMock,
   authManagerMock,
   guestType,
+  i18nMock,
   mockInitializeCompanionIntegration,
   mockInitializeWebPlayerModeSync,
   mockProxyEnsureReady,
@@ -70,6 +71,12 @@ const {
     apiMock,
     authManagerMock,
     guestType,
+    i18nMock: {
+      global: {
+        locale: { value: "en" },
+        t: (key: string) => key,
+      },
+    },
     mockInitializeCompanionIntegration: vi.fn(),
     mockInitializeWebPlayerModeSync: vi.fn(),
     mockProxyEnsureReady: vi.fn(),
@@ -179,14 +186,12 @@ vi.mock("@/plugins/remote/http-proxy", () => ({
   },
 }));
 
-vi.mock("@/plugins/i18n", () => ({
-  i18n: {
-    global: {
-      locale: { value: "en" },
-      t: (key: string) => key,
-    },
-  },
-}));
+vi.mock("@/plugins/i18n", () => {
+  // App.vue watches the UI locale to push it to the server, so the mock has to
+  // carry a real ref: assignments to a plain { value } never reach the watcher.
+  i18nMock.global.locale = ref(i18nMock.global.locale.value);
+  return { i18n: i18nMock };
+});
 
 vi.mock("@vueuse/core", () => ({
   useColorMode: () => ({ value: "auto" }),
@@ -245,7 +250,9 @@ describe("App initialization", () => {
     vi.clearAllMocks();
     vi.resetModules();
     guestType.value = null;
+    i18nMock.global.locale.value = "en";
     apiMock.state.value = "authenticated";
+    apiMock.supportsServerSideTranslations = false;
     apiMock.serverInfo.value = {
       onboard_done: true,
       server_id: "server-id",
@@ -279,6 +286,7 @@ describe("App initialization", () => {
     mockPruneStaleProviderFilters.mockResolvedValue(undefined);
     storeMock.currentUser = undefined;
     storeMock.enabledPlugins = new Set<string>();
+    storeMock.isIngressSession = false;
     storeMock.isOnboarding = false;
     webPlayerMock.audioSource = "disabled";
     webPlayerMock.interacted = false;
@@ -560,19 +568,137 @@ describe("App initialization", () => {
     expect(authManagerMock.clearGuestSession).not.toHaveBeenCalled();
     expect(apiMock.requireAuthentication).toHaveBeenCalledOnce();
   });
+
+  it("re-authenticates an ingress session through the proxy on reconnect", async () => {
+    storeMock.isIngressSession = true;
+    wrapper = await mountApp();
+    const ingressUser = {
+      preferences: {},
+      role: "admin",
+      user_id: "ingress-user",
+      username: "ingress-user",
+    };
+    apiMock.getCurrentUserInfo.mockResolvedValue(ingressUser);
+
+    await startReconnect();
+
+    await vi.waitFor(() => {
+      expect(authManagerMock.setCurrentUser).toHaveBeenCalledWith(ingressUser);
+    });
+    expect(apiMock.authenticateWithToken).not.toHaveBeenCalled();
+    expect(apiMock.requireAuthentication).not.toHaveBeenCalled();
+  });
+
+  it("asks for authentication when an ingress reconnect finds no user", async () => {
+    storeMock.isIngressSession = true;
+    wrapper = await mountApp();
+    apiMock.getCurrentUserInfo.mockClear();
+    apiMock.getCurrentUserInfo.mockResolvedValue(null);
+
+    await startReconnect();
+
+    await vi.waitFor(() => {
+      expect(apiMock.requireAuthentication).toHaveBeenCalledOnce();
+    });
+    expect(apiMock.getCurrentUserInfo).toHaveBeenCalledOnce();
+  });
+
+  it("asks for authentication when an ingress reconnect fails", async () => {
+    storeMock.isIngressSession = true;
+    wrapper = await mountApp();
+    apiMock.getCurrentUserInfo.mockClear();
+    apiMock.getCurrentUserInfo.mockRejectedValue(new Error("proxy down"));
+    vi.spyOn(console, "error").mockImplementation(() => {});
+
+    await startReconnect();
+
+    await vi.waitFor(() => {
+      expect(apiMock.requireAuthentication).toHaveBeenCalledOnce();
+    });
+    expect(apiMock.getCurrentUserInfo).toHaveBeenCalledOnce();
+  });
+
+  it("pushes a locale change to a server that localizes its own strings", async () => {
+    apiMock.supportsServerSideTranslations = true;
+    wrapper = await mountAuthenticatedApp();
+
+    i18nMock.global.locale.value = "de";
+
+    await vi.waitFor(() => {
+      expect(apiMock.setLocale).toHaveBeenCalledWith("de");
+    });
+    expect(apiMock.fetchState).toHaveBeenCalledOnce();
+  });
+
+  it("keeps the locale local on a server without server-side translations", async () => {
+    wrapper = await mountAuthenticatedApp();
+
+    i18nMock.global.locale.value = "de";
+    await nextTick();
+
+    expect(apiMock.setLocale).not.toHaveBeenCalled();
+    expect(apiMock.fetchState).not.toHaveBeenCalled();
+  });
+
+  it("skips the state refresh for a guest after a locale change", async () => {
+    apiMock.supportsServerSideTranslations = true;
+    guestType.value = "party";
+    wrapper = await mountAuthenticatedApp();
+
+    i18nMock.global.locale.value = "de";
+
+    await vi.waitFor(() => {
+      expect(apiMock.setLocale).toHaveBeenCalledWith("de");
+    });
+    expect(apiMock.fetchState).not.toHaveBeenCalled();
+  });
+
+  it("survives a failed locale push", async () => {
+    apiMock.supportsServerSideTranslations = true;
+    apiMock.setLocale.mockRejectedValue(new Error("offline"));
+    wrapper = await mountAuthenticatedApp();
+
+    i18nMock.global.locale.value = "de";
+
+    await vi.waitFor(() => {
+      expect(apiMock.setLocale).toHaveBeenCalledWith("de");
+    });
+    expect(apiMock.fetchState).not.toHaveBeenCalled();
+  });
 });
 
 /**
  * Drive the connection through a reconnect, which re-authenticates the token.
  */
 async function reconnect() {
-  apiMock.state.value = "reconnecting";
-  await nextTick();
-  apiMock.state.value = "connected";
+  await startReconnect();
   await vi.waitFor(() => {
     expect(apiMock.authenticateWithToken).toHaveBeenCalled();
   });
   await nextTick();
+}
+
+/**
+ * Take the connection down and back up, without waiting for a particular
+ * re-authentication route.
+ */
+async function startReconnect() {
+  apiMock.state.value = "reconnecting";
+  await nextTick();
+  apiMock.state.value = "connected";
+  await nextTick();
+}
+
+/**
+ * Mount the app and leave it in the authenticated state, with the calls made
+ * during initialization cleared so later assertions only see fresh ones.
+ */
+async function mountAuthenticatedApp() {
+  const mounted = await mountApp();
+  apiMock.state.value = "authenticated";
+  await nextTick();
+  apiMock.fetchState.mockClear();
+  return mounted;
 }
 
 async function mountApp() {

--- a/tests/components/party/PartyQR.test.ts
+++ b/tests/components/party/PartyQR.test.ts
@@ -125,6 +125,22 @@ describe("PartyQR", () => {
     wrapper.unmount();
   });
 
+  it("falls back to generic wording when the party has no config", async () => {
+    mocks.partyConfig.value = null;
+
+    const wrapper = mount(PartyQR);
+    await flushPromises();
+
+    expect(wrapper.text()).toContain("Scan to join");
+    expect(mocks.createInvitationFile).toHaveBeenCalledWith({
+      description: "Join the party",
+      joinLink: JOIN_LINK,
+      logoUrl: expect.stringContaining("logo"),
+      title: "Join the Music Assistant party",
+    });
+    wrapper.unmount();
+  });
+
   it("keeps copy link available alongside native sharing", async () => {
     const wrapper = mount(PartyQR);
     await flushPromises();

--- a/tests/composables/useSidebarScrollbarGutter.test.ts
+++ b/tests/composables/useSidebarScrollbarGutter.test.ts
@@ -1,10 +1,23 @@
-import { describe, expect, it, vi } from "vitest";
+import { mount } from "@vue/test-utils";
+import { defineComponent, nextTick, ref } from "vue";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
-vi.mock("@/components/ui/sidebar", () => ({
-  useSidebar: vi.fn(() => ({ state: { value: "expanded" } })),
+const mocks = vi.hoisted(() => ({
+  sidebarState: { value: "expanded" as string },
 }));
 
-import { applySidebarScrollbarGutter } from "@/composables/useSidebarScrollbarGutter";
+vi.mock("@/components/ui/sidebar", async () => {
+  // The composable watches the sidebar state, so the mock has to carry a real
+  // ref: assignments to a plain { value } would never reach the watcher.
+  const { ref } = await vi.importActual<typeof import("vue")>("vue");
+  mocks.sidebarState = ref(mocks.sidebarState.value);
+  return { useSidebar: vi.fn(() => ({ state: mocks.sidebarState })) };
+});
+
+import {
+  applySidebarScrollbarGutter,
+  useSidebarScrollbarGutter,
+} from "@/composables/useSidebarScrollbarGutter";
 
 interface SidebarDomOptions {
   scrollHeight?: number;
@@ -142,5 +155,75 @@ describe("applySidebarScrollbarGutter", () => {
     expect(sidebarEl.style.getPropertyValue("--sidebar-width-icon")).toBe(
       "calc(3rem + 6px)",
     );
+  });
+});
+
+describe("useSidebarScrollbarGutter", () => {
+  afterEach(() => {
+    mocks.sidebarState.value = "expanded";
+    vi.unstubAllGlobals();
+  });
+
+  /**
+   * Mount a sidebar whose content overflows, wired up through the composable.
+   */
+  function mountSidebar(shortcuts = ref<string[]>([])) {
+    vi.stubGlobal(
+      "ResizeObserver",
+      class {
+        observe() {}
+        disconnect() {}
+      },
+    );
+    const wrapper = mount(
+      defineComponent({
+        setup: () => useSidebarScrollbarGutter(shortcuts),
+        template: `
+          <div data-slot="sidebar">
+            <div data-slot="sidebar-content"><div ref="navEl" /></div>
+          </div>
+        `,
+      }),
+    );
+    const contentEl = wrapper.get<HTMLElement>(
+      "[data-slot=sidebar-content]",
+    ).element;
+    Object.defineProperty(contentEl, "scrollHeight", {
+      configurable: true,
+      get: () => 200,
+    });
+    Object.defineProperty(contentEl, "clientHeight", {
+      configurable: true,
+      get: () => 100,
+    });
+    return { contentEl, sidebarEl: wrapper.element as HTMLElement, wrapper };
+  }
+
+  it("applies the gutter when the sidebar collapses", async () => {
+    const { contentEl, sidebarEl, wrapper } = mountSidebar();
+    expect(contentEl.style.scrollbarGutter).toBe("");
+
+    mocks.sidebarState.value = "collapsed";
+    await nextTick();
+
+    expect(contentEl.style.scrollbarGutter).toBe("stable");
+    expect(sidebarEl.style.getPropertyValue("--sidebar-width-icon")).toBe(
+      "calc(3rem + 6px)",
+    );
+    wrapper.unmount();
+  });
+
+  it("re-evaluates the gutter when the shortcut list changes", async () => {
+    const shortcuts = ref<string[]>([]);
+    const { contentEl } = mountSidebar(shortcuts);
+    mocks.sidebarState.value = "collapsed";
+    await nextTick();
+    contentEl.style.scrollbarGutter = "";
+
+    shortcuts.value = ["shortcut"];
+    await nextTick();
+    await nextTick();
+
+    expect(contentEl.style.scrollbarGutter).toBe("stable");
   });
 });

--- a/tests/composables/useSidebarScrollbarGutter.test.ts
+++ b/tests/composables/useSidebarScrollbarGutter.test.ts
@@ -215,7 +215,7 @@ describe("useSidebarScrollbarGutter", () => {
 
   it("re-evaluates the gutter when the shortcut list changes", async () => {
     const shortcuts = ref<string[]>([]);
-    const { contentEl } = mountSidebar(shortcuts);
+    const { contentEl, wrapper } = mountSidebar(shortcuts);
     mocks.sidebarState.value = "collapsed";
     await nextTick();
     contentEl.style.scrollbarGutter = "";
@@ -225,5 +225,6 @@ describe("useSidebarScrollbarGutter", () => {
     await nextTick();
 
     expect(contentEl.style.scrollbarGutter).toBe("stable");
+    wrapper.unmount();
   });
 });

--- a/tests/plugins/api/helpers.test.ts
+++ b/tests/plugins/api/helpers.test.ts
@@ -1,14 +1,30 @@
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { nextTick, ref } from "vue";
 
-vi.mock("@/plugins/api", () => ({
-  default: {
-    serverInfo: { value: null },
-    providers: {},
-    queues: {},
-  },
+const mocks = vi.hoisted(() => ({
+  apiState: { value: "connected" as string },
 }));
 
-import { isAudioSource, isQueueInfiniteStream } from "@/plugins/api/helpers";
+vi.mock("@/plugins/api", () => {
+  // waitForApiInitialization watches api.state, so the mock has to carry a real
+  // ref: assignments to a plain { value } would never reach the watcher.
+  mocks.apiState = ref(mocks.apiState.value);
+  return {
+    default: {
+      serverInfo: { value: null },
+      providers: {},
+      queues: {},
+      state: mocks.apiState,
+    },
+    ConnectionState: { INITIALIZED: "initialized" },
+  };
+});
+
+import {
+  isAudioSource,
+  isQueueInfiniteStream,
+  waitForApiInitialization,
+} from "@/plugins/api/helpers";
 import { MediaType } from "@/plugins/api/interfaces";
 import type { MediaItemType, PlayerQueue } from "@/plugins/api/interfaces";
 
@@ -65,5 +81,32 @@ describe("isQueueInfiniteStream", () => {
   it("returns false when the queue or current item is missing", () => {
     expect(isQueueInfiniteStream(undefined)).toBe(false);
     expect(isQueueInfiniteStream(makeQueue(undefined))).toBe(false);
+  });
+});
+
+describe("waitForApiInitialization", () => {
+  beforeEach(() => {
+    mocks.apiState.value = "connected";
+  });
+
+  it("resolves immediately when the api is already initialized", async () => {
+    mocks.apiState.value = "initialized";
+
+    await expect(waitForApiInitialization()).resolves.toBeUndefined();
+  });
+
+  it("waits for the api to reach the initialized state", async () => {
+    let resolved = false;
+    const pending = waitForApiInitialization().then(() => {
+      resolved = true;
+    });
+
+    mocks.apiState.value = "authenticated";
+    await nextTick();
+    expect(resolved).toBe(false);
+
+    mocks.apiState.value = "initialized";
+    await pending;
+    expect(resolved).toBe(true);
   });
 });

--- a/tests/plugins/api/helpers.test.ts
+++ b/tests/plugins/api/helpers.test.ts
@@ -1,13 +1,14 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { nextTick, ref } from "vue";
+import { nextTick } from "vue";
 
 const mocks = vi.hoisted(() => ({
   apiState: { value: "connected" as string },
 }));
 
-vi.mock("@/plugins/api", () => {
+vi.mock("@/plugins/api", async () => {
   // waitForApiInitialization watches api.state, so the mock has to carry a real
   // ref: assignments to a plain { value } would never reach the watcher.
+  const { ref } = await vi.importActual<typeof import("vue")>("vue");
   mocks.apiState = ref(mocks.apiState.value);
   return {
     default: {

--- a/tests/views/Login.test.ts
+++ b/tests/views/Login.test.ts
@@ -862,6 +862,7 @@ describe("connection state changes", () => {
     await vi.waitFor(() => {
       expect(wrapper.text()).toContain("Reconnecting");
     });
+    wrapper.unmount();
   });
 
   it("returns to the server picker when a reconnect fails", async () => {
@@ -879,6 +880,7 @@ describe("connection state changes", () => {
       expect(wrapper.text()).not.toContain("Reconnecting");
     });
     expect(wrapper.text()).toContain("Connect");
+    wrapper.unmount();
   });
 
   it("keeps explaining an ended guest session while the connection churns", async () => {
@@ -894,5 +896,6 @@ describe("connection state changes", () => {
 
     expect(wrapper.text()).toContain("Your party session has ended");
     expect(wrapper.text()).not.toContain("Reconnecting");
+    wrapper.unmount();
   });
 });

--- a/tests/views/Login.test.ts
+++ b/tests/views/Login.test.ts
@@ -3,6 +3,7 @@ import { flushPromises, mount, type VueWrapper } from "@vue/test-utils";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
+  apiState: { value: "disconnected" as string },
   authenticateWithToken: vi.fn(),
   clearAuth: vi.fn(),
   clearGuestSession: vi.fn(),
@@ -27,24 +28,30 @@ const mocks = vi.hoisted(() => ({
   setToken: vi.fn(),
 }));
 
-vi.mock("@/plugins/api", () => ({
-  ConnectionState: {
-    AUTHENTICATED: "authenticated",
-    AUTHENTICATING: "authenticating",
-    AUTH_REQUIRED: "auth_required",
-    DISCONNECTED: "disconnected",
-    FAILED: "failed",
-    RECONNECTING: "reconnecting",
-  },
-  api: {
-    authenticateWithToken: mocks.authenticateWithToken,
-    disconnect: vi.fn(),
-    getCurrentUserInfo: mocks.getCurrentUserInfo,
-    sendCommand: mocks.sendCommand,
-    serverInfo: mocks.serverInfo,
-    state: { value: "disconnected" },
-  },
-}));
+vi.mock("@/plugins/api", async () => {
+  // Login.vue watches api.state, so the mock has to carry a real ref:
+  // assignments to a plain { value } would never reach the watcher.
+  const { ref } = await vi.importActual<typeof import("vue")>("vue");
+  mocks.apiState = ref(mocks.apiState.value);
+  return {
+    ConnectionState: {
+      AUTHENTICATED: "authenticated",
+      AUTHENTICATING: "authenticating",
+      AUTH_REQUIRED: "auth_required",
+      DISCONNECTED: "disconnected",
+      FAILED: "failed",
+      RECONNECTING: "reconnecting",
+    },
+    api: {
+      authenticateWithToken: mocks.authenticateWithToken,
+      disconnect: vi.fn(),
+      getCurrentUserInfo: mocks.getCurrentUserInfo,
+      sendCommand: mocks.sendCommand,
+      serverInfo: mocks.serverInfo,
+      state: mocks.apiState,
+    },
+  };
+});
 
 vi.mock("@/plugins/auth", () => ({
   authManager: {
@@ -223,6 +230,7 @@ beforeEach(() => {
   setLocation("");
   vi.clearAllMocks();
   vi.useRealTimers();
+  mocks.apiState.value = "disconnected";
   mocks.routerReplace.mockResolvedValue(undefined);
   vi.stubGlobal("WebSocket", WebSocketMock);
   mocks.clearAuth.mockImplementation(() => {
@@ -840,5 +848,51 @@ describe("ingress login", () => {
       expect(wrapper.text()).toContain("Username");
     });
     expect(mocks.getCurrentUserInfo).not.toHaveBeenCalled();
+  });
+});
+
+describe("connection state changes", () => {
+  it("shows the reconnecting screen when the connection drops", async () => {
+    mockStandaloneFrontend();
+    const wrapper = mountLogin();
+    await flushPromises();
+
+    mocks.apiState.value = "reconnecting";
+
+    await vi.waitFor(() => {
+      expect(wrapper.text()).toContain("Reconnecting");
+    });
+  });
+
+  it("returns to the server picker when a reconnect fails", async () => {
+    mockStandaloneFrontend();
+    const wrapper = mountLogin();
+    await flushPromises();
+    mocks.apiState.value = "reconnecting";
+    await vi.waitFor(() => {
+      expect(wrapper.text()).toContain("Reconnecting");
+    });
+
+    mocks.apiState.value = "disconnected";
+
+    await vi.waitFor(() => {
+      expect(wrapper.text()).not.toContain("Reconnecting");
+    });
+    expect(wrapper.text()).toContain("Connect");
+  });
+
+  it("keeps explaining an ended guest session while the connection churns", async () => {
+    mockStandaloneFrontend();
+    sessionStorage.setItem("ma_guest_session_ended", "party");
+    const wrapper = mountLogin();
+    await vi.waitFor(() => {
+      expect(wrapper.text()).toContain("Your party session has ended");
+    });
+
+    mocks.apiState.value = "reconnecting";
+    await flushPromises();
+
+    expect(wrapper.text()).toContain("Your party session has ended");
+    expect(wrapper.text()).not.toContain("Reconnecting");
   });
 });

--- a/tests/views/MusicQuizDashboardView.test.ts
+++ b/tests/views/MusicQuizDashboardView.test.ts
@@ -37,7 +37,7 @@ vi.mock("@/components/music-quiz/game_types", () => ({
 vi.mock("@/plugins/api", async () => {
   // The connection banner re-renders on api.state, so the mock has to carry a
   // real ref: assignments to a plain { value } would never reach the computed.
-  const { ref } = await import("vue");
+  const { ref } = await vi.importActual<typeof import("vue")>("vue");
   apiMock.state = ref(apiMock.state.value);
   const api = {
     sendCommand: mockSendCommand,

--- a/tests/views/MusicQuizDashboardView.test.ts
+++ b/tests/views/MusicQuizDashboardView.test.ts
@@ -1,9 +1,11 @@
 import MusicQuizDashboardView from "@/views/MusicQuizDashboardView.vue";
 import { ProviderType } from "@/plugins/api/interfaces";
 import { flushPromises, mount } from "@vue/test-utils";
+import { nextTick } from "vue";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const {
+  apiMock,
   mockAdminState,
   mockGetProviderConfigs,
   mockResolveMusicQuizDefinition,
@@ -12,6 +14,7 @@ const {
   mockSubscribe,
   mockToastError,
 } = vi.hoisted(() => ({
+  apiMock: { state: { value: "connected" as string } },
   mockAdminState: {
     current: undefined as { value: boolean } | undefined,
   },
@@ -31,12 +34,16 @@ vi.mock("@/components/music-quiz/game_types", () => ({
   supportsMusicQuizListenIn: vi.fn(() => false),
 }));
 
-vi.mock("@/plugins/api", () => {
+vi.mock("@/plugins/api", async () => {
+  // The connection banner re-renders on api.state, so the mock has to carry a
+  // real ref: assignments to a plain { value } would never reach the computed.
+  const { ref } = await import("vue");
+  apiMock.state = ref(apiMock.state.value);
   const api = {
     sendCommand: mockSendCommand,
     subscribe: mockSubscribe,
     getProviderConfigs: mockGetProviderConfigs,
-    state: { value: "connected" },
+    state: apiMock.state,
   };
   return {
     api,
@@ -78,6 +85,7 @@ vi.mock("vue-sonner", () => ({
 
 describe("MusicQuizDashboardView", () => {
   beforeEach(() => {
+    apiMock.state.value = "connected";
     mockSendCommand.mockReset();
     mockSubscribe.mockReset();
     mockToastError.mockReset();
@@ -102,6 +110,21 @@ describe("MusicQuizDashboardView", () => {
       return Promise.resolve(null);
     });
     mockSubscribe.mockReturnValue(() => {});
+  });
+
+  it("warns the host when the connection degrades", async () => {
+    const wrapper = mountDashboard();
+    await flushPromises();
+    const banner = wrapper.findComponent({
+      name: "MusicQuizConnectionBanners",
+    });
+    expect(banner.props("degraded")).toBe(false);
+
+    apiMock.state.value = "reconnecting";
+    await nextTick();
+
+    expect(banner.props("degraded")).toBe(true);
+    wrapper.unmount();
   });
 
   it("renders a compact empty state and opens setup on demand", async () => {

--- a/tests/views/MusicQuizPlayerView.test.ts
+++ b/tests/views/MusicQuizPlayerView.test.ts
@@ -81,7 +81,7 @@ vi.mock("@/helpers/music_quiz", () => ({
 vi.mock("@/plugins/api", async () => {
   // The connection banner re-renders on api.state, so the mock has to carry a
   // real ref: assignments to a plain { value } would never reach the computed.
-  const { ref } = await import("vue");
+  const { ref } = await vi.importActual<typeof import("vue")>("vue");
   apiMock.state = ref(apiMock.state.value);
   return {
     default: {

--- a/tests/views/MusicQuizPlayerView.test.ts
+++ b/tests/views/MusicQuizPlayerView.test.ts
@@ -6,6 +6,7 @@ import { h, nextTick, ref } from "vue";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const {
+  apiMock,
   mockGameAdapterSetup,
   mockGetMusicQuizRoundScore,
   mockGetTrackLyrics,
@@ -16,6 +17,7 @@ const {
   mockToastSuccess,
   mockUseMusicQuizPlayer,
 } = vi.hoisted(() => ({
+  apiMock: { state: { value: "connected" as string } },
   mockGameAdapterSetup: vi.fn(),
   mockGetMusicQuizRoundScore: vi.fn(),
   mockGetTrackLyrics: vi.fn(),
@@ -76,17 +78,23 @@ vi.mock("@/helpers/music_quiz", () => ({
   rankMusicQuizPlayers: () => [],
 }));
 
-vi.mock("@/plugins/api", () => ({
-  default: {
-    state: { value: "connected" },
-    sendCommand: vi.fn(),
-    getTrackLyrics: mockGetTrackLyrics,
-  },
-  ConnectionState: {
-    RECONNECTING: "reconnecting",
-    DISCONNECTED: "disconnected",
-  },
-}));
+vi.mock("@/plugins/api", async () => {
+  // The connection banner re-renders on api.state, so the mock has to carry a
+  // real ref: assignments to a plain { value } would never reach the computed.
+  const { ref } = await import("vue");
+  apiMock.state = ref(apiMock.state.value);
+  return {
+    default: {
+      state: apiMock.state,
+      sendCommand: vi.fn(),
+      getTrackLyrics: mockGetTrackLyrics,
+    },
+    ConnectionState: {
+      RECONNECTING: "reconnecting",
+      DISCONNECTED: "disconnected",
+    },
+  };
+});
 
 vi.mock("@/plugins/i18n", () => ({
   $t: (key: string, values: unknown[] = []) => {
@@ -218,6 +226,7 @@ describe("MusicQuizPlayerView routing", () => {
   });
 
   beforeEach(() => {
+    apiMock.state.value = "connected";
     mockGameAdapterSetup.mockReset();
     mockGetMusicQuizRoundScore.mockReset();
     mockGetTrackLyrics.mockReset();
@@ -340,6 +349,22 @@ describe("MusicQuizPlayerView routing", () => {
 
     expect(mockListenInSetup).toHaveBeenCalledOnce();
     expect(wrapper.find('[data-testid="listen-in"]').exists()).toBe(true);
+    wrapper.unmount();
+  });
+
+  it("warns the player when the connection degrades mid-game", async () => {
+    mockResolveMusicQuizDefinition.mockReturnValue(createDefinition(true));
+
+    const wrapper = mountView();
+    const banner = wrapper.findComponent({
+      name: "MusicQuizConnectionBanners",
+    });
+    expect(banner.props("degraded")).toBe(false);
+
+    apiMock.state.value = "reconnecting";
+    await nextTick();
+
+    expect(banner.props("degraded")).toBe(true);
     wrapper.unmount();
   });
 


### PR DESCRIPTION
Several tests replaced live values (the server connection state, the interface language, the sidebar state) with static stand-ins. Because those stand-ins never change, the code that reacts to them changing was never run — including the reconnect path where a real bug was recently found.

- Make the connection state, interface language and sidebar state behave like the real values in tests
- Cover reconnecting a Home Assistant Ingress session
- Cover sending a language change to the server and reloading translated content
- Cover how the sign-in screen reacts to the connection dropping, including keeping the "session has ended" message visible
- Cover the "connection lost" warning on the Music Quiz host and player screens
- Cover waiting for the server connection to be ready, and the collapsed-sidebar scrollbar fix
- Cover the party invitation wording when no party name or QR text is set