### PR TITLE
Fix a broken test assertion

### DIFF
--- a/tests/composables/useGuestEntryResolver.test.ts
+++ b/tests/composables/useGuestEntryResolver.test.ts
@@ -264,7 +264,7 @@ describe("guest entry transitions", () => {
     signalProvidersUpdated();
 
     await expectState("party");
-    expect(routeMock.path).toBe("/guest/party");
+    expect(getRoutePath()).toBe("/guest/party");
     expect(apiMock.sendCommand).not.toHaveBeenCalled();
   });
 


### PR DESCRIPTION
Two test PRs landed at the same time: [#2251](https://github.com/music-assistant/frontend/pull/2251) replaced the route mock in `useGuestEntryResolver.test.ts` with a `getRoutePath()` helper, while [#2253](https://github.com/music-assistant/frontend/pull/2253) added an assertion still referencing the old `routeMock`. Each was green against the main it branched from, so neither PR caught it.

`main` now fails with `ReferenceError: routeMock is not defined`, and since the pre-commit hook runs the full suite, this blocks every commit in the repo.

- Use `getRoutePath()` in the Party transition assertion, matching the other 13 call sites in the file