### PR TITLE
Explain why protocol settings skip the player-control plumbing

### DIFF
--- a/src/views/settings/EditConfig.vue
+++ b/src/views/settings/EditConfig.vue
@@ -35,7 +35,7 @@
       </div>
     </div>
 
-    <!-- No provider domain: that is only set for a provider config, which carries no protocol
+    <!-- No provider-domain: that is only set for a provider config, which carries no protocol
          categories. No set-entry-value handler: its only emitter is the Home Assistant entity
          picker, which sits with the player controls on the parent player. -->
     <ProtocolConfigSection

--- a/src/views/settings/EditConfig.vue
+++ b/src/views/settings/EditConfig.vue
@@ -35,6 +35,10 @@
       </div>
     </div>
 
+    <!-- A protocol output only carries its own audio and transport settings. The player
+         controls, and the Home Assistant entity picker that fills them in, belong to the
+         parent player, so this section is given no provider domain or set-entry-value
+         handler. -->
     <ProtocolConfigSection
       :entries="entries || []"
       :protocol-panels="protocolPanels"

--- a/src/views/settings/EditConfig.vue
+++ b/src/views/settings/EditConfig.vue
@@ -35,10 +35,9 @@
       </div>
     </div>
 
-    <!-- A protocol output only carries its own audio and transport settings. The player
-         controls, and the Home Assistant entity picker that fills them in, belong to the
-         parent player, so this section is given no provider domain or set-entry-value
-         handler. -->
+    <!-- No provider domain: that is only set for a provider config, which carries no protocol
+         categories. No set-entry-value handler: its only emitter is the Home Assistant entity
+         picker, which sits with the player controls on the parent player. -->
     <ProtocolConfigSection
       :entries="entries || []"
       :protocol-panels="protocolPanels"


### PR DESCRIPTION
The protocol settings section in a player's config renders its config rows without the provider domain and the "set another entry's value" handler that the two neighbouring sections do pass along. That reads as an oversight, but it is deliberate, and nothing said so.

The provider domain is only ever set for a provider's config screen, which has no protocol settings at all. And the only thing that sets another entry's value is the Home Assistant entity picker, which sits with the player controls — those live on the parent player, never on one of its protocol outputs.

- add a short comment at the protocol section recording why it takes neither