### PR TITLE
Clean up unused props on the player bar timeline

### DIFF
--- a/src/layouts/default/PlayerOSD/Player.vue
+++ b/src/layouts/default/PlayerOSD/Player.vue
@@ -30,17 +30,7 @@
           }"
         />
         <!-- progress bar -->
-        <PlayerTimeline
-          v-if="getBreakpointValue('bp6')"
-          :is-progress-bar="false"
-          :disabled="
-            !store.activePlayerQueue?.active ||
-            !timelineMediaTypes.includes(
-              store.activePlayerQueue?.current_item?.media_item
-                ?.media_type as MediaType,
-            )
-          "
-        />
+        <PlayerTimeline v-if="getBreakpointValue('bp6')" />
       </div>
       <div class="mediacontrols-bottom-right">
         <div>
@@ -114,7 +104,6 @@
 
 <script setup lang="ts">
 import { ImageColorPalette, paletteFromServer } from "@/helpers/utils";
-import { MediaType } from "@/plugins/api/interfaces";
 import { getBreakpointValue } from "@/plugins/breakpoint";
 import { store } from "@/plugins/store";
 import vuetify from "@/plugins/vuetify";
@@ -152,10 +141,6 @@ const themeColor = computed(() =>
 const playIconStyle = computed(() => ({
   "--play-icon-color": vuetify.theme.current.value.dark ? "#212121" : "#fff",
 }));
-
-// Media types that get a fully-featured timeline. AudioSource items decide
-// seekability via their own can_seek flag (read inside PlayerTimeline).
-const timelineMediaTypes = [MediaType.TRACK, MediaType.AUDIO_SOURCE];
 </script>
 
 <style scoped lang="scss">


### PR DESCRIPTION
The player bar passed two props to `PlayerTimeline` that the component does not declare: `is-progress-bar` and `disabled`. Vue passed them straight through as plain HTML attributes onto the component's root `<div>`, so a meaningless `disabled` attribute ended up in the DOM (always present, regardless of the value the expression produced) and that expression was re-evaluated on every render for nothing.

Whether the timeline can be seeked is already decided inside `PlayerTimeline` itself, based on the player's power state, the media duration and the source's own `can_seek` flag — which is more accurate than the old expression (it also allows seeking in audiobooks and podcasts).

- Remove the `is-progress-bar` and `disabled` props from the player bar timeline
- Remove the now-unused `timelineMediaTypes` list and `MediaType` import

No visible change.