### PR TITLE
Fix the media session progress bar throwing on every position update

### DIFF
--- a/src/helpers/useMediaBrowserMetaData.ts
+++ b/src/helpers/useMediaBrowserMetaData.ts
@@ -1,4 +1,4 @@
-import computeElapsedTime from "@/helpers/elapsed";
+import { computeElapsedTime } from "@/helpers/elapsed";
 import { getMediaImageUrl } from "@/helpers/utils";
 import api from "@/plugins/api";
 import { MediaType, PlayerMedia } from "@/plugins/api/interfaces";


### PR DESCRIPTION
`useMediaBrowserMetaData` imports `computeElapsedTime` as a default export, but `src/helpers/elapsed.ts` only exports it as a named export. Every position update therefore threw `TypeError: default is not a function`, so the progress bar in the OS media notification never updated.

`esModuleInterop: true` implies `allowSyntheticDefaultImports`, so `vue-tsc` accepted the bad import and the build passed — it only surfaced at runtime, and in CI as 16 failing tests in `tests/helpers/useMediaBrowserMetaData.test.ts`.

- Import `computeElapsedTime` as a named export

The tests added in #2261 cover this, so no new test is needed.