### PR TITLE
Take the lyrics position from the active queue only

### DIFF
--- a/src/composables/lyrics/useLyricsElapsedTime.ts
+++ b/src/composables/lyrics/useLyricsElapsedTime.ts
@@ -5,21 +5,26 @@
  * suitable for smooth lyrics synchronization. Automatically starts/stops the
  * rAF loop based on the active queue's playback state and an optional
  * `enabled` guard.
+ *
+ * The position comes from that same queue, matching where its consumers take the
+ * lyrics from: the queue's current item. A source playing on the player outside a
+ * Music Assistant queue leaves them without lyrics, so there is nothing to
+ * synchronize either.
  */
 
 import { ref, watchEffect, onScopeDispose, type Ref } from "vue";
 import { PlaybackState } from "@/plugins/api/interfaces";
 import { store } from "@/plugins/store";
-import { resolveActiveElapsedTime } from "@/helpers/activeElapsedTime";
+import { resolveQueueElapsedTime } from "@/helpers/activeElapsedTime";
 
 export function useLyricsElapsedTime(enabled?: Ref<boolean>) {
   const elapsedTime = ref(0);
   let rafId: number | null = null;
 
   const update = () => {
-    // Keep the last known position when no source reports a timing, so the
+    // Keep the last known position when the queue reports no position, so the
     // lyrics do not snap back to the start of the track.
-    const elapsed = resolveActiveElapsedTime();
+    const elapsed = resolveQueueElapsedTime();
     if (elapsed !== undefined) {
       elapsedTime.value = elapsed;
     }
@@ -52,6 +57,11 @@ export function useLyricsElapsedTime(enabled?: Ref<boolean>) {
   };
   document.addEventListener("visibilitychange", handleVisibilityChange);
 
+  // The queue's own state and active flag both change rarely, unlike the resolved
+  // position: that is backed by a high-frequency reactive map, so reading it here
+  // would re-run the gate on every server timing push. The resolver checks
+  // `active` as well, for the position it returns; here it decides whether the
+  // loop burns frames at all.
   watchEffect(() => {
     const queue = store.activePlayerQueue;
     const playing = queue?.state === PlaybackState.PLAYING;

--- a/src/helpers/activeElapsedTime.ts
+++ b/src/helpers/activeElapsedTime.ts
@@ -3,8 +3,10 @@
  *
  * Resolves the timing source, its playback state and the playback speed in one
  * place, so progress indicators do not each work the position out differently.
- * Both functions read the current values on each call and hold no state, which
- * makes them equally usable inside a `computed` and inside a rAF/interval loop.
+ * The `resolveQueue*` variants narrow that to the active queue, for consumers that
+ * only render what that queue is playing. Every function reads the current values
+ * on each call and holds no state, which makes them equally usable inside a
+ * `computed` and inside a rAF/interval loop.
  */
 import { computeElapsedTime, queueItemPlaybackSpeed } from "@/helpers/elapsed";
 import api from "@/plugins/api";
@@ -29,28 +31,14 @@ export interface ActiveTiming {
  * never combine a queue position with a player state or the other way around.
  */
 export function resolveActiveTiming(): ActiveTiming | undefined {
-  const playbackSpeed = queueItemPlaybackSpeed(store.curQueueItem);
-
   // Prefer the active queue's own elapsed_time when it reports one.
-  const queue = store.activePlayerQueue;
-  if (queue) {
-    const queueTime = api.queueElapsedTime[queue.queue_id];
-    if (
-      queueTime?.elapsed_time != null &&
-      queueTime.elapsed_time_last_updated != null
-    ) {
-      return {
-        elapsedTime: queueTime.elapsed_time,
-        lastUpdated: queueTime.elapsed_time_last_updated,
-        playbackState: queue.state,
-        playbackSpeed,
-      };
-    }
-  }
+  const queueTiming = resolveQueueTiming();
+  if (queueTiming) return queueTiming;
 
   // Fall back to the player's own timing, which is what external/3rd-party
   // sources playing on the player report: current_media first, then the legacy
   // player-level fields.
+  const playbackSpeed = queueItemPlaybackSpeed(store.curQueueItem);
   const player = store.activePlayer;
   // An unknown state must not extrapolate from the last update.
   const playerState = player?.playback_state ?? PlaybackState.IDLE;
@@ -82,11 +70,52 @@ export function resolveActiveTiming(): ActiveTiming | undefined {
 }
 
 /**
+ * The timing reported by the active player's active queue, or undefined when there
+ * is no such queue or it reports no position.
+ *
+ * Use this rather than `resolveActiveTiming` for consumers that take their content
+ * from `store.curQueueItem`: the player fallback would hand them a position for
+ * content they cannot display.
+ */
+export function resolveQueueTiming(): ActiveTiming | undefined {
+  const queue = store.activePlayerQueue;
+  // An inactive queue holds the position it stopped at, while curQueueItem is
+  // already gone; pairing the two would mix a stale position with a default speed.
+  if (!queue?.active) return undefined;
+
+  const queueTime = api.queueElapsedTime[queue.queue_id];
+  if (
+    queueTime?.elapsed_time == null ||
+    queueTime.elapsed_time_last_updated == null
+  ) {
+    return undefined;
+  }
+
+  return {
+    elapsedTime: queueTime.elapsed_time,
+    lastUpdated: queueTime.elapsed_time_last_updated,
+    playbackState: queue.state,
+    playbackSpeed: queueItemPlaybackSpeed(store.curQueueItem),
+  };
+}
+
+/**
  * The current playback position of the active player in seconds, or undefined
  * when no timing source is available.
  */
 export function resolveActiveElapsedTime(): number | undefined {
-  const timing = resolveActiveTiming();
+  return toElapsedTime(resolveActiveTiming());
+}
+
+/**
+ * The current playback position of the active player's active queue in seconds, or
+ * undefined when there is no such queue or it reports no timing.
+ */
+export function resolveQueueElapsedTime(): number | undefined {
+  return toElapsedTime(resolveQueueTiming());
+}
+
+function toElapsedTime(timing: ActiveTiming | undefined): number | undefined {
   if (!timing) return undefined;
 
   return computeElapsedTime(

--- a/tests/composables/useLyricsElapsedTime.test.ts
+++ b/tests/composables/useLyricsElapsedTime.test.ts
@@ -33,7 +33,13 @@ const storeMock = reactive({
   activePlayerQueue: undefined as
     | { queue_id: string; state: PlaybackState; active: boolean }
     | undefined,
-  activePlayer: undefined as { playback_state?: PlaybackState } | undefined,
+  activePlayer: undefined as
+    | {
+        playback_state?: PlaybackState;
+        elapsed_time?: number;
+        elapsed_time_last_updated?: number;
+      }
+    | undefined,
   curQueueItem: undefined as
     | { extra_attributes?: { playback_speed?: number } }
     | undefined,
@@ -70,6 +76,22 @@ function makeQueue(overrides: Record<string, unknown> = {}) {
   };
 }
 
+// Stands in for the `enabled` ref and counts how often the gate re-runs: the
+// watchEffect is the only reader, so a read means the effect ran. It never
+// changes value, so it needs no reactivity of its own.
+function countingEnabled() {
+  let reads = 0;
+  return {
+    ref: {
+      get value() {
+        reads++;
+        return true;
+      },
+    } as unknown as Ref<boolean>,
+    reads: () => reads,
+  };
+}
+
 // Disposed in afterEach so a failed assertion cannot leave an effect
 // subscribed to the shared store mock and corrupt the tests that follow.
 let activeScope: EffectScope | undefined;
@@ -103,7 +125,9 @@ describe("useLyricsElapsedTime", () => {
       }),
     );
 
-    apiMock.queueElapsedTime = {};
+    // reactive like the real map, so a timing push can be seen to (not) wake
+    // anything that subscribed to it
+    apiMock.queueElapsedTime = reactive({});
     storeMock.activePlayerQueue = undefined;
     storeMock.activePlayer = undefined;
     storeMock.curQueueItem = undefined;
@@ -206,6 +230,56 @@ describe("useLyricsElapsedTime", () => {
     await nextTick();
 
     expect(pendingFrames.size).toBe(0);
+  });
+
+  it("holds the last queue position rather than adopting the player's", async () => {
+    storeMock.activePlayerQueue = makeQueue();
+    apiMock.queueElapsedTime["q1"] = {
+      elapsed_time: 10,
+      elapsed_time_last_updated: NOW,
+    };
+
+    const { elapsedTime } = await runComposable();
+    await nextTick();
+    flushFrame();
+    expect(elapsedTime.value).toBe(10);
+
+    // the queue stops reporting a position while the player still reports one
+    delete apiMock.queueElapsedTime["q1"];
+    storeMock.activePlayer = {
+      playback_state: PlaybackState.PLAYING,
+      elapsed_time: 999,
+      elapsed_time_last_updated: NOW,
+    };
+    await nextTick();
+    flushFrame();
+
+    expect(elapsedTime.value).toBe(10);
+  });
+
+  it("does not re-run the gate when the queue timing updates", async () => {
+    storeMock.activePlayerQueue = makeQueue();
+    apiMock.queueElapsedTime["q1"] = {
+      elapsed_time: 10,
+      elapsed_time_last_updated: NOW,
+    };
+    const enabled = countingEnabled();
+
+    const { elapsedTime } = await runComposable(enabled.ref);
+    await nextTick();
+    const gateRuns = enabled.reads();
+    expect(gateRuns).toBeGreaterThan(0);
+
+    // a burst of QUEUE_TIME_UPDATED events
+    for (let second = 1; second <= 5; second++) {
+      apiMock.queueElapsedTime["q1"].elapsed_time = 10 + second;
+      await nextTick();
+    }
+
+    expect(enabled.reads()).toBe(gateRuns);
+    // and the loop is still running off those pushes
+    flushFrame();
+    expect(elapsedTime.value).toBe(15);
   });
 
   it("stops the loop and removes the visibilitychange listener when the scope is disposed", async () => {

--- a/tests/helpers/activeElapsedTime.test.ts
+++ b/tests/helpers/activeElapsedTime.test.ts
@@ -1,6 +1,8 @@
 import {
   resolveActiveElapsedTime,
   resolveActiveTiming,
+  resolveQueueElapsedTime,
+  resolveQueueTiming,
 } from "@/helpers/activeElapsedTime";
 import { PlaybackState } from "@/plugins/api/interfaces";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -15,7 +17,7 @@ const { apiMock, storeMock } = vi.hoisted(() => ({
   // Only the fields the helper actually reads are mocked.
   storeMock: {
     activePlayerQueue: undefined as
-      | { queue_id: string; state?: PlaybackState }
+      | { queue_id: string; state?: PlaybackState; active?: boolean }
       | undefined,
     activePlayer: undefined as
       | {
@@ -45,33 +47,70 @@ vi.mock("@/plugins/store", () => ({
 // epoch seconds the fake clock starts at; timestamps below are relative to this
 const NOW = 1_700_000_000;
 
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.setSystemTime(NOW * 1000);
+  apiMock.queueElapsedTime = {};
+  storeMock.activePlayerQueue = undefined;
+  storeMock.activePlayer = undefined;
+  storeMock.curQueueItem = undefined;
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
 describe("resolveActiveTiming / resolveActiveElapsedTime", () => {
-  beforeEach(() => {
-    vi.useFakeTimers();
-    vi.setSystemTime(NOW * 1000);
-    apiMock.queueElapsedTime = {};
-    storeMock.activePlayerQueue = undefined;
-    storeMock.activePlayer = undefined;
-    storeMock.curQueueItem = undefined;
-  });
-
-  afterEach(() => {
-    vi.useRealTimers();
-  });
-
   it("returns undefined when neither the queue nor the player reports a timing", () => {
     expect(resolveActiveTiming()).toBeUndefined();
     expect(resolveActiveElapsedTime()).toBeUndefined();
 
-    storeMock.activePlayerQueue = { queue_id: "q1" };
+    storeMock.activePlayerQueue = { queue_id: "q1", active: true };
     storeMock.activePlayer = {};
     expect(resolveActiveTiming()).toBeUndefined();
+  });
+
+  it("falls back to the player when the queue is not active", () => {
+    // a queue still selected on the player, holding the position it stopped at
+    storeMock.activePlayerQueue = {
+      queue_id: "q1",
+      state: PlaybackState.PLAYING,
+      active: false,
+    };
+    apiMock.queueElapsedTime["q1"] = {
+      elapsed_time: 10,
+      elapsed_time_last_updated: NOW,
+    };
+    storeMock.activePlayer = {
+      playback_state: PlaybackState.PLAYING,
+      current_media: { elapsed_time: 20, elapsed_time_last_updated: NOW },
+    };
+
+    vi.setSystemTime((NOW + 4) * 1000);
+    expect(resolveActiveElapsedTime()).toBeCloseTo(24, 6);
+  });
+
+  it("reports no position for an inactive queue when the player has none either", () => {
+    storeMock.activePlayerQueue = {
+      queue_id: "q1",
+      state: PlaybackState.PLAYING,
+      active: false,
+    };
+    apiMock.queueElapsedTime["q1"] = {
+      elapsed_time: 10,
+      elapsed_time_last_updated: NOW,
+    };
+    storeMock.activePlayer = { playback_state: PlaybackState.IDLE };
+
+    expect(resolveActiveTiming()).toBeUndefined();
+    expect(resolveActiveElapsedTime()).toBeUndefined();
   });
 
   it("prefers queue timing, paired with the queue's own state", () => {
     storeMock.activePlayerQueue = {
       queue_id: "q1",
       state: PlaybackState.PLAYING,
+      active: true,
     };
     apiMock.queueElapsedTime["q1"] = {
       elapsed_time: 10,
@@ -93,6 +132,7 @@ describe("resolveActiveTiming / resolveActiveElapsedTime", () => {
     storeMock.activePlayerQueue = {
       queue_id: "q1",
       state: PlaybackState.PAUSED,
+      active: true,
     };
     apiMock.queueElapsedTime["q1"] = {
       elapsed_time: 10,
@@ -109,6 +149,7 @@ describe("resolveActiveTiming / resolveActiveElapsedTime", () => {
     storeMock.activePlayerQueue = {
       queue_id: "q1",
       state: PlaybackState.PLAYING,
+      active: true,
     };
     storeMock.activePlayer = {
       playback_state: PlaybackState.PLAYING,
@@ -136,6 +177,7 @@ describe("resolveActiveTiming / resolveActiveElapsedTime", () => {
     storeMock.activePlayerQueue = {
       queue_id: "q1",
       state: PlaybackState.PLAYING,
+      active: true,
     };
     apiMock.queueElapsedTime["q1"] = {
       elapsed_time: 0,
@@ -155,6 +197,7 @@ describe("resolveActiveTiming / resolveActiveElapsedTime", () => {
     storeMock.activePlayerQueue = {
       queue_id: "q1",
       state: PlaybackState.PLAYING,
+      active: true,
     };
     apiMock.queueElapsedTime["q1"] = { elapsed_time: 10 };
     storeMock.activePlayer = {
@@ -190,6 +233,7 @@ describe("resolveActiveTiming / resolveActiveElapsedTime", () => {
     storeMock.activePlayerQueue = {
       queue_id: "q1",
       state: PlaybackState.PLAYING,
+      active: true,
     };
     apiMock.queueElapsedTime["q1"] = {
       elapsed_time: 10,
@@ -228,6 +272,7 @@ describe("resolveActiveTiming / resolveActiveElapsedTime", () => {
     storeMock.activePlayerQueue = {
       queue_id: "q1",
       state: PlaybackState.PAUSED,
+      active: true,
     };
     apiMock.queueElapsedTime["q1"] = {
       elapsed_time: 42,
@@ -237,5 +282,85 @@ describe("resolveActiveTiming / resolveActiveElapsedTime", () => {
 
     vi.setSystemTime((NOW + 50) * 1000);
     expect(resolveActiveElapsedTime()).toBe(42);
+  });
+});
+
+describe("resolveQueueTiming / resolveQueueElapsedTime", () => {
+  it("returns the queue timing, paired with the queue's own state", () => {
+    storeMock.activePlayerQueue = {
+      queue_id: "q1",
+      state: PlaybackState.PLAYING,
+      active: true,
+    };
+    apiMock.queueElapsedTime["q1"] = {
+      elapsed_time: 10,
+      elapsed_time_last_updated: NOW,
+    };
+    storeMock.curQueueItem = { extra_attributes: { playback_speed: 1.5 } };
+
+    expect(resolveQueueTiming()?.playbackState).toBe(PlaybackState.PLAYING);
+
+    vi.setSystemTime((NOW + 4) * 1000);
+    expect(resolveQueueElapsedTime()).toBeCloseTo(16, 6); // 10 + 4 * 1.5
+  });
+
+  it("returns undefined when there is no queue, whatever the player reports", () => {
+    storeMock.activePlayer = {
+      playback_state: PlaybackState.PLAYING,
+      current_media: { elapsed_time: 20, elapsed_time_last_updated: NOW },
+      elapsed_time: 30,
+      elapsed_time_last_updated: NOW,
+    };
+
+    expect(resolveQueueTiming()).toBeUndefined();
+    expect(resolveQueueElapsedTime()).toBeUndefined();
+    // the general resolver still falls back to the player for external sources
+    expect(resolveActiveElapsedTime()).toBeCloseTo(20, 6);
+  });
+
+  it("returns undefined for a queue that is no longer active", () => {
+    storeMock.activePlayerQueue = {
+      queue_id: "q1",
+      state: PlaybackState.PLAYING,
+      active: false,
+    };
+    apiMock.queueElapsedTime["q1"] = {
+      elapsed_time: 10,
+      elapsed_time_last_updated: NOW,
+    };
+
+    expect(resolveQueueTiming()).toBeUndefined();
+    expect(resolveQueueElapsedTime()).toBeUndefined();
+  });
+
+  it("returns undefined when the queue reports no timing, instead of falling back to the player", () => {
+    storeMock.activePlayerQueue = {
+      queue_id: "q1",
+      state: PlaybackState.PLAYING,
+      active: true,
+    };
+    apiMock.queueElapsedTime["q1"] = { elapsed_time: 10 };
+    storeMock.activePlayer = {
+      playback_state: PlaybackState.PLAYING,
+      elapsed_time: 500,
+      elapsed_time_last_updated: NOW,
+    };
+
+    expect(resolveQueueElapsedTime()).toBeUndefined();
+  });
+
+  it("does not advance while the queue is paused", () => {
+    storeMock.activePlayerQueue = {
+      queue_id: "q1",
+      state: PlaybackState.PAUSED,
+      active: true,
+    };
+    apiMock.queueElapsedTime["q1"] = {
+      elapsed_time: 42,
+      elapsed_time_last_updated: NOW,
+    };
+
+    vi.setSystemTime((NOW + 50) * 1000);
+    expect(resolveQueueElapsedTime()).toBe(42);
   });
 });


### PR DESCRIPTION
The lyrics animation loop read its position from the shared player-position helper, which falls back to the player's own timing for sources playing outside a Music Assistant queue. Lyrics can never use that fallback: they are looked up for the queue's current item, and the loop only runs while a queue is active. This makes the queue-only intent explicit instead of leaving an unreachable fallback in that path.

- Add a queue-only variant of the playback-position helper and use it for lyrics
- Require the queue to be active before using its timing, so a position and a playback speed can no longer come from different queue items
- Keep the player fallback for the progress bar and the other position consumers
- Note why the animation loop's start/stop gate stays off the high-frequency position data
- Add test coverage for the lyrics animation loop and the new helper