### PR TITLE
Restrict the test workflow to read-only repository access

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,6 +13,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+# Checking out the code is all this workflow needs.
+permissions:
+  contents: read
+
 env:
   NODE_VERSION: "22.x" # set this to the node version to use
 


### PR DESCRIPTION
The "Test and Lint Vue frontend" workflow did not declare any `permissions`, so its `GITHUB_TOKEN` fell back to the repository default permissions. The job only checks out the code and runs the test suite, lint and build — it never writes anything back.

- Added `permissions: contents: read` to `.github/workflows/test.yml`, matching how the other workflows in this repo already declare their scopes.