### PR TITLE
Make the app startup tests fast and reliable

### DIFF
--- a/tests/App.test.ts
+++ b/tests/App.test.ts
@@ -1,5 +1,5 @@
 import { EventType, ProviderType } from "@/plugins/api/interfaces";
-import { shallowMount, type VueWrapper } from "@vue/test-utils";
+import { flushPromises, shallowMount, type VueWrapper } from "@vue/test-utils";
 import { nextTick } from "vue";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -499,9 +499,8 @@ describe("App initialization", () => {
       },
     });
 
-    await vi.waitFor(() => {
-      expect(mockRememberCurrentRemoteConnection).toHaveBeenCalledOnce();
-    });
+    await flushPromises();
+    expect(mockRememberCurrentRemoteConnection).toHaveBeenCalledOnce();
     expect(authManagerMock.setToken).toHaveBeenCalledWith(
       "regular-token",
       "local:http://music-assistant.test",
@@ -523,11 +522,10 @@ describe("App initialization", () => {
       .findComponent({ name: "Login" })
       .vm.$emit("local-connect", "http://music-assistant.local:8095");
 
-    await vi.waitFor(() => {
-      expect(apiMock.initialize).toHaveBeenCalledWith(
-        "http://music-assistant.local:8095",
-      );
-    });
+    await flushPromises();
+    expect(apiMock.initialize).toHaveBeenCalledWith(
+      "http://music-assistant.local:8095",
+    );
     expect(mockProxyEnsureReady).toHaveBeenCalledOnce();
     expect(mockProxySetTransport).toHaveBeenCalledWith(null);
     expect(mockProxySetTransport.mock.invocationCallOrder[0]).toBeLessThan(
@@ -628,9 +626,8 @@ describe("App initialization", () => {
 
     await startReconnect();
 
-    await vi.waitFor(() => {
-      expect(authManagerMock.setCurrentUser).toHaveBeenCalledWith(ingressUser);
-    });
+    await flushPromises();
+    expect(authManagerMock.setCurrentUser).toHaveBeenCalledWith(ingressUser);
     expect(apiMock.authenticateWithToken).not.toHaveBeenCalled();
     expect(apiMock.requireAuthentication).not.toHaveBeenCalled();
   });
@@ -643,9 +640,8 @@ describe("App initialization", () => {
 
     await startReconnect();
 
-    await vi.waitFor(() => {
-      expect(apiMock.requireAuthentication).toHaveBeenCalledOnce();
-    });
+    await flushPromises();
+    expect(apiMock.requireAuthentication).toHaveBeenCalledOnce();
     expect(apiMock.getCurrentUserInfo).toHaveBeenCalledOnce();
   });
 
@@ -658,9 +654,8 @@ describe("App initialization", () => {
 
     await startReconnect();
 
-    await vi.waitFor(() => {
-      expect(apiMock.requireAuthentication).toHaveBeenCalledOnce();
-    });
+    await flushPromises();
+    expect(apiMock.requireAuthentication).toHaveBeenCalledOnce();
     expect(apiMock.getCurrentUserInfo).toHaveBeenCalledOnce();
   });
 
@@ -670,9 +665,8 @@ describe("App initialization", () => {
 
     i18nMock.global.locale.value = "de";
 
-    await vi.waitFor(() => {
-      expect(apiMock.setLocale).toHaveBeenCalledWith("de");
-    });
+    await flushPromises();
+    expect(apiMock.setLocale).toHaveBeenCalledWith("de");
     expect(apiMock.fetchState).toHaveBeenCalledOnce();
   });
 
@@ -680,7 +674,7 @@ describe("App initialization", () => {
     wrapper = await mountAuthenticatedApp();
 
     i18nMock.global.locale.value = "de";
-    await nextTick();
+    await flushPromises();
 
     expect(apiMock.setLocale).not.toHaveBeenCalled();
     expect(apiMock.fetchState).not.toHaveBeenCalled();
@@ -693,9 +687,8 @@ describe("App initialization", () => {
 
     i18nMock.global.locale.value = "de";
 
-    await vi.waitFor(() => {
-      expect(apiMock.setLocale).toHaveBeenCalledWith("de");
-    });
+    await flushPromises();
+    expect(apiMock.setLocale).toHaveBeenCalledWith("de");
     expect(apiMock.fetchState).not.toHaveBeenCalled();
   });
 
@@ -706,9 +699,8 @@ describe("App initialization", () => {
 
     i18nMock.global.locale.value = "de";
 
-    await vi.waitFor(() => {
-      expect(apiMock.setLocale).toHaveBeenCalledWith("de");
-    });
+    await flushPromises();
+    expect(apiMock.setLocale).toHaveBeenCalledWith("de");
     expect(apiMock.fetchState).not.toHaveBeenCalled();
   });
 });
@@ -718,10 +710,8 @@ describe("App initialization", () => {
  */
 async function reconnect() {
   await startReconnect();
-  await vi.waitFor(() => {
-    expect(apiMock.authenticateWithToken).toHaveBeenCalled();
-  });
-  await nextTick();
+  await flushPromises();
+  expect(apiMock.authenticateWithToken).toHaveBeenCalled();
 }
 
 /**
@@ -747,21 +737,30 @@ async function mountAuthenticatedApp() {
   return mounted;
 }
 
+/**
+ * Mount the app, register it for teardown, and wait for initialization to
+ * settle.
+ *
+ * Initialization runs entirely on the microtask queue, so one flush covers it;
+ * a timer anywhere in that path would need vi.waitFor instead.
+ */
 async function mountApp() {
   const { default: App } = await import("@/App.vue");
-  const mounted = shallowMount(App, {
+  // Registered before the assertions below so afterEach unmounts the app even
+  // when one of them throws: a live instance keeps reacting to api.state and
+  // corrupts every later test.
+  wrapper = shallowMount(App, {
     global: {
       stubs: {
         RouterView: true,
       },
     },
   });
-  await vi.waitFor(() => {
-    expect(apiMock.state.value).toBe("initialized");
-    expect(mockInitializeWebPlayerModeSync).toHaveBeenCalledOnce();
-    expect(apiMock.subscribe).toHaveBeenCalledTimes(3);
-  });
-  return mounted;
+  await flushPromises();
+  expect(apiMock.state.value).toBe("initialized");
+  expect(mockInitializeWebPlayerModeSync).toHaveBeenCalledOnce();
+  expect(apiMock.subscribe).toHaveBeenCalledTimes(3);
+  return wrapper;
 }
 
 async function signalProvidersUpdated() {

--- a/tests/composables/useGuestEntryResolver.test.ts
+++ b/tests/composables/useGuestEntryResolver.test.ts
@@ -5,7 +5,7 @@ import {
 } from "@/composables/guest/useGuestEntryResolver";
 import { markMusicQuizJoinedGameEnded } from "@/helpers/music_quiz_guest_state";
 import { EventType } from "@/plugins/api/interfaces";
-import { mount } from "@vue/test-utils";
+import { flushPromises, mount } from "@vue/test-utils";
 import { defineComponent, h, type DeepReadonly, type Ref } from "vue";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -377,7 +377,8 @@ describe("guest entry transitions", () => {
       resolverState = state;
     });
 
-    await vi.waitFor(() => expect(apiMock.sendCommand).toHaveBeenCalledOnce());
+    await flushPromises();
+    expect(apiMock.sendCommand).toHaveBeenCalledOnce();
 
     signalProviderEvent({ event: "game_updated", state: {} });
     expect(apiMock.sendCommand).toHaveBeenCalledOnce();
@@ -404,7 +405,8 @@ describe("guest entry transitions", () => {
     wrapper = mountResolver((state) => {
       resolverState = state;
     });
-    await vi.waitFor(() => expect(apiMock.sendCommand).toHaveBeenCalledOnce());
+    await flushPromises();
+    expect(apiMock.sendCommand).toHaveBeenCalledOnce();
 
     signalProviderEvent({ event: "game_updated", state: {} });
     resolveFirstRequest({ game_id: "stale" });
@@ -466,9 +468,8 @@ describe("guest entry transitions", () => {
       )
       .mockResolvedValue(null);
     signalProviderEvent({ event: "game_updated", state: {} });
-    await vi.waitFor(() =>
-      expect(apiMock.sendCommand).toHaveBeenCalledTimes(2),
-    );
+    await flushPromises();
+    expect(apiMock.sendCommand).toHaveBeenCalledTimes(2);
 
     markMusicQuizJoinedGameEnded();
     signalProviderEvent({ event: "game_removed" });
@@ -495,7 +496,8 @@ describe("guest entry transitions", () => {
     wrapper = mountResolver((state) => {
       resolverState = state;
     });
-    await vi.waitFor(() => expect(apiMock.sendCommand).toHaveBeenCalledOnce());
+    await flushPromises();
+    expect(apiMock.sendCommand).toHaveBeenCalledOnce();
     expect(resolverState.value).toBe("loading");
 
     markMusicQuizJoinedGameEnded();
@@ -552,7 +554,7 @@ describe("guest entry transitions", () => {
     expect(apiMock.sendCommand).toHaveBeenCalledTimes(2);
 
     signalProviderEvent({ event: "game_updated", state: {} }, "other-instance");
-    await Promise.resolve();
+    await flushPromises();
     expect(apiMock.sendCommand).toHaveBeenCalledTimes(2);
   });
 
@@ -567,7 +569,8 @@ describe("guest entry transitions", () => {
 
     setRoutePath("/guest");
 
-    await vi.waitFor(() => expect(getRoutePath()).toBe("/guest/quiz"));
+    await flushPromises();
+    expect(getRoutePath()).toBe("/guest/quiz");
     expect(routerReplace.mock.calls.map(([path]) => path)).toEqual([
       "/guest/quiz",
       "/guest/quiz",
@@ -575,7 +578,8 @@ describe("guest entry transitions", () => {
   });
 
   async function expectState(expected: GuestEntryState) {
-    await vi.waitFor(() => expect(resolverState.value).toBe(expected));
+    await flushPromises();
+    expect(resolverState.value).toBe(expected);
   }
 });
 

--- a/tests/views/Login.test.ts
+++ b/tests/views/Login.test.ts
@@ -312,16 +312,15 @@ describe("guest join login", () => {
 
       const wrapper = mountLogin();
 
-      await vi.waitFor(() => {
-        expect(wrapper.emitted("authenticated")).toEqual([
-          [
-            {
-              token: "guest-token",
-              user: { user_id: "guest-id", username, role: "guest" },
-            },
-          ],
-        ]);
-      });
+      await flushPromises();
+      expect(wrapper.emitted("authenticated")).toEqual([
+        [
+          {
+            token: "guest-token",
+            user: { user_id: "guest-id", username, role: "guest" },
+          },
+        ],
+      ]);
       expect(wrapper.emitted("local-connect")).toEqual([
         ["http://music-assistant.local:8095"],
       ]);
@@ -359,9 +358,8 @@ describe("guest join login", () => {
     await wrapper.find("input").setValue("http://selected-server:8095");
     await wrapper.find("button").trigger("click");
 
-    await vi.waitFor(() => {
-      expect(wrapper.emitted("authenticated")).toHaveLength(1);
-    });
+    await flushPromises();
+    expect(wrapper.emitted("authenticated")).toHaveLength(1);
     expect(wrapper.emitted("local-connect")).toEqual([
       ["http://selected-server:8095"],
     ]);
@@ -387,9 +385,8 @@ describe("guest join login", () => {
 
     const wrapper = mountLogin();
 
-    await vi.waitFor(() => {
-      expect(wrapper.emitted("authenticated")).toHaveLength(1);
-    });
+    await flushPromises();
+    expect(wrapper.emitted("authenticated")).toHaveLength(1);
     expect(mocks.sendCommand).toHaveBeenCalledWith("auth/join_code/exchange", {
       code: "ABCD1234",
     });
@@ -411,15 +408,14 @@ describe("guest join login", () => {
 
     const wrapper = mountLogin();
 
-    await vi.waitFor(() => {
-      expect(wrapper.emitted("authenticated")?.[0]?.[0]).toEqual({
-        token: "admin-token",
-        user: {
-          user_id: "regular-id",
-          username: "regular-user",
-          role: "admin",
-        },
-      });
+    await flushPromises();
+    expect(wrapper.emitted("authenticated")?.[0]?.[0]).toEqual({
+      token: "admin-token",
+      user: {
+        user_id: "regular-id",
+        username: "regular-user",
+        role: "admin",
+      },
     });
     expect(mocks.clearAuth).not.toHaveBeenCalled();
     expect(localStorage.getItem("ma_access_token")).toBe("admin-token");
@@ -455,9 +451,8 @@ describe("guest join login", () => {
 
     const wrapper = mountLogin();
 
-    await vi.waitFor(() => {
-      expect(wrapper.text()).toContain("Couldn't join the party");
-    });
+    await flushPromises();
+    expect(wrapper.text()).toContain("Couldn't join the party");
     expect(wrapper.get(".text-h6").text()).toBe("Couldn't join the party");
     expect(wrapper.text()).toContain("Invalid or expired join code");
     expect(wrapper.text()).not.toContain("Connection Failed");
@@ -483,9 +478,8 @@ describe("guest join login", () => {
 
     const wrapper = mountLogin();
 
-    await vi.waitFor(() => {
-      expect(wrapper.text()).toContain("Couldn't join the party");
-    });
+    await flushPromises();
+    expect(wrapper.text()).toContain("Couldn't join the party");
     expect(wrapper.get(".text-h6").text()).toBe("Couldn't join the party");
     expect(wrapper.text()).toContain(
       "Too many failed attempts. Please try again in 120 seconds.",
@@ -501,9 +495,8 @@ describe("guest join login", () => {
 
     const wrapper = mountLogin();
 
-    await vi.waitFor(() => {
-      expect(wrapper.emitted("authenticated")).toHaveLength(1);
-    });
+    await flushPromises();
+    expect(wrapper.emitted("authenticated")).toHaveLength(1);
     expect(wrapper.emitted("local-connect")).toEqual([
       ["http://localhost:3000"],
     ]);
@@ -523,9 +516,8 @@ describe("guest join login", () => {
 
     const wrapper = mountLogin();
 
-    await vi.waitFor(() => {
-      expect(wrapper.emitted("authenticated")).toHaveLength(1);
-    });
+    await flushPromises();
+    expect(wrapper.emitted("authenticated")).toHaveLength(1);
     expect(mocks.connectRemote).toHaveBeenCalledWith(remoteId, {
       remember: false,
     });
@@ -546,15 +538,14 @@ describe("guest join login", () => {
 
     const wrapper = mountLogin();
 
-    await vi.waitFor(() => {
-      expect(wrapper.emitted("authenticated")?.[0]?.[0]).toEqual({
-        token: "admin-token",
-        user: {
-          user_id: "regular-id",
-          username: "regular-user",
-          role: "admin",
-        },
-      });
+    await flushPromises();
+    expect(wrapper.emitted("authenticated")?.[0]?.[0]).toEqual({
+      token: "admin-token",
+      user: {
+        user_id: "regular-id",
+        username: "regular-user",
+        role: "admin",
+      },
     });
     expect(mocks.authenticateWithToken).toHaveBeenCalledWith("admin-token");
     expect(mocks.sendCommand).not.toHaveBeenCalledWith(
@@ -578,15 +569,14 @@ describe("guest join login", () => {
 
     const wrapper = mountLogin();
 
-    await vi.waitFor(() => {
-      expect(wrapper.emitted("authenticated")?.[0]?.[0]).toEqual({
-        token: "guest-token",
-        user: {
-          user_id: "guest-id",
-          username: "party_guest",
-          role: "guest",
-        },
-      });
+    await flushPromises();
+    expect(wrapper.emitted("authenticated")?.[0]?.[0]).toEqual({
+      token: "guest-token",
+      user: {
+        user_id: "guest-id",
+        username: "party_guest",
+        role: "guest",
+      },
     });
     expect(mocks.authenticateWithToken).not.toHaveBeenCalledWith("admin-token");
     expect(mocks.sendCommand).toHaveBeenCalledWith("auth/join_code/exchange", {
@@ -601,9 +591,8 @@ describe("guest join login", () => {
 
     const wrapper = mountLogin();
 
-    await vi.waitFor(() => {
-      expect(wrapper.text()).toContain("Network unavailable");
-    });
+    await flushPromises();
+    expect(wrapper.text()).toContain("Network unavailable");
     expect(sessionStorage.getItem("ma_pending_join_code")).toBe("abcd1234");
     expect(sessionStorage.getItem("ma_pending_join_type")).toBe("remote");
     expect(sessionStorage.getItem("ma_guest_remote_id")).toBe(remoteId);
@@ -643,14 +632,13 @@ describe("guest join login", () => {
 
     const wrapper = mountLogin();
 
-    await vi.waitFor(() => {
-      expect(wrapper.emitted("authenticated")?.[0]?.[0]).toEqual({
-        user: {
-          user_id: "ingress-user",
-          username: "ingress-user",
-          role: "admin",
-        },
-      });
+    await flushPromises();
+    expect(wrapper.emitted("authenticated")?.[0]?.[0]).toEqual({
+      user: {
+        user_id: "ingress-user",
+        username: "ingress-user",
+        role: "admin",
+      },
     });
 
     expect(mocks.getCurrentUserInfo).toHaveBeenCalledOnce();
@@ -672,9 +660,8 @@ describe("guest join login", () => {
 
     const wrapper = mountLogin();
 
-    await vi.waitFor(() => {
-      expect(mocks.returnToFullApp).toHaveBeenCalledOnce();
-    });
+    await flushPromises();
+    expect(mocks.returnToFullApp).toHaveBeenCalledOnce();
     await flushPromises();
 
     // The reload is already under way, so nothing should replace it with a
@@ -717,9 +704,8 @@ describe("ended guest session", () => {
 
     const wrapper = mountLogin();
 
-    await vi.waitFor(() => {
-      expect(wrapper.text()).toContain("Your party session has ended");
-    });
+    await flushPromises();
+    expect(wrapper.text()).toContain("Your party session has ended");
     expect(wrapper.text()).toContain(
       "Ask the host to share the party link or QR code again to rejoin.",
     );
@@ -736,9 +722,8 @@ describe("ended guest session", () => {
 
     const wrapper = mountLogin();
 
-    await vi.waitFor(() => {
-      expect(wrapper.text()).toContain("Your quiz session has ended");
-    });
+    await flushPromises();
+    expect(wrapper.text()).toContain("Your quiz session has ended");
     expect(sessionStorage.getItem("ma_guest_session_ended")).toBe("music_quiz");
   });
 
@@ -749,9 +734,8 @@ describe("ended guest session", () => {
 
     const wrapper = mountLogin();
 
-    await vi.waitFor(() => {
-      expect(wrapper.text()).toContain("Your party session has ended");
-    });
+    await flushPromises();
+    expect(wrapper.text()).toContain("Your party session has ended");
     expect(mocks.authenticateWithToken).not.toHaveBeenCalled();
     expect(mocks.connectRemote).not.toHaveBeenCalled();
   });
@@ -767,9 +751,8 @@ describe("ended guest session", () => {
 
     const wrapper = mountLogin();
 
-    await vi.waitFor(() => {
-      expect(wrapper.emitted("authenticated")).toBeTruthy();
-    });
+    await flushPromises();
+    expect(wrapper.emitted("authenticated")).toBeTruthy();
     expect(sessionStorage.getItem("ma_guest_session_ended")).toBeNull();
     expect(mocks.sendCommand).toHaveBeenCalledWith("auth/join_code/exchange", {
       code: "ABCD1234",
@@ -781,9 +764,8 @@ describe("ended guest session", () => {
 
     const wrapper = mountLogin();
 
-    await vi.waitFor(() => {
-      expect(wrapper.text()).toContain("Your party session has ended");
-    });
+    await flushPromises();
+    expect(wrapper.text()).toContain("Your party session has ended");
     const leaveButton = wrapper
       .findAll("button")
       .find((button) => button.text() === "Continue to Music Assistant");
@@ -805,14 +787,13 @@ describe("ingress login", () => {
 
     const wrapper = mountLogin();
 
-    await vi.waitFor(() => {
-      expect(wrapper.emitted("authenticated")?.[0]?.[0]).toEqual({
-        user: {
-          role: "admin",
-          user_id: "ingress-user",
-          username: "ingress-user",
-        },
-      });
+    await flushPromises();
+    expect(wrapper.emitted("authenticated")?.[0]?.[0]).toEqual({
+      user: {
+        role: "admin",
+        user_id: "ingress-user",
+        username: "ingress-user",
+      },
     });
     expect(mocks.getCurrentUserInfo).toHaveBeenCalledOnce();
     expect(mocks.authenticateWithToken).not.toHaveBeenCalled();
@@ -825,15 +806,14 @@ describe("ingress login", () => {
 
     const wrapper = mountLogin();
 
-    await vi.waitFor(() => {
-      expect(wrapper.emitted("authenticated")?.[0]?.[0]).toEqual({
-        token: "admin-token",
-        user: {
-          role: "admin",
-          user_id: "regular-id",
-          username: "regular-user",
-        },
-      });
+    await flushPromises();
+    expect(wrapper.emitted("authenticated")?.[0]?.[0]).toEqual({
+      token: "admin-token",
+      user: {
+        role: "admin",
+        user_id: "regular-id",
+        username: "regular-user",
+      },
     });
     expect(mocks.authenticateWithToken).toHaveBeenCalledWith("admin-token");
     expect(mocks.getCurrentUserInfo).not.toHaveBeenCalled();
@@ -845,9 +825,8 @@ describe("ingress login", () => {
 
     const wrapper = mountLogin();
 
-    await vi.waitFor(() => {
-      expect(wrapper.text()).toContain("Username");
-    });
+    await flushPromises();
+    expect(wrapper.text()).toContain("Username");
     expect(mocks.getCurrentUserInfo).not.toHaveBeenCalled();
   });
 });
@@ -860,9 +839,8 @@ describe("connection state changes", () => {
 
     mocks.apiState.value = "reconnecting";
 
-    await vi.waitFor(() => {
-      expect(wrapper.text()).toContain("Reconnecting");
-    });
+    await flushPromises();
+    expect(wrapper.text()).toContain("Reconnecting");
     wrapper.unmount();
   });
 
@@ -871,15 +849,13 @@ describe("connection state changes", () => {
     const wrapper = mountLogin();
     await flushPromises();
     mocks.apiState.value = "reconnecting";
-    await vi.waitFor(() => {
-      expect(wrapper.text()).toContain("Reconnecting");
-    });
+    await flushPromises();
+    expect(wrapper.text()).toContain("Reconnecting");
 
     mocks.apiState.value = "disconnected";
 
-    await vi.waitFor(() => {
-      expect(wrapper.text()).not.toContain("Reconnecting");
-    });
+    await flushPromises();
+    expect(wrapper.text()).not.toContain("Reconnecting");
     expect(wrapper.text()).toContain("Connect");
     wrapper.unmount();
   });
@@ -888,9 +864,8 @@ describe("connection state changes", () => {
     mockStandaloneFrontend();
     sessionStorage.setItem("ma_guest_session_ended", "party");
     const wrapper = mountLogin();
-    await vi.waitFor(() => {
-      expect(wrapper.text()).toContain("Your party session has ended");
-    });
+    await flushPromises();
+    expect(wrapper.text()).toContain("Your party session has ended");
 
     mocks.apiState.value = "reconnecting";
     await flushPromises();


### PR DESCRIPTION
The tests for app startup, sign-in and guest entry paused for a fixed 50ms after every step, waiting for background work that had usually already finished. On a busy machine those pauses stretch out and the tests can run out of time and fail for no real reason. Worse, when a mount timed out the test app was left running in the background, so it kept reacting and knocked over the tests that came after it — one slow test turned into a whole cluster of failures.

- Wait for the pending work itself to finish, instead of pausing on a timer
- Always clean up the test app, so a single failure can no longer cascade
- These three test files now run around five times faster