### PR TITLE
Remove leftover panel-expansion state from the settings config editor

### DIFF
--- a/src/views/settings/EditConfig.vue
+++ b/src/views/settings/EditConfig.vue
@@ -215,7 +215,6 @@ const emit = defineEmits<{
 const entries = ref<ConfigEntryUI[]>();
 const valid = ref(false);
 const form = ref<InstanceType<typeof import("vuetify/components").VForm>>();
-const activePanel = ref<string[]>([]);
 const showPasswordValues = ref(false);
 const showAdvancedSettings = ref(false);
 const showHelpInfo = ref<ConfigEntryUI>();
@@ -344,12 +343,6 @@ watch(
       entries.value.push(entry);
     }
     oldValuesInitialized.value = true;
-    // Set active panels after entries are populated
-    // Expand all panels by default, except protocol categories which stay collapsed
-    const expandedPanels = panels.value.filter((p) => !isProtocolCategory(p));
-    activePanel.value = expandedPanels;
-    // Protocol config sections stay collapsed by default; the user opens the one
-    // they want to configure.
   },
   { immediate: true },
 );


### PR DESCRIPTION
The config editor kept an `activePanel` ref that was recalculated on every config reload but never read anywhere. The category sections are plain divs, not expansion panels, and the protocol section manages its own open/closed state, so nothing consumed it.

- Removed the unused `activePanel` ref and the code that recomputed it
- Removed the two comments describing panel-expansion behaviour that no longer exists