### PR TITLE
Move shared value and device helpers into their own modules

### DIFF
--- a/src/components/InfoHeader.vue
+++ b/src/components/InfoHeader.vue
@@ -518,12 +518,12 @@ import {
   handleMediaItemClick,
   handlePlayBtnClick,
 } from "@/helpers/media_item_actions";
+import { parseBool } from "@/helpers/parse";
 import {
   getAuthorsNarratorsArray,
   getAudiobookCollectionArtists,
   getImageThumbForItem,
   markdownToHtml,
-  parseBool,
   truncateString,
 } from "@/helpers/utils";
 import { getContextMenuItems } from "@/layouts/default/ItemContextMenu.vue";

--- a/src/components/ListviewItemTitle.vue
+++ b/src/components/ListviewItemTitle.vue
@@ -49,7 +49,8 @@
 </template>
 
 <script setup lang="ts">
-import { getBrowseFolderName, parseBool } from "@/helpers/utils";
+import { parseBool } from "@/helpers/parse";
+import { getBrowseFolderName } from "@/helpers/utils";
 import {
   MediaType,
   type BrowseFolder,

--- a/src/components/PanelviewItem.vue
+++ b/src/components/PanelviewItem.vue
@@ -61,7 +61,7 @@ import MAButton from "@/components/Button.vue";
 import EditorialMediaCard from "@/components/discover/EditorialMediaCard.vue";
 import FavouriteButton from "@/components/FavoriteButton.vue";
 import { handleMenuBtnClick } from "@/helpers/media_item_actions";
-import { parseBool } from "@/helpers/utils";
+import { parseBool } from "@/helpers/parse";
 import { ContentType, type MediaItemType } from "@/plugins/api/interfaces";
 import { getBreakpointValue } from "@/plugins/breakpoint";
 import { computed } from "vue";

--- a/src/helpers/device.ts
+++ b/src/helpers/device.ts
@@ -1,0 +1,19 @@
+export function isTouchscreenDevice() {
+  // detect if device/browser is touch enabled
+  let result = false;
+  if (window.PointerEvent && "maxTouchPoints" in navigator) {
+    if (navigator.maxTouchPoints > 0) {
+      result = true;
+    }
+  } else {
+    if (
+      window.matchMedia &&
+      window.matchMedia("(any-pointer:coarse)").matches
+    ) {
+      result = true;
+    } else if (window.TouchEvent || "ontouchstart" in window) {
+      result = true;
+    }
+  }
+  return result;
+}

--- a/src/helpers/parse.ts
+++ b/src/helpers/parse.ts
@@ -1,0 +1,6 @@
+export const parseBool = (val: string | boolean | undefined | null) => {
+  if (val == undefined || val == null) return false;
+  if (!val) return false;
+  if (typeof val === "boolean") return val;
+  return !!JSON.parse(String(val).toLowerCase());
+};

--- a/src/helpers/utils.ts
+++ b/src/helpers/utils.ts
@@ -75,13 +75,6 @@ const openWebUrlOnce = (url: string) => {
   a.remove();
 };
 
-export const parseBool = (val: string | boolean | undefined | null) => {
-  if (val == undefined || val == null) return false;
-  if (!val) return false;
-  if (typeof val === "boolean") return val;
-  return !!JSON.parse(String(val).toLowerCase());
-};
-
 export const formatDuration = function (totalSeconds: number) {
   totalSeconds = Math.floor(totalSeconds); // round to whole seconds
   const hours = Math.floor(totalSeconds / 3600);
@@ -655,26 +648,6 @@ export const panelViewItemResponsive = function (displaySize: number) {
     return 0;
   }
 };
-
-export function isTouchscreenDevice() {
-  // detect if device/browser is touch enabled
-  let result = false;
-  if (window.PointerEvent && "maxTouchPoints" in navigator) {
-    if (navigator.maxTouchPoints > 0) {
-      result = true;
-    }
-  } else {
-    if (
-      window.matchMedia &&
-      window.matchMedia("(any-pointer:coarse)").matches
-    ) {
-      result = true;
-    } else if (window.TouchEvent || "ontouchstart" in window) {
-      result = true;
-    }
-  }
-  return result;
-}
 
 export const markdownToHtml = function (text: string): string {
   text = text

--- a/src/plugins/store.ts
+++ b/src/plugins/store.ts
@@ -8,9 +8,10 @@ import {
   User,
 } from "./api/interfaces";
 
-import { StoredState } from "@/components/ItemsListing.vue";
+import type { StoredState } from "@/components/ItemsListing.vue";
+import { isTouchscreenDevice } from "@/helpers/device";
 import { isHomeAssistantIngressSession } from "@/helpers/ingress";
-import { isTouchscreenDevice, parseBool } from "@/helpers/utils";
+import { parseBool } from "@/helpers/parse";
 import api from "./api";
 import { resolvePlayerQueue } from "./api/helpers";
 

--- a/tests/helpers/parse.test.ts
+++ b/tests/helpers/parse.test.ts
@@ -1,0 +1,26 @@
+import { parseBool } from "@/helpers/parse";
+import { describe, expect, it } from "vitest";
+
+describe("parseBool", () => {
+  it("parses boolean values correctly", () => {
+    expect(parseBool(true)).toBe(true);
+    expect(parseBool(false)).toBe(false);
+  });
+
+  it("parses string values correctly", () => {
+    expect(parseBool("true")).toBe(true);
+    expect(parseBool("false")).toBe(false);
+    expect(parseBool("TRUE")).toBe(true);
+    expect(parseBool("FALSE")).toBe(false);
+  });
+
+  it("handles null/undefined", () => {
+    expect(parseBool(null)).toBe(false);
+    expect(parseBool(undefined)).toBe(false);
+  });
+
+  it("handles empty values", () => {
+    expect(parseBool("")).toBe(false);
+    expect(parseBool("0")).toBe(false);
+  });
+});

--- a/tests/helpers/utils.test.ts
+++ b/tests/helpers/utils.test.ts
@@ -7,7 +7,6 @@ import {
   markdownToHtml,
   numberRange,
   paletteFromServer,
-  parseBool,
   rgbToHex,
   sleep,
   truncateString,
@@ -69,30 +68,6 @@ describe("truncateString", () => {
     expect(truncateString(null, 5)).toBe("");
     // @ts-expect-error testing invalid input
     expect(truncateString(undefined, 5)).toBe("");
-  });
-});
-
-describe("parseBool", () => {
-  it("parses boolean values correctly", () => {
-    expect(parseBool(true)).toBe(true);
-    expect(parseBool(false)).toBe(false);
-  });
-
-  it("parses string values correctly", () => {
-    expect(parseBool("true")).toBe(true);
-    expect(parseBool("false")).toBe(false);
-    expect(parseBool("TRUE")).toBe(true);
-    expect(parseBool("FALSE")).toBe(false);
-  });
-
-  it("handles null/undefined", () => {
-    expect(parseBool(null)).toBe(false);
-    expect(parseBool(undefined)).toBe(false);
-  });
-
-  it("handles empty values", () => {
-    expect(parseBool("")).toBe(false);
-    expect(parseBool("0")).toBe(false);
   });
 });
 


### PR DESCRIPTION
Follow-up to #2318. The shared `utils` helper was still part of a circular import group, because the app store imported two small helpers from it.

Both helpers are tiny and have no dependencies of their own, so they now live in their own modules. This takes `utils` out of that group.

- Moved `parseBool` to a new `helpers/parse` module
- Moved `isTouchscreenDevice` to a new `helpers/device` module
- Marked the store's `StoredState` import as type-only, so it is explicit that it carries no runtime dependency (the bundler already dropped it)
- Moved the matching `parseBool` tests to `tests/helpers/parse.test.ts`

No behaviour changes.
