### PR TITLE
Align the PR label check with the labels the repo has

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -14,7 +14,6 @@ categories:
 
   - title: "🚀 Features and enhancements"
     labels:
-      - "feature"
       - "enhancement"
       - "new-feature"
 
@@ -26,8 +25,8 @@ categories:
     collapse-after: 3
     labels:
       - "ci"
-      - "documentation"
       - "maintenance"
+      - "refactor"
       - "dependencies"
 
 template: |

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -7,21 +7,27 @@ exclude-contributors:
   - github-actions
   - github-actions[bot]
 
+# A PR can carry labels from more than one category, so every category is
+# exclusive: the first one matching below wins and the PR is listed only once.
 categories:
   - title: "⚠ Breaking Changes"
+    exclusive: true
     labels:
       - "breaking-change"
 
   - title: "🚀 Features and enhancements"
+    exclusive: true
     labels:
       - "enhancement"
       - "new-feature"
 
   - title: "🐛 Bugfixes"
+    exclusive: true
     labels:
       - "bugfix"
 
   - title: "🧰 Maintenance and dependency bumps"
+    exclusive: true
     collapse-after: 3
     labels:
       - "ci"

--- a/.github/workflows/pr-labels.yaml
+++ b/.github/workflows/pr-labels.yaml
@@ -23,4 +23,4 @@ jobs:
         uses: ludeeus/action-require-labels@be19cd7f04c6fad46a85336f9e9cebdf961807bb # 2.0.0
         with:
           labels: >-
-            breaking-change, bugfix, refactor, new-feature, maintenance, ci, dependencies, documentation, new-provider, enhancement
+            breaking-change, bugfix, refactor, new-feature, maintenance, ci, dependencies, enhancement


### PR DESCRIPTION
The PR label check accepted two labels that don't exist in this repo, so anyone told to add one would find it isn't there. On top of that `refactor` had no release notes category, so refactor PRs ended up ungrouped at the top of the release notes next to real features and fixes (the same problem just fixed for the weekly translations PR).

- The label check no longer accepts `documentation` and `new-provider`; both are server-repo categories that don't apply here and were never used
- `refactor` PRs now land in the collapsed maintenance section instead of ungrouped at the top
- Release notes sections are now exclusive, so a PR carrying two category labels (such as `refactor` + `enhancement`) is listed once instead of twice
- Dropped the leftover `documentation` and `feature` entries from the release notes config, since neither exists as a label

Every label the check accepts now exists in the repo and maps to exactly one release notes section.
