### PR TITLE
Fix the player progress bar standing still or starting at zero

### DIFF
--- a/src/layouts/default/PlayerOSD/PlayerTimeline.vue
+++ b/src/layouts/default/PlayerOSD/PlayerTimeline.vue
@@ -278,12 +278,12 @@ const serverTiming = computed(() => resolveActiveTiming());
 
 const serverElapsedTime = computed(() => {
   // include nowTick.value so this computed re-evaluates periodically while
-  // mounted; the resolved position extrapolates from Date.now(), which is not
-  // reactive by itself
+  // mounted; the resolved position extrapolates from the current time, which is
+  // not reactive by itself
   void nowTick.value;
 
   // Adaptive tick: the resolved position only advances on its own while the
-  // source that reports it is playing, whichever source that turns out to be.
+  // source it came from is playing.
   if (serverTiming.value?.playbackState === PlaybackState.PLAYING) startTick();
   else stopTick();
 
@@ -349,11 +349,17 @@ watch(serverTiming, (timing) => {
   }
 });
 
-watch(displayedElapsedTime, (newTime) => {
-  if (!isDragging.value) {
-    curTimeValue.value = newTime;
-  }
-});
+// immediate, so a fresh mount adopts the position that is already playing or
+// paused; a paused one never changes again to trigger the watcher
+watch(
+  displayedElapsedTime,
+  (newTime) => {
+    if (!isDragging.value) {
+      curTimeValue.value = newTime;
+    }
+  },
+  { immediate: true },
+);
 
 watch(
   () => store.curQueueItem?.queue_item_id,

--- a/src/layouts/default/PlayerOSD/PlayerTimeline.vue
+++ b/src/layouts/default/PlayerOSD/PlayerTimeline.vue
@@ -277,20 +277,14 @@ const playerTotalTimeStr = computed(() => {
 const serverTiming = computed(() => resolveActiveTiming());
 
 const serverElapsedTime = computed(() => {
-  // include nowTick.value so this computed re-evaluates periodically while mounted
-  // and updates UI for fallback player-level current_media that relies on Date.now()
+  // include nowTick.value so this computed re-evaluates periodically while
+  // mounted; the resolved position extrapolates from Date.now(), which is not
+  // reactive by itself
   void nowTick.value;
 
-  // Adaptive tick: only run the timer when we have a playing source that relies on time progression
-  const isPlaying = serverTiming.value?.playbackState === PlaybackState.PLAYING;
-  const usingQueue = !!(
-    store.activePlayerQueue && store.activePlayerQueue.active
-  );
-  const hasCurrentMedia =
-    store.activePlayer?.current_media?.elapsed_time != null;
-
-  // Start ticking when playing and either using queue or external current_media
-  if (isPlaying && (usingQueue || hasCurrentMedia)) startTick();
+  // Adaptive tick: the resolved position only advances on its own while the
+  // source that reports it is playing, whichever source that turns out to be.
+  if (serverTiming.value?.playbackState === PlaybackState.PLAYING) startTick();
   else stopTick();
 
   return resolveActiveElapsedTime() ?? 0;

--- a/tests/helpers/activeElapsedTime.test.ts
+++ b/tests/helpers/activeElapsedTime.test.ts
@@ -173,6 +173,20 @@ describe("resolveActiveTiming / resolveActiveElapsedTime", () => {
     expect(resolveActiveElapsedTime()).toBe(5);
   });
 
+  it("falls back to player-level elapsed_time when current_media carries no position", () => {
+    // the shape players report when they only expose a position at player
+    // level, e.g. a Home Assistant media_player with a media_position
+    storeMock.activePlayer = {
+      playback_state: PlaybackState.PLAYING,
+      elapsed_time: 30,
+      elapsed_time_last_updated: NOW,
+      current_media: {},
+    };
+
+    vi.setSystemTime((NOW + 6) * 1000);
+    expect(resolveActiveElapsedTime()).toBeCloseTo(36, 6);
+  });
+
   it("prefers a queue elapsed_time of 0 over a player timing", () => {
     storeMock.activePlayerQueue = {
       queue_id: "q1",

--- a/tests/helpers/activeElapsedTime.test.ts
+++ b/tests/helpers/activeElapsedTime.test.ts
@@ -173,7 +173,7 @@ describe("resolveActiveTiming / resolveActiveElapsedTime", () => {
     expect(resolveActiveElapsedTime()).toBe(5);
   });
 
-  it("falls back to player-level elapsed_time when current_media carries no position", () => {
+  it("falls through an empty current_media to the player-level elapsed_time", () => {
     // the shape players report when they only expose a position at player
     // level, e.g. a Home Assistant media_player with a media_position
     storeMock.activePlayer = {

--- a/tests/layouts/PlayerTimeline.test.ts
+++ b/tests/layouts/PlayerTimeline.test.ts
@@ -66,6 +66,8 @@ const store = storeModule as unknown as TestStore;
 // epoch seconds the fake clock starts at; timestamps below are relative to this
 const NOW = 1_700_000_000;
 
+let wrapper: VueWrapper | undefined;
+
 beforeEach(() => {
   vi.useFakeTimers();
   vi.setSystemTime(NOW * 1000);
@@ -76,10 +78,30 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+  // the store is shared, so an instance left mounted would react to the next
+  // test's state and its timers would count towards that test's timer budget
+  wrapper?.unmount();
+  wrapper = undefined;
   vi.useRealTimers();
 });
 
-describe("PlayerTimeline adaptive tick", () => {
+describe("PlayerTimeline", () => {
+  it.each([
+    ["playing", PlaybackState.PLAYING],
+    ["paused", PlaybackState.PAUSED],
+  ])("shows the position it mounts on for a %s player", (_state, state) => {
+    store.activePlayer = {
+      player_id: "p1",
+      playback_state: state,
+      elapsed_time: 30,
+      elapsed_time_last_updated: NOW,
+      current_media: { duration: 300 },
+    };
+
+    mountTimeline();
+    expect(elapsedLabel()).toBe("00:30");
+  });
+
   it("animates a queue-sourced position", async () => {
     store.activePlayerQueue = {
       queue_id: "q1",
@@ -96,8 +118,8 @@ describe("PlayerTimeline adaptive tick", () => {
       current_media: { duration: 300 },
     };
 
-    const wrapper = mountTimeline();
-    expect(await elapsedLabelAfter(wrapper, 4)).toBe("00:14");
+    mountTimeline();
+    expect(await elapsedLabelAfter(4)).toBe("00:14");
   });
 
   it("animates a current_media position for an external source", async () => {
@@ -111,8 +133,8 @@ describe("PlayerTimeline adaptive tick", () => {
       },
     };
 
-    const wrapper = mountTimeline();
-    expect(await elapsedLabelAfter(wrapper, 5)).toBe("00:25");
+    mountTimeline();
+    expect(await elapsedLabelAfter(5)).toBe("00:25");
   });
 
   it("animates a player-level position when current_media reports none", async () => {
@@ -126,8 +148,8 @@ describe("PlayerTimeline adaptive tick", () => {
       current_media: { duration: 300 },
     };
 
-    const wrapper = mountTimeline();
-    expect(await elapsedLabelAfter(wrapper, 6)).toBe("00:36");
+    mountTimeline();
+    expect(await elapsedLabelAfter(6)).toBe("00:36");
   });
 
   it("animates a player-level position with no current_media at all", async () => {
@@ -138,8 +160,8 @@ describe("PlayerTimeline adaptive tick", () => {
       elapsed_time_last_updated: NOW,
     };
 
-    const wrapper = mountTimeline();
-    expect(await elapsedLabelAfter(wrapper, 6)).toBe("00:36");
+    mountTimeline();
+    expect(await elapsedLabelAfter(6)).toBe("00:36");
   });
 
   it("does not start the tick for a source that is paused", async () => {
@@ -152,7 +174,7 @@ describe("PlayerTimeline adaptive tick", () => {
     };
 
     mountTimeline();
-    await vi.advanceTimersByTimeAsync(10_000);
+    expect(await elapsedLabelAfter(10)).toBe("00:30");
     expect(vi.getTimerCount()).toBe(0);
   });
 
@@ -165,8 +187,8 @@ describe("PlayerTimeline adaptive tick", () => {
       current_media: { duration: 300 },
     };
 
-    const wrapper = mountTimeline();
-    expect(await elapsedLabelAfter(wrapper, 4)).toBe("00:34");
+    mountTimeline();
+    expect(await elapsedLabelAfter(4)).toBe("00:34");
 
     store.activePlayer = {
       player_id: "p1",
@@ -178,7 +200,7 @@ describe("PlayerTimeline adaptive tick", () => {
     await nextTick();
     // the timers are released rather than left spinning behind a frozen label
     expect(vi.getTimerCount()).toBe(0);
-    expect(await elapsedLabelAfter(wrapper, 20)).toBe("00:34");
+    expect(await elapsedLabelAfter(20)).toBe("00:34");
   });
 
   it("shows no position when no source reports one", async () => {
@@ -188,18 +210,35 @@ describe("PlayerTimeline adaptive tick", () => {
       current_media: { duration: 300 },
     };
 
-    const wrapper = mountTimeline();
-    expect(await elapsedLabelAfter(wrapper, 10)).toBe("00:00");
+    mountTimeline();
+    expect(await elapsedLabelAfter(10)).toBe("00:00");
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it("releases the tick on unmount", async () => {
+    store.activePlayer = {
+      player_id: "p1",
+      playback_state: PlaybackState.PLAYING,
+      elapsed_time: 30,
+      elapsed_time_last_updated: NOW,
+      current_media: { duration: 300 },
+    };
+
+    mountTimeline();
+    await elapsedLabelAfter(1);
+    expect(vi.getTimerCount()).toBeGreaterThan(0);
+
+    wrapper!.unmount();
     expect(vi.getTimerCount()).toBe(0);
   });
 });
 
 function mountTimeline() {
-  return mount(PlayerTimeline, {
+  wrapper = mount(PlayerTimeline, {
     props: { showLabels: true },
     global: {
-      // reka's slider measures the DOM; the timeline renders its own text
-      // labels outside of it.
+      // mounting reka's slider for real costs orders of magnitude more than the
+      // rest of the component; the time labels render outside of it anyway.
       stubs: {
         SliderRoot: true,
         SliderTrack: true,
@@ -210,19 +249,16 @@ function mountTimeline() {
   });
 }
 
-function elapsedLabel(wrapper: VueWrapper): string {
-  return wrapper.find(".time-text-left").text();
+function elapsedLabel(): string {
+  return wrapper!.find(".time-text-left").text();
 }
 
 /**
  * The elapsed-time label after `seconds` of wall-clock time have passed with no
  * store update in between, so only the component's own tick can move it.
  */
-async function elapsedLabelAfter(
-  wrapper: VueWrapper,
-  seconds: number,
-): Promise<string> {
+async function elapsedLabelAfter(seconds: number): Promise<string> {
   await vi.advanceTimersByTimeAsync(seconds * 1000);
   await nextTick();
-  return elapsedLabel(wrapper);
+  return elapsedLabel();
 }

--- a/tests/layouts/PlayerTimeline.test.ts
+++ b/tests/layouts/PlayerTimeline.test.ts
@@ -1,0 +1,228 @@
+import PlayerTimeline from "@/layouts/default/PlayerOSD/PlayerTimeline.vue";
+import apiDefault from "@/plugins/api";
+import { PlaybackState } from "@/plugins/api/interfaces";
+import { store as storeModule } from "@/plugins/store";
+import { mount, type VueWrapper } from "@vue/test-utils";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { nextTick } from "vue";
+
+// Only the fields the timeline and the elapsed-time resolver read are mocked;
+// both are reactive so a state change is picked up the way the real store's is.
+vi.mock("@/plugins/api", async () => {
+  const { reactive } = await vi.importActual<typeof import("vue")>("vue");
+  const api = reactive({
+    queueElapsedTime: {},
+    playerCommandSeek: vi.fn(),
+    playMedia: vi.fn(),
+  });
+  return { api, default: api };
+});
+
+vi.mock("@/plugins/store", async () => {
+  const { reactive } = await vi.importActual<typeof import("vue")>("vue");
+  return {
+    store: reactive({
+      activePlayer: undefined,
+      activePlayerQueue: undefined,
+      curQueueItem: undefined,
+    }),
+  };
+});
+
+// The timeline only consults the sources to decide whether seeking is allowed,
+// which is unrelated to the tick.
+vi.mock("@/composables/activeSource", () => ({
+  useActiveSource: () => ({ activeSource: { value: undefined } }),
+}));
+
+vi.mock("@/composables/activeAudioSource", () => ({
+  useActiveAudioSource: () => ({ activeAudioSource: { value: undefined } }),
+}));
+
+interface TestTiming {
+  elapsed_time?: number;
+  elapsed_time_last_updated?: number;
+}
+
+interface TestStore {
+  activePlayer?: TestTiming & {
+    player_id: string;
+    playback_state?: PlaybackState;
+    current_media?: TestTiming & { duration?: number };
+  };
+  activePlayerQueue?: {
+    queue_id: string;
+    state?: PlaybackState;
+    active?: boolean;
+  };
+  curQueueItem?: { queue_item_id?: string };
+}
+
+const api = apiDefault as unknown as {
+  queueElapsedTime: Record<string, TestTiming>;
+};
+const store = storeModule as unknown as TestStore;
+
+// epoch seconds the fake clock starts at; timestamps below are relative to this
+const NOW = 1_700_000_000;
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.setSystemTime(NOW * 1000);
+  api.queueElapsedTime = {};
+  store.activePlayer = undefined;
+  store.activePlayerQueue = undefined;
+  store.curQueueItem = undefined;
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("PlayerTimeline adaptive tick", () => {
+  it("animates a queue-sourced position", async () => {
+    store.activePlayerQueue = {
+      queue_id: "q1",
+      state: PlaybackState.PLAYING,
+      active: true,
+    };
+    api.queueElapsedTime["q1"] = {
+      elapsed_time: 10,
+      elapsed_time_last_updated: NOW,
+    };
+    store.activePlayer = {
+      player_id: "p1",
+      playback_state: PlaybackState.PLAYING,
+      current_media: { duration: 300 },
+    };
+
+    const wrapper = mountTimeline();
+    expect(await elapsedLabelAfter(wrapper, 4)).toBe("00:14");
+  });
+
+  it("animates a current_media position for an external source", async () => {
+    store.activePlayer = {
+      player_id: "p1",
+      playback_state: PlaybackState.PLAYING,
+      current_media: {
+        duration: 300,
+        elapsed_time: 20,
+        elapsed_time_last_updated: NOW,
+      },
+    };
+
+    const wrapper = mountTimeline();
+    expect(await elapsedLabelAfter(wrapper, 5)).toBe("00:25");
+  });
+
+  it("animates a player-level position when current_media reports none", async () => {
+    // players that only report their position at player level, e.g. a Home
+    // Assistant media_player with a media_position but no media_title
+    store.activePlayer = {
+      player_id: "p1",
+      playback_state: PlaybackState.PLAYING,
+      elapsed_time: 30,
+      elapsed_time_last_updated: NOW,
+      current_media: { duration: 300 },
+    };
+
+    const wrapper = mountTimeline();
+    expect(await elapsedLabelAfter(wrapper, 6)).toBe("00:36");
+  });
+
+  it("animates a player-level position with no current_media at all", async () => {
+    store.activePlayer = {
+      player_id: "p1",
+      playback_state: PlaybackState.PLAYING,
+      elapsed_time: 30,
+      elapsed_time_last_updated: NOW,
+    };
+
+    const wrapper = mountTimeline();
+    expect(await elapsedLabelAfter(wrapper, 6)).toBe("00:36");
+  });
+
+  it("does not start the tick for a source that is paused", async () => {
+    store.activePlayer = {
+      player_id: "p1",
+      playback_state: PlaybackState.PAUSED,
+      elapsed_time: 30,
+      elapsed_time_last_updated: NOW,
+      current_media: { duration: 300 },
+    };
+
+    mountTimeline();
+    await vi.advanceTimersByTimeAsync(10_000);
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it("stops ticking once playback stops", async () => {
+    store.activePlayer = {
+      player_id: "p1",
+      playback_state: PlaybackState.PLAYING,
+      elapsed_time: 30,
+      elapsed_time_last_updated: NOW,
+      current_media: { duration: 300 },
+    };
+
+    const wrapper = mountTimeline();
+    expect(await elapsedLabelAfter(wrapper, 4)).toBe("00:34");
+
+    store.activePlayer = {
+      player_id: "p1",
+      playback_state: PlaybackState.PAUSED,
+      elapsed_time: 34,
+      elapsed_time_last_updated: NOW + 4,
+      current_media: { duration: 300 },
+    };
+    await nextTick();
+    // the timers are released rather than left spinning behind a frozen label
+    expect(vi.getTimerCount()).toBe(0);
+    expect(await elapsedLabelAfter(wrapper, 20)).toBe("00:34");
+  });
+
+  it("shows no position when no source reports one", async () => {
+    store.activePlayer = {
+      player_id: "p1",
+      playback_state: PlaybackState.PLAYING,
+      current_media: { duration: 300 },
+    };
+
+    const wrapper = mountTimeline();
+    expect(await elapsedLabelAfter(wrapper, 10)).toBe("00:00");
+    expect(vi.getTimerCount()).toBe(0);
+  });
+});
+
+function mountTimeline() {
+  return mount(PlayerTimeline, {
+    props: { showLabels: true },
+    global: {
+      // reka's slider measures the DOM; the timeline renders its own text
+      // labels outside of it.
+      stubs: {
+        SliderRoot: true,
+        SliderTrack: true,
+        SliderRange: true,
+        SliderThumb: true,
+      },
+    },
+  });
+}
+
+function elapsedLabel(wrapper: VueWrapper): string {
+  return wrapper.find(".time-text-left").text();
+}
+
+/**
+ * The elapsed-time label after `seconds` of wall-clock time have passed with no
+ * store update in between, so only the component's own tick can move it.
+ */
+async function elapsedLabelAfter(
+  wrapper: VueWrapper,
+  seconds: number,
+): Promise<string> {
+  await vi.advanceTimersByTimeAsync(seconds * 1000);
+  await nextTick();
+  return elapsedLabel(wrapper);
+}


### PR DESCRIPTION
Two problems with the position shown by the player's progress bar and time counter:

- Some players report their playback position at player level only, without a per-track position — a Home Assistant media_player that exposes a `media_position` but no track title, for example. For those the progress bar sat still and only jumped forward whenever the server sent an update, instead of running smoothly.
- Opening the fullscreen player or the Now Playing dashboard on a paused track showed 0:00 instead of the position it was paused at, until playback resumed.

- Animate the progress bar whenever the position it shows is playing, whatever reports it
- Show that position as soon as the progress bar appears, instead of waiting for it to change
- Add tests for the progress bar, covering all three position sources