### PR TITLE
Clean up unreachable error handling in the logout path

### DIFF
--- a/src/plugins/auth.ts
+++ b/src/plugins/auth.ts
@@ -304,14 +304,10 @@ export class AuthManager {
 
     // Send logout command to server first (best effort)
     if (this.token) {
-      try {
-        // Send logout command but don't wait for response to avoid race condition
-        api.logout().catch(() => {
-          // Ignore errors - we're logging out anyway
-        });
-      } catch (error) {
+      // Send logout command but don't wait for response to avoid race condition
+      api.logout().catch(() => {
         // Ignore errors - we're logging out anyway
-      }
+      });
     }
 
     // Clear auth immediately to prevent any auth error messages


### PR DESCRIPTION
The logout path in the auth plugin had a `try/catch` that no longer guarded anything. It used to wrap a dynamic `import()` of the API client, which could fail on a bad chunk load. Since #2294 the client is imported normally, so the only remaining statement inside the `try` is the `api.logout()` call — an async method that can only reject, never throw synchronously, and its rejection is already handled by the attached `.catch()`.

No functional change.

- Removed the redundant outer `try/catch` (and its unused error binding) around the logout command
- Kept the fire-and-forget `.catch()` and the comment explaining why we don't await the response
