### PR TITLE
Keep progress in sync for audiobooks and podcasts at non-1x speed

### DIFF
--- a/src/components/MiniEqualizer.vue
+++ b/src/components/MiniEqualizer.vue
@@ -11,10 +11,9 @@
 <script setup lang="ts">
 import { onMounted, onUnmounted, ref, watch } from "vue";
 import { useActiveTrackWaveform } from "@/composables/useActiveTrackWaveform";
-import computeElapsedTime from "@/helpers/elapsed";
-import { store } from "@/plugins/store";
-import api from "@/plugins/api";
+import { resolveActiveElapsedTime } from "@/helpers/activeElapsedTime";
 import { PlaybackState } from "@/plugins/api/interfaces";
+import { store } from "@/plugins/store";
 
 export interface Props {
   color?: string;
@@ -33,43 +32,6 @@ const props = withDefaults(defineProps<Props>(), {
 const { waveformBins, trackDurationSecs } = useActiveTrackWaveform();
 const canvasEl = ref<HTMLCanvasElement>();
 let timerId: ReturnType<typeof setInterval> | null = null;
-
-function getElapsedSecs(): number {
-  const queue = store.activePlayerQueue;
-  const queueId = queue?.queue_id;
-  const queueTime = queueId ? api.queueElapsedTime[queueId] : undefined;
-  const playbackSpeed =
-    store.curQueueItem?.extra_attributes?.playback_speed ?? 1;
-  if (
-    queueTime?.elapsed_time != null &&
-    queueTime?.elapsed_time_last_updated != null
-  ) {
-    return (
-      computeElapsedTime(
-        queueTime.elapsed_time,
-        queueTime.elapsed_time_last_updated,
-        queue!.state,
-        playbackSpeed,
-      ) ?? 0
-    );
-  }
-  const player = store.activePlayer;
-  if (
-    player?.elapsed_time != null &&
-    player?.elapsed_time_last_updated != null
-  ) {
-    return (
-      computeElapsedTime(
-        player.elapsed_time,
-        player.elapsed_time_last_updated,
-        // An unknown state must not extrapolate from the last update.
-        player.playback_state ?? PlaybackState.IDLE,
-        playbackSpeed,
-      ) ?? 0
-    );
-  }
-  return 0;
-}
 
 function resolveColor(color: string): string {
   // Canvas fillStyle cannot resolve CSS variables — extract and resolve them.
@@ -107,7 +69,7 @@ function draw() {
   const duration = trackDurationSecs.value;
   if (!duration) return;
 
-  const elapsed = getElapsedSecs();
+  const elapsed = resolveActiveElapsedTime() ?? 0;
   const progress = Math.min(1, Math.max(0, elapsed / duration));
   const centerBin = Math.floor(progress * (bins.length - 1));
 
@@ -153,7 +115,10 @@ function stopTimer() {
 }
 
 function syncTimer() {
-  if (store.activePlayerQueue?.state === "playing" && waveformBins.value) {
+  if (
+    store.activePlayerQueue?.state === PlaybackState.PLAYING &&
+    waveformBins.value
+  ) {
     startTimer();
   } else {
     stopTimer();
@@ -170,7 +135,7 @@ watch(
   () => store.activePlayerQueue?.state,
   (state) => {
     syncTimer();
-    if (state !== "playing") draw();
+    if (state !== PlaybackState.PLAYING) draw();
   },
   { immediate: true },
 );

--- a/src/components/party/PartyTrackCard.vue
+++ b/src/components/party/PartyTrackCard.vue
@@ -58,11 +58,9 @@ import MarqueeText from "@/components/MarqueeText.vue";
 import MediaItemThumb from "@/components/MediaItemThumb.vue";
 import NowPlayingBadge from "@/components/NowPlayingBadge.vue";
 import { usePartyConfig } from "@/composables/usePartyConfig";
-import computeElapsedTime from "@/helpers/elapsed";
-import api from "@/plugins/api";
+import { resolveActiveElapsedTime } from "@/helpers/activeElapsedTime";
 import type { QueueItem } from "@/plugins/api/interfaces";
 import { $t } from "@/plugins/i18n";
-import { store } from "@/plugins/store";
 import { Rocket, UserRound } from "@lucide/vue";
 import Color from "color";
 import { computed, onMounted, onUnmounted, ref, watch } from "vue";
@@ -248,24 +246,8 @@ const progressPercentage = computed(() => {
     return 0;
   }
 
-  // Get elapsed time from the isolated reactive map
-  const queue = store.activePlayerQueue;
-  const queueId = queue?.queue_id;
-  const queueTime = queueId ? api.queueElapsedTime[queueId] : undefined;
-  if (
-    queueTime?.elapsed_time != null &&
-    queueTime?.elapsed_time_last_updated != null
-  ) {
-    const elapsed =
-      computeElapsedTime(
-        queueTime.elapsed_time,
-        queueTime.elapsed_time_last_updated,
-        queue!.state,
-      ) ?? 0;
-    return Math.min((elapsed / duration) * 100, 100);
-  }
-
-  return 0;
+  const elapsed = resolveActiveElapsedTime() ?? 0;
+  return Math.min((elapsed / duration) * 100, 100);
 });
 
 // Watch for changes in position and isPlaying to start/stop ticking

--- a/src/composables/lyrics/useLyricsElapsedTime.ts
+++ b/src/composables/lyrics/useLyricsElapsedTime.ts
@@ -9,27 +9,18 @@
 import { ref, watchEffect, onScopeDispose, type Ref } from "vue";
 import { PlaybackState } from "@/plugins/api/interfaces";
 import { store } from "@/plugins/store";
-import { computeElapsedTime } from "@/helpers/elapsed";
-import api from "@/plugins/api";
+import { resolveActiveElapsedTime } from "@/helpers/activeElapsedTime";
 
 export function useLyricsElapsedTime(enabled?: Ref<boolean>) {
   const elapsedTime = ref(0);
   let rafId: number | null = null;
 
   const update = () => {
-    const queue = store.activePlayerQueue;
-    const queueId = queue?.queue_id;
-    const queueTime = queueId ? api.queueElapsedTime[queueId] : undefined;
-    if (
-      queueTime?.elapsed_time != null &&
-      queueTime?.elapsed_time_last_updated != null
-    ) {
-      elapsedTime.value =
-        computeElapsedTime(
-          queueTime.elapsed_time,
-          queueTime.elapsed_time_last_updated,
-          store.activePlayer?.playback_state,
-        ) ?? 0;
+    // Keep the last known position when no source reports a timing, so the
+    // lyrics do not snap back to the start of the track.
+    const elapsed = resolveActiveElapsedTime();
+    if (elapsed !== undefined) {
+      elapsedTime.value = elapsed;
     }
     rafId = requestAnimationFrame(update);
   };

--- a/src/helpers/activeElapsedTime.ts
+++ b/src/helpers/activeElapsedTime.ts
@@ -1,0 +1,99 @@
+/**
+ * Playback position of whatever is currently playing on the active player.
+ *
+ * Resolves the timing source, its playback state and the playback speed in one
+ * place, so progress indicators do not each work the position out differently.
+ * Both functions read the current values on each call and hold no state, which
+ * makes them equally usable inside a `computed` and inside a rAF/interval loop.
+ */
+import { computeElapsedTime } from "@/helpers/elapsed";
+import api from "@/plugins/api";
+import { store } from "@/plugins/store";
+import { PlaybackState } from "@/plugins/api/interfaces";
+
+export interface ActiveTiming {
+  elapsedTime: number;
+  lastUpdated: number;
+  playbackState: PlaybackState;
+  /**
+   * Speed the current queue item plays at, e.g. an audiobook at 1.5x. It applies
+   * to every source, because the player is playing that same item.
+   */
+  playbackSpeed: number;
+}
+
+/**
+ * The timing source for the active player, or undefined when none reports a position.
+ *
+ * Each source is paired with the playback state that belongs to it, so callers
+ * never combine a queue position with a player state or the other way around.
+ */
+export function resolveActiveTiming(): ActiveTiming | undefined {
+  const playbackSpeed =
+    store.curQueueItem?.extra_attributes?.playback_speed ?? 1;
+
+  // Prefer the active queue's own elapsed_time when it reports one.
+  const queue = store.activePlayerQueue;
+  if (queue) {
+    const queueTime = api.queueElapsedTime[queue.queue_id];
+    if (
+      queueTime?.elapsed_time != null &&
+      queueTime.elapsed_time_last_updated != null
+    ) {
+      return {
+        elapsedTime: queueTime.elapsed_time,
+        lastUpdated: queueTime.elapsed_time_last_updated,
+        playbackState: queue.state,
+        playbackSpeed,
+      };
+    }
+  }
+
+  // Fall back to the player's own timing, which is what external/3rd-party
+  // sources playing on the player report: current_media first, then the legacy
+  // player-level fields.
+  const player = store.activePlayer;
+  // An unknown state must not extrapolate from the last update.
+  const playerState = player?.playback_state ?? PlaybackState.IDLE;
+  if (
+    player?.current_media?.elapsed_time != null &&
+    player.current_media.elapsed_time_last_updated != null
+  ) {
+    return {
+      elapsedTime: player.current_media.elapsed_time,
+      lastUpdated: player.current_media.elapsed_time_last_updated,
+      playbackState: playerState,
+      playbackSpeed,
+    };
+  }
+
+  if (
+    player?.elapsed_time != null &&
+    player.elapsed_time_last_updated != null
+  ) {
+    return {
+      elapsedTime: player.elapsed_time,
+      lastUpdated: player.elapsed_time_last_updated,
+      playbackState: playerState,
+      playbackSpeed,
+    };
+  }
+
+  return undefined;
+}
+
+/**
+ * The current playback position of the active player in seconds, or undefined
+ * when no timing source is available.
+ */
+export function resolveActiveElapsedTime(): number | undefined {
+  const timing = resolveActiveTiming();
+  if (!timing) return undefined;
+
+  return computeElapsedTime(
+    timing.elapsedTime,
+    timing.lastUpdated,
+    timing.playbackState,
+    timing.playbackSpeed,
+  );
+}

--- a/src/helpers/elapsed.test.ts
+++ b/src/helpers/elapsed.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import computeElapsedTime from "./elapsed";
+import { computeElapsedTime } from "./elapsed";
 import { PlaybackState } from "../plugins/api/interfaces";
 
 describe("computeElapsedTime", () => {

--- a/src/helpers/elapsed.ts
+++ b/src/helpers/elapsed.ts
@@ -36,5 +36,3 @@ export function computeElapsedTime(
 
   return elapsed_time + delta * playback_speed;
 }
-
-export default computeElapsedTime;

--- a/src/layouts/default/PlayerOSD/PlayerTimeline.vue
+++ b/src/layouts/default/PlayerOSD/PlayerTimeline.vue
@@ -127,7 +127,10 @@ import { useActiveAudioSource } from "@/composables/activeAudioSource";
 import { useActiveSource } from "@/composables/activeSource";
 import { formatDuration } from "@/helpers/utils";
 import { ref, computed, watch, toRef, onUnmounted } from "vue";
-import computeElapsedTime from "@/helpers/elapsed";
+import {
+  resolveActiveElapsedTime,
+  resolveActiveTiming,
+} from "@/helpers/activeElapsedTime";
 import { computeChapterTicks } from "@/helpers/chapters";
 import { SliderRange, SliderRoot, SliderThumb, SliderTrack } from "reka-ui";
 import { cn } from "@/lib/utils";
@@ -267,51 +270,7 @@ const playerTotalTimeStr = computed(() => {
   return formatDuration(duration);
 });
 
-const serverTiming = computed(() => {
-  // Prefer queue-level elapsed_time if available (from isolated reactive map)
-  const queue = store.activePlayerQueue;
-  const queueId = queue?.queue_id;
-  const queueTime = queueId ? api.queueElapsedTime[queueId] : undefined;
-  if (
-    queueTime?.elapsed_time != null &&
-    queueTime?.elapsed_time_last_updated != null
-  ) {
-    return {
-      elapsedTime: queueTime.elapsed_time,
-      lastUpdated: queueTime.elapsed_time_last_updated,
-      playbackState: queue!.state,
-    };
-  }
-
-  // Fallback to player-level elapsed_time. This is used for external/3rd-party
-  // sources currently playing on the player (not for Music Assistant queue
-  // playback). Use the player-level fields when no activePlayerQueue is set.
-  // Prefer current_media timing when available (external source playing on the player)
-  if (
-    store.activePlayer?.current_media?.elapsed_time != null &&
-    store.activePlayer?.current_media?.elapsed_time_last_updated != null
-  ) {
-    return {
-      elapsedTime: store.activePlayer.current_media.elapsed_time,
-      lastUpdated: store.activePlayer.current_media.elapsed_time_last_updated,
-      playbackState: store.activePlayer.playback_state,
-    };
-  }
-
-  // Fall back to player-level elapsed_time (legacy / provider-level value)
-  if (
-    store.activePlayer?.elapsed_time != null &&
-    store.activePlayer?.elapsed_time_last_updated != null
-  ) {
-    return {
-      elapsedTime: store.activePlayer.elapsed_time,
-      lastUpdated: store.activePlayer.elapsed_time_last_updated,
-      playbackState: store.activePlayer.playback_state,
-    };
-  }
-
-  return null;
-});
+const serverTiming = computed(() => resolveActiveTiming());
 
 const serverElapsedTime = computed(() => {
   // include nowTick.value so this computed re-evaluates periodically while mounted
@@ -330,17 +289,7 @@ const serverElapsedTime = computed(() => {
   if (isPlaying && (usingQueue || hasCurrentMedia)) startTick();
   else stopTick();
 
-  const timing = serverTiming.value;
-  if (!timing) return 0;
-
-  return (
-    computeElapsedTime(
-      timing.elapsedTime,
-      timing.lastUpdated,
-      timing.playbackState,
-      store.curQueueItem?.extra_attributes?.playback_speed ?? 1,
-    ) ?? 0
-  );
+  return resolveActiveElapsedTime() ?? 0;
 });
 
 const displayedElapsedTime = computed(() => {

--- a/tests/helpers/activeElapsedTime.test.ts
+++ b/tests/helpers/activeElapsedTime.test.ts
@@ -1,0 +1,241 @@
+import {
+  resolveActiveElapsedTime,
+  resolveActiveTiming,
+} from "@/helpers/activeElapsedTime";
+import { PlaybackState } from "@/plugins/api/interfaces";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { apiMock, storeMock } = vi.hoisted(() => ({
+  apiMock: {
+    queueElapsedTime: {} as Record<
+      string,
+      { elapsed_time?: number; elapsed_time_last_updated?: number }
+    >,
+  },
+  // Only the fields the helper actually reads are mocked.
+  storeMock: {
+    activePlayerQueue: undefined as
+      | { queue_id: string; state?: PlaybackState }
+      | undefined,
+    activePlayer: undefined as
+      | {
+          playback_state?: PlaybackState;
+          elapsed_time?: number;
+          elapsed_time_last_updated?: number;
+          current_media?: {
+            elapsed_time?: number;
+            elapsed_time_last_updated?: number;
+          };
+        }
+      | undefined,
+    curQueueItem: undefined as
+      | { extra_attributes?: { playback_speed?: number } }
+      | undefined,
+  },
+}));
+
+vi.mock("@/plugins/api", () => ({
+  default: apiMock,
+}));
+
+vi.mock("@/plugins/store", () => ({
+  store: storeMock,
+}));
+
+// epoch seconds the fake clock starts at; timestamps below are relative to this
+const NOW = 1_700_000_000;
+
+describe("resolveActiveTiming / resolveActiveElapsedTime", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW * 1000);
+    apiMock.queueElapsedTime = {};
+    storeMock.activePlayerQueue = undefined;
+    storeMock.activePlayer = undefined;
+    storeMock.curQueueItem = undefined;
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("returns undefined when neither the queue nor the player reports a timing", () => {
+    expect(resolveActiveTiming()).toBeUndefined();
+    expect(resolveActiveElapsedTime()).toBeUndefined();
+
+    storeMock.activePlayerQueue = { queue_id: "q1" };
+    storeMock.activePlayer = {};
+    expect(resolveActiveTiming()).toBeUndefined();
+  });
+
+  it("prefers queue timing, paired with the queue's own state", () => {
+    storeMock.activePlayerQueue = {
+      queue_id: "q1",
+      state: PlaybackState.PLAYING,
+    };
+    apiMock.queueElapsedTime["q1"] = {
+      elapsed_time: 10,
+      elapsed_time_last_updated: NOW,
+    };
+    // player disagrees on both state and position; it must be ignored
+    storeMock.activePlayer = {
+      playback_state: PlaybackState.PAUSED,
+      current_media: { elapsed_time: 999, elapsed_time_last_updated: NOW },
+    };
+
+    expect(resolveActiveTiming()?.playbackState).toBe(PlaybackState.PLAYING);
+
+    vi.setSystemTime((NOW + 4) * 1000);
+    expect(resolveActiveElapsedTime()).toBeCloseTo(14, 6);
+  });
+
+  it("does not advance when the queue is paused, even if the player is playing", () => {
+    storeMock.activePlayerQueue = {
+      queue_id: "q1",
+      state: PlaybackState.PAUSED,
+    };
+    apiMock.queueElapsedTime["q1"] = {
+      elapsed_time: 10,
+      elapsed_time_last_updated: NOW,
+    };
+    storeMock.activePlayer = { playback_state: PlaybackState.PLAYING };
+
+    vi.setSystemTime((NOW + 4) * 1000);
+    expect(resolveActiveElapsedTime()).toBe(10);
+  });
+
+  it("falls back to current_media timing, paired with the player's playback_state", () => {
+    // a queue is active but has no reported elapsed time of its own
+    storeMock.activePlayerQueue = {
+      queue_id: "q1",
+      state: PlaybackState.PLAYING,
+    };
+    storeMock.activePlayer = {
+      playback_state: PlaybackState.PLAYING,
+      current_media: { elapsed_time: 20, elapsed_time_last_updated: NOW },
+    };
+
+    expect(resolveActiveTiming()?.playbackState).toBe(PlaybackState.PLAYING);
+
+    vi.setSystemTime((NOW + 3) * 1000);
+    expect(resolveActiveElapsedTime()).toBeCloseTo(23, 6);
+  });
+
+  it("falls back to player-level elapsed_time when there is no queue or current_media timing", () => {
+    storeMock.activePlayer = {
+      playback_state: PlaybackState.PAUSED,
+      elapsed_time: 5,
+      elapsed_time_last_updated: NOW,
+    };
+
+    vi.setSystemTime((NOW + 100) * 1000);
+    expect(resolveActiveElapsedTime()).toBe(5);
+  });
+
+  it("prefers a queue elapsed_time of 0 over a player timing", () => {
+    storeMock.activePlayerQueue = {
+      queue_id: "q1",
+      state: PlaybackState.PLAYING,
+    };
+    apiMock.queueElapsedTime["q1"] = {
+      elapsed_time: 0,
+      elapsed_time_last_updated: NOW,
+    };
+    storeMock.activePlayer = {
+      playback_state: PlaybackState.PLAYING,
+      elapsed_time: 500,
+      elapsed_time_last_updated: NOW,
+    };
+
+    vi.setSystemTime((NOW + 4) * 1000);
+    expect(resolveActiveElapsedTime()).toBeCloseTo(4, 6);
+  });
+
+  it("falls through to the player when the queue reports no last-updated time", () => {
+    storeMock.activePlayerQueue = {
+      queue_id: "q1",
+      state: PlaybackState.PLAYING,
+    };
+    apiMock.queueElapsedTime["q1"] = { elapsed_time: 10 };
+    storeMock.activePlayer = {
+      playback_state: PlaybackState.PLAYING,
+      elapsed_time: 500,
+      elapsed_time_last_updated: NOW,
+    };
+
+    vi.setSystemTime((NOW + 4) * 1000);
+    expect(resolveActiveElapsedTime()).toBeCloseTo(504, 6);
+  });
+
+  it.each([
+    [
+      "current_media",
+      {
+        current_media: { elapsed_time: 10, elapsed_time_last_updated: NOW },
+      },
+    ],
+    ["player-level", { elapsed_time: 10, elapsed_time_last_updated: NOW }],
+  ])(
+    "does not extrapolate a %s timing when the player reports no state",
+    (_source, player) => {
+      storeMock.activePlayer = player;
+
+      vi.setSystemTime((NOW + 4) * 1000);
+      expect(resolveActiveTiming()?.playbackState).toBe(PlaybackState.IDLE);
+      expect(resolveActiveElapsedTime()).toBe(10);
+    },
+  );
+
+  it("scales the queue-sourced delta by curQueueItem's playback_speed", () => {
+    storeMock.activePlayerQueue = {
+      queue_id: "q1",
+      state: PlaybackState.PLAYING,
+    };
+    apiMock.queueElapsedTime["q1"] = {
+      elapsed_time: 10,
+      elapsed_time_last_updated: NOW,
+    };
+    storeMock.curQueueItem = { extra_attributes: { playback_speed: 1.5 } };
+
+    vi.setSystemTime((NOW + 4) * 1000);
+    expect(resolveActiveElapsedTime()).toBeCloseTo(16, 6); // 10 + 4 * 1.5
+  });
+
+  it("scales a player-level fallback delta by curQueueItem's playback_speed too", () => {
+    storeMock.activePlayer = {
+      playback_state: PlaybackState.PLAYING,
+      elapsed_time: 10,
+      elapsed_time_last_updated: NOW,
+    };
+    storeMock.curQueueItem = { extra_attributes: { playback_speed: 1.5 } };
+
+    vi.setSystemTime((NOW + 4) * 1000);
+    expect(resolveActiveElapsedTime()).toBeCloseTo(16, 6);
+  });
+
+  it("defaults playback_speed to 1 when curQueueItem has no extra_attributes", () => {
+    storeMock.activePlayer = {
+      playback_state: PlaybackState.PLAYING,
+      elapsed_time: 10,
+      elapsed_time_last_updated: NOW,
+    };
+
+    vi.setSystemTime((NOW + 4) * 1000);
+    expect(resolveActiveElapsedTime()).toBeCloseTo(14, 6);
+  });
+
+  it("returns the stored elapsed_time unchanged when paused, regardless of speed", () => {
+    storeMock.activePlayerQueue = {
+      queue_id: "q1",
+      state: PlaybackState.PAUSED,
+    };
+    apiMock.queueElapsedTime["q1"] = {
+      elapsed_time: 42,
+      elapsed_time_last_updated: NOW,
+    };
+    storeMock.curQueueItem = { extra_attributes: { playback_speed: 2 } };
+
+    vi.setSystemTime((NOW + 50) * 1000);
+    expect(resolveActiveElapsedTime()).toBe(42);
+  });
+});


### PR DESCRIPTION
When an audiobook or podcast plays faster or slower than 1x, the progress shown in party view and in the lyrics view slowly drifted away from the real position: those views worked out the position themselves and never applied the playback speed. The lyrics view also combined the queue's position with the player's play/pause state, so it could keep scrolling while the queue was paused.

Four views each had their own copy of the "use the queue position, else the player position" logic, with slightly different details, which is how they drifted apart. The position of the active player is now worked out in one shared place that every progress indicator uses.

- Apply the playback speed to the progress in party view and the lyrics view
- Use the queue's own play/pause state for the lyrics position
- Don't advance the position when a player doesn't report whether it is playing
- Move the shared position logic into a single helper used by the player bar, party view, the lyrics view and the mini equalizer
- Add tests for the new helper