### PR TITLE
Hide status labels and alerts whose dependency is not met

### DIFF
--- a/src/components/SetupFlowDialog.vue
+++ b/src/components/SetupFlowDialog.vue
@@ -377,7 +377,7 @@ let expiryReconciledFor: string | null = null;
 // reconnect; the double underscores keep it out of reach of server-sent slugs
 const SESSION_ENDED_STEP_ID = "__session_ended__";
 
-// terminal steps: closing them must not abort (the flow already ended server-side)
+// entry types that carry no value, so they take no part in validation or submission
 const PRESENTATIONAL_TYPES = [
   ConfigEntryType.DIVIDER,
   ConfigEntryType.LABEL,
@@ -386,6 +386,7 @@ const PRESENTATIONAL_TYPES = [
   ConfigEntryType.ACTION,
 ];
 
+// terminal steps: closing them must not abort (the flow already ended server-side)
 const isTerminal = computed(
   () =>
     step.value?.type === FlowStepType.FINISH ||

--- a/src/components/SetupFlowDialog.vue
+++ b/src/components/SetupFlowDialog.vue
@@ -312,6 +312,7 @@ import {
 import { Progress } from "@/components/ui/progress";
 import { Spinner } from "@/components/ui/spinner";
 import { serverNow } from "@/composables/useServerTime";
+import { NON_INTERACTIVE_ENTRY_TYPES } from "@/helpers/config_entry_ui";
 import { api, ConnectionState } from "@/plugins/api";
 import {
   type ConfigEntry,
@@ -429,7 +430,15 @@ const dialogTitle = computed(() => {
 });
 
 const visibleFormEntries = computed(() =>
-  formEntries.value.filter((entry) => !entry.hidden),
+  formEntries.value.filter(
+    (entry) =>
+      !entry.hidden &&
+      // an unmet dependency can only be expressed by hiding these types
+      !(
+        NON_INTERACTIVE_ENTRY_TYPES.includes(entry.type) &&
+        isEntryDisabled(entry)
+      ),
+  ),
 );
 
 const canSubmit = computed(() => {

--- a/src/helpers/config_entry_ui.ts
+++ b/src/helpers/config_entry_ui.ts
@@ -1,4 +1,4 @@
-import type { ConfigEntry, ConfigEntryType } from "@/plugins/api/interfaces";
+import { ConfigEntryType, type ConfigEntry } from "@/plugins/api/interfaces";
 
 export const CONFIG_KEY_UI = {
   DSP_SETTINGS_LINK: "dsp_settings_link",
@@ -26,6 +26,20 @@ export type ServerConfigEntryUI = ConfigEntry & {
   injected?: false;
 };
 export type ConfigEntryUI = ServerConfigEntryUI | InjectedConfigEntry;
+
+/**
+ * Entry types that render no interactive control.
+ *
+ * An unmet `depends_on` normally leaves an entry visible but disabled. These types
+ * have nothing to disable, so a form must hide them instead or they read as if the
+ * dependency were met.
+ */
+export const NON_INTERACTIVE_ENTRY_TYPES: ConfigEntryUIType[] = [
+  ConfigEntryType.DIVIDER,
+  ConfigEntryType.LABEL,
+  ConfigEntryType.ALERT,
+  ConfigEntryType.IMAGE,
+];
 
 export const isInjected = (e: ConfigEntryUI): e is InjectedConfigEntry =>
   (e as InjectedConfigEntry).injected === true;

--- a/src/helpers/config_entry_ui.ts
+++ b/src/helpers/config_entry_ui.ts
@@ -28,7 +28,7 @@ export type ServerConfigEntryUI = ConfigEntry & {
 export type ConfigEntryUI = ServerConfigEntryUI | InjectedConfigEntry;
 
 /**
- * Entry types that render no interactive control.
+ * Entry types whose ConfigEntryField branch takes no `disabled` binding.
  *
  * An unmet `depends_on` normally leaves an entry visible but disabled. These types
  * have nothing to disable, so a form must hide them instead or they read as if the
@@ -72,6 +72,27 @@ export const mergeConfigEntries = (
     merged[key] = currentEntry
       ? { ...incomingEntry, value: currentEntry.value }
       : { ...incomingEntry };
+  }
+  return merged;
+};
+
+/**
+ * Merges the entries a config action returned into the ones currently on screen.
+ *
+ * An action response carries entry definitions without the stored values, so every
+ * entry it does not explicitly set keeps the value the form already holds. Without
+ * that, pressing any action button would drop the whole form back to its defaults.
+ */
+export const mergeActionEntries = (
+  current: Record<string, ConfigEntry>,
+  incoming: ConfigEntry[],
+): Record<string, ConfigEntry> => {
+  const merged: Record<string, ConfigEntry> = {};
+  for (const entry of incoming) {
+    merged[entry.key] = {
+      ...entry,
+      value: entry.value ?? current[entry.key]?.value,
+    };
   }
   return merged;
 };

--- a/src/views/settings/EditConfig.vue
+++ b/src/views/settings/EditConfig.vue
@@ -159,7 +159,11 @@
 </template>
 
 <script setup lang="ts">
-import { ConfigEntryUI, isInjected } from "@/helpers/config_entry_ui";
+import {
+  ConfigEntryUI,
+  isInjected,
+  NON_INTERACTIVE_ENTRY_TYPES,
+} from "@/helpers/config_entry_ui";
 import { markdownToHtml } from "@/helpers/utils";
 import {
   ConfigEntryType,
@@ -455,10 +459,6 @@ const isNullOrUndefined = function (value: unknown) {
   return value === null || value === undefined;
 };
 
-const isVisible = function (entry: ConfigEntryUI) {
-  return !entry.hidden;
-};
-
 const isDisabled = function (entry: ConfigEntryUI) {
   if (!isNullOrUndefined(entry.depends_on)) {
     const dependentEntry = entries.value?.find(
@@ -479,6 +479,14 @@ const isDisabled = function (entry: ConfigEntryUI) {
     return !dependentValue;
   }
   return false;
+};
+
+const isVisible = function (entry: ConfigEntryUI) {
+  if (entry.hidden) return false;
+  // an unmet dependency can only be expressed by hiding these types
+  return !(
+    NON_INTERACTIVE_ENTRY_TYPES.includes(entry.type) && isDisabled(entry)
+  );
 };
 
 const visibleEntriesByCategory = computed(() => {

--- a/src/views/settings/EditCoreConfig.vue
+++ b/src/views/settings/EditCoreConfig.vue
@@ -42,6 +42,7 @@
 </template>
 
 <script setup lang="ts">
+import { mergeActionEntries } from "@/helpers/config_entry_ui";
 import { openActionUrlEntries } from "@/helpers/utils";
 import { api } from "@/plugins/api";
 import { ConfigValueType, CoreConfig } from "@/plugins/api/interfaces";
@@ -154,10 +155,7 @@ const onAction = async function (
         loading.value = false;
         return;
       }
-      config.value!.values = {};
-      for (const entry of entries) {
-        config.value!.values[entry.key] = entry;
-      }
+      config.value!.values = mergeActionEntries(config.value!.values, entries);
       // If the action has immediate_apply, save the updated values right away
       if (immediateApply) {
         const saveValues: Record<string, ConfigValueType> = {};

--- a/src/views/settings/EditCoreConfig.vue
+++ b/src/views/settings/EditCoreConfig.vue
@@ -159,7 +159,7 @@ const onAction = async function (
       // If the action has immediate_apply, save the updated values right away
       if (immediateApply) {
         const saveValues: Record<string, ConfigValueType> = {};
-        for (const entry of entries) {
+        for (const entry of Object.values(config.value!.values)) {
           if (entry.value !== undefined) {
             saveValues[entry.key] = entry.value;
           }

--- a/src/views/settings/EditPlayer.vue
+++ b/src/views/settings/EditPlayer.vue
@@ -263,6 +263,7 @@ import {
   ConfigEntryUI,
   UI_ENTRY_TYPE,
   isInjected,
+  mergeActionEntries,
   mergeConfigEntries,
 } from "@/helpers/config_entry_ui";
 import { openActionUrlEntries, openLinkInNewTab } from "@/helpers/utils";
@@ -479,10 +480,7 @@ const onAction = async function (
         toast.success($t("settings.action_completed"));
         return;
       }
-      config.value!.values = {};
-      for (const entry of entries) {
-        config.value!.values[entry.key] = entry;
-      }
+      config.value!.values = mergeActionEntries(config.value!.values, entries);
       // If the action has immediate_apply, save the updated values right away
       if (immediateApply) {
         const saveValues: Record<string, ConfigValueType> = {};

--- a/src/views/settings/EditPlayer.vue
+++ b/src/views/settings/EditPlayer.vue
@@ -484,7 +484,7 @@ const onAction = async function (
       // If the action has immediate_apply, save the updated values right away
       if (immediateApply) {
         const saveValues: Record<string, ConfigValueType> = {};
-        for (const entry of entries) {
+        for (const entry of Object.values(config.value!.values)) {
           if (entry.value !== undefined) {
             saveValues[entry.key] = entry.value;
           }

--- a/src/views/settings/EditProvider.vue
+++ b/src/views/settings/EditProvider.vue
@@ -201,7 +201,10 @@
 import ProviderIcon from "@/components/ProviderIcon.vue";
 import ProviderSaveErrorDialog from "@/components/ProviderSaveErrorDialog.vue";
 import { Button } from "@/components/ui/button";
-import { mergeConfigEntries } from "@/helpers/config_entry_ui";
+import {
+  mergeActionEntries,
+  mergeConfigEntries,
+} from "@/helpers/config_entry_ui";
 import { canReconfigureProvider } from "@/helpers/provider_config";
 import { markdownToHtml, openActionUrlEntries } from "@/helpers/utils";
 import { api } from "@/plugins/api";
@@ -385,10 +388,7 @@ const onAction = async function (
         toast.success(t("settings.action_completed"));
         return;
       }
-      config.value!.values = {};
-      for (const entry of entries) {
-        config.value!.values[entry.key] = entry;
-      }
+      config.value!.values = mergeActionEntries(config.value!.values, entries);
       // If the action has immediate_apply, save the updated values right away
       if (immediateApply) {
         const saveValues: Record<string, ConfigValueType> = {};

--- a/src/views/settings/EditProvider.vue
+++ b/src/views/settings/EditProvider.vue
@@ -392,7 +392,7 @@ const onAction = async function (
       // If the action has immediate_apply, save the updated values right away
       if (immediateApply) {
         const saveValues: Record<string, ConfigValueType> = {};
-        for (const entry of entries) {
+        for (const entry of Object.values(config.value!.values)) {
           if (entry.value !== undefined) {
             saveValues[entry.key] = entry.value;
           }

--- a/tests/components/SetupFlowDialog.test.ts
+++ b/tests/components/SetupFlowDialog.test.ts
@@ -221,6 +221,7 @@ describe("SetupFlowDialog", () => {
     expect(
       rows.map((row) => (row.props("confEntry") as ConfigEntry).key),
     ).toEqual(["enable_feature", "feature_detail"]);
+    expect(rows[0].props("disabled")).toBe(false);
     expect(rows[1].props("disabled")).toBe(true);
   });
 });

--- a/tests/components/SetupFlowDialog.test.ts
+++ b/tests/components/SetupFlowDialog.test.ts
@@ -1,6 +1,11 @@
 import { flushPromises, shallowMount } from "@vue/test-utils";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { FlowStepType, type SetupFlowStep } from "@/plugins/api/interfaces";
+import {
+  ConfigEntryType,
+  FlowStepType,
+  type ConfigEntry,
+  type SetupFlowStep,
+} from "@/plugins/api/interfaces";
 import SetupFlowDialog from "@/components/SetupFlowDialog.vue";
 
 const { apiMock, eventbusMock, routerMock, storeMock, toastMock } = vi.hoisted(
@@ -66,6 +71,8 @@ vi.mock("@/plugins/store", () => ({
 
 vi.mock("@/views/settings/ConfigEntryRow.vue", () => ({
   default: {
+    name: "ConfigEntryRow",
+    props: ["confEntry", "disabled"],
     template: "<div />",
   },
 }));
@@ -180,6 +187,42 @@ describe("SetupFlowDialog", () => {
 
     expect(wrapper.text()).toContain("submitted");
   });
+
+  it("hides an alert while its dependency is unmet, but keeps the input", async () => {
+    apiMock.reconfigureProvider.mockResolvedValue(
+      formStep([
+        entry({ key: "enable_feature", type: ConfigEntryType.BOOLEAN }),
+        entry({
+          key: "feature_warning",
+          type: ConfigEntryType.ALERT,
+          depends_on: "enable_feature",
+          depends_on_value: true,
+        }),
+        entry({
+          key: "feature_detail",
+          type: ConfigEntryType.STRING,
+          depends_on: "enable_feature",
+          depends_on_value: true,
+        }),
+      ]),
+    );
+    const wrapper = shallowMount(SetupFlowDialog, {
+      global: { renderStubDefaultSlot: true },
+    });
+
+    await launchSetupFlow?.({
+      kind: "reconfigure",
+      instanceId: "spotify--test",
+      onFlowEnded: vi.fn(),
+    });
+    await flushPromises();
+
+    const rows = wrapper.findAllComponents({ name: "ConfigEntryRow" });
+    expect(
+      rows.map((row) => (row.props("confEntry") as ConfigEntry).key),
+    ).toEqual(["enable_feature", "feature_detail"]);
+    expect(rows[1].props("disabled")).toBe(true);
+  });
 });
 
 function terminalStep(type: FlowStepType): SetupFlowStep {
@@ -192,14 +235,27 @@ function terminalStep(type: FlowStepType): SetupFlowStep {
   };
 }
 
-function formStep(): SetupFlowStep {
+function formStep(entries: ConfigEntry[] = []): SetupFlowStep {
   return {
-    entries: [],
+    entries,
     errors: {},
     flow_id: "flow-1",
     step_id: "form",
     type: FlowStepType.FORM,
   };
+}
+
+function entry(
+  overrides: Partial<ConfigEntry> & { key: string; type: ConfigEntryType },
+): ConfigEntry {
+  return {
+    category: "generic",
+    default_value: null,
+    label: overrides.key,
+    required: false,
+    value: null,
+    ...overrides,
+  } as ConfigEntry;
 }
 
 function progressStep(progressText: string): SetupFlowStep {

--- a/tests/helpers/config_entry_ui.test.ts
+++ b/tests/helpers/config_entry_ui.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { mergeConfigEntries } from "@/helpers/config_entry_ui";
+import {
+  mergeActionEntries,
+  mergeConfigEntries,
+} from "@/helpers/config_entry_ui";
 import { ConfigEntryType, type ConfigEntry } from "@/plugins/api/interfaces";
 
 function entry(overrides: Partial<ConfigEntry> = {}): ConfigEntry {
@@ -75,6 +78,64 @@ describe("mergeConfigEntries", () => {
     const incomingSnapshot = JSON.parse(JSON.stringify(incoming));
 
     mergeConfigEntries(current, incoming);
+
+    expect(current).toEqual(currentSnapshot);
+    expect(incoming).toEqual(incomingSnapshot);
+  });
+});
+
+describe("mergeActionEntries", () => {
+  it("keeps the current value for an entry the action left unset", () => {
+    const current = { engine: entry({ value: "current value" }) };
+    const incoming = [entry({ read_only: true })];
+
+    const merged = mergeActionEntries(current, incoming);
+
+    expect(merged.engine.value).toBe("current value");
+    expect(merged.engine.read_only).toBe(true);
+  });
+
+  it("keeps a falsy current value", () => {
+    const current = {
+      enabled: entry({ key: "enabled", type: ConfigEntryType.BOOLEAN }),
+    };
+    current.enabled.value = false;
+
+    const merged = mergeActionEntries(current, [
+      entry({ key: "enabled", type: ConfigEntryType.BOOLEAN }),
+    ]);
+
+    expect(merged.enabled.value).toBe(false);
+  });
+
+  it("takes the value the action did set", () => {
+    const current = { engine: entry({ value: "current value" }) };
+    const incoming = [entry({ value: "set by the action" })];
+
+    const merged = mergeActionEntries(current, incoming);
+
+    expect(merged.engine.value).toBe("set by the action");
+  });
+
+  it("adds an entry that only the action returned", () => {
+    const merged = mergeActionEntries({}, [entry({ key: "fresh" })]);
+
+    expect(merged.fresh.key).toBe("fresh");
+  });
+
+  it("drops an entry the action no longer returns", () => {
+    const current = { stale: entry({ key: "stale" }) };
+
+    expect(mergeActionEntries(current, [])).toEqual({});
+  });
+
+  it("does not mutate either input", () => {
+    const current = { engine: entry({ value: "current value" }) };
+    const incoming = [entry({ read_only: true })];
+    const currentSnapshot = JSON.parse(JSON.stringify(current));
+    const incomingSnapshot = JSON.parse(JSON.stringify(incoming));
+
+    mergeActionEntries(current, incoming);
 
     expect(current).toEqual(currentSnapshot);
     expect(incoming).toEqual(incomingSnapshot);

--- a/tests/views/EditConfig.test.ts
+++ b/tests/views/EditConfig.test.ts
@@ -1,0 +1,116 @@
+import { shallowMount, type VueWrapper } from "@vue/test-utils";
+import { describe, expect, it, vi } from "vitest";
+import {
+  ConfigEntryType,
+  type ConfigEntry,
+  type ConfigValueType,
+} from "@/plugins/api/interfaces";
+import EditConfig from "@/views/settings/EditConfig.vue";
+
+const { apiMock, routerMock } = vi.hoisted(() => ({
+  apiMock: {
+    players: {},
+    providers: {},
+  },
+  routerMock: {
+    push: vi.fn(),
+  },
+}));
+
+vi.mock("@/plugins/api", () => ({
+  api: apiMock,
+  default: apiMock,
+}));
+
+vi.mock("@/plugins/i18n", () => ({
+  $t: (key: string) => key,
+}));
+
+vi.mock("vue-router", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("vue-router")>();
+  return {
+    ...actual,
+    useRouter: () => routerMock,
+  };
+});
+
+describe("EditConfig", () => {
+  it.each([
+    ConfigEntryType.DIVIDER,
+    ConfigEntryType.LABEL,
+    ConfigEntryType.ALERT,
+    ConfigEntryType.IMAGE,
+  ])("hides a %s entry while its dependency is unmet", (type) => {
+    const wrapper = mountEntries([
+      entry({ key: "enable_feature", type: ConfigEntryType.BOOLEAN }),
+      dependentEntry({ key: "feature_status", type }),
+    ]);
+
+    expect(renderedKeys(wrapper)).toEqual(["enable_feature"]);
+  });
+
+  it.each([
+    ConfigEntryType.DIVIDER,
+    ConfigEntryType.LABEL,
+    ConfigEntryType.ALERT,
+    ConfigEntryType.IMAGE,
+  ])("shows a %s entry once its dependency is met", (type) => {
+    const wrapper = mountEntries([
+      entry({
+        key: "enable_feature",
+        type: ConfigEntryType.BOOLEAN,
+        value: true,
+      }),
+      dependentEntry({ key: "feature_status", type }),
+    ]);
+
+    expect(renderedKeys(wrapper)).toEqual(["enable_feature", "feature_status"]);
+  });
+
+  it("keeps an input with an unmet dependency visible but disabled", () => {
+    const wrapper = mountEntries([
+      entry({ key: "enable_feature", type: ConfigEntryType.BOOLEAN }),
+      dependentEntry({ key: "feature_detail", type: ConfigEntryType.STRING }),
+    ]);
+
+    const rows = wrapper.findAllComponents({ name: "ConfigEntryRow" });
+    expect(renderedKeys(wrapper)).toEqual(["enable_feature", "feature_detail"]);
+    expect(rows[1].props("disabled")).toBe(true);
+  });
+});
+
+function entry(
+  overrides: Partial<ConfigEntry> & { key: string; type: ConfigEntryType },
+): ConfigEntry {
+  return {
+    category: "generic",
+    default_value: null,
+    label: overrides.key,
+    required: false,
+    value: null as ConfigValueType,
+    ...overrides,
+  } as ConfigEntry;
+}
+
+function dependentEntry(
+  overrides: Partial<ConfigEntry> & { key: string; type: ConfigEntryType },
+): ConfigEntry {
+  return entry({
+    depends_on: "enable_feature",
+    depends_on_value: true,
+    ...overrides,
+  });
+}
+
+function mountEntries(configEntries: ConfigEntry[]) {
+  return shallowMount(EditConfig, {
+    props: { configEntries, disabled: false },
+    global: { renderStubDefaultSlot: true },
+  });
+}
+
+function renderedKeys(wrapper: VueWrapper) {
+  return wrapper
+    .findAllComponents({ name: "ConfigEntryRow" })
+    .map((row) => (row.props("confEntry") as ConfigEntry).key);
+}

--- a/tests/views/EditConfig.test.ts
+++ b/tests/views/EditConfig.test.ts
@@ -1,5 +1,6 @@
 import { shallowMount, type VueWrapper } from "@vue/test-utils";
 import { describe, expect, it, vi } from "vitest";
+import { nextTick } from "vue";
 import {
   ConfigEntryType,
   type ConfigEntry,
@@ -75,7 +76,26 @@ describe("EditConfig", () => {
 
     const rows = wrapper.findAllComponents({ name: "ConfigEntryRow" });
     expect(renderedKeys(wrapper)).toEqual(["enable_feature", "feature_detail"]);
+    expect(rows[0].props("disabled")).toBe(false);
     expect(rows[1].props("disabled")).toBe(true);
+  });
+
+  it("reveals a label as soon as the dependency flips, without a save", async () => {
+    const entries = [
+      entry({ key: "enable_feature", type: ConfigEntryType.BOOLEAN }),
+      dependentEntry({ key: "feature_status", type: ConfigEntryType.LABEL }),
+    ];
+    const wrapper = mountEntries(entries);
+    expect(renderedKeys(wrapper)).toEqual(["enable_feature"]);
+
+    // onValueUpdate edits the entry object in place, so this is what ticking the box does
+    const toggle = wrapper
+      .findAllComponents({ name: "ConfigEntryRow" })[0]
+      .props("confEntry") as ConfigEntry;
+    toggle.value = true;
+    await nextTick();
+
+    expect(renderedKeys(wrapper)).toEqual(["enable_feature", "feature_status"]);
   });
 });
 

--- a/tests/views/EditCoreConfig.test.ts
+++ b/tests/views/EditCoreConfig.test.ts
@@ -187,6 +187,46 @@ describe("EditCoreConfig", () => {
       }),
     ]);
   });
+
+  it("saves the kept values, not the empty ones, on an immediate_apply action", async () => {
+    apiMock.getCoreConfig.mockResolvedValueOnce(coreConfig());
+    apiMock.invokeCoreConfigAction.mockResolvedValueOnce([
+      {
+        category: "generic",
+        default_value: false,
+        key: "clear_on_start",
+        label: "Clear cache on start",
+        required: false,
+        type: ConfigEntryType.BOOLEAN,
+        value: null,
+      },
+    ]);
+    apiMock.saveCoreConfig.mockResolvedValueOnce({
+      ...coreConfig(),
+      values: {},
+    });
+
+    const wrapper = shallowMount(EditCoreConfig, {
+      props: {
+        domain: "cache",
+      },
+      global: {
+        mocks: {
+          $t: (key: string) => key,
+        },
+      },
+    });
+    await flushPromises();
+
+    const editConfig = wrapper.findComponent({ name: "EditConfig" });
+
+    await editConfig.vm.$emit("action", "do_thing", {}, true);
+    await flushPromises();
+
+    expect(apiMock.saveCoreConfig).toHaveBeenCalledWith("cache", {
+      clear_on_start: "current value",
+    });
+  });
 });
 
 function coreConfig(): CoreConfig {

--- a/tests/views/EditCoreConfig.test.ts
+++ b/tests/views/EditCoreConfig.test.ts
@@ -108,7 +108,7 @@ describe("EditCoreConfig", () => {
     ).toBe(false);
   });
 
-  it("still replaces the form when an action returns entries (transitional path)", async () => {
+  it("takes the value an action did provide", async () => {
     apiMock.getCoreConfig.mockResolvedValueOnce(coreConfig());
     apiMock.invokeCoreConfigAction.mockResolvedValueOnce([
       {
@@ -147,6 +147,45 @@ describe("EditCoreConfig", () => {
     ]);
     expect(apiMock.saveCoreConfig).not.toHaveBeenCalled();
     expect(toastMock.success).not.toHaveBeenCalled();
+  });
+
+  it("keeps the current value for an entry the action returned without one", async () => {
+    apiMock.getCoreConfig.mockResolvedValueOnce(coreConfig());
+    // an action response carries entry definitions only, never the stored values
+    apiMock.invokeCoreConfigAction.mockResolvedValueOnce([
+      {
+        category: "generic",
+        default_value: false,
+        key: "clear_on_start",
+        label: "Clear cache on start",
+        required: false,
+        type: ConfigEntryType.BOOLEAN,
+      },
+    ]);
+
+    const wrapper = shallowMount(EditCoreConfig, {
+      props: {
+        domain: "cache",
+      },
+      global: {
+        mocks: {
+          $t: (key: string) => key,
+        },
+      },
+    });
+    await flushPromises();
+
+    const editConfig = wrapper.findComponent({ name: "EditConfig" });
+
+    await editConfig.vm.$emit("action", "verify_ssl", {}, false);
+    await flushPromises();
+
+    expect(editConfig.props("configEntries")).toEqual([
+      expect.objectContaining({
+        key: "clear_on_start",
+        value: "current value",
+      }),
+    ]);
   });
 });
 

--- a/tests/views/EditProvider.test.ts
+++ b/tests/views/EditProvider.test.ts
@@ -180,6 +180,46 @@ describe("EditProvider", () => {
     ]);
   });
 
+  it("keeps form values when an action returns entries without them", async () => {
+    apiMock.getProviderConfig.mockResolvedValue(
+      providerConfig(ProviderStatus.LOADED, "current value"),
+    );
+    // an action response carries entry definitions only, never the stored values
+    apiMock.invokeProviderConfigAction.mockResolvedValue([
+      {
+        category: "generic",
+        default_value: null,
+        key: "account",
+        label: "Account",
+        required: false,
+        type: ConfigEntryType.STRING,
+      },
+    ]);
+
+    const wrapper = shallowMount(EditProvider, {
+      props: {
+        instanceId: "spotify--test",
+      },
+      global: {
+        mocks: {
+          $t: (key: string) => key,
+        },
+      },
+    });
+    await flushPromises();
+
+    const editConfig = wrapper.findComponent({ name: "EditConfig" });
+    editConfig.vm.$emit("action", "verify", {}, false);
+    await flushPromises();
+
+    expect(editConfig.props("configEntries")).toEqual([
+      expect.objectContaining({
+        key: "account",
+        value: "current value",
+      }),
+    ]);
+  });
+
   it("refreshes provider status when reconfiguration ends", async () => {
     apiMock.getProviderConfig
       .mockResolvedValueOnce(providerConfig(ProviderStatus.AUTH_REQUIRED))


### PR DESCRIPTION
Config entries can declare a `depends_on`, which is meant to keep them out of sight until the setting they depend on is switched on. In practice the frontend only ever *disabled* such an entry. That works for inputs (a greyed-out field), but labels, alerts, dividers and images have nothing to disable, so they rendered at full strength as if the dependency were met.

Visible today as, for example, the Sonic Similarity settings showing "Character engine: disabled" and "Text encoder: disabled" status rows even with both engines switched off, and Smart Playlist warning about a missing AI engine with AI descriptions switched off.

Fixing that surfaced a second problem underneath it. Pressing an action button that does return entries (Verify SSL certificate, Rebuild index, ...) made the form fall back to its default values, because an action responds with entry definitions that carry no values and the settings forms replaced their state with it wholesale. Dependent entries then read the wrong dependency value — so Verify SSL certificate would have hidden the very label holding its result. #2260 covered the empty-response case; this covers the rest.

Changes:
- Added a shared list of entry types that render no interactive control (divider, label, alert, image)
- An unmet dependency now hides those types instead of disabling them, on the settings page and in the setup flow dialog
- Inputs and action buttons keep greying out as before
- Action responses now keep the values already in the form, on the provider, player and core settings forms
- Test coverage for both forms and all three action paths