### PR TITLE
Stop the lyrics timer from running in the background

### DIFF
--- a/src/composables/lyrics/useLyricsElapsedTime.ts
+++ b/src/composables/lyrics/useLyricsElapsedTime.ts
@@ -12,7 +12,7 @@
  * synchronize either.
  */
 
-import { ref, watchEffect, onScopeDispose, type Ref } from "vue";
+import { ref, watch, watchEffect, onScopeDispose, type Ref } from "vue";
 import { PlaybackState } from "@/plugins/api/interfaces";
 import { store } from "@/plugins/store";
 import { resolveQueueElapsedTime } from "@/helpers/activeElapsedTime";
@@ -21,13 +21,17 @@ export function useLyricsElapsedTime(enabled?: Ref<boolean>) {
   const elapsedTime = ref(0);
   let rafId: number | null = null;
 
-  const update = () => {
-    // Keep the last known position when the queue reports no position, so the
-    // lyrics do not snap back to the start of the track.
+  // Keeps the last known position when the queue reports no position, so the
+  // lyrics do not snap back to the start of the track.
+  const syncPosition = () => {
     const elapsed = resolveQueueElapsedTime();
     if (elapsed !== undefined) {
       elapsedTime.value = elapsed;
     }
+  };
+
+  const update = () => {
+    syncPosition();
     rafId = requestAnimationFrame(update);
   };
 
@@ -56,6 +60,18 @@ export function useLyricsElapsedTime(enabled?: Ref<boolean>) {
     }
   };
   document.addEventListener("visibilitychange", handleVisibilityChange);
+
+  // A gated consumer renders the moment `enabled` flips, so it gets a position
+  // straight away rather than one frame late — and while the queue is paused no
+  // frame comes at all. The callback is untracked, keeping the high-frequency
+  // position out of the gate below.
+  watch(
+    () => enabled?.value ?? true,
+    (isEnabled) => {
+      if (isEnabled) syncPosition();
+    },
+    { immediate: true },
+  );
 
   // The queue's own state and active flag both change rarely, unlike the resolved
   // position: that is backed by a high-frequency reactive map, so reading it here

--- a/src/layouts/default/PlayerOSD/PlayerFullscreen.vue
+++ b/src/layouts/default/PlayerOSD/PlayerFullscreen.vue
@@ -557,8 +557,6 @@ watch(
   { immediate: true },
 );
 
-const { elapsedTime: lyricsElapsedTime } = useLyricsElapsedTime();
-
 // Local reactive state for lyrics
 const currentLyrics = ref<{ plain: string | null; synced: string | null }>({
   plain: null,
@@ -599,6 +597,14 @@ const lyricsActive = computed(() => showLyrics.value);
 const toggleLyrics = () => {
   showLyrics.value = !showLyrics.value;
 };
+
+// This component stays mounted while the dialog is closed and the lyrics panel
+// keeps its state across open/close, so both are checked: the ~60fps loop only
+// runs while the lyrics viewer it feeds is actually on screen.
+const lyricsVisible = computed(
+  () => store.showFullscreenPlayer && showLyrics.value,
+);
+const { elapsedTime: lyricsElapsedTime } = useLyricsElapsedTime(lyricsVisible);
 
 // If the panel was opened optimistically while lyrics were still loading but
 // the track turns out to have none, close it again so we don't show an empty

--- a/src/layouts/default/PlayerOSD/PlayerTrackDetails.vue
+++ b/src/layouts/default/PlayerOSD/PlayerTrackDetails.vue
@@ -182,10 +182,7 @@
       </div>
     </template>
   </v-list-item>
-  <PlayerFullscreen
-    :show-fullscreen="store.showFullscreenPlayer"
-    :color-palette="colorPalette"
-  />
+  <PlayerFullscreen :color-palette="colorPalette" />
 </template>
 
 <script setup lang="ts">

--- a/tests/composables/useLyricsElapsedTime.test.ts
+++ b/tests/composables/useLyricsElapsedTime.test.ts
@@ -275,6 +275,27 @@ describe("useLyricsElapsedTime", () => {
     expect(pendingFrames.size).toBe(0);
   });
 
+  it("resolves the position when the enabled ref flips to true on a paused queue", async () => {
+    seedQueue({ state: PlaybackState.PAUSED });
+    apiMock.queueElapsedTime["q1"] = {
+      elapsed_time: 42,
+      elapsed_time_last_updated: NOW,
+    };
+    const enabled = ref(false);
+
+    const { elapsedTime } = await runComposable(enabled);
+    await nextTick();
+    expect(elapsedTime.value).toBe(0);
+
+    enabled.value = true;
+    await nextTick();
+
+    // A paused queue schedules no frames, so the position has to be there
+    // without one.
+    expect(pendingFrames.size).toBe(0);
+    expect(elapsedTime.value).toBe(42);
+  });
+
   it("holds the last queue position rather than adopting the player's", async () => {
     seedQueue();
     apiMock.queueElapsedTime["q1"] = {

--- a/tests/layouts/PlayerFullscreen.test.ts
+++ b/tests/layouts/PlayerFullscreen.test.ts
@@ -1,0 +1,221 @@
+import { EMPTY_COLOR_PALETTE } from "@/helpers/utils";
+import PlayerFullscreen from "@/layouts/default/PlayerOSD/PlayerFullscreen.vue";
+import { PlaybackState } from "@/plugins/api/interfaces";
+import { shallowMount, type VueWrapper } from "@vue/test-utils";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { nextTick } from "vue";
+
+// Only the fields the lyrics clock and its gate read are mocked; the elapsed
+// time resolver reaches the queue through the player's active_source, so both
+// the api and the store are seeded.
+vi.mock("@/plugins/api", async () => {
+  const { reactive } = await vi.importActual<typeof import("vue")>("vue");
+  const api = reactive({
+    queues: {},
+    queueElapsedTime: {},
+    subscribe: vi.fn(() => vi.fn()),
+    getTrackLyrics: vi.fn(),
+  });
+  return { api, default: api };
+});
+
+vi.mock("@/plugins/store", async () => {
+  const { reactive } = await vi.importActual<typeof import("vue")>("vue");
+  return {
+    store: reactive({
+      activePlayer: undefined,
+      activePlayerQueue: undefined,
+      curQueueItem: undefined,
+      showFullscreenPlayer: false,
+      showQueueItems: false,
+    }),
+  };
+});
+
+vi.mock("@/composables/useServerTime", () => ({
+  serverNow: () => NOW,
+}));
+
+// The queue list and the waveform are unrelated to the lyrics clock and pull in
+// their own scrolling/loading machinery.
+vi.mock("@/layouts/default/PlayerOSD/useFullscreenQueue", async () => {
+  const { computed, ref: vueRef } =
+    await vi.importActual<typeof import("vue")>("vue");
+  return {
+    useFullscreenQueue: () => ({
+      queueScrollRef: vueRef(null),
+      virtualRows: computed(() => []),
+      totalItems: computed(() => 0),
+      upNextCount: computed(() => 0),
+      queueEnded: computed(() => false),
+      totalSize: computed(() => 0),
+      measureRow: vi.fn(),
+      playerActive: computed(() => false),
+      hoveredMarqueeSync: vueRef(undefined),
+      requestBadgeColor: computed(() => ""),
+      boostBadgeColor: computed(() => ""),
+      queueTitleFontSize: computed(() => "1em"),
+      queueSubtitleFontSize: computed(() => "1em"),
+      openQueueItemMenu: vi.fn(),
+      chapterClicked: vi.fn(),
+      startItemDrag: vi.fn(),
+      draggingIndex: vueRef(undefined),
+      isDragging: vueRef(false),
+      draggedItem: vueRef(undefined),
+      ghostY: vueRef(0),
+      rowOffset: computed(() => 0),
+    }),
+  };
+});
+
+vi.mock("@/composables/useActiveTrackWaveform", async () => {
+  const { ref: vueRef } = await vi.importActual<typeof import("vue")>("vue");
+  return {
+    useActiveTrackWaveform: () => ({ waveformBins: vueRef(undefined) }),
+  };
+});
+
+vi.mock("@/plugins/vuetify", async () => {
+  const { ref: vueRef } = await vi.importActual<typeof import("vue")>("vue");
+  return {
+    default: {
+      display: { height: vueRef(900), mdAndUp: vueRef(true) },
+      theme: { current: vueRef({ dark: true }) },
+    },
+  };
+});
+
+vi.mock("vuetify", async () => {
+  const { ref: vueRef } = await vi.importActual<typeof import("vue")>("vue");
+  return {
+    useDisplay: () => ({ name: vueRef("lg"), mdAndUp: vueRef(true) }),
+  };
+});
+
+vi.mock("@/plugins/router", () => ({ default: { push: vi.fn() } }));
+
+vi.mock("@/plugins/i18n", () => ({ $t: (key: string) => key }));
+
+const NOW = 1_700_000_000;
+const QUEUE_ID = "q1";
+
+interface TestStore {
+  activePlayer?: { player_id: string; active_source?: string };
+  activePlayerQueue?: {
+    queue_id: string;
+    state: PlaybackState;
+    active: boolean;
+  };
+  showFullscreenPlayer: boolean;
+  showQueueItems: boolean;
+}
+
+interface TestApi {
+  queues: Record<
+    string,
+    { queue_id: string; state: PlaybackState; active: boolean }
+  >;
+  queueElapsedTime: Record<
+    string,
+    { elapsed_time?: number; elapsed_time_last_updated?: number }
+  >;
+}
+
+// Records scheduled callbacks instead of running them, so a test can see how
+// many frames the component's lyrics clock has pending.
+let pendingFrames: Map<number, FrameRequestCallback>;
+let nextRafId: number;
+let wrapper: VueWrapper | undefined;
+
+/** Put a playing queue on the active player, the way the store reports one. */
+async function seedPlayingQueue(): Promise<void> {
+  const { store } = await import("@/plugins/store");
+  const api = (await import("@/plugins/api")).default;
+  const testStore = store as unknown as TestStore;
+  const testApi = api as unknown as TestApi;
+
+  testApi.queues[QUEUE_ID] = {
+    queue_id: QUEUE_ID,
+    state: PlaybackState.PLAYING,
+    active: true,
+  };
+  testApi.queueElapsedTime[QUEUE_ID] = {
+    elapsed_time: 10,
+    elapsed_time_last_updated: NOW,
+  };
+  testStore.activePlayer = { player_id: "p1", active_source: QUEUE_ID };
+  testStore.activePlayerQueue = {
+    queue_id: QUEUE_ID,
+    state: PlaybackState.PLAYING,
+    active: true,
+  };
+}
+
+beforeEach(() => {
+  pendingFrames = new Map();
+  nextRafId = 0;
+  vi.stubGlobal(
+    "requestAnimationFrame",
+    vi.fn((callback: FrameRequestCallback) => {
+      const id = ++nextRafId;
+      pendingFrames.set(id, callback);
+      return id;
+    }),
+  );
+  vi.stubGlobal(
+    "cancelAnimationFrame",
+    vi.fn((id: number) => {
+      pendingFrames.delete(id);
+    }),
+  );
+});
+
+afterEach(async () => {
+  wrapper?.unmount();
+  wrapper = undefined;
+  vi.unstubAllGlobals();
+
+  const { store } = await import("@/plugins/store");
+  const api = (await import("@/plugins/api")).default;
+  const testStore = store as unknown as TestStore;
+  const testApi = api as unknown as TestApi;
+  testStore.activePlayer = undefined;
+  testStore.activePlayerQueue = undefined;
+  testStore.showFullscreenPlayer = false;
+  testStore.showQueueItems = false;
+  testApi.queues = {};
+  testApi.queueElapsedTime = {};
+});
+
+describe("PlayerFullscreen lyrics clock", () => {
+  it("only runs while the lyrics panel is on screen", async () => {
+    await seedPlayingQueue();
+    const { store } = await import("@/plugins/store");
+    const testStore = store as unknown as TestStore;
+
+    wrapper = shallowMount(PlayerFullscreen, {
+      props: { colorPalette: EMPTY_COLOR_PALETTE },
+    });
+    await nextTick();
+
+    // The component stays mounted while the dialog is closed.
+    expect(pendingFrames.size).toBe(0);
+
+    testStore.showFullscreenPlayer = true;
+    await nextTick();
+    // Open, but showing the queue rather than the lyrics.
+    expect(pendingFrames.size).toBe(0);
+
+    // The lyrics toggle lives on a header button inside the dialog, which a
+    // shallow mount does not render, so the panel is opened through the binding
+    // that button drives.
+    const vm = wrapper.vm as unknown as { showLyrics: boolean };
+    vm.showLyrics = true;
+    await nextTick();
+    expect(pendingFrames.size).toBe(1);
+
+    testStore.showFullscreenPlayer = false;
+    await nextTick();
+    expect(pendingFrames.size).toBe(0);
+  });
+});


### PR DESCRIPTION
The fullscreen player stays mounted even when it is closed, so the lyrics elapsed-time loop kept running at ~60fps in the background whenever something was playing — burning CPU (and battery) while nothing was showing lyrics.

- Gate the lyrics clock on the fullscreen player being open *and* the lyrics panel being shown, so it only runs while the lyrics viewer is on screen
- Resolve the playback position as soon as the lyrics panel opens, so it is correct right away (and also while the track is paused, when no frames run at all)
- Drop a leftover `show-fullscreen` binding that the fullscreen player doesn't declare as a prop
- Add tests for the above
