### PR TITLE
Remove an unused config setting type

### DIFF
--- a/src/helpers/config_entry_ui.ts
+++ b/src/helpers/config_entry_ui.ts
@@ -1,15 +1,8 @@
 import { ConfigEntryType, type ConfigEntry } from "@/plugins/api/interfaces";
 
-export const CONFIG_KEY_UI = {
-  DSP_SETTINGS_LINK: "dsp_settings_link",
-} as const;
-
-export type UiOnlyKey = (typeof CONFIG_KEY_UI)[keyof typeof CONFIG_KEY_UI];
-export type ConfigKeyUI = string | UiOnlyKey;
-
 export const UI_ENTRY_TYPE = {
-  // entry type equals key for dsp_settings_link
-  DSP_SETTINGS_LINK: CONFIG_KEY_UI.DSP_SETTINGS_LINK,
+  // the injected DSP entry carries key `dsp_settings` and this as its type
+  DSP_SETTINGS_LINK: "dsp_settings_link",
 } as const;
 
 export type UiOnlyEntryType =

--- a/src/plugins/api/interfaces.ts
+++ b/src/plugins/api/interfaces.ts
@@ -475,7 +475,6 @@ export enum ConfigEntryType {
   URL = "url",
 
   // Only used in the frontend
-  DSP_SETTINGS = "dsp_settings",
   OPTIONS = "options",
 }
 


### PR DESCRIPTION
The `dsp_settings` config entry type was left over in the frontend: the server no longer has it in its config entry types, and nothing in the frontend ever matched against it.

It was also confusing to read, because the DSP link we add to the player settings uses `dsp_settings` as its *key* while its *type* is `dsp_settings_link` — a nearby comment claimed those were the same thing.

- Removed the unused `dsp_settings` config entry type
- Corrected the comment describing the injected DSP entry's key and type
- Dropped the unused UI-only config key constants that went with it