### PR TITLE
Import the API client normally in the companion and auth plugins

### DIFF
--- a/src/plugins/auth.ts
+++ b/src/plugins/auth.ts
@@ -12,6 +12,7 @@ import {
   setGuestSessionEnded,
 } from "@/helpers/guest_session";
 import type { ConnectionIdentity } from "@/helpers/connection_identity";
+import { api } from "./api";
 import type { User } from "./api/interfaces";
 import { store } from "./store";
 
@@ -304,8 +305,6 @@ export class AuthManager {
     // Send logout command to server first (best effort)
     if (this.token) {
       try {
-        // Import api dynamically to avoid circular dependency
-        const { api } = await import("@/plugins/api");
         // Send logout command but don't wait for response to avoid race condition
         api.logout().catch(() => {
           // Ignore errors - we're logging out anyway

--- a/src/plugins/companion.ts
+++ b/src/plugins/companion.ts
@@ -25,6 +25,7 @@ import {
   toElapsedTime,
 } from "@/helpers/activeElapsedTime";
 import { getMediaImageUrl } from "@/helpers/utils";
+import { api } from "@/plugins/api";
 import { PlaybackState, Player, PlayerSource } from "@/plugins/api/interfaces";
 import { store } from "@/plugins/store";
 import { ref, watch } from "vue";
@@ -290,9 +291,6 @@ const handlePlayerCommand = async (command: string): Promise<void> => {
   }
 
   try {
-    // Import api dynamically to avoid circular dependency
-    const { api } = await import("@/plugins/api");
-
     switch (command) {
       case "play":
         await api.playerCommandPlay(player.player_id);


### PR DESCRIPTION
The companion and auth plugins both loaded the API client through a dynamic import, with a comment saying this was needed to avoid a circular dependency. The dynamic import did not achieve that: both files already import `store` statically, which pulls the API client in eagerly, so nothing was ever actually deferred — the build reported both as ineffective dynamic imports. The API client is only used inside function bodies, so a plain import is safe here.

No user-visible change.

- Import the API client with a normal static import in `src/plugins/companion.ts` and `src/plugins/auth.ts`
- Drop both dynamic imports and their inaccurate comments
- Leave the `auth` <-> `companion` dynamic imports alone, since those do break a real cycle between those two files