### PR TITLE
Fix the Discord playback position after seeking

### DIFF
--- a/src/helpers/activeElapsedTime.ts
+++ b/src/helpers/activeElapsedTime.ts
@@ -8,8 +8,8 @@
  * the current values on each call and holds no state, which makes them equally
  * usable inside a `computed` and inside a rAF/interval loop.
  *
- * Every function defaults to the active player; pass a `player_id` to resolve
- * another player, such as the one an OS media session targets.
+ * Every `resolve*` function defaults to the active player; pass a `player_id` to
+ * resolve another player, such as the one an OS media session targets.
  */
 import { computeElapsedTime, queueItemPlaybackSpeed } from "@/helpers/elapsed";
 import api from "@/plugins/api";

--- a/src/helpers/activeElapsedTime.ts
+++ b/src/helpers/activeElapsedTime.ts
@@ -127,17 +127,16 @@ export function resolveQueueElapsedTime(
   return toElapsedTime(resolveQueueTiming(player_id));
 }
 
-function resolvePlayer(player_id?: string): Player | undefined {
-  if (player_id === undefined) return store.activePlayer;
-  return api.players[player_id];
-}
-
-function resolveCurrentItem(player?: Player): QueueItem | undefined {
-  const queue = resolvePlayerQueue(player);
-  return queue?.active ? queue.current_item : undefined;
-}
-
-function toElapsedTime(timing: ActiveTiming | undefined): number | undefined {
+/**
+ * The position a timing source reports as of now, in seconds, or undefined when
+ * there is no timing.
+ *
+ * Use this to project a timing that was captured earlier, such as the one a
+ * previous push was based on, forward to the current moment.
+ */
+export function toElapsedTime(
+  timing: ActiveTiming | undefined,
+): number | undefined {
   if (!timing) return undefined;
 
   return computeElapsedTime(
@@ -146,4 +145,14 @@ function toElapsedTime(timing: ActiveTiming | undefined): number | undefined {
     timing.playbackState,
     timing.playbackSpeed,
   );
+}
+
+function resolvePlayer(player_id?: string): Player | undefined {
+  if (player_id === undefined) return store.activePlayer;
+  return api.players[player_id];
+}
+
+function resolveCurrentItem(player?: Player): QueueItem | undefined {
+  const queue = resolvePlayerQueue(player);
+  return queue?.active ? queue.current_item : undefined;
 }

--- a/src/plugins/companion.ts
+++ b/src/plugins/companion.ts
@@ -273,8 +273,8 @@ const extractNowPlaying = (player: Player | undefined): NowPlaying => {
 
 // Store the unwatch function for cleanup
 let unwatchNowPlaying: (() => void) | null = null;
-// Timer of a push that is waiting for the rest of a change to arrive
-let pendingPush: ReturnType<typeof setTimeout> | undefined;
+// Drops a push that is still waiting for the rest of a change to arrive
+let cancelPendingPush: (() => void) | null = null;
 
 /**
  * Handle player commands from the companion app (tray controls)
@@ -337,6 +337,9 @@ const unregisterPlayerCommandHandler = (): void => {
 /**
  * Everything about the active player that decides whether the companion app
  * needs a fresh now-playing push.
+ *
+ * `timing` is a snapshot, carrying the playback state of the source it came from,
+ * so it stays usable as the baseline a later position is compared against.
  */
 interface NowPlayingSignal {
   uri?: string;
@@ -348,15 +351,19 @@ interface NowPlayingSignal {
 }
 
 // How far the position may drift from the projection of the last push before it
-// counts as a jump rather than normal progression. The server applies the same
-// threshold before it reports a position change at all.
+// counts as a jump rather than normal progression. Smaller offsets are not worth
+// an update: Discord's bar is only accurate to the second anyway. The comparison
+// cancels out the current time, so neither clock drift nor a refreshed server
+// time estimate can register as a jump.
 const POSITION_JUMP_SECONDS = 2;
 
 // How long to let the rest of a change arrive before pushing it. One change
 // reaches the frontend as several messages - the queue's timing and the player's
 // media are separate events - so pushing on the first would send the new track
-// with the old position, and Discord may rate-limit the correction away.
-const PUSH_COALESCE_MS = 1000;
+// with the old position, and Discord may rate-limit the correction away. Kept
+// short because the messages arrive in one burst, and because the tray and the
+// OS media controls consume the same push and should not visibly lag.
+const PUSH_COALESCE_MS = 250;
 
 /**
  * Whether the companion app has to be told about this signal, given the one the
@@ -420,12 +427,18 @@ const startNowPlayingWatcher = (): void => {
   // against, and the most recent one seen, which the next push is built from.
   let pushedSignal: NowPlayingSignal | undefined;
   let latestSignal: NowPlayingSignal | undefined;
+  let pushTimer: ReturnType<typeof setTimeout> | undefined;
 
   const push = (): void => {
-    pendingPush = undefined;
+    pushTimer = undefined;
     pushedSignal = latestSignal;
     const nowPlaying = extractNowPlaying(store.activePlayer);
     updateNowPlaying(nowPlaying);
+  };
+
+  cancelPendingPush = (): void => {
+    clearTimeout(pushTimer);
+    pushTimer = undefined;
   };
 
   // Watch for changes in track, playback state or position
@@ -442,16 +455,12 @@ const startNowPlayingWatcher = (): void => {
       latestSignal = signal;
       if (pushedSignal && !needsNowPlayingPush(signal, pushedSignal)) return;
 
-      // The first push has nothing to coalesce with, and the companion app
-      // should not sit without any state until the next change.
-      if (!pushedSignal) {
-        push();
-        return;
-      }
-
-      // Already waiting: the push takes whatever has arrived by the time it runs.
-      if (pendingPush === undefined) {
-        pendingPush = setTimeout(push, PUSH_COALESCE_MS);
+      // Every push waits, including the first: at startup the player and its
+      // timing arrive separately too. Already waiting means the push takes
+      // whatever has arrived by the time it runs, so the timer is not restarted
+      // - a steady stream of changes must not hold it off indefinitely.
+      if (pushTimer === undefined) {
+        pushTimer = setTimeout(push, PUSH_COALESCE_MS);
       }
     },
     { immediate: true },
@@ -463,9 +472,9 @@ const startNowPlayingWatcher = (): void => {
  */
 const stopNowPlayingWatcher = (): void => {
   // A pending push would otherwise land after the cleared state and revive it
-  if (pendingPush !== undefined) {
-    clearTimeout(pendingPush);
-    pendingPush = undefined;
+  if (cancelPendingPush) {
+    cancelPendingPush();
+    cancelPendingPush = null;
   }
   if (unwatchNowPlaying) {
     console.log("[Companion] Stopping existing now-playing watcher");

--- a/src/plugins/companion.ts
+++ b/src/plugins/companion.ts
@@ -18,7 +18,12 @@
  * When not running in a companion app (e.g., in a browser), all functions are no-ops.
  */
 
-import { resolveActiveElapsedTime } from "@/helpers/activeElapsedTime";
+import {
+  ActiveTiming,
+  resolveActiveElapsedTime,
+  resolveActiveTiming,
+  toElapsedTime,
+} from "@/helpers/activeElapsedTime";
 import { getMediaImageUrl } from "@/helpers/utils";
 import { PlaybackState, Player, PlayerSource } from "@/plugins/api/interfaces";
 import { store } from "@/plugins/store";
@@ -268,6 +273,8 @@ const extractNowPlaying = (player: Player | undefined): NowPlaying => {
 
 // Store the unwatch function for cleanup
 let unwatchNowPlaying: (() => void) | null = null;
+// Timer of a push that is waiting for the rest of a change to arrive
+let pendingPush: ReturnType<typeof setTimeout> | undefined;
 
 /**
  * Handle player commands from the companion app (tray controls)
@@ -328,6 +335,66 @@ const unregisterPlayerCommandHandler = (): void => {
 };
 
 /**
+ * Everything about the active player that decides whether the companion app
+ * needs a fresh now-playing push.
+ */
+interface NowPlayingSignal {
+  uri?: string;
+  title?: string;
+  artist?: string;
+  state?: PlaybackState;
+  playerId?: string;
+  timing?: ActiveTiming;
+}
+
+// How far the position may drift from the projection of the last push before it
+// counts as a jump rather than normal progression. The server applies the same
+// threshold before it reports a position change at all.
+const POSITION_JUMP_SECONDS = 2;
+
+// How long to let the rest of a change arrive before pushing it. One change
+// reaches the frontend as several messages - the queue's timing and the player's
+// media are separate events - so pushing on the first would send the new track
+// with the old position, and Discord may rate-limit the correction away.
+const PUSH_COALESCE_MS = 1000;
+
+/**
+ * Whether the companion app has to be told about this signal, given the one the
+ * last push was based on.
+ *
+ * Discord Rich Presence turns a push into absolute start/end timestamps and runs
+ * its own progress bar from them, so it needs one whenever the track, the state
+ * or the position moves off that projection - and none while the position merely
+ * advances, because Discord rate-limits activity updates.
+ */
+const needsNowPlayingPush = (
+  signal: NowPlayingSignal,
+  pushed: NowPlayingSignal,
+): boolean => {
+  if (
+    signal.uri !== pushed.uri ||
+    signal.title !== pushed.title ||
+    signal.artist !== pushed.artist ||
+    signal.state !== pushed.state ||
+    signal.playerId !== pushed.playerId
+  ) {
+    return true;
+  }
+
+  // A speed change leaves the position where it is but moves the end timestamp.
+  if (signal.timing?.playbackSpeed !== pushed.timing?.playbackSpeed)
+    return true;
+
+  const projected = toElapsedTime(pushed.timing);
+  const current = toElapsedTime(signal.timing);
+  if (projected === undefined || current === undefined) {
+    return projected !== current;
+  }
+
+  return Math.abs(current - projected) > POSITION_JUMP_SECONDS;
+};
+
+/**
  * Start watching the active player and push updates to Tauri
  */
 const startNowPlayingWatcher = (): void => {
@@ -349,30 +416,43 @@ const startNowPlayingWatcher = (): void => {
     console.warn("[Companion] Failed to start services:", e),
   );
 
-  // Watch for changes in track or playback state
+  // The signal the last push was based on, which every later one is judged
+  // against, and the most recent one seen, which the next push is built from.
+  let pushedSignal: NowPlayingSignal | undefined;
+  let latestSignal: NowPlayingSignal | undefined;
+
+  const push = (): void => {
+    pendingPush = undefined;
+    pushedSignal = latestSignal;
+    const nowPlaying = extractNowPlaying(store.activePlayer);
+    updateNowPlaying(nowPlaying);
+  };
+
+  // Watch for changes in track, playback state or position
   unwatchNowPlaying = watch(
-    () => ({
+    (): NowPlayingSignal => ({
       uri: store.activePlayer?.current_media?.uri,
       title: store.activePlayer?.current_media?.title,
       artist: store.activePlayer?.current_media?.artist,
       state: store.activePlayer?.playback_state,
       playerId: store.activePlayer?.player_id,
+      timing: resolveActiveTiming(store.activePlayer?.player_id),
     }),
-    (newVal, oldVal) => {
-      // Skip if nothing meaningful changed
-      if (
-        oldVal &&
-        newVal.uri === oldVal.uri &&
-        newVal.title === oldVal.title &&
-        newVal.artist === oldVal.artist &&
-        newVal.state === oldVal.state &&
-        newVal.playerId === oldVal.playerId
-      ) {
+    (signal) => {
+      latestSignal = signal;
+      if (pushedSignal && !needsNowPlayingPush(signal, pushedSignal)) return;
+
+      // The first push has nothing to coalesce with, and the companion app
+      // should not sit without any state until the next change.
+      if (!pushedSignal) {
+        push();
         return;
       }
 
-      const nowPlaying = extractNowPlaying(store.activePlayer);
-      updateNowPlaying(nowPlaying);
+      // Already waiting: the push takes whatever has arrived by the time it runs.
+      if (pendingPush === undefined) {
+        pendingPush = setTimeout(push, PUSH_COALESCE_MS);
+      }
     },
     { immediate: true },
   );
@@ -382,6 +462,11 @@ const startNowPlayingWatcher = (): void => {
  * Stop watching the active player queue
  */
 const stopNowPlayingWatcher = (): void => {
+  // A pending push would otherwise land after the cleared state and revive it
+  if (pendingPush !== undefined) {
+    clearTimeout(pendingPush);
+    pendingPush = undefined;
+  }
   if (unwatchNowPlaying) {
     console.log("[Companion] Stopping existing now-playing watcher");
     unwatchNowPlaying();

--- a/tests/plugins/companion.test.ts
+++ b/tests/plugins/companion.test.ts
@@ -110,9 +110,18 @@ function lastNowPlaying(): NowPlaying {
 /**
  * Let the window in which a push waits for the rest of a change elapse, moving
  * the clock along with it the way real time would.
+ *
+ * Comfortably longer than the watcher's own window, which the positions expected
+ * below therefore round away rather than depend on.
  */
 async function settlePush(): Promise<void> {
-  await vi.advanceTimersByTimeAsync(1000);
+  await vi.advanceTimersByTimeAsync(500);
+}
+
+/** Start the integration and let its first push go out. */
+async function initializeAndSettle(): Promise<void> {
+  await initializeCompanionIntegration("");
+  await settlePush();
 }
 
 beforeEach(() => {
@@ -142,7 +151,7 @@ describe("companion now-playing position", () => {
     seedPlayer({ playback_state: PlaybackState.PLAYING });
 
     vi.setSystemTime((NOW + 4) * 1000);
-    await initializeCompanionIntegration("");
+    await initializeAndSettle();
 
     expect(lastNowPlaying().elapsed).toBe(14);
   });
@@ -162,7 +171,7 @@ describe("companion now-playing position", () => {
     seedPlayer({ playback_state: PlaybackState.PLAYING });
 
     vi.setSystemTime((NOW + 10) * 1000);
-    await initializeCompanionIntegration("");
+    await initializeAndSettle();
 
     expect(lastNowPlaying().elapsed).toBe(115); // 100 + 10 * 1.5
   });
@@ -180,7 +189,7 @@ describe("companion now-playing position", () => {
     });
 
     vi.setSystemTime((NOW + 3) * 1000);
-    await initializeCompanionIntegration("");
+    await initializeAndSettle();
 
     expect(lastNowPlaying().elapsed).toBe(23);
   });
@@ -194,7 +203,7 @@ describe("companion now-playing position", () => {
     });
 
     vi.setSystemTime((NOW + 6) * 1000);
-    await initializeCompanionIntegration("");
+    await initializeAndSettle();
 
     expect(lastNowPlaying().elapsed).toBe(36);
   });
@@ -208,7 +217,7 @@ describe("companion now-playing position", () => {
     seedPlayer({ playback_state: PlaybackState.PAUSED });
 
     vi.setSystemTime((NOW + 50) * 1000);
-    await initializeCompanionIntegration("");
+    await initializeAndSettle();
 
     const nowPlaying = lastNowPlaying();
     expect(nowPlaying.elapsed).toBe(42);
@@ -221,7 +230,7 @@ describe("companion now-playing position", () => {
       current_media: { title: "Track" },
     });
 
-    await initializeCompanionIntegration("");
+    await initializeAndSettle();
 
     expect(lastNowPlaying().elapsed).toBeNull();
   });
@@ -247,7 +256,7 @@ describe("companion now-playing position", () => {
     };
 
     vi.setSystemTime((NOW + 4) * 1000);
-    await initializeCompanionIntegration("");
+    await initializeAndSettle();
 
     const nowPlaying = lastNowPlaying();
     expect(nowPlaying.player_id).toBe(PLAYER_ID);
@@ -268,7 +277,7 @@ describe("companion now-playing position", () => {
       current_media: { uri: "track://1", title: "First" },
     });
 
-    await initializeCompanionIntegration("");
+    await initializeAndSettle();
     expect(lastNowPlaying().elapsed).toBe(0);
 
     // a track change 30s later re-pushes, with the position as of the push
@@ -283,7 +292,7 @@ describe("companion now-playing position", () => {
 
     const nowPlaying = lastNowPlaying();
     expect(nowPlaying.track).toBe("Second");
-    expect(nowPlaying.elapsed).toBe(8); // 5 + (31 - 28)
+    expect(nowPlaying.elapsed).toBe(7); // 5 + (30 - 28)
   });
 
   it("re-pushes after a seek, so Discord stops running from the old position", async () => {
@@ -297,7 +306,7 @@ describe("companion now-playing position", () => {
       current_media: { uri: "track://1", title: "First", duration: 300 },
     });
 
-    await initializeCompanionIntegration("");
+    await initializeAndSettle();
     const pushCount = nowPlayingPushes().length;
 
     // 5s later the user seeks to 2:00, which changes neither track nor state
@@ -310,7 +319,7 @@ describe("companion now-playing position", () => {
     await settlePush();
 
     expect(nowPlayingPushes()).toHaveLength(pushCount + 1);
-    expect(lastNowPlaying().elapsed).toBe(121); // 120, a second on into the push
+    expect(lastNowPlaying().elapsed).toBe(120);
   });
 
   it("pushes a seek once, not again for the player update that follows it", async () => {
@@ -326,7 +335,7 @@ describe("companion now-playing position", () => {
       current_media: { uri: "track://1", title: "First", duration: 300 },
     });
 
-    await initializeCompanionIntegration("");
+    await initializeAndSettle();
     const pushCount = nowPlayingPushes().length;
 
     vi.setSystemTime((NOW + 5) * 1000);
@@ -361,7 +370,7 @@ describe("companion now-playing position", () => {
       current_media: { uri: "track://1", title: "First", duration: 300 },
     });
 
-    await initializeCompanionIntegration("");
+    await initializeAndSettle();
 
     // seek, then disconnect before the push it scheduled comes due
     apiMock.queueElapsedTime["q1"] = {
@@ -375,9 +384,71 @@ describe("companion now-playing position", () => {
     expect(lastNowPlaying().track).toBeNull();
   });
 
-  it("does not push while the server merely ticks the position along", async () => {
-    // Discord rate-limits activity updates to roughly one per 15s, so the
-    // per-second position updates the server sends must not each become a push.
+  it("keeps pushing during a run of changes instead of holding off", async () => {
+    // Dragging a seek slider reports a new position over and over; each push
+    // waits for the rest of a change, but a next change must not defer it again.
+    seedQueue({ queue_id: "q1", state: PlaybackState.PLAYING, active: true });
+    apiMock.queueElapsedTime["q1"] = {
+      elapsed_time: 0,
+      elapsed_time_last_updated: NOW,
+    };
+    seedPlayer({
+      playback_state: PlaybackState.PLAYING,
+      current_media: { uri: "track://1", title: "First", duration: 600 },
+    });
+
+    await initializeAndSettle();
+    const pushCount = nowPlayingPushes().length;
+
+    for (let step = 1; step <= 5; step++) {
+      apiMock.queueElapsedTime["q1"] = {
+        elapsed_time: step * 30,
+        elapsed_time_last_updated: NOW,
+      };
+      await nextTick();
+      await vi.advanceTimersByTimeAsync(100);
+    }
+    await settlePush();
+
+    expect(nowPlayingPushes().length).toBeGreaterThan(pushCount);
+    // the position last dragged to, not one of the four before it
+    expect(lastNowPlaying().elapsed).toBeGreaterThanOrEqual(150);
+    expect(lastNowPlaying().elapsed).toBeLessThan(155);
+  });
+
+  it("re-pushes after a reconnect rather than reusing the old watcher", async () => {
+    seedQueue({ queue_id: "q1", state: PlaybackState.PLAYING, active: true });
+    apiMock.queueElapsedTime["q1"] = {
+      elapsed_time: 10,
+      elapsed_time_last_updated: NOW,
+    };
+    seedPlayer({
+      playback_state: PlaybackState.PLAYING,
+      current_media: { uri: "track://1", title: "First", duration: 300 },
+    });
+
+    await initializeAndSettle();
+
+    // a seek arms a push, then the connection is re-established before it runs
+    apiMock.queueElapsedTime["q1"] = {
+      elapsed_time: 120,
+      elapsed_time_last_updated: NOW,
+    };
+    await nextTick();
+    await initializeCompanionIntegration("");
+    const pushCount = nowPlayingPushes().length;
+    await settlePush();
+
+    // the fresh watcher pushes once; the abandoned one does not push at all
+    expect(nowPlayingPushes()).toHaveLength(pushCount + 1);
+    // and it carries the seeked-to position, not the one it started from
+    expect(lastNowPlaying().elapsed).toBeGreaterThanOrEqual(120);
+    expect(lastNowPlaying().elapsed).toBeLessThan(125);
+  });
+
+  it("does not push while the timing source only re-bases on itself", async () => {
+    // Discord rate-limits activity updates to roughly one per 15s, so a timing
+    // source that re-anchors as it goes must not turn each re-anchor into a push.
     seedQueue({ queue_id: "q1", state: PlaybackState.PLAYING, active: true });
     apiMock.queueElapsedTime["q1"] = {
       elapsed_time: 0,
@@ -388,7 +459,7 @@ describe("companion now-playing position", () => {
       current_media: { uri: "track://1", title: "First", duration: 300 },
     });
 
-    await initializeCompanionIntegration("");
+    await initializeAndSettle();
     const pushCount = nowPlayingPushes().length;
 
     for (let second = 1; second <= 30; second++) {
@@ -424,7 +495,7 @@ describe("companion now-playing position", () => {
         current_media: { uri: "track://1", title: "First", duration: 240 },
       });
 
-      await initializeCompanionIntegration("");
+      await initializeAndSettle();
       const pushCount = nowPlayingPushes().length;
 
       vi.setSystemTime((NOW + 1) * 1000);
@@ -449,7 +520,7 @@ describe("companion now-playing position", () => {
       const nowPlaying = lastNowPlaying();
       expect(nowPlayingPushes()).toHaveLength(pushCount + 1);
       expect(nowPlaying.track).toBe("Second");
-      expect(nowPlaying.elapsed).toBe(1); // 0, a second on into the push
+      expect(nowPlaying.elapsed).toBe(0);
     },
   );
 
@@ -470,7 +541,7 @@ describe("companion now-playing position", () => {
       current_media: { uri: "book://1", title: "Chapter 1", duration: 3600 },
     });
 
-    await initializeCompanionIntegration("");
+    await initializeAndSettle();
     const pushCount = nowPlayingPushes().length;
 
     apiMock.queues["q1"].current_item = {
@@ -495,7 +566,7 @@ describe("companion now-playing position", () => {
       current_media: { uri: "track://1", title: "First" },
     });
 
-    await initializeCompanionIntegration("");
+    await initializeAndSettle();
     const pushCount = nowPlayingPushes().length;
 
     // the position advances and any interval would come due

--- a/tests/plugins/companion.test.ts
+++ b/tests/plugins/companion.test.ts
@@ -33,18 +33,19 @@ interface MockPlayer {
   };
 }
 
-// The store has to be reactive for the now-playing watcher to fire on changes.
+// Both have to be reactive for the now-playing watcher to fire on changes, the
+// same way the real store and api expose their state.
 const { apiMock, storeMock } = await vi.hoisted(async () => {
   const { reactive } = await import("vue");
   return {
-    apiMock: {
+    apiMock: reactive({
       players: {} as Record<string, MockPlayer>,
       queues: {} as Record<string, MockQueue>,
       queueElapsedTime: {} as Record<
         string,
         { elapsed_time?: number; elapsed_time_last_updated?: number }
       >,
-    },
+    }),
     storeMock: reactive({
       activePlayer: undefined as MockPlayer | undefined,
       companionPlayerId: undefined as string | undefined,
@@ -104,6 +105,14 @@ function lastNowPlaying(): NowPlaying {
   const pushes = nowPlayingPushes();
   expect(pushes.length).toBeGreaterThan(0);
   return pushes[pushes.length - 1];
+}
+
+/**
+ * Let the window in which a push waits for the rest of a change elapse, moving
+ * the clock along with it the way real time would.
+ */
+async function settlePush(): Promise<void> {
+  await vi.advanceTimersByTimeAsync(1000);
 }
 
 beforeEach(() => {
@@ -262,7 +271,7 @@ describe("companion now-playing position", () => {
     await initializeCompanionIntegration("");
     expect(lastNowPlaying().elapsed).toBe(0);
 
-    // a track change 30s later re-pushes, with the position as of then
+    // a track change 30s later re-pushes, with the position as of the push
     vi.setSystemTime((NOW + 30) * 1000);
     apiMock.queueElapsedTime["q1"] = {
       elapsed_time: 5,
@@ -270,10 +279,207 @@ describe("companion now-playing position", () => {
     };
     seedPlayer({ current_media: { uri: "track://2", title: "Second" } });
     await nextTick();
+    await settlePush();
 
     const nowPlaying = lastNowPlaying();
     expect(nowPlaying.track).toBe("Second");
-    expect(nowPlaying.elapsed).toBe(7); // 5 + (30 - 28)
+    expect(nowPlaying.elapsed).toBe(8); // 5 + (31 - 28)
+  });
+
+  it("re-pushes after a seek, so Discord stops running from the old position", async () => {
+    seedQueue({ queue_id: "q1", state: PlaybackState.PLAYING, active: true });
+    apiMock.queueElapsedTime["q1"] = {
+      elapsed_time: 10,
+      elapsed_time_last_updated: NOW,
+    };
+    seedPlayer({
+      playback_state: PlaybackState.PLAYING,
+      current_media: { uri: "track://1", title: "First", duration: 300 },
+    });
+
+    await initializeCompanionIntegration("");
+    const pushCount = nowPlayingPushes().length;
+
+    // 5s later the user seeks to 2:00, which changes neither track nor state
+    vi.setSystemTime((NOW + 5) * 1000);
+    apiMock.queueElapsedTime["q1"] = {
+      elapsed_time: 120,
+      elapsed_time_last_updated: NOW + 5,
+    };
+    await nextTick();
+    await settlePush();
+
+    expect(nowPlayingPushes()).toHaveLength(pushCount + 1);
+    expect(lastNowPlaying().elapsed).toBe(121); // 120, a second on into the push
+  });
+
+  it("pushes a seek once, not again for the player update that follows it", async () => {
+    // The server re-bases the queue timing and then triggers a player update
+    // carrying the same fresh position; Discord must not be told twice.
+    seedQueue({ queue_id: "q1", state: PlaybackState.PLAYING, active: true });
+    apiMock.queueElapsedTime["q1"] = {
+      elapsed_time: 10,
+      elapsed_time_last_updated: NOW,
+    };
+    seedPlayer({
+      playback_state: PlaybackState.PLAYING,
+      current_media: { uri: "track://1", title: "First", duration: 300 },
+    });
+
+    await initializeCompanionIntegration("");
+    const pushCount = nowPlayingPushes().length;
+
+    vi.setSystemTime((NOW + 5) * 1000);
+    apiMock.queueElapsedTime["q1"] = {
+      elapsed_time: 120,
+      elapsed_time_last_updated: NOW + 5,
+    };
+    await nextTick();
+    seedPlayer({
+      current_media: {
+        uri: "track://1",
+        title: "First",
+        duration: 300,
+        elapsed_time: 120,
+        elapsed_time_last_updated: NOW + 5,
+      },
+    });
+    await nextTick();
+    await settlePush();
+
+    expect(nowPlayingPushes()).toHaveLength(pushCount + 1);
+  });
+
+  it("drops a pending push on cleanup instead of reviving the cleared state", async () => {
+    seedQueue({ queue_id: "q1", state: PlaybackState.PLAYING, active: true });
+    apiMock.queueElapsedTime["q1"] = {
+      elapsed_time: 10,
+      elapsed_time_last_updated: NOW,
+    };
+    seedPlayer({
+      playback_state: PlaybackState.PLAYING,
+      current_media: { uri: "track://1", title: "First", duration: 300 },
+    });
+
+    await initializeCompanionIntegration("");
+
+    // seek, then disconnect before the push it scheduled comes due
+    apiMock.queueElapsedTime["q1"] = {
+      elapsed_time: 120,
+      elapsed_time_last_updated: NOW,
+    };
+    await nextTick();
+    cleanupCompanionIntegration();
+    await settlePush();
+
+    expect(lastNowPlaying().track).toBeNull();
+  });
+
+  it("does not push while the server merely ticks the position along", async () => {
+    // Discord rate-limits activity updates to roughly one per 15s, so the
+    // per-second position updates the server sends must not each become a push.
+    seedQueue({ queue_id: "q1", state: PlaybackState.PLAYING, active: true });
+    apiMock.queueElapsedTime["q1"] = {
+      elapsed_time: 0,
+      elapsed_time_last_updated: NOW,
+    };
+    seedPlayer({
+      playback_state: PlaybackState.PLAYING,
+      current_media: { uri: "track://1", title: "First", duration: 300 },
+    });
+
+    await initializeCompanionIntegration("");
+    const pushCount = nowPlayingPushes().length;
+
+    for (let second = 1; second <= 30; second++) {
+      vi.setSystemTime((NOW + second) * 1000);
+      // the reported position lags the update a little, as a real one does
+      apiMock.queueElapsedTime["q1"] = {
+        elapsed_time: second - 0.4,
+        elapsed_time_last_updated: NOW + second,
+      };
+      await nextTick();
+    }
+    // let any push these wrongly scheduled come due, so it is not missed here
+    await settlePush();
+
+    expect(nowPlayingPushes()).toHaveLength(pushCount);
+  });
+
+  it.each([
+    ["the player update first", ["player", "queue"]],
+    ["the queue update first", ["queue", "player"]],
+  ] as const)(
+    "pushes a track change once and with the new track's position, %s",
+    async (_name, order) => {
+      // The new media and the re-based queue timing arrive as separate events,
+      // so either one alone describes half of the old track and half of the new.
+      seedQueue({ queue_id: "q1", state: PlaybackState.PLAYING, active: true });
+      apiMock.queueElapsedTime["q1"] = {
+        elapsed_time: 240,
+        elapsed_time_last_updated: NOW,
+      };
+      seedPlayer({
+        playback_state: PlaybackState.PLAYING,
+        current_media: { uri: "track://1", title: "First", duration: 240 },
+      });
+
+      await initializeCompanionIntegration("");
+      const pushCount = nowPlayingPushes().length;
+
+      vi.setSystemTime((NOW + 1) * 1000);
+      const events = {
+        player: () =>
+          seedPlayer({
+            current_media: { uri: "track://2", title: "Second", duration: 200 },
+          }),
+        queue: () => {
+          apiMock.queueElapsedTime["q1"] = {
+            elapsed_time: 0,
+            elapsed_time_last_updated: NOW + 1,
+          };
+        },
+      };
+      for (const event of order) {
+        events[event]();
+        await nextTick();
+      }
+      await settlePush();
+
+      const nowPlaying = lastNowPlaying();
+      expect(nowPlayingPushes()).toHaveLength(pushCount + 1);
+      expect(nowPlaying.track).toBe("Second");
+      expect(nowPlaying.elapsed).toBe(1); // 0, a second on into the push
+    },
+  );
+
+  it("re-pushes when the playback speed changes", async () => {
+    // The position stays put but Discord's implied end timestamp moves.
+    seedQueue({
+      queue_id: "q1",
+      state: PlaybackState.PLAYING,
+      active: true,
+      current_item: { extra_attributes: { playback_speed: 1 } },
+    });
+    apiMock.queueElapsedTime["q1"] = {
+      elapsed_time: 60,
+      elapsed_time_last_updated: NOW,
+    };
+    seedPlayer({
+      playback_state: PlaybackState.PLAYING,
+      current_media: { uri: "book://1", title: "Chapter 1", duration: 3600 },
+    });
+
+    await initializeCompanionIntegration("");
+    const pushCount = nowPlayingPushes().length;
+
+    apiMock.queues["q1"].current_item = {
+      extra_attributes: { playback_speed: 1.5 },
+    };
+    await nextTick();
+    await settlePush();
+
+    expect(nowPlayingPushes()).toHaveLength(pushCount + 1);
   });
 
   it("does not push on its own while a track plays on", async () => {


### PR DESCRIPTION
Seeking while a track plays left Discord Rich Presence showing the old position for the rest of the track. #2291 fixed the position *value* we send, but nothing triggered a new update after a seek: the companion watcher only reacted to track and playback state changes, and a seek changes neither. Discord turns each update into fixed start/end timestamps and animates from them, so without a new update its progress bar stayed offset.

The same watcher also sent the new track's title together with the previous track's position on every track change, because the two arrive as separate events.

- Push a fresh update when the position jumps away from where the last one projected it to be, so a seek is picked up while normal playback still sends nothing (Discord rate-limits updates)
- Push on a playback speed change too, since that moves the point Discord thinks the track ends
- Briefly wait before pushing, so a change that reaches us as separate queue and player events is sent once, with the new track and its own position
- Cancel a pending update on disconnect so it cannot revive the cleared now-playing state