### PR TITLE
Update release notes config to the supported category format

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -12,28 +12,32 @@ exclude-contributors:
 categories:
   - title: "⚠ Breaking Changes"
     exclusive: true
-    labels:
-      - "breaking-change"
+    when:
+      - labels:
+          - "breaking-change"
 
   - title: "🚀 Features and enhancements"
     exclusive: true
-    labels:
-      - "enhancement"
-      - "new-feature"
+    when:
+      - labels:
+          - "enhancement"
+          - "new-feature"
 
   - title: "🐛 Bugfixes"
     exclusive: true
-    labels:
-      - "bugfix"
+    when:
+      - labels:
+          - "bugfix"
 
   - title: "🧰 Maintenance and dependency bumps"
     exclusive: true
     collapse-after: 3
-    labels:
-      - "ci"
-      - "maintenance"
-      - "refactor"
-      - "dependencies"
+    when:
+      - labels:
+          - "ci"
+          - "maintenance"
+          - "refactor"
+          - "dependencies"
 
 template: |
 


### PR DESCRIPTION
The release workflow logs four deprecation warnings on every run: our release notes config still assigns labels to categories with the old `labels:` field, which the pinned Release Drafter version has deprecated and will remove.

Switches each category to the supported `when:` form. Purely a config format change — the release notes come out exactly the same.

- Moved `labels:` into a `when:` condition for all four categories
- Kept the section order, `exclusive: true` and the collapse setting untouched, so PRs land in the same sections as before