### PR TITLE
Clean up a stale queue lookup in the party guest page

### DIFF
--- a/src/composables/guest/useGuestQueue.ts
+++ b/src/composables/guest/useGuestQueue.ts
@@ -5,7 +5,6 @@
 
 import { ref, computed, watch, nextTick } from "vue";
 import api from "@/plugins/api";
-import { store } from "@/plugins/store";
 import type { PlayerQueue, QueueItem } from "@/plugins/api/interfaces";
 import { EventType, type EventMessage } from "@/plugins/api/interfaces";
 import { currentQueueIndex as resolveCurrentQueueIndex } from "@/helpers/queue_position";
@@ -19,7 +18,7 @@ export function useGuestQueue(options?: { onItemsChanged?: () => void }) {
   const loadingMoreQueueItems = ref(false);
 
   const currentQueue = computed(() => {
-    const queueId = partyQueueId.value || store.activePlayerQueue?.queue_id;
+    const queueId = partyQueueId.value;
     return queueId ? api.queues[queueId] : null;
   });
 
@@ -73,7 +72,7 @@ export function useGuestQueue(options?: { onItemsChanged?: () => void }) {
   );
 
   const fetchQueueItems = async (reset = true) => {
-    const queueId = partyQueueId.value || store.activePlayerQueue?.queue_id;
+    const queueId = partyQueueId.value;
     if (!queueId) {
       queueItems.value = [];
       return;
@@ -134,8 +133,7 @@ export function useGuestQueue(options?: { onItemsChanged?: () => void }) {
     const unsub1 = api.subscribe(
       EventType.QUEUE_ITEMS_UPDATED,
       (evt: EventMessage) => {
-        const queueId = partyQueueId.value || store.activePlayerQueue?.queue_id;
-        if (evt.object_id === queueId) {
+        if (evt.object_id === partyQueueId.value) {
           fetchQueueItems(true);
         }
       },
@@ -144,8 +142,7 @@ export function useGuestQueue(options?: { onItemsChanged?: () => void }) {
     const unsub2 = api.subscribe(
       EventType.QUEUE_UPDATED,
       (evt: EventMessage) => {
-        const queueId = partyQueueId.value || store.activePlayerQueue?.queue_id;
-        if (evt.object_id === queueId) {
+        if (evt.object_id === partyQueueId.value) {
           const currentIdx = currentQueueIndex.value;
           const fetchedStart = queueFetchOffset.value;
           const fetchedEnd = fetchedStart + queueItems.value.length;

--- a/tests/composables/useGuestQueue.test.ts
+++ b/tests/composables/useGuestQueue.test.ts
@@ -1,23 +1,21 @@
 import {
   EventType,
   PlaybackState,
+  type EventMessage,
   type PlayerQueue,
 } from "@/plugins/api/interfaces";
+import { BEFORE_FIRST_INDEX } from "@/helpers/queue_position";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const { mockSendCommand, mockGetPlayerQueueItems, mockSubscribe, storeMock } =
-  vi.hoisted(() => {
+const { mockSendCommand, mockGetPlayerQueueItems, mockSubscribe } = vi.hoisted(
+  () => {
     return {
       mockSendCommand: vi.fn(),
       mockGetPlayerQueueItems: vi.fn(),
       mockSubscribe: vi.fn(),
-      storeMock: {
-        activePlayerQueue: { queue_id: "queue1" } as {
-          queue_id: string;
-        } | null,
-      },
     };
-  });
+  },
+);
 
 vi.mock("@/plugins/api", () => {
   return {
@@ -30,10 +28,6 @@ vi.mock("@/plugins/api", () => {
   };
 });
 
-vi.mock("@/plugins/store", () => ({
-  store: storeMock,
-}));
-
 // Import after mocks so that composable uses the mocked modules
 import api from "@/plugins/api";
 import { useGuestQueue } from "@/composables/guest/useGuestQueue";
@@ -43,11 +37,10 @@ describe("useGuestQueue", () => {
     mockSendCommand.mockReset();
     mockGetPlayerQueueItems.mockReset();
     mockSubscribe.mockReset();
-    storeMock.activePlayerQueue = { queue_id: "queue1" };
     for (const key of Object.keys(api.queues)) delete api.queues[key];
   });
 
-  it("fetches queue items using active player queue when no party queue id is set", async () => {
+  it("fetches queue items for the party queue", async () => {
     const queue = {
       queue_id: "queue1",
       current_index: 5,
@@ -58,8 +51,14 @@ describe("useGuestQueue", () => {
     mockSendCommand.mockResolvedValueOnce(queue);
     mockGetPlayerQueueItems.mockResolvedValueOnce(items);
 
-    const { queueItems, queueFetchOffset, queueTotalItems, fetchQueueItems } =
-      useGuestQueue();
+    const {
+      partyQueueId,
+      queueItems,
+      queueFetchOffset,
+      queueTotalItems,
+      fetchQueueItems,
+    } = useGuestQueue();
+    partyQueueId.value = "queue1";
 
     await fetchQueueItems(true);
 
@@ -73,8 +72,7 @@ describe("useGuestQueue", () => {
     expect(queueItems.value).toEqual(items);
   });
 
-  it("returns early when no active queue id is available", async () => {
-    storeMock.activePlayerQueue = null;
+  it("returns early when no party queue id is set", async () => {
     const { queueItems, fetchQueueItems } = useGuestQueue();
 
     await fetchQueueItems(true);
@@ -103,12 +101,14 @@ describe("useGuestQueue", () => {
       .mockResolvedValueOnce(moreItems);
 
     const {
+      partyQueueId,
       queueItems,
       queueFetchOffset,
       queueTotalItems,
       fetchQueueItems,
       handleQueueScroll,
     } = useGuestQueue();
+    partyQueueId.value = "queue1";
 
     await fetchQueueItems(true);
 
@@ -148,7 +148,7 @@ describe("useGuestQueue", () => {
     expect(currentQueueIndex.value).toBe(3);
   });
 
-  it("falls back to the active player queue when no party queue id is set", () => {
+  it("exposes no queue when no party queue id is set", () => {
     api.queues["queue1"] = {
       queue_id: "queue1",
       current_index: 7,
@@ -157,8 +157,8 @@ describe("useGuestQueue", () => {
 
     const { currentQueue, currentQueueIndex } = useGuestQueue();
 
-    expect(currentQueue.value?.queue_id).toBe("queue1");
-    expect(currentQueueIndex.value).toBe(7);
+    expect(currentQueue.value).toBeNull();
+    expect(currentQueueIndex.value).toBe(BEFORE_FIRST_INDEX);
   });
 
   it("subscribes to queue events and returns a cleanup function", () => {
@@ -187,5 +187,40 @@ describe("useGuestQueue", () => {
 
     expect(unsub1).toHaveBeenCalledTimes(1);
     expect(unsub2).toHaveBeenCalledTimes(1);
+  });
+
+  it.each([
+    ["QUEUE_ITEMS_UPDATED", 0],
+    ["QUEUE_UPDATED", 1],
+  ])("only refetches for %s events targeting the party queue", (_name, i) => {
+    mockSubscribe.mockReturnValue(vi.fn());
+    mockSendCommand.mockResolvedValue({
+      queue_id: "party-player",
+      current_index: 0,
+      items: 1,
+    });
+    mockGetPlayerQueueItems.mockResolvedValue([{ queue_item_id: "item1" }]);
+
+    const { partyQueueId, subscribeToEvents } = useGuestQueue();
+    subscribeToEvents();
+
+    const handler = mockSubscribe.mock.calls[i][1] as (
+      evt: EventMessage,
+    ) => void;
+
+    // Without a party queue id, an event carrying no object_id must not match either
+    handler({ object_id: "other-queue" } as EventMessage);
+    handler({} as EventMessage);
+    expect(mockSendCommand).not.toHaveBeenCalled();
+
+    partyQueueId.value = "party-player";
+
+    handler({ object_id: "other-queue" } as EventMessage);
+    expect(mockSendCommand).not.toHaveBeenCalled();
+
+    handler({ object_id: "party-player" } as EventMessage);
+    expect(mockSendCommand).toHaveBeenCalledWith("player_queues/get", {
+      queue_id: "party-player",
+    });
   });
 });


### PR DESCRIPTION
The party guest queue composable looked up its queue id as "the party queue, or else the active player's queue". That second half never adds anything: the guest page sets the active player to the same id it already stores as the party queue, and nothing else in a guest session changes it. The one case where the two differ is when the party player goes away - the party queue id clears but the active player id keeps its old value, so the fallback would resolve a stale, non-party queue.

- Derive the guest queue id from the party queue only, in one place instead of four
- Drop the now-unused store dependency from the composable
- Rework the tests to drive the party queue id, keeping the "no queue available" cases
- Add coverage that queue events only trigger a refetch for the party queue