### PR TITLE
Player card no longer uses its own copy of the queue lookup

### DIFF
--- a/src/components/PlayerCard.vue
+++ b/src/components/PlayerCard.vue
@@ -218,6 +218,7 @@ import {
   isBuiltinPlayer,
 } from "@/helpers/utils";
 import api from "@/plugins/api";
+import { resolvePlayerQueue } from "@/plugins/api/helpers";
 import {
   PlaybackState,
   type Player,
@@ -259,15 +260,7 @@ const emit = defineEmits<{
 const artworkFailed = ref(false);
 const { activeSource } = useActiveSource(toRef(props, "player"));
 
-const playerQueue = computed(() => {
-  if (props.player.active_source && props.player.active_source in api.queues) {
-    return api.queues[props.player.active_source];
-  }
-  if (!props.player.active_source && props.player.player_id in api.queues) {
-    return api.queues[props.player.player_id];
-  }
-  return undefined;
-});
+const playerQueue = computed(() => resolvePlayerQueue(props.player));
 
 const artworkUrl = computed(() => {
   if (


### PR DESCRIPTION
The player card worked out which queue it belongs to with its own copy of logic that already lives in a shared helper. The copy was missing one check, so during the moment a player switches between Music Assistant and an external source (line-in, Spotify Connect) the card could briefly act on the wrong queue.

The "queue ended" and "queue empty" hints in the full screen player already use the shared helper, so the card now matches them.

- Use the shared `resolvePlayerQueue` helper in `PlayerCard.vue` instead of a local copy.
