### PR TITLE
Label the mono downmix in the stream details panel

### DIFF
--- a/src/composables/useAudioProcessingDetails.ts
+++ b/src/composables/useAudioProcessingDetails.ts
@@ -5,6 +5,7 @@ import {
   File as FileIcon,
   FileAudio,
   Gauge,
+  Merge,
   SlidersHorizontal,
   Speaker,
   Split,
@@ -344,12 +345,17 @@ function buildOutputDisplay(
   }
 
   if (output.source_channel) {
+    // ALL marks the fold-down of both source channels, so there is no single
+    // source channel to name here
+    const mixedToMono = output.source_channel === AudioChannel.ALL;
     stages.push({
       key: `source-channel-${index}`,
-      icon: Split,
-      title: translate("streamdetails.audio_processing.source_channel", [
-        sourceChannelLabel(output.source_channel, translate),
-      ]),
+      icon: mixedToMono ? Merge : Split,
+      title: mixedToMono
+        ? translate("streamdetails.audio_processing.mixed_to_mono")
+        : translate("streamdetails.audio_processing.source_channel", [
+            sourceChannelLabel(output.source_channel, translate),
+          ]),
     });
   }
   stages.push(finalOutputStage(output, index, translate, dependencies.locale));

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -925,6 +925,7 @@
             "source_channel": "Source channel: {0}",
             "source_channel_left": "Left",
             "source_channel_right": "Right",
+            "mixed_to_mono": "Mixed to mono",
             "dsp_preset": "DSP preset: {0}",
             "dsp_preset_label": "DSP preset",
             "dsp_title": "DSP",

--- a/tests/components/AudioProcessingDetails.test.ts
+++ b/tests/components/AudioProcessingDetails.test.ts
@@ -299,6 +299,26 @@ describe("AudioProcessingDetails", () => {
     ).toContain("Floating-point headroom is available for: Crossfade.");
   });
 
+  it("names a mono downmix instead of a selected source channel", () => {
+    const wrapper = mountDetails({
+      outputs: [
+        {
+          player_ids: ["player-1"],
+          dsp: { state: DSPState.DISABLED },
+          source_channel: AudioChannel.ALL,
+          output_format: makeFormat(),
+        },
+      ],
+    });
+
+    expect(
+      wrapper
+        .find('[data-stage="source-channel-0"] .audio-processing-stage-title')
+        .text(),
+    ).toBe("Mixed to mono");
+    expect(wrapper.text()).not.toContain("Source channel:");
+  });
+
   it("excludes disabled crossfade from component headroom reasons", () => {
     const wrapper = mountDetails({
       queue_processing: {

--- a/tests/composables/useAudioProcessingDetails.test.ts
+++ b/tests/composables/useAudioProcessingDetails.test.ts
@@ -1,5 +1,5 @@
 import { mount } from "@vue/test-utils";
-import { File as FileIcon } from "@lucide/vue";
+import { File as FileIcon, Merge, Split } from "@lucide/vue";
 import { defineComponent, h, nextTick, ref } from "vue";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
@@ -9,6 +9,7 @@ import {
 } from "@/composables/useAudioProcessingDetails";
 import { $t, i18n } from "@/plugins/i18n";
 import {
+  AudioChannel,
   type AudioFormat,
   type AudioProcessingChain,
   AudioQuality,
@@ -418,6 +419,31 @@ describe("buildAudioProcessingDetailsDisplay", () => {
     presetNames.set("preset-1", "Cinema");
     expect(buildDisplay(chain).outputPaths[0].stages[1].title).toBe("Cinema");
   });
+
+  it.each([
+    [AudioChannel.ALL, "Mixed to mono", Merge],
+    [AudioChannel.FL, "Source channel: Left", Split],
+    [AudioChannel.FR, "Source channel: Right", Split],
+  ])(
+    "pairs source channel %s with its own title and icon",
+    (sourceChannel, title, icon) => {
+      const display = buildDisplay({
+        outputs: [
+          {
+            player_ids: ["office"],
+            source_channel: sourceChannel,
+            output_format: makeFormat(),
+          },
+        ],
+      });
+
+      expect(
+        display.outputPaths[0].stages.find((stage) =>
+          stage.key.startsWith("source-channel-"),
+        ),
+      ).toMatchObject({ title, icon });
+    },
+  );
 
   it.each([CrossfadeMode.UNKNOWN, "future_crossfade" as CrossfadeMode])(
     "keeps %s crossfade in headroom reasons",


### PR DESCRIPTION
The stream details panel showed "Source channel: Unknown" for every player with the output channels setting on Mono. In that case there is no single source channel to name — both channels are folded into one — and the panel had no wording for it.

- Show "Mixed to mono" for a mono downmix instead of naming a source channel
- Use a merge icon for the fold-down, keeping the split icon for left/right routing

Frontend side of music-assistant/server#5329.
