### PR TITLE
Remove a redundant computed in the fullscreen player

### DIFF
--- a/src/layouts/default/PlayerOSD/PlayerFullscreen.vue
+++ b/src/layouts/default/PlayerOSD/PlayerFullscreen.vue
@@ -27,7 +27,7 @@
         <template #append>
           <PlayerFullscreenHeaderControls
             :lyrics-state="lyricsState"
-            :lyrics-active="lyricsActive"
+            :lyrics-active="showLyrics"
             @toggle-lyrics="toggleLyrics"
           />
 
@@ -592,7 +592,6 @@ const lyricsState = computed<
 // Lyrics are reached through a dedicated button in the header and shown in
 // their own panel, independent of the queue list (which has its own toggle).
 const showLyrics = ref(false);
-const lyricsActive = computed(() => showLyrics.value);
 
 const toggleLyrics = () => {
   showLyrics.value = !showLyrics.value;


### PR DESCRIPTION
The fullscreen player's lyrics button was wired up through a computed that did nothing but forward the `showLyrics` flag. The template can use that flag directly, so the extra indirection is just noise.

No visible change.

- Bind the lyrics header control to `showLyrics` directly
- Drop the pass-through `lyricsActive` computed