### PR TITLE
Add tests for the settings field disabled state

### DIFF
--- a/src/views/settings/EditConfig.vue
+++ b/src/views/settings/EditConfig.vue
@@ -22,7 +22,7 @@
           :key="conf_entry.key"
           :conf-entry="conf_entry"
           :show-password-values="showPasswordValues"
-          :disabled="isDisabled(conf_entry)"
+          :disabled="isRowDisabled(conf_entry)"
           @update:value="onValueUpdate(conf_entry, $event)"
           @toggle-password="showPasswordValues = !showPasswordValues"
           @action="onEntryAction(conf_entry)"
@@ -38,7 +38,7 @@
       :protocol-panels="protocolPanels"
       :visible-entries-by-category="visibleEntriesByCategory"
       :show-password-values="showPasswordValues"
-      :is-disabled="isDisabled"
+      :is-disabled="isRowDisabled"
       :output-protocols="outputProtocols"
       @update:value="onValueUpdate"
       @action="onEntryAction"
@@ -70,7 +70,7 @@
           :key="conf_entry.key"
           :conf-entry="conf_entry"
           :show-password-values="showPasswordValues"
-          :disabled="isDisabled(conf_entry)"
+          :disabled="isRowDisabled(conf_entry)"
           @update:value="onValueUpdate(conf_entry, $event)"
           @toggle-password="showPasswordValues = !showPasswordValues"
           @action="onEntryAction(conf_entry)"
@@ -438,6 +438,12 @@ window.addEventListener("beforeunload", handleBeforeUnload);
 
 const isDisabled = function (entry: ConfigEntryUI) {
   return isEntryDisabled(entry, entries.value || []);
+};
+
+// the form-wide disabled state has to be handed to every field: v-form only reaches
+// Vuetify's own inputs, so the number field beside a slider would stay editable
+const isRowDisabled = function (entry: ConfigEntryUI) {
+  return props.disabled || isDisabled(entry);
 };
 
 const isVisible = function (entry: ConfigEntryUI) {

--- a/tests/views/ConfigEntryField.test.ts
+++ b/tests/views/ConfigEntryField.test.ts
@@ -1,0 +1,186 @@
+import { mount, type DOMWrapper, type VueWrapper } from "@vue/test-utils";
+import { describe, expect, it, vi } from "vitest";
+import { createVuetify } from "vuetify";
+import * as components from "vuetify/components";
+import * as directives from "vuetify/directives";
+import {
+  ConfigEntryType,
+  type ConfigEntry,
+  type ConfigValueType,
+} from "@/plugins/api/interfaces";
+import {
+  NON_INTERACTIVE_ENTRY_TYPES,
+  type ConfigEntryUI,
+} from "@/helpers/config_entry_ui";
+import ConfigEntryField from "@/views/settings/ConfigEntryField.vue";
+
+vi.mock("@/plugins/i18n", () => ({
+  $t: (key: string) => key,
+}));
+
+// A `disabled` binding only proves anything once it reaches a rendered control, so this
+// suite mounts the real Vuetify and reka-ui controls instead of stubbing them.
+const vuetify = createVuetify({ components, directives });
+
+const IMAGE_DATA_URI =
+  "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAAAAAA6fptVAAAACklEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg==";
+
+const INTERACTIVE_ENTRIES: [string, ConfigEntry][] = [
+  ["a text input", entry({ key: "name", type: ConfigEntryType.STRING })],
+  [
+    "a password input",
+    entry({ key: "password", type: ConfigEntryType.SECURE_STRING }),
+  ],
+  ["a checkbox", entry({ key: "flow_mode", type: ConfigEntryType.BOOLEAN })],
+  ["an icon picker", entry({ key: "icon", type: ConfigEntryType.ICON })],
+  [
+    "a dropdown",
+    entry({
+      key: "output_codec",
+      type: ConfigEntryType.STRING,
+      options: [
+        { title: "FLAC", value: "flac" },
+        { title: "MP3", value: "mp3" },
+      ],
+      value: "flac",
+    }),
+  ],
+  [
+    "an action button",
+    entry({
+      key: "authenticate",
+      type: ConfigEntryType.ACTION,
+      action: "authenticate",
+    }),
+  ],
+  [
+    "a number input without a range",
+    entry({ key: "port", type: ConfigEntryType.INTEGER, value: 8095 }),
+  ],
+];
+
+describe("ConfigEntryField", () => {
+  it.each([ConfigEntryType.INTEGER, ConfigEntryType.FLOAT])(
+    "disables the slider and the number input of a ranged %s entry together",
+    (type) => {
+      expect(sliderRowStates(mountField(rangedEntry(type)))).toEqual({
+        slider: false,
+        input: false,
+        decrement: false,
+        increment: false,
+      });
+
+      expect(sliderRowStates(mountField(rangedEntry(type), true))).toEqual({
+        slider: true,
+        input: true,
+        decrement: true,
+        increment: true,
+      });
+    },
+  );
+
+  it.each(INTERACTIVE_ENTRIES)("disables %s", (_label, confEntry) => {
+    expect(controlStates(mountField(confEntry))).toEqual([false]);
+    expect(controlStates(mountField(confEntry, true))).toEqual([true]);
+  });
+
+  // these types take no disabled binding; a form hides them while their dependency is unmet
+  it.each(NON_INTERACTIVE_ENTRY_TYPES)(
+    "renders a %s entry with no control to disable",
+    (type) => {
+      // value is what the image branch renders; the other three ignore it
+      const wrapper = mountField(
+        entry({
+          key: "status",
+          type: type as ConfigEntryType,
+          label: "Nothing to configure",
+          value: IMAGE_DATA_URI,
+        }),
+        true,
+      );
+
+      expect(wrapper.html()).toContain("Nothing to configure");
+      expect(controlStates(wrapper)).toEqual([]);
+    },
+  );
+
+  it("disables a read_only entry while the form itself is enabled", () => {
+    const confEntry = entry({
+      key: "server_id",
+      type: ConfigEntryType.STRING,
+      read_only: true,
+    });
+
+    expect(controlStates(mountField(confEntry))).toEqual([true]);
+  });
+
+  it("disables a read_only ranged entry while the form itself is enabled", () => {
+    const confEntry = {
+      ...rangedEntry(ConfigEntryType.INTEGER),
+      read_only: true,
+    };
+
+    expect(sliderRowStates(mountField(confEntry))).toEqual({
+      slider: true,
+      input: true,
+      decrement: true,
+      increment: true,
+    });
+  });
+});
+
+function entry(
+  overrides: Partial<ConfigEntry> & { key: string; type: ConfigEntryType },
+): ConfigEntry {
+  return {
+    category: "generic",
+    default_value: null,
+    label: overrides.key,
+    required: false,
+    value: null as ConfigValueType,
+    ...overrides,
+  } as ConfigEntry;
+}
+
+function rangedEntry(type: ConfigEntryType): ConfigEntry {
+  return entry({ key: "crossfade_duration", type, range: [0, 10], value: 5 });
+}
+
+function mountField(confEntry: ConfigEntryUI, disabled = false) {
+  return mount(ConfigEntryField, {
+    props: { confEntry, showPasswordValues: false, disabled },
+    global: { plugins: [vuetify] },
+  });
+}
+
+/**
+ * The disabled state of every control the field rendered, in document order.
+ *
+ * A v-select mirrors its value into a hidden native select that no user can reach,
+ * so hidden elements are left out.
+ */
+function controlStates(wrapper: VueWrapper): boolean[] {
+  return wrapper
+    .findAll("input, button, textarea, select")
+    .filter((el) => el.attributes("hidden") === undefined)
+    .map(isDisabled);
+}
+
+/**
+ * The disabled state of each control in the slider row, keyed by the control it belongs
+ * to: the slider itself plus the number field's input and its two step buttons.
+ */
+function sliderRowStates(wrapper: VueWrapper): Record<string, boolean> {
+  const numberFieldParts = wrapper
+    .findAll("[data-slot]")
+    .map((el) => [el.attributes("data-slot") as string, isDisabled(el)]);
+
+  return {
+    slider: isDisabled(wrapper.get(".config-slider input")),
+    ...Object.fromEntries(numberFieldParts),
+  };
+}
+
+function isDisabled(el: Pick<DOMWrapper<Element>, "attributes">): boolean {
+  return el.attributes("disabled") !== undefined;
+}

--- a/tests/views/ConfigEntryField.test.ts
+++ b/tests/views/ConfigEntryField.test.ts
@@ -165,8 +165,10 @@ function mountField(confEntry: ConfigEntryUI, disabled = false) {
 /**
  * The disabled state of every control the field rendered, in document order.
  *
- * A v-select mirrors its value into a hidden native select that no user can reach,
- * so hidden elements are left out.
+ * Elements carrying the `hidden` attribute are left out, since a v-select mirrors its
+ * value into a hidden native select that no user can reach. Everything else counts, so
+ * a control that escapes the field's disabled state fails the assertion rather than
+ * being filtered away.
  */
 function controlStates(wrapper: VueWrapper): boolean[] {
   return wrapper

--- a/tests/views/ConfigEntryField.test.ts
+++ b/tests/views/ConfigEntryField.test.ts
@@ -57,6 +57,15 @@ const INTERACTIVE_ENTRIES: [string, ConfigEntry][] = [
     "a number input without a range",
     entry({ key: "port", type: ConfigEntryType.INTEGER, value: 8095 }),
   ],
+  [
+    "a multi-value combobox",
+    entry({
+      key: "manual_discovery_ips",
+      type: ConfigEntryType.STRING,
+      multi_value: true,
+      value: ["192.168.1.10"],
+    }),
+  ],
 ];
 
 describe("ConfigEntryField", () => {
@@ -167,12 +176,12 @@ function controlStates(wrapper: VueWrapper): boolean[] {
 }
 
 /**
- * The disabled state of each control in the slider row, keyed by the control it belongs
- * to: the slider itself plus the number field's input and its two step buttons.
+ * The disabled state of each control in the slider row: the value input Vuetify renders
+ * for the slider, plus the number field's own input and its two step buttons.
  */
 function sliderRowStates(wrapper: VueWrapper): Record<string, boolean> {
   const numberFieldParts = wrapper
-    .findAll("[data-slot]")
+    .findAll(".config-slider-input [data-slot]")
     .map((el) => [el.attributes("data-slot") as string, isDisabled(el)]);
 
   return {

--- a/tests/views/EditConfig.test.ts
+++ b/tests/views/EditConfig.test.ts
@@ -107,6 +107,31 @@ describe("EditConfig", () => {
     expect(rows[0].props("disabled")).toBe(true);
   });
 
+  it("disables every field while the whole form is disabled", () => {
+    const wrapper = mountEntries(
+      [
+        entry({ key: "enable_feature", type: ConfigEntryType.BOOLEAN }),
+        entry({ key: "feature_detail", type: ConfigEntryType.STRING }),
+      ],
+      true,
+    );
+
+    const rows = wrapper.findAllComponents({ name: "ConfigEntryRow" });
+    expect(rows.map((row) => row.props("disabled"))).toEqual([true, true]);
+  });
+
+  it("keeps a label visible while the whole form is disabled", () => {
+    const wrapper = mountEntries(
+      [
+        entry({ key: "enable_feature", type: ConfigEntryType.BOOLEAN }),
+        entry({ key: "feature_status", type: ConfigEntryType.LABEL }),
+      ],
+      true,
+    );
+
+    expect(renderedKeys(wrapper)).toEqual(["enable_feature", "feature_status"]);
+  });
+
   it("reveals a label as soon as the dependency flips, without a save", async () => {
     const entries = [
       entry({ key: "enable_feature", type: ConfigEntryType.BOOLEAN }),
@@ -226,9 +251,9 @@ function dependentEntry(
   });
 }
 
-function mountEntries(configEntries: ConfigEntry[]) {
+function mountEntries(configEntries: ConfigEntry[], disabled = false) {
   return shallowMount(EditConfig, {
-    props: { configEntries, disabled: false },
+    props: { configEntries, disabled },
     global: { renderStubDefaultSlot: true },
   });
 }


### PR DESCRIPTION
Settings with an unmet dependency recently stayed editable through the number box next to their slider (#2273). The settings field component had no test file at all, so nothing caught it - and the same gap turned out to still be open on a second path.

While a whole settings form is disabled (a disabled provider's settings page), only Vuetify's own inputs were greyed out, because the form-wide disabled state was applied by `v-form` and never handed to the fields themselves. The number box next to each slider stayed fully editable.

- hand the form-wide disabled state to every field instead of relying on `v-form`
- new `tests/views/ConfigEntryField.test.ts`, mounting the real Vuetify and reka-ui controls so a disabled binding is checked on the rendered control
- covers the slider + number input pair, text, password, checkbox, icon picker, dropdown, combobox, action button and plain number field
- covers divider/label/alert/image, which have no control to disable, and `read_only`, which disables a field on its own
