### PR TITLE
Automatically label the weekly translations PR

### DIFF
--- a/.github/workflows/lokalise-download.yml
+++ b/.github/workflows/lokalise-download.yml
@@ -3,7 +3,7 @@ on:
   schedule:
     - cron: "0 2 * * 2"
 
-# Pushing the translations branch needs contents, opening the PR needs pull-requests.
+# Pushing the translations branch needs contents, opening and labelling the PR needs pull-requests.
 permissions:
   contents: write
   pull-requests: write
@@ -47,5 +47,5 @@ jobs:
              else
               git commit -m 'Translations update'
               git push --set-upstream origin ${{ env.GITHUB_NEW_BRANCH_NAME }}
-              gh pr create --base main --head ${{ env.GITHUB_NEW_BRANCH_NAME }} --title "Lokalise translations update" --body ""
+              gh pr create --base main --head ${{ env.GITHUB_NEW_BRANCH_NAME }} --title "Lokalise translations update" --body "" --label maintenance
              fi


### PR DESCRIPTION
The weekly Lokalise translations PR opens without a category label, so it lands ungrouped at the top of the release notes next to actual features and fixes, instead of in the collapsed maintenance section.

- The scheduled translations PR now opens with the `maintenance` label
- No extra token permissions needed: applying an existing label is covered by the `pull-requests: write` the workflow already has