### PR TITLE
Stop the player timeline animating when there is no track length

### DIFF
--- a/src/layouts/default/PlayerOSD/PlayerTimeline.vue
+++ b/src/layouts/default/PlayerOSD/PlayerTimeline.vue
@@ -189,27 +189,40 @@ const wrappedCurTimeValue = computed<number[]>({
   },
 });
 
-const startTick = () => {
-  if (rafId === null) {
-    const tick = () => {
-      const now = Date.now();
-      if (now - nowTick.value >= 64) {
-        nowTick.value = now;
-      }
-      rafId = requestAnimationFrame(tick);
-    };
+const startRaf = () => {
+  if (rafId !== null) return;
+  const tick = () => {
+    const now = Date.now();
+    if (now - nowTick.value >= 64) {
+      nowTick.value = now;
+    }
     rafId = requestAnimationFrame(tick);
-  }
+  };
+  rafId = requestAnimationFrame(tick);
+};
+
+const stopRaf = () => {
+  if (rafId === null) return;
+  cancelAnimationFrame(rafId);
+  rafId = null;
+};
+
+const startTick = () => {
+  // The slider is scaled by the media duration, so without one (radio, or a
+  // player that only reports a bare elapsed_time) it stays pinned and the time
+  // label is the only thing that moves; the 1s interval alone keeps that fresh.
+  // Reading the duration here also makes it a dependency of the computed that
+  // drives the tick, so the rAF loop follows a duration arriving or going away.
+  if (store.activePlayer?.current_media?.duration) startRaf();
+  else stopRaf();
+
   if (fallbackTimer === null) {
     fallbackTimer = setInterval(() => (nowTick.value = Date.now()), 1000);
   }
 };
 
 const stopTick = () => {
-  if (rafId !== null) {
-    cancelAnimationFrame(rafId);
-    rafId = null;
-  }
+  stopRaf();
   if (fallbackTimer !== null) {
     clearInterval(fallbackTimer);
     fallbackTimer = null;

--- a/tests/layouts/PlayerTimeline.test.ts
+++ b/tests/layouts/PlayerTimeline.test.ts
@@ -207,12 +207,16 @@ describe("PlayerTimeline", () => {
     expect(timerCount()).toEqual({ raf: 0, interval: 1 });
   });
 
+  // the duration is changed in place in both tests below: replacing current_media
+  // would move the timing fields the tick already watches, and the tick has to
+  // follow the duration on its own
   it("starts the smooth tick once a duration arrives", async () => {
     store.activePlayer = {
       player_id: "p1",
       playback_state: PlaybackState.PLAYING,
       elapsed_time: 30,
       elapsed_time_last_updated: NOW,
+      current_media: {},
     };
 
     mountTimeline();
@@ -220,7 +224,7 @@ describe("PlayerTimeline", () => {
     expect(timerCount()).toEqual({ raf: 0, interval: 1 });
 
     // e.g. a radio stream handing over to a track with a known length
-    store.activePlayer!.current_media = { duration: 300 };
+    store.activePlayer!.current_media!.duration = 300;
     await nextTick();
     expect(timerCount()).toEqual({ raf: 1, interval: 1 });
   });
@@ -238,7 +242,7 @@ describe("PlayerTimeline", () => {
     await elapsedLabelAfter(1);
     expect(timerCount()).toEqual({ raf: 1, interval: 1 });
 
-    store.activePlayer!.current_media = {};
+    store.activePlayer!.current_media!.duration = undefined;
     await nextTick();
     expect(timerCount()).toEqual({ raf: 0, interval: 1 });
   });
@@ -334,7 +338,8 @@ function elapsedLabel(): string {
 
 /**
  * The tickers the mounted timeline is currently running: the rAF loop that
- * animates the slider and the 1s interval that refreshes the time labels.
+ * animates the slider, and everything else it has scheduled, which with no seek
+ * in flight is just the 1s interval that refreshes the time labels.
  */
 function timerCount(): { raf: number; interval: number } {
   return {

--- a/tests/layouts/PlayerTimeline.test.ts
+++ b/tests/layouts/PlayerTimeline.test.ts
@@ -67,10 +67,31 @@ const store = storeModule as unknown as TestStore;
 const NOW = 1_700_000_000;
 
 let wrapper: VueWrapper | undefined;
+// fake timers fake requestAnimationFrame as well, so a scheduled frame counts
+// towards vi.getTimerCount(); the outstanding frames are tracked separately to
+// tell the two tickers apart.
+let pendingFrames: Set<number>;
 
 beforeEach(() => {
   vi.useFakeTimers();
   vi.setSystemTime(NOW * 1000);
+  pendingFrames = new Set();
+  const scheduleFrame = globalThis.requestAnimationFrame;
+  const cancelFrame = globalThis.cancelAnimationFrame;
+  vi.spyOn(globalThis, "requestAnimationFrame").mockImplementation(
+    (callback) => {
+      const id = scheduleFrame((time) => {
+        pendingFrames.delete(id);
+        callback(time);
+      });
+      pendingFrames.add(id);
+      return id;
+    },
+  );
+  vi.spyOn(globalThis, "cancelAnimationFrame").mockImplementation((id) => {
+    pendingFrames.delete(id);
+    cancelFrame(id);
+  });
   api.queues = {};
   api.queueElapsedTime = {};
   store.activePlayer = undefined;
@@ -82,6 +103,8 @@ afterEach(() => {
   // test's state and its timers would count towards that test's timer budget
   wrapper?.unmount();
   wrapper = undefined;
+  // restore before the fake timers go, so the spies do not outlive them
+  vi.restoreAllMocks();
   vi.useRealTimers();
 });
 
@@ -165,6 +188,61 @@ describe("PlayerTimeline", () => {
     expect(await elapsedLabelAfter(6)).toBe("00:36");
   });
 
+  it.each([
+    ["there is no current_media", undefined],
+    ["current_media reports no duration", {}],
+  ])("only runs the label timer when %s", async (_case, currentMedia) => {
+    store.activePlayer = {
+      player_id: "p1",
+      playback_state: PlaybackState.PLAYING,
+      elapsed_time: 30,
+      elapsed_time_last_updated: NOW,
+      current_media: currentMedia,
+    };
+
+    mountTimeline();
+    // the slider cannot move without a duration, so the label is all that is
+    // left to refresh and the rAF loop would repaint an unchanged track
+    expect(await elapsedLabelAfter(6)).toBe("00:36");
+    expect(timerCount()).toEqual({ raf: 0, interval: 1 });
+  });
+
+  it("starts the smooth tick once a duration arrives", async () => {
+    store.activePlayer = {
+      player_id: "p1",
+      playback_state: PlaybackState.PLAYING,
+      elapsed_time: 30,
+      elapsed_time_last_updated: NOW,
+    };
+
+    mountTimeline();
+    await elapsedLabelAfter(1);
+    expect(timerCount()).toEqual({ raf: 0, interval: 1 });
+
+    // e.g. a radio stream handing over to a track with a known length
+    store.activePlayer!.current_media = { duration: 300 };
+    await nextTick();
+    expect(timerCount()).toEqual({ raf: 1, interval: 1 });
+  });
+
+  it("stops the smooth tick once the duration goes away", async () => {
+    store.activePlayer = {
+      player_id: "p1",
+      playback_state: PlaybackState.PLAYING,
+      elapsed_time: 30,
+      elapsed_time_last_updated: NOW,
+      current_media: { duration: 300 },
+    };
+
+    mountTimeline();
+    await elapsedLabelAfter(1);
+    expect(timerCount()).toEqual({ raf: 1, interval: 1 });
+
+    store.activePlayer!.current_media = {};
+    await nextTick();
+    expect(timerCount()).toEqual({ raf: 0, interval: 1 });
+  });
+
   it("does not start the tick for a source that is paused", async () => {
     store.activePlayer = {
       player_id: "p1",
@@ -176,7 +254,7 @@ describe("PlayerTimeline", () => {
 
     mountTimeline();
     expect(await elapsedLabelAfter(10)).toBe("00:30");
-    expect(vi.getTimerCount()).toBe(0);
+    expect(timerCount()).toEqual({ raf: 0, interval: 0 });
   });
 
   it("stops ticking once playback stops", async () => {
@@ -200,7 +278,7 @@ describe("PlayerTimeline", () => {
     };
     await nextTick();
     // the timers are released rather than left spinning behind a frozen label
-    expect(vi.getTimerCount()).toBe(0);
+    expect(timerCount()).toEqual({ raf: 0, interval: 0 });
     expect(await elapsedLabelAfter(20)).toBe("00:34");
   });
 
@@ -213,7 +291,7 @@ describe("PlayerTimeline", () => {
 
     mountTimeline();
     expect(await elapsedLabelAfter(10)).toBe("00:00");
-    expect(vi.getTimerCount()).toBe(0);
+    expect(timerCount()).toEqual({ raf: 0, interval: 0 });
   });
 
   it("releases the tick on unmount", async () => {
@@ -227,10 +305,10 @@ describe("PlayerTimeline", () => {
 
     mountTimeline();
     await elapsedLabelAfter(1);
-    expect(vi.getTimerCount()).toBeGreaterThan(0);
+    expect(timerCount()).toEqual({ raf: 1, interval: 1 });
 
     wrapper!.unmount();
-    expect(vi.getTimerCount()).toBe(0);
+    expect(timerCount()).toEqual({ raf: 0, interval: 0 });
   });
 });
 
@@ -252,6 +330,17 @@ function mountTimeline() {
 
 function elapsedLabel(): string {
   return wrapper!.find(".time-text-left").text();
+}
+
+/**
+ * The tickers the mounted timeline is currently running: the rAF loop that
+ * animates the slider and the 1s interval that refreshes the time labels.
+ */
+function timerCount(): { raf: number; interval: number } {
+  return {
+    raf: pendingFrames.size,
+    interval: vi.getTimerCount() - pendingFrames.size,
+  };
 }
 
 /**


### PR DESCRIPTION
The player timeline runs a 60fps animation loop to move the progress slider smoothly. That loop only has something to animate when the track length is known: without one (radio streams, and players that only report a bare playback position) the slider stays pinned and the time label is the only thing that changes. It kept waking up ~60 times a second anyway, for no visible effect.

- Only run the animation loop when a track length is known; the 1s timer that refreshes the time labels always runs
- Start or stop the loop as a track length appears or disappears
- Extended the timeline tests to cover both cases