### PR TITLE
Split router and player logic out of the shared utils helper

### DIFF
--- a/src/components/InfoHeader.vue
+++ b/src/components/InfoHeader.vue
@@ -512,18 +512,20 @@ import {
   useHoldToOpenMenu,
 } from "@/composables/useHoldToOpenMenu";
 import { useUserPreferences } from "@/composables/userPreferences";
+import type { ContextMenuItem } from "@/helpers/context_menu_item";
 import { MarqueeTextSync } from "@/helpers/marquee_text_sync";
+import {
+  handleMediaItemClick,
+  handlePlayBtnClick,
+} from "@/helpers/media_item_actions";
 import {
   getAuthorsNarratorsArray,
   getAudiobookCollectionArtists,
   getImageThumbForItem,
-  handleMediaItemClick,
-  handlePlayBtnClick,
   markdownToHtml,
   parseBool,
   truncateString,
 } from "@/helpers/utils";
-import type { ContextMenuItem } from "@/helpers/context_menu_item";
 import { getContextMenuItems } from "@/layouts/default/ItemContextMenu.vue";
 import { api } from "@/plugins/api";
 import {

--- a/src/components/ItemsListing.vue
+++ b/src/components/ItemsListing.vue
@@ -241,11 +241,8 @@ import {
   EmptyMedia,
 } from "@/components/ui/empty";
 import { useUserPreferences } from "@/composables/userPreferences";
-import {
-  handleMenuBtnClick,
-  panelViewItemResponsive,
-  scrollElement,
-} from "@/helpers/utils";
+import { handleMenuBtnClick } from "@/helpers/media_item_actions";
+import { panelViewItemResponsive, scrollElement } from "@/helpers/utils";
 import { api } from "@/plugins/api";
 import { itemIsAvailable } from "@/plugins/api/helpers";
 import {

--- a/src/components/ListviewItem.vue
+++ b/src/components/ListviewItem.vue
@@ -308,12 +308,14 @@ import FavouriteButton from "@/components/FavoriteButton.vue";
 import ListItem from "@/components/ListItem.vue";
 import NowPlayingBadge from "@/components/NowPlayingBadge.vue";
 import {
-  formatDuration,
-  getArtistsString,
-  getAuthorsNarratorsArray,
   handleMediaItemClick,
   handleMenuBtnClick,
   handlePlayBtnClick,
+} from "@/helpers/media_item_actions";
+import {
+  formatDuration,
+  getArtistsString,
+  getAuthorsNarratorsArray,
   truncateString,
 } from "@/helpers/utils";
 import { getListItemProviderIconDomain } from "@/plugins/api/helpers";

--- a/src/components/PanelviewItem.vue
+++ b/src/components/PanelviewItem.vue
@@ -60,7 +60,8 @@
 import MAButton from "@/components/Button.vue";
 import EditorialMediaCard from "@/components/discover/EditorialMediaCard.vue";
 import FavouriteButton from "@/components/FavoriteButton.vue";
-import { handleMenuBtnClick, parseBool } from "@/helpers/utils";
+import { handleMenuBtnClick } from "@/helpers/media_item_actions";
+import { parseBool } from "@/helpers/utils";
 import { ContentType, type MediaItemType } from "@/plugins/api/interfaces";
 import { getBreakpointValue } from "@/plugins/breakpoint";
 import { computed } from "vue";

--- a/src/components/PlayerCard.vue
+++ b/src/components/PlayerCard.vue
@@ -211,12 +211,9 @@ import {
   useHoldToOpenMenu,
 } from "@/composables/useHoldToOpenMenu";
 import { getPlayerMenuItems } from "@/helpers/player_menu_items";
+import { isBuiltinPlayer } from "@/helpers/players";
 import { isQueueEnded } from "@/helpers/queue_position";
-import {
-  getMediaImageUrl,
-  getPlayerName,
-  isBuiltinPlayer,
-} from "@/helpers/utils";
+import { getMediaImageUrl, getPlayerName } from "@/helpers/utils";
 import api from "@/plugins/api";
 import { resolvePlayerQueue } from "@/plugins/api/helpers";
 import {

--- a/src/components/PlayerGroupMembers.vue
+++ b/src/components/PlayerGroupMembers.vue
@@ -46,7 +46,7 @@
 import PlayerIcon from "@/components/PlayerIcon.vue";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Separator } from "@/components/ui/separator";
-import { groupMemberPickerVisible } from "@/helpers/utils";
+import { groupMemberPickerVisible } from "@/helpers/players";
 import { api } from "@/plugins/api";
 import {
   type Player,

--- a/src/components/discover/EditorialGenreTile.vue
+++ b/src/components/discover/EditorialGenreTile.vue
@@ -24,7 +24,7 @@
 
 <script setup lang="ts">
 import { itemArtwork } from "@/components/discover/editorialArtwork";
-import { handleMediaItemClick } from "@/helpers/utils";
+import { handleMediaItemClick } from "@/helpers/media_item_actions";
 import type { Genre } from "@/plugins/api/interfaces";
 import { computed } from "vue";
 

--- a/src/components/discover/EditorialHeroCard.vue
+++ b/src/components/discover/EditorialHeroCard.vue
@@ -43,11 +43,11 @@
 <script setup lang="ts">
 import { itemArtwork } from "@/components/discover/editorialArtwork";
 import {
-  getArtistsString,
   handleMediaItemClick,
   handleMenuBtnClick,
   handlePlayBtnClick,
-} from "@/helpers/utils";
+} from "@/helpers/media_item_actions";
+import { getArtistsString } from "@/helpers/utils";
 import {
   type Album,
   type ItemMapping,

--- a/src/components/discover/EditorialMediaCard.vue
+++ b/src/components/discover/EditorialMediaCard.vue
@@ -87,12 +87,14 @@ import { itemArtwork } from "@/components/discover/editorialArtwork";
 import NowPlayingBadge from "@/components/NowPlayingBadge.vue";
 import ProviderIcon from "@/components/ProviderIcon.vue";
 import {
-  getArtistsString,
-  getAuthorsNarratorsArray,
-  getBrowseFolderName,
   handleMediaItemClick,
   handleMenuBtnClick,
   handlePlayBtnClick,
+} from "@/helpers/media_item_actions";
+import {
+  getArtistsString,
+  getAuthorsNarratorsArray,
+  getBrowseFolderName,
 } from "@/helpers/utils";
 import { getListItemProviderIconDomain } from "@/plugins/api/helpers";
 import {

--- a/src/composables/useOrderedPlayers.ts
+++ b/src/composables/useOrderedPlayers.ts
@@ -1,4 +1,4 @@
-import { isBuiltinPlayer, playerVisible } from "@/helpers/utils";
+import { isBuiltinPlayer, playerVisible } from "@/helpers/players";
 import { api } from "@/plugins/api";
 import { PlaybackState, type Player } from "@/plugins/api/interfaces";
 import { store } from "@/plugins/store";

--- a/src/helpers/media_item_actions.ts
+++ b/src/helpers/media_item_actions.ts
@@ -1,0 +1,145 @@
+// Shared handlers for the click/play/menu interactions on a media item,
+// dispatching to the details views and the item context menu.
+import {
+  showContextMenuForMediaItem,
+  showPlayMenuForMediaItem,
+} from "@/layouts/default/ItemContextMenu.vue";
+import { api } from "@/plugins/api";
+import { itemIsAvailable } from "@/plugins/api/helpers";
+import {
+  BrowseFolder,
+  MediaItemType,
+  MediaItemTypeOrItemMapping,
+  MediaType,
+} from "@/plugins/api/interfaces";
+import { $t } from "@/plugins/i18n";
+import router from "@/plugins/router";
+import { store } from "@/plugins/store";
+import { toast } from "vue-sonner";
+
+/**
+ * Handle a click on the play button of a media item.
+ *
+ * posX/posY anchor the play menu, which is shown instead of playing directly
+ * when there is no usable active player or when forceMenu is set. sortBy is the
+ * sort order of the list the item was played from.
+ */
+export const handlePlayBtnClick = function (
+  item: MediaItemTypeOrItemMapping,
+  posX: number,
+  posY: number,
+  parentItem?: MediaItemType,
+  forceMenu?: boolean,
+  sortBy?: string,
+) {
+  // a failed play action must never be silent: without feedback the play
+  // button appears dead (e.g. while the connection is re-establishing)
+  const onPlayError = (err: Error) => {
+    console.error("Play action failed:", err);
+    toast.error($t("play_failed"));
+  };
+  // we show the play menu for the item once (if playerTip has not been dismissed)
+  if (!forceMenu && store.activePlayer?.available) {
+    if (
+      item.media_type == MediaType.TRACK &&
+      (parentItem?.media_type == MediaType.PLAYLIST ||
+        parentItem?.media_type == MediaType.ALBUM) &&
+      store.activePlayerQueue
+    ) {
+      // special case: playing a track from a playlist/album - play from here
+      api
+        .playMedia(parentItem.uri, undefined, item.item_id, undefined, sortBy)
+        .catch(onPlayError);
+      return;
+    }
+    // else: play the item directly
+    api.playMedia(item).catch(onPlayError);
+    return;
+  }
+  showPlayMenuForMediaItem(item, parentItem, posX, posY).catch(onPlayError);
+};
+
+/**
+ * Handle a click on a media item, opening its details view.
+ *
+ * posX/posY anchor the menu for item types that show one instead.
+ */
+export const handleMediaItemClick = function (
+  item: MediaItemTypeOrItemMapping,
+  posX: number,
+  posY: number,
+  parentItem?: MediaItemType,
+) {
+  // open menu when item is unavailable so the user has a way to remove/refresh the item
+  if (!itemIsAvailable(item)) {
+    handleMenuBtnClick(item, posX, posY, undefined, false);
+    return;
+  }
+
+  // folder items always open in browse view
+  if (item.media_type == MediaType.FOLDER) {
+    router.push({
+      name: "browse",
+      query: {
+        path: (item as BrowseFolder).path,
+      },
+    });
+    return;
+  }
+
+  // podcast episode has no details view so show play menu directly
+  // TODO: revisit this once we have a proper podcast episode details view
+  if (item.media_type == MediaType.PODCAST_EPISODE) {
+    handlePlayBtnClick(item, posX, posY, parentItem, true);
+    return;
+  }
+
+  // open menu for collection items
+  if (item.media_type == MediaType.COLLECTION) {
+    router.push({
+      name: "collection",
+      params: {
+        itemId: item.item_id,
+        provider: item.provider,
+      },
+    });
+    return;
+  }
+
+  // all other: go to details view
+  router.push({
+    name: item.media_type,
+    params: {
+      itemId: item.item_id,
+      provider: item.provider,
+    },
+  });
+};
+
+/**
+ * Handle a click on the context menu button of one or more media items.
+ *
+ * posX/posY anchor the menu. Set includePlayMenuItems to false to leave out the
+ * play actions. sortBy is the sort order of the list the items came from.
+ */
+export const handleMenuBtnClick = function (
+  item: MediaItemTypeOrItemMapping | MediaItemTypeOrItemMapping[],
+  posX: number,
+  posY: number,
+  parentItem?: MediaItemType,
+  includePlayMenuItems = true,
+  sortBy?: string,
+) {
+  const mediaItems: MediaItemTypeOrItemMapping[] = Array.isArray(item)
+    ? item
+    : [item];
+  showContextMenuForMediaItem(
+    mediaItems,
+    parentItem,
+    posX,
+    posY,
+    includePlayMenuItems,
+    includePlayMenuItems,
+    sortBy,
+  );
+};

--- a/src/helpers/players.ts
+++ b/src/helpers/players.ts
@@ -1,0 +1,74 @@
+// Shared predicates that decide which players this device owns and which of
+// them may be shown in the UI.
+import { Player, PlayerType } from "@/plugins/api/interfaces";
+import { store } from "@/plugins/store";
+import { webPlayer } from "@/plugins/web_player";
+
+/**
+ * Check if the player is (or streams to) the built-in player of this device.
+ */
+export const isBuiltinPlayer = function (player: Player): boolean {
+  return (
+    player.player_id === webPlayer.player_id ||
+    player.player_id === store.companionPlayerId ||
+    player.output_protocols?.filter(
+      (x) =>
+        x.output_protocol_id === webPlayer.player_id ||
+        x.output_protocol_id === store.companionPlayerId,
+    ).length > 0
+  );
+};
+
+/**
+ * Check if the player may be shown to the user.
+ *
+ * Set allowGroupChilds to also include players that are synced to or part of a
+ * group, and allowNeedsSetup to include players that still need to be set up.
+ */
+export const playerVisible = function (
+  player: Player,
+  allowGroupChilds = false,
+  allowNeedsSetup = false,
+): boolean {
+  // perform some basic checks if we may use/show the player
+  if (!player.enabled) return false;
+  if (player.synced_to && !allowGroupChilds) {
+    return false;
+  }
+  if (player.active_group && !allowGroupChilds) return false;
+  // A player that needs setup is serialized as unavailable. Only surface it
+  // (dimmed, with a "Setup required" affordance) where a click launches its
+  // setup flow (opt-in via allowNeedsSetup); elsewhere a click would select or
+  // play the player, so an unusable needs_setup player must stay hidden.
+  if (!player.available && !(player.needs_setup && allowNeedsSetup)) {
+    return false;
+  }
+  if (isBuiltinPlayer(player)) {
+    return true;
+  }
+  if (player.hide_in_ui) {
+    return false;
+  }
+  if (
+    store.currentUser &&
+    store.currentUser.player_filter.length > 0 &&
+    player.player_id != webPlayer.player_id &&
+    !store.currentUser.player_filter.includes(player.player_id)
+  ) {
+    // for non-admin users, the playerfilter is applied in the backend
+    // but for admin users we need to filter here as well
+    return false;
+  }
+  return true;
+};
+
+// Keep hidden players out of group pickers unless they represent this device or
+// are player types intended to be grouped with audio players.
+export const groupMemberPickerVisible = function (player: Player): boolean {
+  return (
+    !player.hide_in_ui ||
+    isBuiltinPlayer(player) ||
+    player.type === PlayerType.LIGHT ||
+    player.type === PlayerType.VISUALIZER
+  );
+};

--- a/src/helpers/utils.ts
+++ b/src/helpers/utils.ts
@@ -8,7 +8,6 @@ import {
   ItemMapping,
   MediaItemImage,
   MediaItemType,
-  MediaItemTypeOrItemMapping,
   MediaType,
   Player,
   PlayerConfig,
@@ -20,21 +19,11 @@ import { getBreakpointValue } from "@/plugins/breakpoint";
 import DOMPurify from "dompurify";
 import { marked } from "marked";
 
-import {
-  showContextMenuForMediaItem,
-  showPlayMenuForMediaItem,
-} from "@/layouts/default/ItemContextMenu.vue";
-import { itemIsAvailable } from "@/plugins/api/helpers";
 import type {
   Audiobook,
   MediaCollection,
   MediaItemPalette,
 } from "@/plugins/api/interfaces";
-import router from "@/plugins/router";
-import { store } from "@/plugins/store";
-import { $t } from "@/plugins/i18n";
-import { toast } from "vue-sonner";
-import { webPlayer } from "@/plugins/web_player";
 import { Volume, Volume1, Volume2, VolumeX } from "@lucide/vue";
 
 export const openLinkInNewTab = function (url: string) {
@@ -753,178 +742,6 @@ export async function copyToClipboard(text: string): Promise<boolean> {
     host.removeChild(textArea);
   }
 }
-
-export const isBuiltinPlayer = function (player: Player): boolean {
-  return (
-    player.player_id === webPlayer.player_id ||
-    player.player_id === store.companionPlayerId ||
-    player.output_protocols?.filter(
-      (x) =>
-        x.output_protocol_id === webPlayer.player_id ||
-        x.output_protocol_id === store.companionPlayerId,
-    ).length > 0
-  );
-};
-
-export const playerVisible = function (
-  player: Player,
-  allowGroupChilds = false,
-  allowNeedsSetup = false,
-): boolean {
-  // perform some basic checks if we may use/show the player
-  if (!player.enabled) return false;
-  if (player.synced_to && !allowGroupChilds) {
-    return false;
-  }
-  if (player.active_group && !allowGroupChilds) return false;
-  // A player that needs setup is serialized as unavailable. Only surface it
-  // (dimmed, with a "Setup required" affordance) where a click launches its
-  // setup flow (opt-in via allowNeedsSetup); elsewhere a click would select or
-  // play the player, so an unusable needs_setup player must stay hidden.
-  if (!player.available && !(player.needs_setup && allowNeedsSetup)) {
-    return false;
-  }
-  if (isBuiltinPlayer(player)) {
-    return true;
-  }
-  if (player.hide_in_ui) {
-    return false;
-  }
-  if (
-    store.currentUser &&
-    store.currentUser.player_filter.length > 0 &&
-    player.player_id != webPlayer.player_id &&
-    !store.currentUser.player_filter.includes(player.player_id)
-  ) {
-    // for non-admin users, the playerfilter is applied in the backend
-    // but for admin users we need to filter here as well
-    return false;
-  }
-  return true;
-};
-
-// Keep hidden players out of group pickers unless they represent this device or
-// are player types intended to be grouped with audio players.
-export const groupMemberPickerVisible = function (player: Player): boolean {
-  return (
-    !player.hide_in_ui ||
-    isBuiltinPlayer(player) ||
-    player.type === PlayerType.LIGHT ||
-    player.type === PlayerType.VISUALIZER
-  );
-};
-
-/* Handle play button click */
-export const handlePlayBtnClick = function (
-  item: MediaItemTypeOrItemMapping,
-  posX: number,
-  posY: number,
-  parentItem?: MediaItemType,
-  forceMenu?: boolean,
-  sortBy?: string,
-) {
-  // a failed play action must never be silent: without feedback the play
-  // button appears dead (e.g. while the connection is re-establishing)
-  const onPlayError = (err: Error) => {
-    console.error("Play action failed:", err);
-    toast.error($t("play_failed"));
-  };
-  // we show the play menu for the item once (if playerTip has not been dismissed)
-  if (!forceMenu && store.activePlayer?.available) {
-    if (
-      item.media_type == MediaType.TRACK &&
-      (parentItem?.media_type == MediaType.PLAYLIST ||
-        parentItem?.media_type == MediaType.ALBUM) &&
-      store.activePlayerQueue
-    ) {
-      // special case: playing a track from a playlist/album - play from here
-      api
-        .playMedia(parentItem.uri, undefined, item.item_id, undefined, sortBy)
-        .catch(onPlayError);
-      return;
-    }
-    // else: play the item directly
-    api.playMedia(item).catch(onPlayError);
-    return;
-  }
-  showPlayMenuForMediaItem(item, parentItem, posX, posY).catch(onPlayError);
-};
-
-/* Handle media item click */
-export const handleMediaItemClick = function (
-  item: MediaItemTypeOrItemMapping,
-  posX: number,
-  posY: number,
-  parentItem?: MediaItemType,
-) {
-  // open menu when item is unavailable so the user has a way to remove/refresh the item
-  if (!itemIsAvailable(item)) {
-    handleMenuBtnClick(item, posX, posY, undefined, false);
-    return;
-  }
-
-  // folder items always open in browse view
-  if (item.media_type == MediaType.FOLDER) {
-    router.push({
-      name: "browse",
-      query: {
-        path: (item as BrowseFolder).path,
-      },
-    });
-    return;
-  }
-
-  // podcast episode has no details view so show play menu directly
-  // TODO: revisit this once we have a proper podcast episode details view
-  if (item.media_type == MediaType.PODCAST_EPISODE) {
-    handlePlayBtnClick(item, posX, posY, parentItem, true);
-    return;
-  }
-
-  // open menu for collection items
-  if (item.media_type == MediaType.COLLECTION) {
-    router.push({
-      name: "collection",
-      params: {
-        itemId: item.item_id,
-        provider: item.provider,
-      },
-    });
-    return;
-  }
-
-  // all other: go to details view
-  router.push({
-    name: item.media_type,
-    params: {
-      itemId: item.item_id,
-      provider: item.provider,
-    },
-  });
-};
-
-/* Handle menu button click */
-export const handleMenuBtnClick = function (
-  item: MediaItemTypeOrItemMapping | MediaItemTypeOrItemMapping[],
-  posX: number,
-  posY: number,
-  parentItem?: MediaItemType,
-  includePlayMenuItems = true,
-  sortBy?: string,
-) {
-  const mediaItems: MediaItemTypeOrItemMapping[] = Array.isArray(item)
-    ? item
-    : [item];
-  showContextMenuForMediaItem(
-    mediaItems,
-    parentItem,
-    posX,
-    posY,
-    includePlayMenuItems,
-    includePlayMenuItems,
-    sortBy,
-  );
-};
 
 /**
  * Check if a player config should be hidden from settings due to being a

--- a/src/layouts/default/ItemContextMenu.vue
+++ b/src/layouts/default/ItemContextMenu.vue
@@ -213,13 +213,13 @@ import {
   unpinShortcutStandaloneItem,
 } from "@/composables/useShortcuts";
 import { genresShareTaxonomy } from "@/helpers/genreTaxonomy";
+import { playerVisible } from "@/helpers/players";
 import {
   gotoRadio,
   radioActionLabelKey,
   radioRelevant,
   radioSupported,
 } from "@/helpers/radio";
-import { playerVisible } from "@/helpers/utils";
 import { isItemInLibrary, itemIsAvailable } from "@/plugins/api/helpers";
 import {
   Album,

--- a/src/views/settings/AddPlayerGroup.vue
+++ b/src/views/settings/AddPlayerGroup.vue
@@ -91,7 +91,8 @@
 import { computed, ref } from "vue";
 import { useRouter } from "vue-router";
 import { api } from "@/plugins/api";
-import { groupMemberPickerVisible, markdownToHtml } from "@/helpers/utils";
+import { groupMemberPickerVisible } from "@/helpers/players";
+import { markdownToHtml } from "@/helpers/utils";
 import { PlayerFeature, PlayerType } from "@/plugins/api/interfaces";
 
 // global refs

--- a/tests/components/PlayerCard.test.ts
+++ b/tests/components/PlayerCard.test.ts
@@ -80,6 +80,9 @@ vi.mock("@/helpers/utils", () => ({
       ? `${player.name} +${childCount}`
       : player.name;
   },
+}));
+
+vi.mock("@/helpers/players", () => ({
   isBuiltinPlayer: (player: Player) => player.player_id === "builtin",
 }));
 

--- a/tests/components/PlayerGroupMembers.test.ts
+++ b/tests/components/PlayerGroupMembers.test.ts
@@ -20,7 +20,7 @@ vi.mock("@/plugins/api", async () => {
   return { api, default: api };
 });
 
-vi.mock("@/helpers/utils", () => ({
+vi.mock("@/helpers/players", () => ({
   groupMemberPickerVisible: () => true,
 }));
 

--- a/tests/components/VolumeControl.test.ts
+++ b/tests/components/VolumeControl.test.ts
@@ -20,7 +20,7 @@ vi.mock("@/plugins/api", async () => {
   return { api, default: api };
 });
 
-vi.mock("@/helpers/utils", () => ({
+vi.mock("@/helpers/players", () => ({
   groupMemberPickerVisible: () => true,
 }));
 

--- a/tests/helpers/playBtnErrorFeedback.test.ts
+++ b/tests/helpers/playBtnErrorFeedback.test.ts
@@ -59,7 +59,7 @@ vi.mock("vue-sonner", () => ({
   toast: { error: mockToastError },
 }));
 
-import { handlePlayBtnClick } from "@/helpers/utils";
+import { handlePlayBtnClick } from "@/helpers/media_item_actions";
 import { MediaType, type Playlist, type Track } from "@/plugins/api/interfaces";
 
 const track = {

--- a/tests/helpers/playFromHereSort.test.ts
+++ b/tests/helpers/playFromHereSort.test.ts
@@ -67,7 +67,10 @@ vi.mock("colorthief", () => ({
   },
 }));
 
-import { handlePlayBtnClick, handleMenuBtnClick } from "@/helpers/utils";
+import {
+  handlePlayBtnClick,
+  handleMenuBtnClick,
+} from "@/helpers/media_item_actions";
 import {
   MediaType,
   type Album,

--- a/tests/helpers/players.test.ts
+++ b/tests/helpers/players.test.ts
@@ -1,0 +1,95 @@
+import { groupMemberPickerVisible } from "@/helpers/players";
+import {
+  IdentifierType,
+  type Player,
+  PlayerType,
+} from "@/plugins/api/interfaces";
+import { store } from "@/plugins/store";
+import { webPlayer } from "@/plugins/web_player";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/plugins/store", () => ({
+  store: { companionPlayerId: undefined },
+}));
+
+vi.mock("@/plugins/web_player", () => ({
+  webPlayer: { player_id: null },
+  WebPlayerMode: {},
+}));
+
+function createPlayer(overrides: Partial<Player> = {}): Player {
+  return {
+    player_id: "player",
+    provider: "test",
+    type: PlayerType.PLAYER,
+    name: "Player",
+    available: true,
+    device_info: {
+      model: "Test",
+      manufacturer: "Test",
+      identifiers: {
+        [IdentifierType.MAC_ADDRESS]: "",
+        [IdentifierType.SERIAL_NUMBER]: "",
+        [IdentifierType.UUID]: "",
+        [IdentifierType.IP_ADDRESS]: "",
+        [IdentifierType.UNKNOWN]: "",
+      },
+    },
+    supported_features: [],
+    can_group_with: [],
+    enabled: true,
+    group_members: [],
+    static_group_members: [],
+    source_list: [],
+    sound_mode_list: [],
+    options: [],
+    group_volume: null,
+    group_volume_muted: null,
+    hide_in_ui: false,
+    icon: "speaker",
+    power_control: "power",
+    volume_control: "volume",
+    mute_control: "mute",
+    needs_setup: false,
+    output_protocols: [],
+    active_output_protocol: null,
+    ...overrides,
+  };
+}
+
+describe("groupMemberPickerVisible", () => {
+  beforeEach(() => {
+    store.companionPlayerId = undefined;
+    webPlayer.player_id = null;
+  });
+
+  it("shows the hidden web player owned by this browser", () => {
+    const player = createPlayer({
+      player_id: "local-web-player",
+      hide_in_ui: true,
+    });
+    webPlayer.player_id = player.player_id;
+
+    expect(groupMemberPickerVisible(player)).toBe(true);
+  });
+
+  it("shows the hidden companion player owned by this app", () => {
+    const player = createPlayer({
+      player_id: "local-companion-player",
+      hide_in_ui: true,
+    });
+    store.companionPlayerId = player.player_id;
+
+    expect(groupMemberPickerVisible(player)).toBe(true);
+  });
+
+  it("keeps unrelated hidden players out of the picker", () => {
+    const player = createPlayer({
+      player_id: "remote-web-player",
+      hide_in_ui: true,
+    });
+    webPlayer.player_id = "local-web-player";
+
+    expect(groupMemberPickerVisible(player)).toBe(false);
+  });
+});

--- a/tests/helpers/utils.test.ts
+++ b/tests/helpers/utils.test.ts
@@ -2,7 +2,6 @@ import {
   formatAliasName,
   formatDuration,
   formatRelativeTime,
-  groupMemberPickerVisible,
   hexToRgb,
   kebabize,
   markdownToHtml,
@@ -13,15 +12,8 @@ import {
   sleep,
   truncateString,
 } from "@/helpers/utils";
-import {
-  IdentifierType,
-  type MediaItemPalette,
-  type Player,
-  PlayerType,
-} from "@/plugins/api/interfaces";
-import { store } from "@/plugins/store";
-import { webPlayer } from "@/plugins/web_player";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { MediaItemPalette } from "@/plugins/api/interfaces";
+import { describe, expect, it, vi } from "vitest";
 
 vi.mock("@/plugins/api", () => ({
   api: {
@@ -30,108 +22,9 @@ vi.mock("@/plugins/api", () => ({
   },
 }));
 
-vi.mock("@/plugins/store", () => ({
-  store: { companionPlayerId: undefined },
-}));
-
 vi.mock("@/plugins/breakpoint", () => ({
   getBreakpointValue: vi.fn(() => false),
 }));
-
-vi.mock("@/plugins/router", () => ({
-  default: { push: vi.fn() },
-}));
-
-vi.mock("@/plugins/web_player", () => ({
-  webPlayer: { player_id: null },
-  WebPlayerMode: {},
-}));
-
-vi.mock("@/layouts/default/ItemContextMenu.vue", () => ({
-  showContextMenuForMediaItem: vi.fn(),
-  showPlayMenuForMediaItem: vi.fn(),
-}));
-
-vi.mock("@/plugins/api/helpers", () => ({
-  itemIsAvailable: vi.fn(),
-}));
-
-function createPlayer(overrides: Partial<Player> = {}): Player {
-  return {
-    player_id: "player",
-    provider: "test",
-    type: PlayerType.PLAYER,
-    name: "Player",
-    available: true,
-    device_info: {
-      model: "Test",
-      manufacturer: "Test",
-      identifiers: {
-        [IdentifierType.MAC_ADDRESS]: "",
-        [IdentifierType.SERIAL_NUMBER]: "",
-        [IdentifierType.UUID]: "",
-        [IdentifierType.IP_ADDRESS]: "",
-        [IdentifierType.UNKNOWN]: "",
-      },
-    },
-    supported_features: [],
-    can_group_with: [],
-    enabled: true,
-    group_members: [],
-    static_group_members: [],
-    source_list: [],
-    sound_mode_list: [],
-    options: [],
-    group_volume: null,
-    group_volume_muted: null,
-    hide_in_ui: false,
-    icon: "speaker",
-    power_control: "power",
-    volume_control: "volume",
-    mute_control: "mute",
-    needs_setup: false,
-    output_protocols: [],
-    active_output_protocol: null,
-    ...overrides,
-  };
-}
-
-describe("groupMemberPickerVisible", () => {
-  beforeEach(() => {
-    store.companionPlayerId = undefined;
-    webPlayer.player_id = null;
-  });
-
-  it("shows the hidden web player owned by this browser", () => {
-    const player = createPlayer({
-      player_id: "local-web-player",
-      hide_in_ui: true,
-    });
-    webPlayer.player_id = player.player_id;
-
-    expect(groupMemberPickerVisible(player)).toBe(true);
-  });
-
-  it("shows the hidden companion player owned by this app", () => {
-    const player = createPlayer({
-      player_id: "local-companion-player",
-      hide_in_ui: true,
-    });
-    store.companionPlayerId = player.player_id;
-
-    expect(groupMemberPickerVisible(player)).toBe(true);
-  });
-
-  it("keeps unrelated hidden players out of the picker", () => {
-    const player = createPlayer({
-      player_id: "remote-web-player",
-      hide_in_ui: true,
-    });
-    webPlayer.player_id = "local-web-player";
-
-    expect(groupMemberPickerVisible(player)).toBe(false);
-  });
-});
 
 describe("formatDuration", () => {
   it("formats seconds correctly", () => {

--- a/tests/layouts/PlayerSelect.test.ts
+++ b/tests/layouts/PlayerSelect.test.ts
@@ -77,7 +77,7 @@ vi.mock("@/composables/userPreferences", () => ({
   }),
 }));
 
-vi.mock("@/helpers/utils", () => ({
+vi.mock("@/helpers/players", () => ({
   isBuiltinPlayer: (player: Player) => player.player_id === "builtin",
   playerVisible: () => true,
 }));


### PR DESCRIPTION
## Problem

`src/helpers/utils.ts` had grown into a grab-bag that reached into the router, the web player plugin and even a Vue layout component. Because almost every screen imports something from it, those imports dragged the router, auth, store and player plugins into one big tangle. The visible cost: the build shipped two `INEFFECTIVE_DYNAMIC_IMPORT` warnings, and ~30 test files had to stub out the whole utils module just to keep the router and auth out of their test run.

## Changes

- Moved the media item click/play/menu handlers to a new `helpers/media_item_actions.ts`
- Moved the player visibility predicates (`isBuiltinPlayer`, `playerVisible`, `groupMemberPickerVisible`) to a new `helpers/players.ts`
- `helpers/utils.ts` no longer imports the router, the web player, the store or any component
- Updated all call sites and split the matching tests into `tests/helpers/players.test.ts`

## Result

- Both build warnings are gone: the router and companion plugins now get their own chunks instead of being pulled into the main bundle
- No behaviour change — the moved functions are unchanged