### PR TITLE
Keep progress indicators in sync with the play state they follow

### DIFF
--- a/src/composables/lyrics/useLyricsElapsedTime.ts
+++ b/src/composables/lyrics/useLyricsElapsedTime.ts
@@ -3,7 +3,8 @@
  *
  * Provides a reactive `elapsedTime` ref that updates at ~60fps while playing,
  * suitable for smooth lyrics synchronization. Automatically starts/stops the
- * rAF loop based on playback state and an optional `enabled` guard.
+ * rAF loop based on the active queue's playback state and an optional
+ * `enabled` guard.
  */
 
 import { ref, watchEffect, onScopeDispose, type Ref } from "vue";

--- a/src/composables/lyrics/useLyricsElapsedTime.ts
+++ b/src/composables/lyrics/useLyricsElapsedTime.ts
@@ -52,9 +52,8 @@ export function useLyricsElapsedTime(enabled?: Ref<boolean>) {
   document.addEventListener("visibilitychange", handleVisibilityChange);
 
   watchEffect(() => {
-    const playing =
-      store.activePlayer?.playback_state === PlaybackState.PLAYING;
     const queue = store.activePlayerQueue;
+    const playing = queue?.state === PlaybackState.PLAYING;
     const isEnabled = enabled ? enabled.value : true;
 
     shouldRun = playing && !!queue?.active && isEnabled;

--- a/src/layouts/default/PlayerOSD/PlayerTimeline.vue
+++ b/src/layouts/default/PlayerOSD/PlayerTimeline.vue
@@ -121,7 +121,11 @@
 
 <script setup lang="ts">
 import api from "@/plugins/api";
-import { MediaType, type MediaItemChapter } from "@/plugins/api/interfaces";
+import {
+  MediaType,
+  PlaybackState,
+  type MediaItemChapter,
+} from "@/plugins/api/interfaces";
 import { store } from "@/plugins/store";
 import { useActiveAudioSource } from "@/composables/activeAudioSource";
 import { useActiveSource } from "@/composables/activeSource";
@@ -278,7 +282,7 @@ const serverElapsedTime = computed(() => {
   void nowTick.value;
 
   // Adaptive tick: only run the timer when we have a playing source that relies on time progression
-  const isPlaying = store.activePlayer?.playback_state === "playing";
+  const isPlaying = serverTiming.value?.playbackState === PlaybackState.PLAYING;
   const usingQueue = !!(
     store.activePlayerQueue && store.activePlayerQueue.active
   );

--- a/src/views/PartyDashboardView.vue
+++ b/src/views/PartyDashboardView.vue
@@ -470,8 +470,10 @@ onBeforeUnmount(() => {
 // Album art background is always active
 const useAlbumArtBackground = computed(() => true);
 
+// The track cards show the queue's position, so their play state comes from
+// the queue too.
 const isPlaying = computed(
-  () => store.activePlayer?.playback_state === PlaybackState.PLAYING,
+  () => store.activePlayerQueue?.state === PlaybackState.PLAYING,
 );
 
 // Queue items state

--- a/tests/composables/useLyricsElapsedTime.test.ts
+++ b/tests/composables/useLyricsElapsedTime.test.ts
@@ -1,4 +1,11 @@
-import { effectScope, nextTick, reactive, ref, type Ref } from "vue";
+import {
+  effectScope,
+  nextTick,
+  reactive,
+  ref,
+  type EffectScope,
+  type Ref,
+} from "vue";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { PlaybackState } from "@/plugins/api/interfaces";
 
@@ -24,7 +31,7 @@ vi.mock("@/composables/useServerTime", () => ({
 // the pattern used by the other composable tests in this directory.
 const storeMock = reactive({
   activePlayerQueue: undefined as
-    | { queue_id: string; state?: PlaybackState; active?: boolean }
+    | { queue_id: string; state: PlaybackState; active: boolean }
     | undefined,
   activePlayer: undefined as { playback_state?: PlaybackState } | undefined,
   curQueueItem: undefined as
@@ -63,19 +70,22 @@ function makeQueue(overrides: Record<string, unknown> = {}) {
   };
 }
 
-// The composable is imported per test so the mocked store module is already
-// initialised by the time its module factory runs.
+// Disposed in afterEach so a failed assertion cannot leave an effect
+// subscribed to the shared store mock and corrupt the tests that follow.
+let activeScope: EffectScope | undefined;
+
 async function runComposable(enabled?: Ref<boolean>) {
   const { useLyricsElapsedTime } =
     await import("@/composables/lyrics/useLyricsElapsedTime");
-  const scope = effectScope();
-  const composable = scope.run(() => useLyricsElapsedTime(enabled));
+  activeScope = effectScope();
+  const composable = activeScope.run(() => useLyricsElapsedTime(enabled));
   if (!composable) throw new Error("useLyricsElapsedTime did not run");
-  return { ...composable, scope };
+  return { ...composable, scope: activeScope };
 }
 
 describe("useLyricsElapsedTime", () => {
   beforeEach(() => {
+    activeScope = undefined;
     pendingFrames = new Map();
     nextRafId = 0;
     vi.stubGlobal(
@@ -102,11 +112,12 @@ describe("useLyricsElapsedTime", () => {
   });
 
   afterEach(() => {
+    activeScope?.stop();
     vi.unstubAllGlobals();
     vi.restoreAllMocks();
   });
 
-  it("does not advance the position while the queue is paused", async () => {
+  it("reads a frozen position from a paused queue even while the loop runs", async () => {
     storeMock.activePlayerQueue = makeQueue({ state: PlaybackState.PAUSED });
     storeMock.activePlayer = { playback_state: PlaybackState.PLAYING };
     apiMock.queueElapsedTime["q1"] = {
@@ -114,11 +125,12 @@ describe("useLyricsElapsedTime", () => {
       elapsed_time_last_updated: NOW,
     };
 
-    const { elapsedTime, start, scope } = await runComposable();
+    const { elapsedTime, start } = await runComposable();
     await nextTick();
+    expect(pendingFrames.size).toBe(0);
 
-    // The gate already keeps the loop stopped here, so drive it by hand to
-    // prove the position itself is frozen rather than merely unpolled.
+    // Drive the loop by hand to prove the position itself is frozen rather
+    // than merely unpolled.
     start();
     flushFrame();
     expect(elapsedTime.value).toBe(42);
@@ -126,8 +138,6 @@ describe("useLyricsElapsedTime", () => {
     serverNowMock.mockReturnValue(NOW + 50);
     flushFrame();
     expect(elapsedTime.value).toBe(42);
-
-    scope.stop();
   });
 
   it("advances the position as serverNow advances while the queue plays", async () => {
@@ -137,7 +147,7 @@ describe("useLyricsElapsedTime", () => {
       elapsed_time_last_updated: NOW,
     };
 
-    const { elapsedTime, scope } = await runComposable();
+    const { elapsedTime } = await runComposable();
     await nextTick();
     flushFrame();
     expect(elapsedTime.value).toBe(10);
@@ -145,36 +155,36 @@ describe("useLyricsElapsedTime", () => {
     serverNowMock.mockReturnValue(NOW + 5);
     flushFrame();
     expect(elapsedTime.value).toBe(15);
-
-    scope.stop();
   });
 
   it("runs the loop from the queue's state even when the player disagrees", async () => {
     storeMock.activePlayerQueue = makeQueue({ state: PlaybackState.PLAYING });
     storeMock.activePlayer = { playback_state: PlaybackState.PAUSED };
 
-    const { scope } = await runComposable();
+    await runComposable();
     await nextTick();
 
     expect(pendingFrames.size).toBe(1);
-    scope.stop();
   });
 
-  it("does not run the loop when the queue is paused even though the player plays", async () => {
-    storeMock.activePlayerQueue = makeQueue({ state: PlaybackState.PAUSED });
+  it("stops the loop when the queue pauses even though the player keeps playing", async () => {
+    storeMock.activePlayerQueue = makeQueue({ state: PlaybackState.PLAYING });
     storeMock.activePlayer = { playback_state: PlaybackState.PLAYING };
 
-    const { scope } = await runComposable();
+    await runComposable();
+    await nextTick();
+    expect(pendingFrames.size).toBe(1);
+
+    storeMock.activePlayerQueue = makeQueue({ state: PlaybackState.PAUSED });
     await nextTick();
 
     expect(pendingFrames.size).toBe(0);
-    scope.stop();
   });
 
   it("stops the loop when the queue becomes inactive", async () => {
     storeMock.activePlayerQueue = makeQueue({ active: true });
 
-    const { scope } = await runComposable();
+    await runComposable();
     await nextTick();
     expect(pendingFrames.size).toBe(1);
 
@@ -182,14 +192,13 @@ describe("useLyricsElapsedTime", () => {
     await nextTick();
 
     expect(pendingFrames.size).toBe(0);
-    scope.stop();
   });
 
   it("stops the loop when the enabled ref flips to false", async () => {
     storeMock.activePlayerQueue = makeQueue();
     const enabled = ref(true);
 
-    const { scope } = await runComposable(enabled);
+    await runComposable(enabled);
     await nextTick();
     expect(pendingFrames.size).toBe(1);
 
@@ -197,7 +206,6 @@ describe("useLyricsElapsedTime", () => {
     await nextTick();
 
     expect(pendingFrames.size).toBe(0);
-    scope.stop();
   });
 
   it("stops the loop and removes the visibilitychange listener when the scope is disposed", async () => {

--- a/tests/composables/useLyricsElapsedTime.test.ts
+++ b/tests/composables/useLyricsElapsedTime.test.ts
@@ -1,0 +1,223 @@
+import { effectScope, nextTick, reactive, ref, type Ref } from "vue";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { PlaybackState } from "@/plugins/api/interfaces";
+
+const { apiMock, serverNowMock } = vi.hoisted(() => ({
+  apiMock: {
+    queueElapsedTime: {} as Record<
+      string,
+      { elapsed_time?: number; elapsed_time_last_updated?: number }
+    >,
+  },
+  serverNowMock: vi.fn<() => number>(),
+}));
+
+vi.mock("@/plugins/api", () => ({
+  default: apiMock,
+}));
+
+vi.mock("@/composables/useServerTime", () => ({
+  serverNow: serverNowMock,
+}));
+
+// Reactive so the composable's watchEffect reacts to mutations, mirroring
+// the pattern used by the other composable tests in this directory.
+const storeMock = reactive({
+  activePlayerQueue: undefined as
+    | { queue_id: string; state?: PlaybackState; active?: boolean }
+    | undefined,
+  activePlayer: undefined as { playback_state?: PlaybackState } | undefined,
+  curQueueItem: undefined as
+    | { extra_attributes?: { playback_speed?: number } }
+    | undefined,
+});
+
+vi.mock("@/plugins/store", () => ({
+  store: storeMock,
+}));
+
+// ---------------------------------------------------------------------------
+// Manual requestAnimationFrame driver
+// ---------------------------------------------------------------------------
+//
+// Records scheduled callbacks by id instead of auto-recursing, so a test can
+// flush exactly one frame and inspect how many frames are still pending.
+
+let pendingFrames: Map<number, FrameRequestCallback>;
+let nextRafId: number;
+
+function flushFrame(): void {
+  const callbacks = [...pendingFrames.values()];
+  pendingFrames.clear();
+  for (const callback of callbacks) callback(0);
+}
+
+const NOW = 1_700_000_000;
+
+function makeQueue(overrides: Record<string, unknown> = {}) {
+  return {
+    queue_id: "q1",
+    state: PlaybackState.PLAYING,
+    active: true,
+    ...overrides,
+  };
+}
+
+// The composable is imported per test so the mocked store module is already
+// initialised by the time its module factory runs.
+async function runComposable(enabled?: Ref<boolean>) {
+  const { useLyricsElapsedTime } =
+    await import("@/composables/lyrics/useLyricsElapsedTime");
+  const scope = effectScope();
+  const composable = scope.run(() => useLyricsElapsedTime(enabled));
+  if (!composable) throw new Error("useLyricsElapsedTime did not run");
+  return { ...composable, scope };
+}
+
+describe("useLyricsElapsedTime", () => {
+  beforeEach(() => {
+    pendingFrames = new Map();
+    nextRafId = 0;
+    vi.stubGlobal(
+      "requestAnimationFrame",
+      vi.fn((callback: FrameRequestCallback) => {
+        const id = ++nextRafId;
+        pendingFrames.set(id, callback);
+        return id;
+      }),
+    );
+    vi.stubGlobal(
+      "cancelAnimationFrame",
+      vi.fn((id: number) => {
+        pendingFrames.delete(id);
+      }),
+    );
+
+    apiMock.queueElapsedTime = {};
+    storeMock.activePlayerQueue = undefined;
+    storeMock.activePlayer = undefined;
+    storeMock.curQueueItem = undefined;
+    serverNowMock.mockReset();
+    serverNowMock.mockReturnValue(NOW);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it("does not advance the position while the queue is paused", async () => {
+    storeMock.activePlayerQueue = makeQueue({ state: PlaybackState.PAUSED });
+    storeMock.activePlayer = { playback_state: PlaybackState.PLAYING };
+    apiMock.queueElapsedTime["q1"] = {
+      elapsed_time: 42,
+      elapsed_time_last_updated: NOW,
+    };
+
+    const { elapsedTime, start, scope } = await runComposable();
+    await nextTick();
+
+    // The gate already keeps the loop stopped here, so drive it by hand to
+    // prove the position itself is frozen rather than merely unpolled.
+    start();
+    flushFrame();
+    expect(elapsedTime.value).toBe(42);
+
+    serverNowMock.mockReturnValue(NOW + 50);
+    flushFrame();
+    expect(elapsedTime.value).toBe(42);
+
+    scope.stop();
+  });
+
+  it("advances the position as serverNow advances while the queue plays", async () => {
+    storeMock.activePlayerQueue = makeQueue();
+    apiMock.queueElapsedTime["q1"] = {
+      elapsed_time: 10,
+      elapsed_time_last_updated: NOW,
+    };
+
+    const { elapsedTime, scope } = await runComposable();
+    await nextTick();
+    flushFrame();
+    expect(elapsedTime.value).toBe(10);
+
+    serverNowMock.mockReturnValue(NOW + 5);
+    flushFrame();
+    expect(elapsedTime.value).toBe(15);
+
+    scope.stop();
+  });
+
+  it("runs the loop from the queue's state even when the player disagrees", async () => {
+    storeMock.activePlayerQueue = makeQueue({ state: PlaybackState.PLAYING });
+    storeMock.activePlayer = { playback_state: PlaybackState.PAUSED };
+
+    const { scope } = await runComposable();
+    await nextTick();
+
+    expect(pendingFrames.size).toBe(1);
+    scope.stop();
+  });
+
+  it("does not run the loop when the queue is paused even though the player plays", async () => {
+    storeMock.activePlayerQueue = makeQueue({ state: PlaybackState.PAUSED });
+    storeMock.activePlayer = { playback_state: PlaybackState.PLAYING };
+
+    const { scope } = await runComposable();
+    await nextTick();
+
+    expect(pendingFrames.size).toBe(0);
+    scope.stop();
+  });
+
+  it("stops the loop when the queue becomes inactive", async () => {
+    storeMock.activePlayerQueue = makeQueue({ active: true });
+
+    const { scope } = await runComposable();
+    await nextTick();
+    expect(pendingFrames.size).toBe(1);
+
+    storeMock.activePlayerQueue = makeQueue({ active: false });
+    await nextTick();
+
+    expect(pendingFrames.size).toBe(0);
+    scope.stop();
+  });
+
+  it("stops the loop when the enabled ref flips to false", async () => {
+    storeMock.activePlayerQueue = makeQueue();
+    const enabled = ref(true);
+
+    const { scope } = await runComposable(enabled);
+    await nextTick();
+    expect(pendingFrames.size).toBe(1);
+
+    enabled.value = false;
+    await nextTick();
+
+    expect(pendingFrames.size).toBe(0);
+    scope.stop();
+  });
+
+  it("stops the loop and removes the visibilitychange listener when the scope is disposed", async () => {
+    const addEventListenerSpy = vi.spyOn(document, "addEventListener");
+    const removeEventListenerSpy = vi.spyOn(document, "removeEventListener");
+    storeMock.activePlayerQueue = makeQueue();
+
+    const { scope } = await runComposable();
+    await nextTick();
+    expect(pendingFrames.size).toBe(1);
+
+    scope.stop();
+
+    expect(pendingFrames.size).toBe(0);
+    const [, visibilityHandler] = addEventListenerSpy.mock.calls.find(
+      ([eventName]) => eventName === "visibilitychange",
+    )!;
+    expect(removeEventListenerSpy).toHaveBeenCalledWith(
+      "visibilitychange",
+      visibilityHandler,
+    );
+  });
+});


### PR DESCRIPTION
The progress indicators take their position from the queue, but some of them checked the *player* to decide whether that position was moving. When the two briefly disagree, the position and the play state come from different places and the UI goes wrong: the lyrics freeze while the track keeps playing, the player bar stops moving, and the party progress bar jumps back to zero.

Each indicator now takes its play state from the same source it takes its position from.

- Start and stop the lyrics animation from the active queue's state
- Keep the player bar ticking based on whichever source supplied the position
- Take the party track card play state from the queue
- Add test coverage for the lyrics position
