### PR TITLE
Tidy up how output protocols are checked

### DIFF
--- a/src/composables/useAudioProcessingDetails.ts
+++ b/src/composables/useAudioProcessingDetails.ts
@@ -81,7 +81,7 @@ export interface AudioProcessingDisplayPlayer {
   name: string;
   provider: string;
   active_output_protocol?: string | null;
-  output_protocols?: Array<{
+  output_protocols: Array<{
     output_protocol_id: string;
     is_native: boolean;
     protocol_domain?: string | null;
@@ -445,7 +445,7 @@ function resolveDestination(
 ): DestinationResolution | undefined {
   for (const player of Object.values(dependencies.players)) {
     if (player.player_id === playerId) continue;
-    const protocol = player.output_protocols?.find(
+    const protocol = player.output_protocols.find(
       (outputProtocol) =>
         !outputProtocol.is_native &&
         outputProtocol.output_protocol_id === playerId,
@@ -473,7 +473,7 @@ function resolveDestination(
     };
   }
 
-  const activeProtocol = player.output_protocols?.find(
+  const activeProtocol = player.output_protocols.find(
     (protocol) => protocol.output_protocol_id === activeProtocolId,
   );
   return {

--- a/src/helpers/players.ts
+++ b/src/helpers/players.ts
@@ -11,11 +11,11 @@ export const isBuiltinPlayer = function (player: Player): boolean {
   return (
     player.player_id === webPlayer.player_id ||
     player.player_id === store.companionPlayerId ||
-    player.output_protocols?.filter(
+    player.output_protocols.some(
       (x) =>
         x.output_protocol_id === webPlayer.player_id ||
         x.output_protocol_id === store.companionPlayerId,
-    ).length > 0
+    )
   );
 };
 

--- a/src/layouts/default/PlayerOSD/PlayerFullscreen.vue
+++ b/src/layouts/default/PlayerOSD/PlayerFullscreen.vue
@@ -680,7 +680,7 @@ const showLyricsOffset = computed(() => {
     player.active_output_protocol !== "native"
   ) {
     domain =
-      player.output_protocols?.find(
+      player.output_protocols.find(
         (p) => p.output_protocol_id === player.active_output_protocol,
       )?.protocol_domain ?? undefined;
   }

--- a/src/views/settings/EditPlayer.vue
+++ b/src/views/settings/EditPlayer.vue
@@ -81,7 +81,7 @@
               </span>
             </div>
             <div
-              v-if="api.players[config.player_id]?.output_protocols?.length"
+              v-if="api.players[config.player_id]?.output_protocols.length"
               class="protocol-chips"
             >
               <v-chip

--- a/src/views/settings/Players.vue
+++ b/src/views/settings/Players.vue
@@ -418,7 +418,7 @@ const getAllFilteredPlayers = function () {
 
       // Check if any output protocol's domain matches a selected provider domain
       const player = api.players[item.player_id];
-      if (player?.output_protocols) {
+      if (player) {
         return player.output_protocols.some(
           (protocol) =>
             protocol.protocol_domain &&

--- a/tests/components/AudioProcessingDetails.test.ts
+++ b/tests/components/AudioProcessingDetails.test.ts
@@ -23,7 +23,7 @@ interface PlayerDisplayMock {
   name: string;
   provider: string;
   active_output_protocol?: string | null;
-  output_protocols?: Array<{
+  output_protocols: Array<{
     output_protocol_id: string;
     is_native: boolean;
     protocol_domain?: string | null;


### PR DESCRIPTION
The `Player` type says every player always has an `output_protocols` list, but a few places in the code still checked whether it was missing before reading it. Those checks could never fire — the server always sends the field (an empty list when a player has no protocols) — so they were dead code that quietly hid the mismatch.

Verified against the server's player model before changing anything: the field has a default of an empty list and is always included when a player is sent to the frontend.

- Removed the redundant "might be missing" checks on `output_protocols`
- Marked the field as always present on the audio processing display type as well
- Simplified the built-in player check to a plain `some()`

No behaviour change; checks that guard against a *player* not being found are left as they were.

Label: maintenance
