### PR TITLE
Fix the mini equalizer position at non-standard playback speeds

### DIFF
--- a/src/components/MiniEqualizer.vue
+++ b/src/components/MiniEqualizer.vue
@@ -38,6 +38,8 @@ function getElapsedSecs(): number {
   const queue = store.activePlayerQueue;
   const queueId = queue?.queue_id;
   const queueTime = queueId ? api.queueElapsedTime[queueId] : undefined;
+  const playbackSpeed =
+    store.curQueueItem?.extra_attributes?.playback_speed ?? 1;
   if (
     queueTime?.elapsed_time != null &&
     queueTime?.elapsed_time_last_updated != null
@@ -47,7 +49,7 @@ function getElapsedSecs(): number {
         queueTime.elapsed_time,
         queueTime.elapsed_time_last_updated,
         queue!.state,
-        store.curQueueItem?.extra_attributes?.playback_speed ?? 1,
+        playbackSpeed,
       ) ?? 0
     );
   }
@@ -62,6 +64,7 @@ function getElapsedSecs(): number {
         player.elapsed_time_last_updated,
         // An unknown state must not extrapolate from the last update.
         player.playback_state ?? PlaybackState.IDLE,
+        playbackSpeed,
       ) ?? 0
     );
   }

--- a/src/components/MiniEqualizer.vue
+++ b/src/components/MiniEqualizer.vue
@@ -11,9 +11,10 @@
 <script setup lang="ts">
 import { onMounted, onUnmounted, ref, watch } from "vue";
 import { useActiveTrackWaveform } from "@/composables/useActiveTrackWaveform";
-import { serverNow } from "@/composables/useServerTime";
+import computeElapsedTime from "@/helpers/elapsed";
 import { store } from "@/plugins/store";
 import api from "@/plugins/api";
+import { PlaybackState } from "@/plugins/api/interfaces";
 
 export interface Props {
   color?: string;
@@ -34,28 +35,35 @@ const canvasEl = ref<HTMLCanvasElement>();
 let timerId: ReturnType<typeof setInterval> | null = null;
 
 function getElapsedSecs(): number {
-  const queueId = store.activePlayerQueue?.queue_id;
+  const queue = store.activePlayerQueue;
+  const queueId = queue?.queue_id;
   const queueTime = queueId ? api.queueElapsedTime[queueId] : undefined;
   if (
     queueTime?.elapsed_time != null &&
     queueTime?.elapsed_time_last_updated != null
   ) {
-    const isPlaying = store.activePlayerQueue?.state === "playing";
-    const delta = isPlaying
-      ? Math.max(0, serverNow() - queueTime.elapsed_time_last_updated)
-      : 0;
-    return queueTime.elapsed_time + delta;
+    return (
+      computeElapsedTime(
+        queueTime.elapsed_time,
+        queueTime.elapsed_time_last_updated,
+        queue!.state,
+        store.curQueueItem?.extra_attributes?.playback_speed ?? 1,
+      ) ?? 0
+    );
   }
   const player = store.activePlayer;
   if (
     player?.elapsed_time != null &&
     player?.elapsed_time_last_updated != null
   ) {
-    const isPlaying = player.playback_state === "playing";
-    const delta = isPlaying
-      ? Math.max(0, serverNow() - player.elapsed_time_last_updated)
-      : 0;
-    return player.elapsed_time + delta;
+    return (
+      computeElapsedTime(
+        player.elapsed_time,
+        player.elapsed_time_last_updated,
+        // An unknown state must not extrapolate from the last update.
+        player.playback_state ?? PlaybackState.IDLE,
+      ) ?? 0
+    );
   }
   return 0;
 }


### PR DESCRIPTION
The mini equalizer worked out the playback position with its own copy of the
timing math instead of using the shared helper the rest of the app uses. That
copy ignores the playback speed, so at a non-1x speed (audiobooks, podcasts)
the waveform sat at the wrong spot.

- Use the shared `computeElapsedTime()` helper for both the queue and player position
- Pick up the playback speed of the current queue item