### PR TITLE
Search for a Home Assistant entity to use as a player control

### DIFF
--- a/src/components/HassEntityPickerDialog.vue
+++ b/src/components/HassEntityPickerDialog.vue
@@ -72,14 +72,15 @@
               <Badge v-if="isAdded(entity)" variant="secondary">
                 {{ $t("settings.hass_controls.already_added") }}
               </Badge>
-              <Badge
-                v-for="role of extraRoles(entity)"
-                v-else
-                :key="role"
-                variant="outline"
-              >
-                {{ $t(`settings.hass_controls.role.${role}`) }}
-              </Badge>
+              <template v-else>
+                <Badge
+                  v-for="role of extraRoles(entity)"
+                  :key="role"
+                  variant="outline"
+                >
+                  {{ $t(`settings.hass_controls.role.${role}`) }}
+                </Badge>
+              </template>
             </button>
           </div>
           <p
@@ -150,8 +151,9 @@ const searchThrottle = ref<number | undefined>();
 let searchRequestId = 0;
 
 watch(model, (open) => {
-  if (!open) return;
+  // also on close, or a search scheduled just before it still reaches Home Assistant
   clearTimeout(searchThrottle.value);
+  if (!open) return;
   search.value = "";
   groups.value = [];
   truncated.value = false;

--- a/src/components/HassEntityPickerDialog.vue
+++ b/src/components/HassEntityPickerDialog.vue
@@ -12,6 +12,7 @@
       <div class="px-5 py-4">
         <SearchInput
           :model-value="search"
+          :aria-label="$t('settings.hass_controls.search_placeholder')"
           :placeholder="$t('settings.hass_controls.search_placeholder')"
           clearable
           @update:model-value="onSearchInput"
@@ -93,7 +94,7 @@
       </div>
 
       <DialogFooter class="border-t px-5 py-3">
-        <Button variant="outline" @click="model = false">
+        <Button type="button" variant="outline" @click="model = false">
           {{ $t("close") }}
         </Button>
       </DialogFooter>

--- a/src/components/HassEntityPickerDialog.vue
+++ b/src/components/HassEntityPickerDialog.vue
@@ -1,0 +1,217 @@
+<template>
+  <Dialog v-model:open="model">
+    <DialogContent
+      class="flex max-h-[85vh] flex-col gap-0 p-0 sm:max-w-[560px]"
+    >
+      <DialogHeader class="border-b px-5 py-4 pr-12 text-left">
+        <DialogTitle>
+          {{ $t(`settings.hass_controls.title.${controlType}`) }}
+        </DialogTitle>
+      </DialogHeader>
+
+      <div class="px-5 py-4">
+        <SearchInput
+          :model-value="search"
+          :placeholder="$t('settings.hass_controls.search_placeholder')"
+          clearable
+          @update:model-value="onSearchInput"
+        />
+      </div>
+
+      <div
+        class="min-h-[180px] flex-1 overflow-y-auto px-5 pb-4"
+        :class="{ 'opacity-60': loading }"
+      >
+        <div
+          v-if="loading && groups.length === 0"
+          class="flex justify-center py-10"
+        >
+          <Spinner :size="32" class="text-primary" />
+        </div>
+        <p v-else-if="error" class="text-destructive py-8 text-center text-sm">
+          {{ error }}
+        </p>
+        <p
+          v-else-if="groups.length === 0"
+          class="text-muted-foreground py-8 text-center text-sm"
+        >
+          {{ $t("settings.hass_controls.no_results") }}
+        </p>
+        <template v-else>
+          <div
+            v-for="group of groups"
+            :key="groupKey(group)"
+            class="entity-group mb-3 last:mb-0"
+          >
+            <div
+              class="text-muted-foreground mb-1 flex items-baseline gap-2 border-b pb-1 text-xs"
+            >
+              <span class="min-w-0 truncate font-semibold">
+                {{
+                  group.device_name || $t("settings.hass_controls.no_device")
+                }}
+              </span>
+              <span class="min-w-0 truncate">
+                {{ group.area_name || $t("settings.hass_controls.no_area") }}
+              </span>
+            </div>
+            <button
+              v-for="entity of group.entities"
+              :key="entity.entity_id"
+              type="button"
+              class="entity-option hover:bg-accent flex w-full items-center gap-2 rounded-md px-2 py-2 text-left disabled:pointer-events-none disabled:opacity-50"
+              :disabled="isAdded(entity)"
+              @click="pick(entity)"
+            >
+              <span class="min-w-0 flex-1">
+                <span class="block truncate text-sm">{{ entity.name }}</span>
+                <span class="text-muted-foreground block truncate text-xs">
+                  {{ entity.entity_id }}
+                </span>
+              </span>
+              <Badge v-if="isAdded(entity)" variant="secondary">
+                {{ $t("settings.hass_controls.already_added") }}
+              </Badge>
+              <Badge
+                v-for="role of extraRoles(entity)"
+                v-else
+                :key="role"
+                variant="outline"
+              >
+                {{ $t(`settings.hass_controls.role.${role}`) }}
+              </Badge>
+            </button>
+          </div>
+          <p
+            v-if="truncated"
+            class="text-muted-foreground pt-2 text-center text-xs"
+          >
+            {{ $t("settings.hass_controls.truncated") }}
+          </p>
+        </template>
+      </div>
+
+      <DialogFooter class="border-t px-5 py-3">
+        <Button variant="outline" @click="model = false">
+          {{ $t("close") }}
+        </Button>
+      </DialogFooter>
+    </DialogContent>
+  </Dialog>
+</template>
+
+<script setup lang="ts">
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { SearchInput } from "@/components/ui/search-input";
+import { Spinner } from "@/components/ui/spinner";
+import type { HassControlKey } from "@/helpers/config_entry_ui";
+import {
+  searchHassControlEntities,
+  type HassControlEntity,
+  type HassControlEntityGroup,
+} from "@/helpers/hass_controls";
+import { $t } from "@/plugins/i18n";
+import { onBeforeUnmount, ref, watch } from "vue";
+
+const SEARCH_THROTTLE_MS = 400;
+
+const CAPABILITY_BY_CONTROL_KEY = {
+  power_controls: "power",
+  volume_controls: "volume",
+  mute_controls: "mute",
+} as const;
+
+const CAPABILITIES = ["power", "volume", "mute"] as const;
+
+const props = defineProps<{
+  controlType: HassControlKey;
+  // entities already registered for this role, offered but not pickable again
+  addedEntityIds?: string[];
+}>();
+
+const model = defineModel<boolean>();
+
+const emit = defineEmits<{ pick: [entity: HassControlEntity] }>();
+
+const search = ref("");
+const loading = ref(false);
+const error = ref("");
+const groups = ref<HassControlEntityGroup[]>([]);
+const truncated = ref(false);
+const searchThrottle = ref<number | undefined>();
+let searchRequestId = 0;
+
+watch(model, (open) => {
+  if (!open) return;
+  clearTimeout(searchThrottle.value);
+  search.value = "";
+  groups.value = [];
+  truncated.value = false;
+  error.value = "";
+  void runSearch();
+});
+
+onBeforeUnmount(() => {
+  clearTimeout(searchThrottle.value);
+});
+
+const onSearchInput = (value: string) => {
+  search.value = value;
+  clearTimeout(searchThrottle.value);
+  searchThrottle.value = window.setTimeout(
+    () => void runSearch(),
+    SEARCH_THROTTLE_MS,
+  );
+};
+
+const isAdded = (entity: HassControlEntity) =>
+  props.addedEntityIds?.includes(entity.entity_id) ?? false;
+
+// every result can serve the role the picker was opened for, so only the other roles an
+// entity can take on tell the user something new
+const extraRoles = (entity: HassControlEntity) =>
+  CAPABILITIES.filter(
+    (capability) =>
+      capability !== CAPABILITY_BY_CONTROL_KEY[props.controlType] &&
+      entity[capability],
+  );
+
+// a device with entities in several areas is reported once per area
+const groupKey = (group: HassControlEntityGroup) =>
+  `${group.device_id ?? ""}|${group.area_name ?? ""}`;
+
+const pick = (entity: HassControlEntity) => {
+  model.value = false;
+  emit("pick", entity);
+};
+
+const runSearch = async () => {
+  const requestId = ++searchRequestId;
+  loading.value = true;
+  try {
+    const result = await searchHassControlEntities(
+      props.controlType,
+      search.value,
+    );
+    if (requestId !== searchRequestId) return;
+    groups.value = result.groups;
+    truncated.value = result.truncated;
+    error.value = "";
+  } catch {
+    if (requestId !== searchRequestId) return;
+    groups.value = [];
+    truncated.value = false;
+    error.value = $t("settings.hass_controls.search_failed");
+  } finally {
+    if (requestId === searchRequestId) loading.value = false;
+  }
+};
+</script>

--- a/src/helpers/config_entry_ui.ts
+++ b/src/helpers/config_entry_ui.ts
@@ -3,7 +3,28 @@ import { ConfigEntryType, type ConfigEntry } from "@/plugins/api/interfaces";
 export const UI_ENTRY_TYPE = {
   // the injected DSP entry carries key `dsp_settings` and this as its type
   DSP_SETTINGS_LINK: "dsp_settings_link",
+  HASS_CONTROL_PICKER: "hass_control_picker",
 } as const;
+
+/**
+ * The Home Assistant provider config key listing the entities offered for each of the
+ * player control entries.
+ */
+export const HASS_CONTROL_KEY_BY_PLAYER_KEY = {
+  power_control: "power_controls",
+  volume_control: "volume_controls",
+  mute_control: "mute_controls",
+} as const;
+
+export type HassControlPlayerKey = keyof typeof HASS_CONTROL_KEY_BY_PLAYER_KEY;
+export type HassControlKey =
+  (typeof HASS_CONTROL_KEY_BY_PLAYER_KEY)[HassControlPlayerKey];
+
+// the Home Assistant provider config entries that hold a list of control entities; only
+// those of that provider get the entity picker, whoever else uses the same key names
+export const HASS_CONTROL_KEYS: ReadonlySet<string> = new Set(
+  Object.values(HASS_CONTROL_KEY_BY_PLAYER_KEY),
+);
 
 export type UiOnlyEntryType =
   (typeof UI_ENTRY_TYPE)[keyof typeof UI_ENTRY_TYPE];
@@ -19,6 +40,20 @@ export type ServerConfigEntryUI = ConfigEntry & {
   injected?: false;
 };
 export type ConfigEntryUI = ServerConfigEntryUI | InjectedConfigEntry;
+
+/**
+ * The affordance that adds a Home Assistant entity as the control of a single player
+ * control entry, injected beside the entry it fills in.
+ */
+export type HassControlPickerEntry = InjectedConfigEntry & {
+  type: typeof UI_ENTRY_TYPE.HASS_CONTROL_PICKER;
+  // the Home Assistant provider instance the picked entity is registered with
+  hass_instance_id: string;
+  // the provider config list the picked entity is added to
+  hass_control_key: HassControlKey;
+  // the player config entry the picked entity is set on
+  target_key: HassControlPlayerKey;
+};
 
 /**
  * Entry types whose ConfigEntryField branch takes no `disabled` binding.
@@ -117,6 +152,11 @@ export const isDspLinkEntry = (
 ): e is InjectedConfigEntry & {
   type: typeof UI_ENTRY_TYPE.DSP_SETTINGS_LINK;
 } => isInjected(e) && e.type === UI_ENTRY_TYPE.DSP_SETTINGS_LINK;
+
+export const isHassControlPickerEntry = (
+  e: ConfigEntryUI,
+): e is HassControlPickerEntry =>
+  isInjected(e) && e.type === UI_ENTRY_TYPE.HASS_CONTROL_PICKER;
 
 /**
  * Merges a freshly fetched set of config entries into the entries currently

--- a/src/helpers/hass_controls.ts
+++ b/src/helpers/hass_controls.ts
@@ -1,0 +1,85 @@
+import type { HassControlKey } from "@/helpers/config_entry_ui";
+import { api } from "@/plugins/api";
+import type { ProviderInstance } from "@/plugins/api/interfaces";
+
+export const HASS_DOMAIN = "hass";
+
+const SEARCH_CONTROL_ENTITIES_COMMAND = `${HASS_DOMAIN}/search_control_entities`;
+
+export interface HassControlEntity {
+  entity_id: string;
+  name: string;
+  power: boolean;
+  volume: boolean;
+  mute: boolean;
+}
+
+export interface HassControlEntityGroup {
+  device_id: string | null;
+  // null when the entity has no device, respectively no area
+  device_name: string | null;
+  area_name: string | null;
+  entities: HassControlEntity[];
+}
+
+export interface HassControlEntitySearchResult {
+  groups: HassControlEntityGroup[];
+  // true when matches were left out to honour the requested limit
+  truncated: boolean;
+}
+
+/**
+ * The available Home Assistant provider instance, or undefined when there is none.
+ */
+export const getHassProviderInstance = (): ProviderInstance | undefined =>
+  Object.values(api.providers).find(
+    (provider) => provider.domain === HASS_DOMAIN && provider.available,
+  );
+
+/**
+ * Search the Home Assistant entities that can act as a player control, grouped by the
+ * device and area they belong to.
+ *
+ * Rejects when Home Assistant cannot be searched; the caller reports that itself, so no
+ * global error toast is raised.
+ *
+ * @param controlType Control role the returned entities must be able to serve.
+ * @param search Text to match against the entity, device and area names. Every eligible
+ *   entity matches when empty.
+ * @param limit Maximum number of entities to return; the server decides when omitted.
+ */
+export const searchHassControlEntities = (
+  controlType: HassControlKey,
+  search: string,
+  limit?: number,
+): Promise<HassControlEntitySearchResult> =>
+  api.sendCommand<HassControlEntitySearchResult>(
+    SEARCH_CONTROL_ENTITIES_COMMAND,
+    { control_type: controlType, search, limit },
+    { suppressGlobalError: true },
+  );
+
+/**
+ * Add an entity to one of the Home Assistant provider's player control lists.
+ *
+ * Only the affected list is written, so a concurrent edit of the rest of the provider
+ * config survives. Adding an entity that is already listed does nothing.
+ *
+ * @param instanceId The Home Assistant provider instance to write to.
+ * @param controlKey The control list the entity is added to.
+ * @param entityId The Home Assistant entity to register as a control.
+ */
+export const addHassControlEntity = async (
+  instanceId: string,
+  controlKey: HassControlKey,
+  entityId: string,
+): Promise<void> => {
+  const config = await api.getProviderConfig(instanceId);
+  const current = (config.values[controlKey]?.value ?? []) as string[];
+  if (current.includes(entityId)) return;
+  await api.saveProviderConfig(
+    config.domain,
+    { [controlKey]: [...current, entityId] },
+    instanceId,
+  );
+};

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -343,6 +343,28 @@
         "dsp_note_multi_device_group_unsupported": {
             "label": "This group type does not support DSP when playing to multiple devices."
         },
+        "hass_controls": {
+            "add_hass_entity": "Add a Home Assistant entity...",
+            "add_entity": "Add entity...",
+            "title": {
+                "power_controls": "Select a power control",
+                "volume_controls": "Select a volume control",
+                "mute_controls": "Select a mute control"
+            },
+            "search_placeholder": "Search by entity, device or area...",
+            "no_results": "No matching entities",
+            "search_failed": "Could not search Home Assistant entities. Check that Home Assistant is connected.",
+            "truncated": "More entities match than can be shown here, refine your search to narrow it down.",
+            "no_device": "No device",
+            "no_area": "No area",
+            "none_selected": "No entities selected",
+            "already_added": "Added",
+            "role": {
+                "power": "Power",
+                "volume": "Volume",
+                "mute": "Mute"
+            }
+        },
         "add_group_player_desc_universal": "By creating a Universal Player Group, you can group players from different providers\/ecosystems together. \nThis will distribute the same audio to all member players (but not in sync).",
         "edit_provider": "Edit provider: {0}",
         "metadata": "Metadata",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -358,6 +358,7 @@
             "no_device": "No device",
             "no_area": "No area",
             "none_selected": "No entities selected",
+            "remove_entity": "Remove entity",
             "already_added": "Added",
             "role": {
                 "power": "Power",

--- a/src/views/settings/ConfigEntryField.vue
+++ b/src/views/settings/ConfigEntryField.vue
@@ -74,7 +74,7 @@
       :entry="confEntry"
       :disabled="isFieldDisabled"
       @set-entry-value="
-        (key: string, value: string, label?: string) =>
+        (key: string, value: ConfigValueType, label?: string) =>
           emit('setEntryValue', key, value, label)
       "
     />
@@ -428,6 +428,7 @@ const displayOptions = computed(() => {
     if (value === null || value === undefined || listedValues.has(value)) {
       continue;
     }
+    listedValues.add(value);
     options.push({ title: value.toString(), value });
   }
   return options;

--- a/src/views/settings/ConfigEntryField.vue
+++ b/src/views/settings/ConfigEntryField.vue
@@ -68,6 +68,25 @@
       </v-btn>
     </div>
 
+    <!-- Home Assistant entity picker for a single player control -->
+    <HassControlPickerField
+      v-else-if="isHassControlPickerEntry(confEntry)"
+      :entry="confEntry"
+      :disabled="isFieldDisabled"
+      @set-entry-value="
+        (key: string, value: string) => emit('setEntryValue', key, value)
+      "
+    />
+
+    <!-- Home Assistant control entities: current selection plus an entity picker -->
+    <HassControlsField
+      v-else-if="isHassControlsEntry"
+      :entry="confEntry"
+      :label="displayLabel()"
+      :disabled="isFieldDisabled"
+      @update:value="onUpdateValue($event)"
+    />
+
     <!-- Player Options Button -->
     <div
       v-else-if="confEntry.type == ConfigEntryType.OPTIONS"
@@ -297,8 +316,16 @@ import {
 } from "@/plugins/api/interfaces";
 import IconPicker from "@/components/IconPicker.vue";
 import AlertField from "./fields/AlertField.vue";
+import HassControlPickerField from "./fields/HassControlPickerField.vue";
+import HassControlsField from "./fields/HassControlsField.vue";
 import LabelField from "./fields/LabelField.vue";
-import { ConfigEntryUI, isDspLinkEntry } from "@/helpers/config_entry_ui";
+import {
+  ConfigEntryUI,
+  HASS_CONTROL_KEYS,
+  isDspLinkEntry,
+  isHassControlPickerEntry,
+} from "@/helpers/config_entry_ui";
+import { HASS_DOMAIN } from "@/helpers/hass_controls";
 import { $t } from "@/plugins/i18n";
 import { computed } from "vue";
 
@@ -306,7 +333,17 @@ const props = defineProps<{
   confEntry: ConfigEntryUI;
   showPasswordValues: boolean;
   disabled?: boolean;
+  // domain of the provider this config belongs to; absent for player and core configs
+  providerDomain?: string;
 }>();
+
+// only the Home Assistant provider's own control lists get the entity picker, not any
+// other provider that happens to use the same key names
+const isHassControlsEntry = computed(
+  () =>
+    props.providerDomain === HASS_DOMAIN &&
+    HASS_CONTROL_KEYS.has(props.confEntry.key),
+);
 
 const isFieldDisabled = computed(() => {
   return props.disabled || props.confEntry.read_only;
@@ -327,6 +364,8 @@ const emit = defineEmits<{
   (e: "openDsp"): void;
   (e: "openOptions"): void;
   (e: "update:value", value: ConfigValueType): void;
+  // set the value of another entry on the same form
+  (e: "setEntryValue", key: string, value: ConfigValueType): void;
 }>();
 
 // Labels arrive display-ready: server-provided entries are resolved server-side for the
@@ -372,6 +411,18 @@ const displayOptions = computed(() => {
       option.title += ` [${$t("settings.default")}]`;
     }
     options.push(option);
+  }
+  // a value the server has not listed yet - a player control registered moments ago -
+  // would leave the select blank, so it is offered as an option of its own
+  const listedValues = new Set(options.map((option) => option.value));
+  const values = Array.isArray(props.confEntry.value)
+    ? props.confEntry.value
+    : [props.confEntry.value];
+  for (const value of values) {
+    if (value === null || value === undefined || listedValues.has(value)) {
+      continue;
+    }
+    options.push({ title: value.toString(), value });
   }
   return options;
 });

--- a/src/views/settings/ConfigEntryField.vue
+++ b/src/views/settings/ConfigEntryField.vue
@@ -74,7 +74,8 @@
       :entry="confEntry"
       :disabled="isFieldDisabled"
       @set-entry-value="
-        (key: string, value: string) => emit('setEntryValue', key, value)
+        (key: string, value: string, label?: string) =>
+          emit('setEntryValue', key, value, label)
       "
     />
 
@@ -365,7 +366,12 @@ const emit = defineEmits<{
   (e: "openOptions"): void;
   (e: "update:value", value: ConfigValueType): void;
   // set the value of another entry on the same form
-  (e: "setEntryValue", key: string, value: ConfigValueType): void;
+  (
+    e: "setEntryValue",
+    key: string,
+    value: ConfigValueType,
+    label?: string,
+  ): void;
 }>();
 
 // Labels arrive display-ready: server-provided entries are resolved server-side for the

--- a/src/views/settings/ConfigEntryRow.vue
+++ b/src/views/settings/ConfigEntryRow.vue
@@ -14,8 +14,8 @@
       @open-dsp="emit('open-dsp')"
       @open-options="emit('open-options')"
       @set-entry-value="
-        (key: string, value: ConfigValueType) =>
-          emit('set-entry-value', key, value)
+        (key: string, value: ConfigValueType, label?: string) =>
+          emit('set-entry-value', key, value, label)
       "
     />
     <v-chip
@@ -64,7 +64,12 @@ const emit = defineEmits<{
   (e: "open-dsp"): void;
   (e: "open-options"): void;
   (e: "help"): void;
-  (e: "set-entry-value", key: string, value: ConfigValueType): void;
+  (
+    e: "set-entry-value",
+    key: string,
+    value: ConfigValueType,
+    label?: string,
+  ): void;
 }>();
 
 const hasDescriptionOrHelpLink = computed(() => {

--- a/src/views/settings/ConfigEntryRow.vue
+++ b/src/views/settings/ConfigEntryRow.vue
@@ -7,11 +7,16 @@
       :conf-entry="confEntry"
       :show-password-values="showPasswordValues"
       :disabled="disabled"
+      :provider-domain="providerDomain"
       @toggle-password="emit('toggle-password')"
       @update:value="emit('update:value', $event)"
       @action="emit('action')"
       @open-dsp="emit('open-dsp')"
       @open-options="emit('open-options')"
+      @set-entry-value="
+        (key: string, value: ConfigValueType) =>
+          emit('set-entry-value', key, value)
+      "
     />
     <v-chip
       v-if="confEntry.advanced"
@@ -49,6 +54,7 @@ const props = defineProps<{
   confEntry: ConfigEntryUI;
   showPasswordValues: boolean;
   disabled: boolean;
+  providerDomain?: string;
 }>();
 
 const emit = defineEmits<{
@@ -58,6 +64,7 @@ const emit = defineEmits<{
   (e: "open-dsp"): void;
   (e: "open-options"): void;
   (e: "help"): void;
+  (e: "set-entry-value", key: string, value: ConfigValueType): void;
 }>();
 
 const hasDescriptionOrHelpLink = computed(() => {

--- a/src/views/settings/EditConfig.vue
+++ b/src/views/settings/EditConfig.vue
@@ -23,12 +23,14 @@
           :conf-entry="conf_entry"
           :show-password-values="showPasswordValues"
           :disabled="isRowDisabled(conf_entry)"
+          :provider-domain="providerDomain"
           @update:value="onValueUpdate(conf_entry, $event)"
           @toggle-password="showPasswordValues = !showPasswordValues"
           @action="onEntryAction(conf_entry)"
           @open-dsp="openDspConfig"
           @open-options="openPlayerOptions"
           @help="onEntryHelp(conf_entry)"
+          @set-entry-value="onEntryValueSet"
         />
       </div>
     </div>
@@ -71,12 +73,14 @@
           :conf-entry="conf_entry"
           :show-password-values="showPasswordValues"
           :disabled="isRowDisabled(conf_entry)"
+          :provider-domain="providerDomain"
           @update:value="onValueUpdate(conf_entry, $event)"
           @toggle-password="showPasswordValues = !showPasswordValues"
           @action="onEntryAction(conf_entry)"
           @open-dsp="openDspConfig"
           @open-options="openPlayerOptions"
           @help="onEntryHelp(conf_entry)"
+          @set-entry-value="onEntryValueSet"
         />
       </div>
     </div>
@@ -205,6 +209,9 @@ export interface Props {
   // Output protocols of the player being configured; drives derived-transport labelling
   // in the protocol section. Omitted for provider/core configs.
   outputProtocols?: OutputProtocol[];
+  // Domain of the provider being configured; lets a field recognise the entries of the
+  // provider it belongs to. Omitted for player/core configs.
+  providerDomain?: string;
 }
 
 const emit = defineEmits<{
@@ -360,6 +367,13 @@ const onValueUpdate = function (entry: ConfigEntryUI, value: ConfigValueType) {
         : value;
   }
 };
+// a field can fill in another entry of the same form, e.g. the Home Assistant entity
+// picker setting the player control it sits under
+const onEntryValueSet = function (key: string, value: ConfigValueType) {
+  const entry = entries.value?.find((e) => e.key === key);
+  if (entry) onValueUpdate(entry, value);
+};
+
 const openLink = function (url: string) {
   // window.open(url, "_blank");
   const a = document.createElement("a");

--- a/src/views/settings/EditConfig.vue
+++ b/src/views/settings/EditConfig.vue
@@ -369,9 +369,19 @@ const onValueUpdate = function (entry: ConfigEntryUI, value: ConfigValueType) {
 };
 // a field can fill in another entry of the same form, e.g. the Home Assistant entity
 // picker setting the player control it sits under
-const onEntryValueSet = function (key: string, value: ConfigValueType) {
+const onEntryValueSet = function (
+  key: string,
+  value: ConfigValueType,
+  label?: string,
+) {
   const entry = entries.value?.find((e) => e.key === key);
-  if (entry) onValueUpdate(entry, value);
+  if (!entry) return;
+  // the server does not know of the value yet, so carry the name the field gave us or
+  // the field would read back the bare id until the config is fetched again
+  if (label && !entry.options?.some((option) => option.value === value)) {
+    entry.options = [...(entry.options ?? []), { title: label, value }];
+  }
+  onValueUpdate(entry, value);
 };
 
 const openLink = function (url: string) {

--- a/src/views/settings/EditPlayer.vue
+++ b/src/views/settings/EditPlayer.vue
@@ -261,10 +261,14 @@ import { watch } from "vue";
 
 import {
   ConfigEntryUI,
+  HASS_CONTROL_KEY_BY_PLAYER_KEY,
+  HassControlPickerEntry,
+  HassControlPlayerKey,
   UI_ENTRY_TYPE,
   isInjected,
   mergeConfigEntries,
 } from "@/helpers/config_entry_ui";
+import { getHassProviderInstance } from "@/helpers/hass_controls";
 import { useConfigAction } from "@/composables/useConfigAction";
 import { openLinkInNewTab } from "@/helpers/utils";
 import { eventbus } from "@/plugins/eventbus";
@@ -315,8 +319,34 @@ const config_entries = computed(() => {
   const player = api.players[config.value.player_id];
   if (!player) return [];
 
+  // offer the Home Assistant entity picker beneath each player control entry, but only
+  // while there is a Home Assistant provider to register the picked entity with
+  const hassInstance = getHassProviderInstance();
+  const entries: ConfigEntryUI[] = [];
+  for (const entry of Object.values(config.value.values)) {
+    entries.push(entry);
+    const hassControlKey =
+      HASS_CONTROL_KEY_BY_PLAYER_KEY[entry.key as HassControlPlayerKey];
+    if (!hassInstance || !hassControlKey) continue;
+    const pickerEntry: HassControlPickerEntry = {
+      injected: true,
+      key: `${entry.key}_${UI_ENTRY_TYPE.HASS_CONTROL_PICKER}`,
+      type: UI_ENTRY_TYPE.HASS_CONTROL_PICKER,
+      category: entry.category,
+      // stay with the entry it fills in when the form hides or folds that one away
+      advanced: entry.advanced,
+      hidden: entry.hidden,
+      label: "",
+      required: false,
+      default_value: null,
+      hass_instance_id: hassInstance.instance_id,
+      hass_control_key: hassControlKey,
+      target_key: entry.key as HassControlPlayerKey,
+    };
+    entries.push(pickerEntry);
+  }
+
   // inject a link to the DSP config if the player is not a group
-  const entries: ConfigEntryUI[] = Object.values(config.value.values);
   if (player.type !== PlayerType.GROUP) {
     entries.push({
       injected: true,

--- a/src/views/settings/EditPlayer.vue
+++ b/src/views/settings/EditPlayer.vue
@@ -333,9 +333,12 @@ const config_entries = computed(() => {
       key: `${entry.key}_${UI_ENTRY_TYPE.HASS_CONTROL_PICKER}`,
       type: UI_ENTRY_TYPE.HASS_CONTROL_PICKER,
       category: entry.category,
-      // stay with the entry it fills in when the form hides or folds that one away
+      // stay with the entry it fills in when the form hides, folds away or gates that one
       advanced: entry.advanced,
       hidden: entry.hidden,
+      depends_on: entry.depends_on,
+      depends_on_value: entry.depends_on_value,
+      depends_on_value_not: entry.depends_on_value_not,
       label: "",
       required: false,
       default_value: null,

--- a/src/views/settings/EditProvider.vue
+++ b/src/views/settings/EditProvider.vue
@@ -145,6 +145,7 @@
       v-if="config"
       :config-entries="allConfigEntries"
       :disabled="!config.enabled"
+      :provider-domain="config.domain"
       @submit="onSubmit"
       @action="onAction"
       @immediate-apply="onImmediateApply"

--- a/src/views/settings/fields/HassControlPickerField.vue
+++ b/src/views/settings/fields/HassControlPickerField.vue
@@ -15,7 +15,9 @@ const props = defineProps<{
   disabled?: boolean;
 }>();
 
-const emit = defineEmits<{ setEntryValue: [key: string, value: string] }>();
+const emit = defineEmits<{
+  setEntryValue: [key: string, value: string, label?: string];
+}>();
 
 const showPicker = ref(false);
 const saving = ref(false);
@@ -31,7 +33,12 @@ const onPick = async (entity: HassControlEntity) => {
       props.entry.hass_control_key,
       entity.entity_id,
     );
-    emit("setEntryValue", props.entry.target_key, entity.entity_id);
+    emit(
+      "setEntryValue",
+      props.entry.target_key,
+      entity.entity_id,
+      entity.name,
+    );
   } catch {
     // the API layer reports the failure; leaving the entry untouched keeps the form in
     // step with what the provider actually holds

--- a/src/views/settings/fields/HassControlPickerField.vue
+++ b/src/views/settings/fields/HassControlPickerField.vue
@@ -1,0 +1,62 @@
+<script setup lang="ts">
+import HassEntityPickerDialog from "@/components/HassEntityPickerDialog.vue";
+import { Button } from "@/components/ui/button";
+import type { HassControlPickerEntry } from "@/helpers/config_entry_ui";
+import {
+  addHassControlEntity,
+  type HassControlEntity,
+} from "@/helpers/hass_controls";
+import { $t } from "@/plugins/i18n";
+import { Plus } from "@lucide/vue";
+import { ref } from "vue";
+
+const props = defineProps<{
+  entry: HassControlPickerEntry;
+  disabled?: boolean;
+}>();
+
+const emit = defineEmits<{ setEntryValue: [key: string, value: string] }>();
+
+const showPicker = ref(false);
+const saving = ref(false);
+
+const onPick = async (entity: HassControlEntity) => {
+  saving.value = true;
+  try {
+    // registering the entity with the Home Assistant provider is what makes it selectable
+    // as a control, so it is stored right away; the player entry itself is only filled in
+    // on the form and persists when the user saves
+    await addHassControlEntity(
+      props.entry.hass_instance_id,
+      props.entry.hass_control_key,
+      entity.entity_id,
+    );
+    emit("setEntryValue", props.entry.target_key, entity.entity_id);
+  } catch {
+    // the API layer reports the failure; leaving the entry untouched keeps the form in
+    // step with what the provider actually holds
+  } finally {
+    saving.value = false;
+  }
+};
+</script>
+
+<template>
+  <div>
+    <Button
+      variant="ghost"
+      size="sm"
+      class="text-primary -ml-2"
+      :disabled="disabled || saving"
+      @click="showPicker = true"
+    >
+      <Plus class="size-4" />
+      {{ $t("settings.hass_controls.add_hass_entity") }}
+    </Button>
+    <HassEntityPickerDialog
+      v-model="showPicker"
+      :control-type="entry.hass_control_key"
+      @pick="onPick"
+    />
+  </div>
+</template>

--- a/src/views/settings/fields/HassControlPickerField.vue
+++ b/src/views/settings/fields/HassControlPickerField.vue
@@ -51,6 +51,7 @@ const onPick = async (entity: HassControlEntity) => {
 <template>
   <div>
     <Button
+      type="button"
       variant="ghost"
       size="sm"
       class="text-primary -ml-2"

--- a/src/views/settings/fields/HassControlsField.vue
+++ b/src/views/settings/fields/HassControlsField.vue
@@ -1,0 +1,102 @@
+<script setup lang="ts">
+import HassEntityPickerDialog from "@/components/HassEntityPickerDialog.vue";
+import type { ConfigEntryUI, HassControlKey } from "@/helpers/config_entry_ui";
+import type { HassControlEntity } from "@/helpers/hass_controls";
+import { $t } from "@/plugins/i18n";
+import { computed, ref } from "vue";
+
+const props = defineProps<{
+  entry: ConfigEntryUI;
+  label: string;
+  disabled?: boolean;
+}>();
+
+const emit = defineEmits<{ "update:value": [value: string[]] }>();
+
+const showPicker = ref(false);
+
+const controlType = computed(() => props.entry.key as HassControlKey);
+
+const selected = computed(() => (props.entry.value ?? []) as string[]);
+
+// the entity name is only known while the server still ships the options; the entity ID
+// it falls back to identifies the entity just as unambiguously
+const entityTitle = (entityId: string) =>
+  props.entry.options
+    ?.find((option) => option.value === entityId)
+    ?.title?.toString() || entityId;
+
+const onPick = (entity: HassControlEntity) => {
+  if (selected.value.includes(entity.entity_id)) return;
+  emit("update:value", [...selected.value, entity.entity_id]);
+};
+
+const remove = (entityId: string) => {
+  emit(
+    "update:value",
+    selected.value.filter((id) => id !== entityId),
+  );
+};
+</script>
+
+<template>
+  <div class="hass-controls">
+    <v-label class="hass-controls-label">{{ label }}</v-label>
+    <div class="hass-controls-selection">
+      <v-chip
+        v-for="entityId of selected"
+        :key="entityId"
+        size="small"
+        :closable="!disabled"
+        :disabled="disabled"
+        @click:close="remove(entityId)"
+      >
+        {{ entityTitle(entityId) }}
+      </v-chip>
+      <span v-if="selected.length === 0" class="hass-controls-empty">
+        {{ $t("settings.hass_controls.none_selected") }}
+      </span>
+    </div>
+    <div>
+      <v-btn
+        variant="outlined"
+        size="small"
+        :disabled="disabled"
+        @click="showPicker = true"
+      >
+        {{ $t("settings.hass_controls.add_entity") }}
+      </v-btn>
+    </div>
+    <HassEntityPickerDialog
+      v-model="showPicker"
+      :control-type="controlType"
+      :added-entity-ids="selected"
+      @pick="onPick"
+    />
+  </div>
+</template>
+
+<style scoped>
+.hass-controls {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 8px 0;
+}
+
+.hass-controls-label {
+  font-size: 0.875rem;
+  color: rgba(var(--v-theme-on-surface), 0.7);
+}
+
+.hass-controls-selection {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.hass-controls-empty {
+  font-size: 0.813rem;
+  color: rgba(var(--v-theme-on-surface), 0.5);
+}
+</style>

--- a/src/views/settings/fields/HassControlsField.vue
+++ b/src/views/settings/fields/HassControlsField.vue
@@ -52,7 +52,7 @@ const remove = (entityId: string) => {
           v-if="!disabled"
           type="button"
           class="hover:text-foreground ml-1 cursor-pointer"
-          :aria-label="$t('settings.hass_controls.remove_entity')"
+          :aria-label="`${$t('settings.hass_controls.remove_entity')}: ${entityTitle(entityId)}`"
           @click="remove(entityId)"
         >
           <X class="size-3" />

--- a/src/views/settings/fields/HassControlsField.vue
+++ b/src/views/settings/fields/HassControlsField.vue
@@ -1,8 +1,11 @@
 <script setup lang="ts">
 import HassEntityPickerDialog from "@/components/HassEntityPickerDialog.vue";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
 import type { ConfigEntryUI, HassControlKey } from "@/helpers/config_entry_ui";
 import type { HassControlEntity } from "@/helpers/hass_controls";
 import { $t } from "@/plugins/i18n";
+import { Plus, X } from "@lucide/vue";
 import { computed, ref } from "vue";
 
 const props = defineProps<{
@@ -40,32 +43,35 @@ const remove = (entityId: string) => {
 </script>
 
 <template>
-  <div class="hass-controls">
-    <v-label class="hass-controls-label">{{ label }}</v-label>
-    <div class="hass-controls-selection">
-      <v-chip
-        v-for="entityId of selected"
-        :key="entityId"
-        size="small"
-        :closable="!disabled"
-        :disabled="disabled"
-        @click:close="remove(entityId)"
-      >
+  <div class="flex flex-col gap-2 py-2">
+    <span class="text-muted-foreground text-sm">{{ label }}</span>
+    <div class="flex flex-wrap gap-1.5">
+      <Badge v-for="entityId of selected" :key="entityId" variant="secondary">
         {{ entityTitle(entityId) }}
-      </v-chip>
-      <span v-if="selected.length === 0" class="hass-controls-empty">
+        <button
+          v-if="!disabled"
+          type="button"
+          class="hover:text-foreground ml-1 cursor-pointer"
+          :aria-label="$t('settings.hass_controls.remove_entity')"
+          @click="remove(entityId)"
+        >
+          <X class="size-3" />
+        </button>
+      </Badge>
+      <span v-if="selected.length === 0" class="text-muted-foreground text-xs">
         {{ $t("settings.hass_controls.none_selected") }}
       </span>
     </div>
     <div>
-      <v-btn
-        variant="outlined"
-        size="small"
+      <Button
+        variant="outline"
+        size="sm"
         :disabled="disabled"
         @click="showPicker = true"
       >
+        <Plus class="size-4" />
         {{ $t("settings.hass_controls.add_entity") }}
-      </v-btn>
+      </Button>
     </div>
     <HassEntityPickerDialog
       v-model="showPicker"
@@ -75,28 +81,3 @@ const remove = (entityId: string) => {
     />
   </div>
 </template>
-
-<style scoped>
-.hass-controls {
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-  padding: 8px 0;
-}
-
-.hass-controls-label {
-  font-size: 0.875rem;
-  color: rgba(var(--v-theme-on-surface), 0.7);
-}
-
-.hass-controls-selection {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 6px;
-}
-
-.hass-controls-empty {
-  font-size: 0.813rem;
-  color: rgba(var(--v-theme-on-surface), 0.5);
-}
-</style>

--- a/src/views/settings/fields/HassControlsField.vue
+++ b/src/views/settings/fields/HassControlsField.vue
@@ -64,6 +64,7 @@ const remove = (entityId: string) => {
     </div>
     <div>
       <Button
+        type="button"
         variant="outline"
         size="sm"
         :disabled="disabled"

--- a/tests/components/HassEntityPickerDialog.test.ts
+++ b/tests/components/HassEntityPickerDialog.test.ts
@@ -1,0 +1,197 @@
+import HassEntityPickerDialog from "@/components/HassEntityPickerDialog.vue";
+import type {
+  HassControlEntity,
+  HassControlEntityGroup,
+} from "@/helpers/hass_controls";
+import { flushPromises, mount, type VueWrapper } from "@vue/test-utils";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { apiMock } = vi.hoisted(() => ({
+  apiMock: {
+    sendCommand: vi.fn(),
+  },
+}));
+
+vi.mock("@/plugins/api", () => ({
+  api: apiMock,
+  default: apiMock,
+}));
+
+vi.mock("@/plugins/i18n", () => ({
+  $t: (key: string) => key,
+}));
+
+const SEARCH_THROTTLE_MS = 400;
+
+const LIVING_ROOM_GROUP: HassControlEntityGroup = {
+  device_id: "device-1",
+  device_name: "Living room amplifier",
+  area_name: "Living room",
+  entities: [
+    entity({ entity_id: "media_player.amp", name: "Amplifier", volume: true }),
+  ],
+};
+
+const ORPHAN_GROUP: HassControlEntityGroup = {
+  device_id: null,
+  device_name: null,
+  area_name: null,
+  entities: [entity({ entity_id: "switch.relay", name: "Relay" })],
+};
+
+describe("HassEntityPickerDialog", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    apiMock.sendCommand.mockResolvedValue({ groups: [], truncated: false });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("renders the results grouped by device and area", async () => {
+    const wrapper = await openPicker([LIVING_ROOM_GROUP, ORPHAN_GROUP]);
+
+    const groupTexts = wrapper
+      .findAll(".entity-group")
+      .map((group) => group.text());
+    expect(groupTexts).toHaveLength(2);
+    expect(groupTexts[0]).toContain("Living room amplifier");
+    expect(groupTexts[0]).toContain("Living room");
+    expect(groupTexts[0]).toContain("Amplifier");
+    expect(groupTexts[0]).toContain("media_player.amp");
+    // the role the picker was opened for holds for every result; the others are badged
+    expect(groupTexts[0]).toContain("settings.hass_controls.role.volume");
+    expect(groupTexts[0]).not.toContain("settings.hass_controls.role.power");
+    // a null device or area is named by a translated label, not by the component
+    expect(groupTexts[1]).toContain("settings.hass_controls.no_device");
+    expect(groupTexts[1]).toContain("settings.hass_controls.no_area");
+    expect(groupTexts[1]).toContain("Relay");
+  });
+
+  it("searches for the requested control type as soon as it opens", async () => {
+    await openPicker([]);
+
+    expect(apiMock.sendCommand).toHaveBeenCalledOnce();
+    expect(apiMock.sendCommand.mock.calls[0][0]).toBe(
+      "hass/search_control_entities",
+    );
+    expect(apiMock.sendCommand.mock.calls[0][1]).toMatchObject({
+      control_type: "power_controls",
+      search: "",
+    });
+  });
+
+  it("searches once for a burst of keystrokes", async () => {
+    vi.useFakeTimers();
+    const wrapper = await openPicker([]);
+    expect(apiMock.sendCommand).toHaveBeenCalledOnce();
+
+    await wrapper.get("input").setValue("kit");
+    await wrapper.get("input").setValue("kitchen");
+    vi.advanceTimersByTime(SEARCH_THROTTLE_MS - 1);
+    await flushPromises();
+
+    expect(apiMock.sendCommand).toHaveBeenCalledOnce();
+
+    vi.advanceTimersByTime(1);
+    await flushPromises();
+
+    expect(apiMock.sendCommand).toHaveBeenCalledTimes(2);
+    expect(apiMock.sendCommand.mock.calls[1][1]).toMatchObject({
+      search: "kitchen",
+    });
+  });
+
+  it("tells the user to narrow a truncated search", async () => {
+    const wrapper = await openPicker([LIVING_ROOM_GROUP], true);
+
+    expect(wrapper.text()).toContain("settings.hass_controls.truncated");
+  });
+
+  it("keeps the truncation hint away from a complete result", async () => {
+    const wrapper = await openPicker([LIVING_ROOM_GROUP]);
+
+    expect(wrapper.text()).not.toContain("settings.hass_controls.truncated");
+  });
+
+  it("reports a search that failed instead of letting it escape", async () => {
+    apiMock.sendCommand.mockRejectedValue(new Error("provider unavailable"));
+    const wrapper = mountPicker();
+
+    await wrapper.setProps({ modelValue: true });
+    await flushPromises();
+
+    expect(wrapper.text()).toContain("settings.hass_controls.search_failed");
+  });
+
+  it("shows nothing to pick when no entity matches", async () => {
+    const wrapper = await openPicker([]);
+
+    expect(wrapper.text()).toContain("settings.hass_controls.no_results");
+  });
+
+  it("emits the picked entity and closes", async () => {
+    const wrapper = await openPicker([LIVING_ROOM_GROUP]);
+
+    await wrapper.get(".entity-option").trigger("click");
+
+    expect(wrapper.emitted("pick")).toEqual([[LIVING_ROOM_GROUP.entities[0]]]);
+    expect(wrapper.emitted("update:modelValue")?.at(-1)).toEqual([false]);
+  });
+
+  it("offers an entity that is already added, but not for picking again", async () => {
+    const wrapper = await openPicker([LIVING_ROOM_GROUP], false, [
+      "media_player.amp",
+    ]);
+
+    const entityButton = wrapper.get(".entity-option");
+    expect(entityButton.text()).toContain(
+      "settings.hass_controls.already_added",
+    );
+    expect(entityButton.attributes("disabled")).toBeDefined();
+  });
+});
+
+function entity(overrides: Partial<HassControlEntity>): HassControlEntity {
+  return {
+    entity_id: "switch.example",
+    name: "Example",
+    power: true,
+    volume: false,
+    mute: false,
+    ...overrides,
+  };
+}
+
+function mountPicker(addedEntityIds?: string[]) {
+  const passthrough = { template: "<div><slot /></div>" };
+  return mount(HassEntityPickerDialog, {
+    props: {
+      modelValue: false,
+      controlType: "power_controls" as const,
+      addedEntityIds,
+    },
+    global: {
+      stubs: {
+        Dialog: passthrough,
+        DialogContent: passthrough,
+        DialogHeader: passthrough,
+        DialogTitle: passthrough,
+        DialogFooter: passthrough,
+      },
+    },
+  });
+}
+
+async function openPicker(
+  groups: HassControlEntityGroup[],
+  truncated = false,
+  addedEntityIds?: string[],
+): Promise<VueWrapper> {
+  apiMock.sendCommand.mockResolvedValue({ groups, truncated });
+  const wrapper = mountPicker(addedEntityIds);
+  await wrapper.setProps({ modelValue: true });
+  await flushPromises();
+  return wrapper;
+}

--- a/tests/helpers/hass_controls.test.ts
+++ b/tests/helpers/hass_controls.test.ts
@@ -1,0 +1,96 @@
+import {
+  addHassControlEntity,
+  getHassProviderInstance,
+} from "@/helpers/hass_controls";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { apiMock } = vi.hoisted(() => ({
+  apiMock: {
+    providers: {} as Record<
+      string,
+      { instance_id: string; domain: string; available: boolean }
+    >,
+    getProviderConfig: vi.fn(),
+    saveProviderConfig: vi.fn(),
+  },
+}));
+
+vi.mock("@/plugins/api", () => ({
+  api: apiMock,
+  default: apiMock,
+}));
+
+describe("getHassProviderInstance", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    apiMock.providers = {};
+  });
+
+  it("finds the available Home Assistant provider", () => {
+    apiMock.providers = {
+      "spotify--1": {
+        instance_id: "spotify--1",
+        domain: "spotify",
+        available: true,
+      },
+      "hass--1": { instance_id: "hass--1", domain: "hass", available: true },
+    };
+
+    expect(getHassProviderInstance()?.instance_id).toBe("hass--1");
+  });
+
+  it("ignores a Home Assistant provider that is not available", () => {
+    apiMock.providers = {
+      "hass--1": { instance_id: "hass--1", domain: "hass", available: false },
+    };
+
+    expect(getHassProviderInstance()).toBeUndefined();
+  });
+});
+
+describe("addHassControlEntity", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    apiMock.saveProviderConfig.mockResolvedValue({});
+  });
+
+  it("appends the entity to the list the provider already holds", async () => {
+    givenControls(["switch.tv"]);
+
+    await addHassControlEntity("hass--1", "power_controls", "switch.amp");
+
+    expect(apiMock.saveProviderConfig).toHaveBeenCalledWith(
+      "hass",
+      { power_controls: ["switch.tv", "switch.amp"] },
+      "hass--1",
+    );
+  });
+
+  it("starts the list when the provider holds none", async () => {
+    givenControls(null);
+
+    await addHassControlEntity("hass--1", "power_controls", "switch.amp");
+
+    expect(apiMock.saveProviderConfig).toHaveBeenCalledWith(
+      "hass",
+      { power_controls: ["switch.amp"] },
+      "hass--1",
+    );
+  });
+
+  it("leaves the config untouched for an entity that is already listed", async () => {
+    givenControls(["switch.amp"]);
+
+    await addHassControlEntity("hass--1", "power_controls", "switch.amp");
+
+    expect(apiMock.saveProviderConfig).not.toHaveBeenCalled();
+  });
+});
+
+function givenControls(value: string[] | null) {
+  apiMock.getProviderConfig.mockResolvedValue({
+    domain: "hass",
+    instance_id: "hass--1",
+    values: { power_controls: { key: "power_controls", value } },
+  });
+}

--- a/tests/views/ConfigEntryField.test.ts
+++ b/tests/views/ConfigEntryField.test.ts
@@ -146,6 +146,39 @@ describe("ConfigEntryField", () => {
     },
   );
 
+  it("offers the entity picker for a Home Assistant control list", () => {
+    const wrapper = mountField(hassControlsEntry(), false, "hass");
+
+    expect(wrapper.findComponent({ name: "HassControlsField" }).exists()).toBe(
+      true,
+    );
+    expect(wrapper.find(".v-select").exists()).toBe(false);
+  });
+
+  it("leaves the same key on another provider as a plain dropdown", () => {
+    const wrapper = mountField(hassControlsEntry(), false, "snapcast");
+
+    expect(wrapper.findComponent({ name: "HassControlsField" }).exists()).toBe(
+      false,
+    );
+    expect(wrapper.find(".v-select").exists()).toBe(true);
+  });
+
+  it("shows a value the options do not list yet", () => {
+    const wrapper = mountField(
+      entry({
+        key: "power_control",
+        type: ConfigEntryType.STRING,
+        options: [{ title: "None", value: "none" }],
+        value: "switch.registered_moments_ago",
+      }),
+    );
+
+    expect(wrapper.get(".v-select").text()).toContain(
+      "switch.registered_moments_ago",
+    );
+  });
+
   it("disables a read_only entry while the form itself is enabled", () => {
     const confEntry = entry({
       key: "server_id",
@@ -191,9 +224,23 @@ function rangedEntry(type: ConfigEntryType): ConfigEntryUI {
   return entry({ key: "crossfade_duration", type, range: [0, 10], value: 5 });
 }
 
-function mountField(confEntry: ConfigEntryUI, disabled = false) {
+function hassControlsEntry(): ConfigEntry {
+  return entry({
+    key: "power_controls",
+    type: ConfigEntryType.STRING,
+    multi_value: true,
+    options: [{ title: "Living room TV", value: "switch.tv" }],
+    value: ["switch.tv"],
+  });
+}
+
+function mountField(
+  confEntry: ConfigEntryUI,
+  disabled = false,
+  providerDomain?: string,
+) {
   return mount(ConfigEntryField, {
-    props: { confEntry, showPasswordValues: false, disabled },
+    props: { confEntry, showPasswordValues: false, disabled, providerDomain },
     global: { plugins: [vuetify] },
   });
 }

--- a/tests/views/ConfigEntryField.test.ts
+++ b/tests/views/ConfigEntryField.test.ts
@@ -224,7 +224,7 @@ function rangedEntry(type: ConfigEntryType): ConfigEntryUI {
   return entry({ key: "crossfade_duration", type, range: [0, 10], value: 5 });
 }
 
-function hassControlsEntry(): ConfigEntry {
+function hassControlsEntry(): ConfigEntryUI {
   return entry({
     key: "power_controls",
     type: ConfigEntryType.STRING,

--- a/tests/views/EditConfig.test.ts
+++ b/tests/views/EditConfig.test.ts
@@ -36,6 +36,38 @@ vi.mock("vue-router", async (importOriginal) => {
 });
 
 describe("EditConfig", () => {
+  it.each([
+    ConfigEntryType.DIVIDER,
+    ConfigEntryType.LABEL,
+    ConfigEntryType.ALERT,
+    ConfigEntryType.IMAGE,
+  ])("hides a %s entry while its dependency is unmet", (type) => {
+    const wrapper = mountEntries([
+      entry({ key: "enable_feature", type: ConfigEntryType.BOOLEAN }),
+      dependentEntry({ key: "feature_status", type }),
+    ]);
+
+    expect(renderedKeys(wrapper)).toEqual(["enable_feature"]);
+  });
+
+  it.each([
+    ConfigEntryType.DIVIDER,
+    ConfigEntryType.LABEL,
+    ConfigEntryType.ALERT,
+    ConfigEntryType.IMAGE,
+  ])("shows a %s entry once its dependency is met", (type) => {
+    const wrapper = mountEntries([
+      entry({
+        key: "enable_feature",
+        type: ConfigEntryType.BOOLEAN,
+        value: true,
+      }),
+      dependentEntry({ key: "feature_status", type }),
+    ]);
+
+    expect(renderedKeys(wrapper)).toEqual(["enable_feature", "feature_status"]);
+  });
+
   it("fills in the entry a field points at and offers the value under its name", async () => {
     const wrapper = mountEntries([
       entry({

--- a/tests/views/EditConfig.test.ts
+++ b/tests/views/EditConfig.test.ts
@@ -36,36 +36,28 @@ vi.mock("vue-router", async (importOriginal) => {
 });
 
 describe("EditConfig", () => {
-  it.each([
-    ConfigEntryType.DIVIDER,
-    ConfigEntryType.LABEL,
-    ConfigEntryType.ALERT,
-    ConfigEntryType.IMAGE,
-  ])("hides a %s entry while its dependency is unmet", (type) => {
-    const wrapper = mountEntries([
-      entry({ key: "enable_feature", type: ConfigEntryType.BOOLEAN }),
-      dependentEntry({ key: "feature_status", type }),
-    ]);
-
-    expect(renderedKeys(wrapper)).toEqual(["enable_feature"]);
-  });
-
-  it.each([
-    ConfigEntryType.DIVIDER,
-    ConfigEntryType.LABEL,
-    ConfigEntryType.ALERT,
-    ConfigEntryType.IMAGE,
-  ])("shows a %s entry once its dependency is met", (type) => {
+  it("fills in the entry a field points at and offers the value under its name", async () => {
     const wrapper = mountEntries([
       entry({
-        key: "enable_feature",
-        type: ConfigEntryType.BOOLEAN,
-        value: true,
+        key: "power_control",
+        type: ConfigEntryType.STRING,
+        value: "none",
+        options: [{ title: "None", value: "none" }],
       }),
-      dependentEntry({ key: "feature_status", type }),
     ]);
 
-    expect(renderedKeys(wrapper)).toEqual(["enable_feature", "feature_status"]);
+    const row = wrapper.findAllComponents({ name: "ConfigEntryRow" })[0];
+    row.vm.$emit("set-entry-value", "power_control", "switch.amp", "Amplifier");
+    await nextTick();
+
+    const target = row.props("confEntry") as ConfigEntry;
+    expect(target.value).toBe("switch.amp");
+    // the server has not listed it yet, so the name must come from the field
+    expect(target.options).toContainEqual({
+      title: "Amplifier",
+      value: "switch.amp",
+    });
+    expect(saveDisabled(wrapper)).toBe(false);
   });
 
   it("keeps an input with an unmet dependency visible but disabled", () => {

--- a/tests/views/EditPlayer.test.ts
+++ b/tests/views/EditPlayer.test.ts
@@ -1,0 +1,160 @@
+import {
+  isHassControlPickerEntry,
+  type ConfigEntryUI,
+} from "@/helpers/config_entry_ui";
+import {
+  ConfigEntryType,
+  PlayerType,
+  type ConfigEntry,
+} from "@/plugins/api/interfaces";
+import EditPlayer from "@/views/settings/EditPlayer.vue";
+import { flushPromises, shallowMount } from "@vue/test-utils";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { apiMock, routerMock } = vi.hoisted(() => ({
+  apiMock: {
+    getDSPConfig: vi.fn(),
+    getPlayerConfig: vi.fn(),
+    getProviderManifest: vi.fn(),
+    players: {} as Record<string, unknown>,
+    providerManifests: {} as Record<string, unknown>,
+    providers: {} as Record<string, unknown>,
+    savePlayerConfig: vi.fn(),
+    subscribe: vi.fn(),
+  },
+  routerMock: {
+    back: vi.fn(),
+    push: vi.fn(),
+  },
+}));
+
+vi.mock("@/plugins/api", () => ({
+  api: apiMock,
+  default: apiMock,
+}));
+
+vi.mock("@/plugins/i18n", () => ({
+  $t: (key: string) => key,
+}));
+
+vi.mock("vue-router", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("vue-router")>();
+  return { ...actual, useRouter: () => routerMock };
+});
+
+const CONTROL_KEYS = ["power_control", "volume_control", "mute_control"];
+
+describe("EditPlayer", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    apiMock.subscribe.mockReturnValue(vi.fn());
+    apiMock.getDSPConfig.mockResolvedValue({ enabled: false });
+    apiMock.getPlayerConfig.mockResolvedValue(playerConfig());
+    apiMock.getProviderManifest.mockReturnValue({ domain: "chromecast" });
+    apiMock.providerManifests = { chromecast: { name: "Chromecast" } };
+    apiMock.players = {
+      "player-1": {
+        player_id: "player-1",
+        type: PlayerType.PLAYER,
+        supported_features: [],
+        options: [],
+        output_protocols: [],
+        device_info: { manufacturer: "", model: "", identifiers: {} },
+      },
+    };
+    apiMock.providers = {
+      "hass--1": { instance_id: "hass--1", domain: "hass", available: true },
+    };
+  });
+
+  it("offers the entity picker under every player control entry", async () => {
+    const keys = (await mountEditPlayer()).map((entry) => entry.key);
+
+    for (const controlKey of CONTROL_KEYS) {
+      expect(keys[keys.indexOf(controlKey) + 1]).toBe(
+        `${controlKey}_hass_control_picker`,
+      );
+    }
+  });
+
+  it("points each picker at the control list that registers its entity", async () => {
+    const entries = await mountEditPlayer();
+    const pickers = entries.filter(isHassControlPickerEntry);
+
+    expect(
+      pickers.map((picker) => [
+        picker.target_key,
+        picker.hass_control_key,
+        picker.hass_instance_id,
+      ]),
+    ).toEqual([
+      ["power_control", "power_controls", "hass--1"],
+      ["volume_control", "volume_controls", "hass--1"],
+      ["mute_control", "mute_controls", "hass--1"],
+    ]);
+  });
+
+  it("leaves the picker out while Home Assistant is unavailable", async () => {
+    apiMock.providers = {
+      "hass--1": { instance_id: "hass--1", domain: "hass", available: false },
+    };
+
+    const entries = await mountEditPlayer();
+
+    expect(entries.some(isHassControlPickerEntry)).toBe(false);
+  });
+
+  it("leaves the picker out without a Home Assistant provider", async () => {
+    apiMock.providers = {};
+
+    const entries = await mountEditPlayer();
+
+    expect(entries.some(isHassControlPickerEntry)).toBe(false);
+  });
+});
+
+function controlEntry(key: string): ConfigEntry {
+  return {
+    key,
+    type: ConfigEntryType.STRING,
+    label: key,
+    category: "player_controls",
+    required: false,
+    default_value: "none",
+    value: "none",
+    options: [{ title: "none", value: "none" }],
+  } as ConfigEntry;
+}
+
+function playerConfig() {
+  return {
+    player_id: "player-1",
+    provider: "chromecast--1",
+    enabled: true,
+    values: {
+      volume_normalization: {
+        key: "volume_normalization",
+        type: ConfigEntryType.BOOLEAN,
+        label: "volume_normalization",
+        category: "audio",
+        required: false,
+        default_value: true,
+        value: true,
+      },
+      ...Object.fromEntries(
+        CONTROL_KEYS.map((key) => [key, controlEntry(key)]),
+      ),
+    },
+  };
+}
+
+async function mountEditPlayer(): Promise<ConfigEntryUI[]> {
+  const wrapper = shallowMount(EditPlayer, {
+    props: { playerId: "player-1" },
+    global: { mocks: { $t: (key: string) => key } },
+  });
+  await flushPromises();
+  return wrapper
+    .findComponent({ name: "EditConfig" })
+    .props("configEntries") as ConfigEntryUI[];
+}

--- a/tests/views/HassControlFields.test.ts
+++ b/tests/views/HassControlFields.test.ts
@@ -1,0 +1,198 @@
+import type {
+  ConfigEntryUI,
+  HassControlPickerEntry,
+} from "@/helpers/config_entry_ui";
+import { UI_ENTRY_TYPE } from "@/helpers/config_entry_ui";
+import type { HassControlEntity } from "@/helpers/hass_controls";
+import { ConfigEntryType } from "@/plugins/api/interfaces";
+import HassControlPickerField from "@/views/settings/fields/HassControlPickerField.vue";
+import HassControlsField from "@/views/settings/fields/HassControlsField.vue";
+import { flushPromises, mount } from "@vue/test-utils";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createVuetify } from "vuetify";
+import * as components from "vuetify/components";
+import * as directives from "vuetify/directives";
+
+const { apiMock } = vi.hoisted(() => ({
+  apiMock: {
+    getProviderConfig: vi.fn(),
+    saveProviderConfig: vi.fn(),
+    savePlayerConfig: vi.fn(),
+  },
+}));
+
+vi.mock("@/plugins/api", () => ({
+  api: apiMock,
+  default: apiMock,
+}));
+
+vi.mock("@/plugins/i18n", () => ({
+  $t: (key: string) => key,
+}));
+
+const vuetify = createVuetify({ components, directives });
+
+const PickerDialogStub = {
+  name: "HassEntityPickerDialog",
+  props: ["modelValue", "controlType", "addedEntityIds"],
+  emits: ["pick", "update:modelValue"],
+  template: "<div />",
+};
+
+const PICKED_ENTITY: HassControlEntity = {
+  entity_id: "switch.living_room_amp",
+  name: "Amplifier",
+  power: true,
+  volume: false,
+  mute: false,
+};
+
+describe("HassControlPickerField", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    apiMock.getProviderConfig.mockResolvedValue({
+      domain: "hass",
+      instance_id: "hass--1",
+      values: {
+        power_controls: { key: "power_controls", value: ["switch.tv"] },
+      },
+    });
+    apiMock.saveProviderConfig.mockResolvedValue({});
+  });
+
+  it("registers the picked entity with the Home Assistant provider and fills in the player entry", async () => {
+    const wrapper = mountPickerField();
+
+    wrapper.findComponent(PickerDialogStub).vm.$emit("pick", PICKED_ENTITY);
+    await flushPromises();
+
+    // only the affected control list is written back
+    expect(apiMock.saveProviderConfig).toHaveBeenCalledWith(
+      "hass",
+      { power_controls: ["switch.tv", "switch.living_room_amp"] },
+      "hass--1",
+    );
+    // the player entry is only filled in on the form; saving it is up to the user
+    expect(apiMock.savePlayerConfig).not.toHaveBeenCalled();
+    expect(wrapper.emitted("setEntryValue")).toEqual([
+      ["power_control", "switch.living_room_amp"],
+    ]);
+  });
+
+  it("leaves the player entry alone when the entity could not be registered", async () => {
+    apiMock.saveProviderConfig.mockRejectedValue(new Error("write failed"));
+    const wrapper = mountPickerField();
+
+    wrapper.findComponent(PickerDialogStub).vm.$emit("pick", PICKED_ENTITY);
+    await flushPromises();
+
+    expect(wrapper.emitted("setEntryValue")).toBeUndefined();
+  });
+
+  it("opens the picker for the control role it sits under", () => {
+    const wrapper = mountPickerField();
+
+    expect(wrapper.findComponent(PickerDialogStub).props("controlType")).toBe(
+      "power_controls",
+    );
+  });
+});
+
+describe("HassControlsField", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("lists the selected entities without saving anything itself", async () => {
+    const wrapper = mountControlsField(["switch.tv"]);
+
+    expect(wrapper.text()).toContain("switch.tv");
+
+    wrapper.findComponent(PickerDialogStub).vm.$emit("pick", PICKED_ENTITY);
+    await flushPromises();
+
+    expect(wrapper.emitted("update:value")).toEqual([
+      [["switch.tv", "switch.living_room_amp"]],
+    ]);
+    expect(apiMock.saveProviderConfig).not.toHaveBeenCalled();
+  });
+
+  it("names a selected entity by the option title while the server still ships one", () => {
+    const wrapper = mountControlsField(
+      ["switch.tv"],
+      [{ title: "Living room TV", value: "switch.tv" }],
+    );
+
+    expect(wrapper.text()).toContain("Living room TV");
+  });
+
+  it("removes a selected entity", async () => {
+    const wrapper = mountControlsField(["switch.tv", "switch.amp"]);
+
+    await wrapper.get(".v-chip__close").trigger("click");
+
+    expect(wrapper.emitted("update:value")).toEqual([[["switch.amp"]]]);
+  });
+
+  it("keeps entities that are already selected out of a second pick", () => {
+    const wrapper = mountControlsField(["switch.tv"]);
+
+    expect(
+      wrapper.findComponent(PickerDialogStub).props("addedEntityIds"),
+    ).toEqual(["switch.tv"]);
+  });
+});
+
+function pickerEntry(): HassControlPickerEntry {
+  return {
+    injected: true,
+    key: "power_control_hass_control_picker",
+    type: UI_ENTRY_TYPE.HASS_CONTROL_PICKER,
+    category: "player_controls",
+    label: "",
+    required: false,
+    default_value: null,
+    hass_instance_id: "hass--1",
+    hass_control_key: "power_controls",
+    target_key: "power_control",
+  };
+}
+
+function controlsEntry(
+  value: string[],
+  options?: { title: string; value: string }[],
+): ConfigEntryUI {
+  return {
+    key: "power_controls",
+    type: ConfigEntryType.STRING,
+    multi_value: true,
+    category: "player_controls",
+    label: "Power controls",
+    required: false,
+    default_value: [],
+    value,
+    options,
+  } as ConfigEntryUI;
+}
+
+function mountPickerField() {
+  return mount(HassControlPickerField, {
+    props: { entry: pickerEntry() },
+    global: {
+      stubs: { HassEntityPickerDialog: PickerDialogStub },
+    },
+  });
+}
+
+function mountControlsField(
+  value: string[],
+  options?: { title: string; value: string }[],
+) {
+  return mount(HassControlsField, {
+    props: { entry: controlsEntry(value, options), label: "Power controls" },
+    global: {
+      plugins: [vuetify],
+      stubs: { HassEntityPickerDialog: PickerDialogStub },
+    },
+  });
+}

--- a/tests/views/HassControlFields.test.ts
+++ b/tests/views/HassControlFields.test.ts
@@ -74,8 +74,10 @@ describe("HassControlPickerField", () => {
     );
     // the player entry is only filled in on the form; saving it is up to the user
     expect(apiMock.savePlayerConfig).not.toHaveBeenCalled();
+    // the name travels with it, so the field reads back "Amplifier" rather than the bare
+    // id while the server still knows nothing of the entity
     expect(wrapper.emitted("setEntryValue")).toEqual([
-      ["power_control", "switch.living_room_amp"],
+      ["power_control", "switch.living_room_amp", "Amplifier"],
     ]);
   });
 

--- a/tests/views/HassControlFields.test.ts
+++ b/tests/views/HassControlFields.test.ts
@@ -131,7 +131,8 @@ describe("HassControlsField", () => {
   it("removes a selected entity", async () => {
     const wrapper = mountControlsField(["switch.tv", "switch.amp"]);
 
-    await wrapper.get(".v-chip__close").trigger("click");
+    // the first badge's remove button, i.e. the one for switch.tv
+    await wrapper.findAll("button[aria-label]")[0].trigger("click");
 
     expect(wrapper.emitted("update:value")).toEqual([[["switch.amp"]]]);
   });


### PR DESCRIPTION
Using a Home Assistant entity as a player's power, volume or mute control meant first picking it out of a dropdown listing every eligible entity in the house, and that dropdown only exists in the Home Assistant settings — so most people never discovered the feature was there at all.

A search dialog now replaces that list, and the same picker sits right under the power, volume and mute settings of each player, which is where people actually look.

Needs music-assistant/server#5271 for the search itself.

### Changes

- add a searchable entity picker, matching on the entity, device and area name and grouping the results per device
- offer it under each of the power, volume and mute control settings of a player, where picking an entity registers it and fills in that control
- use the same picker for the entity lists in the Home Assistant settings