### PR TITLE
Handle settings action buttons in one shared place

### DIFF
--- a/src/composables/useConfigAction.ts
+++ b/src/composables/useConfigAction.ts
@@ -1,0 +1,81 @@
+/**
+ * Shared handler for the action buttons on a settings config form.
+ * Provider, player and core config forms all invoke an action the same way and
+ * differ only in which API commands they talk to, so they pass those in.
+ */
+
+import type { Ref } from "vue";
+import { toast } from "vue-sonner";
+import { mergeActionEntries } from "@/helpers/config_entry_ui";
+import { openActionUrlEntries } from "@/helpers/utils";
+import type { ConfigEntry, ConfigValueType } from "@/plugins/api/interfaces";
+import { $t } from "@/plugins/i18n";
+
+/** The part of a Provider/Player/Core config this handler touches. */
+interface ConfigWithValues {
+  values: Record<string, ConfigEntry>;
+}
+
+interface UseConfigActionOptions<T extends ConfigWithValues> {
+  /** The form's config, refreshed in place with whatever the action returns. */
+  config: Ref<T | undefined>;
+  /** Toggled around the invoke so the form can show its loading overlay. */
+  loading: Ref<boolean>;
+  /** Runs the action on the server and returns the entries to re-render. */
+  invokeAction: (action: string) => Promise<ConfigEntry[]>;
+  /** Persists the given raw values and returns the stored config. */
+  saveValues: (
+    values: Record<string, ConfigValueType>,
+  ) => Promise<ConfigWithValues>;
+}
+
+/**
+ * Build the `action` event handler for an EditConfig form.
+ *
+ * :param config: Ref holding the config the form renders.
+ * :param loading: Ref driving the form's loading overlay.
+ * :param invokeAction: Invokes the action for this config's flavour.
+ * :param saveValues: Saves raw values for this config's flavour.
+ */
+export function useConfigAction<T extends ConfigWithValues>({
+  config,
+  loading,
+  invokeAction,
+  saveValues,
+}: UseConfigActionOptions<T>) {
+  const onAction = async function (
+    action: string,
+    _values: Record<string, ConfigValueType>,
+    immediateApply: boolean,
+  ) {
+    loading.value = true;
+    try {
+      const entries = openActionUrlEntries(await invokeAction(action));
+      // An empty response means the action was a one-off side effect with
+      // nothing to re-render: leave the form untouched.
+      if (entries.length === 0) {
+        toast.success($t("settings.action_completed"));
+        return;
+      }
+      config.value!.values = mergeActionEntries(config.value!.values, entries);
+      if (immediateApply) {
+        const rawValues: Record<string, ConfigValueType> = {};
+        for (const entry of Object.values(config.value!.values)) {
+          if (entry.value !== undefined) {
+            rawValues[entry.key] = entry.value;
+          }
+        }
+        const updatedConfig = await saveValues(rawValues);
+        for (const [key, entry] of Object.entries(updatedConfig.values)) {
+          config.value!.values[key] = entry;
+        }
+      }
+    } catch (err) {
+      toast.error(String(err));
+    } finally {
+      loading.value = false;
+    }
+  };
+
+  return { onAction };
+}

--- a/src/composables/useConfigAction.ts
+++ b/src/composables/useConfigAction.ts
@@ -29,10 +29,10 @@ interface UseConfigActionOptions<T extends Config> {
 /**
  * Build the `action` event handler for an EditConfig form.
  *
- * :param config: Ref holding the config the form renders.
- * :param loading: Ref driving the form's loading overlay.
- * :param invokeAction: Invokes the action for this config's flavour.
- * :param saveValues: Saves raw values for this config's flavour.
+ * @param config - Ref holding the config the form renders.
+ * @param loading - Ref driving the form's loading overlay.
+ * @param invokeAction - Invokes the action for this config's flavour.
+ * @param saveValues - Saves raw values for this config's flavour.
  */
 export function useConfigAction<T extends Config>({
   config,

--- a/src/composables/useConfigAction.ts
+++ b/src/composables/useConfigAction.ts
@@ -8,15 +8,14 @@ import type { Ref } from "vue";
 import { toast } from "vue-sonner";
 import { mergeActionEntries } from "@/helpers/config_entry_ui";
 import { openActionUrlEntries } from "@/helpers/utils";
-import type { ConfigEntry, ConfigValueType } from "@/plugins/api/interfaces";
+import type {
+  Config,
+  ConfigEntry,
+  ConfigValueType,
+} from "@/plugins/api/interfaces";
 import { $t } from "@/plugins/i18n";
 
-/** The part of a Provider/Player/Core config this handler touches. */
-interface ConfigWithValues {
-  values: Record<string, ConfigEntry>;
-}
-
-interface UseConfigActionOptions<T extends ConfigWithValues> {
+interface UseConfigActionOptions<T extends Config> {
   /** The form's config, refreshed in place with whatever the action returns. */
   config: Ref<T | undefined>;
   /** Toggled around the invoke so the form can show its loading overlay. */
@@ -24,9 +23,7 @@ interface UseConfigActionOptions<T extends ConfigWithValues> {
   /** Runs the action on the server and returns the entries to re-render. */
   invokeAction: (action: string) => Promise<ConfigEntry[]>;
   /** Persists the given raw values and returns the stored config. */
-  saveValues: (
-    values: Record<string, ConfigValueType>,
-  ) => Promise<ConfigWithValues>;
+  saveValues: (values: Record<string, ConfigValueType>) => Promise<Config>;
 }
 
 /**
@@ -37,7 +34,7 @@ interface UseConfigActionOptions<T extends ConfigWithValues> {
  * :param invokeAction: Invokes the action for this config's flavour.
  * :param saveValues: Saves raw values for this config's flavour.
  */
-export function useConfigAction<T extends ConfigWithValues>({
+export function useConfigAction<T extends Config>({
   config,
   loading,
   invokeAction,
@@ -71,7 +68,9 @@ export function useConfigAction<T extends ConfigWithValues>({
         }
       }
     } catch (err) {
-      toast.error(String(err));
+      // the api rejects with a plain string, but a dropped connection rejects
+      // with an Error whose name would otherwise be prefixed onto the toast
+      toast.error(err instanceof Error ? err.message : String(err));
     } finally {
       loading.value = false;
     }

--- a/src/plugins/api/index.ts
+++ b/src/plugins/api/index.ts
@@ -2328,9 +2328,9 @@ export class MusicAssistantApi {
   public async saveCoreConfig(
     domain: string,
     values: Record<string, ConfigValueType>,
-  ): Promise<ProviderConfig> {
+  ): Promise<CoreConfig> {
     // Save Core controller Config.
-    // domain: (mandatory) domain of the provider.
+    // domain: (mandatory) domain of the core controller.
     // values: the raw values for config entries that need to be stored/updated.
     // action: [optional] action key called from config entries UI.
     return this.sendCommand("config/core/save", {

--- a/src/views/settings/EditCoreConfig.vue
+++ b/src/views/settings/EditCoreConfig.vue
@@ -42,8 +42,7 @@
 </template>
 
 <script setup lang="ts">
-import { mergeActionEntries } from "@/helpers/config_entry_ui";
-import { openActionUrlEntries } from "@/helpers/utils";
+import { useConfigAction } from "@/composables/useConfigAction";
 import { api } from "@/plugins/api";
 import { ConfigValueType, CoreConfig } from "@/plugins/api/interfaces";
 import { computed, ref, watch } from "vue";
@@ -138,47 +137,13 @@ const onImmediateApply = async function (
   }
 };
 
-const onAction = async function (
-  action: string,
-  _values: Record<string, ConfigValueType>,
-  immediateApply: boolean,
-) {
-  loading.value = true;
-  api
-    .invokeCoreConfigAction(config.value!.domain, action)
-    .then(async (entries) => {
-      entries = openActionUrlEntries(entries);
-      // An empty response means the action was a one-off side effect with
-      // nothing to re-render: leave the form untouched.
-      if (entries.length === 0) {
-        toast.success(t("settings.action_completed"));
-        loading.value = false;
-        return;
-      }
-      config.value!.values = mergeActionEntries(config.value!.values, entries);
-      // If the action has immediate_apply, save the updated values right away
-      if (immediateApply) {
-        const saveValues: Record<string, ConfigValueType> = {};
-        for (const entry of Object.values(config.value!.values)) {
-          if (entry.value !== undefined) {
-            saveValues[entry.key] = entry.value;
-          }
-        }
-        const updatedConfig = await api.saveCoreConfig(
-          config.value!.domain,
-          saveValues,
-        );
-        for (const [key, entry] of Object.entries(updatedConfig.values)) {
-          config.value!.values[key] = entry;
-        }
-      }
-      loading.value = false;
-    })
-    .catch((err) => {
-      toast.error(err.message || err);
-      loading.value = false;
-    });
-};
+const { onAction } = useConfigAction({
+  config,
+  loading,
+  invokeAction: (action) =>
+    api.invokeCoreConfigAction(config.value!.domain, action),
+  saveValues: (values) => api.saveCoreConfig(config.value!.domain, values),
+});
 </script>
 
 <style scoped>

--- a/src/views/settings/EditPlayer.vue
+++ b/src/views/settings/EditPlayer.vue
@@ -263,10 +263,10 @@ import {
   ConfigEntryUI,
   UI_ENTRY_TYPE,
   isInjected,
-  mergeActionEntries,
   mergeConfigEntries,
 } from "@/helpers/config_entry_ui";
-import { openActionUrlEntries, openLinkInNewTab } from "@/helpers/utils";
+import { useConfigAction } from "@/composables/useConfigAction";
+import { openLinkInNewTab } from "@/helpers/utils";
 import { eventbus } from "@/plugins/eventbus";
 import { $t } from "@/plugins/i18n";
 // global refs
@@ -464,47 +464,13 @@ const onImmediateApply = async function (
     });
 };
 
-const onAction = async function (
-  action: string,
-  _values: Record<string, ConfigValueType>,
-  immediateApply: boolean,
-) {
-  loading.value = true;
-  api
-    .invokePlayerConfigAction(config.value!.player_id, action)
-    .then(async (entries) => {
-      entries = openActionUrlEntries(entries);
-      // An empty response means the action was a one-off side effect with
-      // nothing to re-render: leave the form untouched.
-      if (entries.length === 0) {
-        toast.success($t("settings.action_completed"));
-        return;
-      }
-      config.value!.values = mergeActionEntries(config.value!.values, entries);
-      // If the action has immediate_apply, save the updated values right away
-      if (immediateApply) {
-        const saveValues: Record<string, ConfigValueType> = {};
-        for (const entry of Object.values(config.value!.values)) {
-          if (entry.value !== undefined) {
-            saveValues[entry.key] = entry.value;
-          }
-        }
-        const updatedConfig = await api.savePlayerConfig(
-          props.playerId!,
-          saveValues,
-        );
-        for (const [key, entry] of Object.entries(updatedConfig.values)) {
-          config.value!.values[key] = entry;
-        }
-      }
-    })
-    .catch((err) => {
-      toast.error(String(err));
-    })
-    .finally(() => {
-      loading.value = false;
-    });
-};
+const { onAction } = useConfigAction({
+  config,
+  loading,
+  invokeAction: (action) =>
+    api.invokePlayerConfigAction(config.value!.player_id, action),
+  saveValues: (values) => api.savePlayerConfig(props.playerId!, values),
+});
 
 async function loadConfig(playerId: string) {
   const requestId = ++configLoadRequestId;

--- a/src/views/settings/EditProvider.vue
+++ b/src/views/settings/EditProvider.vue
@@ -201,12 +201,10 @@
 import ProviderIcon from "@/components/ProviderIcon.vue";
 import ProviderSaveErrorDialog from "@/components/ProviderSaveErrorDialog.vue";
 import { Button } from "@/components/ui/button";
-import {
-  mergeActionEntries,
-  mergeConfigEntries,
-} from "@/helpers/config_entry_ui";
+import { useConfigAction } from "@/composables/useConfigAction";
+import { mergeConfigEntries } from "@/helpers/config_entry_ui";
 import { canReconfigureProvider } from "@/helpers/provider_config";
-import { markdownToHtml, openActionUrlEntries } from "@/helpers/utils";
+import { markdownToHtml } from "@/helpers/utils";
 import { api } from "@/plugins/api";
 import {
   ConfigValueType,
@@ -372,48 +370,18 @@ const onImmediateApply = async function (
   }
 };
 
-const onAction = async function (
-  action: string,
-  _values: Record<string, ConfigValueType>,
-  immediateApply: boolean,
-) {
-  loading.value = true;
-  api
-    .invokeProviderConfigAction(config.value!.instance_id, action)
-    .then(async (entries) => {
-      entries = openActionUrlEntries(entries);
-      // An empty response means the action was a one-off side effect with
-      // nothing to re-render: leave the form untouched.
-      if (entries.length === 0) {
-        toast.success(t("settings.action_completed"));
-        return;
-      }
-      config.value!.values = mergeActionEntries(config.value!.values, entries);
-      // If the action has immediate_apply, save the updated values right away
-      if (immediateApply) {
-        const saveValues: Record<string, ConfigValueType> = {};
-        for (const entry of Object.values(config.value!.values)) {
-          if (entry.value !== undefined) {
-            saveValues[entry.key] = entry.value;
-          }
-        }
-        const updatedConfig = await api.saveProviderConfig(
-          config.value!.domain,
-          saveValues,
-          config.value!.instance_id,
-        );
-        for (const [key, entry] of Object.entries(updatedConfig.values)) {
-          config.value!.values[key] = entry;
-        }
-      }
-    })
-    .catch((err) => {
-      toast.error(String(err));
-    })
-    .finally(() => {
-      loading.value = false;
-    });
-};
+const { onAction } = useConfigAction({
+  config,
+  loading,
+  invokeAction: (action) =>
+    api.invokeProviderConfigAction(config.value!.instance_id, action),
+  saveValues: (values) =>
+    api.saveProviderConfig(
+      config.value!.domain,
+      values,
+      config.value!.instance_id,
+    ),
+});
 
 const getAuthorsMarkdown = function (authors: string[]) {
   const allAuthors: string[] = [];

--- a/tests/composables/useConfigAction.test.ts
+++ b/tests/composables/useConfigAction.test.ts
@@ -1,0 +1,147 @@
+import { ref } from "vue";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useConfigAction } from "@/composables/useConfigAction";
+import {
+  ConfigEntryType,
+  type ConfigEntry,
+  type ConfigValueType,
+} from "@/plugins/api/interfaces";
+
+const { toastMock } = vi.hoisted(() => ({
+  toastMock: {
+    error: vi.fn(),
+    success: vi.fn(),
+  },
+}));
+
+vi.mock("vue-sonner", () => ({
+  toast: toastMock,
+}));
+
+vi.mock("@/plugins/i18n", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/plugins/i18n")>()),
+  $t: (key: string) => key,
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("useConfigAction", () => {
+  it("shows a toast and leaves the form untouched when an action returns no entries", async () => {
+    const { config, loading, invokeAction, saveValues, onAction } = setup();
+    invokeAction.mockResolvedValueOnce([]);
+
+    await onAction("do_thing", {}, false);
+
+    expect(invokeAction).toHaveBeenCalledWith("do_thing");
+    expect(config.value!.values).toEqual({ existing: entry() });
+    expect(saveValues).not.toHaveBeenCalled();
+    expect(toastMock.success).toHaveBeenCalledWith("settings.action_completed");
+    expect(loading.value).toBe(false);
+  });
+
+  it("merges the entries an action returned into the form", async () => {
+    const { config, saveValues, invokeAction, onAction } = setup();
+    invokeAction.mockResolvedValueOnce([entry({ key: "fresh", value: "new" })]);
+
+    await onAction("do_thing", {}, false);
+
+    expect(config.value!.values).toEqual({
+      fresh: expect.objectContaining({ key: "fresh", value: "new" }),
+    });
+    expect(saveValues).not.toHaveBeenCalled();
+    expect(toastMock.success).not.toHaveBeenCalled();
+  });
+
+  it("saves the merged values and takes back the stored ones on immediate_apply", async () => {
+    const { config, saveValues, invokeAction, onAction } = setup();
+    invokeAction.mockResolvedValueOnce([entry({ key: "fresh", value: "new" })]);
+    saveValues.mockResolvedValueOnce({
+      values: { fresh: entry({ key: "fresh", value: "stored" }) },
+    });
+
+    await onAction("do_thing", {}, true);
+
+    expect(saveValues).toHaveBeenCalledWith({ fresh: "new" });
+    expect(config.value!.values.fresh.value).toBe("stored");
+  });
+
+  it("opens url entries and keeps them out of the form", async () => {
+    const openSpy = vi
+      .spyOn(HTMLAnchorElement.prototype, "click")
+      .mockImplementation(() => {});
+    const { config, invokeAction, onAction } = setup();
+    invokeAction.mockResolvedValueOnce([
+      entry({
+        key: "auth_url",
+        type: ConfigEntryType.URL,
+        value: "https://example.com/auth",
+      }),
+      entry({ key: "fresh", value: "new" }),
+    ]);
+
+    await onAction("do_thing", {}, false);
+
+    expect(openSpy).toHaveBeenCalledTimes(1);
+    expect(Object.keys(config.value!.values)).toEqual(["fresh"]);
+    openSpy.mockRestore();
+  });
+
+  it("reports a failed action and clears loading", async () => {
+    const { loading, invokeAction, onAction } = setup();
+    invokeAction.mockRejectedValueOnce("action failed");
+
+    await onAction("do_thing", {}, false);
+
+    expect(toastMock.error).toHaveBeenCalledWith("action failed");
+    expect(loading.value).toBe(false);
+  });
+
+  it("clears loading when the immediate_apply save fails", async () => {
+    const { loading, invokeAction, saveValues, onAction } = setup();
+    invokeAction.mockResolvedValueOnce([entry({ key: "fresh", value: "new" })]);
+    saveValues.mockRejectedValueOnce("save failed");
+
+    await onAction("do_thing", {}, true);
+
+    expect(toastMock.error).toHaveBeenCalledWith("save failed");
+    expect(loading.value).toBe(false);
+  });
+});
+
+function setup() {
+  const config = ref<{ values: Record<string, ConfigEntry> }>({
+    values: { existing: entry() },
+  });
+  const loading = ref(false);
+  const invokeAction = vi.fn<(action: string) => Promise<ConfigEntry[]>>();
+  const saveValues =
+    vi.fn<
+      (
+        values: Record<string, ConfigValueType>,
+      ) => Promise<{ values: Record<string, ConfigEntry> }>
+    >();
+
+  const { onAction } = useConfigAction({
+    config,
+    loading,
+    invokeAction,
+    saveValues,
+  });
+
+  return { config, loading, invokeAction, saveValues, onAction };
+}
+
+function entry(overrides: Partial<ConfigEntry> = {}): ConfigEntry {
+  return {
+    category: "generic",
+    default_value: null,
+    key: "existing",
+    label: "Existing",
+    required: false,
+    type: ConfigEntryType.STRING,
+    value: "current",
+    ...overrides,
+  } as ConfigEntry;
+}

--- a/tests/composables/useConfigAction.test.ts
+++ b/tests/composables/useConfigAction.test.ts
@@ -18,8 +18,7 @@ vi.mock("vue-sonner", () => ({
   toast: toastMock,
 }));
 
-vi.mock("@/plugins/i18n", async (importOriginal) => ({
-  ...(await importOriginal<typeof import("@/plugins/i18n")>()),
+vi.mock("@/plugins/i18n", () => ({
   $t: (key: string) => key,
 }));
 
@@ -95,6 +94,35 @@ describe("useConfigAction", () => {
     await onAction("do_thing", {}, false);
 
     expect(toastMock.error).toHaveBeenCalledWith("action failed");
+    expect(loading.value).toBe(false);
+  });
+
+  it("reports a rejected Error without its class name", async () => {
+    const { invokeAction, onAction } = setup();
+    // a dropped connection rejects in-flight commands with an Error subclass
+    const connectionLost = new Error("Connection lost");
+    connectionLost.name = "ConnectionLostError";
+    invokeAction.mockRejectedValueOnce(connectionLost);
+
+    await onAction("do_thing", {}, false);
+
+    expect(toastMock.error).toHaveBeenCalledWith("Connection lost");
+  });
+
+  it("holds loading while the action is in flight", async () => {
+    const { loading, invokeAction, onAction } = setup();
+    let release: (entries: ConfigEntry[]) => void;
+    invokeAction.mockReturnValueOnce(
+      new Promise((resolve) => {
+        release = resolve;
+      }),
+    );
+
+    const pending = onAction("do_thing", {}, false);
+    expect(loading.value).toBe(true);
+
+    release!([]);
+    await pending;
     expect(loading.value).toBe(false);
   });
 

--- a/tests/views/EditCoreConfig.test.ts
+++ b/tests/views/EditCoreConfig.test.ts
@@ -41,8 +41,7 @@ vi.mock("@/helpers/utils", () => ({
   openActionUrlEntries: <T>(entries: T) => entries,
 }));
 
-vi.mock("@/plugins/i18n", async (importOriginal) => ({
-  ...(await importOriginal<typeof import("@/plugins/i18n")>()),
+vi.mock("@/plugins/i18n", () => ({
   $t: (key: string) => key,
 }));
 

--- a/tests/views/EditCoreConfig.test.ts
+++ b/tests/views/EditCoreConfig.test.ts
@@ -41,6 +41,11 @@ vi.mock("@/helpers/utils", () => ({
   openActionUrlEntries: <T>(entries: T) => entries,
 }));
 
+vi.mock("@/plugins/i18n", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/plugins/i18n")>()),
+  $t: (key: string) => key,
+}));
+
 vi.mock("vue-sonner", () => ({
   toast: toastMock,
 }));

--- a/tests/views/EditProvider.test.ts
+++ b/tests/views/EditProvider.test.ts
@@ -60,8 +60,7 @@ vi.mock("@/helpers/utils", () => ({
   openActionUrlEntries: <T>(entries: T) => entries,
 }));
 
-vi.mock("@/plugins/i18n", async (importOriginal) => ({
-  ...(await importOriginal<typeof import("@/plugins/i18n")>()),
+vi.mock("@/plugins/i18n", () => ({
   $t: (key: string) => key,
 }));
 

--- a/tests/views/EditProvider.test.ts
+++ b/tests/views/EditProvider.test.ts
@@ -60,6 +60,11 @@ vi.mock("@/helpers/utils", () => ({
   openActionUrlEntries: <T>(entries: T) => entries,
 }));
 
+vi.mock("@/plugins/i18n", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/plugins/i18n")>()),
+  $t: (key: string) => key,
+}));
+
 vi.mock("vue-sonner", () => ({
   toast: toastMock,
 }));


### PR DESCRIPTION
The action buttons on the provider, player and core settings forms all behave the same, but each form carried its own copy of the handler. The copies had already drifted apart, so a change to how actions work meant remembering to touch three files.

- Move the shared handler into a new `useConfigAction` composable; the three forms now only supply their own API calls
- Give the core settings form the same loading-overlay handling as the other two, instead of clearing it by hand in three separate spots
- Keep the plain error text when a dropped connection interrupts an action, instead of prefixing it with the error class name
- Correct the return type of the core settings save call
- Add tests for the shared handler, covering paths the form tests could not reach

The upcoming typed action result lands in this one composable rather than in three places.