### PR TITLE
Cover the config link buttons in the disabled-state tests

### DIFF
--- a/src/components/discover/EditorialTimeline.vue
+++ b/src/components/discover/EditorialTimeline.vue
@@ -7,7 +7,7 @@
     :gap="gap"
   >
     <template #actions>
-      <slot name="actions" />
+      <slot name="actions"></slot>
     </template>
 
     <EditorialMediaCard

--- a/tests/views/ConfigEntryField.test.ts
+++ b/tests/views/ConfigEntryField.test.ts
@@ -5,12 +5,14 @@ import * as components from "vuetify/components";
 import * as directives from "vuetify/directives";
 import {
   ConfigEntryType,
-  type ConfigEntry,
   type ConfigValueType,
 } from "@/plugins/api/interfaces";
 import {
   NON_INTERACTIVE_ENTRY_TYPES,
+  UI_ENTRY_TYPE,
   type ConfigEntryUI,
+  type ConfigEntryUIType,
+  type InjectedConfigEntry,
 } from "@/helpers/config_entry_ui";
 import ConfigEntryField from "@/views/settings/ConfigEntryField.vue";
 
@@ -25,7 +27,7 @@ const vuetify = createVuetify({ components, directives });
 const IMAGE_DATA_URI =
   "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAAAAAA6fptVAAAACklEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg==";
 
-const INTERACTIVE_ENTRIES: [string, ConfigEntry][] = [
+const INTERACTIVE_ENTRIES: [string, ConfigEntryUI][] = [
   ["a text input", entry({ key: "name", type: ConfigEntryType.STRING })],
   [
     "a password input",
@@ -51,6 +53,24 @@ const INTERACTIVE_ENTRIES: [string, ConfigEntry][] = [
       key: "authenticate",
       type: ConfigEntryType.ACTION,
       action: "authenticate",
+    }),
+  ],
+  // the two link buttons EditPlayer injects, shaped as that view builds them
+  [
+    "a DSP settings link",
+    entry({
+      key: "dsp_settings",
+      type: UI_ENTRY_TYPE.DSP_SETTINGS_LINK,
+      injected: true,
+      read_only: false,
+    }),
+  ],
+  [
+    "a player options link",
+    entry({
+      key: "player_options",
+      type: ConfigEntryType.OPTIONS,
+      injected: true,
     }),
   ],
   [
@@ -101,7 +121,7 @@ describe("ConfigEntryField", () => {
       const wrapper = mountField(
         entry({
           key: "status",
-          type: type as ConfigEntryType,
+          type,
           label: "Nothing to configure",
           value: IMAGE_DATA_URI,
         }),
@@ -139,8 +159,11 @@ describe("ConfigEntryField", () => {
 });
 
 function entry(
-  overrides: Partial<ConfigEntry> & { key: string; type: ConfigEntryType },
-): ConfigEntry {
+  overrides: Partial<InjectedConfigEntry> & {
+    key: string;
+    type: ConfigEntryUIType;
+  },
+): ConfigEntryUI {
   return {
     category: "generic",
     default_value: null,
@@ -148,10 +171,10 @@ function entry(
     required: false,
     value: null as ConfigValueType,
     ...overrides,
-  } as ConfigEntry;
+  } as ConfigEntryUI;
 }
 
-function rangedEntry(type: ConfigEntryType): ConfigEntry {
+function rangedEntry(type: ConfigEntryType): ConfigEntryUI {
   return entry({ key: "crossfade_duration", type, range: [0, 10], value: 5 });
 }
 

--- a/tests/views/ConfigEntryField.test.ts
+++ b/tests/views/ConfigEntryField.test.ts
@@ -27,7 +27,11 @@ const vuetify = createVuetify({ components, directives });
 const IMAGE_DATA_URI =
   "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAAAAAA6fptVAAAACklEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg==";
 
-const INTERACTIVE_ENTRIES: [string, ConfigEntryUI][] = [
+// Third element: text the field only renders on the branch under test. Every branch but
+// the two link buttons is picked by entry type alone, and an entry that matches none of
+// them still renders a text input that honours the disabled state — so without this the
+// link button rows would keep passing after losing their branch.
+const INTERACTIVE_ENTRIES: [string, ConfigEntryUI, string?][] = [
   ["a text input", entry({ key: "name", type: ConfigEntryType.STRING })],
   [
     "a password input",
@@ -55,23 +59,26 @@ const INTERACTIVE_ENTRIES: [string, ConfigEntryUI][] = [
       action: "authenticate",
     }),
   ],
-  // the two link buttons EditPlayer injects, shaped as that view builds them
+  // both link buttons are injected by EditPlayer; the DSP one is recognised by the
+  // `injected` flag alongside its type, so it carries the flag here too
   [
-    "a DSP settings link",
+    "a DSP settings button",
     entry({
       key: "dsp_settings",
       type: UI_ENTRY_TYPE.DSP_SETTINGS_LINK,
       injected: true,
       read_only: false,
     }),
+    "open_dsp_settings",
   ],
   [
-    "a player options link",
+    "a player options button",
     entry({
       key: "player_options",
       type: ConfigEntryType.OPTIONS,
       injected: true,
     }),
+    "player_options.open",
   ],
   [
     "a number input without a range",
@@ -108,10 +115,16 @@ describe("ConfigEntryField", () => {
     },
   );
 
-  it.each(INTERACTIVE_ENTRIES)("disables %s", (_label, confEntry) => {
-    expect(controlStates(mountField(confEntry))).toEqual([false]);
-    expect(controlStates(mountField(confEntry, true))).toEqual([true]);
-  });
+  it.each(INTERACTIVE_ENTRIES)(
+    "disables %s",
+    (_label, confEntry, branchText) => {
+      const wrapper = mountField(confEntry);
+
+      if (branchText) expect(wrapper.text()).toContain(branchText);
+      expect(controlStates(wrapper)).toEqual([false]);
+      expect(controlStates(mountField(confEntry, true))).toEqual([true]);
+    },
+  );
 
   // these types take no disabled binding; a form hides them while their dependency is unmet
   it.each(NON_INTERACTIVE_ENTRY_TYPES)(


### PR DESCRIPTION
The settings form has a test that checks every interactive config field honours the form-wide disabled state. Two fields were missing from it: the "Open DSP settings" and "Open player options" buttons. Both already respect the disabled state, but nothing guarded that, so a future change could silently leave either button clickable on a form that is meant to be locked.

Also fixes a lint error that is currently failing the build on main, so this can go green.

- Add both buttons to the disabled-state test table
- Have those rows also check the field rendered the right control, since an unrecognised entry falls back to a plain text box that would satisfy the disabled check on its own
- Widen the test entry factory to cover the frontend-injected entries, dropping a cast it no longer needs
- Close the self-closing slot tag on the artist timeline, which trips vue/html-self-closing