### PR TITLE
Run the PR label check when a PR is opened

### DIFF
--- a/.github/workflows/pr-labels.yaml
+++ b/.github/workflows/pr-labels.yaml
@@ -5,6 +5,8 @@ name: PR Labels
 on:
   pull_request:
     types:
+      - opened
+      - reopened
       - synchronize
       - labeled
       - unlabeled


### PR DESCRIPTION
The PR label check never ran on a newly opened PR. It only triggered on `synchronize`, `labeled` and `unlabeled`, so a PR opened without a category label got no check at all until someone pushed another commit or added/removed a label. That is exactly the case the check is meant to catch.

- Also run the check when a PR is opened or reopened
