### PR TITLE
Only load track waveforms while something is showing them

### DIFF
--- a/src/composables/useActiveTrackWaveform.ts
+++ b/src/composables/useActiveTrackWaveform.ts
@@ -1,4 +1,11 @@
-import { ref, watch } from "vue";
+import {
+  effectScope,
+  getCurrentScope,
+  onScopeDispose,
+  ref,
+  watch,
+  type WatchStopHandle,
+} from "vue";
 import api from "@/plugins/api";
 import { store } from "@/plugins/store";
 import { MediaType } from "@/plugins/api/interfaces";
@@ -10,52 +17,90 @@ import { useUserPreferences } from "@/composables/userPreferences";
 const waveformBins = ref<number[] | null>(null);
 const trackDurationSecs = ref<number>(0);
 
-let lastFetchKey: string | undefined;
-
 const { getPreference } = useUserPreferences();
 const showWaveformPref = getPreference("show_waveform", true);
 
+// Survives a watcher restart so that a consumer remounting on an unchanged
+// track keeps the cached bins instead of refetching them.
+let lastFetchKey: string | undefined;
+
+let consumerCount = 0;
+let stopWatcher: WatchStopHandle | undefined;
+
+// Detached scope, so the watcher does not get collected by the effect scope of
+// whichever consumer happened to register first.
+const watcherScope = effectScope(true);
+
+/**
+ * Waveform bins and duration of the currently playing track.
+ *
+ * The data is shared between all callers and fetched once per track. Fetching
+ * only runs while at least one caller is alive.
+ */
+export function useActiveTrackWaveform() {
+  if (++consumerCount === 1) startWatcher();
+
+  // A caller outside an effect scope cannot signal teardown, so it keeps the
+  // watcher alive for the lifetime of the module.
+  if (getCurrentScope()) {
+    onScopeDispose(() => {
+      if (--consumerCount === 0) {
+        stopWatcher?.();
+        stopWatcher = undefined;
+      }
+    });
+  }
+
+  return { waveformBins, trackDurationSecs };
+}
+
 // Watch queue/stream IDs and the show_waveform preference together so that
 // toggling the preference re-triggers a fetch without a track change.
-watch(
-  () =>
-    [
-      store.curQueueItem?.queue_item_id,
-      store.curQueueItem?.streamdetails?.item_id,
-      showWaveformPref.value,
-    ] as const,
-  async ([queueItemId, streamItemId, showWaveform]) => {
-    const fetchKey = `${showWaveform}:${queueItemId}:${streamItemId}`;
-    if (fetchKey === lastFetchKey) return;
-    lastFetchKey = fetchKey;
+function startWatcher() {
+  stopWatcher = watcherScope.run(() =>
+    watch(
+      () =>
+        [
+          store.curQueueItem?.queue_item_id,
+          store.curQueueItem?.streamdetails?.item_id,
+          showWaveformPref.value,
+        ] as const,
+      loadWaveform,
+      { immediate: true },
+    ),
+  );
+}
 
-    waveformBins.value = null;
-    trackDurationSecs.value = store.curQueueItem?.duration ?? 0;
+async function loadWaveform([
+  queueItemId,
+  streamItemId,
+  showWaveform,
+]: readonly [string | undefined, string | undefined, boolean]) {
+  const fetchKey = `${showWaveform}:${queueItemId}:${streamItemId}`;
+  if (fetchKey === lastFetchKey) return;
+  lastFetchKey = fetchKey;
 
-    const mediaItem = store.curQueueItem?.media_item;
-    if (!mediaItem || mediaItem.media_type !== MediaType.TRACK) return;
-    if (!showWaveform) return;
+  waveformBins.value = null;
+  trackDurationSecs.value = store.curQueueItem?.duration ?? 0;
 
-    // Without streamdetails there is nothing to analyse yet; this refires once
-    // they arrive, because the watcher tracks their item id.
-    const streamDetails = store.curQueueItem?.streamdetails;
-    if (!streamDetails) return;
+  const mediaItem = store.curQueueItem?.media_item;
+  if (!mediaItem || mediaItem.media_type !== MediaType.TRACK) return;
+  if (!showWaveform) return;
 
-    try {
-      const bins = await api.getWaveForm(
-        streamDetails.item_id,
-        streamDetails.provider,
-      );
-      const currentKey = `${showWaveformPref.value}:${store.curQueueItem?.queue_item_id}:${store.curQueueItem?.streamdetails?.item_id}`;
-      if (currentKey !== fetchKey) return;
-      waveformBins.value = bins?.length ? bins : null;
-    } catch {
-      // No audio analysis available.
-    }
-  },
-  { immediate: true },
-);
+  // Without streamdetails there is nothing to analyse yet; this refires once
+  // they arrive, because the watcher tracks their item id.
+  const streamDetails = store.curQueueItem?.streamdetails;
+  if (!streamDetails) return;
 
-export function useActiveTrackWaveform() {
-  return { waveformBins, trackDurationSecs };
+  try {
+    const bins = await api.getWaveForm(
+      streamDetails.item_id,
+      streamDetails.provider,
+    );
+    const currentKey = `${showWaveformPref.value}:${store.curQueueItem?.queue_item_id}:${store.curQueueItem?.streamdetails?.item_id}`;
+    if (currentKey !== fetchKey) return;
+    waveformBins.value = bins?.length ? bins : null;
+  } catch {
+    // No audio analysis available.
+  }
 }

--- a/src/composables/useActiveTrackWaveform.ts
+++ b/src/composables/useActiveTrackWaveform.ts
@@ -56,28 +56,25 @@ export function useActiveTrackWaveform() {
 
 function startWatcher() {
   stopWatcher = watcherScope.run(() =>
-    watch(
-      // Queue/stream IDs and the show_waveform preference are tracked together
-      // so that toggling the preference re-triggers a fetch without a track
-      // change.
-      () =>
-        [
-          store.curQueueItem?.queue_item_id,
-          store.curQueueItem?.streamdetails?.item_id,
-          showWaveformPref.value,
-        ] as const,
-      loadWaveform,
-      { immediate: true },
-    ),
+    watch(currentFetchKey, loadWaveform, { immediate: true }),
   );
 }
 
-async function loadWaveform([
-  queueItemId,
-  streamItemId,
-  showWaveform,
-]: readonly [string | undefined, string | undefined, boolean]) {
-  const fetchKey = `${showWaveform}:${queueItemId}:${streamItemId}`;
+/**
+ * Identifies everything the waveform request depends on, so that a change in
+ * any of it triggers a fetch and cached bins are never reused across it.
+ */
+function currentFetchKey() {
+  const streamDetails = store.curQueueItem?.streamdetails;
+  return [
+    showWaveformPref.value,
+    store.curQueueItem?.queue_item_id,
+    streamDetails?.item_id,
+    streamDetails?.provider,
+  ].join(":");
+}
+
+async function loadWaveform(fetchKey: string) {
   if (fetchKey === lastFetchKey) return;
   lastFetchKey = fetchKey;
 
@@ -86,10 +83,10 @@ async function loadWaveform([
 
   const mediaItem = store.curQueueItem?.media_item;
   if (!mediaItem || mediaItem.media_type !== MediaType.TRACK) return;
-  if (!showWaveform) return;
+  if (!showWaveformPref.value) return;
 
   // Without streamdetails there is nothing to analyse yet; this refires once
-  // they arrive, because the watcher tracks their item id.
+  // they arrive, because the key covers them.
   const streamDetails = store.curQueueItem?.streamdetails;
   if (!streamDetails) return;
 
@@ -102,8 +99,7 @@ async function loadWaveform([
     // cache claims to hold; while the watcher is stopped the two can drift, and
     // storing bins the cache key does not describe would serve them for the
     // wrong track on the next mount.
-    const currentKey = `${showWaveformPref.value}:${store.curQueueItem?.queue_item_id}:${store.curQueueItem?.streamdetails?.item_id}`;
-    if (currentKey !== fetchKey || lastFetchKey !== fetchKey) return;
+    if (currentFetchKey() !== fetchKey || lastFetchKey !== fetchKey) return;
     waveformBins.value = bins?.length ? bins : null;
   } catch {
     // No audio analysis available.

--- a/src/composables/useActiveTrackWaveform.ts
+++ b/src/composables/useActiveTrackWaveform.ts
@@ -27,8 +27,8 @@ let lastFetchKey: string | undefined;
 let consumerCount = 0;
 let stopWatcher: WatchStopHandle | undefined;
 
-// Detached scope, so the watcher does not get collected by the effect scope of
-// whichever consumer happened to register first.
+// Detached scope, so the shared watcher is not torn down together with the
+// effect scope of whichever consumer happened to register first.
 const watcherScope = effectScope(true);
 
 /**
@@ -54,11 +54,12 @@ export function useActiveTrackWaveform() {
   return { waveformBins, trackDurationSecs };
 }
 
-// Watch queue/stream IDs and the show_waveform preference together so that
-// toggling the preference re-triggers a fetch without a track change.
 function startWatcher() {
   stopWatcher = watcherScope.run(() =>
     watch(
+      // Queue/stream IDs and the show_waveform preference are tracked together
+      // so that toggling the preference re-triggers a fetch without a track
+      // change.
       () =>
         [
           store.curQueueItem?.queue_item_id,
@@ -97,8 +98,12 @@ async function loadWaveform([
       streamDetails.item_id,
       streamDetails.provider,
     );
+    // Drop the result unless it still matches both what is playing and what the
+    // cache claims to hold; while the watcher is stopped the two can drift, and
+    // storing bins the cache key does not describe would serve them for the
+    // wrong track on the next mount.
     const currentKey = `${showWaveformPref.value}:${store.curQueueItem?.queue_item_id}:${store.curQueueItem?.streamdetails?.item_id}`;
-    if (currentKey !== fetchKey) return;
+    if (currentKey !== fetchKey || lastFetchKey !== fetchKey) return;
     waveformBins.value = bins?.length ? bins : null;
   } catch {
     // No audio analysis available.

--- a/tests/composables/useActiveTrackWaveform.test.ts
+++ b/tests/composables/useActiveTrackWaveform.test.ts
@@ -269,6 +269,26 @@ describe("useActiveTrackWaveform", () => {
     expect(second.waveformBins.value).toEqual([0.5]);
   });
 
+  it("refetches when only the stream provider changes", async () => {
+    mockGetWaveForm.mockResolvedValueOnce([0.5]).mockResolvedValueOnce([0.7]);
+
+    const { waveformBins } = addConsumer(await importComposable());
+
+    storeMock.curQueueItem = makeQueueItem();
+    await nextTick();
+    await nextTick();
+
+    storeMock.curQueueItem = makeQueueItem({
+      streamdetails: { item_id: "stream-1", provider: "qobuz" },
+    });
+    await nextTick();
+    await nextTick();
+
+    expect(mockGetWaveForm).toHaveBeenLastCalledWith("stream-1", "qobuz");
+    expect(mockGetWaveForm).toHaveBeenCalledTimes(2);
+    expect(waveformBins.value).toEqual([0.7]);
+  });
+
   it("does not fetch when the show_waveform preference is off", async () => {
     mockGetWaveForm.mockResolvedValue([0.5]);
     storeMock.currentUser = { preferences: { show_waveform: false } };

--- a/tests/composables/useActiveTrackWaveform.test.ts
+++ b/tests/composables/useActiveTrackWaveform.test.ts
@@ -16,6 +16,7 @@ vi.mock("@/plugins/api", () => ({
 // Reactive store mock so the composable's watch fires when we mutate it.
 const storeMock = reactive({
   curQueueItem: null as unknown,
+  currentUser: null as unknown,
 });
 
 vi.mock("@/plugins/store", () => ({
@@ -49,12 +50,15 @@ function makeQueueItem(overrides: Record<string, unknown> = {}) {
   };
 }
 
+type UseActiveTrackWaveform =
+  typeof import("@/composables/useActiveTrackWaveform").useActiveTrackWaveform;
+
 let scopes: EffectScope[] = [];
 
 /**
  * Imports a fresh copy of the composable module.
  */
-async function importComposable() {
+async function importComposable(): Promise<UseActiveTrackWaveform> {
   const module = await import("@/composables/useActiveTrackWaveform");
   return module.useActiveTrackWaveform;
 }
@@ -63,15 +67,10 @@ async function importComposable() {
  * Registers a consumer inside its own effect scope, mimicking a mounted
  * component. The returned scope can be stopped to simulate unmounting.
  */
-function addConsumer(useActiveTrackWaveform: () => unknown) {
+function addConsumer(useActiveTrackWaveform: UseActiveTrackWaveform) {
   const scope = effectScope();
   scopes.push(scope);
-  return {
-    scope,
-    ...(scope.run(useActiveTrackWaveform) as ReturnType<
-      typeof import("@/composables/useActiveTrackWaveform").useActiveTrackWaveform
-    >),
-  };
+  return { scope, ...scope.run(useActiveTrackWaveform)! };
 }
 
 // ---------------------------------------------------------------------------
@@ -81,10 +80,13 @@ function addConsumer(useActiveTrackWaveform: () => unknown) {
 describe("useActiveTrackWaveform", () => {
   beforeEach(async () => {
     // A fresh module per test, so the shared cache and consumer count reset.
+    // This relies on "vue" staying a single instance across the reset, so that
+    // effect scopes created here are the ones the composable sees.
     vi.resetModules();
     mockGetWaveForm.mockReset();
     scopes = [];
     storeMock.curQueueItem = null;
+    storeMock.currentUser = null;
     await nextTick();
   });
 
@@ -265,6 +267,104 @@ describe("useActiveTrackWaveform", () => {
     expect(mockGetWaveForm).toHaveBeenCalledTimes(1);
     expect(first.waveformBins).toBe(second.waveformBins);
     expect(second.waveformBins.value).toEqual([0.5]);
+  });
+
+  it("does not fetch when the show_waveform preference is off", async () => {
+    mockGetWaveForm.mockResolvedValue([0.5]);
+    storeMock.currentUser = { preferences: { show_waveform: false } };
+
+    const { waveformBins } = addConsumer(await importComposable());
+
+    storeMock.curQueueItem = makeQueueItem();
+    await nextTick();
+    await nextTick();
+
+    expect(mockGetWaveForm).not.toHaveBeenCalled();
+    expect(waveformBins.value).toBeNull();
+  });
+
+  it("fetches once the show_waveform preference is switched back on", async () => {
+    mockGetWaveForm.mockResolvedValue([0.5]);
+    storeMock.currentUser = { preferences: { show_waveform: false } };
+
+    const { waveformBins } = addConsumer(await importComposable());
+
+    storeMock.curQueueItem = makeQueueItem();
+    await nextTick();
+    await nextTick();
+    expect(mockGetWaveForm).not.toHaveBeenCalled();
+
+    storeMock.currentUser = { preferences: { show_waveform: true } };
+    await nextTick();
+    await nextTick();
+
+    expect(mockGetWaveForm).toHaveBeenCalledTimes(1);
+    expect(waveformBins.value).toEqual([0.5]);
+  });
+
+  it("refetches when the track changed while no consumer was alive", async () => {
+    mockGetWaveForm.mockResolvedValueOnce([0.5]).mockResolvedValueOnce([0.7]);
+
+    const useActiveTrackWaveform = await importComposable();
+    const first = addConsumer(useActiveTrackWaveform);
+
+    storeMock.curQueueItem = makeQueueItem();
+    await nextTick();
+    await nextTick();
+
+    first.scope.stop();
+
+    storeMock.curQueueItem = makeQueueItem({
+      queue_item_id: "qi-2",
+      streamdetails: { item_id: "stream-2", provider: "spotify" },
+    });
+
+    const second = addConsumer(useActiveTrackWaveform);
+    await nextTick();
+    await nextTick();
+
+    expect(mockGetWaveForm).toHaveBeenCalledTimes(2);
+    expect(second.waveformBins.value).toEqual([0.7]);
+  });
+
+  it("discards a fetch that resolves after the last consumer is torn down", async () => {
+    let resolveFirst!: (v: number[]) => void;
+    mockGetWaveForm
+      .mockReturnValueOnce(new Promise<number[]>((r) => (resolveFirst = r)))
+      .mockResolvedValueOnce([0.9]);
+
+    const useActiveTrackWaveform = await importComposable();
+    const first = addConsumer(useActiveTrackWaveform);
+
+    const trackA = makeQueueItem();
+    const trackB = makeQueueItem({
+      queue_item_id: "qi-2",
+      streamdetails: { item_id: "stream-2", provider: "spotify" },
+    });
+
+    // Track A's fetch hangs, then track B plays and resolves.
+    storeMock.curQueueItem = trackA;
+    await nextTick();
+    storeMock.curQueueItem = trackB;
+    await nextTick();
+    await nextTick();
+    expect(first.waveformBins.value).toEqual([0.9]);
+
+    first.scope.stop();
+
+    // Track A comes around again unobserved and its stale fetch resolves.
+    storeMock.curQueueItem = trackA;
+    resolveFirst([0.1]);
+    await nextTick();
+
+    // Track B is playing again when a consumer returns, so the cached bins
+    // must still be B's rather than the late arrival from A.
+    storeMock.curQueueItem = trackB;
+    const second = addConsumer(useActiveTrackWaveform);
+    await nextTick();
+    await nextTick();
+
+    expect(second.waveformBins.value).toEqual([0.9]);
   });
 
   it("reuses the cached bins when a consumer remounts on the same track", async () => {

--- a/tests/composables/useActiveTrackWaveform.test.ts
+++ b/tests/composables/useActiveTrackWaveform.test.ts
@@ -1,5 +1,5 @@
-import { nextTick, reactive } from "vue";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { effectScope, nextTick, reactive, type EffectScope } from "vue";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 // ---------------------------------------------------------------------------
 // Hoisted mocks
@@ -13,7 +13,7 @@ vi.mock("@/plugins/api", () => ({
   default: { getWaveForm: mockGetWaveForm },
 }));
 
-// Reactive store mock so the module-level watch fires when we mutate it.
+// Reactive store mock so the composable's watch fires when we mutate it.
 const storeMock = reactive({
   curQueueItem: null as unknown,
 });
@@ -49,24 +49,55 @@ function makeQueueItem(overrides: Record<string, unknown> = {}) {
   };
 }
 
+let scopes: EffectScope[] = [];
+
+/**
+ * Imports a fresh copy of the composable module.
+ */
+async function importComposable() {
+  const module = await import("@/composables/useActiveTrackWaveform");
+  return module.useActiveTrackWaveform;
+}
+
+/**
+ * Registers a consumer inside its own effect scope, mimicking a mounted
+ * component. The returned scope can be stopped to simulate unmounting.
+ */
+function addConsumer(useActiveTrackWaveform: () => unknown) {
+  const scope = effectScope();
+  scopes.push(scope);
+  return {
+    scope,
+    ...(scope.run(useActiveTrackWaveform) as ReturnType<
+      typeof import("@/composables/useActiveTrackWaveform").useActiveTrackWaveform
+    >),
+  };
+}
+
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
 
 describe("useActiveTrackWaveform", () => {
   beforeEach(async () => {
+    // A fresh module per test, so the shared cache and consumer count reset.
+    vi.resetModules();
     mockGetWaveForm.mockReset();
+    scopes = [];
     storeMock.curQueueItem = null;
-    // Allow the immediate watch triggered by resetting to settle.
     await nextTick();
+  });
+
+  afterEach(() => {
+    scopes.forEach((scope) => scope.stop());
   });
 
   it("fetches waveform and sets bins when track with streamdetails plays", async () => {
     mockGetWaveForm.mockResolvedValueOnce([0.1, 0.5, 0.9]);
 
-    const { useActiveTrackWaveform } =
-      await import("@/composables/useActiveTrackWaveform");
-    const { waveformBins, trackDurationSecs } = useActiveTrackWaveform();
+    const { waveformBins, trackDurationSecs } = addConsumer(
+      await importComposable(),
+    );
 
     storeMock.curQueueItem = makeQueueItem();
     await nextTick();
@@ -78,9 +109,7 @@ describe("useActiveTrackWaveform", () => {
   });
 
   it("does not fetch when media_type is not track", async () => {
-    const { useActiveTrackWaveform } =
-      await import("@/composables/useActiveTrackWaveform");
-    const { waveformBins } = useActiveTrackWaveform();
+    const { waveformBins } = addConsumer(await importComposable());
 
     storeMock.curQueueItem = makeQueueItem({
       media_item: { item_id: "r-1", provider: "spotify", media_type: "radio" },
@@ -93,9 +122,7 @@ describe("useActiveTrackWaveform", () => {
   });
 
   it("does not fetch when streamdetails are absent", async () => {
-    const { useActiveTrackWaveform } =
-      await import("@/composables/useActiveTrackWaveform");
-    const { waveformBins } = useActiveTrackWaveform();
+    const { waveformBins } = addConsumer(await importComposable());
 
     storeMock.curQueueItem = makeQueueItem({ streamdetails: undefined });
     await nextTick();
@@ -108,9 +135,7 @@ describe("useActiveTrackWaveform", () => {
   it("keeps waveformBins null when api throws", async () => {
     mockGetWaveForm.mockRejectedValueOnce(new Error("no analysis"));
 
-    const { useActiveTrackWaveform } =
-      await import("@/composables/useActiveTrackWaveform");
-    const { waveformBins } = useActiveTrackWaveform();
+    const { waveformBins } = addConsumer(await importComposable());
 
     storeMock.curQueueItem = makeQueueItem();
     await nextTick();
@@ -122,9 +147,7 @@ describe("useActiveTrackWaveform", () => {
   it("keeps waveformBins null when api returns empty array", async () => {
     mockGetWaveForm.mockResolvedValueOnce([]);
 
-    const { useActiveTrackWaveform } =
-      await import("@/composables/useActiveTrackWaveform");
-    const { waveformBins } = useActiveTrackWaveform();
+    const { waveformBins } = addConsumer(await importComposable());
 
     storeMock.curQueueItem = makeQueueItem();
     await nextTick();
@@ -140,9 +163,7 @@ describe("useActiveTrackWaveform", () => {
       .mockReturnValueOnce(promise1)
       .mockResolvedValueOnce([0.8, 0.9]);
 
-    const { useActiveTrackWaveform } =
-      await import("@/composables/useActiveTrackWaveform");
-    const { waveformBins } = useActiveTrackWaveform();
+    const { waveformBins } = addConsumer(await importComposable());
 
     // Start first fetch.
     storeMock.curQueueItem = makeQueueItem({ queue_item_id: "qi-1" });
@@ -167,9 +188,7 @@ describe("useActiveTrackWaveform", () => {
   it("does not re-fetch when the same queue_item_id is set again", async () => {
     mockGetWaveForm.mockResolvedValue([0.5]);
 
-    const { useActiveTrackWaveform } =
-      await import("@/composables/useActiveTrackWaveform");
-    useActiveTrackWaveform();
+    addConsumer(await importComposable());
 
     storeMock.curQueueItem = makeQueueItem({ queue_item_id: "qi-same" });
     await nextTick();
@@ -180,5 +199,91 @@ describe("useActiveTrackWaveform", () => {
     await nextTick();
 
     expect(mockGetWaveForm).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not fetch while the module is imported but unused", async () => {
+    mockGetWaveForm.mockResolvedValue([0.5]);
+
+    await importComposable();
+
+    storeMock.curQueueItem = makeQueueItem();
+    await nextTick();
+    await nextTick();
+
+    expect(mockGetWaveForm).not.toHaveBeenCalled();
+  });
+
+  it("stops fetching once the last consumer is torn down", async () => {
+    mockGetWaveForm.mockResolvedValue([0.5]);
+
+    const { scope } = addConsumer(await importComposable());
+
+    storeMock.curQueueItem = makeQueueItem();
+    await nextTick();
+    await nextTick();
+    expect(mockGetWaveForm).toHaveBeenCalledTimes(1);
+
+    scope.stop();
+
+    storeMock.curQueueItem = makeQueueItem({
+      queue_item_id: "qi-2",
+      streamdetails: { item_id: "stream-2", provider: "spotify" },
+    });
+    await nextTick();
+    await nextTick();
+
+    expect(mockGetWaveForm).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps fetching while another consumer is still alive", async () => {
+    mockGetWaveForm.mockResolvedValue([0.5]);
+
+    const useActiveTrackWaveform = await importComposable();
+    const first = addConsumer(useActiveTrackWaveform);
+    addConsumer(useActiveTrackWaveform);
+
+    first.scope.stop();
+
+    storeMock.curQueueItem = makeQueueItem();
+    await nextTick();
+    await nextTick();
+
+    expect(mockGetWaveForm).toHaveBeenCalledTimes(1);
+  });
+
+  it("shares one fetch and the same state between consumers", async () => {
+    mockGetWaveForm.mockResolvedValue([0.5]);
+
+    const useActiveTrackWaveform = await importComposable();
+    const first = addConsumer(useActiveTrackWaveform);
+    const second = addConsumer(useActiveTrackWaveform);
+
+    storeMock.curQueueItem = makeQueueItem();
+    await nextTick();
+    await nextTick();
+
+    expect(mockGetWaveForm).toHaveBeenCalledTimes(1);
+    expect(first.waveformBins).toBe(second.waveformBins);
+    expect(second.waveformBins.value).toEqual([0.5]);
+  });
+
+  it("reuses the cached bins when a consumer remounts on the same track", async () => {
+    mockGetWaveForm.mockResolvedValue([0.5]);
+
+    const useActiveTrackWaveform = await importComposable();
+    const first = addConsumer(useActiveTrackWaveform);
+
+    storeMock.curQueueItem = makeQueueItem();
+    await nextTick();
+    await nextTick();
+    expect(mockGetWaveForm).toHaveBeenCalledTimes(1);
+
+    first.scope.stop();
+
+    const second = addConsumer(useActiveTrackWaveform);
+    await nextTick();
+
+    expect(mockGetWaveForm).toHaveBeenCalledTimes(1);
+    expect(second.waveformBins.value).toEqual([0.5]);
   });
 });


### PR DESCRIPTION
The waveform data for the playing track was loaded by a watcher that started as soon as its module was imported, rather than when something actually needed it. On pages that show no waveform at all the app still requested waveform data on every track change, and the watcher could never be stopped.

In the normal layout the player bar is always on screen, so there is a waveform consumer anyway. The wasted requests happen on the frameless pages (party dashboard and other viewer pages), which is where this was spotted.

- The waveform is now loaded only while at least one component that shows it is on screen, and loading stops when the last one goes away.
- Waveform data stays shared between all components showing it, so a track is still only fetched once.
- A slow request that finishes after the last consumer went away no longer leaves the wrong waveform behind for the next page that shows one.
- The "show waveform" preference still switches loading on and off as before.
- Added tests for the start/stop behaviour, the shared cache and the preference.
