### PR TITLE
Move device type detection into the device helper

### DIFF
--- a/src/helpers/device.ts
+++ b/src/helpers/device.ts
@@ -4,10 +4,16 @@ export type DeviceType = "desktop" | "phone" | "tablet";
 
 const md = new MobileDetect(window.navigator.userAgent);
 
-// resolved once from the user agent, so it never changes while the app runs
-export const DEVICE_TYPE: DeviceType = md.tablet()
+// All resolved once from the user agent, so they never change while the app runs.
+// The three flags say nothing about the viewport and overlap: a phone or tablet is
+// also mobile, while mobile on its own covers devices too obscure to classify further.
+export const IS_TABLET_UA = Boolean(md.tablet());
+export const IS_PHONE_UA = Boolean(md.phone());
+export const IS_MOBILE_UA = Boolean(md.mobile());
+
+export const DEVICE_TYPE: DeviceType = IS_TABLET_UA
   ? "tablet"
-  : md.phone() || md.mobile()
+  : IS_PHONE_UA || IS_MOBILE_UA
     ? "phone"
     : "desktop";
 

--- a/src/helpers/device.ts
+++ b/src/helpers/device.ts
@@ -1,3 +1,16 @@
+import MobileDetect from "mobile-detect";
+
+export type DeviceType = "desktop" | "phone" | "tablet";
+
+const md = new MobileDetect(window.navigator.userAgent);
+
+// resolved once from the user agent, so it never changes while the app runs
+export const DEVICE_TYPE: DeviceType = md.tablet()
+  ? "tablet"
+  : md.phone() || md.mobile()
+    ? "phone"
+    : "desktop";
+
 export function isTouchscreenDevice() {
   // detect if device/browser is touch enabled
   let result = false;

--- a/src/helpers/device.ts
+++ b/src/helpers/device.ts
@@ -5,8 +5,8 @@ export type DeviceType = "desktop" | "phone" | "tablet";
 const md = new MobileDetect(window.navigator.userAgent);
 
 // All resolved once from the user agent, so they never change while the app runs.
-// The three flags say nothing about the viewport and overlap: a phone or tablet is
-// also mobile, while mobile on its own covers devices too obscure to classify further.
+// The flags say nothing about the viewport and overlap: a phone or tablet is also
+// mobile, while mobile on its own means the device could not be sized as either.
 export const IS_TABLET_UA = Boolean(md.tablet());
 export const IS_PHONE_UA = Boolean(md.phone());
 export const IS_MOBILE_UA = Boolean(md.mobile());

--- a/src/plugins/breakpoint.ts
+++ b/src/plugins/breakpoint.ts
@@ -1,8 +1,7 @@
 import { App, reactive, toRefs, watch, Directive } from "vue";
-import MobileDetect from "mobile-detect";
+import { IS_MOBILE_UA, IS_PHONE_UA, IS_TABLET_UA } from "@/helpers/device";
 
 type MobileDeviceType = "mobile" | "phone" | "tablet";
-const md = new MobileDetect(window.navigator.userAgent);
 
 type Breakpoints =
   | "bp0"
@@ -73,19 +72,19 @@ export const getBreakpointValue = (key: Key): boolean => {
     if (typeof key === "object") condition = key.condition || "lt";
     switch (breakpoint) {
       case "mobile":
-        return md.mobile()
+        return IS_MOBILE_UA
           ? true
           : condition === "lt"
             ? state.width < breakpoints["bp3"]
             : state.width >= breakpoints["bp3"];
       case "phone":
-        return md.phone()
+        return IS_PHONE_UA
           ? true
           : condition === "lt"
             ? state.width < breakpoints["bp3"]
             : state.width >= breakpoints["bp3"];
       case "tablet":
-        return md.tablet()
+        return IS_TABLET_UA
           ? true
           : condition === "lt"
             ? state.width < breakpoints["bp3"]
@@ -127,24 +126,21 @@ const vBreakpoint: Directive = {
 
     const isMobileDevice = (device: MobileDeviceType) => {
       if (device === "mobile") {
-        const isMobileDevice = md.mobile() ? true : false;
-        return isMobileDevice
+        return IS_MOBILE_UA
           ? true
           : condition === "lt"
             ? state.width < breakpoints["bp3"]
             : state.width >= breakpoints["bp3"];
       }
       if (device === "phone") {
-        const isPhoneDevice = md.phone() ? true : false;
-        return isPhoneDevice
+        return IS_PHONE_UA
           ? true
           : condition === "lt"
             ? state.width < breakpoints["bp3"]
             : state.width >= breakpoints["bp3"];
       }
       if (device === "tablet") {
-        const isTabletDevice = md.tablet() ? true : false;
-        return isTabletDevice
+        return IS_TABLET_UA
           ? true
           : condition === "lt"
             ? state.width < breakpoints["bp3"]

--- a/src/plugins/store.ts
+++ b/src/plugins/store.ts
@@ -9,23 +9,17 @@ import {
 } from "./api/interfaces";
 
 import type { StoredState } from "@/components/ItemsListing.vue";
-import { isTouchscreenDevice } from "@/helpers/device";
+import {
+  DEVICE_TYPE,
+  isTouchscreenDevice,
+  type DeviceType,
+} from "@/helpers/device";
 import { isHomeAssistantIngressSession } from "@/helpers/ingress";
 import { parseBool } from "@/helpers/parse";
 import api from "./api";
 import { resolvePlayerQueue } from "./api/helpers";
 
-import MobileDetect from "mobile-detect";
 import { getBreakpointValue } from "./breakpoint";
-
-type DeviceType = "desktop" | "phone" | "tablet";
-const md = new MobileDetect(window.navigator.userAgent);
-
-const DEVICE_TYPE: DeviceType = md.tablet()
-  ? "tablet"
-  : md.phone() || md.mobile()
-    ? "phone"
-    : "desktop";
 
 interface Store {
   activePlayerId?: string;

--- a/tests/plugins/breakpoint.test.ts
+++ b/tests/plugins/breakpoint.test.ts
@@ -1,0 +1,106 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+type UserAgentFlags = {
+  IS_MOBILE_UA: boolean;
+  IS_PHONE_UA: boolean;
+  IS_TABLET_UA: boolean;
+};
+
+// the width the device keys compare against when the user agent says nothing
+const BP3 = 575;
+
+const NO_FLAGS: UserAgentFlags = {
+  IS_MOBILE_UA: false,
+  IS_PHONE_UA: false,
+  IS_TABLET_UA: false,
+};
+
+/**
+ * Load a fresh breakpoint plugin for the given viewport width and user agent flags.
+ */
+async function loadBreakpoint(
+  width: number,
+  flags: Partial<UserAgentFlags> = {},
+) {
+  Object.defineProperty(window, "innerWidth", {
+    value: width,
+    writable: true,
+    configurable: true,
+  });
+  vi.resetModules();
+  vi.doMock("@/helpers/device", () => ({ ...NO_FLAGS, ...flags }));
+  return (await import("@/plugins/breakpoint")).getBreakpointValue;
+}
+
+afterEach(() => {
+  vi.doUnmock("@/helpers/device");
+  vi.resetModules();
+});
+
+describe("getBreakpointValue", () => {
+  describe("numeric breakpoints", () => {
+    it("compares the viewport width against the breakpoint", async () => {
+      const getBreakpointValue = await loadBreakpoint(900);
+
+      expect(getBreakpointValue("bp5")).toBe(true);
+      expect(getBreakpointValue("bp8")).toBe(false);
+    });
+
+    it("honours an explicit condition and offset", async () => {
+      const getBreakpointValue = await loadBreakpoint(769);
+
+      expect(getBreakpointValue({ breakpoint: "bp5", condition: "lt" })).toBe(
+        true,
+      );
+      expect(
+        getBreakpointValue({ breakpoint: "bp5", condition: "lt", offset: -31 }),
+      ).toBe(false);
+    });
+  });
+
+  describe("device keys without a matching user agent", () => {
+    it("falls back to the viewport width", async () => {
+      const wide = await loadBreakpoint(BP3);
+      expect(wide("phone")).toBe(true);
+
+      const narrow = await loadBreakpoint(BP3 - 1);
+      expect(narrow("phone")).toBe(false);
+    });
+
+    it("defaults an object key to the 'lt' condition", async () => {
+      const getBreakpointValue = await loadBreakpoint(BP3 - 1);
+
+      expect(getBreakpointValue({ breakpoint: "phone" })).toBe(true);
+      expect(getBreakpointValue("phone")).toBe(false);
+    });
+  });
+
+  describe("device keys with a matching user agent", () => {
+    // each flag must drive only its own key, on a viewport where the width
+    // fallback is false, so a mixed-up flag cannot pass unnoticed
+    const cases: Array<[keyof UserAgentFlags, "mobile" | "phone" | "tablet"]> =
+      [
+        ["IS_MOBILE_UA", "mobile"],
+        ["IS_PHONE_UA", "phone"],
+        ["IS_TABLET_UA", "tablet"],
+      ];
+
+    it.each(cases)("%s only matches the %s key", async (flag, key) => {
+      const getBreakpointValue = await loadBreakpoint(BP3 - 1, {
+        [flag]: true,
+      });
+
+      for (const other of ["mobile", "phone", "tablet"] as const) {
+        expect(getBreakpointValue(other)).toBe(other === key);
+      }
+    });
+
+    it("wins over the viewport width", async () => {
+      const getBreakpointValue = await loadBreakpoint(1920, {
+        IS_TABLET_UA: true,
+      });
+
+      expect(getBreakpointValue({ breakpoint: "tablet" })).toBe(true);
+    });
+  });
+});

--- a/tests/plugins/breakpoint.test.ts
+++ b/tests/plugins/breakpoint.test.ts
@@ -32,7 +32,15 @@ async function loadBreakpoint(
   return (await import("@/plugins/breakpoint")).getBreakpointValue;
 }
 
+const originalInnerWidth = Object.getOwnPropertyDescriptor(
+  window,
+  "innerWidth",
+);
+
 afterEach(() => {
+  if (originalInnerWidth) {
+    Object.defineProperty(window, "innerWidth", originalInnerWidth);
+  }
   vi.doUnmock("@/helpers/device");
   vi.resetModules();
 });


### PR DESCRIPTION
Follow-up to #2321. Device detection was spread across two places: the store and the breakpoint plugin each parsed the browser's user agent themselves, so the same detection ran twice at startup.

- Moved the device type into `src/helpers/device.ts`, which is now the single place device detection lives
- The breakpoint plugin reuses those results instead of doing its own detection
- The store imports the device type instead of working it out itself
- Added tests for the breakpoint plugin's phone/tablet/mobile handling, which had none

No change in behaviour.