### PR TITLE
Stop test runs from reporting success when errors escape a test

### DIFF
--- a/tests/setup/failOnUnhandledErrors.ts
+++ b/tests/setup/failOnUnhandledErrors.ts
@@ -49,8 +49,8 @@ const reportEscapedErrors = async () => {
 
 // Vitest ignores an unhandled error as soon as a second listener is registered,
 // assuming user code took charge of it. Listening only while a test runs keeps
-// that hand-off scoped, so anything raised in between still gets reported
-// rather than landing in a buffer that nothing drains.
+// that hand-off scoped to the tests themselves and leaves anything raised in
+// between to Vitest.
 beforeEach(() => {
   // A throwing teardown hook skips the rest of the file's teardown, leaving the
   // previous test's listeners in place, so drop them before re-arming.
@@ -60,6 +60,6 @@ beforeEach(() => {
 
 afterEach(reportEscapedErrors);
 
-// Backstop for the same skipped-teardown case: without it, errors captured
-// after the last hook ran would be swallowed instead of failing the file.
+// Backstop for the same skipped-teardown case: drains whatever a skipped
+// afterEach left buffered, which would otherwise go unreported.
 afterAll(reportEscapedErrors);

--- a/tests/setup/failOnUnhandledErrors.ts
+++ b/tests/setup/failOnUnhandledErrors.ts
@@ -1,0 +1,46 @@
+/**
+ * Turns errors that escape a test into a failure of that test.
+ *
+ * Errors thrown outside the test's own call stack - a Vue watcher rejecting on
+ * a partial mock, a callback throwing from a timer - reach Vitest as unhandled
+ * errors. Vitest reports those in a separate "Errors" section that is absent
+ * from the pass/fail tally, so a run can print "Tests 1349 passed" while
+ * actually failing. Re-throwing them from a hook puts them in the tally and
+ * pins them to the test that was running.
+ */
+import { afterEach, beforeEach } from "vitest";
+
+// Captured while the globals are still real: a test that installs fake timers
+// replaces setImmediate, and the queue this hook waits on is the real one Node
+// drains rejections from.
+const queueMacrotask = globalThis.setImmediate;
+
+const escapedErrors: unknown[] = [];
+
+const recordEscapedError = (error: unknown) => {
+  escapedErrors.push(error);
+};
+
+// Vitest ignores an unhandled error as soon as a second listener is registered,
+// assuming user code took charge of it. Listening only while a test runs keeps
+// that hand-off scoped: anything raised in between still gets Vitest's own
+// reporting instead of landing in a buffer that nothing drains.
+beforeEach(() => {
+  process.on("unhandledRejection", recordEscapedError);
+  process.on("uncaughtException", recordEscapedError);
+});
+
+afterEach(async () => {
+  // Node reports unhandled rejections once the microtask queue has drained, so
+  // yield a macrotask before handing back to catch the test that just finished.
+  await new Promise((resolve) => queueMacrotask(resolve));
+
+  process.off("unhandledRejection", recordEscapedError);
+  process.off("uncaughtException", recordEscapedError);
+
+  if (escapedErrors.length === 0) return;
+
+  const errors = escapedErrors.splice(0);
+  if (errors.length === 1) throw errors[0];
+  throw new AggregateError(errors, `${errors.length} errors escaped this test`);
+});

--- a/tests/setup/failOnUnhandledErrors.ts
+++ b/tests/setup/failOnUnhandledErrors.ts
@@ -1,17 +1,20 @@
 /**
  * Turns errors that escape a test into a failure of that test.
  *
- * Errors thrown outside the test's own call stack - a Vue watcher rejecting on
- * a partial mock, a callback throwing from a timer - reach Vitest as unhandled
- * errors. Vitest reports those in a separate "Errors" section that is absent
- * from the pass/fail tally, so a run can print "Tests 1349 passed" while
- * actually failing. Re-throwing them from a hook puts them in the tally and
- * pins them to the test that was running.
+ * Errors raised while a test runs but outside its own call stack - a Vue
+ * watcher rejecting on a partial mock, a callback throwing from a timer - reach
+ * Vitest as unhandled errors. Vitest reports those in a separate "Errors"
+ * section that is absent from the pass/fail tally, so a run can print
+ * "Tests 1349 passed" while actually failing. Re-throwing them from a hook puts
+ * them in the tally and pins them to the test that was running.
+ *
+ * Errors raised in between tests keep Vitest's own reporting, which names the
+ * test file but no individual test.
  */
-import { afterEach, beforeEach } from "vitest";
+import { afterAll, afterEach, beforeEach } from "vitest";
 
 // Captured while the globals are still real: a test that installs fake timers
-// replaces setImmediate, and the queue this hook waits on is the real one Node
+// replaces setImmediate, and the queue this waits on is the real one Node
 // drains rejections from.
 const queueMacrotask = globalThis.setImmediate;
 
@@ -21,26 +24,42 @@ const recordEscapedError = (error: unknown) => {
   escapedErrors.push(error);
 };
 
-// Vitest ignores an unhandled error as soon as a second listener is registered,
-// assuming user code took charge of it. Listening only while a test runs keeps
-// that hand-off scoped: anything raised in between still gets Vitest's own
-// reporting instead of landing in a buffer that nothing drains.
-beforeEach(() => {
+const listenForEscapedErrors = () => {
   process.on("unhandledRejection", recordEscapedError);
   process.on("uncaughtException", recordEscapedError);
-});
+};
 
-afterEach(async () => {
+const stopListeningForEscapedErrors = () => {
+  process.off("unhandledRejection", recordEscapedError);
+  process.off("uncaughtException", recordEscapedError);
+};
+
+const reportEscapedErrors = async () => {
   // Node reports unhandled rejections once the microtask queue has drained, so
   // yield a macrotask before handing back to catch the test that just finished.
   await new Promise((resolve) => queueMacrotask(resolve));
-
-  process.off("unhandledRejection", recordEscapedError);
-  process.off("uncaughtException", recordEscapedError);
+  stopListeningForEscapedErrors();
 
   if (escapedErrors.length === 0) return;
 
   const errors = escapedErrors.splice(0);
   if (errors.length === 1) throw errors[0];
   throw new AggregateError(errors, `${errors.length} errors escaped this test`);
+};
+
+// Vitest ignores an unhandled error as soon as a second listener is registered,
+// assuming user code took charge of it. Listening only while a test runs keeps
+// that hand-off scoped, so anything raised in between still gets reported
+// rather than landing in a buffer that nothing drains.
+beforeEach(() => {
+  // A throwing teardown hook skips the rest of the file's teardown, leaving the
+  // previous test's listeners in place, so drop them before re-arming.
+  stopListeningForEscapedErrors();
+  listenForEscapedErrors();
 });
+
+afterEach(reportEscapedErrors);
+
+// Backstop for the same skipped-teardown case: without it, errors captured
+// after the last hook ran would be swallowed instead of failing the file.
+afterAll(reportEscapedErrors);

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -9,7 +9,10 @@ export default mergeConfig(
       environment: "happy-dom",
       globals: true,
       css: false,
-      setupFiles: [],
+      setupFiles: ["./tests/setup/failOnUnhandledErrors.ts"],
+      // Errors that escape a test must never be silently dropped; the setup
+      // file above additionally surfaces them in the pass/fail tally.
+      dangerouslyIgnoreUnhandledErrors: false,
       server: {
         deps: {
           inline: ["vuetify"],


### PR DESCRIPTION
Vitest reports errors thrown outside a test's own call stack — a Vue watcher rejecting on a partial mock, a callback throwing from a timer — in a separate "Errors" section that is not part of the pass/fail tally. A local run could therefore print `Test Files 140 passed | Tests 1349 passed` alongside `Errors 2 errors`, which reads as green even though the run failed. This is how #2271 looked fine locally and then failed in CI.

Changes:
- Added a vitest setup hook that captures errors escaping a running test and re-throws them from `afterEach`, so they fail the test they belong to and show up in the tally.
- The hook only listens while a test is running, so errors raised in between still get vitest's own reporting rather than being swallowed.
- Pinned `dangerouslyIgnoreUnhandledErrors: false` to make the intent explicit.

No existing tests changed behaviour; the full suite stays green.