### PR TITLE
Fix skip forward/backward in the OS media notification

### DIFF
--- a/src/components/SendspinPlayer.vue
+++ b/src/components/SendspinPlayer.vue
@@ -9,6 +9,7 @@
 </template>
 
 <script setup lang="ts">
+import { resolveActiveElapsedTime } from "@/helpers/activeElapsedTime";
 import { useMediaBrowserMetaData } from "@/helpers/useMediaBrowserMetaData";
 import {
   isMediaSessionDisabled,
@@ -432,7 +433,7 @@ function registerMediaSessionActionHandlers(): void {
 
   navigator.mediaSession.setActionHandler("seekto", (evt) => {
     const targetId = getTargetPlayerId();
-    if (!targetId || !evt.seekTime) return;
+    if (!targetId || evt.seekTime == null) return;
     api.playerCommandSeek(targetId, Math.round(evt.seekTime));
   });
 
@@ -442,9 +443,8 @@ function registerMediaSessionActionHandlers(): void {
       const targetId = getTargetPlayerId();
       if (!targetId) return;
       const offset = evt.seekOffset || 10;
-      const queueId = store.activePlayerQueue?.queue_id;
-      const queueTime = queueId ? api.queueElapsedTime[queueId] : undefined;
-      const elapsed = lastSeekPos ?? queueTime?.elapsed_time ?? 0;
+      const elapsed = lastSeekPos ?? resolveActiveElapsedTime(targetId);
+      if (elapsed == null) return;
       const newPos = Math.round(elapsed + offset);
       lastSeekPos = newPos;
       resetLastSeekPos();
@@ -455,9 +455,8 @@ function registerMediaSessionActionHandlers(): void {
       const targetId = getTargetPlayerId();
       if (!targetId) return;
       const offset = evt.seekOffset || 10;
-      const queueId = store.activePlayerQueue?.queue_id;
-      const queueTime = queueId ? api.queueElapsedTime[queueId] : undefined;
-      const elapsed = lastSeekPos ?? queueTime?.elapsed_time ?? 0;
+      const elapsed = lastSeekPos ?? resolveActiveElapsedTime(targetId);
+      if (elapsed == null) return;
       const newPos = Math.round(Math.max(0, elapsed - offset));
       lastSeekPos = newPos;
       resetLastSeekPos();

--- a/src/helpers/activeElapsedTime.ts
+++ b/src/helpers/activeElapsedTime.ts
@@ -1,17 +1,21 @@
 /**
- * Playback position of whatever is currently playing on the active player.
+ * Playback position of whatever is currently playing on a player.
  *
  * Resolves the timing source, its playback state and the playback speed in one
  * place, so progress indicators do not each work the position out differently.
- * The `resolveQueue*` variants narrow that to the active queue, for consumers that
- * only render what that queue is playing. Every function reads the current values
- * on each call and holds no state, which makes them equally usable inside a
- * `computed` and inside a rAF/interval loop.
+ * The `resolveQueue*` variants narrow that to the player's active queue, for
+ * consumers that only render what that queue is playing. Every function reads
+ * the current values on each call and holds no state, which makes them equally
+ * usable inside a `computed` and inside a rAF/interval loop.
+ *
+ * Every function defaults to the active player; pass a `player_id` to resolve
+ * another player, such as the one an OS media session targets.
  */
 import { computeElapsedTime, queueItemPlaybackSpeed } from "@/helpers/elapsed";
 import api from "@/plugins/api";
+import { resolvePlayerQueue } from "@/plugins/api/helpers";
 import { store } from "@/plugins/store";
-import { PlaybackState } from "@/plugins/api/interfaces";
+import { PlaybackState, Player, QueueItem } from "@/plugins/api/interfaces";
 
 export interface ActiveTiming {
   elapsedTime: number;
@@ -25,21 +29,23 @@ export interface ActiveTiming {
 }
 
 /**
- * The timing source for the active player, or undefined when none reports a position.
+ * The timing source for a player, or undefined when none reports a position.
  *
  * Each source is paired with the playback state that belongs to it, so callers
  * never combine a queue position with a player state or the other way around.
  */
-export function resolveActiveTiming(): ActiveTiming | undefined {
+export function resolveActiveTiming(
+  player_id?: string,
+): ActiveTiming | undefined {
   // Prefer the active queue's own elapsed_time when it reports one.
-  const queueTiming = resolveQueueTiming();
+  const queueTiming = resolveQueueTiming(player_id);
   if (queueTiming) return queueTiming;
 
   // Fall back to the player's own timing, which is what external/3rd-party
   // sources playing on the player report: current_media first, then the legacy
   // player-level fields.
-  const playbackSpeed = queueItemPlaybackSpeed(store.curQueueItem);
-  const player = store.activePlayer;
+  const player = resolvePlayer(player_id);
+  const playbackSpeed = queueItemPlaybackSpeed(resolveCurrentItem(player));
   // An unknown state must not extrapolate from the last update.
   const playerState = player?.playback_state ?? PlaybackState.IDLE;
   if (
@@ -70,16 +76,18 @@ export function resolveActiveTiming(): ActiveTiming | undefined {
 }
 
 /**
- * The timing reported by the active player's active queue, or undefined when there
- * is no such queue or it reports no position.
+ * The timing reported by a player's active queue, or undefined when there is no
+ * such queue or it reports no position.
  *
  * Use this rather than `resolveActiveTiming` for consumers that take their content
- * from `store.curQueueItem`: the player fallback would hand them a position for
- * content they cannot display.
+ * from that queue's current item: the player fallback would hand them a position
+ * for content they cannot display.
  */
-export function resolveQueueTiming(): ActiveTiming | undefined {
-  const queue = store.activePlayerQueue;
-  // An inactive queue holds the position it stopped at, while curQueueItem is
+export function resolveQueueTiming(
+  player_id?: string,
+): ActiveTiming | undefined {
+  const queue = resolvePlayerQueue(resolvePlayer(player_id));
+  // An inactive queue holds the position it stopped at, while its current item is
   // already gone; pairing the two would mix a stale position with a default speed.
   if (!queue?.active) return undefined;
 
@@ -95,24 +103,38 @@ export function resolveQueueTiming(): ActiveTiming | undefined {
     elapsedTime: queueTime.elapsed_time,
     lastUpdated: queueTime.elapsed_time_last_updated,
     playbackState: queue.state,
-    playbackSpeed: queueItemPlaybackSpeed(store.curQueueItem),
+    playbackSpeed: queueItemPlaybackSpeed(queue.current_item),
   };
 }
 
 /**
- * The current playback position of the active player in seconds, or undefined
- * when no timing source is available.
+ * The current playback position of a player in seconds, or undefined when no
+ * timing source is available.
  */
-export function resolveActiveElapsedTime(): number | undefined {
-  return toElapsedTime(resolveActiveTiming());
+export function resolveActiveElapsedTime(
+  player_id?: string,
+): number | undefined {
+  return toElapsedTime(resolveActiveTiming(player_id));
 }
 
 /**
- * The current playback position of the active player's active queue in seconds, or
+ * The current playback position of a player's active queue in seconds, or
  * undefined when there is no such queue or it reports no timing.
  */
-export function resolveQueueElapsedTime(): number | undefined {
-  return toElapsedTime(resolveQueueTiming());
+export function resolveQueueElapsedTime(
+  player_id?: string,
+): number | undefined {
+  return toElapsedTime(resolveQueueTiming(player_id));
+}
+
+function resolvePlayer(player_id?: string): Player | undefined {
+  if (player_id === undefined) return store.activePlayer;
+  return api.players[player_id];
+}
+
+function resolveCurrentItem(player?: Player): QueueItem | undefined {
+  const queue = resolvePlayerQueue(player);
+  return queue?.active ? queue.current_item : undefined;
 }
 
 function toElapsedTime(timing: ActiveTiming | undefined): number | undefined {

--- a/src/helpers/useMediaBrowserMetaData.ts
+++ b/src/helpers/useMediaBrowserMetaData.ts
@@ -1,6 +1,7 @@
 import { computeElapsedTime, queueItemPlaybackSpeed } from "@/helpers/elapsed";
 import { getMediaImageUrl } from "@/helpers/utils";
 import api from "@/plugins/api";
+import { resolvePlayerQueue } from "@/plugins/api/helpers";
 import { MediaType, PlayerMedia } from "@/plugins/api/interfaces";
 import authManager from "@/plugins/auth";
 import { store } from "@/plugins/store";
@@ -70,23 +71,7 @@ export function useMediaBrowserMetaData(player_id?: string) {
     );
   });
 
-  const playerQueue = computed(() => {
-    if (
-      player.value?.active_source &&
-      player.value.active_source in api.queues
-    ) {
-      return api.queues[player.value.active_source];
-    }
-    if (
-      player.value &&
-      !player.value.active_source &&
-      player.value.player_id in api.queues &&
-      api.queues[player.value.player_id].active
-    ) {
-      return api.queues[player.value.player_id];
-    }
-    return undefined;
-  });
+  const playerQueue = computed(() => resolvePlayerQueue(player.value));
 
   const mediaMetadata = computed(() => {
     if (shouldSuppressMetadata.value) {

--- a/src/layouts/default/PlayerOSD/PlayerBrowserMediaControls.vue
+++ b/src/layouts/default/PlayerOSD/PlayerBrowserMediaControls.vue
@@ -12,6 +12,7 @@
 // First second of this file has an inaudible 15Hz tone (-64dB), rest is silent.
 // We only play the tone once at the start to ensure that the notification is shown.
 import audio from "@/assets/almost_silent.mp3";
+import { resolveActiveElapsedTime } from "@/helpers/activeElapsedTime";
 import { useMediaBrowserMetaData } from "@/helpers/useMediaBrowserMetaData";
 import api from "@/plugins/api";
 import { PlaybackState } from "@/plugins/api/interfaces";
@@ -105,17 +106,14 @@ const seekHandler = function (
   player_id: string,
 ) {
   let to = null;
-  if (evt.action === "seekto" && evt.seekTime) {
+  if (evt.action === "seekto" && evt.seekTime != null) {
     to = evt.seekTime;
   } else if (evt.action === "seekforward" || evt.action === "seekbackward") {
     const offset = evt.seekOffset || 10;
-    const queueId = store.activePlayerQueue?.queue_id;
-    const queueTime = queueId ? api.queueElapsedTime[queueId] : undefined;
-    const elapsed_time =
-      lastSeekPos != null ? lastSeekPos : queueTime?.elapsed_time;
+    const elapsed_time = lastSeekPos ?? resolveActiveElapsedTime(player_id);
     if (elapsed_time == null) return;
     if (evt.action === "seekbackward") {
-      to = elapsed_time - offset;
+      to = Math.max(0, elapsed_time - offset);
     } else {
       to = elapsed_time + offset;
     }

--- a/src/plugins/api/helpers.ts
+++ b/src/plugins/api/helpers.ts
@@ -182,6 +182,27 @@ export const getSourceName = function (player: Player) {
   return source_id;
 };
 
+/**
+ * The queue playing on the given player, or undefined when it has none.
+ *
+ * A player either plays the queue of the source it is attached to, or its own
+ * queue when it has no source; an inactive own queue does not count.
+ */
+export function resolvePlayerQueue(player?: Player): PlayerQueue | undefined {
+  if (player?.active_source && player.active_source in api.queues) {
+    return api.queues[player.active_source];
+  }
+  if (
+    player &&
+    !player.active_source &&
+    player.player_id in api.queues &&
+    api.queues[player.player_id].active
+  ) {
+    return api.queues[player.player_id];
+  }
+  return undefined;
+}
+
 export const getCollectionMediaTypeFromItemId = function (itemId: string) {
   // the item id is defined by the backend as "<MediaType>___<collection_name>"
   const itemIdType = itemId.split("___", 1)[0];

--- a/src/plugins/store.ts
+++ b/src/plugins/store.ts
@@ -12,6 +12,7 @@ import { StoredState } from "@/components/ItemsListing.vue";
 import { isHomeAssistantIngressSession } from "@/helpers/ingress";
 import { isTouchscreenDevice, parseBool } from "@/helpers/utils";
 import api from "./api";
+import { resolvePlayerQueue } from "./api/helpers";
 
 import MobileDetect from "mobile-detect";
 import { getBreakpointValue } from "./breakpoint";
@@ -82,23 +83,7 @@ export const store: Store = reactive({
     }
     return undefined;
   }),
-  activePlayerQueue: computed(() => {
-    if (
-      store.activePlayer?.active_source &&
-      store.activePlayer.active_source in api.queues
-    ) {
-      return api.queues[store.activePlayer.active_source];
-    }
-    if (
-      store.activePlayer &&
-      !store.activePlayer.active_source &&
-      store.activePlayer.player_id in api.queues &&
-      api.queues[store.activePlayer.player_id].active
-    ) {
-      return api.queues[store.activePlayer.player_id];
-    }
-    return undefined;
-  }),
+  activePlayerQueue: computed(() => resolvePlayerQueue(store.activePlayer)),
   curQueueItem: computed(() => {
     if (store.activePlayerQueue && store.activePlayerQueue.active)
       return store.activePlayerQueue.current_item;

--- a/tests/components/SendspinPlayer.test.ts
+++ b/tests/components/SendspinPlayer.test.ts
@@ -1,4 +1,5 @@
 import SendspinPlayer from "@/components/SendspinPlayer.vue";
+import { PlaybackState } from "@/plugins/api/interfaces";
 import { webPlayer, WebPlayerMode } from "@/plugins/web_player";
 import { flushPromises, mount } from "@vue/test-utils";
 import { nextTick } from "vue";
@@ -32,8 +33,26 @@ afterAll(() => {
   }
 });
 
+// Only the fields the component and the timing helper read are mocked.
+interface MockPlayer {
+  player_id?: string;
+  active_source?: string;
+  playback_state?: PlaybackState;
+  synced_to?: string;
+  group_members: string[];
+}
+
+interface MockQueue {
+  queue_id: string;
+  state?: PlaybackState;
+  active?: boolean;
+  current_item?: { extra_attributes?: { playback_speed?: number } };
+}
+
 const {
   authState,
+  apiMock,
+  storeMock,
   mockPlayerCommandNext,
   mockPlayerCommandPause,
   mockPlayerCommandPlay,
@@ -44,23 +63,48 @@ const {
   mockSendspinUnlock,
   mockUseMediaBrowserMetaData,
   routeState,
-} = vi.hoisted(() => ({
-  authState: {
-    guest: null as "music_quiz" | "party" | null,
-  },
-  mockPlayerCommandNext: vi.fn(),
-  mockPlayerCommandPause: vi.fn(),
-  mockPlayerCommandPlay: vi.fn(),
-  mockPlayerCommandPrevious: vi.fn(),
-  mockPlayerCommandSeek: vi.fn(),
-  mockPrepareSendspinSession: vi.fn(),
-  mockRegisterWebPlayerAudioUnlock: vi.fn<(handler: () => boolean) => void>(),
-  mockSendspinUnlock: vi.fn<() => Promise<void>>(),
-  mockUseMediaBrowserMetaData: vi.fn(() => vi.fn()),
-  routeState: {
-    current: null as { meta: Record<string, unknown> } | null,
-  },
-}));
+} = vi.hoisted(() => {
+  const mockPlayerCommandNext = vi.fn();
+  const mockPlayerCommandPause = vi.fn();
+  const mockPlayerCommandPlay = vi.fn();
+  const mockPlayerCommandPrevious = vi.fn();
+  const mockPlayerCommandSeek = vi.fn();
+  return {
+    authState: {
+      guest: null as "music_quiz" | "party" | null,
+    },
+    // Mutable so tests can drive the players/queues the seek handlers read.
+    apiMock: {
+      players: {} as Record<string, MockPlayer>,
+      queues: {} as Record<string, MockQueue>,
+      queueElapsedTime: {} as Record<
+        string,
+        { elapsed_time?: number; elapsed_time_last_updated?: number }
+      >,
+      playerCommandNext: mockPlayerCommandNext,
+      playerCommandPause: mockPlayerCommandPause,
+      playerCommandPlay: mockPlayerCommandPlay,
+      playerCommandPrevious: mockPlayerCommandPrevious,
+      playerCommandSeek: mockPlayerCommandSeek,
+    },
+    storeMock: {
+      activePlayerId: "active-player",
+      activePlayer: undefined as MockPlayer | undefined,
+    },
+    mockPlayerCommandNext,
+    mockPlayerCommandPause,
+    mockPlayerCommandPlay,
+    mockPlayerCommandPrevious,
+    mockPlayerCommandSeek,
+    mockPrepareSendspinSession: vi.fn(),
+    mockRegisterWebPlayerAudioUnlock: vi.fn<(handler: () => boolean) => void>(),
+    mockSendspinUnlock: vi.fn<() => Promise<void>>(),
+    mockUseMediaBrowserMetaData: vi.fn(() => vi.fn()),
+    routeState: {
+      current: null as { meta: Record<string, unknown> } | null,
+    },
+  };
+});
 
 vi.mock("@/helpers/useMediaBrowserMetaData", () => ({
   useMediaBrowserMetaData: mockUseMediaBrowserMetaData,
@@ -84,36 +128,11 @@ vi.mock("vue-router", async () => {
 });
 
 vi.mock("@/plugins/api", () => ({
-  default: {
-    players: {
-      "web-player": {
-        playback_state: "playing",
-        group_members: [],
-      },
-    },
-    queueElapsedTime: {
-      queue: {
-        elapsed_time: 30,
-      },
-    },
-    playerCommandNext: mockPlayerCommandNext,
-    playerCommandPause: mockPlayerCommandPause,
-    playerCommandPlay: mockPlayerCommandPlay,
-    playerCommandPrevious: mockPlayerCommandPrevious,
-    playerCommandSeek: mockPlayerCommandSeek,
-  },
+  default: apiMock,
 }));
 
 vi.mock("@/plugins/store", () => ({
-  store: {
-    activePlayerId: "active-player",
-    activePlayer: {
-      playback_state: "playing",
-    },
-    activePlayerQueue: {
-      queue_id: "queue",
-    },
-  },
+  store: storeMock,
 }));
 
 vi.mock("@/plugins/web_player", async () => {
@@ -139,7 +158,8 @@ vi.mock("@/plugins/sendspin-connection", () => ({
   prepareSendspinSession: mockPrepareSendspinSession,
 }));
 
-vi.mock("@/plugins/api/helpers", () => ({
+vi.mock("@/plugins/api/helpers", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/plugins/api/helpers")>()),
   getDeviceName: () => "Browser",
 }));
 
@@ -178,6 +198,9 @@ const actions: MediaSessionAction[] = [
   "seekbackward",
 ];
 
+// epoch seconds the fake clock starts at; timestamps below are relative to this
+const ANCHOR = 1_700_000_000;
+
 describe("SendspinPlayer MediaSession", () => {
   beforeEach(() => {
     authState.guest = null;
@@ -208,6 +231,21 @@ describe("SendspinPlayer MediaSession", () => {
       value: mediaSession,
     });
     vi.stubGlobal("localStorage", createStorage());
+    apiMock.players = {
+      "web-player": {
+        player_id: "web-player",
+        playback_state: PlaybackState.PLAYING,
+        active_source: "queue",
+        group_members: [],
+      },
+    };
+    apiMock.queues = { queue: { queue_id: "queue", active: true } };
+    apiMock.queueElapsedTime = { queue: { elapsed_time: 30 } };
+    storeMock.activePlayer = {
+      player_id: "active-player",
+      playback_state: PlaybackState.PLAYING,
+      group_members: [],
+    };
   });
 
   afterEach(() => {
@@ -420,12 +458,185 @@ describe("SendspinPlayer MediaSession", () => {
     expect(handlers.get("seekbackward")).toBeNull();
     wrapper.unmount();
   });
+
+  // Registering seekforward/seekbackward is skipped on iOS/Mac (see
+  // registerMediaSessionActionHandlers), so these override the file-wide
+  // "iPhone" user agent to exercise the handlers.
+  describe("seekforward/seekbackward extrapolation", () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+      vi.setSystemTime(ANCHOR * 1000);
+      Object.defineProperty(navigator, "userAgent", {
+        configurable: true,
+        value: "Android",
+      });
+    });
+
+    afterEach(() => {
+      Object.defineProperty(navigator, "userAgent", {
+        configurable: true,
+        value: "iPhone",
+      });
+    });
+
+    it("seeks forward from the extrapolated (displayed) position at 2x speed", () => {
+      seedPlayingQueue({ elapsed_time: 30, secondsAgo: 3, playback_speed: 2 });
+
+      const wrapper = mount(SendspinPlayer, {
+        props: { playerId: "web-player" },
+      });
+      invokeAction("seekforward", { seekOffset: 10 });
+
+      // Displayed position is 30 + 3s * 2x = 36, so a +10s skip lands on 46;
+      // the raw stored position would give 40.
+      expect(mockPlayerCommandSeek).toHaveBeenCalledWith("web-player", 46);
+      wrapper.unmount();
+    });
+
+    it("seeks backward from the extrapolated (displayed) position at 2x speed", () => {
+      seedPlayingQueue({ elapsed_time: 30, secondsAgo: 3, playback_speed: 2 });
+
+      const wrapper = mount(SendspinPlayer, {
+        props: { playerId: "web-player" },
+      });
+      invokeAction("seekbackward", { seekOffset: 10 });
+
+      expect(mockPlayerCommandSeek).toHaveBeenCalledWith("web-player", 26);
+      wrapper.unmount();
+    });
+
+    it("clamps seekbackward at 0 instead of going negative", () => {
+      seedPlayingQueue({ elapsed_time: 2, secondsAgo: 1, playback_speed: 2 });
+
+      const wrapper = mount(SendspinPlayer, {
+        props: { playerId: "web-player" },
+      });
+      invokeAction("seekbackward", { seekOffset: 10 });
+
+      // Displayed position is 2 + 1s * 2x = 4; 4 - 10 would go negative.
+      expect(mockPlayerCommandSeek).toHaveBeenCalledWith("web-player", 0);
+      wrapper.unmount();
+    });
+
+    it("chains repeated seekforward presses off the previous target instead of re-resolving", () => {
+      seedPlayingQueue({ elapsed_time: 30, secondsAgo: 3, playback_speed: 2 });
+
+      const wrapper = mount(SendspinPlayer, {
+        props: { playerId: "web-player" },
+      });
+      invokeAction("seekforward", { seekOffset: 10 });
+      expect(mockPlayerCommandSeek).toHaveBeenLastCalledWith("web-player", 46);
+
+      // Resolving the position again instead of chaining would land on 16 here.
+      apiMock.queueElapsedTime.queue.elapsed_time = 0;
+      invokeAction("seekforward", { seekOffset: 10 });
+      expect(mockPlayerCommandSeek).toHaveBeenLastCalledWith("web-player", 56);
+
+      wrapper.unmount();
+    });
+
+    it("resolves the position again once the chained seek position expires", () => {
+      seedPlayingQueue({ elapsed_time: 30, secondsAgo: 3, playback_speed: 2 });
+
+      const wrapper = mount(SendspinPlayer, {
+        props: { playerId: "web-player" },
+      });
+      invokeAction("seekforward", { seekOffset: 10 });
+      expect(mockPlayerCommandSeek).toHaveBeenLastCalledWith("web-player", 46);
+
+      vi.advanceTimersByTime(2000);
+
+      // Displayed position is now 30 + 5s * 2x = 40, so the skip lands on 50;
+      // chaining off the previous target would give 56.
+      invokeAction("seekforward", { seekOffset: 10 });
+      expect(mockPlayerCommandSeek).toHaveBeenLastCalledWith("web-player", 50);
+
+      wrapper.unmount();
+    });
+
+    it("seeks relative to the target player, not the active player", () => {
+      // The web player is listening in at 36s while the selected player, whose
+      // metadata the media session would otherwise follow, sits at 500s.
+      seedPlayingQueue({ elapsed_time: 30, secondsAgo: 3, playback_speed: 2 });
+      apiMock.players["active-player"] = {
+        player_id: "active-player",
+        playback_state: PlaybackState.PLAYING,
+        active_source: "other-queue",
+        group_members: [],
+      };
+      apiMock.queues["other-queue"] = {
+        queue_id: "other-queue",
+        state: PlaybackState.PLAYING,
+        active: true,
+      };
+      apiMock.queueElapsedTime["other-queue"] = {
+        elapsed_time: 500,
+        elapsed_time_last_updated: ANCHOR,
+      };
+      storeMock.activePlayer = apiMock.players["active-player"];
+
+      const wrapper = mount(SendspinPlayer, {
+        props: { playerId: "web-player" },
+      });
+      invokeAction("seekforward", { seekOffset: 10 });
+
+      // The active player's position would give 510.
+      expect(mockPlayerCommandSeek).toHaveBeenCalledWith("web-player", 46);
+      wrapper.unmount();
+    });
+
+    it("does not seek when no timing source is available", () => {
+      apiMock.queues = {};
+      apiMock.queueElapsedTime = {};
+
+      const wrapper = mount(SendspinPlayer, {
+        props: { playerId: "web-player" },
+      });
+      invokeAction("seekforward", { seekOffset: 10 });
+      invokeAction("seekbackward", { seekOffset: 10 });
+
+      expect(mockPlayerCommandSeek).not.toHaveBeenCalled();
+      wrapper.unmount();
+    });
+
+    it("seeks to the start for a seekto of 0", () => {
+      const wrapper = mount(SendspinPlayer, {
+        props: { playerId: "web-player" },
+      });
+      invokeAction("seekto", { seekTime: 0 });
+
+      expect(mockPlayerCommandSeek).toHaveBeenCalledWith("web-player", 0);
+      wrapper.unmount();
+    });
+  });
 });
 
 function getAudioUnlockHandler(): () => boolean {
   const handler = mockRegisterWebPlayerAudioUnlock.mock.calls.at(-1)?.[0];
   if (!handler) throw new Error("Audio unlock handler was not registered");
   return handler;
+}
+
+/**
+ * Set the queue the web player is attached to playing at the given position.
+ */
+function seedPlayingQueue(timing: {
+  elapsed_time: number;
+  secondsAgo: number;
+  playback_speed: number;
+}): void {
+  apiMock.queues.queue = {
+    queue_id: "queue",
+    state: PlaybackState.PLAYING,
+    active: true,
+    current_item: {
+      extra_attributes: { playback_speed: timing.playback_speed },
+    },
+  };
+  apiMock.queueElapsedTime.queue = {
+    elapsed_time: timing.elapsed_time,
+    elapsed_time_last_updated: ANCHOR - timing.secondsAgo,
+  };
 }
 
 function seedStaleMediaSession(): void {

--- a/tests/composables/useLyricsElapsedTime.test.ts
+++ b/tests/composables/useLyricsElapsedTime.test.ts
@@ -9,8 +9,23 @@ import {
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { PlaybackState } from "@/plugins/api/interfaces";
 
+interface MockQueue {
+  queue_id: string;
+  state: PlaybackState;
+  active: boolean;
+}
+
+interface MockPlayer {
+  player_id: string;
+  active_source?: string;
+  playback_state?: PlaybackState;
+  elapsed_time?: number;
+  elapsed_time_last_updated?: number;
+}
+
 const { apiMock, serverNowMock } = vi.hoisted(() => ({
   apiMock: {
+    queues: {} as Record<string, MockQueue>,
     queueElapsedTime: {} as Record<
       string,
       { elapsed_time?: number; elapsed_time_last_updated?: number }
@@ -30,19 +45,8 @@ vi.mock("@/composables/useServerTime", () => ({
 // Reactive so the composable's watchEffect reacts to mutations, mirroring
 // the pattern used by the other composable tests in this directory.
 const storeMock = reactive({
-  activePlayerQueue: undefined as
-    | { queue_id: string; state: PlaybackState; active: boolean }
-    | undefined,
-  activePlayer: undefined as
-    | {
-        playback_state?: PlaybackState;
-        elapsed_time?: number;
-        elapsed_time_last_updated?: number;
-      }
-    | undefined,
-  curQueueItem: undefined as
-    | { extra_attributes?: { playback_speed?: number } }
-    | undefined,
+  activePlayerQueue: undefined as MockQueue | undefined,
+  activePlayer: undefined as MockPlayer | undefined,
 });
 
 vi.mock("@/plugins/store", () => ({
@@ -67,12 +71,32 @@ function flushFrame(): void {
 
 const NOW = 1_700_000_000;
 
-function makeQueue(overrides: Record<string, unknown> = {}) {
-  return {
+const PLAYER_ID = "p1";
+
+/**
+ * Seed the active player's queue.
+ *
+ * The resolver reaches the queue through the player's `active_source`, while the
+ * composable's own gate reads it off the store, so both are pointed at it.
+ */
+function seedQueue(overrides: Partial<MockQueue> = {}): void {
+  const queue: MockQueue = {
     queue_id: "q1",
     state: PlaybackState.PLAYING,
     active: true,
     ...overrides,
+  };
+  storeMock.activePlayerQueue = queue;
+  apiMock.queues[queue.queue_id] = queue;
+  seedPlayer({ active_source: queue.queue_id });
+}
+
+/** Seed the active player's own fields, keeping any queue already seeded. */
+function seedPlayer(player: Omit<MockPlayer, "player_id">): void {
+  storeMock.activePlayer = {
+    ...storeMock.activePlayer,
+    player_id: PLAYER_ID,
+    ...player,
   };
 }
 
@@ -128,9 +152,9 @@ describe("useLyricsElapsedTime", () => {
     // reactive like the real map, so a timing push can be seen to (not) wake
     // anything that subscribed to it
     apiMock.queueElapsedTime = reactive({});
+    apiMock.queues = {};
     storeMock.activePlayerQueue = undefined;
     storeMock.activePlayer = undefined;
-    storeMock.curQueueItem = undefined;
     serverNowMock.mockReset();
     serverNowMock.mockReturnValue(NOW);
   });
@@ -142,8 +166,8 @@ describe("useLyricsElapsedTime", () => {
   });
 
   it("reads a frozen position from a paused queue even while the loop runs", async () => {
-    storeMock.activePlayerQueue = makeQueue({ state: PlaybackState.PAUSED });
-    storeMock.activePlayer = { playback_state: PlaybackState.PLAYING };
+    seedQueue({ state: PlaybackState.PAUSED });
+    seedPlayer({ playback_state: PlaybackState.PLAYING });
     apiMock.queueElapsedTime["q1"] = {
       elapsed_time: 42,
       elapsed_time_last_updated: NOW,
@@ -165,7 +189,7 @@ describe("useLyricsElapsedTime", () => {
   });
 
   it("advances the position as serverNow advances while the queue plays", async () => {
-    storeMock.activePlayerQueue = makeQueue();
+    seedQueue();
     apiMock.queueElapsedTime["q1"] = {
       elapsed_time: 10,
       elapsed_time_last_updated: NOW,
@@ -182,8 +206,8 @@ describe("useLyricsElapsedTime", () => {
   });
 
   it("runs the loop from the queue's state even when the player disagrees", async () => {
-    storeMock.activePlayerQueue = makeQueue({ state: PlaybackState.PLAYING });
-    storeMock.activePlayer = { playback_state: PlaybackState.PAUSED };
+    seedQueue({ state: PlaybackState.PLAYING });
+    seedPlayer({ playback_state: PlaybackState.PAUSED });
 
     await runComposable();
     await nextTick();
@@ -192,34 +216,34 @@ describe("useLyricsElapsedTime", () => {
   });
 
   it("stops the loop when the queue pauses even though the player keeps playing", async () => {
-    storeMock.activePlayerQueue = makeQueue({ state: PlaybackState.PLAYING });
-    storeMock.activePlayer = { playback_state: PlaybackState.PLAYING };
+    seedQueue({ state: PlaybackState.PLAYING });
+    seedPlayer({ playback_state: PlaybackState.PLAYING });
 
     await runComposable();
     await nextTick();
     expect(pendingFrames.size).toBe(1);
 
-    storeMock.activePlayerQueue = makeQueue({ state: PlaybackState.PAUSED });
+    seedQueue({ state: PlaybackState.PAUSED });
     await nextTick();
 
     expect(pendingFrames.size).toBe(0);
   });
 
   it("stops the loop when the queue becomes inactive", async () => {
-    storeMock.activePlayerQueue = makeQueue({ active: true });
+    seedQueue({ active: true });
 
     await runComposable();
     await nextTick();
     expect(pendingFrames.size).toBe(1);
 
-    storeMock.activePlayerQueue = makeQueue({ active: false });
+    seedQueue({ active: false });
     await nextTick();
 
     expect(pendingFrames.size).toBe(0);
   });
 
   it("stops the loop when the enabled ref flips to false", async () => {
-    storeMock.activePlayerQueue = makeQueue();
+    seedQueue();
     const enabled = ref(true);
 
     await runComposable(enabled);
@@ -233,7 +257,7 @@ describe("useLyricsElapsedTime", () => {
   });
 
   it("holds the last queue position rather than adopting the player's", async () => {
-    storeMock.activePlayerQueue = makeQueue();
+    seedQueue();
     apiMock.queueElapsedTime["q1"] = {
       elapsed_time: 10,
       elapsed_time_last_updated: NOW,
@@ -246,11 +270,11 @@ describe("useLyricsElapsedTime", () => {
 
     // the queue stops reporting a position while the player still reports one
     delete apiMock.queueElapsedTime["q1"];
-    storeMock.activePlayer = {
+    seedPlayer({
       playback_state: PlaybackState.PLAYING,
       elapsed_time: 999,
       elapsed_time_last_updated: NOW,
-    };
+    });
     await nextTick();
     flushFrame();
 
@@ -258,7 +282,7 @@ describe("useLyricsElapsedTime", () => {
   });
 
   it("does not re-run the gate when the queue timing updates", async () => {
-    storeMock.activePlayerQueue = makeQueue();
+    seedQueue();
     apiMock.queueElapsedTime["q1"] = {
       elapsed_time: 10,
       elapsed_time_last_updated: NOW,
@@ -285,7 +309,7 @@ describe("useLyricsElapsedTime", () => {
   it("stops the loop and removes the visibilitychange listener when the scope is disposed", async () => {
     const addEventListenerSpy = vi.spyOn(document, "addEventListener");
     const removeEventListenerSpy = vi.spyOn(document, "removeEventListener");
-    storeMock.activePlayerQueue = makeQueue();
+    seedQueue();
 
     const { scope } = await runComposable();
     await nextTick();

--- a/tests/helpers/activeElapsedTime.test.ts
+++ b/tests/helpers/activeElapsedTime.test.ts
@@ -7,32 +7,37 @@ import {
 import { PlaybackState } from "@/plugins/api/interfaces";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+// Only the fields the helper actually reads are mocked.
+interface MockQueue {
+  queue_id: string;
+  state?: PlaybackState;
+  active?: boolean;
+  current_item?: { extra_attributes?: { playback_speed?: number } };
+}
+
+interface MockPlayer {
+  player_id: string;
+  active_source?: string;
+  playback_state?: PlaybackState;
+  elapsed_time?: number;
+  elapsed_time_last_updated?: number;
+  current_media?: {
+    elapsed_time?: number;
+    elapsed_time_last_updated?: number;
+  };
+}
+
 const { apiMock, storeMock } = vi.hoisted(() => ({
   apiMock: {
+    players: {} as Record<string, MockPlayer>,
+    queues: {} as Record<string, MockQueue>,
     queueElapsedTime: {} as Record<
       string,
       { elapsed_time?: number; elapsed_time_last_updated?: number }
     >,
   },
-  // Only the fields the helper actually reads are mocked.
   storeMock: {
-    activePlayerQueue: undefined as
-      | { queue_id: string; state?: PlaybackState; active?: boolean }
-      | undefined,
-    activePlayer: undefined as
-      | {
-          playback_state?: PlaybackState;
-          elapsed_time?: number;
-          elapsed_time_last_updated?: number;
-          current_media?: {
-            elapsed_time?: number;
-            elapsed_time_last_updated?: number;
-          };
-        }
-      | undefined,
-    curQueueItem: undefined as
-      | { extra_attributes?: { playback_speed?: number } }
-      | undefined,
+    activePlayer: undefined as MockPlayer | undefined,
   },
 }));
 
@@ -47,13 +52,39 @@ vi.mock("@/plugins/store", () => ({
 // epoch seconds the fake clock starts at; timestamps below are relative to this
 const NOW = 1_700_000_000;
 
+const ACTIVE_PLAYER_ID = "p1";
+
+/**
+ * Seed a queue and point the active player at it.
+ *
+ * The queue is reached through the player's `active_source`, so a queue on its
+ * own is invisible to the resolver.
+ */
+function seedQueue(queue: MockQueue): void {
+  apiMock.queues[queue.queue_id] = queue;
+  storeMock.activePlayer = {
+    ...storeMock.activePlayer,
+    player_id: ACTIVE_PLAYER_ID,
+    active_source: queue.queue_id,
+  };
+}
+
+/** Seed the active player's own fields, keeping any queue already seeded. */
+function seedPlayer(player: Omit<MockPlayer, "player_id">): void {
+  storeMock.activePlayer = {
+    ...storeMock.activePlayer,
+    player_id: ACTIVE_PLAYER_ID,
+    ...player,
+  };
+}
+
 beforeEach(() => {
   vi.useFakeTimers();
   vi.setSystemTime(NOW * 1000);
+  apiMock.players = {};
+  apiMock.queues = {};
   apiMock.queueElapsedTime = {};
-  storeMock.activePlayerQueue = undefined;
   storeMock.activePlayer = undefined;
-  storeMock.curQueueItem = undefined;
 });
 
 afterEach(() => {
@@ -65,62 +96,62 @@ describe("resolveActiveTiming / resolveActiveElapsedTime", () => {
     expect(resolveActiveTiming()).toBeUndefined();
     expect(resolveActiveElapsedTime()).toBeUndefined();
 
-    storeMock.activePlayerQueue = { queue_id: "q1", active: true };
-    storeMock.activePlayer = {};
+    // an active queue without a timing entry, on a player reporting none either
+    seedQueue({ queue_id: "q1", active: true });
     expect(resolveActiveTiming()).toBeUndefined();
   });
 
   it("falls back to the player when the queue is not active", () => {
     // a queue still selected on the player, holding the position it stopped at
-    storeMock.activePlayerQueue = {
+    seedQueue({
       queue_id: "q1",
       state: PlaybackState.PLAYING,
       active: false,
-    };
+    });
     apiMock.queueElapsedTime["q1"] = {
       elapsed_time: 10,
       elapsed_time_last_updated: NOW,
     };
-    storeMock.activePlayer = {
+    seedPlayer({
       playback_state: PlaybackState.PLAYING,
       current_media: { elapsed_time: 20, elapsed_time_last_updated: NOW },
-    };
+    });
 
     vi.setSystemTime((NOW + 4) * 1000);
     expect(resolveActiveElapsedTime()).toBeCloseTo(24, 6);
   });
 
   it("reports no position for an inactive queue when the player has none either", () => {
-    storeMock.activePlayerQueue = {
+    seedQueue({
       queue_id: "q1",
       state: PlaybackState.PLAYING,
       active: false,
-    };
+    });
     apiMock.queueElapsedTime["q1"] = {
       elapsed_time: 10,
       elapsed_time_last_updated: NOW,
     };
-    storeMock.activePlayer = { playback_state: PlaybackState.IDLE };
+    seedPlayer({ playback_state: PlaybackState.IDLE });
 
     expect(resolveActiveTiming()).toBeUndefined();
     expect(resolveActiveElapsedTime()).toBeUndefined();
   });
 
   it("prefers queue timing, paired with the queue's own state", () => {
-    storeMock.activePlayerQueue = {
+    seedQueue({
       queue_id: "q1",
       state: PlaybackState.PLAYING,
       active: true,
-    };
+    });
     apiMock.queueElapsedTime["q1"] = {
       elapsed_time: 10,
       elapsed_time_last_updated: NOW,
     };
     // player disagrees on both state and position; it must be ignored
-    storeMock.activePlayer = {
+    seedPlayer({
       playback_state: PlaybackState.PAUSED,
       current_media: { elapsed_time: 999, elapsed_time_last_updated: NOW },
-    };
+    });
 
     expect(resolveActiveTiming()?.playbackState).toBe(PlaybackState.PLAYING);
 
@@ -129,16 +160,16 @@ describe("resolveActiveTiming / resolveActiveElapsedTime", () => {
   });
 
   it("does not advance when the queue is paused, even if the player is playing", () => {
-    storeMock.activePlayerQueue = {
+    seedQueue({
       queue_id: "q1",
       state: PlaybackState.PAUSED,
       active: true,
-    };
+    });
     apiMock.queueElapsedTime["q1"] = {
       elapsed_time: 10,
       elapsed_time_last_updated: NOW,
     };
-    storeMock.activePlayer = { playback_state: PlaybackState.PLAYING };
+    seedPlayer({ playback_state: PlaybackState.PLAYING });
 
     vi.setSystemTime((NOW + 4) * 1000);
     expect(resolveActiveElapsedTime()).toBe(10);
@@ -146,15 +177,15 @@ describe("resolveActiveTiming / resolveActiveElapsedTime", () => {
 
   it("falls back to current_media timing, paired with the player's playback_state", () => {
     // a queue is active but has no reported elapsed time of its own
-    storeMock.activePlayerQueue = {
+    seedQueue({
       queue_id: "q1",
       state: PlaybackState.PLAYING,
       active: true,
-    };
-    storeMock.activePlayer = {
+    });
+    seedPlayer({
       playback_state: PlaybackState.PLAYING,
       current_media: { elapsed_time: 20, elapsed_time_last_updated: NOW },
-    };
+    });
 
     expect(resolveActiveTiming()?.playbackState).toBe(PlaybackState.PLAYING);
 
@@ -163,11 +194,11 @@ describe("resolveActiveTiming / resolveActiveElapsedTime", () => {
   });
 
   it("falls back to player-level elapsed_time when there is no queue or current_media timing", () => {
-    storeMock.activePlayer = {
+    seedPlayer({
       playback_state: PlaybackState.PAUSED,
       elapsed_time: 5,
       elapsed_time_last_updated: NOW,
-    };
+    });
 
     vi.setSystemTime((NOW + 100) * 1000);
     expect(resolveActiveElapsedTime()).toBe(5);
@@ -176,49 +207,49 @@ describe("resolveActiveTiming / resolveActiveElapsedTime", () => {
   it("falls through an empty current_media to the player-level elapsed_time", () => {
     // the shape players report when they only expose a position at player
     // level, e.g. a Home Assistant media_player with a media_position
-    storeMock.activePlayer = {
+    seedPlayer({
       playback_state: PlaybackState.PLAYING,
       elapsed_time: 30,
       elapsed_time_last_updated: NOW,
       current_media: {},
-    };
+    });
 
     vi.setSystemTime((NOW + 6) * 1000);
     expect(resolveActiveElapsedTime()).toBeCloseTo(36, 6);
   });
 
   it("prefers a queue elapsed_time of 0 over a player timing", () => {
-    storeMock.activePlayerQueue = {
+    seedQueue({
       queue_id: "q1",
       state: PlaybackState.PLAYING,
       active: true,
-    };
+    });
     apiMock.queueElapsedTime["q1"] = {
       elapsed_time: 0,
       elapsed_time_last_updated: NOW,
     };
-    storeMock.activePlayer = {
+    seedPlayer({
       playback_state: PlaybackState.PLAYING,
       elapsed_time: 500,
       elapsed_time_last_updated: NOW,
-    };
+    });
 
     vi.setSystemTime((NOW + 4) * 1000);
     expect(resolveActiveElapsedTime()).toBeCloseTo(4, 6);
   });
 
   it("falls through to the player when the queue reports no last-updated time", () => {
-    storeMock.activePlayerQueue = {
+    seedQueue({
       queue_id: "q1",
       state: PlaybackState.PLAYING,
       active: true,
-    };
+    });
     apiMock.queueElapsedTime["q1"] = { elapsed_time: 10 };
-    storeMock.activePlayer = {
+    seedPlayer({
       playback_state: PlaybackState.PLAYING,
       elapsed_time: 500,
       elapsed_time_last_updated: NOW,
-    };
+    });
 
     vi.setSystemTime((NOW + 4) * 1000);
     expect(resolveActiveElapsedTime()).toBeCloseTo(504, 6);
@@ -235,7 +266,7 @@ describe("resolveActiveTiming / resolveActiveElapsedTime", () => {
   ])(
     "does not extrapolate a %s timing when the player reports no state",
     (_source, player) => {
-      storeMock.activePlayer = player;
+      seedPlayer(player);
 
       vi.setSystemTime((NOW + 4) * 1000);
       expect(resolveActiveTiming()?.playbackState).toBe(PlaybackState.IDLE);
@@ -243,74 +274,131 @@ describe("resolveActiveTiming / resolveActiveElapsedTime", () => {
     },
   );
 
-  it("scales the queue-sourced delta by curQueueItem's playback_speed", () => {
-    storeMock.activePlayerQueue = {
+  it("scales the queue-sourced delta by the current item's playback_speed", () => {
+    seedQueue({
       queue_id: "q1",
       state: PlaybackState.PLAYING,
       active: true,
-    };
+      current_item: { extra_attributes: { playback_speed: 1.5 } },
+    });
     apiMock.queueElapsedTime["q1"] = {
       elapsed_time: 10,
       elapsed_time_last_updated: NOW,
     };
-    storeMock.curQueueItem = { extra_attributes: { playback_speed: 1.5 } };
 
     vi.setSystemTime((NOW + 4) * 1000);
     expect(resolveActiveElapsedTime()).toBeCloseTo(16, 6); // 10 + 4 * 1.5
   });
 
-  it("scales a player-level fallback delta by curQueueItem's playback_speed too", () => {
-    storeMock.activePlayer = {
+  it("scales a player-level fallback delta by the current item's playback_speed too", () => {
+    // the queue reports no position of its own, but its item sets the speed
+    seedQueue({
+      queue_id: "q1",
+      state: PlaybackState.PLAYING,
+      active: true,
+      current_item: { extra_attributes: { playback_speed: 1.5 } },
+    });
+    seedPlayer({
       playback_state: PlaybackState.PLAYING,
       elapsed_time: 10,
       elapsed_time_last_updated: NOW,
-    };
-    storeMock.curQueueItem = { extra_attributes: { playback_speed: 1.5 } };
+    });
 
     vi.setSystemTime((NOW + 4) * 1000);
     expect(resolveActiveElapsedTime()).toBeCloseTo(16, 6);
   });
 
-  it("defaults playback_speed to 1 when curQueueItem has no extra_attributes", () => {
-    storeMock.activePlayer = {
+  it("defaults playback_speed to 1 when the current item has no extra_attributes", () => {
+    seedQueue({
+      queue_id: "q1",
+      state: PlaybackState.PLAYING,
+      active: true,
+      current_item: {},
+    });
+    seedPlayer({
       playback_state: PlaybackState.PLAYING,
       elapsed_time: 10,
       elapsed_time_last_updated: NOW,
-    };
+    });
 
     vi.setSystemTime((NOW + 4) * 1000);
     expect(resolveActiveElapsedTime()).toBeCloseTo(14, 6);
   });
 
   it("returns the stored elapsed_time unchanged when paused, regardless of speed", () => {
-    storeMock.activePlayerQueue = {
+    seedQueue({
       queue_id: "q1",
       state: PlaybackState.PAUSED,
       active: true,
-    };
+      current_item: { extra_attributes: { playback_speed: 2 } },
+    });
     apiMock.queueElapsedTime["q1"] = {
       elapsed_time: 42,
       elapsed_time_last_updated: NOW,
     };
-    storeMock.curQueueItem = { extra_attributes: { playback_speed: 2 } };
 
     vi.setSystemTime((NOW + 50) * 1000);
     expect(resolveActiveElapsedTime()).toBe(42);
+  });
+
+  it("resolves the requested player, not the active one", () => {
+    seedQueue({
+      queue_id: "q1",
+      state: PlaybackState.PLAYING,
+      active: true,
+    });
+    apiMock.queueElapsedTime["q1"] = {
+      elapsed_time: 10,
+      elapsed_time_last_updated: NOW,
+    };
+    // a second player, playing something else at its own speed
+    apiMock.players["p2"] = { player_id: "p2", active_source: "q2" };
+    apiMock.queues["q2"] = {
+      queue_id: "q2",
+      state: PlaybackState.PLAYING,
+      active: true,
+      current_item: { extra_attributes: { playback_speed: 2 } },
+    };
+    apiMock.queueElapsedTime["q2"] = {
+      elapsed_time: 100,
+      elapsed_time_last_updated: NOW,
+    };
+
+    vi.setSystemTime((NOW + 4) * 1000);
+    expect(resolveActiveTiming("p2")?.playbackSpeed).toBe(2);
+    expect(resolveActiveElapsedTime("p2")).toBeCloseTo(108, 6); // 100 + 4 * 2
+    // the active player sits at 14, so falling back to it is unmistakable
+    expect(resolveActiveElapsedTime()).toBeCloseTo(14, 6);
+  });
+
+  it("returns undefined for an unknown player id", () => {
+    seedQueue({
+      queue_id: "q1",
+      state: PlaybackState.PLAYING,
+      active: true,
+    });
+    apiMock.queueElapsedTime["q1"] = {
+      elapsed_time: 10,
+      elapsed_time_last_updated: NOW,
+    };
+
+    expect(resolveActiveTiming("unknown")).toBeUndefined();
+    expect(resolveActiveElapsedTime("unknown")).toBeUndefined();
   });
 });
 
 describe("resolveQueueTiming / resolveQueueElapsedTime", () => {
   it("returns the queue timing, paired with the queue's own state", () => {
-    storeMock.activePlayerQueue = {
+    seedQueue({
       queue_id: "q1",
       state: PlaybackState.PLAYING,
       active: true,
-    };
+      current_item: { extra_attributes: { playback_speed: 1.5 } },
+    });
     apiMock.queueElapsedTime["q1"] = {
       elapsed_time: 10,
       elapsed_time_last_updated: NOW,
     };
-    storeMock.curQueueItem = { extra_attributes: { playback_speed: 1.5 } };
 
     expect(resolveQueueTiming()?.playbackState).toBe(PlaybackState.PLAYING);
 
@@ -319,12 +407,12 @@ describe("resolveQueueTiming / resolveQueueElapsedTime", () => {
   });
 
   it("returns undefined when there is no queue, whatever the player reports", () => {
-    storeMock.activePlayer = {
+    seedPlayer({
       playback_state: PlaybackState.PLAYING,
       current_media: { elapsed_time: 20, elapsed_time_last_updated: NOW },
       elapsed_time: 30,
       elapsed_time_last_updated: NOW,
-    };
+    });
 
     expect(resolveQueueTiming()).toBeUndefined();
     expect(resolveQueueElapsedTime()).toBeUndefined();
@@ -333,11 +421,11 @@ describe("resolveQueueTiming / resolveQueueElapsedTime", () => {
   });
 
   it("returns undefined for a queue that is no longer active", () => {
-    storeMock.activePlayerQueue = {
+    seedQueue({
       queue_id: "q1",
       state: PlaybackState.PLAYING,
       active: false,
-    };
+    });
     apiMock.queueElapsedTime["q1"] = {
       elapsed_time: 10,
       elapsed_time_last_updated: NOW,
@@ -348,27 +436,27 @@ describe("resolveQueueTiming / resolveQueueElapsedTime", () => {
   });
 
   it("returns undefined when the queue reports no timing, instead of falling back to the player", () => {
-    storeMock.activePlayerQueue = {
+    seedQueue({
       queue_id: "q1",
       state: PlaybackState.PLAYING,
       active: true,
-    };
+    });
     apiMock.queueElapsedTime["q1"] = { elapsed_time: 10 };
-    storeMock.activePlayer = {
+    seedPlayer({
       playback_state: PlaybackState.PLAYING,
       elapsed_time: 500,
       elapsed_time_last_updated: NOW,
-    };
+    });
 
     expect(resolveQueueElapsedTime()).toBeUndefined();
   });
 
   it("does not advance while the queue is paused", () => {
-    storeMock.activePlayerQueue = {
+    seedQueue({
       queue_id: "q1",
       state: PlaybackState.PAUSED,
       active: true,
-    };
+    });
     apiMock.queueElapsedTime["q1"] = {
       elapsed_time: 42,
       elapsed_time_last_updated: NOW,

--- a/tests/layouts/PlayerBrowserMediaControls.test.ts
+++ b/tests/layouts/PlayerBrowserMediaControls.test.ts
@@ -1,0 +1,197 @@
+import PlayerBrowserMediaControls from "@/layouts/default/PlayerOSD/PlayerBrowserMediaControls.vue";
+import { PlaybackState } from "@/plugins/api/interfaces";
+import { mount } from "@vue/test-utils";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Only the fields the component and the timing helper read are mocked.
+interface MockPlayer {
+  player_id?: string;
+  active_source?: string;
+  playback_state?: PlaybackState;
+}
+
+interface MockQueue {
+  queue_id: string;
+  state?: PlaybackState;
+  active?: boolean;
+  current_item?: { extra_attributes?: { playback_speed?: number } };
+}
+
+const {
+  apiMock,
+  storeMock,
+  mockPlayerCommandSeek,
+  mockUseMediaBrowserMetaData,
+} = vi.hoisted(() => {
+  const mockPlayerCommandSeek = vi.fn();
+  return {
+    apiMock: {
+      players: {} as Record<string, MockPlayer>,
+      queues: {} as Record<string, MockQueue>,
+      queueElapsedTime: {} as Record<
+        string,
+        { elapsed_time?: number; elapsed_time_last_updated?: number }
+      >,
+      playerCommandPlay: vi.fn(),
+      playerCommandPause: vi.fn(),
+      playerCommandNext: vi.fn(),
+      playerCommandPrevious: vi.fn(),
+      playerCommandSeek: mockPlayerCommandSeek,
+    },
+    storeMock: {
+      activePlayer: undefined as MockPlayer | undefined,
+    },
+    mockPlayerCommandSeek,
+    mockUseMediaBrowserMetaData: vi.fn(),
+  };
+});
+
+vi.mock("@/plugins/api", () => ({
+  default: apiMock,
+}));
+
+vi.mock("@/plugins/store", () => ({
+  store: storeMock,
+}));
+
+vi.mock("@/helpers/useMediaBrowserMetaData", () => ({
+  useMediaBrowserMetaData: mockUseMediaBrowserMetaData,
+}));
+
+type ActionHandler = ((details: MediaSessionActionDetails) => void) | null;
+
+const handlers = new Map<MediaSessionAction, ActionHandler>();
+const mediaSession = {
+  setActionHandler: vi.fn(
+    (action: MediaSessionAction, handler: ActionHandler) => {
+      handlers.set(action, handler);
+    },
+  ),
+};
+
+const ANCHOR = 1_700_000_000;
+
+describe("PlayerBrowserMediaControls seek handling", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(ANCHOR * 1000);
+    handlers.clear();
+    mediaSession.setActionHandler.mockClear();
+    mediaSession.setActionHandler.mockImplementation((action, handler) => {
+      handlers.set(action, handler);
+    });
+    Object.defineProperty(navigator, "mediaSession", {
+      configurable: true,
+      value: mediaSession,
+    });
+    // Registering seekforward/seekbackward is skipped on iOS/Mac.
+    Object.defineProperty(navigator, "userAgent", {
+      configurable: true,
+      value: "Android",
+    });
+    apiMock.queues = {};
+    apiMock.queueElapsedTime = {};
+    // The component seeks store.activePlayer, and the timing helper looks that
+    // same player up in api.players.
+    apiMock.players = { "player-1": { player_id: "player-1" } };
+    storeMock.activePlayer = apiMock.players["player-1"];
+    mockPlayerCommandSeek.mockClear();
+    mockUseMediaBrowserMetaData.mockClear();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    Reflect.deleteProperty(navigator, "mediaSession");
+    Reflect.deleteProperty(navigator, "userAgent");
+  });
+
+  it("seeks forward from the extrapolated (displayed) position at 2x speed", () => {
+    seedPlayingQueue({ elapsed_time: 30, secondsAgo: 3, playback_speed: 2 });
+
+    const wrapper = mount(PlayerBrowserMediaControls);
+    invokeAction("seekforward", { seekOffset: 10 });
+
+    // Displayed position is 30 + 3s * 2x = 36, so a +10s skip lands on 46; the
+    // raw stored position would give 40.
+    expect(mockPlayerCommandSeek).toHaveBeenCalledWith("player-1", 46);
+    wrapper.unmount();
+  });
+
+  it("seeks backward from the extrapolated (displayed) position at 2x speed", () => {
+    seedPlayingQueue({ elapsed_time: 30, secondsAgo: 3, playback_speed: 2 });
+
+    const wrapper = mount(PlayerBrowserMediaControls);
+    invokeAction("seekbackward", { seekOffset: 10 });
+
+    expect(mockPlayerCommandSeek).toHaveBeenCalledWith("player-1", 26);
+    wrapper.unmount();
+  });
+
+  it("clamps seekbackward at 0 instead of going negative", () => {
+    seedPlayingQueue({ elapsed_time: 2, secondsAgo: 1, playback_speed: 2 });
+
+    const wrapper = mount(PlayerBrowserMediaControls);
+    invokeAction("seekbackward", { seekOffset: 10 });
+
+    expect(mockPlayerCommandSeek).toHaveBeenCalledWith("player-1", 0);
+    wrapper.unmount();
+  });
+
+  it("passes seekTime straight through for seekto", () => {
+    const wrapper = mount(PlayerBrowserMediaControls);
+    invokeAction("seekto", { seekTime: 12.6 });
+
+    expect(mockPlayerCommandSeek).toHaveBeenCalledWith("player-1", 13);
+    wrapper.unmount();
+  });
+
+  it("seeks to the start for a seekto of 0", () => {
+    const wrapper = mount(PlayerBrowserMediaControls);
+    invokeAction("seekto", { seekTime: 0 });
+
+    expect(mockPlayerCommandSeek).toHaveBeenCalledWith("player-1", 0);
+    wrapper.unmount();
+  });
+
+  it("does not seek when no timing source is available", () => {
+    const wrapper = mount(PlayerBrowserMediaControls);
+    invokeAction("seekforward", { seekOffset: 10 });
+
+    expect(mockPlayerCommandSeek).not.toHaveBeenCalled();
+    wrapper.unmount();
+  });
+});
+
+function seedPlayingQueue(timing: {
+  elapsed_time: number;
+  secondsAgo: number;
+  playback_speed: number;
+}): void {
+  apiMock.players["player-1"] = {
+    player_id: "player-1",
+    active_source: "queue",
+  };
+  storeMock.activePlayer = apiMock.players["player-1"];
+  apiMock.queues.queue = {
+    queue_id: "queue",
+    state: PlaybackState.PLAYING,
+    active: true,
+    current_item: {
+      extra_attributes: { playback_speed: timing.playback_speed },
+    },
+  };
+  apiMock.queueElapsedTime.queue = {
+    elapsed_time: timing.elapsed_time,
+    elapsed_time_last_updated: ANCHOR - timing.secondsAgo,
+  };
+}
+
+function invokeAction(
+  action: MediaSessionAction,
+  details: Partial<MediaSessionActionDetails> = {},
+): void {
+  handlers.get(action)?.({
+    action,
+    ...details,
+  } as MediaSessionActionDetails);
+}

--- a/tests/layouts/PlayerTimeline.test.ts
+++ b/tests/layouts/PlayerTimeline.test.ts
@@ -11,6 +11,7 @@ import { nextTick } from "vue";
 vi.mock("@/plugins/api", async () => {
   const { reactive } = await vi.importActual<typeof import("vue")>("vue");
   const api = reactive({
+    queues: {},
     queueElapsedTime: {},
     playerCommandSeek: vi.fn(),
     playMedia: vi.fn(),
@@ -23,7 +24,6 @@ vi.mock("@/plugins/store", async () => {
   return {
     store: reactive({
       activePlayer: undefined,
-      activePlayerQueue: undefined,
       curQueueItem: undefined,
     }),
   };
@@ -47,18 +47,18 @@ interface TestTiming {
 interface TestStore {
   activePlayer?: TestTiming & {
     player_id: string;
+    active_source?: string;
     playback_state?: PlaybackState;
     current_media?: TestTiming & { duration?: number };
-  };
-  activePlayerQueue?: {
-    queue_id: string;
-    state?: PlaybackState;
-    active?: boolean;
   };
   curQueueItem?: { queue_item_id?: string };
 }
 
 const api = apiDefault as unknown as {
+  queues: Record<
+    string,
+    { queue_id: string; state?: PlaybackState; active?: boolean }
+  >;
   queueElapsedTime: Record<string, TestTiming>;
 };
 const store = storeModule as unknown as TestStore;
@@ -71,9 +71,9 @@ let wrapper: VueWrapper | undefined;
 beforeEach(() => {
   vi.useFakeTimers();
   vi.setSystemTime(NOW * 1000);
+  api.queues = {};
   api.queueElapsedTime = {};
   store.activePlayer = undefined;
-  store.activePlayerQueue = undefined;
   store.curQueueItem = undefined;
 });
 
@@ -103,7 +103,7 @@ describe("PlayerTimeline", () => {
   });
 
   it("animates a queue-sourced position", async () => {
-    store.activePlayerQueue = {
+    api.queues["q1"] = {
       queue_id: "q1",
       state: PlaybackState.PLAYING,
       active: true,
@@ -114,6 +114,7 @@ describe("PlayerTimeline", () => {
     };
     store.activePlayer = {
       player_id: "p1",
+      active_source: "q1",
       playback_state: PlaybackState.PLAYING,
       current_media: { duration: 300 },
     };

--- a/tests/plugins/api/helpers.test.ts
+++ b/tests/plugins/api/helpers.test.ts
@@ -21,13 +21,19 @@ vi.mock("@/plugins/api", async () => {
   };
 });
 
+import api from "@/plugins/api";
 import {
   isAudioSource,
   isQueueInfiniteStream,
+  resolvePlayerQueue,
   waitForApiInitialization,
 } from "@/plugins/api/helpers";
 import { MediaType } from "@/plugins/api/interfaces";
-import type { MediaItemType, PlayerQueue } from "@/plugins/api/interfaces";
+import type {
+  MediaItemType,
+  Player,
+  PlayerQueue,
+} from "@/plugins/api/interfaces";
 
 describe("isAudioSource", () => {
   it("returns true for AUDIO_SOURCE media type", () => {
@@ -82,6 +88,42 @@ describe("isQueueInfiniteStream", () => {
   it("returns false when the queue or current item is missing", () => {
     expect(isQueueInfiniteStream(undefined)).toBe(false);
     expect(isQueueInfiniteStream(makeQueue(undefined))).toBe(false);
+  });
+});
+
+describe("resolvePlayerQueue", () => {
+  const player = (fields: Partial<Player>) =>
+    ({ player_id: "p1", ...fields }) as Player;
+
+  beforeEach(() => {
+    for (const key of Object.keys(api.queues)) delete api.queues[key];
+  });
+
+  it("returns the queue of the source the player is attached to", () => {
+    api.queues["source-q"] = { queue_id: "source-q" } as PlayerQueue;
+
+    expect(
+      resolvePlayerQueue(player({ active_source: "source-q" }))?.queue_id,
+    ).toBe("source-q");
+  });
+
+  it("returns the player's own active queue when it has no source", () => {
+    api.queues["p1"] = { queue_id: "p1", active: true } as PlayerQueue;
+
+    expect(resolvePlayerQueue(player({}))?.queue_id).toBe("p1");
+  });
+
+  it("ignores the player's own queue while it is inactive", () => {
+    api.queues["p1"] = { queue_id: "p1", active: false } as PlayerQueue;
+
+    expect(resolvePlayerQueue(player({}))).toBeUndefined();
+  });
+
+  it("returns undefined for an unknown source and for no player", () => {
+    expect(
+      resolvePlayerQueue(player({ active_source: "gone" })),
+    ).toBeUndefined();
+    expect(resolvePlayerQueue(undefined)).toBeUndefined();
   });
 });
 


### PR DESCRIPTION
The skip forward/backward buttons in the OS media notification worked out their target from the last position the server reported, not the position shown on the progress bar. For audiobooks and podcasts played faster than 1x, that made a "skip 10 seconds" jump land short — up to about 2 seconds off at 2x speed.

The offset was also measured against the selected player rather than the player the notification is actually controlling, so during listen-in the jump could start from a completely different position.

- Skip forward/backward now measure their offset from the position on screen, for the player the notification targets
- Dragging the notification scrubber all the way to the start now works
- One shared accessor for "which queue plays on this player" and for the playback speed, replacing three copies of the first and two of the second
- Add test coverage for the seek handlers in both media notification components