### PR TITLE
Avoid duplicate waveform requests after a hot reload during development

### DIFF
--- a/src/composables/useActiveTrackWaveform.ts
+++ b/src/composables/useActiveTrackWaveform.ts
@@ -33,8 +33,11 @@ const watcherScope = effectScope(true);
 
 // A hot update evaluates a fresh copy of this module, so the watcher of the
 // replaced copy has to be stopped or it keeps fetching alongside the new one.
+// Accepting makes this module the boundary that receives that disposal, and
+// invalidating passes the update on so consumers render against the new copy.
 if (import.meta.hot) {
   import.meta.hot.dispose(() => watcherScope.stop());
+  import.meta.hot.accept(() => import.meta.hot?.invalidate());
 }
 
 /**

--- a/src/composables/useActiveTrackWaveform.ts
+++ b/src/composables/useActiveTrackWaveform.ts
@@ -31,6 +31,12 @@ let stopWatcher: WatchStopHandle | undefined;
 // effect scope of whichever consumer happened to register first.
 const watcherScope = effectScope(true);
 
+// A hot update evaluates a fresh copy of this module, so the watcher of the
+// replaced copy has to be stopped or it keeps fetching alongside the new one.
+if (import.meta.hot) {
+  import.meta.hot.dispose(() => watcherScope.stop());
+}
+
 /**
  * Waveform bins and duration of the currently playing track.
  *


### PR DESCRIPTION
The shared waveform watcher lives in a module-level effect scope that is not tied to any component. During development, editing the composable leaves the watcher from the replaced module copy running next to the newly loaded one, so every track change fires the waveform request twice until the page is fully reloaded.

- Stop the shared watcher scope when Vite replaces the module
- Accept the update in this module, so it becomes the boundary the disposal is tied to, and pass the update on to the components afterwards

Development-only cleanup, no change in behaviour for users.