### PR TITLE
Add test coverage for the guest entry route watcher

### DIFF
--- a/tests/composables/useGuestEntryResolver.test.ts
+++ b/tests/composables/useGuestEntryResolver.test.ts
@@ -13,11 +13,11 @@ const {
   apiMock,
   authManagerMock,
   guestIdentity,
-  routeMock,
+  routeState,
   routerReplace,
   storeMock,
 } = vi.hoisted(() => {
-  const routeMock = { path: "/guest" };
+  const routeState = { current: undefined as { path: string } | undefined };
   const guestIdentity = { value: "guest-token-1" as string | undefined };
   return {
     apiMock: {
@@ -33,9 +33,9 @@ const {
       isGuestAccessSession: vi.fn(() => true),
     },
     guestIdentity,
-    routeMock,
+    routeState,
     routerReplace: vi.fn(async (path: string) => {
-      routeMock.path = path;
+      setRoutePath(path);
     }),
     storeMock: {
       currentUser: undefined as { user_id: string } | undefined,
@@ -62,10 +62,14 @@ vi.mock("@/plugins/store", () => ({
   store: storeMock,
 }));
 
-vi.mock("vue-router", () => ({
-  useRoute: () => routeMock,
-  useRouter: () => ({ replace: routerReplace }),
-}));
+vi.mock("vue-router", async () => {
+  const { reactive } = await vi.importActual<typeof import("vue")>("vue");
+  routeState.current = reactive({ path: "/guest" });
+  return {
+    useRoute: () => routeState.current,
+    useRouter: () => ({ replace: routerReplace }),
+  };
+});
 
 afterEach(() => {
   vi.unstubAllGlobals();
@@ -84,7 +88,7 @@ describe("guest entry decisions", () => {
     vi.stubGlobal("localStorage", createStorage());
     vi.stubGlobal("sessionStorage", createStorage());
     storeMock.currentUser = undefined;
-    routeMock.path = "/guest";
+    setRoutePath("/guest");
   });
 
   it("routes an active Music Quiz ahead of Party", async () => {
@@ -195,7 +199,7 @@ describe("guest entry transitions", () => {
     vi.stubGlobal("localStorage", createStorage());
     vi.stubGlobal("sessionStorage", createStorage());
     storeMock.currentUser = undefined;
-    routeMock.path = "/guest";
+    setRoutePath("/guest");
   });
 
   afterEach(() => {
@@ -204,7 +208,7 @@ describe("guest entry transitions", () => {
 
   it("shows an error state when the initial resolution fails", async () => {
     setProviders("party", "music_quiz");
-    routeMock.path = "/guest/party";
+    setRoutePath("/guest/party");
     apiMock.sendCommand.mockRejectedValue(new Error("boom"));
     wrapper = mountResolver((state) => {
       resolverState = state;
@@ -212,7 +216,7 @@ describe("guest entry transitions", () => {
 
     await expectState("error");
 
-    expect(routeMock.path).toBe("/guest");
+    expect(getRoutePath()).toBe("/guest");
     expect(routerReplace).toHaveBeenCalledOnce();
     expect(routerReplace).toHaveBeenCalledWith("/guest");
   });
@@ -231,7 +235,7 @@ describe("guest entry transitions", () => {
     await resolveEntry();
 
     expect(resolverState.value).toBe("quiz");
-    expect(routeMock.path).toBe("/guest/quiz");
+    expect(getRoutePath()).toBe("/guest/quiz");
     expect(routerReplace).toHaveBeenCalledOnce();
   });
 
@@ -247,7 +251,7 @@ describe("guest entry transitions", () => {
     signalProviderEvent({ event: "game_updated", state: {} });
 
     await expectState("quiz");
-    expect(routeMock.path).toBe("/guest/quiz");
+    expect(getRoutePath()).toBe("/guest/quiz");
   });
 
   it("keeps a Party guest in Quiz context and returns to the next game", async () => {
@@ -265,7 +269,7 @@ describe("guest entry transitions", () => {
     markMusicQuizJoinedGameEnded();
     signalProviderEvent({ event: "game_removed" });
     await expectState("quiz-inactive");
-    expect(routeMock.path).toBe("/guest");
+    expect(getRoutePath()).toBe("/guest");
 
     apiMock.sendCommand.mockResolvedValue({ game_id: "next" });
     signalProviderEvent({ event: "game_updated", state: {} });
@@ -290,14 +294,14 @@ describe("guest entry transitions", () => {
 
     wrapper.unmount();
     wrapper = undefined;
-    routeMock.path = "/guest";
+    setRoutePath("/guest");
     apiMock.sendCommand.mockResolvedValue(null);
     wrapper = mountResolver((state) => {
       resolverState = state;
     });
 
     await expectState("quiz-inactive");
-    expect(routeMock.path).toBe("/guest");
+    expect(getRoutePath()).toBe("/guest");
   });
 
   it("restores Quiz affinity for a regular authenticated user", async () => {
@@ -312,7 +316,7 @@ describe("guest entry transitions", () => {
 
     wrapper.unmount();
     wrapper = undefined;
-    routeMock.path = "/guest";
+    setRoutePath("/guest");
     apiMock.sendCommand.mockResolvedValue(null);
     wrapper = mountResolver((state) => {
       resolverState = state;
@@ -339,7 +343,7 @@ describe("guest entry transitions", () => {
     signalProviderEvent({ event: "game_updated", state: {} });
 
     await expectState("party");
-    expect(routeMock.path).toBe("/guest/party");
+    expect(getRoutePath()).toBe("/guest/party");
     expect(getStoredAffinity()).toBeNull();
   });
 
@@ -410,7 +414,7 @@ describe("guest entry transitions", () => {
     signalProviderEvent({ event: "game_removed" });
     await expectState("quiz-inactive");
 
-    expect(routeMock.path).toBe("/guest");
+    expect(getRoutePath()).toBe("/guest");
     expect(apiMock.sendCommand).toHaveBeenCalledTimes(2);
   });
 
@@ -427,7 +431,7 @@ describe("guest entry transitions", () => {
     signalProviderEvent({ event: "game_removed" });
     await expectState("quiz-inactive");
 
-    expect(routeMock.path).toBe("/guest");
+    expect(getRoutePath()).toBe("/guest");
   });
 
   it("does not let an in-flight refresh overwrite the ended state", async () => {
@@ -457,13 +461,13 @@ describe("guest entry transitions", () => {
     resolveRefresh(null);
     await expectState("quiz-inactive");
 
-    expect(routeMock.path).toBe("/guest");
+    expect(getRoutePath()).toBe("/guest");
     expect(apiMock.sendCommand).toHaveBeenCalledTimes(3);
   });
 
   it("restores the no-active state while the guest route is loading", async () => {
     setProviders("music_quiz");
-    routeMock.path = "/guest/quiz";
+    setRoutePath("/guest/quiz");
     storeAffinity("guest-token-1");
     let resolveInitialRequest!: (value: null) => void;
     apiMock.sendCommand
@@ -485,7 +489,7 @@ describe("guest entry transitions", () => {
     resolveInitialRequest(null);
     await expectState("quiz-inactive");
 
-    expect(routeMock.path).toBe("/guest");
+    expect(getRoutePath()).toBe("/guest");
     expect(apiMock.sendCommand).toHaveBeenCalledTimes(2);
   });
 
@@ -514,7 +518,7 @@ describe("guest entry transitions", () => {
     signalProviderEvent({ event: "game_removed" });
     await expectState("quiz-inactive");
 
-    expect(routeMock.path).toBe("/guest");
+    expect(getRoutePath()).toBe("/guest");
   });
 
   it("ignores a provider event from an unrelated instance once scoped", async () => {
@@ -538,6 +542,24 @@ describe("guest entry transitions", () => {
     expect(apiMock.sendCommand).toHaveBeenCalledTimes(2);
   });
 
+  it("returns a guest who navigates away to the active Quiz route", async () => {
+    setProviders("music_quiz");
+    apiMock.sendCommand.mockResolvedValue({ game_id: "active" });
+    wrapper = mountResolver((state) => {
+      resolverState = state;
+    });
+    await expectState("quiz");
+    expect(getRoutePath()).toBe("/guest/quiz");
+
+    setRoutePath("/guest");
+
+    await vi.waitFor(() => expect(getRoutePath()).toBe("/guest/quiz"));
+    expect(routerReplace.mock.calls.map(([path]) => path)).toEqual([
+      "/guest/quiz",
+      "/guest/quiz",
+    ]);
+  });
+
   async function expectState(expected: GuestEntryState) {
     await vi.waitFor(() => expect(resolverState.value).toBe(expected));
   }
@@ -558,6 +580,19 @@ function mountResolver(
       },
     }),
   );
+}
+
+function getRoutePath() {
+  return getRoute().path;
+}
+
+function setRoutePath(path: string) {
+  getRoute().path = path;
+}
+
+function getRoute() {
+  if (!routeState.current) throw new Error("vue-router mock is not set up");
+  return routeState.current;
 }
 
 function setProviders(...domains: string[]) {


### PR DESCRIPTION
The guest entry resolver re-asserts the canonical guest route when a guest navigates away manually (for example browser-back to `/guest` while a quiz is active). That watcher had no test coverage: the mocked route was a plain object, so it never became reactive and the watcher never fired.

- Build the mocked route with `reactive()` inside the `vue-router` mock factory so route changes are tracked
- Route the existing route assertions through `getRoutePath()`/`setRoutePath()` helpers
- Add a test asserting the resolver returns a guest who navigates away back to the active quiz route