### PR TITLE
Make the self-closing tag lint rule actually run

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -47,8 +47,8 @@ export default defineConfigWithVueTs(
   eslintConfigPrettier,
   oxlint.configs["flat/recommended"],
   {
-    // Must stay after the two blocks above: `eslint-config-prettier` turns
-    // `vue/html-self-closing` off wholesale, so configuring it any earlier
+    // Must stay after `eslintConfigPrettier`, which turns
+    // `vue/html-self-closing` off wholesale — configuring it any earlier
     // leaves it disabled. Prettier only dictates the `void` style (it always
     // self-closes `<img>` and friends), which is what `void: "always"` asks
     // for, so the two agree and the remaining tag styles stay ours to pick.

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -38,6 +38,22 @@ export default defineConfigWithVueTs(
       // (see the inline disables it used). Empty/`{}` interface patterns are
       // used intentionally here (e.g. Vue SFC shims, nominal interfaces).
       "@typescript-eslint/no-empty-object-type": "off",
+    },
+  },
+  // `eslint-config-prettier` disables stylistic rules that conflict with
+  // Prettier (formatting lives in the standalone `format` script). `oxlint`
+  // then disables rules already covered by Oxlint, which runs first and
+  // faster, to avoid double-reporting.
+  eslintConfigPrettier,
+  oxlint.configs["flat/recommended"],
+  {
+    // Must stay after the two blocks above: `eslint-config-prettier` turns
+    // `vue/html-self-closing` off wholesale, so configuring it any earlier
+    // leaves it disabled. Prettier only dictates the `void` style (it always
+    // self-closes `<img>` and friends), which is what `void: "always"` asks
+    // for, so the two agree and the remaining tag styles stay ours to pick.
+    name: "app/overrides-post-prettier",
+    rules: {
       "vue/html-self-closing": [
         "error",
         {
@@ -48,10 +64,4 @@ export default defineConfigWithVueTs(
       ],
     },
   },
-  // Keep these LAST. `eslint-config-prettier` disables stylistic rules that
-  // conflict with Prettier (formatting lives in the standalone `format`
-  // script). `oxlint` then disables rules already covered by Oxlint, which
-  // runs first and faster, to avoid double-reporting.
-  eslintConfigPrettier,
-  oxlint.configs["flat/recommended"],
 );

--- a/src/components/MiniEqualizer.vue
+++ b/src/components/MiniEqualizer.vue
@@ -5,7 +5,7 @@
     class="mini-eq"
     aria-hidden="true"
     role="presentation"
-  />
+  ></canvas>
 </template>
 
 <script setup lang="ts">

--- a/src/components/PlayerCardTitle.vue
+++ b/src/components/PlayerCardTitle.vue
@@ -4,7 +4,7 @@
       <span class="player-card-name truncate text-sm font-medium">
         {{ playerName }}
       </span>
-      <slot />
+      <slot></slot>
     </div>
     <p
       v-if="memberNames.length > 0"

--- a/src/components/music-quiz/MusicQuizHostPanel.vue
+++ b/src/components/music-quiz/MusicQuizHostPanel.vue
@@ -7,7 +7,7 @@
     />
 
     <div class="flex flex-col gap-4">
-      <slot name="game" />
+      <slot name="game"></slot>
 
       <div
         v-if="state.phase === 'lobby' && state.playback"

--- a/src/components/music-quiz/MusicQuizPlayerTile.vue
+++ b/src/components/music-quiz/MusicQuizPlayerTile.vue
@@ -5,7 +5,7 @@
   >
     <MusicQuizAvatar :name="name" class="size-8 shrink-0" />
     <span class="min-w-0 flex-1 truncate font-medium">{{ name }}</span>
-    <slot name="trailing" />
+    <slot name="trailing"></slot>
   </div>
 </template>
 

--- a/src/components/music-quiz/MusicQuizSessionHeader.vue
+++ b/src/components/music-quiz/MusicQuizSessionHeader.vue
@@ -53,7 +53,7 @@
       </div>
     </div>
     <div v-if="$slots.actions" class="flex shrink-0 justify-end">
-      <slot name="actions" />
+      <slot name="actions"></slot>
     </div>
   </section>
 </template>

--- a/src/components/music-quiz/answer-types/multiple-choice/MultipleChoiceHostAnswer.vue
+++ b/src/components/music-quiz/answer-types/multiple-choice/MultipleChoiceHostAnswer.vue
@@ -24,7 +24,7 @@
       :statuses="roundPlayerStatuses"
       :answered-count="answeredPlayerCount"
     />
-    <slot name="leaderboard" />
+    <slot name="leaderboard"></slot>
   </div>
 </template>
 

--- a/src/components/music-quiz/answer-types/multiple-choice/MultipleChoicePresentAnswer.vue
+++ b/src/components/music-quiz/answer-types/multiple-choice/MultipleChoicePresentAnswer.vue
@@ -25,12 +25,12 @@
           :answered-count="answeredCount"
           scrollable
         />
-        <slot name="leaderboard" />
+        <slot name="leaderboard"></slot>
       </div>
     </div>
   </template>
   <template v-else-if="state.phase === 'reveal'">
-    <slot name="leaderboard" />
+    <slot name="leaderboard"></slot>
   </template>
 </template>
 

--- a/src/components/music-quiz/answer-types/timeline/TimelineAudienceAnswer.vue
+++ b/src/components/music-quiz/answer-types/timeline/TimelineAudienceAnswer.vue
@@ -110,9 +110,9 @@
         data-testid="timeline-leaderboard-region"
         class="lg:min-h-0 lg:overflow-hidden"
       >
-        <slot name="leaderboard" />
+        <slot name="leaderboard"></slot>
       </div>
-      <slot v-else name="leaderboard" />
+      <slot v-else name="leaderboard"></slot>
     </div>
   </div>
 </template>

--- a/src/components/music-quiz/answer-types/timeline/TimelineDisplay.vue
+++ b/src/components/music-quiz/answer-types/timeline/TimelineDisplay.vue
@@ -84,7 +84,7 @@
               data-testid="timeline-selected-boundary"
               class="w-full max-w-xl"
             >
-              <slot name="selected-boundary" />
+              <slot name="selected-boundary"></slot>
             </div>
           </li>
           <li

--- a/src/components/music-quiz/answer-types/timeline/TimelineHostAnswer.vue
+++ b/src/components/music-quiz/answer-types/timeline/TimelineHostAnswer.vue
@@ -1,7 +1,7 @@
 <template>
   <TimelineAudienceAnswer :state="state" :current-round="currentRound">
     <template #leaderboard>
-      <slot name="leaderboard" />
+      <slot name="leaderboard"></slot>
     </template>
   </TimelineAudienceAnswer>
 </template>

--- a/src/components/music-quiz/answer-types/timeline/TimelinePresentAnswer.vue
+++ b/src/components/music-quiz/answer-types/timeline/TimelinePresentAnswer.vue
@@ -5,7 +5,7 @@
     :present="true"
   >
     <template #leaderboard>
-      <slot name="leaderboard" />
+      <slot name="leaderboard"></slot>
     </template>
   </TimelineAudienceAnswer>
 </template>

--- a/src/components/music-quiz/game-types/guess-the-song/GuessTheSongSetup.vue
+++ b/src/components/music-quiz/game-types/guess-the-song/GuessTheSongSetup.vue
@@ -73,7 +73,7 @@
       </Field>
     </div>
 
-    <slot name="before-sources" />
+    <slot name="before-sources"></slot>
 
     <MusicQuizSourceSelector
       v-model="sourceUris"

--- a/src/components/music-quiz/game-types/music-timeline/MusicTimelineSetup.vue
+++ b/src/components/music-quiz/game-types/music-timeline/MusicTimelineSetup.vue
@@ -76,7 +76,7 @@
       </Field>
     </div>
 
-    <slot name="before-sources" />
+    <slot name="before-sources"></slot>
 
     <MusicQuizSourceSelector
       v-model="sourceUris"

--- a/src/components/music-quiz/game-types/trivia/TriviaSetup.vue
+++ b/src/components/music-quiz/game-types/trivia/TriviaSetup.vue
@@ -111,7 +111,7 @@
       </Field>
     </div>
 
-    <slot name="before-sources" />
+    <slot name="before-sources"></slot>
 
     <MusicQuizSourceSelector
       v-model="sourceUris"

--- a/src/components/ui/search-input/SearchInput.vue
+++ b/src/components/ui/search-input/SearchInput.vue
@@ -65,6 +65,6 @@ defineExpose({
       <X class="size-4" />
     </InputGroupButton>
     <!-- trailing controls rendered inside the input, e.g. an inline filter -->
-    <slot name="append" />
+    <slot name="append"></slot>
   </InputGroup>
 </template>

--- a/src/layouts/GuestLayout.vue
+++ b/src/layouts/GuestLayout.vue
@@ -8,7 +8,7 @@
         class="justify-self-start"
         @open-host-panel="returnToHostPanel"
       />
-      <div v-else />
+      <div v-else></div>
       <img
         :src="logoSrc"
         alt="Music Assistant"

--- a/src/layouts/default/PlayerOSD/PlayerTimeline.vue
+++ b/src/layouts/default/PlayerOSD/PlayerTimeline.vue
@@ -30,7 +30,7 @@
             v-if="!hasWaveform"
             class="absolute inset-0 rounded-full"
             :style="trackBackgroundStyle"
-          />
+          ></div>
           <WaveformTrack
             v-else
             :data="waveform!"


### PR DESCRIPTION
The `vue/html-self-closing` rule was configured in `eslint.config.js`, but the block sat before `eslint-config-prettier`, which turns that rule off wholesale. So the rule never ran and the config only looked like it was enforcing something — confirmed with `eslint --print-config`, which reported it at severity 0.

It was the only rule in our overrides affected; every other entry there survives with its intended severity.

- Moved `vue/html-self-closing` into a config block after the prettier and oxlint blocks so it is actually enforced
- Fixed the 19 places that had drifted (mostly `<slot />` → `<slot></slot>`)
- Kept the existing options: they match what the codebase already does almost everywhere, and Prettier only dictates the void-element style, which they already agree on