### PR TITLE
Share the app mount helper across the initialization tests

### DIFF
--- a/tests/App.test.ts
+++ b/tests/App.test.ts
@@ -771,14 +771,14 @@ async function mountApp() {
 }
 
 /**
- * Mount the app and register it for teardown, leaving initialization in
- * flight for the test to drive.
+ * Mount the app and register it for teardown, without waiting for
+ * initialization to settle; the test drives what happens next.
  */
 async function mountAppWithoutSettling() {
   const { default: App } = await import("@/App.vue");
-  // Registered before any assertion runs so afterEach unmounts the app even
-  // when one of them throws: a live instance keeps reacting to api.state and
-  // corrupts every later test.
+  // Registered at mount time so afterEach unmounts the app even when a
+  // caller's assertion throws: a live instance keeps reacting to api.state
+  // and corrupts every later test.
   wrapper = shallowMount(App, {
     global: {
       stubs: {

--- a/tests/App.test.ts
+++ b/tests/App.test.ts
@@ -409,14 +409,7 @@ describe("App initialization", () => {
     const pluginConfigs = createDeferred<Array<{ enabled: boolean }>>();
     apiMock.fetchState.mockReturnValue(serverState.promise);
     apiMock.getProviderConfigs.mockReturnValue(pluginConfigs.promise);
-    const { default: App } = await import("@/App.vue");
-    wrapper = shallowMount(App, {
-      global: {
-        stubs: {
-          RouterView: true,
-        },
-      },
-    });
+    wrapper = await mountAppWithoutSettling();
 
     await flushPromises();
     expect(apiMock.fetchState).toHaveBeenCalledOnce();
@@ -518,14 +511,7 @@ describe("App initialization", () => {
 
   it("remembers a temporary remote connection after regular login", async () => {
     apiMock.state.value = "auth_required";
-    const { default: App } = await import("@/App.vue");
-    wrapper = shallowMount(App, {
-      global: {
-        stubs: {
-          RouterView: true,
-        },
-      },
-    });
+    wrapper = await mountAppWithoutSettling();
 
     wrapper.findComponent({ name: "Login" }).vm.$emit("authenticated", {
       token: "regular-token",
@@ -547,14 +533,7 @@ describe("App initialization", () => {
 
   it("clears proxy mode before connecting to a local server", async () => {
     apiMock.state.value = "disconnected";
-    const { default: App } = await import("@/App.vue");
-    wrapper = shallowMount(App, {
-      global: {
-        stubs: {
-          RouterView: true,
-        },
-      },
-    });
+    wrapper = await mountAppWithoutSettling();
 
     wrapper
       .findComponent({ name: "Login" })
@@ -783,8 +762,21 @@ async function mountAuthenticatedApp() {
  * a timer anywhere in that path would need vi.waitFor instead.
  */
 async function mountApp() {
+  const mounted = await mountAppWithoutSettling();
+  await flushPromises();
+  expect(apiMock.state.value).toBe("initialized");
+  expect(mockInitializeWebPlayerModeSync).toHaveBeenCalledOnce();
+  expect(apiMock.subscribe).toHaveBeenCalledTimes(3);
+  return mounted;
+}
+
+/**
+ * Mount the app and register it for teardown, leaving initialization in
+ * flight for the test to drive.
+ */
+async function mountAppWithoutSettling() {
   const { default: App } = await import("@/App.vue");
-  // Registered before the assertions below so afterEach unmounts the app even
+  // Registered before any assertion runs so afterEach unmounts the app even
   // when one of them throws: a live instance keeps reacting to api.state and
   // corrupts every later test.
   wrapper = shallowMount(App, {
@@ -794,10 +786,6 @@ async function mountApp() {
       },
     },
   });
-  await flushPromises();
-  expect(apiMock.state.value).toBe("initialized");
-  expect(mockInitializeWebPlayerModeSync).toHaveBeenCalledOnce();
-  expect(apiMock.subscribe).toHaveBeenCalledTimes(3);
   return wrapper;
 }
 


### PR DESCRIPTION
Three tests in the app initialization suite duplicated the mount boilerplate instead of using the shared `mountApp()` helper, because that helper also waits for initialization to settle — which those tests need to drive themselves. The duplicated stub config could drift from the helper's.

- Extracted the mount-only part of `mountApp()` into `mountAppWithoutSettling()`, which mounts the app and registers it for teardown
- `mountApp()` now builds on it and keeps its settle-and-assert step, so the mount config lives in one place
- Updated the three tests that drive initialization themselves to use the new helper