### PR TITLE
Document when a queue counts as active

### DIFF
--- a/src/helpers/activeElapsedTime.ts
+++ b/src/helpers/activeElapsedTime.ts
@@ -87,8 +87,9 @@ export function resolveQueueTiming(
   player_id?: string,
 ): ActiveTiming | undefined {
   const queue = resolvePlayerQueue(resolvePlayer(player_id));
-  // An inactive queue holds the position it stopped at, while its current item is
-  // already gone; pairing the two would mix a stale position with a default speed.
+  // The queue only reads inactive while a handover back to it is still propagating;
+  // the position it holds is then from before the source took over, so it is not
+  // reported as this queue's timing.
   if (!queue?.active) return undefined;
 
   const queueTime = api.queueElapsedTime[queue.queue_id];

--- a/src/plugins/api/helpers.ts
+++ b/src/plugins/api/helpers.ts
@@ -187,6 +187,11 @@ export const getSourceName = function (player: Player) {
  *
  * A player either plays the queue of the source it is attached to, or its own
  * queue when it has no source; an inactive own queue does not count.
+ *
+ * A player taken over by an external source is attached to no queue at all, so
+ * callers get undefined for it rather than an inactive queue. The queue that is
+ * returned reads `active` in every settled state, and reads inactive only while a
+ * handover back to it is still propagating.
  */
 export function resolvePlayerQueue(player?: Player): PlayerQueue | undefined {
   if (player?.active_source && player.active_source in api.queues) {

--- a/tests/plugins/api/helpers.test.ts
+++ b/tests/plugins/api/helpers.test.ts
@@ -113,6 +113,14 @@ describe("resolvePlayerQueue", () => {
     expect(resolvePlayerQueue(player({}))?.queue_id).toBe("p1");
   });
 
+  it("returns the player's own queue reached through its source while inactive", () => {
+    api.queues["p1"] = { queue_id: "p1", active: false } as PlayerQueue;
+
+    expect(resolvePlayerQueue(player({ active_source: "p1" }))?.queue_id).toBe(
+      "p1",
+    );
+  });
+
   it("ignores the player's own queue while it is inactive", () => {
     api.queues["p1"] = { queue_id: "p1", active: false } as PlayerQueue;
 


### PR DESCRIPTION
Nine places check `PlayerQueue.active` before showing queue info, which suggests the check is what keeps an external source (line-in, Spotify Connect, a group parent) from leaking queue data into the UI. It isn't: `resolvePlayerQueue()` already returns nothing for a player playing an external source, so every one of those checks only ever fires for the split second a handover back to the queue takes to reach us. One comment stated the wrong reason for the check, which is how the duplication kept growing.

No behaviour change - only the reasoning is recorded, so the next reader doesn't add a tenth check or move the existing ones somewhere that would break the queue list and "playing from ..." messages.

- Documented in `resolvePlayerQueue()` that a returned queue is the one the player is attached to, and when its `active` flag can briefly disagree
- Corrected the stale reason given for the timing guard in `resolveQueueTiming()`
- Added a test pinning that resolving by source ignores a lagging `active` flag
