### PR TITLE
Confirm when a settings action button has run

### DIFF
--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -636,6 +636,7 @@
         "provider_saved": "Provider settings saved",
         "provider_reloading": "Reloading provider…",
         "provider_removed": "Provider removed",
+        "action_completed": "Action completed",
         "queue_settings": "Queue settings",
         "audio_analysis_failures": {
             "title": "Audio Analysis Failures",

--- a/src/views/settings/EditConfig.vue
+++ b/src/views/settings/EditConfig.vue
@@ -394,7 +394,6 @@ const openPlayerOptions = function () {
 
 const onEntryAction = function (entry: ConfigEntryUI) {
   action(entry.action || entry.key, !!entry.immediate_apply);
-  entry.value = entry.action ? null : entry.key;
 };
 
 const onEntryHelp = function (entry: ConfigEntryUI) {

--- a/src/views/settings/EditCoreConfig.vue
+++ b/src/views/settings/EditCoreConfig.vue
@@ -147,6 +147,13 @@ const onAction = async function (
     .invokeCoreConfigAction(config.value!.domain, action)
     .then(async (entries) => {
       entries = openActionUrlEntries(entries);
+      // An empty response means the action was a one-off side effect with
+      // nothing to re-render: leave the form untouched.
+      if (entries.length === 0) {
+        toast.success(t("settings.action_completed"));
+        loading.value = false;
+        return;
+      }
       config.value!.values = {};
       for (const entry of entries) {
         config.value!.values[entry.key] = entry;

--- a/src/views/settings/EditPlayer.vue
+++ b/src/views/settings/EditPlayer.vue
@@ -473,6 +473,12 @@ const onAction = async function (
     .invokePlayerConfigAction(config.value!.player_id, action)
     .then(async (entries) => {
       entries = openActionUrlEntries(entries);
+      // An empty response means the action was a one-off side effect with
+      // nothing to re-render: leave the form untouched.
+      if (entries.length === 0) {
+        toast.success($t("settings.action_completed"));
+        return;
+      }
       config.value!.values = {};
       for (const entry of entries) {
         config.value!.values[entry.key] = entry;

--- a/src/views/settings/EditProvider.vue
+++ b/src/views/settings/EditProvider.vue
@@ -379,6 +379,12 @@ const onAction = async function (
     .invokeProviderConfigAction(config.value!.instance_id, action)
     .then(async (entries) => {
       entries = openActionUrlEntries(entries);
+      // An empty response means the action was a one-off side effect with
+      // nothing to re-render: leave the form untouched.
+      if (entries.length === 0) {
+        toast.success(t("settings.action_completed"));
+        return;
+      }
       config.value!.values = {};
       for (const entry of entries) {
         config.value!.values[entry.key] = entry;

--- a/tests/views/EditCoreConfig.test.ts
+++ b/tests/views/EditCoreConfig.test.ts
@@ -1,0 +1,183 @@
+import { flushPromises, shallowMount } from "@vue/test-utils";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  ConfigEntryType,
+  ProviderStage,
+  ProviderType,
+  type CoreConfig,
+} from "@/plugins/api/interfaces";
+import EditCoreConfig from "@/views/settings/EditCoreConfig.vue";
+
+const { apiMock, routerMock, toastMock } = vi.hoisted(() => ({
+  apiMock: {
+    getCoreConfig: vi.fn(),
+    invokeCoreConfigAction: vi.fn(),
+    providerManifests: {
+      cache: {
+        codeowners: [],
+        credits: [],
+        description: "Cache controller",
+        has_setup_flow: false,
+        name: "Cache",
+      },
+    },
+    saveCoreConfig: vi.fn(),
+  },
+  routerMock: {
+    push: vi.fn(),
+  },
+  toastMock: {
+    error: vi.fn(),
+    success: vi.fn(),
+  },
+}));
+
+vi.mock("@/plugins/api", () => ({
+  api: apiMock,
+  default: apiMock,
+}));
+
+vi.mock("@/helpers/utils", () => ({
+  openActionUrlEntries: <T>(entries: T) => entries,
+}));
+
+vi.mock("vue-sonner", () => ({
+  toast: toastMock,
+}));
+
+vi.mock("vue-i18n", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("vue-i18n")>();
+  return {
+    ...actual,
+    useI18n: () => ({
+      t: (key: string) => key,
+    }),
+  };
+});
+
+vi.mock("vue-router", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("vue-router")>();
+  return {
+    ...actual,
+    useRouter: () => routerMock,
+  };
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("EditCoreConfig", () => {
+  it("keeps a pending local edit, shows a toast and clears loading when an action returns no entries", async () => {
+    apiMock.getCoreConfig.mockResolvedValueOnce(coreConfig());
+    apiMock.invokeCoreConfigAction.mockResolvedValueOnce([]);
+
+    const wrapper = shallowMount(EditCoreConfig, {
+      props: {
+        domain: "cache",
+      },
+      global: {
+        mocks: {
+          $t: (key: string) => key,
+        },
+      },
+    });
+    await flushPromises();
+
+    // EditConfig edits the entry objects in place, so this is what a user
+    // typing into the form leaves behind
+    const editConfig = wrapper.findComponent({ name: "EditConfig" });
+    const editedEntry = editConfig.props("configEntries")[0];
+    editedEntry.value = "typed but not saved";
+
+    await editConfig.vm.$emit("action", "do_thing", {}, false);
+    await flushPromises();
+
+    expect(apiMock.invokeCoreConfigAction).toHaveBeenCalledWith(
+      "cache",
+      "do_thing",
+    );
+    const entriesAfter = editConfig.props("configEntries");
+    expect(entriesAfter).toHaveLength(1);
+    expect(entriesAfter[0]).toBe(editedEntry);
+    expect(entriesAfter[0].value).toBe("typed but not saved");
+    expect(apiMock.saveCoreConfig).not.toHaveBeenCalled();
+    expect(toastMock.success).toHaveBeenCalledWith("settings.action_completed");
+    expect(
+      wrapper.findComponent({ name: "v-overlay" }).props("modelValue"),
+    ).toBe(false);
+  });
+
+  it("still replaces the form when an action returns entries (transitional path)", async () => {
+    apiMock.getCoreConfig.mockResolvedValueOnce(coreConfig());
+    apiMock.invokeCoreConfigAction.mockResolvedValueOnce([
+      {
+        category: "generic",
+        default_value: null,
+        key: "new_field",
+        label: "New field",
+        required: false,
+        type: ConfigEntryType.STRING,
+        value: "server value",
+      },
+    ]);
+
+    const wrapper = shallowMount(EditCoreConfig, {
+      props: {
+        domain: "cache",
+      },
+      global: {
+        mocks: {
+          $t: (key: string) => key,
+        },
+      },
+    });
+    await flushPromises();
+
+    const editConfig = wrapper.findComponent({ name: "EditConfig" });
+
+    await editConfig.vm.$emit("action", "do_thing", {}, false);
+    await flushPromises();
+
+    expect(editConfig.props("configEntries")).toEqual([
+      expect.objectContaining({
+        key: "new_field",
+        value: "server value",
+      }),
+    ]);
+    expect(apiMock.saveCoreConfig).not.toHaveBeenCalled();
+    expect(toastMock.success).not.toHaveBeenCalled();
+  });
+});
+
+function coreConfig(): CoreConfig {
+  return {
+    domain: "cache",
+    manifest: {
+      allow_disable: false,
+      builtin: true,
+      codeowners: [],
+      credits: [],
+      description: "Cache controller",
+      domain: "cache",
+      icon_images: [],
+      has_setup_flow: false,
+      multi_instance: false,
+      name: "Cache",
+      requirements: [],
+      stage: ProviderStage.STABLE,
+      type: ProviderType.MUSIC,
+    },
+    values: {
+      clear_on_start: {
+        category: "generic",
+        default_value: false,
+        key: "clear_on_start",
+        label: "Clear cache on start",
+        required: false,
+        type: ConfigEntryType.BOOLEAN,
+        value: "current value",
+      },
+    },
+  };
+}

--- a/tests/views/EditProvider.test.ts
+++ b/tests/views/EditProvider.test.ts
@@ -211,7 +211,7 @@ describe("EditProvider", () => {
     );
   });
 
-  it("leaves the form untouched and shows a toast when an action returns no entries", async () => {
+  it("keeps a pending local edit and shows a toast when an action returns no entries", async () => {
     apiMock.getProviderConfig.mockResolvedValueOnce(
       providerConfig(ProviderStatus.LOADED),
     );
@@ -229,8 +229,11 @@ describe("EditProvider", () => {
     });
     await flushPromises();
 
+    // EditConfig edits the entry objects in place, so this is what a user
+    // typing into the form leaves behind
     const editConfig = wrapper.findComponent({ name: "EditConfig" });
-    const entriesBefore = editConfig.props("configEntries");
+    const editedEntry = editConfig.props("configEntries")[0];
+    editedEntry.value = "typed but not saved";
 
     await editConfig.vm.$emit("action", "do_thing", {}, false);
     await flushPromises();
@@ -239,7 +242,10 @@ describe("EditProvider", () => {
       "spotify--test",
       "do_thing",
     );
-    expect(editConfig.props("configEntries")).toEqual(entriesBefore);
+    const entriesAfter = editConfig.props("configEntries");
+    expect(entriesAfter).toHaveLength(1);
+    expect(entriesAfter[0]).toBe(editedEntry);
+    expect(entriesAfter[0].value).toBe("typed but not saved");
     expect(apiMock.saveProviderConfig).not.toHaveBeenCalled();
     expect(toastMock.success).toHaveBeenCalledWith("settings.action_completed");
   });

--- a/tests/views/EditProvider.test.ts
+++ b/tests/views/EditProvider.test.ts
@@ -10,8 +10,8 @@ import {
 } from "@/plugins/api/interfaces";
 import EditProvider from "@/views/settings/EditProvider.vue";
 
-const { apiMock, eventbusMock, routerMock, unsubscribeMock } = vi.hoisted(
-  () => ({
+const { apiMock, eventbusMock, routerMock, toastMock, unsubscribeMock } =
+  vi.hoisted(() => ({
     apiMock: {
       getProvider: vi.fn(),
       getProviderConfig: vi.fn(),
@@ -37,9 +37,12 @@ const { apiMock, eventbusMock, routerMock, unsubscribeMock } = vi.hoisted(
     routerMock: {
       push: vi.fn(),
     },
+    toastMock: {
+      error: vi.fn(),
+      success: vi.fn(),
+    },
     unsubscribeMock: vi.fn(),
-  }),
-);
+  }));
 
 let providersUpdated: (() => void) | undefined;
 
@@ -55,6 +58,10 @@ vi.mock("@/plugins/eventbus", () => ({
 vi.mock("@/helpers/utils", () => ({
   markdownToHtml: (value: string) => value,
   openActionUrlEntries: <T>(entries: T) => entries,
+}));
+
+vi.mock("vue-sonner", () => ({
+  toast: toastMock,
 }));
 
 vi.mock("vue-i18n", async (importOriginal) => {
@@ -202,6 +209,82 @@ describe("EditProvider", () => {
     expect(wrapper.text()).not.toContain(
       "settings.provider_requires_attention",
     );
+  });
+
+  it("leaves the form untouched and shows a toast when an action returns no entries", async () => {
+    apiMock.getProviderConfig.mockResolvedValueOnce(
+      providerConfig(ProviderStatus.LOADED),
+    );
+    apiMock.invokeProviderConfigAction.mockResolvedValueOnce([]);
+
+    const wrapper = shallowMount(EditProvider, {
+      props: {
+        instanceId: "spotify--test",
+      },
+      global: {
+        mocks: {
+          $t: (key: string) => key,
+        },
+      },
+    });
+    await flushPromises();
+
+    const editConfig = wrapper.findComponent({ name: "EditConfig" });
+    const entriesBefore = editConfig.props("configEntries");
+
+    await editConfig.vm.$emit("action", "do_thing", {}, false);
+    await flushPromises();
+
+    expect(apiMock.invokeProviderConfigAction).toHaveBeenCalledWith(
+      "spotify--test",
+      "do_thing",
+    );
+    expect(editConfig.props("configEntries")).toEqual(entriesBefore);
+    expect(apiMock.saveProviderConfig).not.toHaveBeenCalled();
+    expect(toastMock.success).toHaveBeenCalledWith("settings.action_completed");
+  });
+
+  it("still replaces the form when an action returns entries (transitional path)", async () => {
+    apiMock.getProviderConfig.mockResolvedValueOnce(
+      providerConfig(ProviderStatus.LOADED),
+    );
+    apiMock.invokeProviderConfigAction.mockResolvedValueOnce([
+      {
+        category: "generic",
+        default_value: null,
+        key: "new_field",
+        label: "New field",
+        required: false,
+        type: ConfigEntryType.STRING,
+        value: "server value",
+      },
+    ]);
+
+    const wrapper = shallowMount(EditProvider, {
+      props: {
+        instanceId: "spotify--test",
+      },
+      global: {
+        mocks: {
+          $t: (key: string) => key,
+        },
+      },
+    });
+    await flushPromises();
+
+    const editConfig = wrapper.findComponent({ name: "EditConfig" });
+
+    await editConfig.vm.$emit("action", "do_thing", {}, false);
+    await flushPromises();
+
+    expect(editConfig.props("configEntries")).toEqual([
+      expect.objectContaining({
+        key: "new_field",
+        value: "server value",
+      }),
+    ]);
+    expect(apiMock.saveProviderConfig).not.toHaveBeenCalled();
+    expect(toastMock.success).not.toHaveBeenCalled();
   });
 });
 

--- a/tests/views/EditProvider.test.ts
+++ b/tests/views/EditProvider.test.ts
@@ -250,6 +250,32 @@ describe("EditProvider", () => {
     expect(toastMock.success).toHaveBeenCalledWith("settings.action_completed");
   });
 
+  it("does not save when an immediate-apply action returns no entries", async () => {
+    apiMock.getProviderConfig.mockResolvedValueOnce(
+      providerConfig(ProviderStatus.LOADED),
+    );
+    apiMock.invokeProviderConfigAction.mockResolvedValueOnce([]);
+
+    const wrapper = shallowMount(EditProvider, {
+      props: {
+        instanceId: "spotify--test",
+      },
+      global: {
+        mocks: {
+          $t: (key: string) => key,
+        },
+      },
+    });
+    await flushPromises();
+
+    const editConfig = wrapper.findComponent({ name: "EditConfig" });
+    await editConfig.vm.$emit("action", "do_thing", {}, true);
+    await flushPromises();
+
+    expect(apiMock.saveProviderConfig).not.toHaveBeenCalled();
+    expect(toastMock.success).toHaveBeenCalledWith("settings.action_completed");
+  });
+
   it("still replaces the form when an action returns entries (transitional path)", async () => {
     apiMock.getProviderConfig.mockResolvedValueOnce(
       providerConfig(ProviderStatus.LOADED),


### PR DESCRIPTION
Buttons on a provider, player or core settings page (things like "clear cache" or "rebuild index") gave no feedback at all when they succeeded, and always rebuilt the whole form from the server response — throwing away anything you had typed but not saved.

Groundwork for making these buttons plain one-off actions: when there is nothing to re-render, the page now just confirms the action ran and leaves your form alone.

- Show a short confirmation toast when an action reports nothing to display
- Leave the form, including unsaved edits, untouched in that case
- Pages still handle actions that do return updated settings, so nothing changes for those yet