### PR TITLE
Party guest page no longer changes your selected player

### DIFF
--- a/src/views/PartyGuestView.vue
+++ b/src/views/PartyGuestView.vue
@@ -186,7 +186,6 @@ import {
   type Track,
 } from "@/plugins/api/interfaces";
 import { $t } from "@/plugins/i18n";
-import { store } from "@/plugins/store";
 import { ArrowLeft, Music, X } from "@lucide/vue";
 import {
   computed,
@@ -476,9 +475,6 @@ const refreshPartyPlayer = async () => {
   try {
     const partyPlayerId = await api.sendCommand<string | null>("party/player");
     partyQueueId.value = partyPlayerId;
-    if (partyPlayerId) {
-      store.activePlayerId = partyPlayerId;
-    }
   } catch (error) {
     console.error("Failed to fetch party player:", error);
   }


### PR DESCRIPTION
The party guest page set the app-wide "active player" to the party player on every refresh. It did that to drive its own now-playing marker, but that reader moved to the party queue in #2278 and the leftover queue lookup went in #2286 — so the assignment now has no reader in the guest flow, while still silently changing the selected player for anyone who opens the page while signed in to the full app (which also moved the desktop companion's tray/Discord status onto the party player).

- Removed the leftover active-player assignment from the party guest page

Checked every remaining reader: the guest page components and the listen-in / sendspin path work purely from the party queue id and the web player id, and the browser media controls (the one globally mounted reader) are switched off on this route. The party *dashboard* still sets the active player on purpose — it renders inside the normal app layout, where the player bar needs it.