### PR TITLE
Run the test suite once per commit

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,8 +1,17 @@
 name: Test and Lint Vue frontend
 on:
+  # pull_request covers PR branches, so push only needs to catch commits
+  # landing directly on main - otherwise every PR runs the suite twice.
   push:
+    branches:
+      - main
   pull_request:
   workflow_dispatch:
+
+# Supersede in-flight runs for a ref instead of running them to completion.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 env:
   NODE_VERSION: "22.x" # set this to the node version to use


### PR DESCRIPTION
Every commit on a branch with an open PR ran the "Test and Lint" suite twice, because the workflow triggered on both `push` and `pull_request` with no branch filter. That doubled runner usage and time-to-feedback - during the runner shortage on 6 August several jobs sat queued and were cancelled at the 15 minute mark.

- Limit the push trigger to `main`, so PR branches are covered once by the `pull_request` event while direct pushes to main still run
- Add a concurrency group per ref, so pushing again cancels the superseded run instead of letting it finish
