### PR TITLE
Read the playback speed from one shared helper

### DIFF
--- a/src/helpers/activeElapsedTime.ts
+++ b/src/helpers/activeElapsedTime.ts
@@ -6,7 +6,7 @@
  * Both functions read the current values on each call and hold no state, which
  * makes them equally usable inside a `computed` and inside a rAF/interval loop.
  */
-import { computeElapsedTime } from "@/helpers/elapsed";
+import { computeElapsedTime, queueItemPlaybackSpeed } from "@/helpers/elapsed";
 import api from "@/plugins/api";
 import { store } from "@/plugins/store";
 import { PlaybackState } from "@/plugins/api/interfaces";
@@ -29,8 +29,7 @@ export interface ActiveTiming {
  * never combine a queue position with a player state or the other way around.
  */
 export function resolveActiveTiming(): ActiveTiming | undefined {
-  const playbackSpeed =
-    store.curQueueItem?.extra_attributes?.playback_speed ?? 1;
+  const playbackSpeed = queueItemPlaybackSpeed(store.curQueueItem);
 
   // Prefer the active queue's own elapsed_time when it reports one.
   const queue = store.activePlayerQueue;

--- a/src/helpers/elapsed.test.ts
+++ b/src/helpers/elapsed.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { computeElapsedTime } from "./elapsed";
-import { PlaybackState } from "../plugins/api/interfaces";
+import { computeElapsedTime, queueItemPlaybackSpeed } from "./elapsed";
+import { PlaybackState, QueueItem } from "../plugins/api/interfaces";
 
 describe("computeElapsedTime", () => {
   const REAL_DATE_NOW = Date.now;
@@ -89,5 +89,39 @@ describe("computeElapsedTime", () => {
     const result = computeElapsedTime(t0, ts, PlaybackState.PLAYING);
     expect(result).toBeGreaterThanOrEqual(11.999);
     expect(result).toBeLessThanOrEqual(12.001);
+  });
+});
+
+describe("queueItemPlaybackSpeed", () => {
+  const itemWithSpeed = (playback_speed?: unknown) =>
+    ({
+      extra_attributes: { playback_speed },
+    }) as QueueItem;
+
+  it.each([
+    ["a speed above 1", 1.5, 1.5],
+    ["a speed below 1", 0.75, 0.75],
+    ["an explicit normal speed", 1, 1],
+  ])("returns %s as-is", (_label, playback_speed, expected) => {
+    expect(queueItemPlaybackSpeed(itemWithSpeed(playback_speed))).toBe(
+      expected,
+    );
+  });
+
+  it.each([
+    ["zero", 0],
+    ["a negative speed", -1],
+    ["infinity", Number.POSITIVE_INFINITY],
+    ["NaN", Number.NaN],
+    ["a non-numeric value", "1.5"],
+    ["null", null],
+    ["an absent speed", undefined],
+  ])("falls back to normal speed for %s", (_label, playback_speed) => {
+    expect(queueItemPlaybackSpeed(itemWithSpeed(playback_speed))).toBe(1);
+  });
+
+  it("falls back to normal speed without extra_attributes or item", () => {
+    expect(queueItemPlaybackSpeed({} as QueueItem)).toBe(1);
+    expect(queueItemPlaybackSpeed(undefined)).toBe(1);
   });
 });

--- a/src/helpers/elapsed.ts
+++ b/src/helpers/elapsed.ts
@@ -1,6 +1,7 @@
+import { serverNow } from "@/composables/useServerTime";
+import { PlaybackState, QueueItem } from "../plugins/api/interfaces";
+
 /**
- * computeElapsedTime
- *
  * Calculate the current elapsed playback time in seconds from a stored
  * `elapsed_time` value and the `elapsed_time_last_updated` UTC timestamp
  * (seconds since epoch), on the server's clock. The function assumes:
@@ -12,9 +13,6 @@
  * `elapsed_time` without applying the time-delta. This avoids advancing the
  * position while paused/stopped.
  */
-import { serverNow } from "@/composables/useServerTime";
-import { PlaybackState, QueueItem } from "../plugins/api/interfaces";
-
 export function computeElapsedTime(
   elapsed_time: number | undefined,
   elapsed_time_last_updated: number | undefined,
@@ -40,9 +38,9 @@ export function computeElapsedTime(
 /**
  * Speed a queue item plays at, e.g. an audiobook at 1.5x.
  *
- * Falls back to normal speed unless the item reports a usable multiplier: zero
- * would freeze every progress indicator, a negative value would run them
- * backwards, and the OS media session rejects both outright.
+ * Only a finite speed above zero is usable: zero would freeze every progress
+ * indicator, a negative value would run them backwards, and the OS media
+ * session rejects such a rate outright. Anything else reads as normal speed.
  */
 export function queueItemPlaybackSpeed(item?: QueueItem): number {
   const speed = item?.extra_attributes?.playback_speed;

--- a/src/helpers/elapsed.ts
+++ b/src/helpers/elapsed.ts
@@ -13,7 +13,7 @@
  * position while paused/stopped.
  */
 import { serverNow } from "@/composables/useServerTime";
-import { PlaybackState } from "../plugins/api/interfaces";
+import { PlaybackState, QueueItem } from "../plugins/api/interfaces";
 
 export function computeElapsedTime(
   elapsed_time: number | undefined,
@@ -35,4 +35,18 @@ export function computeElapsedTime(
   const delta = Math.max(0, serverNow() - elapsed_time_last_updated);
 
   return elapsed_time + delta * playback_speed;
+}
+
+/**
+ * Speed a queue item plays at, e.g. an audiobook at 1.5x.
+ *
+ * Falls back to normal speed unless the item reports a usable multiplier: zero
+ * would freeze every progress indicator, a negative value would run them
+ * backwards, and the OS media session rejects both outright.
+ */
+export function queueItemPlaybackSpeed(item?: QueueItem): number {
+  const speed = item?.extra_attributes?.playback_speed;
+  return typeof speed === "number" && Number.isFinite(speed) && speed > 0
+    ? speed
+    : 1;
 }

--- a/src/helpers/useMediaBrowserMetaData.ts
+++ b/src/helpers/useMediaBrowserMetaData.ts
@@ -1,4 +1,4 @@
-import { computeElapsedTime } from "@/helpers/elapsed";
+import { computeElapsedTime, queueItemPlaybackSpeed } from "@/helpers/elapsed";
 import { getMediaImageUrl } from "@/helpers/utils";
 import api from "@/plugins/api";
 import { MediaType, PlayerMedia } from "@/plugins/api/interfaces";
@@ -123,13 +123,9 @@ export function useMediaBrowserMetaData(player_id?: string) {
   });
   // The OS extrapolates the position from this rate between our updates, and a
   // zero rate is rejected outright, so only a sane value may reach it.
-  const playbackSpeed = computed(() => {
-    const speed =
-      playerQueue.value?.current_item?.extra_attributes?.playback_speed;
-    return typeof speed === "number" && Number.isFinite(speed) && speed > 0
-      ? speed
-      : 1;
-  });
+  const playbackSpeed = computed(() =>
+    queueItemPlaybackSpeed(playerQueue.value?.current_item),
+  );
   const unwatch_position = watch(
     () => [
       queueElapsed.value?.elapsed_time,

--- a/src/helpers/useMediaBrowserMetaData.ts
+++ b/src/helpers/useMediaBrowserMetaData.ts
@@ -121,8 +121,7 @@ export function useMediaBrowserMetaData(player_id?: string) {
     const queueId = playerQueue.value?.queue_id;
     return queueId ? api.queueElapsedTime[queueId] : undefined;
   });
-  // The OS extrapolates the position from this rate between our updates, and a
-  // zero rate is rejected outright, so only a sane value may reach it.
+  // The OS extrapolates the position from this rate between our updates.
   const playbackSpeed = computed(() =>
     queueItemPlaybackSpeed(playerQueue.value?.current_item),
   );

--- a/src/layouts/default/PlayerOSD/PlayerControlBtn/PlayerTrackMenu.vue
+++ b/src/layouts/default/PlayerOSD/PlayerControlBtn/PlayerTrackMenu.vue
@@ -82,6 +82,7 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { Slider } from "@/components/ui/slider";
+import { queueItemPlaybackSpeed } from "@/helpers/elapsed";
 import {
   gotoRadio,
   radioActionLabelKey,
@@ -167,8 +168,7 @@ const playbackSpeedSupported = computed(
 watch(
   () => store.curQueueItem,
   (queueItem) => {
-    currentPlaybackSpeed.value =
-      queueItem?.extra_attributes?.playback_speed ?? 1;
+    currentPlaybackSpeed.value = queueItemPlaybackSpeed(queueItem);
   },
   { immediate: true },
 );
@@ -210,8 +210,7 @@ const onStartRadio = () => {
 const onOpenPlaybackSpeed = () => {
   // Sync from latest queue state before opening so the displayed value is
   // current even if the queue item updated since the menu was last touched.
-  currentPlaybackSpeed.value =
-    store.curQueueItem?.extra_attributes?.playback_speed ?? 1;
+  currentPlaybackSpeed.value = queueItemPlaybackSpeed(store.curQueueItem);
   playbackSpeedDialogOpen.value = true;
 };
 


### PR DESCRIPTION
The playback speed of the playing item was read in four places, each guarding it
differently. Only the OS media notification checked the value it got: a speed of
zero would otherwise freeze every progress indicator in the app, and a negative
one would run them backwards.

- Read the playback speed through one shared helper that only accepts a real
  speed above zero, and otherwise falls back to normal speed
- Use it for the progress indicators, the OS media notification and the playback
  speed dialog
- Add tests for the new helper

No change in behaviour for normal playback speeds.
