### PR TITLE
Add a relative mode and a haptics toggle to the volume slider

### DIFF
--- a/src/layouts/default/PlayerOSD/PlayerVolume.vue
+++ b/src/layouts/default/PlayerOSD/PlayerVolume.vue
@@ -67,9 +67,11 @@
         disabled: isDisabled,
         muted: isMuted,
         'not-powered': player.powered == false,
+        'relative-mode': isRelativeMode,
       }"
       :style="{ width: width }"
       @click="onSliderClick"
+      @mousedown="onMouseDown"
       @pointerdown.capture="onPointerDown"
       @pointermove.capture="onPointerMove"
       @pointerup="onPointerUp"
@@ -96,7 +98,7 @@
         :disabled="isSliderDisabled"
         :min="0"
         :max="100"
-        :step="step"
+        :step="effectiveStep"
         class="volume-slider"
         :class="cn('w-full', props.class)"
         @update:model-value="onSliderUpdate"
@@ -119,6 +121,7 @@
 
 <script setup lang="ts">
 import { Slider } from "@/components/ui/slider";
+import { useUserPreferences } from "@/composables/userPreferences";
 import { getVolumeIconComponent, truncateString } from "@/helpers/utils";
 import { cn } from "@/lib/utils";
 import { api } from "@/plugins/api";
@@ -146,6 +149,7 @@ export interface Props {
   /** Ask the parent to expand inline group controls when the slider is tapped */
   requestExpandOnGroupTap?: boolean;
   width?: string;
+  /** Overrides the user's volume step preference when set */
   step?: number;
   allowWheel?: boolean;
   color?: string;
@@ -160,7 +164,9 @@ const props = withDefaults(defineProps<Props>(), {
   enablePopout: true,
   requestExpandOnGroupTap: false,
   width: "100%",
-  step: 2,
+  // No default: falling through to undefined is what lets the user's
+  // volume_step preference apply (see effectiveStep below)
+  step: undefined,
   allowWheel: false,
   color: "secondary",
   class: "",
@@ -170,6 +176,35 @@ const emit = defineEmits<{
   (e: "update:local-value", value: number): void;
   (e: "toggle-group-expansion"): void;
 }>();
+
+// --- User preferences (Settings -> Frontend -> Volume control) ---
+
+const { getPreference } = useUserPreferences();
+
+const DEFAULT_VOLUME_STEP = 2;
+const MIN_VOLUME_STEP = 1;
+const MAX_VOLUME_STEP = 10;
+
+// "absolute": the drag/tap position sets the volume (upstream default).
+// "relative": the drag distance adjusts the volume from where the drag started.
+const volumeSliderMode = getPreference<string>(
+  "volume_slider_mode",
+  "absolute",
+);
+const isRelativeMode = computed(() => volumeSliderMode.value === "relative");
+
+const hapticsEnabled = getPreference<boolean>("volume_haptics", true);
+
+const volumeStep = getPreference<number>("volume_step", DEFAULT_VOLUME_STEP);
+
+// An explicit prop wins; otherwise follow the preference. Sanitised because
+// preferences are free-form JSON on the server side.
+const effectiveStep = computed(() => {
+  if (props.step) return props.step;
+  const pref = Number(volumeStep.value);
+  if (!Number.isFinite(pref)) return DEFAULT_VOLUME_STEP;
+  return Math.min(Math.max(Math.round(pref), MIN_VOLUME_STEP), MAX_VOLUME_STEP);
+});
 
 // --- Player-aware computed properties ---
 
@@ -412,6 +447,11 @@ let pointerStartX: number | null = null;
 let pointerStartValue = 0;
 let pointerMoved = false;
 
+// Mouse drag tracking (relative mode only)
+const isMouseDragging = ref(false);
+const mouseStartX = ref(0);
+const mouseStartValue = ref(0);
+
 let sliderUpdateDebounceTimeout: ReturnType<typeof setTimeout> | null = null;
 const SLIDER_UPDATE_DEBOUNCE_MS = 100;
 const POINTER_DRAG_THRESHOLD = 4;
@@ -419,13 +459,15 @@ const POINTER_DRAG_THRESHOLD = 4;
 onUnmounted(() => {
   if (dragEndTimeout) clearTimeout(dragEndTimeout);
   if (sliderUpdateDebounceTimeout) clearTimeout(sliderUpdateDebounceTimeout);
+  document.removeEventListener("mousemove", onMouseMove);
+  document.removeEventListener("mouseup", onMouseUp);
 });
 
 const clamp = (value: number, min: number, max: number) =>
   Math.min(Math.max(value, min), max);
 
 const roundToStep = (value: number) =>
-  Math.round(value / props.step) * props.step;
+  Math.round(value / effectiveStep.value) * effectiveStep.value;
 
 // --- Drag helpers ---
 
@@ -486,11 +528,13 @@ const onMuteToggle = () => {
 // --- Helpers ---
 
 const vibrate = (duration: number = 10) => {
+  if (!hapticsEnabled.value) return;
   if (store.isTouchscreen && "vibrate" in navigator && navigator.vibrate) {
     navigator.vibrate(duration);
   }
 };
 
+// Absolute mode: the pointer position maps directly onto the 0-100 range.
 const getPercentageFromX = (clientX: number): number => {
   if (!sliderContainerRef.value) return displayValue.value;
 
@@ -500,6 +544,25 @@ const getPercentageFromX = (clientX: number): number => {
 
   return clamp(roundToStep(percentage), 0, 100);
 };
+
+// Relative mode: the drag *distance* is applied to the value the drag started
+// from, at reduced speed so small adjustments are easier to land.
+const RELATIVE_DRAG_SENSITIVITY = 0.5;
+
+const getValueFromDelta = (startValue: number, deltaX: number): number => {
+  if (!sliderContainerRef.value) return displayValue.value;
+
+  const rect = sliderContainerRef.value.getBoundingClientRect();
+  const deltaPercent = (deltaX / rect.width) * 100 * RELATIVE_DRAG_SENSITIVITY;
+
+  return clamp(roundToStep(startValue + deltaPercent), 0, 100);
+};
+
+// Resolves a touch drag position through whichever mode is active.
+const getDragValue = (clientX: number): number =>
+  isRelativeMode.value
+    ? getValueFromDelta(touchStartValue.value, clientX - touchStartX.value)
+    : getPercentageFromX(clientX);
 
 // --- Touch handlers ---
 
@@ -560,7 +623,7 @@ const onTouchMove = (event: TouchEvent) => {
   if (isDrag.value) {
     event.preventDefault();
 
-    const newValue = getPercentageFromX(touch.clientX);
+    const newValue = getDragValue(touch.clientX);
     const valueChanged = newValue !== displayValue.value;
 
     displayValue.value = newValue;
@@ -607,13 +670,9 @@ const onTouchEnd = (event: TouchEvent) => {
       }
     }
   } else if (!isSliderDisabled.value) {
-    // Drag end: send the final absolute value to the server
+    // Drag end: send the final value to the server
     const touch = event.changedTouches[0];
-    const finalValue = clamp(
-      roundToStep(getPercentageFromX(touch.clientX)),
-      0,
-      100,
-    );
+    const finalValue = getDragValue(touch.clientX);
     displayValue.value = finalValue;
     emit("update:local-value", finalValue);
     setVolume(finalValue);
@@ -717,6 +776,73 @@ const onTouchCancel = () => {
   isTouching.value = false;
 };
 
+// --- Mouse drag handlers (relative mode only) ---
+//
+// In absolute mode the Slider owns mouse input and onPointerDown/onSliderClick
+// own the group tap, so every handler here bails out early. In relative mode
+// the slider has pointer-events disabled, which also makes the pointer
+// handlers inert (their targetsSlider check can never match).
+
+const MOUSE_DRAG_THRESHOLD_PX = 5;
+
+const onMouseMove = (event: MouseEvent) => {
+  if (!isMouseDragging.value || isSliderDisabled.value) return;
+
+  const newValue = getValueFromDelta(
+    mouseStartValue.value,
+    event.clientX - mouseStartX.value,
+  );
+  displayValue.value = newValue;
+  emit("update:local-value", newValue);
+};
+
+const onMouseUp = (event: MouseEvent) => {
+  document.removeEventListener("mousemove", onMouseMove);
+  document.removeEventListener("mouseup", onMouseUp);
+
+  if (!isMouseDragging.value) return;
+  isMouseDragging.value = false;
+
+  const deltaX = event.clientX - mouseStartX.value;
+
+  if (Math.abs(deltaX) < MOUSE_DRAG_THRESHOLD_PX) {
+    // Treated as a click rather than a drag: run the group action. This also
+    // stamps lastPopoutToggleTime, so the click event that follows this
+    // mouseup is a no-op in onSliderClick.
+    if (handlesGroupTap.value) {
+      handleGroupTap();
+    }
+  } else {
+    const finalValue = getValueFromDelta(mouseStartValue.value, deltaX);
+    displayValue.value = finalValue;
+    emit("update:local-value", finalValue);
+    setVolume(finalValue);
+  }
+
+  stopDragging();
+};
+
+const onMouseDown = (event: MouseEvent) => {
+  if (!isRelativeMode.value) return;
+  if (isSliderDisabled.value) return;
+  // Leave the mute button and the volume readout to their own handlers
+  if (
+    (event.target as HTMLElement).closest(".volume-prepend, .volume-append")
+  ) {
+    return;
+  }
+
+  isMouseDragging.value = true;
+  mouseStartX.value = event.clientX;
+  mouseStartValue.value = displayValue.value;
+  startDragging();
+  // Suppress text selection while dragging
+  event.preventDefault();
+
+  document.addEventListener("mousemove", onMouseMove);
+  document.addEventListener("mouseup", onMouseUp);
+};
+
 const onWheel = (event: WheelEvent) => {
   if (!props.allowWheel || isSliderDisabled.value) return;
 
@@ -757,6 +883,8 @@ const onSliderUpdate = (values: number[] | undefined) => {
 
 // Desktop clicks use the same group action as touch taps.
 const onSliderClick = () => {
+  // In relative mode the mouseup handler owns this, so don't run it twice
+  if (isRelativeMode.value) return;
   if (!handlesGroupTap.value || isTouching.value || isDragging.value) return;
   if (Date.now() - lastPopoutToggleTime < 500) return;
   handleGroupTap();
@@ -860,11 +988,24 @@ watch(
 
 /* --- Group volume popout styles are in the unscoped style block below --- */
 
+/* Absolute mode on touch devices: the container owns the gesture, so the
+   slider itself must not swallow pointer events. Mouse input still reaches
+   the slider, which keeps click-to-position and keyboard control working. */
 @media (pointer: coarse) {
   .volume-slider,
   .volume-slider :deep(*) {
     pointer-events: none;
   }
+}
+
+/* Relative mode: the container owns pointer interaction on every device. */
+.player-volume-container.relative-mode {
+  cursor: ew-resize;
+}
+
+.player-volume-container.relative-mode .volume-slider,
+.player-volume-container.relative-mode .volume-slider :deep(*) {
+  pointer-events: none;
 }
 </style>
 

--- a/src/layouts/default/PlayerOSD/PlayerVolume.vue
+++ b/src/layouts/default/PlayerOSD/PlayerVolume.vue
@@ -549,6 +549,8 @@ let lastSentValue: number | null = null;
 // Relative mode: the drag *distance* is applied to the value the drag started
 // from, at reduced speed so small adjustments are easier to land.
 const RELATIVE_DRAG_SENSITIVITY = 0.5;
+// Below this a relative-mode mouse gesture counts as a click, not a drag
+const MOUSE_DRAG_THRESHOLD_PX = 5;
 
 onUnmounted(() => {
   if (dragEndTimeout) clearTimeout(dragEndTimeout);
@@ -1059,10 +1061,15 @@ const onTouchCancel = () => {
 // the slider has pointer-events disabled, which also makes the pointer
 // handlers inert (their targetsSlider check can never match).
 
-const MOUSE_DRAG_THRESHOLD_PX = 5;
-
 const onMouseMove = (event: MouseEvent) => {
-  if (!isMouseDragging.value || isSliderDisabled.value) return;
+  if (!isMouseDragging.value) return;
+  // A mouseup swallowed by a context menu or a window switch would otherwise
+  // leave the drag latched, and with it the block on server volume updates.
+  if (event.buttons === 0) {
+    onMouseUp(event);
+    return;
+  }
+  if (isSliderDisabled.value) return;
 
   const newValue = getValueFromDelta(
     mouseStartValue.value,
@@ -1084,11 +1091,17 @@ const onMouseUp = (event: MouseEvent) => {
 
   if (Math.abs(deltaX) < MOUSE_DRAG_THRESHOLD_PX) {
     // Too little travel to be a drag, so treat it as a click and run the group
-    // action instead of changing the volume.
-    if (handlesGroupTap.value) {
+    // action instead of changing the volume. Guarded like onSliderClick: a tap
+    // on a touchscreen also arrives here as a compatibility mouse event, after
+    // touchend has already run the action.
+    if (
+      handlesGroupTap.value &&
+      !isTouching.value &&
+      Date.now() - lastPopoutToggleTime >= 500
+    ) {
       handleGroupTap();
     }
-  } else {
+  } else if (!isSliderDisabled.value) {
     const finalValue = getValueFromDelta(mouseStartValue.value, deltaX);
     displayValue.value = finalValue;
     emit("update:local-value", finalValue);
@@ -1100,7 +1113,12 @@ const onMouseUp = (event: MouseEvent) => {
 
 const onMouseDown = (event: MouseEvent) => {
   if (!isRelativeMode.value) return;
-  if (isSliderDisabled.value) return;
+  // only the primary button drags: a right click has its own context menu, and
+  // latching on it would block server updates until the mouse moved again
+  if (event.button !== 0) return;
+  // a muted slider still answers a tap by opening the group's own controls,
+  // which is how you get to a child slider to unmute it
+  if (isSliderDisabled.value && !handlesGroupTap.value) return;
   // Leave the mute button and the volume readout to their own handlers
   if (
     (event.target as HTMLElement).closest(".volume-prepend, .volume-append")
@@ -1354,9 +1372,9 @@ watch(
 
 /* --- Group volume popout styles are in the unscoped style block below --- */
 
-/* Absolute mode on touch devices: the container owns the gesture, so the
-   slider itself must not swallow pointer events. Mouse input still reaches
-   the slider, which keeps click-to-position and keyboard control working. */
+/* On touch devices the container owns the gesture, so the slider itself must
+   not swallow pointer events. Mouse input still reaches the slider, which in
+   absolute mode keeps click-to-position and keyboard control working. */
 @media (pointer: coarse) {
   .volume-slider,
   .volume-slider :deep(*) {

--- a/src/layouts/default/PlayerOSD/PlayerVolume.vue
+++ b/src/layouts/default/PlayerOSD/PlayerVolume.vue
@@ -451,14 +451,27 @@ let pointerMoved = false;
 const isMouseDragging = ref(false);
 const mouseStartX = ref(0);
 const mouseStartValue = ref(0);
+// Latched once a mouse gesture has moved far enough to be a drag rather than a
+// click. Until then nothing is sent, so a click still reaches handleGroupTap().
+const mouseDragExceededThreshold = ref(false);
 
 let sliderUpdateDebounceTimeout: ReturnType<typeof setTimeout> | null = null;
 const SLIDER_UPDATE_DEBOUNCE_MS = 100;
 const POINTER_DRAG_THRESHOLD = 4;
 
+// Live drag updates: the volume follows the finger/mouse instead of waiting for
+// release. Throttled because every send is a separate websocket command.
+const LIVE_SEND_THROTTLE_MS = 100;
+let liveSendTimeout: ReturnType<typeof setTimeout> | null = null;
+let lastLiveSendTime = 0;
+// Scoped to one gesture (reset in startDragging) so an external volume change
+// between drags can never make a send look redundant.
+let lastSentValue: number | null = null;
+
 onUnmounted(() => {
   if (dragEndTimeout) clearTimeout(dragEndTimeout);
   if (sliderUpdateDebounceTimeout) clearTimeout(sliderUpdateDebounceTimeout);
+  if (liveSendTimeout) clearTimeout(liveSendTimeout);
   document.removeEventListener("mousemove", onMouseMove);
   document.removeEventListener("mouseup", onMouseUp);
 });
@@ -473,6 +486,7 @@ const roundToStep = (value: number) =>
 
 const startDragging = () => {
   isDragging.value = true;
+  lastSentValue = null;
   if (dragEndTimeout) {
     clearTimeout(dragEndTimeout);
     dragEndTimeout = null;
@@ -495,6 +509,47 @@ const setVolume = (value: number) => {
   } else {
     api.playerCommandVolumeSet(props.player.player_id, value);
   }
+};
+
+const cancelLiveSend = () => {
+  if (liveSendTimeout) {
+    clearTimeout(liveSendTimeout);
+    liveSendTimeout = null;
+  }
+};
+
+// Called while a drag is still in progress. Sends straight away when the last
+// send is old enough, otherwise schedules a trailing send that picks up
+// whatever the value has become by the time it fires.
+const sendVolumeLive = (value: number) => {
+  if (value === lastSentValue) return;
+
+  const elapsed = Date.now() - lastLiveSendTime;
+  if (elapsed >= LIVE_SEND_THROTTLE_MS) {
+    cancelLiveSend();
+    lastLiveSendTime = Date.now();
+    lastSentValue = value;
+    setVolume(value);
+    return;
+  }
+
+  cancelLiveSend();
+  liveSendTimeout = setTimeout(() => {
+    liveSendTimeout = null;
+    lastLiveSendTime = Date.now();
+    lastSentValue = displayValue.value;
+    setVolume(displayValue.value);
+  }, LIVE_SEND_THROTTLE_MS - elapsed);
+};
+
+// Called on release. This value is authoritative, so it cancels any pending
+// throttled send rather than racing it.
+const sendVolumeFinal = (value: number) => {
+  cancelLiveSend();
+  if (value === lastSentValue) return;
+  lastLiveSendTime = Date.now();
+  lastSentValue = value;
+  setVolume(value);
 };
 
 const volumeUp = () => {
@@ -631,6 +686,7 @@ const onTouchMove = (event: TouchEvent) => {
 
     if (valueChanged) {
       vibrate(5);
+      sendVolumeLive(newValue);
     }
   }
 };
@@ -652,6 +708,7 @@ const onTouchEnd = (event: TouchEvent) => {
         clearTimeout(sliderUpdateDebounceTimeout);
         sliderUpdateDebounceTimeout = null;
       }
+      cancelLiveSend();
       displayValue.value = touchStartValue.value;
       emit("update:local-value", touchStartValue.value);
       handleGroupTap();
@@ -670,12 +727,13 @@ const onTouchEnd = (event: TouchEvent) => {
       }
     }
   } else if (!isSliderDisabled.value) {
-    // Drag end: send the final value to the server
+    // Drag end: settle on the exact final value. The drag itself has already
+    // been sending, so this is usually a no-op.
     const touch = event.changedTouches[0];
     const finalValue = getDragValue(touch.clientX);
     displayValue.value = finalValue;
     emit("update:local-value", finalValue);
-    setVolume(finalValue);
+    sendVolumeFinal(finalValue);
     stopDragging();
   }
 
@@ -763,17 +821,28 @@ const resetPointerInteraction = () => {
 };
 
 const onTouchCancel = () => {
+  const wasDragging = isDrag.value;
   isDrag.value = false;
   isScrolling.value = false;
   touchMoveCount.value = 0;
   maxMovement.value = 0;
+  isTouching.value = false;
+
+  if (wasDragging) {
+    // The drag already changed the volume audibly, so an interruption settles
+    // where it left off rather than snapping back to the start.
+    sendVolumeFinal(displayValue.value);
+    stopDragging();
+    return;
+  }
+
+  cancelLiveSend();
   displayValue.value = touchStartValue.value;
   isDragging.value = false;
   if (dragEndTimeout) {
     clearTimeout(dragEndTimeout);
     dragEndTimeout = null;
   }
-  isTouching.value = false;
 };
 
 // --- Mouse drag handlers (relative mode only) ---
@@ -788,12 +857,25 @@ const MOUSE_DRAG_THRESHOLD_PX = 5;
 const onMouseMove = (event: MouseEvent) => {
   if (!isMouseDragging.value || isSliderDisabled.value) return;
 
-  const newValue = getValueFromDelta(
-    mouseStartValue.value,
-    event.clientX - mouseStartX.value,
-  );
+  const deltaX = event.clientX - mouseStartX.value;
+
+  // Hold off until the pointer has travelled far enough to be a drag. Without
+  // this, a click carrying a few pixels of hand jitter would change the volume
+  // before onMouseUp gets to classify it as a click and open the group popout.
+  if (!mouseDragExceededThreshold.value) {
+    if (Math.abs(deltaX) < MOUSE_DRAG_THRESHOLD_PX) return;
+    mouseDragExceededThreshold.value = true;
+  }
+
+  const newValue = getValueFromDelta(mouseStartValue.value, deltaX);
+  const valueChanged = newValue !== displayValue.value;
+
   displayValue.value = newValue;
   emit("update:local-value", newValue);
+
+  if (valueChanged) {
+    sendVolumeLive(newValue);
+  }
 };
 
 const onMouseUp = (event: MouseEvent) => {
@@ -802,6 +884,7 @@ const onMouseUp = (event: MouseEvent) => {
 
   if (!isMouseDragging.value) return;
   isMouseDragging.value = false;
+  mouseDragExceededThreshold.value = false;
 
   const deltaX = event.clientX - mouseStartX.value;
 
@@ -809,6 +892,7 @@ const onMouseUp = (event: MouseEvent) => {
     // Treated as a click rather than a drag: run the group action. This also
     // stamps lastPopoutToggleTime, so the click event that follows this
     // mouseup is a no-op in onSliderClick.
+    cancelLiveSend();
     if (handlesGroupTap.value) {
       handleGroupTap();
     }
@@ -816,7 +900,7 @@ const onMouseUp = (event: MouseEvent) => {
     const finalValue = getValueFromDelta(mouseStartValue.value, deltaX);
     displayValue.value = finalValue;
     emit("update:local-value", finalValue);
-    setVolume(finalValue);
+    sendVolumeFinal(finalValue);
   }
 
   stopDragging();
@@ -835,6 +919,7 @@ const onMouseDown = (event: MouseEvent) => {
   isMouseDragging.value = true;
   mouseStartX.value = event.clientX;
   mouseStartValue.value = displayValue.value;
+  mouseDragExceededThreshold.value = false;
   startDragging();
   // Suppress text selection while dragging
   event.preventDefault();

--- a/src/layouts/default/PlayerOSD/PlayerVolume.vue
+++ b/src/layouts/default/PlayerOSD/PlayerVolume.vue
@@ -82,9 +82,11 @@
         'not-powered': player.powered == false,
         expandable: expandOnTouch,
         expanded: showStepButtons,
+        'relative-mode': isRelativeMode,
       }"
       :style="{ width: width }"
       @click="onSliderClick"
+      @mousedown="onMouseDown"
       @pointerdown.capture="onPointerDown"
       @pointermove.capture="onPointerMove"
       @pointerup="onPointerUp"
@@ -174,6 +176,7 @@
 
 <script setup lang="ts">
 import { Slider } from "@/components/ui/slider";
+import { useUserPreferences } from "@/composables/userPreferences";
 import { deviceInset } from "@/helpers/device";
 import { getVolumeIconComponent, truncateString } from "@/helpers/utils";
 import { cn } from "@/lib/utils";
@@ -230,6 +233,20 @@ const emit = defineEmits<{
   (e: "update:local-value", value: number): void;
   (e: "toggle-group-expansion"): void;
 }>();
+
+// --- User preferences (Settings -> Frontend -> Volume control) ---
+
+const { getPreference } = useUserPreferences();
+
+// "absolute": the drag/tap position sets the volume. "relative": the drag
+// distance adjusts the volume from the value the drag started at.
+const volumeSliderMode = getPreference<string>(
+  "volume_slider_mode",
+  "absolute",
+);
+const isRelativeMode = computed(() => volumeSliderMode.value === "relative");
+
+const hapticsEnabled = getPreference<boolean>("volume_haptics", true);
 
 // --- Player-aware computed properties ---
 
@@ -479,6 +496,10 @@ const touchStartX = ref(0);
 const touchStartY = ref(0);
 const touchStartValue = ref(0);
 const touchStartThumbCenter = ref<number | null>(null);
+// The position at which the gesture crossed the 8px mark and became a drag.
+// Relative adjustments are measured from here, so the travel spent recognising
+// the drag is not itself a volume change.
+const touchDragAnchorX = ref(0);
 const isScrolling = ref(false);
 const isDrag = ref(false);
 const touchMoveCount = ref(0);
@@ -491,6 +512,11 @@ let dragEndTimeout: ReturnType<typeof setTimeout> | null = null;
 let pointerStartX: number | null = null;
 let pointerStartValue = 0;
 let pointerMoved = false;
+
+// Mouse drag tracking (relative mode only)
+const isMouseDragging = ref(false);
+const mouseStartX = ref(0);
+const mouseStartValue = ref(0);
 
 let sliderUpdateDebounceTimeout: ReturnType<typeof setTimeout> | null = null;
 const SLIDER_UPDATE_DEBOUNCE_MS = 100;
@@ -520,10 +546,16 @@ let liveSendTimeout: ReturnType<typeof setTimeout> | null = null;
 let lastLiveSendTime = 0;
 let lastSentValue: number | null = null;
 
+// Relative mode: the drag *distance* is applied to the value the drag started
+// from, at reduced speed so small adjustments are easier to land.
+const RELATIVE_DRAG_SENSITIVITY = 0.5;
+
 onUnmounted(() => {
   if (dragEndTimeout) clearTimeout(dragEndTimeout);
   if (sliderUpdateDebounceTimeout) clearTimeout(sliderUpdateDebounceTimeout);
   if (liveSendTimeout) clearTimeout(liveSendTimeout);
+  document.removeEventListener("mousemove", onMouseMove);
+  document.removeEventListener("mouseup", onMouseUp);
   stopTrackingBubble();
   cancelCollapse();
 });
@@ -731,6 +763,7 @@ const stopTrackingBubble = () => {
 // --- Helpers ---
 
 const vibrate = (duration: number = 10) => {
+  if (!hapticsEnabled.value) return;
   if (store.isTouchscreen && "vibrate" in navigator && navigator.vibrate) {
     navigator.vibrate(duration);
   }
@@ -743,6 +776,7 @@ const getThumbCenter = (): number | null => {
   return rect.left + rect.width / 2;
 };
 
+// Absolute mode: the pointer position maps directly onto the 0-100 range.
 const getPercentageFromX = (clientX: number): number => {
   if (!sliderContainerRef.value) return displayValue.value;
 
@@ -753,6 +787,23 @@ const getPercentageFromX = (clientX: number): number => {
   return clamp(roundToStep(percentage), 0, 100);
 };
 
+// Relative mode: deltaX is the travel since the gesture was recognised as a
+// drag, applied to the value it started from at reduced sensitivity.
+const getValueFromDelta = (startValue: number, deltaX: number): number => {
+  if (!sliderContainerRef.value) return displayValue.value;
+
+  const rect = sliderContainerRef.value.getBoundingClientRect();
+  const deltaPercent = (deltaX / rect.width) * 100 * RELATIVE_DRAG_SENSITIVITY;
+
+  return clamp(roundToStep(startValue + deltaPercent), 0, 100);
+};
+
+// Resolves a touch drag position through whichever mode is active.
+const getDragValue = (clientX: number): number =>
+  isRelativeMode.value
+    ? getValueFromDelta(touchStartValue.value, clientX - touchDragAnchorX.value)
+    : getPercentageFromX(clientX);
+
 // --- Touch handlers ---
 
 const onTouchStart = (event: TouchEvent) => {
@@ -762,6 +813,7 @@ const onTouchStart = (event: TouchEvent) => {
   const touch = event.touches[0];
   touchStartX.value = touch.clientX;
   touchStartY.value = touch.clientY;
+  touchDragAnchorX.value = touch.clientX;
   touchStartValue.value = displayValue.value;
   isScrolling.value = false;
   isDrag.value = false;
@@ -815,6 +867,7 @@ const onTouchMove = (event: TouchEvent) => {
 
     if (absDeltaX > 8) {
       isDrag.value = true;
+      touchDragAnchorX.value = touch.clientX;
       expandControls();
       startDragging();
       event.preventDefault();
@@ -824,7 +877,7 @@ const onTouchMove = (event: TouchEvent) => {
   if (isDrag.value) {
     event.preventDefault();
 
-    const newValue = getPercentageFromX(touch.clientX);
+    const newValue = getDragValue(touch.clientX);
     const valueChanged = newValue !== displayValue.value;
 
     displayValue.value = newValue;
@@ -877,13 +930,9 @@ const onTouchEnd = (event: TouchEvent) => {
       }
     }
   } else if (!isSliderDisabled.value) {
-    // Drag end: settle on the exact value the finger lifted at
+    // Drag end: settle on the exact value the gesture ended at
     const touch = event.changedTouches[0];
-    const finalValue = clamp(
-      roundToStep(getPercentageFromX(touch.clientX)),
-      0,
-      100,
-    );
+    const finalValue = getDragValue(touch.clientX);
     displayValue.value = finalValue;
     emit("update:local-value", finalValue);
     sendVolumeFinal(finalValue);
@@ -1003,6 +1052,73 @@ const onTouchCancel = () => {
   }
 };
 
+// --- Mouse drag handlers (relative mode only) ---
+//
+// In absolute mode the Slider owns mouse input and onPointerDown/onSliderClick
+// own the group tap, so every handler here bails out early. In relative mode
+// the slider has pointer-events disabled, which also makes the pointer
+// handlers inert (their targetsSlider check can never match).
+
+const MOUSE_DRAG_THRESHOLD_PX = 5;
+
+const onMouseMove = (event: MouseEvent) => {
+  if (!isMouseDragging.value || isSliderDisabled.value) return;
+
+  const newValue = getValueFromDelta(
+    mouseStartValue.value,
+    event.clientX - mouseStartX.value,
+  );
+
+  displayValue.value = newValue;
+  emit("update:local-value", newValue);
+};
+
+const onMouseUp = (event: MouseEvent) => {
+  document.removeEventListener("mousemove", onMouseMove);
+  document.removeEventListener("mouseup", onMouseUp);
+
+  if (!isMouseDragging.value) return;
+  isMouseDragging.value = false;
+
+  const deltaX = event.clientX - mouseStartX.value;
+
+  if (Math.abs(deltaX) < MOUSE_DRAG_THRESHOLD_PX) {
+    // Too little travel to be a drag, so treat it as a click and run the group
+    // action instead of changing the volume.
+    if (handlesGroupTap.value) {
+      handleGroupTap();
+    }
+  } else {
+    const finalValue = getValueFromDelta(mouseStartValue.value, deltaX);
+    displayValue.value = finalValue;
+    emit("update:local-value", finalValue);
+    setVolume(finalValue);
+  }
+
+  stopDragging();
+};
+
+const onMouseDown = (event: MouseEvent) => {
+  if (!isRelativeMode.value) return;
+  if (isSliderDisabled.value) return;
+  // Leave the mute button and the volume readout to their own handlers
+  if (
+    (event.target as HTMLElement).closest(".volume-prepend, .volume-append")
+  ) {
+    return;
+  }
+
+  isMouseDragging.value = true;
+  mouseStartX.value = event.clientX;
+  mouseStartValue.value = displayValue.value;
+  startDragging();
+  // Suppress text selection while dragging
+  event.preventDefault();
+
+  document.addEventListener("mousemove", onMouseMove);
+  document.addEventListener("mouseup", onMouseUp);
+};
+
 const onWheel = (event: WheelEvent) => {
   // Only claim the wheel when it changes volume, so sliders inside a scrollable
   // container (the group popout) still scroll it
@@ -1046,6 +1162,8 @@ const onSliderUpdate = (values: number[] | undefined) => {
 
 // Desktop clicks use the same group action as touch taps.
 const onSliderClick = () => {
+  // In relative mode the mouseup handler owns this, so don't run it twice
+  if (isRelativeMode.value) return;
   if (!handlesGroupTap.value || isTouching.value || isDragging.value) return;
   if (Date.now() - lastPopoutToggleTime < 500) return;
   handleGroupTap();
@@ -1236,11 +1354,24 @@ watch(
 
 /* --- Group volume popout styles are in the unscoped style block below --- */
 
+/* Absolute mode on touch devices: the container owns the gesture, so the
+   slider itself must not swallow pointer events. Mouse input still reaches
+   the slider, which keeps click-to-position and keyboard control working. */
 @media (pointer: coarse) {
   .volume-slider,
   .volume-slider :deep(*) {
     pointer-events: none;
   }
+}
+
+/* Relative mode: the container owns pointer interaction on every device. */
+.player-volume-container.relative-mode {
+  cursor: ew-resize;
+}
+
+.player-volume-container.relative-mode .volume-slider,
+.player-volume-container.relative-mode .volume-slider :deep(*) {
+  pointer-events: none;
 }
 </style>
 

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -565,6 +565,7 @@
         "provider_credits": "Made possible by",
         "category": {
             "web_player": "Web Player",
+            "volume_control": "Volume control",
             "protocol_settings": "Output Protocol(s)",
             "options": "Player options",
             "preferences": "Preferences",
@@ -615,6 +616,18 @@
         "ha_kiosk_mode": {
             "label": "Use the full screen in Home Assistant",
             "description": "Hide the Home Assistant header and sidebar so Music Assistant gets the whole screen. The Home Assistant button in the menu brings them back."
+        },
+        "volume_slider_mode": {
+            "label": "Volume slider behaviour",
+            "description": "Absolute: tapping or dragging the bar sets the volume to that position. Relative: dragging adjusts up or down from the current volume at half speed, which makes small changes easier to land.",
+            "options": {
+                "absolute": "Absolute (jump to position)",
+                "relative": "Relative (drag to adjust)"
+            }
+        },
+        "volume_haptics": {
+            "label": "Volume haptic feedback",
+            "description": "Vibrate while adjusting the volume slider. Touch devices with a vibration motor only."
         },
         "add_group_player_desc": "Create a permanent player group with {0} players. When you play to this Player Group, the member players will be automatically synchronized.",
         "add_group_player_desc_sync": "Create a permanent SyncGroup with players that are sync-compatible. When you play to this Player Group, the member players will be automatically synchronized.",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -479,6 +479,7 @@
         "provider_credits": "Made possible by",
         "category": {
             "web_player": "Web Player",
+            "volume_control": "Volume control",
             "protocol_settings": "Output Protocol(s)",
             "options": "Player options",
             "preferences": "Preferences",
@@ -528,6 +529,22 @@
             }
         },
         "add_group_player_desc": "Create a permanent player group with {0} players. When you play to this Player Group, the member players will be automatically synchronized.",
+        "volume_slider_mode": {
+            "label": "Volume slider behaviour",
+            "description": "Absolute: tapping or dragging the bar sets the volume to that position. Relative: dragging adjusts up or down from the current volume at half speed, which makes small changes easier to land.",
+            "options": {
+                "absolute": "Absolute (jump to position)",
+                "relative": "Relative (drag to adjust)"
+            }
+        },
+        "volume_step": {
+            "label": "Volume step size",
+            "description": "How many percent each volume increment changes. Applies to the volume slider, the scroll wheel and tap-to-adjust."
+        },
+        "volume_haptics": {
+            "label": "Volume haptic feedback",
+            "description": "Vibrate while adjusting the volume slider. Touch devices with a vibration motor only."
+        },
         "add_group_player_desc_sync": "Create a permanent SyncGroup with players that are sync-compatible. When you play to this Player Group, the member players will be automatically synchronized.",
         "genre_management": "Genre Management",
         "genre_management_description": "Manage default genres and restore genre defaults",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -618,7 +618,7 @@
             "description": "Hide the Home Assistant header and sidebar so Music Assistant gets the whole screen. The Home Assistant button in the menu brings them back."
         },
         "volume_slider_mode": {
-            "label": "Volume slider behaviour",
+            "label": "Volume slider behavior",
             "description": "Absolute: tapping or dragging the bar sets the volume to that position. Relative: dragging adjusts up or down from the current volume at half speed, which makes small changes easier to land.",
             "options": {
                 "absolute": "Absolute (jump to position)",

--- a/src/views/settings/FrontendConfig.vue
+++ b/src/views/settings/FrontendConfig.vue
@@ -82,8 +82,8 @@ const serializeValue = (value: ConfigValueType | undefined): string =>
 const valueChanged = (key: string, value: ConfigValueType): boolean =>
   serializeValue(value) !== initialValues[key];
 
-// Per-user preferences their consumers read as computed refs, so saving one
-// takes effect immediately and the reload below would achieve nothing.
+// The volume slider reads these as computed refs, so saving one takes effect
+// immediately and the reload below would achieve nothing.
 const RELOAD_EXEMPT_PREFERENCE_KEYS = new Set([
   "volume_slider_mode",
   "volume_haptics",

--- a/src/views/settings/FrontendConfig.vue
+++ b/src/views/settings/FrontendConfig.vue
@@ -172,6 +172,44 @@ onMounted(() => {
       value:
         localStorage.getItem("frontend.settings.mobile_sidebar_side") || "left",
     },
+    {
+      key: "volume_slider_mode",
+      type: ConfigEntryType.STRING,
+      label: "volume_slider_mode",
+      default_value: "absolute",
+      required: false,
+      options: [
+        { title: "absolute", value: "absolute" },
+        { title: "relative", value: "relative" },
+      ],
+      multi_value: false,
+      category: "volume_control",
+      value:
+        (store.currentUser?.preferences?.volume_slider_mode as string) ||
+        "absolute",
+    },
+    {
+      key: "volume_step",
+      type: ConfigEntryType.INTEGER,
+      label: "volume_step",
+      default_value: 2,
+      required: false,
+      range: [1, 10],
+      multi_value: false,
+      category: "volume_control",
+      value: (store.currentUser?.preferences?.volume_step as number) ?? 2,
+    },
+    {
+      key: "volume_haptics",
+      type: ConfigEntryType.BOOLEAN,
+      label: "volume_haptics",
+      default_value: true,
+      required: false,
+      multi_value: false,
+      category: "volume_control",
+      value:
+        (store.currentUser?.preferences?.volume_haptics as boolean) ?? true,
+    },
   ];
 
   // Add web player settings (if not running in companion mode)

--- a/src/views/settings/FrontendConfig.vue
+++ b/src/views/settings/FrontendConfig.vue
@@ -82,6 +82,13 @@ const serializeValue = (value: ConfigValueType | undefined): string =>
 const valueChanged = (key: string, value: ConfigValueType): boolean =>
   serializeValue(value) !== initialValues[key];
 
+// Per-user preferences their consumers read as computed refs, so saving one
+// takes effect immediately and the reload below would achieve nothing.
+const RELOAD_EXEMPT_PREFERENCE_KEYS = new Set([
+  "volume_slider_mode",
+  "volume_haptics",
+]);
+
 onMounted(() => {
   // TODO: Remove localStorage fallbacks below once migration period is over
   // (theme and language moved from localStorage to user preferences)
@@ -204,6 +211,34 @@ onMounted(() => {
       hidden: !store.isIngressSession,
       value: getKioskModePreference(),
     },
+    {
+      key: "volume_slider_mode",
+      type: ConfigEntryType.STRING,
+      label: "volume_slider_mode",
+      default_value: "absolute",
+      required: false,
+      options: [
+        { title: "absolute", value: "absolute" },
+        { title: "relative", value: "relative" },
+      ],
+      multi_value: false,
+      category: "volume_control",
+      value:
+        (store.currentUser?.preferences?.volume_slider_mode as string) ||
+        "absolute",
+    },
+    {
+      key: "volume_haptics",
+      type: ConfigEntryType.BOOLEAN,
+      label: "volume_haptics",
+      default_value: true,
+      required: false,
+      options: [],
+      multi_value: false,
+      category: "volume_control",
+      value:
+        (store.currentUser?.preferences?.volume_haptics as boolean) ?? true,
+    },
   ];
 
   // Add web player settings (if not running in companion mode)
@@ -278,7 +313,12 @@ const saveValues = async function (values: Record<string, ConfigValueType>) {
       } else {
         // Save to backend via user preferences
         await setPreference(key, values[key]);
-        if (valueChanged(key, values[key])) hasPerUserChanges = true;
+        if (
+          !RELOAD_EXEMPT_PREFERENCE_KEYS.has(key) &&
+          valueChanged(key, values[key])
+        ) {
+          hasPerUserChanges = true;
+        }
       }
     }
 

--- a/tests/layouts/PlayerVolumeRelative.test.ts
+++ b/tests/layouts/PlayerVolumeRelative.test.ts
@@ -1,0 +1,332 @@
+import PlayerVolume from "@/layouts/default/PlayerOSD/PlayerVolume.vue";
+import { api } from "@/plugins/api";
+import {
+  IdentifierType,
+  PlaybackState,
+  type Player,
+  PlayerFeature,
+  PlayerType,
+} from "@/plugins/api/interfaces";
+import { store } from "@/plugins/store";
+import { enableAutoUnmount, mount } from "@vue/test-utils";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/plugins/api", async () => {
+  const { reactive } = await vi.importActual<typeof import("vue")>("vue");
+  const api = reactive({
+    players: {} as Record<string, Player>,
+    playerCommandGroupVolume: vi.fn(),
+    playerCommandVolumeSet: vi.fn(),
+    playerCommandVolumeUp: vi.fn(),
+    playerCommandVolumeDown: vi.fn(),
+    playerCommandMuteToggle: vi.fn(),
+  });
+  return { api, default: api };
+});
+
+// Reactive so that flipping volume_slider_mode between tests invalidates the
+// isRelativeMode computed rather than serving a cached value.
+vi.mock("@/plugins/store", async () => {
+  const { reactive } = await vi.importActual<typeof import("vue")>("vue");
+  return {
+    store: reactive({
+      isTouchscreen: false,
+      mobileLayout: false,
+      currentUser: {
+        user_id: "user",
+        preferences: {} as Record<string, unknown>,
+      },
+    }),
+  };
+});
+
+vi.mock("@/helpers/utils", () => ({
+  getVolumeIconComponent: vi.fn(() => "span"),
+  truncateString: (value: string) => value,
+}));
+
+// The mouse tests attach document-level listeners, so a leaked instance would
+// keep reacting to later tests' events.
+enableAutoUnmount(afterEach);
+
+const prefs = () =>
+  (
+    store as unknown as {
+      currentUser: { preferences: Record<string, unknown> };
+    }
+  ).currentUser.preferences;
+
+const START_VOLUME = 30;
+// Chosen so the relative arithmetic lands exactly on the 2% step grid:
+// a 40px drag is 40/200 * 100 * 0.5 = 10 volume points.
+const SLIDER_WIDTH = 200;
+const DRAG_PX = 40;
+const DRAG_POINTS = 10;
+
+function createPlayer(overrides: Partial<Player> = {}): Player {
+  return {
+    player_id: "parent",
+    provider: "test",
+    type: PlayerType.PLAYER,
+    name: "Kitchen",
+    available: true,
+    device_info: {
+      model: "Test",
+      manufacturer: "Test",
+      software_version: null,
+      model_id: null,
+      manufacturer_id: null,
+      identifiers: {
+        [IdentifierType.MAC_ADDRESS]: "",
+        [IdentifierType.SERIAL_NUMBER]: "",
+        [IdentifierType.UUID]: "",
+        [IdentifierType.IP_ADDRESS]: "",
+        [IdentifierType.UNKNOWN]: "",
+      },
+    },
+    supported_features: [PlayerFeature.VOLUME_SET],
+    can_group_with: [],
+    enabled: true,
+    playback_state: PlaybackState.PLAYING,
+    powered: true,
+    volume_level: START_VOLUME,
+    volume_muted: false,
+    group_members: [],
+    static_group_members: [],
+    source_list: [],
+    sound_mode_list: [],
+    options: [],
+    group_volume: START_VOLUME,
+    group_volume_muted: false,
+    hide_in_ui: false,
+    icon: "speaker",
+    power_control: "power",
+    volume_control: "volume",
+    mute_control: "mute",
+    needs_setup: false,
+    has_setup_flow: false,
+    output_protocols: [],
+    active_output_protocol: null,
+    elapsed_time: null,
+    elapsed_time_last_updated: null,
+    current_media: null,
+    active_source: null,
+    active_sound_mode: null,
+    active_group: null,
+    synced_to: null,
+    sleep_timer_expires_at: null,
+    ...overrides,
+  };
+}
+
+function mountVolume(
+  mode: "relative" | "absolute",
+  props: Record<string, unknown> = {},
+  player: Player = createPlayer(),
+) {
+  prefs().volume_slider_mode = mode;
+  if (!api.players[player.player_id]) {
+    api.players = { [player.player_id]: player };
+  }
+
+  const wrapper = mount(PlayerVolume, {
+    props: { player, ...props },
+    global: {
+      stubs: {
+        Slider: {
+          emits: ["update:modelValue"],
+          template: `<div data-slot="slider" role="slider" />`,
+        },
+      },
+    },
+  });
+
+  // happy-dom reports a zero-width rect, which would make every relative delta
+  // divide by zero. Give the container a real width instead.
+  const container = wrapper.find(".player-volume-container");
+  (container.element as HTMLElement).getBoundingClientRect = () =>
+    ({
+      left: 0,
+      top: 0,
+      right: SLIDER_WIDTH,
+      bottom: 40,
+      width: SLIDER_WIDTH,
+      height: 40,
+      x: 0,
+      y: 0,
+      toJSON: () => ({}),
+    }) as DOMRect;
+
+  return { wrapper, container, player };
+}
+
+const mouseMove = (clientX: number) =>
+  document.dispatchEvent(new MouseEvent("mousemove", { clientX }));
+const mouseUp = (clientX: number) =>
+  document.dispatchEvent(new MouseEvent("mouseup", { clientX }));
+
+const touchAt = (container: ReturnType<typeof mountVolume>["container"]) => ({
+  start: (clientX: number) =>
+    container.trigger("touchstart", { touches: [{ clientX, clientY: 10 }] }),
+  move: (clientX: number) =>
+    container.trigger("touchmove", { touches: [{ clientX, clientY: 10 }] }),
+  end: (clientX: number) =>
+    container.trigger("touchend", {
+      changedTouches: [{ clientX, clientY: 10 }],
+    }),
+});
+
+const shownVolume = (wrapper: ReturnType<typeof mountVolume>["wrapper"]) =>
+  Number(wrapper.find(".volume-level-text").text());
+
+describe("PlayerVolume relative mode", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    api.players = {};
+    prefs().volume_slider_mode = "relative";
+  });
+
+  it("adjusts by the distance dragged, from the value the drag started at", async () => {
+    const { container, player } = mountVolume("relative");
+
+    await container.trigger("mousedown", { clientX: 100 });
+    mouseMove(100 + DRAG_PX);
+    mouseUp(100 + DRAG_PX);
+
+    expect(api.playerCommandVolumeSet).toHaveBeenCalledWith(
+      player.player_id,
+      START_VOLUME + DRAG_POINTS,
+    );
+  });
+
+  it("reaches the same value regardless of where the drag began", async () => {
+    const near = mountVolume("relative");
+    await near.container.trigger("mousedown", { clientX: 20 });
+    mouseMove(20 + DRAG_PX);
+    mouseUp(20 + DRAG_PX);
+
+    api.players = {};
+    const far = mountVolume("relative");
+    await far.container.trigger("mousedown", { clientX: 150 });
+    mouseMove(150 + DRAG_PX);
+    mouseUp(150 + DRAG_PX);
+
+    expect(api.playerCommandVolumeSet).toHaveBeenCalledTimes(2);
+    expect(api.playerCommandVolumeSet).toHaveBeenNthCalledWith(
+      1,
+      "parent",
+      START_VOLUME + DRAG_POINTS,
+    );
+    expect(api.playerCommandVolumeSet).toHaveBeenNthCalledWith(
+      2,
+      "parent",
+      START_VOLUME + DRAG_POINTS,
+    );
+  });
+
+  it("sends the volume once, on release", async () => {
+    const { container, wrapper, player } = mountVolume("relative");
+
+    await container.trigger("mousedown", { clientX: 100 });
+    mouseMove(110);
+    mouseMove(120);
+    mouseMove(130);
+    mouseMove(140);
+    await wrapper.vm.$nextTick();
+
+    // The readout follows the pointer, but nothing has been sent yet.
+    expect(shownVolume(wrapper)).toBe(START_VOLUME + DRAG_POINTS);
+    expect(api.playerCommandVolumeSet).not.toHaveBeenCalled();
+
+    mouseUp(140);
+
+    expect(api.playerCommandVolumeSet).toHaveBeenCalledTimes(1);
+    expect(api.playerCommandVolumeSet).toHaveBeenCalledWith(
+      player.player_id,
+      START_VOLUME + DRAG_POINTS,
+    );
+  });
+
+  it("measures a touch drag from the point it was recognised", async () => {
+    const { container, player } = mountVolume("relative");
+    const touch = touchAt(container);
+
+    await touch.start(100);
+    // 9px crosses the 8px mark and latches the drag; the anchor moves here, so
+    // this travel is not itself a volume change.
+    await touch.move(109);
+    await touch.move(109 + DRAG_PX);
+    await touch.end(109 + DRAG_PX);
+
+    expect(api.playerCommandVolumeSet).toHaveBeenCalledWith(
+      player.player_id,
+      START_VOLUME + DRAG_POINTS,
+    );
+  });
+
+  it("leaves the volume alone while a touch gesture is below the drag threshold", async () => {
+    const { container, wrapper } = mountVolume("relative");
+    const touch = touchAt(container);
+
+    await touch.start(100);
+    await touch.move(105);
+
+    expect(shownVolume(wrapper)).toBe(START_VOLUME);
+    expect(api.playerCommandVolumeSet).not.toHaveBeenCalled();
+  });
+
+  it("treats a short mouse gesture on a grouped player as a tap", async () => {
+    const child = createPlayer({ player_id: "child", name: "Office" });
+    const parent = createPlayer({ group_members: ["parent", "child"] });
+    api.players = { parent, child };
+
+    const { container, wrapper } = mountVolume(
+      "relative",
+      {
+        preferGroupVolume: true,
+        enablePopout: false,
+        requestExpandOnGroupTap: true,
+      },
+      parent,
+    );
+
+    await container.trigger("mousedown", { clientX: 100 });
+    mouseUp(102);
+
+    expect(wrapper.emitted("toggle-group-expansion")).toHaveLength(1);
+    expect(api.playerCommandGroupVolume).not.toHaveBeenCalled();
+  });
+});
+
+describe("PlayerVolume absolute mode", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    api.players = {};
+    prefs().volume_slider_mode = "absolute";
+  });
+
+  it("does not start a container drag on mousedown", async () => {
+    const { container } = mountVolume("absolute");
+
+    await container.trigger("mousedown", { clientX: 100 });
+    mouseMove(140);
+    mouseUp(140);
+
+    expect(api.playerCommandVolumeSet).not.toHaveBeenCalled();
+  });
+
+  it("maps a touch drag onto the pointer position", async () => {
+    const { container, player } = mountVolume("absolute");
+    const touch = touchAt(container);
+
+    await touch.start(100);
+    await touch.move(140);
+    await touch.end(140);
+
+    // 140/200 of the track, not a 40px delta applied to the start value.
+    expect(api.playerCommandVolumeSet).toHaveBeenCalledWith(
+      player.player_id,
+      70,
+    );
+  });
+});

--- a/tests/layouts/PlayerVolumeRelative.test.ts
+++ b/tests/layouts/PlayerVolumeRelative.test.ts
@@ -160,8 +160,10 @@ function mountVolume(
   return { wrapper, container, player };
 }
 
-const mouseMove = (clientX: number) =>
-  document.dispatchEvent(new MouseEvent("mousemove", { clientX }));
+// buttons: 1 is what a real browser reports while the left button is held; a
+// move without it means the release was missed.
+const mouseMove = (clientX: number, buttons = 1) =>
+  document.dispatchEvent(new MouseEvent("mousemove", { clientX, buttons }));
 const mouseUp = (clientX: number) =>
   document.dispatchEvent(new MouseEvent("mouseup", { clientX }));
 
@@ -295,6 +297,94 @@ describe("PlayerVolume relative mode", () => {
 
     expect(wrapper.emitted("toggle-group-expansion")).toHaveLength(1);
     expect(api.playerCommandGroupVolume).not.toHaveBeenCalled();
+  });
+
+  it("runs the group action once for a tap that also emits mouse events", async () => {
+    const child = createPlayer({ player_id: "child", name: "Office" });
+    const parent = createPlayer({ group_members: ["parent", "child"] });
+    api.players = { parent, child };
+
+    const { container, wrapper } = mountVolume(
+      "relative",
+      {
+        preferGroupVolume: true,
+        enablePopout: false,
+        requestExpandOnGroupTap: true,
+      },
+      parent,
+    );
+
+    // a touchscreen tap: touchend runs the action, then the browser replays the
+    // gesture as compatibility mouse events
+    await container.trigger("touchstart", {
+      touches: [{ clientX: 100, clientY: 10 }],
+    });
+    await container.trigger("touchend", {
+      changedTouches: [{ clientX: 100, clientY: 10 }],
+    });
+    await container.trigger("mousedown", { clientX: 100 });
+    mouseUp(100);
+
+    expect(wrapper.emitted("toggle-group-expansion")).toHaveLength(1);
+  });
+
+  it("still opens the group controls on a muted slider", async () => {
+    const child = createPlayer({ player_id: "child", name: "Office" });
+    const parent = createPlayer({
+      group_members: ["parent", "child"],
+      group_volume_muted: true,
+    });
+    api.players = { parent, child };
+
+    const { container, wrapper } = mountVolume(
+      "relative",
+      {
+        preferGroupVolume: true,
+        enablePopout: false,
+        requestExpandOnGroupTap: true,
+      },
+      parent,
+    );
+
+    await container.trigger("mousedown", { clientX: 100 });
+    mouseUp(102);
+
+    expect(wrapper.emitted("toggle-group-expansion")).toHaveLength(1);
+    expect(api.playerCommandGroupVolume).not.toHaveBeenCalled();
+  });
+
+  it("ignores a right click", async () => {
+    const { container, wrapper } = mountVolume("relative");
+
+    await container.trigger("mousedown", { clientX: 100, button: 2 });
+    mouseMove(140);
+    mouseUp(140);
+    await wrapper.vm.$nextTick();
+
+    expect(shownVolume(wrapper)).toBe(START_VOLUME);
+    expect(api.playerCommandVolumeSet).not.toHaveBeenCalled();
+  });
+
+  it("ends the drag when the release was missed", async () => {
+    const { container, wrapper, player } = mountVolume("relative");
+
+    await container.trigger("mousedown", { clientX: 100 });
+    mouseMove(140);
+    // no mouseup: a context menu or window switch swallowed it, so the next
+    // move arrives with no button held
+    mouseMove(150, 0);
+    await wrapper.vm.$nextTick();
+
+    const settled = shownVolume(wrapper);
+    expect(api.playerCommandVolumeSet).toHaveBeenCalledWith(
+      player.player_id,
+      settled,
+    );
+
+    // the drag is over, so a later hover must not keep moving the volume
+    mouseMove(200, 0);
+    await wrapper.vm.$nextTick();
+    expect(shownVolume(wrapper)).toBe(settled);
   });
 });
 


### PR DESCRIPTION
# What does this implement/fix?

The volume slider has one fixed behaviour: tap or drag anywhere on the bar and the
volume jumps to that position. That works well with a mouse on a wide slider. On a
phone, where the bar is a thin strip, landing on a specific level is hard and a
mistimed tap can move the volume a long way.

This adds an alternative alongside it, under **Settings → Frontend → Volume control**:

- **Absolute** (default, unchanged) — the tap or drag position sets the volume.
- **Relative** — the volume adjusts by the *distance* dragged, from where the drag
  started, at half pointer speed. Where you first touch does not matter, so a
  mistimed tap cannot jump the volume and small adjustments are practical. This also
  enables click-and-drag with a mouse.

A second setting turns the volume slider's haptic feedback off, for people who do not
want a pulse on every step.

Both defaults reproduce today's behaviour exactly, so nothing changes unless you go
looking for it.

Stacked on #2523, which this needs so that saving these two settings does not reload
the page for no reason.

**Related issue (if applicable):**

- n/a

**Related backend PR (if applicable):**

- n/a

## Changes

- Add a volume slider behaviour setting (absolute / relative) as a per-user
  preference, so it follows you across browsers and devices.
- Add a volume haptic feedback toggle, gating every vibration from the volume
  control in one place.
- In relative mode, measure a touch drag from the point it was recognised as a drag,
  so the travel spent recognising it is not itself a volume change.
- Keep a short gesture a tap in relative mode, so the group popout still opens.
- Skip the settings page reload for these two keys, since the slider reads them live.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm lint:check` passes.
- [x] `pnpm test:run` passes, and tests have been added/updated where applicable.
- [x] `pnpm build` passes.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
