### PR TITLE
Complete the workflow token permissions cleanup

### DIFF
--- a/.github/workflows/auto_approve_dependabot.yml
+++ b/.github/workflows/auto_approve_dependabot.yml
@@ -2,6 +2,9 @@ name: Auto approve Dependabot PR's
 
 on: pull_request_target
 
+# Deny by default; only the approve job needs a token, which it grants itself below.
+permissions: {}
+
 jobs:
   auto-approve:
     runs-on: ubuntu-latest


### PR DESCRIPTION
`auto_approve_dependabot.yml` was the last workflow without a top-level `permissions:` block. It was deliberately left out of #2312 because its single job already sets `pull-requests: write` at job level, so the token is constrained today — this is not a live vulnerability.

The gap is structural: a second job added to this file would silently inherit the repository default (currently `write`) instead of a locked-down baseline. That is worth closing here in particular, since `pull_request_target` runs with a full-access token in the base repo context.

- `auto_approve_dependabot.yml`: added `permissions: {}` at the top level, keeping the existing job-level `pull-requests: write` on the approve job.

Behaviour is unchanged — the approve job's token is byte-identical. Every workflow in the repo now declares its permissions explicitly.
