### PR TITLE
Use the shared queue resolution in the player card

### DIFF
--- a/src/components/PlayerCard.vue
+++ b/src/components/PlayerCard.vue
@@ -218,6 +218,7 @@ import {
   isBuiltinPlayer,
 } from "@/helpers/utils";
 import api from "@/plugins/api";
+import { resolvePlayerQueue } from "@/plugins/api/helpers";
 import {
   PlaybackState,
   type Player,
@@ -259,15 +260,7 @@ const emit = defineEmits<{
 const artworkFailed = ref(false);
 const { activeSource } = useActiveSource(toRef(props, "player"));
 
-const playerQueue = computed(() => {
-  if (props.player.active_source && props.player.active_source in api.queues) {
-    return api.queues[props.player.active_source];
-  }
-  if (!props.player.active_source && props.player.player_id in api.queues) {
-    return api.queues[props.player.player_id];
-  }
-  return undefined;
-});
+const playerQueue = computed(() => resolvePlayerQueue(props.player));
 
 const artworkUrl = computed(() => {
   if (


### PR DESCRIPTION
The player card had its own copy of the logic that works out which queue a player is playing, and that copy missed the check that the player's own queue is actually active. While a queue hand-over is still settling the card could briefly act on the wrong queue, which the shared helper already guards against.

- Player card now uses the shared queue resolution helper instead of its own duplicate.
