### PR TITLE
Add missing test coverage for guest entry provider updates

### DIFF
--- a/tests/composables/useGuestEntryResolver.test.ts
+++ b/tests/composables/useGuestEntryResolver.test.ts
@@ -250,6 +250,20 @@ describe("guest entry transitions", () => {
     expect(routeMock.path).toBe("/guest/quiz");
   });
 
+  it("routes to Party once the Party provider appears", async () => {
+    wrapper = mountResolver((state) => {
+      resolverState = state;
+    });
+    await expectState("inactive");
+
+    setProviders("party");
+    signalProvidersUpdated();
+
+    await expectState("party");
+    expect(routeMock.path).toBe("/guest/party");
+    expect(apiMock.sendCommand).not.toHaveBeenCalled();
+  });
+
   it("keeps a Party guest in Quiz context and returns to the next game", async () => {
     setProviders("party", "music_quiz");
     wrapper = mountResolver((state) => {


### PR DESCRIPTION
The guest entry resolver re-resolves which screen a guest should see when the list of installed providers changes, but that path had no test. The test file even had an unused helper for firing the event, left over and never wired up.

- Added a test that a guest on the "nothing available" screen is moved to Party as soon as the Party provider appears
- Uses the previously dead `signalProvidersUpdated` helper instead of removing it