### PR TITLE
Fix Save button blocked by a setting you cannot fill in

### DIFF
--- a/src/components/SetupFlowDialog.vue
+++ b/src/components/SetupFlowDialog.vue
@@ -313,6 +313,7 @@ import { Progress } from "@/components/ui/progress";
 import { Spinner } from "@/components/ui/spinner";
 import { serverNow } from "@/composables/useServerTime";
 import {
+  allRequiredValuesPresent,
   isEntryDisabled,
   NON_INTERACTIVE_ENTRY_TYPES,
   VALUELESS_ENTRY_TYPES,
@@ -434,21 +435,9 @@ const visibleFormEntries = computed(() =>
   ),
 );
 
-const canSubmit = computed(() => {
-  if (busy.value) return false;
-  for (const entry of formEntries.value) {
-    if (VALUELESS_ENTRY_TYPES.includes(entry.type)) continue;
-    if (isDisabled(entry)) continue;
-    if (
-      entry.required &&
-      isNullOrUndefined(entry.value) &&
-      isNullOrUndefined(entry.default_value)
-    ) {
-      return false;
-    }
-  }
-  return true;
-});
+const canSubmit = computed(
+  () => !busy.value && allRequiredValuesPresent(formEntries.value),
+);
 
 const canOpenInstanceSettings = computed(
   () => launch.value?.kind === "provider" && !!step.value?.result?.instance_id,
@@ -776,9 +765,5 @@ function onEntryHelp(entry: ConfigEntry) {
 
 function isDisabled(entry: ConfigEntry): boolean {
   return isEntryDisabled(entry, formEntries.value);
-}
-
-function isNullOrUndefined(value: unknown): boolean {
-  return value === null || value === undefined;
 }
 </script>

--- a/src/helpers/config_entry_ui.ts
+++ b/src/helpers/config_entry_ui.ts
@@ -64,6 +64,10 @@ type DependencyFields = Pick<
   "key" | "value" | "depends_on" | "depends_on_value" | "depends_on_value_not"
 >;
 
+// what a required-value check reads on top of the dependency it also evaluates
+type ValidationFields = DependencyFields &
+  Pick<ConfigEntry, "required" | "default_value"> & { type: ConfigEntryUIType };
+
 /**
  * Whether `entry` should be disabled because its `depends_on` dependency is unmet
  * within `entries`.
@@ -90,6 +94,27 @@ export const isEntryDisabled = (
   }
   return !dependencyValue;
 };
+
+/**
+ * Whether every required entry in `entries` holds something to submit.
+ *
+ * An entry counts as satisfied by its own value or by a default the server will fall
+ * back to. Entries the user cannot fill in never block a submission: those carrying no
+ * value at all, and those {@link isEntryDisabled} gates behind an unmet dependency —
+ * including a dependency naming a key that is not on the form, which is unsatisfiable
+ * by definition.
+ */
+export const allRequiredValuesPresent = (
+  entries: readonly ValidationFields[],
+): boolean =>
+  entries.every(
+    (entry) =>
+      !entry.required ||
+      VALUELESS_ENTRY_TYPES.includes(entry.type) ||
+      isEntryDisabled(entry, entries) ||
+      !isNullOrUndefined(entry.value) ||
+      !isNullOrUndefined(entry.default_value),
+  );
 
 export const isInjected = (e: ConfigEntryUI): e is InjectedConfigEntry =>
   (e as InjectedConfigEntry).injected === true;

--- a/src/helpers/config_entry_ui.ts
+++ b/src/helpers/config_entry_ui.ts
@@ -64,7 +64,7 @@ type DependencyFields = Pick<
   "key" | "value" | "depends_on" | "depends_on_value" | "depends_on_value_not"
 >;
 
-// what a required-value check reads on top of the dependency it also evaluates
+// the fields a required-value check reads, on top of the dependency fields it also evaluates
 type ValidationFields = DependencyFields &
   Pick<ConfigEntry, "required" | "default_value"> & { type: ConfigEntryUIType };
 
@@ -99,8 +99,8 @@ export const isEntryDisabled = (
  * Whether every required entry in `entries` holds something to submit.
  *
  * An entry counts as satisfied by its own value or by a default the server will fall
- * back to. Entries the user cannot fill in never block a submission: those carrying no
- * value at all, and those {@link isEntryDisabled} gates behind an unmet dependency —
+ * back to. Two kinds never block a submission: {@link VALUELESS_ENTRY_TYPES}, which hold
+ * nothing to give, and those {@link isEntryDisabled} gates behind an unmet dependency —
  * including a dependency naming a key that is not on the form, which is unsatisfiable
  * by definition.
  */

--- a/src/views/settings/EditConfig.vue
+++ b/src/views/settings/EditConfig.vue
@@ -160,6 +160,7 @@
 
 <script setup lang="ts">
 import {
+  allRequiredValuesPresent,
   ConfigEntryUI,
   isEntryDisabled,
   isInjected,
@@ -261,23 +262,9 @@ const protocolPanels = computed(() => {
   return panels.value.filter((p) => isProtocolCategory(p));
 });
 
-const requiredValuesPresent = computed(() => {
-  if (entries.value) {
-    for (const entry of entries.value) {
-      if (
-        entry.required &&
-        !(
-          !isNullOrUndefined(entry.value) ||
-          !isNullOrUndefined(entry.default_value) ||
-          VALUELESS_ENTRY_TYPES.includes(entry.type)
-        )
-      )
-        return false;
-    }
-    return true;
-  }
-  return false;
-});
+const requiredValuesPresent = computed(() =>
+  entries.value ? allRequiredValuesPresent(entries.value) : false,
+);
 
 const hasUnsavedChanges = computed(() => {
   if (!entries.value) return false;
@@ -448,9 +435,6 @@ onBeforeUnmount(() => {
 
 // Add listener when component mounts
 window.addEventListener("beforeunload", handleBeforeUnload);
-const isNullOrUndefined = function (value: unknown) {
-  return value === null || value === undefined;
-};
 
 const isDisabled = function (entry: ConfigEntryUI) {
   return isEntryDisabled(entry, entries.value || []);

--- a/tests/components/SetupFlowDialog.test.ts
+++ b/tests/components/SetupFlowDialog.test.ts
@@ -1,4 +1,4 @@
-import { flushPromises, shallowMount } from "@vue/test-utils";
+import { flushPromises, shallowMount, type VueWrapper } from "@vue/test-utils";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   ConfigEntryType,
@@ -257,7 +257,59 @@ describe("SetupFlowDialog", () => {
     ).toEqual(["feature_detail"]);
     expect(rows[0].props("disabled")).toBe(true);
   });
+
+  it("offers the next step despite a required entry behind an unmet dependency", async () => {
+    const wrapper = await mountFormStep([
+      entry({ key: "use_proxy", type: ConfigEntryType.BOOLEAN, value: false }),
+      entry({
+        key: "proxy_url",
+        type: ConfigEntryType.STRING,
+        required: true,
+        depends_on: "use_proxy",
+      }),
+    ]);
+
+    expect(submitDisabled(wrapper)).toBe(false);
+  });
+
+  it("withholds the next step once that dependency is met", async () => {
+    const wrapper = await mountFormStep([
+      entry({ key: "use_proxy", type: ConfigEntryType.BOOLEAN, value: true }),
+      entry({
+        key: "proxy_url",
+        type: ConfigEntryType.STRING,
+        required: true,
+        depends_on: "use_proxy",
+      }),
+    ]);
+
+    expect(submitDisabled(wrapper)).toBe(true);
+  });
 });
+
+async function mountFormStep(entries: ConfigEntry[]) {
+  apiMock.reconfigureProvider.mockResolvedValue(formStep(entries));
+  const wrapper = shallowMount(SetupFlowDialog, {
+    global: { renderStubDefaultSlot: true },
+  });
+
+  await launchSetupFlow?.({
+    kind: "reconfigure",
+    instanceId: "spotify--test",
+    onFlowEnded: vi.fn(),
+  });
+  await flushPromises();
+
+  return wrapper;
+}
+
+function submitDisabled(wrapper: VueWrapper) {
+  const button = wrapper
+    .findAll("button-stub")
+    .find((btn) => btn.text() === "settings.setup_flow.next");
+  if (!button) throw new Error("submit button not rendered");
+  return button.attributes("disabled") === "true";
+}
 
 function terminalStep(type: FlowStepType): SetupFlowStep {
   return {

--- a/tests/helpers/config_entry_ui.test.ts
+++ b/tests/helpers/config_entry_ui.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  allRequiredValuesPresent,
   isEntryDisabled,
   mergeActionEntries,
   mergeConfigEntries,
@@ -117,6 +118,72 @@ describe("isEntryDisabled", () => {
     ];
 
     expect(isEntryDisabled(target, form)).toBe(false);
+  });
+});
+
+describe("allRequiredValuesPresent", () => {
+  const required = (overrides: Partial<ConfigEntry> = {}) =>
+    entry({ key: "token", required: true, ...overrides });
+
+  it("accepts a form without required entries", () => {
+    expect(allRequiredValuesPresent([entry()])).toBe(true);
+  });
+
+  it("rejects a required entry with neither a value nor a default", () => {
+    expect(allRequiredValuesPresent([required()])).toBe(false);
+  });
+
+  it("accepts a required entry the user filled in", () => {
+    expect(allRequiredValuesPresent([required({ value: "abc" })])).toBe(true);
+  });
+
+  it("accepts a required entry the server defaults", () => {
+    expect(allRequiredValuesPresent([required({ default_value: "abc" })])).toBe(
+      true,
+    );
+  });
+
+  it("accepts a falsy value as present", () => {
+    expect(allRequiredValuesPresent([required({ value: false })])).toBe(true);
+    expect(allRequiredValuesPresent([required({ default_value: 0 })])).toBe(
+      true,
+    );
+  });
+
+  it.each([
+    ConfigEntryType.DIVIDER,
+    ConfigEntryType.LABEL,
+    ConfigEntryType.ALERT,
+    ConfigEntryType.IMAGE,
+    ConfigEntryType.ACTION,
+  ])("ignores a required %s, which holds no value to give", (type) => {
+    expect(allRequiredValuesPresent([required({ type })])).toBe(true);
+  });
+
+  it("ignores a required entry behind an unmet dependency", () => {
+    const form = [
+      entry({ key: "use_proxy", type: ConfigEntryType.BOOLEAN, value: false }),
+      required({ depends_on: "use_proxy" }),
+    ];
+
+    expect(allRequiredValuesPresent(form)).toBe(true);
+  });
+
+  it("enforces a required entry once its dependency is met", () => {
+    const form = [
+      entry({ key: "use_proxy", type: ConfigEntryType.BOOLEAN, value: true }),
+      required({ depends_on: "use_proxy" }),
+    ];
+
+    expect(allRequiredValuesPresent(form)).toBe(false);
+  });
+
+  // a dependency key that is not on the form leaves the entry permanently disabled,
+  // so enforcing it would deadlock the form rather than surface the mistake
+  it("ignores a required entry whose dependency key is not on the form", () => {
+    expect(allRequiredValuesPresent([required({ depends_on: "typo" })])).toBe(
+      true,
+    );
   });
 });
 

--- a/tests/views/EditConfig.test.ts
+++ b/tests/views/EditConfig.test.ts
@@ -154,6 +154,53 @@ describe("EditConfig", () => {
 
     expect(saveDisabled(wrapper)).toBe(true);
   });
+
+  // an unmet dependency greys the input out, so a required entry behind one is
+  // unfillable and must not hold the whole form hostage
+  it("saves a dirty form despite a required entry behind an unmet dependency", async () => {
+    const wrapper = mountEntries([
+      entry({ key: "server", type: ConfigEntryType.STRING }),
+      entry({
+        key: "use_proxy",
+        type: ConfigEntryType.BOOLEAN,
+        value: false,
+      }),
+      entry({
+        key: "proxy_url",
+        type: ConfigEntryType.STRING,
+        required: true,
+        depends_on: "use_proxy",
+      }),
+    ]);
+
+    dirty(wrapper);
+    await nextTick();
+
+    expect(saveDisabled(wrapper)).toBe(false);
+  });
+
+  it("blocks saving again once the dependency is met", async () => {
+    const entries = [
+      entry({ key: "server", type: ConfigEntryType.STRING }),
+      entry({ key: "use_proxy", type: ConfigEntryType.BOOLEAN, value: false }),
+      entry({
+        key: "proxy_url",
+        type: ConfigEntryType.STRING,
+        required: true,
+        depends_on: "use_proxy",
+      }),
+    ];
+    const wrapper = mountEntries(entries);
+    dirty(wrapper);
+
+    const toggle = wrapper
+      .findAllComponents({ name: "ConfigEntryRow" })[1]
+      .props("confEntry") as ConfigEntry;
+    toggle.value = true;
+    await nextTick();
+
+    expect(saveDisabled(wrapper)).toBe(true);
+  });
 });
 
 function entry(


### PR DESCRIPTION
A setting that is marked required but sits behind a toggle that is switched off is greyed out — there is no way to type anything into it. The settings page still counted it as an unfilled required field, so the Save button stayed disabled and nothing else on that page could be saved either. The provider setup wizard already skipped these.

Not reachable with the settings any provider ships today, so this is a latent fix rather than a reported bug.

- Settings pages no longer count a greyed-out setting as blocking Save
- The settings page and the setup wizard now share one check instead of two hand-copied copies of it, which had already drifted apart three times (#2270, #2273, #2275)

Note: the server's own config validation does not look at `depends_on` either, so it would still reject such a setting on save. This is the frontend half; the server needs the matching skip for the case to work end to end.
