### PR TITLE
Set explicit token permissions on the remaining two workflows

### DIFF
--- a/.github/workflows/lokalise-download.yml
+++ b/.github/workflows/lokalise-download.yml
@@ -2,6 +2,12 @@ name: Download Lokalise translations
 on: 
   schedule:
     - cron: "0 2 * * 2"
+
+# Pushing the translations branch needs contents, opening the PR needs pull-requests.
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/pr-labels.yaml
+++ b/.github/workflows/pr-labels.yaml
@@ -11,6 +11,9 @@ on:
     branches:
       - main
 
+# The label check reads the event payload from disk, so it needs no token at all.
+permissions: {}
+
 jobs:
   pr_labels:
     name: Verify


### PR DESCRIPTION
Two workflows had no `permissions:` block, so their `GITHUB_TOKEN` fell back to the repository default (currently `write`). The weekly Lokalise job in particular leaned on a setting that lives outside the repo, and would have broken silently if that default were ever tightened. Both are now pinned to what they actually need, matching `test.yml`, `auto-release.yml` and `dependency-security.yml`.

- `lokalise-download.yml`: `contents: write` + `pull-requests: write` — it pushes the translations branch and opens the PR.
- `pr-labels.yaml`: `permissions: {}` — the label check only reads the event payload from disk, so it needs no token.

Two notes on how these were derived:

**Lokalise is cron-only (weekly), so CI cannot exercise it here.** Its scopes come from walking each step: checkout and the CLI download need no token, the translation pull uses its own Lokalise API secret, `git push` needs `contents: write`, and `gh pr create` needs `pull-requests: write`. Run history backs this up — the last 8 scheduled runs all succeeded and the most recent (4 Aug) exercised the full push + PR path, so capping to these two scopes only removes capability it was never using.

**`pr-labels.yaml` is proven by this PR.** It triggers on `pull_request`, which uses the workflow file from the PR itself, so the `Verify` job here ran under the new block: its log shows `GITHUB_TOKEN Permissions → Metadata: read` (the implicit scope that cannot be removed) and it passed. The pinned action's source at `be19cd7` declares only a `labels` input and does nothing but read `GITHUB_EVENT_PATH` off disk — no API calls.

`auto_approve_dependabot.yml` is deliberately untouched: it has no top-level block, but its only job already sets `pull-requests: write` at job level, so its token never ran on the default.
