### PR TITLE
Tidy up the lyrics elapsed time composable

### DIFF
--- a/src/composables/lyrics/useLyricsElapsedTime.ts
+++ b/src/composables/lyrics/useLyricsElapsedTime.ts
@@ -81,5 +81,5 @@ export function useLyricsElapsedTime(enabled?: Ref<boolean>) {
     document.removeEventListener("visibilitychange", handleVisibilityChange);
   });
 
-  return { elapsedTime, start, stop };
+  return { elapsedTime };
 }

--- a/src/views/PartyDashboardView.vue
+++ b/src/views/PartyDashboardView.vue
@@ -520,8 +520,7 @@ const lyricsEnabled = computed(() => karaokeMode.value);
 const lyricsTextColor = computed(() =>
   albumArtUrl.value ? "#FFFFFF" : isDark.value ? "#FFFFFF" : "#000000",
 );
-const { elapsedTime: lyricsElapsedTime, stop: stopTick } =
-  useLyricsElapsedTime(lyricsEnabled);
+const { elapsedTime: lyricsElapsedTime } = useLyricsElapsedTime(lyricsEnabled);
 
 const colorPalette = computed<ImageColorPalette>(() =>
   paletteFromServer(store.activePlayer?.current_media?.palette),
@@ -847,7 +846,6 @@ onBeforeUnmount(() => {
     clearInterval(burnInInterval);
     burnInInterval = null;
   }
-  stopTick();
   cleanupParentStyles();
   document.removeEventListener("visibilitychange", handleVisibilityChange);
 });

--- a/tests/composables/useLyricsElapsedTime.test.ts
+++ b/tests/composables/useLyricsElapsedTime.test.ts
@@ -69,6 +69,21 @@ function flushFrame(): void {
   for (const callback of callbacks) callback(0);
 }
 
+// Hands back a driver for the frame the composable has scheduled, so a test can
+// keep ticking after the composable stopped scheduling frames itself. The frames
+// the callback re-arms are dropped, leaving `pendingFrames` a view of what the
+// composable scheduled on its own.
+function manualFrameDriver(): () => void {
+  const [callback] = pendingFrames.values();
+  if (!callback) throw new Error("no frame scheduled");
+
+  return () => {
+    const composableFrames = new Map(pendingFrames);
+    callback(0);
+    pendingFrames = composableFrames;
+  };
+}
+
 const NOW = 1_700_000_000;
 
 const PLAYER_ID = "p1";
@@ -166,25 +181,29 @@ describe("useLyricsElapsedTime", () => {
   });
 
   it("reads a frozen position from a paused queue even while the loop runs", async () => {
-    seedQueue({ state: PlaybackState.PAUSED });
+    seedQueue({ state: PlaybackState.PLAYING });
     seedPlayer({ playback_state: PlaybackState.PLAYING });
     apiMock.queueElapsedTime["q1"] = {
       elapsed_time: 42,
       elapsed_time_last_updated: NOW,
     };
 
-    const { elapsedTime, start } = await runComposable();
+    const { elapsedTime } = await runComposable();
+    await nextTick();
+    // Captured while the queue still plays: pausing it below cancels the loop.
+    const tick = manualFrameDriver();
+
+    seedQueue({ state: PlaybackState.PAUSED });
     await nextTick();
     expect(pendingFrames.size).toBe(0);
 
-    // Drive the loop by hand to prove the position itself is frozen rather
-    // than merely unpolled.
-    start();
-    flushFrame();
+    // Driving the loop proves the position itself is frozen rather than merely
+    // unpolled.
+    tick();
     expect(elapsedTime.value).toBe(42);
 
     serverNowMock.mockReturnValue(NOW + 50);
-    flushFrame();
+    tick();
     expect(elapsedTime.value).toBe(42);
   });
 


### PR DESCRIPTION
The lyrics elapsed time composable exposed `start` and `stop` alongside `elapsedTime`. `start` was never called anywhere, and the one `stop` call (in the party dashboard, on unmount) repeated the cleanup the composable already does when its scope is disposed. An external `stop` also left the composable thinking it should still be running, so a later tab visibility change could revive the loop.

- Return only `elapsedTime` from the composable
- Drop the redundant stop call on unmount in the party dashboard view
- Rework the paused-queue test to drive frames without the removed `start`, keeping the same assertion that the position is frozen