### PR TITLE
Guard the startup order in the app initialization tests

### DIFF
--- a/tests/App.test.ts
+++ b/tests/App.test.ts
@@ -397,10 +397,48 @@ describe("App initialization", () => {
       new Set<string>(["party", "music_quiz", "ai_radio"]),
     );
     expect(mockInitializeWebPlayerModeSync).toHaveBeenCalledOnce();
+    expectStartupDataRequestedBeforeReveal();
 
     await signalProvidersUpdated();
     expect(apiMock.getProviderConfigs).toHaveBeenCalledTimes(6);
     expect(mockPruneStaleProviderFilters).toHaveBeenCalledTimes(2);
+  });
+
+  it("waits for the startup data before revealing the main app", async () => {
+    const serverState = createDeferred<void>();
+    const pluginConfigs = createDeferred<Array<{ enabled: boolean }>>();
+    apiMock.fetchState.mockReturnValue(serverState.promise);
+    apiMock.getProviderConfigs.mockReturnValue(pluginConfigs.promise);
+    const { default: App } = await import("@/App.vue");
+    wrapper = shallowMount(App, {
+      global: {
+        stubs: {
+          RouterView: true,
+        },
+      },
+    });
+
+    await flushPromises();
+    expect(apiMock.fetchState).toHaveBeenCalledOnce();
+    expectLibraryCountsNotCalled();
+    expect(apiMock.getProviderConfigs).not.toHaveBeenCalled();
+    expect(apiMock.state.value).not.toBe("initialized");
+
+    serverState.resolve();
+    await flushPromises();
+    expectLibraryCountsCalled();
+    expect(apiMock.getProviderConfigs).toHaveBeenCalledTimes(3);
+    // The plugin lookups are still in flight: revealing the app here would
+    // render it with an unknown set of enabled plugins.
+    expect(apiMock.state.value).not.toBe("initialized");
+    expect(mockInitializeWebPlayerModeSync).not.toHaveBeenCalled();
+    expect(wrapper.find("router-view-stub").exists()).toBe(false);
+
+    pluginConfigs.resolve([{ enabled: true }]);
+    await flushPromises();
+    expect(apiMock.state.value).toBe("initialized");
+    expect(wrapper.find("router-view-stub").exists()).toBe(true);
+    expectStartupDataRequestedBeforeReveal();
   });
 
   it.each(["party", "music_quiz"] as const)(
@@ -791,6 +829,41 @@ function expectLibraryCountsCalled() {
   expect(apiMock.getLibraryPodcastsCount).toHaveBeenCalledOnce();
   expect(apiMock.getLibraryRadiosCount).toHaveBeenCalledOnce();
   expect(apiMock.getLibraryTracksCount).toHaveBeenCalledOnce();
+}
+
+/**
+ * Assert that every startup request is made before the app reveals itself,
+ * which it does right after marking the connection initialized.
+ */
+function expectStartupDataRequestedBeforeReveal() {
+  expect(mockInitializeWebPlayerModeSync).toHaveBeenCalledOnce();
+  const [revealed] = mockInitializeWebPlayerModeSync.mock.invocationCallOrder;
+  for (const method of [
+    apiMock.fetchState,
+    apiMock.getLibraryAlbumsCount,
+    apiMock.getLibraryArtistsCount,
+    apiMock.getLibraryAudiobooksCount,
+    apiMock.getLibraryGenresCount,
+    apiMock.getLibraryPlaylistsCount,
+    apiMock.getLibraryPodcastsCount,
+    apiMock.getLibraryRadiosCount,
+    apiMock.getLibraryTracksCount,
+    apiMock.getProviderConfigs,
+  ]) {
+    expect(method).toHaveBeenCalled();
+    expect(Math.max(...method.mock.invocationCallOrder)).toBeLessThan(revealed);
+  }
+}
+
+/**
+ * Create a promise the test resolves itself, to hold a startup step open.
+ */
+function createDeferred<T = void>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
 }
 
 function createStorage(): Storage {


### PR DESCRIPTION
The app initialization tests did not check *when* the app is revealed during startup. Dropping an `await` on the state fetch or on the plugin lookups kept the whole suite green, and marking the connection initialized too early only tripped an unrelated locale test. In the real app either mistake shows the main UI before the user info, library counts and plugin state have loaded, so it briefly renders empty or wrong content.

- Added a test that holds the state fetch and the plugin lookups open, checking that each startup step waits for the previous one and that the app is only revealed once they have all finished
- Pinned the startup call order in the existing regular-user test, so every startup request has to happen before the app reveals itself

Test coverage only, no source changes.