### PR TITLE
Drop null checks on data the server always sends

### DIFF
--- a/src/components/AddManualLink.vue
+++ b/src/components/AddManualLink.vue
@@ -200,7 +200,7 @@ watch(
     if (active != null) store.dialogActive = active;
     if (active && compProps.editItem) {
       // Pre-populate fields with current values
-      const thumbImage = compProps.editItem.metadata?.images?.find(
+      const thumbImage = compProps.editItem.metadata.images?.find(
         (img) => img.type === ImageType.THUMB,
       );
       form.reset({

--- a/src/components/LyricsViewer.vue
+++ b/src/components/LyricsViewer.vue
@@ -194,7 +194,7 @@ const artistName = computed(() => {
     props.mediaItem.media_type === "track"
   ) {
     const track = props.mediaItem as Track;
-    if (track.artists?.length) {
+    if (track.artists.length) {
       return track.artists.map((a) => a.name).join(", ");
     }
   }

--- a/src/components/MediaSearch.vue
+++ b/src/components/MediaSearch.vue
@@ -173,7 +173,7 @@ const panelVisible = computed(
 const dedupeKey = (item: MediaItemTypeOrItemMapping): string | null => {
   if (!item.name || item.media_type === MediaType.PLAYLIST) return null;
   const artist =
-    "artists" in item ? item.artists?.[0]?.name?.toLowerCase() || "" : "";
+    "artists" in item ? item.artists[0]?.name.toLowerCase() || "" : "";
   return `${item.media_type}:${item.name.toLowerCase()}:${artist}`;
 };
 
@@ -203,7 +203,7 @@ const flatResults = computed<MediaItemTypeOrItemMapping[]>(() => {
 const itemSubtitle = function (item: MediaItemTypeOrItemMapping) {
   const label = $t(item.media_type);
   const artists =
-    "artists" in item && item.artists?.length
+    "artists" in item && item.artists.length
       ? getArtistsString(item.artists)
       : "";
   return artists ? `${label} • ${artists}` : label;

--- a/src/components/SettingsPlayerCard.vue
+++ b/src/components/SettingsPlayerCard.vue
@@ -61,13 +61,13 @@
           >
             <template #prepend>
               <ProviderIcon
-                :domain="protocol.protocol_domain!"
+                :domain="protocol.protocol_domain"
                 :size="14"
                 class="chip-icon"
               />
             </template>
             {{
-              api.getProviderManifest(protocol.protocol_domain!)?.name ||
+              api.getProviderManifest(protocol.protocol_domain)?.name ||
               protocol.protocol_domain
             }}
           </v-chip>
@@ -146,7 +146,7 @@ const playerName = computed(() => {
 });
 
 const outputProtocols = computed(() => {
-  // Return only non-native protocols (ones with a protocol_domain)
+  // all output methods for this player, native included
   return player.value?.output_protocols || [];
 });
 

--- a/src/components/SetupFlowDialog.vue
+++ b/src/components/SetupFlowDialog.vue
@@ -597,7 +597,7 @@ function buildForm(formStep: SetupFlowStep, preserveValues: boolean) {
   if (preserveValues) {
     for (const entry of formEntries.value) previous[entry.key] = entry.value;
   }
-  formEntries.value = (formStep.entries || []).map((entry) => {
+  formEntries.value = formStep.entries.map((entry) => {
     const copy: ConfigEntry = { ...entry };
     if (preserveValues && entry.key in previous) {
       copy.value = previous[entry.key];

--- a/src/components/party/PartyTrackCard.vue
+++ b/src/components/party/PartyTrackCard.vue
@@ -203,7 +203,7 @@ const artistName = computed(() => {
   if (
     props.queueItem.media_item &&
     "artists" in props.queueItem.media_item &&
-    props.queueItem.media_item.artists?.length
+    props.queueItem.media_item.artists.length
   ) {
     const artistStr = props.queueItem.media_item.artists
       .map((a: { name: string }) => a.name)

--- a/src/components/users/EditUserDialog.vue
+++ b/src/components/users/EditUserDialog.vue
@@ -403,7 +403,7 @@ const form = useForm({
         updates.password = value.password;
       }
 
-      const currentPlayerFilter = props.user.player_filter || [];
+      const currentPlayerFilter = props.user.player_filter;
       if (
         JSON.stringify([...value.playerFilter].sort()) !==
         JSON.stringify([...currentPlayerFilter].sort())
@@ -411,7 +411,7 @@ const form = useForm({
         updates.player_filter = value.playerFilter;
       }
 
-      const currentProviderFilter = props.user.provider_filter || [];
+      const currentProviderFilter = props.user.provider_filter;
       if (
         JSON.stringify([...value.providerFilter].sort()) !==
         JSON.stringify([...currentProviderFilter].sort())
@@ -445,8 +445,8 @@ const resetForm = () => {
     form.setFieldValue("role", props.user.role);
     form.setFieldValue("password", "");
     form.setFieldValue("confirmPassword", "");
-    form.setFieldValue("playerFilter", props.user.player_filter || []);
-    form.setFieldValue("providerFilter", props.user.provider_filter || []);
+    form.setFieldValue("playerFilter", props.user.player_filter);
+    form.setFieldValue("providerFilter", props.user.provider_filter);
   }
 };
 

--- a/src/composables/useAudioProcessingDetails.ts
+++ b/src/composables/useAudioProcessingDetails.ts
@@ -453,9 +453,7 @@ function resolveDestination(
     if (!protocol) continue;
     return {
       player,
-      providerDomain:
-        protocol.protocol_domain ??
-        playerProviderDomain(dependencies.players[playerId], dependencies),
+      providerDomain: protocol.protocol_domain,
     };
   }
 
@@ -478,13 +476,7 @@ function resolveDestination(
   );
   return {
     player,
-    providerDomain: activeProtocol
-      ? (activeProtocol.protocol_domain ??
-        playerProviderDomain(
-          dependencies.players[activeProtocolId],
-          dependencies,
-        ))
-      : undefined,
+    providerDomain: activeProtocol?.protocol_domain,
   };
 }
 

--- a/src/composables/useProgressiveSearch.ts
+++ b/src/composables/useProgressiveSearch.ts
@@ -370,10 +370,10 @@ const floatExactMatches = function <T extends { name?: string }>(
 
 const collectField = function <T extends { name?: string }>(
   results: SearchResults[],
-  pick: (result: SearchResults) => T[] | undefined,
+  pick: (result: SearchResults) => T[],
   query: string,
 ): T[] {
   const items: T[] = [];
-  for (const result of results) items.push(...(pick(result) || []));
+  for (const result of results) items.push(...pick(result));
   return floatExactMatches(items, query);
 };

--- a/src/composables/useProgressiveSearch.ts
+++ b/src/composables/useProgressiveSearch.ts
@@ -344,14 +344,14 @@ const emptyResults = (): SearchResults => ({
 });
 
 const isEmptyResult = (result: SearchResults): boolean =>
-  !result.artists?.length &&
-  !result.albums?.length &&
-  !result.tracks?.length &&
-  !result.playlists?.length &&
-  !result.radio?.length &&
-  !result.podcasts?.length &&
-  !result.audiobooks?.length &&
-  !result.genres?.length;
+  !result.artists.length &&
+  !result.albums.length &&
+  !result.tracks.length &&
+  !result.playlists.length &&
+  !result.radio.length &&
+  !result.podcasts.length &&
+  !result.audiobooks.length &&
+  !result.genres.length;
 
 // Keeps the relative order but floats items whose name matches the query
 // exactly, so a late provider with the exact hit still lands on top.

--- a/src/helpers/utils.ts
+++ b/src/helpers/utils.ts
@@ -247,7 +247,7 @@ export const getStreamingProviderMappings = function (
 ) {
   const result: ProviderMapping[] = [];
   if (!itemDetails || !("provider_mappings" in itemDetails)) return result;
-  for (const provider_mapping of itemDetails.provider_mappings || []) {
+  for (const provider_mapping of itemDetails.provider_mappings) {
     if (provider_mapping.provider_domain.startsWith("filesystem")) continue;
     if (provider_mapping.provider_domain == "plex") continue;
     if (
@@ -424,9 +424,7 @@ export const getMediaItemImage = function (
 export const getMediaItemImageUrl = function (
   img: MediaItemImage,
   size?: number,
-  checksum?: string,
 ): string {
-  if (!checksum) checksum = "";
   if (!img || !img.path) return "";
   if (img.path.startsWith("data:image")) return img.path;
   if (
@@ -438,11 +436,9 @@ export const getMediaItemImageUrl = function (
     // Note that we play it safe here and always enforce the proxy if the schema is different
     const normalizedSize = normalizeImageProxySize(size);
     if (img.proxy_id && serverSupportsOpaqueImageProxy()) {
-      // canonical /imageproxy/<proxy_id>?size=&checksum= form. checksum is kept
-      // as a cache-buster query param (the server ignores unknown params).
+      // canonical /imageproxy/<proxy_id>?size= form
       const params = new URLSearchParams();
       if (normalizedSize) params.set("size", String(normalizedSize));
-      if (checksum) params.set("checksum", checksum);
       const qs = params.toString();
       return qs
         ? `${api.baseUrl}/imageproxy/${img.proxy_id}?${qs}`
@@ -450,7 +446,7 @@ export const getMediaItemImageUrl = function (
     }
     // legacy form, for servers on schema < 31 or images without a proxy_id
     const encUrl = encodeURIComponent(encodeURIComponent(img.path));
-    const imageUrl = `${api.baseUrl}/imageproxy?path=${encUrl}&provider=${img.provider}&checksum=${checksum}`;
+    const imageUrl = `${api.baseUrl}/imageproxy?path=${encUrl}&provider=${img.provider}`;
     if (normalizedSize) return imageUrl + `&size=${normalizedSize}`;
     return imageUrl;
   }
@@ -470,9 +466,7 @@ export const getImageThumbForItem = function (
   // find image in mediaitem
   const img = getMediaItemImage(mediaItem, type);
   if (!img || !img.path) return undefined;
-  const checksum =
-    "metadata" in mediaItem ? mediaItem.metadata?.cache_checksum : "";
-  return getMediaItemImageUrl(img, size, checksum);
+  return getMediaItemImageUrl(img, size);
 };
 
 export const numberRange = function (start: number, end: number): number[] {

--- a/src/layouts/default/ItemContextMenu.vue
+++ b/src/layouts/default/ItemContextMenu.vue
@@ -858,7 +858,7 @@ export const getContextMenuItems = async function (
     )
   ) {
     const item = items[0] as Radio | Track | Playlist;
-    const hasBuiltinProvider = item.provider_mappings?.some(
+    const hasBuiltinProvider = item.provider_mappings.some(
       (pm) => pm.provider_domain === "builtin",
     );
     const builtinProvider = api.getProvider("builtin");
@@ -872,7 +872,7 @@ export const getContextMenuItems = async function (
       [MediaType.TRACK]: "edit_track",
       [MediaType.PLAYLIST]: "edit_playlist",
     };
-    const supportsEdit = builtinProvider?.supported_features?.includes(
+    const supportsEdit = builtinProvider?.supported_features.includes(
       featureMap[item.media_type],
     );
     // For playlists, also check is_editable flag (builtin special playlists are not editable)

--- a/src/layouts/default/PlayerOSD/PlayerFullscreen.vue
+++ b/src/layouts/default/PlayerOSD/PlayerFullscreen.vue
@@ -679,10 +679,9 @@ const showLyricsOffset = computed(() => {
     player.active_output_protocol &&
     player.active_output_protocol !== "native"
   ) {
-    domain =
-      player.output_protocols.find(
-        (p) => p.output_protocol_id === player.active_output_protocol,
-      )?.protocol_domain ?? undefined;
+    domain = player.output_protocols.find(
+      (p) => p.output_protocol_id === player.active_output_protocol,
+    )?.protocol_domain;
   }
   if (!domain) {
     domain = player.provider.split("--")[0];
@@ -717,8 +716,8 @@ const fetchLyrics = async () => {
   const track = mediaItem as Track;
 
   // Check if lyrics are already in metadata
-  const existingPlain = track.metadata?.lyrics?.trim() || null;
-  const existingSynced = track.metadata?.lrc_lyrics?.trim() || null;
+  const existingPlain = track.metadata.lyrics?.trim() || null;
+  const existingSynced = track.metadata.lrc_lyrics?.trim() || null;
 
   if (existingPlain || existingSynced) {
     currentLyrics.value = { plain: existingPlain, synced: existingSynced };
@@ -905,7 +904,7 @@ const onTitleClick = async function () {
           const exactMatch = results.find(
             (track) =>
               track.name.toLowerCase() === currentMedia.title!.toLowerCase() &&
-              track.artists?.some(
+              track.artists.some(
                 (artist) =>
                   artist.name.toLowerCase() ===
                   currentMedia.artist!.toLowerCase(),
@@ -981,7 +980,7 @@ const onAlbumClick = async function () {
         // If we have artist info, try to find album by same artist
         if (currentMedia.artist) {
           const matchWithArtist = results.find((album) =>
-            album.artists?.some(
+            album.artists.some(
               (artist) =>
                 artist.name.toLowerCase() ===
                   currentMedia.artist!.toLowerCase() ||

--- a/src/layouts/default/PlayerOSD/PlayerTimeline.vue
+++ b/src/layouts/default/PlayerOSD/PlayerTimeline.vue
@@ -318,7 +318,7 @@ const displayedElapsedTime = computed(() => {
 
 const chapterTicks = computed(() =>
   computeChapterTicks(
-    store.curQueueItem?.media_item?.metadata?.chapters,
+    store.curQueueItem?.media_item?.metadata.chapters,
     store.activePlayer?.current_media?.duration,
   ),
 );

--- a/src/layouts/default/PlayerOSD/QueueListItem.vue
+++ b/src/layouts/default/PlayerOSD/QueueListItem.vue
@@ -209,7 +209,7 @@ const title = computed(() => props.item.media_item?.name || props.item.name);
 
 const artistName = computed(() => {
   const mediaItem = props.item.media_item;
-  if (mediaItem && "artists" in mediaItem && mediaItem.artists?.length) {
+  if (mediaItem && "artists" in mediaItem && mediaItem.artists.length) {
     return mediaItem.artists.map((a) => a.name).join(", ");
   }
   return "";

--- a/src/plugins/api/interfaces.ts
+++ b/src/plugins/api/interfaces.ts
@@ -839,7 +839,6 @@ export interface MediaItemMetadata {
   replaygain?: number;
   popularity?: number;
   release_date?: string;
-  cache_checksum?: string;
   chapters?: MediaItemChapter[];
   life_span?: LifeSpan;
   artist_entity_type?: ArtistEntityType;
@@ -1197,7 +1196,7 @@ export interface OutputProtocol {
   output_protocol_id: string; // Unique ID: "native" or protocol player_id
   name: string; // Display name: "Native (Sonos)" or "AirPlay"
   is_native: boolean; // True if this is the player's native output
-  protocol_domain: string | null; // e.g., "airplay", "dlna" (null for native)
+  protocol_domain: string; // e.g., "airplay", "dlna"; the player's own domain for native
   priority: number; // Lower = more preferred (native = 0 if supported)
   available: boolean; // Whether this output protocol is currently available
   // derived_from: for a derived transport that rides on another protocol (e.g. a Sendspin

--- a/src/views/ArtistDetails.vue
+++ b/src/views/ArtistDetails.vue
@@ -470,7 +470,7 @@ const aggregatedProviderIdsForFeature = (feature: ProviderFeature) =>
   computed(() => {
     if (!itemDetails.value) return [];
     const ids = new Set<string>();
-    for (const mapping of itemDetails.value.provider_mappings || []) {
+    for (const mapping of itemDetails.value.provider_mappings) {
       if (!providerAllowed(mapping.provider_instance)) continue;
       if (
         api.providers[mapping.provider_instance]?.supported_features.includes(

--- a/src/views/PartyDashboardView.vue
+++ b/src/views/PartyDashboardView.vue
@@ -493,8 +493,8 @@ const fetchLyrics = async () => {
   if (!mediaItem || mediaItem.media_type !== MediaType.TRACK) return;
 
   const track = mediaItem as Track;
-  const existingPlain = track.metadata?.lyrics?.trim() || null;
-  const existingSynced = track.metadata?.lrc_lyrics?.trim() || null;
+  const existingPlain = track.metadata.lyrics?.trim() || null;
+  const existingSynced = track.metadata.lrc_lyrics?.trim() || null;
 
   if (existingPlain || existingSynced) {
     currentLyrics.value = { plain: existingPlain, synced: existingSynced };

--- a/src/views/PlaylistDetails.vue
+++ b/src/views/PlaylistDetails.vue
@@ -109,7 +109,7 @@ const listingRef = ref<InstanceType<typeof ItemsListing>>();
 
 const loadItemDetails = async function () {
   itemDetails.value = await api.getPlaylist(props.itemId, props.provider);
-  const isSmartPlaylist = itemDetails.value?.provider_mappings?.some(
+  const isSmartPlaylist = itemDetails.value?.provider_mappings.some(
     (m) => m.provider_domain === "smart_playlist",
   );
   if (isSmartPlaylist) {

--- a/src/views/RadioDetails.vue
+++ b/src/views/RadioDetails.vue
@@ -14,7 +14,6 @@
       :sort-keys="['provider', 'sort_name']"
       :title="$t('other_versions')"
       :hide-on-empty="true"
-      :checksum="provider + itemId"
     />
     <br />
     <!-- provider mapping details -->

--- a/src/views/settings/EditPlayer.vue
+++ b/src/views/settings/EditPlayer.vue
@@ -93,33 +93,33 @@
                 class="protocol-chip"
                 :class="{
                   'protocol-chip--clickable': api.getProviderManifest(
-                    protocol.protocol_domain!,
+                    protocol.protocol_domain,
                   )?.documentation,
                   'protocol-chip--unavailable': !protocol.available,
                 }"
                 @click="
-                  api.getProviderManifest(protocol.protocol_domain!)
+                  api.getProviderManifest(protocol.protocol_domain)
                     ?.documentation &&
                   openLinkInNewTab(
-                    api.getProviderManifest(protocol.protocol_domain!)!
+                    api.getProviderManifest(protocol.protocol_domain)!
                       .documentation!,
                   )
                 "
               >
                 <template #prepend>
                   <ProviderIcon
-                    :domain="protocol.protocol_domain!"
+                    :domain="protocol.protocol_domain"
                     :size="14"
                     class="chip-icon"
                   />
                 </template>
                 {{
-                  api.getProviderManifest(protocol.protocol_domain!)?.name ||
+                  api.getProviderManifest(protocol.protocol_domain)?.name ||
                   protocol.protocol_domain
                 }}
                 <v-icon
                   v-if="
-                    api.getProviderManifest(protocol.protocol_domain!)
+                    api.getProviderManifest(protocol.protocol_domain)
                       ?.documentation
                   "
                   size="12"

--- a/src/views/settings/Players.vue
+++ b/src/views/settings/Players.vue
@@ -100,13 +100,13 @@
                 >
                   <template #prepend>
                     <ProviderIcon
-                      :domain="protocol.protocol_domain!"
+                      :domain="protocol.protocol_domain"
                       :size="14"
                       class="chip-icon"
                     />
                   </template>
                   {{
-                    api.getProviderManifest(protocol.protocol_domain!)?.name ||
+                    api.getProviderManifest(protocol.protocol_domain)?.name ||
                     protocol.protocol_domain
                   }}
                 </v-chip>
@@ -319,7 +319,7 @@ const getPlayerName = function (playerConfig: PlayerConfig) {
 };
 
 const getOutputProtocols = function (playerId: string) {
-  // Return only non-native protocols (ones with a protocol_domain)
+  // all output methods for this player, native included
   return api.players[playerId]?.output_protocols || [];
 };
 
@@ -419,10 +419,8 @@ const getAllFilteredPlayers = function () {
       // Check if any output protocol's domain matches a selected provider domain
       const player = api.players[item.player_id];
       if (player) {
-        return player.output_protocols.some(
-          (protocol) =>
-            protocol.protocol_domain &&
-            selectedProviderDomains.has(protocol.protocol_domain),
+        return player.output_protocols.some((protocol) =>
+          selectedProviderDomains.has(protocol.protocol_domain),
         );
       }
 

--- a/src/views/settings/ProtocolConfigSection.vue
+++ b/src/views/settings/ProtocolConfigSection.vue
@@ -296,10 +296,7 @@ const getProtocolBaseName = function (category: string): string | undefined {
     (p) => p.output_protocol_id === derivedFrom,
   );
   if (!base) return undefined;
-  const provider = base.protocol_domain
-    ? api.getProvider(base.protocol_domain)
-    : undefined;
-  return provider?.name || base.name;
+  return api.getProvider(base.protocol_domain)?.name || base.name;
 };
 
 // Accordion title for a protocol's configuration section; derived transports include

--- a/tests/components/MediaSearch.test.ts
+++ b/tests/components/MediaSearch.test.ts
@@ -55,6 +55,20 @@ function mountSearch(
   return mount(MediaSearch, { props });
 }
 
+// api.search always returns every result list, so fill the ones a case does not
+// exercise rather than letting a partial mock stand in for a server response
+const searchResults = <T extends Record<string, unknown>>(lists: T) => ({
+  artists: [],
+  albums: [],
+  tracks: [],
+  playlists: [],
+  radio: [],
+  podcasts: [],
+  audiobooks: [],
+  genres: [],
+  ...lists,
+});
+
 describe("MediaSearch", () => {
   beforeEach(() => {
     vi.useFakeTimers();
@@ -64,12 +78,14 @@ describe("MediaSearch", () => {
   });
 
   it("searches only the default-selected media types", async () => {
-    mockSearch.mockResolvedValue({
-      tracks: [],
-      playlists: [],
-      albums: [],
-      artists: [],
-    });
+    mockSearch.mockResolvedValue(
+      searchResults({
+        tracks: [],
+        playlists: [],
+        albums: [],
+        artists: [],
+      }),
+    );
     const wrapper = mountSearch({
       allowedMediaTypes: MUSIC_QUIZ_SOURCE_MEDIA_TYPES,
       defaultSelectedMediaTypes: [MediaType.PLAYLIST, MediaType.GENRE],
@@ -88,15 +104,19 @@ describe("MediaSearch", () => {
   });
 
   it("renders a result for each allowed media type", async () => {
-    mockSearch.mockResolvedValue({
-      tracks: [{ uri: "track:1", name: "Some track", media_type: "track" }],
-      playlists: [
-        { uri: "playlist:1", name: "Some playlist", media_type: "playlist" },
-      ],
-      albums: [{ uri: "album:1", name: "Some album", media_type: "album" }],
-      artists: [{ uri: "artist:1", name: "Some artist", media_type: "artist" }],
-      genres: [{ uri: "genre:1", name: "Some genre", media_type: "genre" }],
-    });
+    mockSearch.mockResolvedValue(
+      searchResults({
+        tracks: [{ uri: "track:1", name: "Some track", media_type: "track" }],
+        playlists: [
+          { uri: "playlist:1", name: "Some playlist", media_type: "playlist" },
+        ],
+        albums: [{ uri: "album:1", name: "Some album", media_type: "album" }],
+        artists: [
+          { uri: "artist:1", name: "Some artist", media_type: "artist" },
+        ],
+        genres: [{ uri: "genre:1", name: "Some genre", media_type: "genre" }],
+      }),
+    );
     const wrapper = mountSearch({
       allowedMediaTypes: MUSIC_QUIZ_SOURCE_MEDIA_TYPES,
       defaultSelectedMediaTypes: MUSIC_QUIZ_SOURCE_MEDIA_TYPES,
@@ -121,12 +141,14 @@ describe("MediaSearch", () => {
   });
 
   it("emits select with the chosen item", async () => {
-    mockSearch.mockResolvedValue({
-      tracks: [],
-      playlists: [
-        { uri: "playlist:1", name: "Some playlist", media_type: "playlist" },
-      ],
-    });
+    mockSearch.mockResolvedValue(
+      searchResults({
+        tracks: [],
+        playlists: [
+          { uri: "playlist:1", name: "Some playlist", media_type: "playlist" },
+        ],
+      }),
+    );
     const wrapper = mountSearch({
       allowedMediaTypes: MUSIC_QUIZ_SOURCE_MEDIA_TYPES,
       defaultSelectedMediaTypes: [MediaType.PLAYLIST],
@@ -145,12 +167,14 @@ describe("MediaSearch", () => {
   });
 
   it("hides excluded uris from the results", async () => {
-    mockSearch.mockResolvedValue({
-      tracks: [],
-      playlists: [
-        { uri: "playlist:1", name: "Some playlist", media_type: "playlist" },
-      ],
-    });
+    mockSearch.mockResolvedValue(
+      searchResults({
+        tracks: [],
+        playlists: [
+          { uri: "playlist:1", name: "Some playlist", media_type: "playlist" },
+        ],
+      }),
+    );
     const wrapper = mountSearch({
       allowedMediaTypes: MUSIC_QUIZ_SOURCE_MEDIA_TYPES,
       defaultSelectedMediaTypes: [MediaType.PLAYLIST],
@@ -166,26 +190,36 @@ describe("MediaSearch", () => {
   });
 
   it("collapses the same item from multiple providers", async () => {
-    mockSearch.mockResolvedValue({
-      tracks: [
-        {
-          uri: "library://track/1",
-          name: "Song",
-          media_type: "track",
-          artists: [{ name: "Band" }],
-        },
-        {
-          uri: "spotify://track/9",
-          name: "Song",
-          media_type: "track",
-          artists: [{ name: "Band" }],
-        },
-      ],
-      playlists: [
-        { uri: "library://playlist/1", name: "Party", media_type: "playlist" },
-        { uri: "spotify://playlist/9", name: "Party", media_type: "playlist" },
-      ],
-    });
+    mockSearch.mockResolvedValue(
+      searchResults({
+        tracks: [
+          {
+            uri: "library://track/1",
+            name: "Song",
+            media_type: "track",
+            artists: [{ name: "Band" }],
+          },
+          {
+            uri: "spotify://track/9",
+            name: "Song",
+            media_type: "track",
+            artists: [{ name: "Band" }],
+          },
+        ],
+        playlists: [
+          {
+            uri: "library://playlist/1",
+            name: "Party",
+            media_type: "playlist",
+          },
+          {
+            uri: "spotify://playlist/9",
+            name: "Party",
+            media_type: "playlist",
+          },
+        ],
+      }),
+    );
     const wrapper = mountSearch({
       allowedMediaTypes: [MediaType.TRACK, MediaType.PLAYLIST],
     });

--- a/tests/components/MediaSearch.test.ts
+++ b/tests/components/MediaSearch.test.ts
@@ -234,4 +234,37 @@ describe("MediaSearch", () => {
     expect(rows.filter((row) => row.text().includes("Party"))).toHaveLength(2);
     vi.useRealTimers();
   });
+
+  it("collapses duplicates of a track that lists no artists", async () => {
+    mockSearch.mockResolvedValue(
+      searchResults({
+        tracks: [
+          {
+            uri: "library://track/1",
+            name: "Untitled",
+            media_type: "track",
+            artists: [],
+          },
+          {
+            uri: "spotify://track/9",
+            name: "Untitled",
+            media_type: "track",
+            artists: [],
+          },
+        ],
+      }),
+    );
+    const wrapper = mountSearch({ allowedMediaTypes: [MediaType.TRACK] });
+
+    await wrapper.find("input").setValue("test");
+    await vi.advanceTimersByTimeAsync(300);
+    await flushPromises();
+
+    const rows = wrapper.findAll(".media-search-result");
+    expect(rows.filter((row) => row.text().includes("Untitled"))).toHaveLength(
+      1,
+    );
+
+    vi.useRealTimers();
+  });
 });

--- a/tests/components/music-quiz/GuessTheSongSetup.test.ts
+++ b/tests/components/music-quiz/GuessTheSongSetup.test.ts
@@ -78,6 +78,20 @@ function mountConfig(includeSimilarMusic = false, sharedConfigValid = true) {
   });
 }
 
+// api.search always returns every result list, so fill the ones a case does not
+// exercise rather than letting a partial mock stand in for a server response
+const searchResults = <T extends Record<string, unknown>>(lists: T) => ({
+  artists: [],
+  albums: [],
+  tracks: [],
+  playlists: [],
+  radio: [],
+  podcasts: [],
+  audiobooks: [],
+  genres: [],
+  ...lists,
+});
+
 describe("GuessTheSongSetup", () => {
   beforeEach(() => {
     vi.useFakeTimers();
@@ -120,29 +134,33 @@ describe("GuessTheSongSetup", () => {
       ["library"],
     );
 
-    newSearch.resolve({
-      tracks: [],
-      playlists: [
-        {
-          uri: "playlist:new",
-          name: "Newest result",
-          media_type: MediaType.PLAYLIST,
-        },
-      ],
-    });
+    newSearch.resolve(
+      searchResults({
+        tracks: [],
+        playlists: [
+          {
+            uri: "playlist:new",
+            name: "Newest result",
+            media_type: MediaType.PLAYLIST,
+          },
+        ],
+      }),
+    );
     await flushPromises();
     expect(wrapper.text()).toContain("Newest result");
 
-    oldSearch.resolve({
-      tracks: [],
-      playlists: [
-        {
-          uri: "playlist:old",
-          name: "Older result",
-          media_type: MediaType.PLAYLIST,
-        },
-      ],
-    });
+    oldSearch.resolve(
+      searchResults({
+        tracks: [],
+        playlists: [
+          {
+            uri: "playlist:old",
+            name: "Older result",
+            media_type: MediaType.PLAYLIST,
+          },
+        ],
+      }),
+    );
     await flushPromises();
 
     expect(wrapper.text()).toContain("Newest result");
@@ -150,16 +168,18 @@ describe("GuessTheSongSetup", () => {
   });
 
   it("emits a name-free discriminated create request", async () => {
-    mockSearch.mockResolvedValue({
-      tracks: [],
-      playlists: [
-        {
-          uri: "playlist:test",
-          name: "Test playlist",
-          media_type: MediaType.PLAYLIST,
-        },
-      ],
-    });
+    mockSearch.mockResolvedValue(
+      searchResults({
+        tracks: [],
+        playlists: [
+          {
+            uri: "playlist:test",
+            name: "Test playlist",
+            media_type: MediaType.PLAYLIST,
+          },
+        ],
+      }),
+    );
 
     const wrapper = mountConfig();
     expect(wrapper.find("#quiz-name").exists()).toBe(false);
@@ -193,16 +213,18 @@ describe("GuessTheSongSetup", () => {
   });
 
   it("blocks create when shared setup is invalid", async () => {
-    mockSearch.mockResolvedValue({
-      tracks: [],
-      playlists: [
-        {
-          uri: "playlist:test",
-          name: "Test playlist",
-          media_type: MediaType.PLAYLIST,
-        },
-      ],
-    });
+    mockSearch.mockResolvedValue(
+      searchResults({
+        tracks: [],
+        playlists: [
+          {
+            uri: "playlist:test",
+            name: "Test playlist",
+            media_type: MediaType.PLAYLIST,
+          },
+        ],
+      }),
+    );
     const wrapper = mountConfig(false, false);
 
     await wrapper
@@ -224,16 +246,18 @@ describe("GuessTheSongSetup", () => {
   });
 
   it("hides already selected items from the search results", async () => {
-    mockSearch.mockResolvedValue({
-      tracks: [],
-      playlists: [
-        {
-          uri: "playlist:test",
-          name: "Test playlist",
-          media_type: MediaType.PLAYLIST,
-        },
-      ],
-    });
+    mockSearch.mockResolvedValue(
+      searchResults({
+        tracks: [],
+        playlists: [
+          {
+            uri: "playlist:test",
+            name: "Test playlist",
+            media_type: MediaType.PLAYLIST,
+          },
+        ],
+      }),
+    );
     const wrapper = mountConfig();
 
     await wrapper
@@ -256,19 +280,21 @@ describe("GuessTheSongSetup", () => {
   });
 
   it("emits source uris for a playlist and a genre together", async () => {
-    mockSearch.mockResolvedValue({
-      tracks: [],
-      playlists: [
-        {
-          uri: "playlist:test",
-          name: "Test playlist",
-          media_type: MediaType.PLAYLIST,
-        },
-      ],
-      genres: [
-        { uri: "genre:rock", name: "Rock", media_type: MediaType.GENRE },
-      ],
-    });
+    mockSearch.mockResolvedValue(
+      searchResults({
+        tracks: [],
+        playlists: [
+          {
+            uri: "playlist:test",
+            name: "Test playlist",
+            media_type: MediaType.PLAYLIST,
+          },
+        ],
+        genres: [
+          { uri: "genre:rock", name: "Rock", media_type: MediaType.GENRE },
+        ],
+      }),
+    );
     const wrapper = mountConfig(true);
 
     const searchInput = wrapper.find(
@@ -303,16 +329,18 @@ describe("GuessTheSongSetup", () => {
   });
 
   it("removes a selected source when its chip is clicked", async () => {
-    mockSearch.mockResolvedValue({
-      tracks: [],
-      playlists: [
-        {
-          uri: "playlist:test",
-          name: "Test playlist",
-          media_type: MediaType.PLAYLIST,
-        },
-      ],
-    });
+    mockSearch.mockResolvedValue(
+      searchResults({
+        tracks: [],
+        playlists: [
+          {
+            uri: "playlist:test",
+            name: "Test playlist",
+            media_type: MediaType.PLAYLIST,
+          },
+        ],
+      }),
+    );
     const wrapper = mountConfig();
 
     await wrapper

--- a/tests/components/music-quiz/MusicTimelineSetup.test.ts
+++ b/tests/components/music-quiz/MusicTimelineSetup.test.ts
@@ -41,22 +41,38 @@ async function flushPromises() {
   await nextTick();
 }
 
+// api.search always returns every result list, so fill the ones a case does not
+// exercise rather than letting a partial mock stand in for a server response
+const searchResults = <T extends Record<string, unknown>>(lists: T) => ({
+  artists: [],
+  albums: [],
+  tracks: [],
+  playlists: [],
+  radio: [],
+  podcasts: [],
+  audiobooks: [],
+  genres: [],
+  ...lists,
+});
+
 describe("MusicTimelineSetup", () => {
   beforeEach(() => {
     vi.useFakeTimers();
     mockSearch.mockReset();
     mockGetLibraryGenres.mockReset();
     mockGetLibraryGenres.mockResolvedValue([]);
-    mockSearch.mockResolvedValue({
-      tracks: [],
-      playlists: [
-        {
-          uri: "playlist:test",
-          name: "Test playlist",
-          media_type: MediaType.PLAYLIST,
-        },
-      ],
-    });
+    mockSearch.mockResolvedValue(
+      searchResults({
+        tracks: [],
+        playlists: [
+          {
+            uri: "playlist:test",
+            name: "Test playlist",
+            media_type: MediaType.PLAYLIST,
+          },
+        ],
+      }),
+    );
   });
 
   afterEach(() => {

--- a/tests/composables/useAudioProcessingDetails.test.ts
+++ b/tests/composables/useAudioProcessingDetails.test.ts
@@ -154,32 +154,6 @@ describe("buildAudioProcessingDetailsDisplay", () => {
     expect(destination.details).toBeUndefined();
   });
 
-  it("uses the protocol player provider when the active entry has no domain", () => {
-    dependencies.players.kitchen.active_output_protocol = "sendspin-kitchen";
-    dependencies.players.kitchen.output_protocols = [
-      makeOutputProtocol({
-        output_protocol_id: "sendspin-kitchen",
-        protocol_domain: null,
-      }),
-    ];
-    dependencies.players["sendspin-kitchen"] = {
-      player_id: "sendspin-kitchen",
-      name: "Kitchen",
-      provider: "sendspin--bridge",
-      active_output_protocol: null,
-      output_protocols: [],
-    };
-
-    const destination = buildDisplay({
-      outputs: [{ player_ids: ["kitchen"], output_format: makeFormat() }],
-    }).outputPaths[0].destination;
-
-    expect(destination).toMatchObject({
-      title: "Kitchen",
-      providerIconDomain: "sendspin",
-    });
-  });
-
   it("never falls back to the base provider for an unresolved active protocol", () => {
     dependencies.players.kitchen.active_output_protocol = "missing-protocol";
     dependencies.players.kitchen.output_protocols = [];

--- a/tests/helpers/players.test.ts
+++ b/tests/helpers/players.test.ts
@@ -71,7 +71,7 @@ function createOutputProtocol(
     output_protocol_id: "native",
     name: "Native",
     is_native: true,
-    protocol_domain: null,
+    protocol_domain: "test",
     priority: 0,
     available: true,
     ...overrides,


### PR DESCRIPTION
Follow-up to #2326. A number of reads still checked for null on fields the server always fills. Those checks never do anything, and they make the data look less reliable than it is — which is how the mismatch in #2326 crept in. Each one was cross-checked against the server model before removing it.

- Remove the redundant null checks on always-present fields: item metadata, artists, provider mappings, search results, user filters and setup form entries
- An output protocol always carries its provider domain, including the native one, so drop the null handling and the nine assertions that worked around it (the type comment claiming otherwise was wrong)
- Remove the image cache-buster: it silently stopped working when the server dropped the field it read, so images were never actually cache-busted
- Remove a leftover property passed to the radio "other versions" list that the list stopped accepting in 2023
- Search tests now return the full result set the server sends, instead of a partial stand-in
