### PR TITLE
Document how a queue's active flag relates to the player's active source

### DIFF
--- a/src/plugins/api/interfaces.ts
+++ b/src/plugins/api/interfaces.ts
@@ -1081,6 +1081,11 @@ export interface QueueItem {
 
 export interface PlayerQueue {
   queue_id: string;
+  // active: whether the player is currently playing this queue. Server-derived from the
+  // player's active_source: false only while an external source (line-in, Spotify Connect,
+  // another queue in a group) has taken the player over - a stopped or finished queue stays
+  // active and idle. Recalculated ~0.5s after the active_source change that causes it, so a
+  // queue reached through active_source can briefly still read as inactive.
   active: boolean;
   display_name: string;
   available: boolean;
@@ -1254,6 +1259,10 @@ export interface Player {
   volume_muted?: boolean;
   group_members: string[];
   static_group_members: string[];
+  // active_source: id of the source the player is currently playing - its own queue_id for
+  // Music Assistant playback, or an external source id. PlayerQueue.active is derived from
+  // this, and PLAYER_UPDATED carries a new value before the queue is recalculated, so the
+  // two can disagree for about half a second during a source handover.
   active_source?: string;
   source_list: PlayerSource[];
   active_sound_mode?: string;

--- a/src/plugins/api/interfaces.ts
+++ b/src/plugins/api/interfaces.ts
@@ -1084,8 +1084,8 @@ export interface PlayerQueue {
   // active: whether the player is currently playing this queue. Server-derived from the
   // player's active_source: false only while an external source (line-in, Spotify Connect,
   // another queue in a group) has taken the player over - a stopped or finished queue stays
-  // active and idle. Recalculated ~0.5s after the active_source change that causes it, so a
-  // queue reached through active_source can briefly still read as inactive.
+  // active and idle. Recalculated ~0.5s after the active_source change that causes it, so
+  // during a handover it can briefly still hold the value from before.
   active: boolean;
   display_name: string;
   available: boolean;


### PR DESCRIPTION
PR #2272 added an `active` check to the queue timing helper, which left an open question: can a queue be inactive while the player's `active_source` still points at it, and is that a lasting state? Neither field was documented, so eight different places in the frontend guard for it independently without a shared answer.

Checked against the server: `active` is derived directly from `active_source`, so the two only disagree for about half a second during a source handover. A stopped or finished queue stays active and idle, so nothing rests in that state and no behaviour needed changing.

- Documented `PlayerQueue.active` and `Player.active_source` and how the two relate

No functional changes.
