### PR TITLE
Fix settings that stay editable while their dependency is off

### DIFF
--- a/src/components/SetupFlowDialog.vue
+++ b/src/components/SetupFlowDialog.vue
@@ -785,7 +785,8 @@ function onEntryHelp(entry: ConfigEntry) {
 function isEntryDisabled(entry: ConfigEntry): boolean {
   if (isNullOrUndefined(entry.depends_on)) return false;
   const dependency = formEntries.value.find((e) => e.key === entry.depends_on);
-  if (!dependency) return false;
+  // a key that resolves to nothing stays gated, so a typo cannot silently open the gate
+  if (!dependency) return true;
   const dependencyValue = dependency.value;
   if (!isNullOrUndefined(entry.depends_on_value)) {
     return dependencyValue != entry.depends_on_value;

--- a/src/plugins/api/interfaces.ts
+++ b/src/plugins/api/interfaces.ts
@@ -631,9 +631,9 @@ export interface ConfigEntry {
   help_link?: string;
   // multi_value [optional]: allow multiple values from the list
   multi_value?: boolean;
-  // depends_on [optional]: key of another entry that gates this one. While the dependency is
-  // unmet, input types and ACTION stay visible but render disabled; DIVIDER/LABEL/ALERT/IMAGE
-  // have nothing to disable, so they are hidden instead.
+  // depends_on [optional]: key of another entry that gates this one; an unresolved key counts
+  // as unmet. While unmet, input types and ACTION stay visible but render disabled;
+  // DIVIDER/LABEL/ALERT/IMAGE have nothing to disable, so they are hidden instead.
   depends_on?: string;
   // depends_on_value [optional]: complementary to depends_on, the dependency is only met when
   // the other entry holds this exact value (without it, any truthy value will do)

--- a/src/plugins/api/interfaces.ts
+++ b/src/plugins/api/interfaces.ts
@@ -631,9 +631,14 @@ export interface ConfigEntry {
   help_link?: string;
   // multi_value [optional]: allow multiple values from the list
   multi_value?: boolean;
-  // depends_on [optional]: needs to be set before this setting shows up in frontend
+  // depends_on [optional]: key of another entry that gates this one. While the dependency is
+  // unmet, input types and ACTION stay visible but render disabled; DIVIDER/LABEL/ALERT/IMAGE
+  // have nothing to disable, so they are hidden instead.
   depends_on?: string;
+  // depends_on_value [optional]: complementary to depends_on, the dependency is only met when
+  // the other entry holds this exact value (without it, any truthy value will do)
   depends_on_value?: ConfigValueType;
+  // depends_on_value_not [optional]: same as depends_on_value but inverted
   depends_on_value_not?: ConfigValueType;
   // hidden: hide from UI
   hidden?: boolean;

--- a/src/views/settings/ConfigEntryField.vue
+++ b/src/views/settings/ConfigEntryField.vue
@@ -120,6 +120,7 @@
         <div class="config-slider-input">
           <NumberField
             :model-value="confEntry.value as number"
+            :disabled="isFieldDisabled"
             :min="confEntry.range[0]"
             :max="confEntry.range[1]"
             :step="confEntry.type == ConfigEntryType.FLOAT ? 0.5 : 1"

--- a/src/views/settings/EditConfig.vue
+++ b/src/views/settings/EditConfig.vue
@@ -464,7 +464,8 @@ const isDisabled = function (entry: ConfigEntryUI) {
     const dependentEntry = entries.value?.find(
       (x) => x.key == entry.depends_on,
     );
-    if (!dependentEntry) return false;
+    // a key that resolves to nothing stays gated, so a typo cannot silently open the gate
+    if (!dependentEntry) return true;
 
     const dependentValue = dependentEntry.value;
 

--- a/tests/components/SetupFlowDialog.test.ts
+++ b/tests/components/SetupFlowDialog.test.ts
@@ -224,6 +224,39 @@ describe("SetupFlowDialog", () => {
     expect(rows[0].props("disabled")).toBe(false);
     expect(rows[1].props("disabled")).toBe(true);
   });
+
+  it("gates an entry whose dependency key is not in the step", async () => {
+    apiMock.reconfigureProvider.mockResolvedValue(
+      formStep([
+        entry({
+          key: "feature_warning",
+          type: ConfigEntryType.ALERT,
+          depends_on: "typo_in_this_key",
+        }),
+        entry({
+          key: "feature_detail",
+          type: ConfigEntryType.STRING,
+          depends_on: "typo_in_this_key",
+        }),
+      ]),
+    );
+    const wrapper = shallowMount(SetupFlowDialog, {
+      global: { renderStubDefaultSlot: true },
+    });
+
+    await launchSetupFlow?.({
+      kind: "reconfigure",
+      instanceId: "spotify--test",
+      onFlowEnded: vi.fn(),
+    });
+    await flushPromises();
+
+    const rows = wrapper.findAllComponents({ name: "ConfigEntryRow" });
+    expect(
+      rows.map((row) => (row.props("confEntry") as ConfigEntry).key),
+    ).toEqual(["feature_detail"]);
+    expect(rows[0].props("disabled")).toBe(true);
+  });
 });
 
 function terminalStep(type: FlowStepType): SetupFlowStep {

--- a/tests/views/EditConfig.test.ts
+++ b/tests/views/EditConfig.test.ts
@@ -80,6 +80,33 @@ describe("EditConfig", () => {
     expect(rows[1].props("disabled")).toBe(true);
   });
 
+  it("hides a label whose dependency key is not in the form", () => {
+    const wrapper = mountEntries([
+      entry({ key: "enable_feature", type: ConfigEntryType.BOOLEAN }),
+      entry({
+        key: "feature_status",
+        type: ConfigEntryType.LABEL,
+        depends_on: "typo_in_this_key",
+      }),
+    ]);
+
+    expect(renderedKeys(wrapper)).toEqual(["enable_feature"]);
+  });
+
+  it("disables an input whose dependency key is not in the form", () => {
+    const wrapper = mountEntries([
+      entry({
+        key: "feature_detail",
+        type: ConfigEntryType.STRING,
+        depends_on: "typo_in_this_key",
+      }),
+    ]);
+
+    const rows = wrapper.findAllComponents({ name: "ConfigEntryRow" });
+    expect(renderedKeys(wrapper)).toEqual(["feature_detail"]);
+    expect(rows[0].props("disabled")).toBe(true);
+  });
+
   it("reveals a label as soon as the dependency flips, without a save", async () => {
     const entries = [
       entry({ key: "enable_feature", type: ConfigEntryType.BOOLEAN }),


### PR DESCRIPTION
Settings that depend on another setting didn't always respect that dependency:

- a number setting shown as a slider left the number box beside it fully editable while the dependency was off, so you could still change a value the slider had greyed out. 16 settings are affected, including crossfade duration, min/max volume, and several party and snapcast settings.
- a dependency pointing at a setting that isn't on the form counted as satisfied, so a mistyped key silently showed the setting instead of hiding it.

Also corrects the `depends_on` comment in the API interface, which claimed a setting stays hidden until its dependency is set. Since #2270 that has been two behaviours, and the comment now says so.

- bind `disabled` on the number input next to the slider
- treat an unresolved dependency key as unmet, in both the settings page and the setup flow
- document both render modes on `depends_on` / `depends_on_value` / `depends_on_value_not`

Same comment fix on the model side: music-assistant/models#347.