### PR TITLE
Tidy up leftover dynamic imports of the auth plugin

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -141,7 +141,6 @@ const handleRemoteAuthenticated = async (credentials: {
   user?: User;
 }) => {
   try {
-    const { authManager } = await import("@/plugins/auth");
     let user = credentials.user;
 
     if (credentials.user && !credentials.token && !credentials.username) {
@@ -196,7 +195,6 @@ const handleLocalConnect = async (serverAddress: string) => {
     console.debug("[App] API already initialized, skipping");
     return;
   }
-  const { authManager } = await import("@/plugins/auth");
   authManager.setBaseUrl(serverAddress);
   await httpProxyBridge.ensureReady();
   await httpProxyBridge.setTransport(null);
@@ -483,7 +481,6 @@ onMounted(async () => {
         // Reset initialization flag to allow re-initialization after reconnection
         initializationCompleted = false;
 
-        const { authManager } = await import("@/plugins/auth");
         if (store.isIngressSession) {
           // In Ingress mode, authentication happens via HA proxy headers
           try {

--- a/src/plugins/api/index.ts
+++ b/src/plugins/api/index.ts
@@ -2450,6 +2450,8 @@ export class MusicAssistantApi {
   }
 
   private async _openBackgroundTasks(): Promise<void> {
+    // Imported dynamically: router.ts imports this module statically, so a
+    // static import here would make the api client and the router directly circular.
     const { default: router } = await import("../router");
     if (router.currentRoute.value.name === "backgroundtasks") {
       return;

--- a/src/plugins/auth.ts
+++ b/src/plugins/auth.ts
@@ -318,6 +318,8 @@ export class AuthManager {
 
     // Notify companion app launcher (if running in companion mode)
     // This navigates back to the server selection screen
+    // Imported dynamically: companion.ts imports this module statically, so a
+    // static import here would make the two plugins directly circular.
     const { notifyCompanionLogout, isCompanionApp } =
       await import("@/plugins/companion");
     if (isCompanionApp()) {

--- a/src/plugins/companion.ts
+++ b/src/plugins/companion.ts
@@ -27,6 +27,7 @@ import {
 import { getMediaImageUrl } from "@/helpers/utils";
 import { api } from "@/plugins/api";
 import { PlaybackState, Player, PlayerSource } from "@/plugins/api/interfaces";
+import { authManager } from "@/plugins/auth";
 import { store } from "@/plugins/store";
 import { ref, watch } from "vue";
 
@@ -508,7 +509,6 @@ export const initializeCompanionIntegration = async (
 
   // Configure native Sendspin player (backend will check if enabled)
   if (serverAddress) {
-    const { authManager } = await import("@/plugins/auth");
     const token = authManager.getToken();
     if (token) {
       const playerId = await configureSendspin(serverAddress, token);


### PR DESCRIPTION
The build logged three warnings about dynamic imports that don't actually split anything off into their own chunk. Traced the import graph to see which ones still serve a purpose.

Two were leftovers: `App.vue` was dynamically importing the auth plugin in three places even though it already imports it normally at the top of the same file, and the companion plugin did the same. Neither avoids a circular import, so they're now plain imports.

The other two are kept on purpose — each one is the single edge that keeps two plugins from importing each other directly (auth ↔ companion, and the API client ↔ the router). Both now carry a note saying so, so they don't get "cleaned up" next time.

- Use the already-imported auth plugin in `App.vue` instead of re-importing it three times
- Import the auth plugin normally in the companion plugin
- Document why the auth → companion and API → router imports stay dynamic