### PR TITLE
Read config entry dependencies from one shared helper

### DIFF
--- a/src/components/SetupFlowDialog.vue
+++ b/src/components/SetupFlowDialog.vue
@@ -56,7 +56,7 @@
               <ConfigEntryRow
                 :conf-entry="entry"
                 :show-password-values="showPasswordValues"
-                :disabled="busy || isEntryDisabled(entry)"
+                :disabled="busy || isDisabled(entry)"
                 @update:value="onValueUpdate(entry, $event)"
                 @toggle-password="showPasswordValues = !showPasswordValues"
                 @help="onEntryHelp(entry)"
@@ -312,7 +312,11 @@ import {
 import { Progress } from "@/components/ui/progress";
 import { Spinner } from "@/components/ui/spinner";
 import { serverNow } from "@/composables/useServerTime";
-import { NON_INTERACTIVE_ENTRY_TYPES } from "@/helpers/config_entry_ui";
+import {
+  isEntryDisabled,
+  NON_INTERACTIVE_ENTRY_TYPES,
+  VALUELESS_ENTRY_TYPES,
+} from "@/helpers/config_entry_ui";
 import { api, ConnectionState } from "@/plugins/api";
 import {
   type ConfigEntry,
@@ -377,15 +381,6 @@ let expiryReconciledFor: string | null = null;
 // reconnect; the double underscores keep it out of reach of server-sent slugs
 const SESSION_ENDED_STEP_ID = "__session_ended__";
 
-// entry types that carry no value, so they take no part in validation or submission
-const PRESENTATIONAL_TYPES = [
-  ConfigEntryType.DIVIDER,
-  ConfigEntryType.LABEL,
-  ConfigEntryType.ALERT,
-  ConfigEntryType.IMAGE,
-  ConfigEntryType.ACTION,
-];
-
 // terminal steps: closing them must not abort (the flow already ended server-side)
 const isTerminal = computed(
   () =>
@@ -435,18 +430,15 @@ const visibleFormEntries = computed(() =>
     (entry) =>
       !entry.hidden &&
       // an unmet dependency can only be expressed by hiding these types
-      !(
-        NON_INTERACTIVE_ENTRY_TYPES.includes(entry.type) &&
-        isEntryDisabled(entry)
-      ),
+      !(NON_INTERACTIVE_ENTRY_TYPES.includes(entry.type) && isDisabled(entry)),
   ),
 );
 
 const canSubmit = computed(() => {
   if (busy.value) return false;
   for (const entry of formEntries.value) {
-    if (PRESENTATIONAL_TYPES.includes(entry.type)) continue;
-    if (isEntryDisabled(entry)) continue;
+    if (VALUELESS_ENTRY_TYPES.includes(entry.type)) continue;
+    if (isDisabled(entry)) continue;
     if (
       entry.required &&
       isNullOrUndefined(entry.value) &&
@@ -635,7 +627,7 @@ async function submit() {
   if (!step.value || !canSubmit.value) return;
   const values: Record<string, ConfigValueType> = {};
   for (const entry of formEntries.value) {
-    if (PRESENTATIONAL_TYPES.includes(entry.type)) continue;
+    if (VALUELESS_ENTRY_TYPES.includes(entry.type)) continue;
     let value = entry.value;
     if (value === undefined) value = null;
     // don't send back the obfuscated placeholder for unchanged secure strings
@@ -782,19 +774,8 @@ function onEntryHelp(entry: ConfigEntry) {
   else if (entry.help_link) openLink(entry.help_link);
 }
 
-function isEntryDisabled(entry: ConfigEntry): boolean {
-  if (isNullOrUndefined(entry.depends_on)) return false;
-  const dependency = formEntries.value.find((e) => e.key === entry.depends_on);
-  // a key that resolves to nothing stays gated, so a typo cannot silently open the gate
-  if (!dependency) return true;
-  const dependencyValue = dependency.value;
-  if (!isNullOrUndefined(entry.depends_on_value)) {
-    return dependencyValue != entry.depends_on_value;
-  }
-  if (!isNullOrUndefined(entry.depends_on_value_not)) {
-    return dependencyValue == entry.depends_on_value_not;
-  }
-  return !dependencyValue;
+function isDisabled(entry: ConfigEntry): boolean {
+  return isEntryDisabled(entry, formEntries.value);
 }
 
 function isNullOrUndefined(value: unknown): boolean {

--- a/src/helpers/config_entry_ui.ts
+++ b/src/helpers/config_entry_ui.ts
@@ -33,6 +33,9 @@ export type ConfigEntryUI = ServerConfigEntryUI | InjectedConfigEntry;
  * An unmet `depends_on` normally leaves an entry visible but disabled. These types
  * have nothing to disable, so a form must hide them instead or they read as if the
  * dependency were met.
+ *
+ * {@link VALUELESS_ENTRY_TYPES} derives from this list, so adding a type here also
+ * excludes it from validation and unsaved-change tracking.
  */
 export const NON_INTERACTIVE_ENTRY_TYPES: ConfigEntryUIType[] = [
   ConfigEntryType.DIVIDER,
@@ -42,10 +45,13 @@ export const NON_INTERACTIVE_ENTRY_TYPES: ConfigEntryUIType[] = [
 ];
 
 /**
- * Entry types that hold no value, so they take no part in validation or submission.
+ * Entry types that hold no user-supplied value, so they take no part in validation
+ * or unsaved-change tracking.
  *
- * Wider than {@link NON_INTERACTIVE_ENTRY_TYPES} by ACTION: an action button is
- * interactive (an unmet dependency disables it) but still stores nothing.
+ * A type here may still carry a value the server set — an IMAGE holds its data-URI —
+ * but nothing the form does can change it. Wider than
+ * {@link NON_INTERACTIVE_ENTRY_TYPES} by ACTION: an action button is interactive (an
+ * unmet dependency disables it) but stores nothing.
  */
 export const VALUELESS_ENTRY_TYPES: ConfigEntryUIType[] = [
   ...NON_INTERACTIVE_ENTRY_TYPES,

--- a/src/helpers/config_entry_ui.ts
+++ b/src/helpers/config_entry_ui.ts
@@ -41,6 +41,50 @@ export const NON_INTERACTIVE_ENTRY_TYPES: ConfigEntryUIType[] = [
   ConfigEntryType.IMAGE,
 ];
 
+/**
+ * Entry types that hold no value, so they take no part in validation or submission.
+ *
+ * Wider than {@link NON_INTERACTIVE_ENTRY_TYPES} by ACTION: an action button is
+ * interactive (an unmet dependency disables it) but still stores nothing.
+ */
+export const VALUELESS_ENTRY_TYPES: ConfigEntryUIType[] = [
+  ...NON_INTERACTIVE_ENTRY_TYPES,
+  ConfigEntryType.ACTION,
+];
+
+// the fields a dependency check reads, so both server and UI entry shapes fit
+type DependencyFields = Pick<
+  ConfigEntry,
+  "key" | "value" | "depends_on" | "depends_on_value" | "depends_on_value_not"
+>;
+
+/**
+ * Whether `entry` should be disabled because its `depends_on` dependency is unmet
+ * within `entries`.
+ *
+ * `depends_on_value` requires the dependency to hold that value and
+ * `depends_on_value_not` requires it not to; with neither, any truthy dependency
+ * value satisfies it. An entry without a dependency is never disabled, while one
+ * naming a key that is not on the form always is.
+ */
+export const isEntryDisabled = (
+  entry: DependencyFields,
+  entries: readonly DependencyFields[],
+): boolean => {
+  if (isNullOrUndefined(entry.depends_on)) return false;
+  const dependency = entries.find((e) => e.key === entry.depends_on);
+  // a key that resolves to nothing stays gated, so a typo cannot silently open the gate
+  if (!dependency) return true;
+  const dependencyValue = dependency.value;
+  if (!isNullOrUndefined(entry.depends_on_value)) {
+    return dependencyValue != entry.depends_on_value;
+  }
+  if (!isNullOrUndefined(entry.depends_on_value_not)) {
+    return dependencyValue == entry.depends_on_value_not;
+  }
+  return !dependencyValue;
+};
+
 export const isInjected = (e: ConfigEntryUI): e is InjectedConfigEntry =>
   (e as InjectedConfigEntry).injected === true;
 
@@ -96,3 +140,6 @@ export const mergeActionEntries = (
   }
   return merged;
 };
+
+const isNullOrUndefined = (value: unknown): boolean =>
+  value === null || value === undefined;

--- a/src/views/settings/ConfigEntryField.vue
+++ b/src/views/settings/ConfigEntryField.vue
@@ -73,7 +73,11 @@
       v-else-if="confEntry.type == ConfigEntryType.OPTIONS"
       class="dsp-config"
     >
-      <v-btn variant="outlined" @click="$emit('openOptions')">
+      <v-btn
+        variant="outlined"
+        :disabled="isFieldDisabled"
+        @click="$emit('openOptions')"
+      >
         {{ $t("player_options.open") }}
       </v-btn>
     </div>

--- a/src/views/settings/EditConfig.vue
+++ b/src/views/settings/EditConfig.vue
@@ -161,8 +161,10 @@
 <script setup lang="ts">
 import {
   ConfigEntryUI,
+  isEntryDisabled,
   isInjected,
   NON_INTERACTIVE_ENTRY_TYPES,
+  VALUELESS_ENTRY_TYPES,
 } from "@/helpers/config_entry_ui";
 import { markdownToHtml } from "@/helpers/utils";
 import {
@@ -267,10 +269,7 @@ const requiredValuesPresent = computed(() => {
         !(
           !isNullOrUndefined(entry.value) ||
           !isNullOrUndefined(entry.default_value) ||
-          entry.type == ConfigEntryType.DIVIDER ||
-          entry.type == ConfigEntryType.LABEL ||
-          entry.type == ConfigEntryType.ALERT ||
-          entry.type == ConfigEntryType.ACTION
+          VALUELESS_ENTRY_TYPES.includes(entry.type)
         )
       )
         return false;
@@ -284,13 +283,7 @@ const hasUnsavedChanges = computed(() => {
   if (!entries.value) return false;
   for (const entry of entries.value) {
     // Skip non-value entry types
-    if (
-      entry.type == ConfigEntryType.DIVIDER ||
-      entry.type == ConfigEntryType.LABEL ||
-      entry.type == ConfigEntryType.ALERT ||
-      entry.type == ConfigEntryType.ACTION ||
-      isInjected(entry)
-    ) {
+    if (VALUELESS_ENTRY_TYPES.includes(entry.type) || isInjected(entry)) {
       continue;
     }
     // Skip secure strings that haven't been modified (still showing substitute)
@@ -460,26 +453,7 @@ const isNullOrUndefined = function (value: unknown) {
 };
 
 const isDisabled = function (entry: ConfigEntryUI) {
-  if (!isNullOrUndefined(entry.depends_on)) {
-    const dependentEntry = entries.value?.find(
-      (x) => x.key == entry.depends_on,
-    );
-    // a key that resolves to nothing stays gated, so a typo cannot silently open the gate
-    if (!dependentEntry) return true;
-
-    const dependentValue = dependentEntry.value;
-
-    if (!isNullOrUndefined(entry.depends_on_value)) {
-      return dependentValue != entry.depends_on_value;
-    }
-
-    if (!isNullOrUndefined(entry.depends_on_value_not)) {
-      return dependentValue == entry.depends_on_value_not;
-    }
-
-    return !dependentValue;
-  }
-  return false;
+  return isEntryDisabled(entry, entries.value || []);
 };
 
 const isVisible = function (entry: ConfigEntryUI) {

--- a/tests/helpers/config_entry_ui.test.ts
+++ b/tests/helpers/config_entry_ui.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  isEntryDisabled,
   mergeActionEntries,
   mergeConfigEntries,
 } from "@/helpers/config_entry_ui";
@@ -16,6 +17,97 @@ function entry(overrides: Partial<ConfigEntry> = {}): ConfigEntry {
     ...overrides,
   };
 }
+
+describe("isEntryDisabled", () => {
+  const dependant = (overrides: Partial<ConfigEntry> = {}) =>
+    entry({ key: "engine_option", depends_on: "engine", ...overrides });
+
+  it("leaves an entry without a dependency enabled", () => {
+    expect(isEntryDisabled(entry(), [entry()])).toBe(false);
+  });
+
+  it("disables an entry whose dependency is not on the form", () => {
+    expect(isEntryDisabled(dependant(), [])).toBe(true);
+  });
+
+  it("disables on a falsy dependency value when no expected value is given", () => {
+    const dep = entry({ value: "" });
+
+    expect(isEntryDisabled(dependant(), [dep])).toBe(true);
+  });
+
+  it("enables on a truthy dependency value when no expected value is given", () => {
+    const dep = entry({ value: "ha" });
+
+    expect(isEntryDisabled(dependant(), [dep])).toBe(false);
+  });
+
+  it("enables only while the dependency holds depends_on_value", () => {
+    const target = dependant({ depends_on_value: "ha" });
+
+    expect(isEntryDisabled(target, [entry({ value: "ha" })])).toBe(false);
+    expect(isEntryDisabled(target, [entry({ value: "other" })])).toBe(true);
+  });
+
+  it("matches a falsy depends_on_value", () => {
+    const target = dependant({ depends_on_value: false });
+    const boolDep = (value: boolean) =>
+      entry({ type: ConfigEntryType.BOOLEAN, value });
+
+    expect(isEntryDisabled(target, [boolDep(false)])).toBe(false);
+    expect(isEntryDisabled(target, [boolDep(true)])).toBe(true);
+  });
+
+  it("disables while the dependency holds depends_on_value_not", () => {
+    const target = dependant({ depends_on_value_not: "off" });
+
+    expect(isEntryDisabled(target, [entry({ value: "off" })])).toBe(true);
+    expect(isEntryDisabled(target, [entry({ value: "ha" })])).toBe(false);
+  });
+
+  it("matches a falsy depends_on_value_not", () => {
+    const target = dependant({ depends_on_value_not: false });
+    const boolDep = (value: boolean) =>
+      entry({ type: ConfigEntryType.BOOLEAN, value });
+
+    expect(isEntryDisabled(target, [boolDep(false)])).toBe(true);
+    expect(isEntryDisabled(target, [boolDep(true)])).toBe(false);
+  });
+
+  it("gives depends_on_value precedence when both bounds are set", () => {
+    const target = dependant({
+      depends_on_value: "ha",
+      depends_on_value_not: "ha",
+    });
+
+    expect(isEntryDisabled(target, [entry({ value: "ha" })])).toBe(false);
+  });
+
+  // the server may type a value differently than the entry declares its bound,
+  // so both bounds compare loosely
+  it("compares the bounds loosely across types", () => {
+    expect(
+      isEntryDisabled(dependant({ depends_on_value: 1 }), [
+        entry({ value: "1" }),
+      ]),
+    ).toBe(false);
+    expect(
+      isEntryDisabled(dependant({ depends_on_value_not: 1 }), [
+        entry({ value: "1" }),
+      ]),
+    ).toBe(true);
+  });
+
+  it("resolves the dependency by key rather than by position", () => {
+    const target = dependant({ depends_on_value: "ha" });
+    const form = [
+      entry({ key: "decoy", value: "other" }),
+      entry({ value: "ha" }),
+    ];
+
+    expect(isEntryDisabled(target, form)).toBe(false);
+  });
+});
 
 describe("mergeConfigEntries", () => {
   it("adopts the fresh definition for an untouched key", () => {

--- a/tests/helpers/config_entry_ui.test.ts
+++ b/tests/helpers/config_entry_ui.test.ts
@@ -19,7 +19,7 @@ function entry(overrides: Partial<ConfigEntry> = {}): ConfigEntry {
 }
 
 describe("isEntryDisabled", () => {
-  const dependant = (overrides: Partial<ConfigEntry> = {}) =>
+  const dependentEntry = (overrides: Partial<ConfigEntry> = {}) =>
     entry({ key: "engine_option", depends_on: "engine", ...overrides });
 
   it("leaves an entry without a dependency enabled", () => {
@@ -27,30 +27,41 @@ describe("isEntryDisabled", () => {
   });
 
   it("disables an entry whose dependency is not on the form", () => {
-    expect(isEntryDisabled(dependant(), [])).toBe(true);
+    expect(isEntryDisabled(dependentEntry(), [])).toBe(true);
   });
 
   it("disables on a falsy dependency value when no expected value is given", () => {
     const dep = entry({ value: "" });
 
-    expect(isEntryDisabled(dependant(), [dep])).toBe(true);
+    expect(isEntryDisabled(dependentEntry(), [dep])).toBe(true);
   });
 
   it("enables on a truthy dependency value when no expected value is given", () => {
     const dep = entry({ value: "ha" });
 
-    expect(isEntryDisabled(dependant(), [dep])).toBe(false);
+    expect(isEntryDisabled(dependentEntry(), [dep])).toBe(false);
+  });
+
+  // the server serializes an unset bound as an explicit null rather than omitting it
+  it("treats a null bound as no bound at all", () => {
+    const target = dependentEntry({
+      depends_on_value: null,
+      depends_on_value_not: null,
+    });
+
+    expect(isEntryDisabled(target, [entry({ value: "ha" })])).toBe(false);
+    expect(isEntryDisabled(target, [entry({ value: "" })])).toBe(true);
   });
 
   it("enables only while the dependency holds depends_on_value", () => {
-    const target = dependant({ depends_on_value: "ha" });
+    const target = dependentEntry({ depends_on_value: "ha" });
 
     expect(isEntryDisabled(target, [entry({ value: "ha" })])).toBe(false);
     expect(isEntryDisabled(target, [entry({ value: "other" })])).toBe(true);
   });
 
   it("matches a falsy depends_on_value", () => {
-    const target = dependant({ depends_on_value: false });
+    const target = dependentEntry({ depends_on_value: false });
     const boolDep = (value: boolean) =>
       entry({ type: ConfigEntryType.BOOLEAN, value });
 
@@ -59,14 +70,14 @@ describe("isEntryDisabled", () => {
   });
 
   it("disables while the dependency holds depends_on_value_not", () => {
-    const target = dependant({ depends_on_value_not: "off" });
+    const target = dependentEntry({ depends_on_value_not: "off" });
 
     expect(isEntryDisabled(target, [entry({ value: "off" })])).toBe(true);
     expect(isEntryDisabled(target, [entry({ value: "ha" })])).toBe(false);
   });
 
   it("matches a falsy depends_on_value_not", () => {
-    const target = dependant({ depends_on_value_not: false });
+    const target = dependentEntry({ depends_on_value_not: false });
     const boolDep = (value: boolean) =>
       entry({ type: ConfigEntryType.BOOLEAN, value });
 
@@ -75,7 +86,7 @@ describe("isEntryDisabled", () => {
   });
 
   it("gives depends_on_value precedence when both bounds are set", () => {
-    const target = dependant({
+    const target = dependentEntry({
       depends_on_value: "ha",
       depends_on_value_not: "ha",
     });
@@ -87,19 +98,19 @@ describe("isEntryDisabled", () => {
   // so both bounds compare loosely
   it("compares the bounds loosely across types", () => {
     expect(
-      isEntryDisabled(dependant({ depends_on_value: 1 }), [
+      isEntryDisabled(dependentEntry({ depends_on_value: 1 }), [
         entry({ value: "1" }),
       ]),
     ).toBe(false);
     expect(
-      isEntryDisabled(dependant({ depends_on_value_not: 1 }), [
+      isEntryDisabled(dependentEntry({ depends_on_value_not: 1 }), [
         entry({ value: "1" }),
       ]),
     ).toBe(true);
   });
 
   it("resolves the dependency by key rather than by position", () => {
-    const target = dependant({ depends_on_value: "ha" });
+    const target = dependentEntry({ depends_on_value: "ha" });
     const form = [
       entry({ key: "decoy", value: "other" }),
       entry({ value: "ha" }),

--- a/tests/views/EditConfig.test.ts
+++ b/tests/views/EditConfig.test.ts
@@ -124,6 +124,29 @@ describe("EditConfig", () => {
 
     expect(renderedKeys(wrapper)).toEqual(["enable_feature", "feature_status"]);
   });
+
+  // a presentational entry holds no value, so a required one must never be able
+  // to block saving the entries that do
+  it("can still save alongside a required entry that holds no value", async () => {
+    const entries = [
+      entry({ key: "server", type: ConfigEntryType.STRING }),
+      entry({
+        key: "pairing_code",
+        type: ConfigEntryType.IMAGE,
+        required: true,
+      }),
+    ];
+    const wrapper = mountEntries(entries);
+    expect(saveDisabled(wrapper)).toBe(true);
+
+    const editable = wrapper
+      .findAllComponents({ name: "ConfigEntryRow" })[0]
+      .props("confEntry") as ConfigEntry;
+    editable.value = "localhost";
+    await nextTick();
+
+    expect(saveDisabled(wrapper)).toBe(false);
+  });
 });
 
 function entry(
@@ -160,4 +183,12 @@ function renderedKeys(wrapper: VueWrapper) {
   return wrapper
     .findAllComponents({ name: "ConfigEntryRow" })
     .map((row) => (row.props("confEntry") as ConfigEntry).key);
+}
+
+function saveDisabled(wrapper: VueWrapper) {
+  const button = wrapper
+    .findAll("v-btn-stub")
+    .find((btn) => btn.text() === "settings.save");
+  if (!button) throw new Error("save button not rendered");
+  return button.attributes("disabled") === "true";
 }

--- a/tests/views/EditConfig.test.ts
+++ b/tests/views/EditConfig.test.ts
@@ -125,27 +125,34 @@ describe("EditConfig", () => {
     expect(renderedKeys(wrapper)).toEqual(["enable_feature", "feature_status"]);
   });
 
-  // a presentational entry holds no value, so a required one must never be able
-  // to block saving the entries that do
-  it("can still save alongside a required entry that holds no value", async () => {
-    const entries = [
+  // a presentational entry carries nothing the user can fill in, so a required one
+  // must never be able to block saving the entries that do
+  it("saves a dirty form despite a required entry the user cannot fill in", async () => {
+    const wrapper = mountEntries([
       entry({ key: "server", type: ConfigEntryType.STRING }),
       entry({
         key: "pairing_code",
         type: ConfigEntryType.IMAGE,
         required: true,
       }),
-    ];
-    const wrapper = mountEntries(entries);
-    expect(saveDisabled(wrapper)).toBe(true);
+    ]);
 
-    const editable = wrapper
-      .findAllComponents({ name: "ConfigEntryRow" })[0]
-      .props("confEntry") as ConfigEntry;
-    editable.value = "localhost";
+    dirty(wrapper);
     await nextTick();
 
     expect(saveDisabled(wrapper)).toBe(false);
+  });
+
+  it("still blocks saving on a required input the user left empty", async () => {
+    const wrapper = mountEntries([
+      entry({ key: "server", type: ConfigEntryType.STRING }),
+      entry({ key: "token", type: ConfigEntryType.STRING, required: true }),
+    ]);
+
+    dirty(wrapper);
+    await nextTick();
+
+    expect(saveDisabled(wrapper)).toBe(true);
   });
 });
 
@@ -183,6 +190,14 @@ function renderedKeys(wrapper: VueWrapper) {
   return wrapper
     .findAllComponents({ name: "ConfigEntryRow" })
     .map((row) => (row.props("confEntry") as ConfigEntry).key);
+}
+
+// edits the first entry in place, which is what typing into its field does
+function dirty(wrapper: VueWrapper) {
+  const first = wrapper
+    .findAllComponents({ name: "ConfigEntryRow" })[0]
+    .props("confEntry") as ConfigEntry;
+  first.value = "localhost";
 }
 
 function saveDisabled(wrapper: VueWrapper) {


### PR DESCRIPTION
Follow-up to #2270. That bug existed in two places at once because the settings form and the setup flow dialog each carried their own hand-copied version of the same logic. #2273 then had to make the same one-line fix twice for the same reason. This removes the copies so the next fix only has to be made once.

- Moved the `depends_on` check into a single shared helper used by both the settings form and the setup flow dialog
- Moved the "entry types that hold no user-supplied value" list into one shared constant, replacing three separate copies
- The shared list also covers image entries, which the settings form's copies had missed. A required image can no longer block saving, and an image the server refreshes no longer counts as an unsaved change
- Added the missing disabled state to the player options button, matching the buttons next to it
- Added tests for the shared dependency helper
