### PR TITLE
Show what a settings action did instead of redrawing the form

### DIFF
--- a/src/components/ui/sonner/Sonner.vue
+++ b/src/components/ui/sonner/Sonner.vue
@@ -50,6 +50,14 @@ const props = defineProps<ToasterProps>();
 
 <style>
 /*
+ * Keep the line breaks of a multi-line message (e.g. a certificate summary
+ * reported by a settings action) instead of collapsing them into one run-on line.
+ */
+[data-sonner-toast] [data-title] {
+  white-space: pre-line;
+}
+
+/*
  * Make the toast action button read as a darker variant of the toast bg
  * instead of the default high-contrast popover-foreground button.
  * Each toast type swaps the bg/text vars so the button picks up the

--- a/src/composables/useConfigAction.ts
+++ b/src/composables/useConfigAction.ts
@@ -7,9 +7,10 @@
 import type { Ref } from "vue";
 import { toast } from "vue-sonner";
 import { mergeActionEntries } from "@/helpers/config_entry_ui";
-import { openActionUrlEntries } from "@/helpers/utils";
+import { openActionResultUrl, openActionUrlEntries } from "@/helpers/utils";
 import type {
   Config,
+  ConfigActionResult,
   ConfigEntry,
   ConfigValueType,
 } from "@/plugins/api/interfaces";
@@ -20,8 +21,8 @@ interface UseConfigActionOptions<T extends Config> {
   config: Ref<T | undefined>;
   /** Toggled around the invoke so the form can show its loading overlay. */
   loading: Ref<boolean>;
-  /** Runs the action on the server and returns the entries to re-render. */
-  invokeAction: (action: string) => Promise<ConfigEntry[]>;
+  /** Runs the action on the server and returns the entries to re-render, or its result. */
+  invokeAction: (action: string) => Promise<ConfigEntry[] | ConfigActionResult>;
   /** Persists the given raw values and returns the stored config. */
   saveValues: (values: Record<string, ConfigValueType>) => Promise<Config>;
 }
@@ -47,7 +48,15 @@ export function useConfigAction<T extends Config>({
   ) {
     loading.value = true;
     try {
-      const entries = openActionUrlEntries(await invokeAction(action));
+      const response = await invokeAction(action);
+      if (!Array.isArray(response)) {
+        // A result only reports the outcome of the action: it never carries
+        // values, so the form is left untouched.
+        openActionResultUrl(response.open_url);
+        toast.success(response.message || $t("settings.action_completed"));
+        return;
+      }
+      const entries = openActionUrlEntries(response);
       // An empty response means the action was a one-off side effect with
       // nothing to re-render: leave the form untouched.
       if (entries.length === 0) {

--- a/src/helpers/openActionUrlEntries.test.ts
+++ b/src/helpers/openActionUrlEntries.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, afterEach } from "vitest";
-import { openActionUrlEntries } from "./utils";
+import { openActionResultUrl, openActionUrlEntries } from "./utils";
 import { type ConfigEntry, ConfigEntryType } from "@/plugins/api/interfaces";
 
 const urlEntry = (value: unknown, key = "wizard"): ConfigEntry =>
@@ -72,6 +72,57 @@ describe("openActionUrlEntries", () => {
       .mockImplementation(() => undefined);
     const entries = [stringEntry("a"), stringEntry("b")];
     expect(openActionUrlEntries(entries)).toEqual(entries);
+    expect(click).not.toHaveBeenCalled();
+  });
+});
+
+describe("openActionResultUrl", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("opens a web url via an anchor click", () => {
+    const anchors: HTMLAnchorElement[] = [];
+    const click = vi
+      .spyOn(HTMLAnchorElement.prototype, "click")
+      .mockImplementation(function (this: HTMLAnchorElement) {
+        anchors.push(this);
+      });
+    openActionResultUrl("https://example.com/mcp");
+    expect(click).toHaveBeenCalledTimes(1);
+    expect(anchors[0].getAttribute("href")).toBe("https://example.com/mcp");
+    expect(anchors[0].getAttribute("target")).toBe("_blank");
+    expect(anchors[0].getAttribute("rel")).toBe("noopener");
+    // the anchor is detached again once clicked
+    expect(anchors[0].isConnected).toBe(false);
+  });
+
+  it("opens a plain http url", () => {
+    const click = vi
+      .spyOn(HTMLAnchorElement.prototype, "click")
+      .mockImplementation(() => undefined);
+    openActionResultUrl("http://192.168.1.10:8095/mcp");
+    expect(click).toHaveBeenCalledTimes(1);
+  });
+
+  it("never opens non-web schemes or unparseable urls", () => {
+    const click = vi
+      .spyOn(HTMLAnchorElement.prototype, "click")
+      .mockImplementation(() => undefined);
+    openActionResultUrl("javascript:alert(1)");
+    openActionResultUrl("file:///etc/passwd");
+    openActionResultUrl("data:text/html,hi");
+    openActionResultUrl("not a url at all");
+    expect(click).not.toHaveBeenCalled();
+  });
+
+  it("is a no-op without a url", () => {
+    const click = vi
+      .spyOn(HTMLAnchorElement.prototype, "click")
+      .mockImplementation(() => undefined);
+    openActionResultUrl(null);
+    openActionResultUrl(undefined);
+    openActionResultUrl("");
     expect(click).not.toHaveBeenCalled();
   });
 });

--- a/src/helpers/utils.ts
+++ b/src/helpers/utils.ts
@@ -53,33 +53,37 @@ export const openLinkInNewTab = function (url: string) {
 };
 
 export const openActionUrlEntries = (entries: ConfigEntry[]): ConfigEntry[] => {
-  // Open URL-type entries returned by a config invoke_action response (one-shot)
-  // via an anchor click, which browsers treat more leniently than window.open
-  // when the triggering user gesture has just expired. Only web URLs are
-  // opened, and all URL entries are dropped from the rendered form.
-  const urls: string[] = [];
+  // Open URL-type entries returned by a config invoke_action response (one-shot).
+  // Only web URLs are opened, and all URL entries are dropped from the rendered form.
   for (const entry of entries) {
     if (entry.type !== ConfigEntryType.URL) continue;
     const target = entry.value ?? entry.default_value;
-    if (typeof target !== "string") continue;
-    try {
-      if (["http:", "https:"].includes(new URL(target).protocol)) {
-        urls.push(target);
-      }
-    } catch {
-      // not a parseable url: drop silently
-    }
-  }
-  for (const url of urls) {
-    const a = document.createElement("a");
-    a.setAttribute("href", url);
-    a.setAttribute("target", "_blank");
-    a.setAttribute("rel", "noopener");
-    document.body.appendChild(a);
-    a.click();
-    a.remove();
+    if (typeof target === "string") openWebUrlOnce(target);
   }
   return entries.filter((e) => e.type !== ConfigEntryType.URL);
+};
+
+export const openActionResultUrl = (url?: string | null) => {
+  // Open the url of a config action result (one-shot).
+  if (url) openWebUrlOnce(url);
+};
+
+const openWebUrlOnce = (url: string) => {
+  // Open via an anchor click, which browsers treat more leniently than
+  // window.open when the triggering user gesture has just expired.
+  try {
+    if (!["http:", "https:"].includes(new URL(url).protocol)) return;
+  } catch {
+    // not a parseable url: ignore silently
+    return;
+  }
+  const a = document.createElement("a");
+  a.setAttribute("href", url);
+  a.setAttribute("target", "_blank");
+  a.setAttribute("rel", "noopener");
+  document.body.appendChild(a);
+  a.click();
+  a.remove();
 };
 
 export const parseBool = (val: string | boolean | undefined | null) => {

--- a/src/plugins/api/index.ts
+++ b/src/plugins/api/index.ts
@@ -39,6 +39,7 @@ import {
   AlbumType,
   Audiobook,
   AuthProvider,
+  ConfigActionResult,
   ConfigEntry,
   ConfigValueType,
   CoreConfig,
@@ -2009,9 +2010,10 @@ export class MusicAssistantApi {
   public async invokeProviderConfigAction(
     instance_id: string,
     action: string,
-  ): Promise<ConfigEntry[]> {
-    // Run a one-shot action button from a provider's options
-    // and return the (re-rendered) config entries.
+  ): Promise<ConfigEntry[] | ConfigActionResult> {
+    // Run a one-shot action button from a provider's options.
+    // Returns either the (re-rendered) config entries, or a result
+    // reporting the outcome of the action.
     return this.sendCommand("config/providers/invoke_action", {
       instance_id,
       action,
@@ -2083,9 +2085,10 @@ export class MusicAssistantApi {
   public async invokePlayerConfigAction(
     player_id: string,
     action: string,
-  ): Promise<ConfigEntry[]> {
-    // Run a one-shot action button from a player's config
-    // and return the (re-rendered) config entries.
+  ): Promise<ConfigEntry[] | ConfigActionResult> {
+    // Run a one-shot action button from a player's config.
+    // Returns either the (re-rendered) config entries, or a result
+    // reporting the outcome of the action.
     return this.sendCommand("config/players/invoke_action", {
       player_id,
       action,
@@ -2319,9 +2322,10 @@ export class MusicAssistantApi {
   public async invokeCoreConfigAction(
     domain: string,
     action: string,
-  ): Promise<ConfigEntry[]> {
-    // Run a one-shot action button from a core module's config
-    // and return the (re-rendered) config entries.
+  ): Promise<ConfigEntry[] | ConfigActionResult> {
+    // Run a one-shot action button from a core module's config.
+    // Returns either the (re-rendered) config entries, or a result
+    // reporting the outcome of the action.
     return this.sendCommand("config/core/invoke_action", { domain, action });
   }
 

--- a/src/plugins/api/interfaces.ts
+++ b/src/plugins/api/interfaces.ts
@@ -667,6 +667,14 @@ export interface Config {
   values: Record<string, ConfigEntry>;
 }
 
+export interface ConfigActionResult {
+  // Outcome of a one-shot config action: a message to show to the user
+  // and/or a url to open once. Both are optional.
+  // message: already localized server-side for the connection locale
+  message: string | null;
+  open_url: string | null;
+}
+
 export enum FlowStepType {
   // form: render config entries and wait for the user to submit
   FORM = "form",

--- a/src/plugins/api/interfaces.ts
+++ b/src/plugins/api/interfaces.ts
@@ -669,7 +669,8 @@ export interface Config {
 
 export interface ConfigActionResult {
   // Outcome of a one-shot config action: a message to show to the user
-  // and/or a url to open once. Both are optional.
+  // and/or a url to open once. Either may be null; a result that carries
+  // neither reports a generic success.
   // message: already localized server-side for the connection locale
   message: string | null;
   open_url: string | null;

--- a/tests/composables/useConfigAction.test.ts
+++ b/tests/composables/useConfigAction.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { useConfigAction } from "@/composables/useConfigAction";
 import {
   ConfigEntryType,
+  type ConfigActionResult,
   type ConfigEntry,
   type ConfigValueType,
 } from "@/plugins/api/interfaces";
@@ -87,6 +88,41 @@ describe("useConfigAction", () => {
     openSpy.mockRestore();
   });
 
+  it("toasts the localized message of an action result", async () => {
+    const { config, loading, invokeAction, saveValues, onAction } = setup();
+    invokeAction.mockResolvedValueOnce({
+      message: "Kopieer deze url naar je client",
+      open_url: null,
+    });
+
+    await onAction("do_thing", {}, true);
+
+    expect(config.value!.values).toEqual({ existing: entry() });
+    expect(saveValues).not.toHaveBeenCalled();
+    expect(toastMock.success).toHaveBeenCalledWith(
+      "Kopieer deze url naar je client",
+    );
+    expect(loading.value).toBe(false);
+  });
+
+  it("opens the url of an action result and falls back to the generic message", async () => {
+    const openSpy = vi
+      .spyOn(HTMLAnchorElement.prototype, "click")
+      .mockImplementation(() => {});
+    const { config, invokeAction, onAction } = setup();
+    invokeAction.mockResolvedValueOnce({
+      message: null,
+      open_url: "https://example.com/mcp",
+    });
+
+    await onAction("do_thing", {}, false);
+
+    expect(openSpy).toHaveBeenCalledTimes(1);
+    expect(config.value!.values).toEqual({ existing: entry() });
+    expect(toastMock.success).toHaveBeenCalledWith("settings.action_completed");
+    openSpy.mockRestore();
+  });
+
   it("reports a failed action and clears loading", async () => {
     const { loading, invokeAction, onAction } = setup();
     invokeAction.mockRejectedValueOnce("action failed");
@@ -143,7 +179,8 @@ function setup() {
     values: { existing: entry() },
   });
   const loading = ref(false);
-  const invokeAction = vi.fn<(action: string) => Promise<ConfigEntry[]>>();
+  const invokeAction =
+    vi.fn<(action: string) => Promise<ConfigEntry[] | ConfigActionResult>>();
   const saveValues =
     vi.fn<
       (


### PR DESCRIPTION
Action buttons in a settings form used to report back by returning a whole set of config entries, making the form redraw. Actions that are a pure one-off now just say what happened, and this shows it as a toast.

Needs the server side: music-assistant/server#5402

- Handle an action response that reports an outcome: show its message as a toast, open its url once, and leave the form untouched
- Fall back to the generic "Action completed" toast when an action reports no message
- Keep the line breaks of a multi-line message (e.g. the SSL certificate summary) instead of collapsing them onto one line
- Add tests for the new result handling and the url helper

Actions that genuinely reshape their form (Bose SoundTouch presets, Yandex Music wave presets, Sendspin pairing) still redraw it as before.