### PR TITLE
Fix the progress bar in the OS media notification for audiobooks and podcasts

### DIFF
--- a/src/helpers/useMediaBrowserMetaData.ts
+++ b/src/helpers/useMediaBrowserMetaData.ts
@@ -1,3 +1,4 @@
+import computeElapsedTime from "@/helpers/elapsed";
 import { getMediaImageUrl } from "@/helpers/utils";
 import api from "@/plugins/api";
 import { MediaType, PlayerMedia } from "@/plugins/api/interfaces";
@@ -5,6 +6,14 @@ import authManager from "@/plugins/auth";
 import { store } from "@/plugins/store";
 import { computed, watch } from "vue";
 import { useRouter } from "vue-router";
+
+// Media types that play back a fixed, seekable duration. Live and unbounded
+// sources get no progress bar at all.
+const POSITION_STATE_MEDIA_TYPES = new Set<MediaType>([
+  MediaType.TRACK,
+  MediaType.AUDIOBOOK,
+  MediaType.PODCAST_EPISODE,
+]);
 
 function playerMediaToMetadata(item: PlayerMedia) {
   const artwork = [
@@ -112,31 +121,55 @@ export function useMediaBrowserMetaData(player_id?: string) {
     const queueId = playerQueue.value?.queue_id;
     return queueId ? api.queueElapsedTime[queueId] : undefined;
   });
+  // The OS extrapolates the position from this rate between our updates, and a
+  // zero rate is rejected outright, so only a sane value may reach it.
+  const playbackSpeed = computed(() => {
+    const speed =
+      playerQueue.value?.current_item?.extra_attributes?.playback_speed;
+    return typeof speed === "number" && Number.isFinite(speed) && speed > 0
+      ? speed
+      : 1;
+  });
   const unwatch_position = watch(
     () => [
       queueElapsed.value?.elapsed_time,
       playerQueue.value?.current_item?.duration,
+      playbackSpeed.value,
     ],
     () => {
-      if (
-        !playerQueue.value?.active ||
-        playerQueue.value?.current_item?.media_item?.media_type !==
-          MediaType.TRACK
-      ) {
+      const currentItem = playerQueue.value?.current_item;
+      const mediaType = currentItem?.media_item?.media_type;
+      const duration = currentItem?.duration;
+      // A podcast episode can arrive without a known duration, and there is no
+      // meaningful progress to show for it.
+      const hasProgress =
+        !!playerQueue.value?.active &&
+        !!mediaType &&
+        POSITION_STATE_MEDIA_TYPES.has(mediaType) &&
+        typeof duration === "number" &&
+        Number.isFinite(duration) &&
+        duration > 0;
+      if (!hasProgress) {
         // Clear the progress bar.
         navigator.mediaSession.setPositionState();
         return;
       }
-      const duration = playerQueue.value?.current_item?.duration || 1;
-      const position = Math.min(
-        duration,
-        queueElapsed.value?.elapsed_time != null
-          ? queueElapsed.value.elapsed_time
-          : 0,
-      );
+      // The stored position is anchored to the moment the server reported it,
+      // so it is carried forward to now; the OS takes it as a snapshot of the
+      // present and extrapolates from there.
+      const elapsed =
+        computeElapsedTime(
+          queueElapsed.value?.elapsed_time,
+          queueElapsed.value?.elapsed_time_last_updated,
+          playerQueue.value?.state,
+          playbackSpeed.value,
+        ) ?? 0;
+      const position = Number.isFinite(elapsed)
+        ? Math.min(duration, Math.max(0, elapsed))
+        : 0;
       navigator.mediaSession.setPositionState({
         duration: duration,
-        playbackRate: 1.0,
+        playbackRate: playbackSpeed.value,
         position: position,
       });
     },

--- a/src/helpers/useMediaBrowserMetaData.ts
+++ b/src/helpers/useMediaBrowserMetaData.ts
@@ -133,6 +133,8 @@ export function useMediaBrowserMetaData(player_id?: string) {
   const unwatch_position = watch(
     () => [
       queueElapsed.value?.elapsed_time,
+      queueElapsed.value?.elapsed_time_last_updated,
+      playerQueue.value?.state,
       playerQueue.value?.current_item?.duration,
       playbackSpeed.value,
     ],

--- a/tests/helpers/useMediaBrowserMetaData.test.ts
+++ b/tests/helpers/useMediaBrowserMetaData.test.ts
@@ -1,0 +1,251 @@
+import { useMediaBrowserMetaData } from "@/helpers/useMediaBrowserMetaData";
+import {
+  MediaType,
+  PlaybackState,
+  type PlayableMediaItemType,
+  type Player,
+  type PlayerQueue,
+  type QueueItem,
+} from "@/plugins/api/interfaces";
+import { nextTick } from "vue";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Reactive api mock so mutating a queue fires the composable's watchers.
+const { apiMock } = await vi.hoisted(async () => {
+  const { reactive } = await import("vue");
+  return {
+    apiMock: reactive({
+      players: {} as Record<string, Player>,
+      queues: {} as Record<string, PlayerQueue>,
+      queueElapsedTime: {} as Record<
+        string,
+        { elapsed_time?: number; elapsed_time_last_updated?: number }
+      >,
+    }),
+  };
+});
+
+vi.mock("@/plugins/api", () => ({
+  default: apiMock,
+}));
+
+// The real helpers/utils pulls in the router and the whole component tree; only
+// the artwork url helper is needed here.
+vi.mock("@/helpers/utils", () => ({
+  getMediaImageUrl: (url?: string) => url ?? "",
+}));
+
+vi.mock("@/composables/useServerTime", () => ({
+  serverNow: () => serverTime,
+}));
+
+vi.mock("@/plugins/store", () => ({
+  store: { activePlayerId: undefined },
+}));
+
+vi.mock("@/plugins/auth", () => ({
+  default: { isMusicQuizGuest: () => false },
+}));
+
+vi.mock("vue-router", () => ({
+  useRouter: () => ({ currentRoute: { value: { path: "/" } } }),
+}));
+
+const PLAYER_ID = "player-1";
+const QUEUE_ID = "queue-1";
+const ANCHOR = 1_000_000;
+
+const setPositionState = vi.fn();
+let serverTime = ANCHOR;
+let teardown: (() => void) | undefined;
+
+function makeQueue(
+  currentItem: Partial<QueueItem>,
+  queue: Partial<PlayerQueue> = {},
+): PlayerQueue {
+  apiMock.players[PLAYER_ID] = {
+    player_id: PLAYER_ID,
+    active_source: QUEUE_ID,
+  } as Player;
+  apiMock.queueElapsedTime[QUEUE_ID] = {
+    elapsed_time: 30,
+    elapsed_time_last_updated: ANCHOR,
+  };
+  apiMock.queues[QUEUE_ID] = {
+    queue_id: QUEUE_ID,
+    active: true,
+    state: PlaybackState.PLAYING,
+    current_item: {
+      queue_id: QUEUE_ID,
+      queue_item_id: "queue-item-1",
+      name: "Item",
+      duration: 200,
+      sort_index: 0,
+      available: true,
+      media_item: { media_type: MediaType.TRACK } as PlayableMediaItemType,
+      ...currentItem,
+    },
+    ...queue,
+  } as PlayerQueue;
+  return apiMock.queues[QUEUE_ID];
+}
+
+beforeEach(() => {
+  for (const key of Object.keys(apiMock.players)) delete apiMock.players[key];
+  for (const key of Object.keys(apiMock.queues)) delete apiMock.queues[key];
+  for (const key of Object.keys(apiMock.queueElapsedTime))
+    delete apiMock.queueElapsedTime[key];
+  serverTime = ANCHOR;
+  setPositionState.mockClear();
+  Object.defineProperty(navigator, "mediaSession", {
+    configurable: true,
+    value: { setPositionState },
+  });
+});
+
+afterEach(() => {
+  teardown?.();
+  teardown = undefined;
+  Reflect.deleteProperty(navigator, "mediaSession");
+});
+
+describe("useMediaBrowserMetaData position state", () => {
+  it("reports the playback speed of the current queue item", () => {
+    makeQueue({ extra_attributes: { playback_speed: 1.5 } });
+
+    teardown = useMediaBrowserMetaData(PLAYER_ID);
+
+    expect(setPositionState).toHaveBeenCalledWith({
+      duration: 200,
+      playbackRate: 1.5,
+      position: 30,
+    });
+  });
+
+  it("reports the new speed when the queue item is replaced", async () => {
+    const queue = makeQueue({ extra_attributes: { playback_speed: 1 } });
+
+    teardown = useMediaBrowserMetaData(PLAYER_ID);
+
+    queue.current_item = {
+      ...queue.current_item!,
+      extra_attributes: { playback_speed: 2 },
+    };
+    await nextTick();
+
+    expect(setPositionState).toHaveBeenLastCalledWith({
+      duration: 200,
+      playbackRate: 2,
+      position: 30,
+    });
+  });
+
+  it("re-fires when only the playback speed of the current item changes", async () => {
+    const queue = makeQueue({ extra_attributes: { playback_speed: 1 } });
+
+    teardown = useMediaBrowserMetaData(PLAYER_ID);
+    expect(setPositionState).toHaveBeenCalledTimes(1);
+
+    queue.current_item!.extra_attributes = { playback_speed: 2 };
+    await nextTick();
+
+    expect(setPositionState).toHaveBeenCalledTimes(2);
+    expect(setPositionState).toHaveBeenLastCalledWith(
+      expect.objectContaining({ playbackRate: 2 }),
+    );
+  });
+
+  it("carries the stored position forward at the playback speed", () => {
+    makeQueue({ extra_attributes: { playback_speed: 2 } });
+    serverTime = ANCHOR + 10;
+
+    teardown = useMediaBrowserMetaData(PLAYER_ID);
+
+    expect(setPositionState).toHaveBeenCalledWith(
+      expect.objectContaining({ position: 50 }),
+    );
+  });
+
+  it("keeps the stored position while paused", () => {
+    makeQueue(
+      { extra_attributes: { playback_speed: 2 } },
+      { state: PlaybackState.PAUSED },
+    );
+    serverTime = ANCHOR + 10;
+
+    teardown = useMediaBrowserMetaData(PLAYER_ID);
+
+    expect(setPositionState).toHaveBeenCalledWith(
+      expect.objectContaining({ position: 30 }),
+    );
+  });
+
+  it.each([
+    ["no playback speed", undefined],
+    ["a zero playback speed", 0],
+    ["a negative playback speed", -1],
+    ["a NaN playback speed", NaN],
+    ["an infinite playback speed", Infinity],
+  ])("falls back to normal speed for %s", (_label, playback_speed) => {
+    makeQueue({
+      extra_attributes:
+        playback_speed === undefined ? undefined : { playback_speed },
+    });
+
+    teardown = useMediaBrowserMetaData(PLAYER_ID);
+
+    expect(setPositionState).toHaveBeenCalledWith(
+      expect.objectContaining({ playbackRate: 1, position: 30 }),
+    );
+  });
+
+  it.each([MediaType.AUDIOBOOK, MediaType.PODCAST_EPISODE])(
+    "reports position state for %s",
+    (mediaType) => {
+      makeQueue({
+        duration: 3600,
+        media_item: { media_type: mediaType } as PlayableMediaItemType,
+        extra_attributes: { playback_speed: 1.25 },
+      });
+
+      teardown = useMediaBrowserMetaData(PLAYER_ID);
+
+      expect(setPositionState).toHaveBeenCalledWith({
+        duration: 3600,
+        playbackRate: 1.25,
+        position: 30,
+      });
+    },
+  );
+
+  it("clears the progress bar for an item without a known duration", () => {
+    makeQueue({
+      duration: 0,
+      media_item: {
+        media_type: MediaType.PODCAST_EPISODE,
+      } as PlayableMediaItemType,
+    });
+
+    teardown = useMediaBrowserMetaData(PLAYER_ID);
+
+    expect(setPositionState).toHaveBeenCalledWith();
+  });
+
+  it("clears the progress bar for a source without a fixed duration", () => {
+    makeQueue({
+      media_item: { media_type: MediaType.RADIO } as PlayableMediaItemType,
+    });
+
+    teardown = useMediaBrowserMetaData(PLAYER_ID);
+
+    expect(setPositionState).toHaveBeenCalledWith();
+  });
+
+  it("clears the progress bar for an inactive queue", () => {
+    makeQueue({}, { active: false });
+
+    teardown = useMediaBrowserMetaData(PLAYER_ID);
+
+    expect(setPositionState).toHaveBeenCalledWith();
+  });
+});

--- a/tests/helpers/useMediaBrowserMetaData.test.ts
+++ b/tests/helpers/useMediaBrowserMetaData.test.ts
@@ -122,22 +122,20 @@ describe("useMediaBrowserMetaData position state", () => {
     });
   });
 
-  it("reports the new speed when the queue item is replaced", async () => {
-    const queue = makeQueue({ extra_attributes: { playback_speed: 1 } });
+  // Mirrors a QUEUE_TIME_UPDATED event, which mutates the stored time in place.
+  it("follows an in-place update of the stored position", async () => {
+    makeQueue({ extra_attributes: { playback_speed: 1.5 } });
 
     teardown = useMediaBrowserMetaData(PLAYER_ID);
 
-    queue.current_item = {
-      ...queue.current_item!,
-      extra_attributes: { playback_speed: 2 },
-    };
+    serverTime = ANCHOR + 4;
+    apiMock.queueElapsedTime[QUEUE_ID].elapsed_time = 36;
+    apiMock.queueElapsedTime[QUEUE_ID].elapsed_time_last_updated = serverTime;
     await nextTick();
 
-    expect(setPositionState).toHaveBeenLastCalledWith({
-      duration: 200,
-      playbackRate: 2,
-      position: 30,
-    });
+    expect(setPositionState).toHaveBeenLastCalledWith(
+      expect.objectContaining({ position: 36 }),
+    );
   });
 
   it("re-fires when only the playback speed of the current item changes", async () => {
@@ -163,6 +161,48 @@ describe("useMediaBrowserMetaData position state", () => {
 
     expect(setPositionState).toHaveBeenCalledWith(
       expect.objectContaining({ position: 50 }),
+    );
+  });
+
+  it("never reports a position beyond the duration", () => {
+    makeQueue({ extra_attributes: { playback_speed: 2 } });
+    serverTime = ANCHOR + 3600;
+
+    teardown = useMediaBrowserMetaData(PLAYER_ID);
+
+    expect(setPositionState).toHaveBeenCalledWith(
+      expect.objectContaining({ duration: 200, position: 200 }),
+    );
+  });
+
+  it.each([
+    ["has no stored position yet", undefined],
+    ["reports an unusable position", NaN],
+  ])("starts from zero when the queue %s", (_label, elapsed_time) => {
+    makeQueue({});
+    if (elapsed_time === undefined) delete apiMock.queueElapsedTime[QUEUE_ID];
+    else apiMock.queueElapsedTime[QUEUE_ID].elapsed_time = elapsed_time;
+
+    teardown = useMediaBrowserMetaData(PLAYER_ID);
+
+    expect(setPositionState).toHaveBeenCalledWith(
+      expect.objectContaining({ position: 0 }),
+    );
+  });
+
+  it("freezes the position as soon as the queue pauses", async () => {
+    const queue = makeQueue({ extra_attributes: { playback_speed: 2 } });
+
+    teardown = useMediaBrowserMetaData(PLAYER_ID);
+    expect(setPositionState).toHaveBeenCalledTimes(1);
+
+    serverTime = ANCHOR + 10;
+    queue.state = PlaybackState.PAUSED;
+    await nextTick();
+
+    expect(setPositionState).toHaveBeenCalledTimes(2);
+    expect(setPositionState).toHaveBeenLastCalledWith(
+      expect.objectContaining({ position: 30 }),
     );
   });
 


### PR DESCRIPTION
The media notification of the phone/desktop always assumed playback at normal speed, so its progress bar ran at the wrong pace whenever an audiobook or podcast was played at another speed, and only snapped back when the server sent a position update. The bar also started from the position the server last reported instead of the current one, and audiobooks and podcast episodes got no progress bar at all.

- Report the real playback speed of the current item to the OS media session
- Start the bar at the current position instead of the last one the server reported, and hold it still while playback is paused
- Show progress for audiobooks and podcast episodes as well
- Hide the bar for an item without a known duration, instead of showing a full one-second bar
- Added tests for the media session position state