### PR TITLE
Keep the audio processing player type in sync with the player model

### DIFF
--- a/src/composables/useAudioProcessingDetails.ts
+++ b/src/composables/useAudioProcessingDetails.ts
@@ -30,6 +30,7 @@ import {
   CrossfadeMode,
   DSPFilterType,
   DSPState,
+  type Player,
   type StreamDetails,
   VolumeNormalizationMode,
 } from "@/plugins/api/interfaces";
@@ -76,17 +77,16 @@ export interface AudioProcessingDetailsDisplay {
   outputPaths: AudioProcessingOutputDisplay[];
 }
 
-export interface AudioProcessingDisplayPlayer {
-  player_id: string;
-  name: string;
-  provider: string;
-  active_output_protocol?: string | null;
-  output_protocols: Array<{
-    output_protocol_id: string;
-    is_native: boolean;
-    protocol_domain?: string | null;
-  }>;
-}
+// the subset of Player the display builder needs, so it stays independent of
+// the rest of the player model while tracking its types
+export type AudioProcessingDisplayPlayer = Pick<
+  Player,
+  | "player_id"
+  | "name"
+  | "provider"
+  | "active_output_protocol"
+  | "output_protocols"
+>;
 
 export interface AudioProcessingDetailsDependencies {
   translate: Translate;

--- a/src/composables/useAudioProcessingDetails.ts
+++ b/src/composables/useAudioProcessingDetails.ts
@@ -77,8 +77,8 @@ export interface AudioProcessingDetailsDisplay {
   outputPaths: AudioProcessingOutputDisplay[];
 }
 
-// the subset of Player the display builder needs, so it stays independent of
-// the rest of the player model while tracking its types
+// the fields of Player the display builder reads, derived so they cannot drift
+// from the player model
 export type AudioProcessingDisplayPlayer = Pick<
   Player,
   | "player_id"

--- a/tests/components/AudioProcessingDetails.test.ts
+++ b/tests/components/AudioProcessingDetails.test.ts
@@ -2,6 +2,7 @@ import { mount } from "@vue/test-utils";
 import { nextTick, type Ref } from "vue";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import AudioProcessingDetails from "@/components/AudioProcessingDetails.vue";
+import type { AudioProcessingDisplayPlayer } from "@/composables/useAudioProcessingDetails";
 import { i18n } from "@/plugins/i18n";
 import {
   AudioChannel,
@@ -18,18 +19,6 @@ import {
   VolumeNormalizationMode,
 } from "@/plugins/api/interfaces";
 
-interface PlayerDisplayMock {
-  player_id: string;
-  name: string;
-  provider: string;
-  active_output_protocol?: string | null;
-  output_protocols: Array<{
-    output_protocol_id: string;
-    is_native: boolean;
-    protocol_domain?: string | null;
-  }>;
-}
-
 const apiMock = vi.hoisted(() => ({
   getProviderName: vi.fn(() => "Test provider"),
   getProviderManifest: vi.fn((providerId: string) => ({
@@ -39,7 +28,7 @@ const apiMock = vi.hoisted(() => ({
   // subscribes to config updates on mount; subscribe hands back an unsubscribe.
   getDSPIRs: vi.fn(() => Promise.resolve([])),
   subscribe: vi.fn(() => vi.fn()),
-  players: {} as Record<string, PlayerDisplayMock>,
+  players: {} as Record<string, AudioProcessingDisplayPlayer>,
 }));
 const presetRegistryMock = vi.hoisted(() => ({
   names: undefined as Ref<Map<string, string>> | undefined,
@@ -764,8 +753,11 @@ describe("AudioProcessingDetails", () => {
     apiMock.players["player-1"].output_protocols = [
       {
         output_protocol_id: "airplay-kitchen",
+        name: "AirPlay",
         is_native: false,
         protocol_domain: "airplay",
+        priority: 1,
+        available: true,
       },
     ];
     const wrapper = mountDetails({
@@ -795,8 +787,11 @@ describe("AudioProcessingDetails", () => {
     apiMock.players["player-1"].output_protocols = [
       {
         output_protocol_id: "airplay-kitchen",
+        name: "AirPlay",
         is_native: false,
         protocol_domain: "airplay",
+        priority: 1,
+        available: true,
       },
     ];
     const wrapper = mountDetails({

--- a/tests/composables/useAudioProcessingDetails.test.ts
+++ b/tests/composables/useAudioProcessingDetails.test.ts
@@ -17,6 +17,7 @@ import {
   CrossfadeMode,
   DSPState,
   MediaType,
+  type OutputProtocol,
   type StreamDetails,
   VolumeNormalizationMode,
 } from "@/plugins/api/interfaces";
@@ -119,11 +120,7 @@ describe("buildAudioProcessingDetailsDisplay", () => {
       const protocolId = `${protocolDomain}-kitchen`;
       dependencies.players.kitchen.active_output_protocol = protocolId;
       dependencies.players.kitchen.output_protocols = [
-        {
-          output_protocol_id: protocolId,
-          is_native: false,
-          protocol_domain: protocolDomain,
-        },
+        makeOutputProtocol(protocolId, protocolDomain),
       ];
 
       const destination = buildDisplay({
@@ -157,11 +154,7 @@ describe("buildAudioProcessingDetailsDisplay", () => {
   it("uses the protocol player provider when the active entry has no domain", () => {
     dependencies.players.kitchen.active_output_protocol = "sendspin-kitchen";
     dependencies.players.kitchen.output_protocols = [
-      {
-        output_protocol_id: "sendspin-kitchen",
-        is_native: false,
-        protocol_domain: null,
-      },
+      makeOutputProtocol("sendspin-kitchen", null),
     ];
     dependencies.players["sendspin-kitchen"] = {
       player_id: "sendspin-kitchen",
@@ -275,11 +268,7 @@ describe("buildAudioProcessingDetailsDisplay", () => {
   it("uses a shared active protocol icon for grouped output", () => {
     dependencies.players.office.active_output_protocol = "airplay-office";
     dependencies.players.office.output_protocols = [
-      {
-        output_protocol_id: "airplay-office",
-        is_native: false,
-        protocol_domain: "airplay",
-      },
+      makeOutputProtocol("airplay-office", "airplay"),
     ];
     let destination = buildDisplay({
       outputs: [
@@ -607,13 +596,7 @@ function makePlayers(): AudioProcessingDetailsDependencies["players"] {
       name: "Kitchen",
       provider: "sonos--main",
       active_output_protocol: "airplay-kitchen",
-      output_protocols: [
-        {
-          output_protocol_id: "airplay-kitchen",
-          is_native: false,
-          protocol_domain: "airplay",
-        },
-      ],
+      output_protocols: [makeOutputProtocol("airplay-kitchen", "airplay")],
     },
     office: {
       player_id: "office",
@@ -622,6 +605,20 @@ function makePlayers(): AudioProcessingDetailsDependencies["players"] {
       active_output_protocol: null,
       output_protocols: [],
     },
+  };
+}
+
+function makeOutputProtocol(
+  outputProtocolId: string,
+  protocolDomain: string | null,
+): OutputProtocol {
+  return {
+    output_protocol_id: outputProtocolId,
+    name: outputProtocolId,
+    is_native: false,
+    protocol_domain: protocolDomain,
+    priority: 1,
+    available: true,
   };
 }
 

--- a/tests/composables/useAudioProcessingDetails.test.ts
+++ b/tests/composables/useAudioProcessingDetails.test.ts
@@ -120,7 +120,10 @@ describe("buildAudioProcessingDetailsDisplay", () => {
       const protocolId = `${protocolDomain}-kitchen`;
       dependencies.players.kitchen.active_output_protocol = protocolId;
       dependencies.players.kitchen.output_protocols = [
-        makeOutputProtocol(protocolId, protocolDomain),
+        makeOutputProtocol({
+          output_protocol_id: protocolId,
+          protocol_domain: protocolDomain,
+        }),
       ];
 
       const destination = buildDisplay({
@@ -154,7 +157,10 @@ describe("buildAudioProcessingDetailsDisplay", () => {
   it("uses the protocol player provider when the active entry has no domain", () => {
     dependencies.players.kitchen.active_output_protocol = "sendspin-kitchen";
     dependencies.players.kitchen.output_protocols = [
-      makeOutputProtocol("sendspin-kitchen", null),
+      makeOutputProtocol({
+        output_protocol_id: "sendspin-kitchen",
+        protocol_domain: null,
+      }),
     ];
     dependencies.players["sendspin-kitchen"] = {
       player_id: "sendspin-kitchen",
@@ -268,7 +274,7 @@ describe("buildAudioProcessingDetailsDisplay", () => {
   it("uses a shared active protocol icon for grouped output", () => {
     dependencies.players.office.active_output_protocol = "airplay-office";
     dependencies.players.office.output_protocols = [
-      makeOutputProtocol("airplay-office", "airplay"),
+      makeOutputProtocol({ output_protocol_id: "airplay-office" }),
     ];
     let destination = buildDisplay({
       outputs: [
@@ -596,7 +602,9 @@ function makePlayers(): AudioProcessingDetailsDependencies["players"] {
       name: "Kitchen",
       provider: "sonos--main",
       active_output_protocol: "airplay-kitchen",
-      output_protocols: [makeOutputProtocol("airplay-kitchen", "airplay")],
+      output_protocols: [
+        makeOutputProtocol({ output_protocol_id: "airplay-kitchen" }),
+      ],
     },
     office: {
       player_id: "office",
@@ -609,16 +617,16 @@ function makePlayers(): AudioProcessingDetailsDependencies["players"] {
 }
 
 function makeOutputProtocol(
-  outputProtocolId: string,
-  protocolDomain: string | null,
+  overrides: Partial<OutputProtocol> = {},
 ): OutputProtocol {
   return {
-    output_protocol_id: outputProtocolId,
-    name: outputProtocolId,
+    output_protocol_id: "airplay-kitchen",
+    name: "AirPlay",
     is_native: false,
-    protocol_domain: protocolDomain,
+    protocol_domain: "airplay",
     priority: 1,
     available: true,
+    ...overrides,
   };
 }
 


### PR DESCRIPTION
The audio processing details view uses a small subset of the player data. That subset was written out by hand in the composable and then copied again in the tests, so the copies could (and did) drift from the real player model — a recent fix had to correct one of them.

The subset is now derived from the player type directly, so it can no longer go out of sync.

- Derive `AudioProcessingDisplayPlayer` from `Player` instead of hand-writing it
- Reuse that type in the component test instead of a third hand-written copy
- Add a small helper for building output protocol test fixtures

Maintenance only, no functional change.
