### PR TITLE
Add tests for the player visibility helpers

### DIFF
--- a/src/helpers/players.ts
+++ b/src/helpers/players.ts
@@ -52,7 +52,6 @@ export const playerVisible = function (
   if (
     store.currentUser &&
     store.currentUser.player_filter.length > 0 &&
-    player.player_id != webPlayer.player_id &&
     !store.currentUser.player_filter.includes(player.player_id)
   ) {
     // for non-admin users, the playerfilter is applied in the backend

--- a/tests/helpers/players.test.ts
+++ b/tests/helpers/players.test.ts
@@ -177,6 +177,22 @@ describe("playerVisible", () => {
     expect(playerVisible(player, false, true)).toBe(true);
   });
 
+  it("keeps an unavailable player hidden when it does not need setup", () => {
+    const player = createPlayer({ available: false, needs_setup: false });
+
+    expect(playerVisible(player, false, true)).toBe(false);
+  });
+
+  it("hides an unavailable player of this device", () => {
+    const player = createPlayer({
+      player_id: "local-web-player",
+      available: false,
+    });
+    webPlayer.player_id = player.player_id;
+
+    expect(playerVisible(player)).toBe(false);
+  });
+
   it("hides a player that asks to be hidden", () => {
     expect(playerVisible(createPlayer({ hide_in_ui: true }))).toBe(false);
   });
@@ -238,6 +254,15 @@ describe("groupMemberPickerVisible", () => {
 
     expect(groupMemberPickerVisible(player)).toBe(true);
   });
+
+  it.each([PlayerType.LIGHT, PlayerType.VISUALIZER])(
+    "shows a hidden %s player",
+    (type) => {
+      const player = createPlayer({ type, hide_in_ui: true });
+
+      expect(groupMemberPickerVisible(player)).toBe(true);
+    },
+  );
 
   it("keeps unrelated hidden players out of the picker", () => {
     const player = createPlayer({

--- a/tests/helpers/players.test.ts
+++ b/tests/helpers/players.test.ts
@@ -1,15 +1,22 @@
-import { groupMemberPickerVisible } from "@/helpers/players";
+import {
+  groupMemberPickerVisible,
+  isBuiltinPlayer,
+  playerVisible,
+} from "@/helpers/players";
 import {
   IdentifierType,
+  type OutputProtocol,
   type Player,
   PlayerType,
+  type User,
+  UserRole,
 } from "@/plugins/api/interfaces";
 import { store } from "@/plugins/store";
 import { webPlayer } from "@/plugins/web_player";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@/plugins/store", () => ({
-  store: { companionPlayerId: undefined },
+  store: { companionPlayerId: undefined, currentUser: undefined },
 }));
 
 vi.mock("@/plugins/web_player", () => ({
@@ -57,12 +64,161 @@ function createPlayer(overrides: Partial<Player> = {}): Player {
   };
 }
 
-describe("groupMemberPickerVisible", () => {
-  beforeEach(() => {
-    store.companionPlayerId = undefined;
-    webPlayer.player_id = null;
+function createOutputProtocol(
+  overrides: Partial<OutputProtocol> = {},
+): OutputProtocol {
+  return {
+    output_protocol_id: "native",
+    name: "Native",
+    is_native: true,
+    protocol_domain: null,
+    priority: 0,
+    available: true,
+    ...overrides,
+  };
+}
+
+function createAdminUser(playerFilter: string[]): User {
+  return {
+    user_id: "admin",
+    username: "admin",
+    role: UserRole.ADMIN,
+    enabled: true,
+    created_at: "",
+    preferences: {},
+    provider_filter: [],
+    player_filter: playerFilter,
+  };
+}
+
+beforeEach(() => {
+  store.companionPlayerId = undefined;
+  store.currentUser = undefined;
+  webPlayer.player_id = null;
+});
+
+describe("isBuiltinPlayer", () => {
+  it("matches the web player of this browser", () => {
+    const player = createPlayer({ player_id: "local-web-player" });
+    webPlayer.player_id = player.player_id;
+
+    expect(isBuiltinPlayer(player)).toBe(true);
   });
 
+  it("matches the companion player of this app", () => {
+    const player = createPlayer({ player_id: "local-companion-player" });
+    store.companionPlayerId = player.player_id;
+
+    expect(isBuiltinPlayer(player)).toBe(true);
+  });
+
+  it("matches a player that streams to the web player", () => {
+    const player = createPlayer({
+      output_protocols: [
+        createOutputProtocol(),
+        createOutputProtocol({ output_protocol_id: "local-web-player" }),
+      ],
+    });
+    webPlayer.player_id = "local-web-player";
+
+    expect(isBuiltinPlayer(player)).toBe(true);
+  });
+
+  it("matches a player that streams to the companion player", () => {
+    const player = createPlayer({
+      output_protocols: [
+        createOutputProtocol({ output_protocol_id: "local-companion-player" }),
+      ],
+    });
+    store.companionPlayerId = "local-companion-player";
+
+    expect(isBuiltinPlayer(player)).toBe(true);
+  });
+
+  it("does not match a player of another device", () => {
+    const player = createPlayer({
+      player_id: "remote-player",
+      output_protocols: [],
+    });
+    webPlayer.player_id = "local-web-player";
+    store.companionPlayerId = "local-companion-player";
+
+    expect(isBuiltinPlayer(player)).toBe(false);
+  });
+});
+
+describe("playerVisible", () => {
+  it("hides a disabled player", () => {
+    expect(playerVisible(createPlayer({ enabled: false }))).toBe(false);
+  });
+
+  it("hides a synced player unless group childs are allowed", () => {
+    const player = createPlayer({ synced_to: "leader-player" });
+
+    expect(playerVisible(player)).toBe(false);
+    expect(playerVisible(player, true)).toBe(true);
+  });
+
+  it("hides a group member unless group childs are allowed", () => {
+    const player = createPlayer({ active_group: "group-player" });
+
+    expect(playerVisible(player)).toBe(false);
+    expect(playerVisible(player, true)).toBe(true);
+  });
+
+  it("hides an unavailable player", () => {
+    expect(playerVisible(createPlayer({ available: false }))).toBe(false);
+  });
+
+  it("only shows a player that needs setup where setup can be launched", () => {
+    const player = createPlayer({ available: false, needs_setup: true });
+
+    expect(playerVisible(player)).toBe(false);
+    expect(playerVisible(player, false, true)).toBe(true);
+  });
+
+  it("hides a player that asks to be hidden", () => {
+    expect(playerVisible(createPlayer({ hide_in_ui: true }))).toBe(false);
+  });
+
+  it("shows the hidden player of this device", () => {
+    const player = createPlayer({
+      player_id: "local-web-player",
+      hide_in_ui: true,
+    });
+    webPlayer.player_id = player.player_id;
+
+    expect(playerVisible(player)).toBe(true);
+  });
+
+  it("hides a player that the user filtered out", () => {
+    store.currentUser = createAdminUser(["other-player"]);
+
+    expect(playerVisible(createPlayer({ player_id: "player" }))).toBe(false);
+  });
+
+  it("shows a player that the user filter includes", () => {
+    store.currentUser = createAdminUser(["player"]);
+
+    expect(playerVisible(createPlayer({ player_id: "player" }))).toBe(true);
+  });
+
+  it("shows all players when the user filter is empty", () => {
+    store.currentUser = createAdminUser([]);
+
+    expect(playerVisible(createPlayer({ player_id: "player" }))).toBe(true);
+  });
+
+  it("never filters out the web player of this browser", () => {
+    const player = createPlayer({ player_id: "local-web-player" });
+    webPlayer.player_id = player.player_id;
+    store.currentUser = createAdminUser(["other-player"]);
+
+    expect(playerVisible(player)).toBe(true);
+  });
+});
+
+describe("groupMemberPickerVisible", () => {
   it("shows the hidden web player owned by this browser", () => {
     const player = createPlayer({
       player_id: "local-web-player",


### PR DESCRIPTION
Follow-up to #2318. The player helpers that were split out into `src/helpers/players.ts` had no direct tests of their own — only `groupMemberPickerVisible` was covered, and everywhere else in the test suite `isBuiltinPlayer` and `playerVisible` are stubbed out. This adds real coverage so the visibility rules can't silently change.

While pinning the rules down, one condition in the user player-filter check turned out to be unreachable: the local web player already returns early as a built-in player, so the extra carve-out for it never ran. Removed it — behaviour is unchanged.

- Added tests for `isBuiltinPlayer`: web player, companion player, both via an output protocol, and the no-match case
- Added tests for `playerVisible`: disabled, synced/grouped players (with and without the group-child opt-in), unavailable players, the "needs setup" opt-in path, hidden players, and the admin player filter
- Removed the redundant web player check from the player-filter condition