### PR TITLE
Match the browse folder type to what the server sends

### DIFF
--- a/src/components/Chapters.vue
+++ b/src/components/Chapters.vue
@@ -41,11 +41,11 @@ import Toolbar from "@/components/Toolbar.vue";
 import { formatDuration } from "@/helpers/utils";
 import { api } from "@/plugins/api";
 import { itemIsAvailable } from "@/plugins/api/helpers";
-import { MediaItemChapter, type MediaItemType } from "@/plugins/api/interfaces";
+import { MediaItemChapter, type MediaItem } from "@/plugins/api/interfaces";
 import { computed, ref } from "vue";
 
 export interface Props {
-  itemDetails: MediaItemType;
+  itemDetails: MediaItem;
 }
 const props = defineProps<Props>();
 

--- a/src/components/FavoriteButton.vue
+++ b/src/components/FavoriteButton.vue
@@ -1,10 +1,10 @@
 <script setup lang="ts">
 import api from "@/plugins/api";
-import { type MediaItemType } from "@/plugins/api/interfaces";
+import { type MediaItem } from "@/plugins/api/interfaces";
 import { Heart } from "@lucide/vue";
 
 interface Props {
-  item: MediaItemType;
+  item: MediaItem;
 }
 
 const props = defineProps<Props>();

--- a/src/components/InfoHeader.vue
+++ b/src/components/InfoHeader.vue
@@ -535,6 +535,7 @@ import type {
   Album,
   Artist,
   Audiobook,
+  BrowseFolder,
   Genre,
   ItemMapping,
   MediaItemType,
@@ -561,7 +562,8 @@ import MediaCollectionThumb from "./MediaCollectionThumb.vue";
 
 // properties
 export interface Props {
-  item?: MediaItemType;
+  // browse folders are listed, never opened in a details view
+  item?: Exclude<MediaItemType, BrowseFolder>;
   sortBy?: string;
 }
 const compProps = defineProps<Props>();

--- a/src/components/ItemsListing.vue
+++ b/src/components/ItemsListing.vue
@@ -2039,7 +2039,7 @@ const getFilteredItems = function (
   }
 
   if (params.favoritesOnly) {
-    result = result.filter((x) => x.favorite);
+    result = result.filter((x) => "favorite" in x && x.favorite);
   }
 
   if (params.hideFullyPlayed) {

--- a/src/components/ListviewItem.vue
+++ b/src/components/ListviewItem.vue
@@ -212,7 +212,7 @@
         {{ truncateString(item.metadata.description, 150) }}
       </div>
       <!-- media type label -->
-      <div v-else-if="'media_type' in item && !item.provider_mappings">
+      <div v-else-if="!('provider_mappings' in item)">
         {{ $t(item.media_type) }}
       </div>
     </template>

--- a/src/components/ListviewItemTitle.vue
+++ b/src/components/ListviewItemTitle.vue
@@ -25,7 +25,11 @@
   </span>
   <!-- explicit icon -->
   <template
-    v-if="item && item.metadata && parseBool(item.metadata.explicit || false)"
+    v-if="
+      'metadata' in item &&
+      item.metadata &&
+      parseBool(item.metadata.explicit || false)
+    "
   >
     <Tooltip>
       <TooltipTrigger as-child>

--- a/src/components/LyricsViewer.vue
+++ b/src/components/LyricsViewer.vue
@@ -104,7 +104,11 @@
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { Spinner } from "@/components/ui/spinner";
 import { parseLrcLine } from "@/helpers/lrcParser";
-import { MediaItemType, StreamDetails, Track } from "@/plugins/api/interfaces";
+import {
+  PlayableMediaItemType,
+  StreamDetails,
+  Track,
+} from "@/plugins/api/interfaces";
 import { $t } from "@/plugins/i18n";
 import Color from "color";
 import { computed, nextTick, onBeforeUnmount, ref, watch } from "vue";
@@ -117,7 +121,7 @@ interface DisplayLine {
 }
 
 interface Props {
-  mediaItem?: MediaItemType;
+  mediaItem?: PlayableMediaItemType;
   position?: number;
   streamDetails?: StreamDetails;
   textColor?: string;

--- a/src/components/PanelviewItem.vue
+++ b/src/components/PanelviewItem.vue
@@ -14,7 +14,9 @@
     <template v-if="showActions" #actions>
       <div class="panel-item-actions" @click.stop>
         <v-icon
-          v-if="parseBool(item.metadata.explicit || false)"
+          v-if="
+            'metadata' in item && parseBool(item.metadata.explicit || false)
+          "
           size="30"
           icon="mdi-alpha-e-box"
         />
@@ -44,7 +46,10 @@
           <v-icon size="small" icon="mdi-music-circle-outline" />
           {{ item.position }}
         </span>
-        <FavouriteButton v-if="getBreakpointValue('bp3')" :item="item" />
+        <FavouriteButton
+          v-if="getBreakpointValue('bp3') && 'favorite' in item"
+          :item="item"
+        />
         <v-spacer />
         <MAButton
           variant="list"
@@ -99,6 +104,7 @@ const emit = defineEmits<{
 
 // computed: hi-res audio details (kHz/bit-depth) for lossless formats
 const HiResDetails = computed(() => {
+  if (!("provider_mappings" in compProps.item)) return "";
   for (const prov of compProps.item.provider_mappings) {
     if (prov.audio_format.content_type == undefined) continue;
     if (

--- a/src/components/ProviderDetails.vue
+++ b/src/components/ProviderDetails.vue
@@ -141,7 +141,7 @@ import { api } from "@/plugins/api";
 import {
   MediaType,
   ProviderMapping,
-  type MediaItemType,
+  type MediaItem,
 } from "@/plugins/api/interfaces";
 import { authManager } from "@/plugins/auth";
 import { getBreakpointValue } from "@/plugins/breakpoint";
@@ -151,7 +151,7 @@ import { useI18n } from "vue-i18n";
 import { toast } from "vue-sonner";
 
 export interface Props {
-  itemDetails: MediaItemType;
+  itemDetails: MediaItem;
 }
 const props = defineProps<Props>();
 

--- a/src/composables/useShortcuts.ts
+++ b/src/composables/useShortcuts.ts
@@ -7,6 +7,7 @@ import type {
   EventMessage,
   Genre,
   ItemMapping,
+  MediaItemTypeOrItemMapping,
   Playlist,
   Podcast,
   Radio,
@@ -169,8 +170,13 @@ function findPinnedUriByIdentities(
   return null;
 }
 
-export function isShortcutMediaType(mediaType: MediaType): boolean {
-  return SUPPORTED_TYPES.has(mediaType);
+/**
+ * Type guard for items that can be pinned as a sidebar shortcut.
+ */
+export function isShortcutItem(
+  item: MediaItemTypeOrItemMapping,
+): item is ShortcutItem | ItemMapping {
+  return SUPPORTED_TYPES.has(item.media_type);
 }
 
 // ---------------------------------------------------------------------------
@@ -219,7 +225,7 @@ export async function unpinShortcutStandaloneItem(
 export async function pinShortcutStandalone(
   item: ShortcutItem | ItemMapping,
 ): Promise<void> {
-  if (!isShortcutMediaType(item.media_type)) return;
+  if (!isShortcutItem(item)) return;
   const uris = _getPinnedUris();
   if (uris.length >= MAX_SHORTCUTS) return;
   // Always construct a proper MA URI from provider/media_type/item_id.

--- a/src/layouts/default/AddToPlaylistDialog.vue
+++ b/src/layouts/default/AddToPlaylistDialog.vue
@@ -134,17 +134,22 @@ const fetchPlaylists = async function () {
     undefined,
     undefined,
   );
-  let refItem = selectedItems.value.length ? selectedItems.value[0] : undefined;
+  const selected = selectedItems.value.length
+    ? selectedItems.value[0]
+    : undefined;
 
-  if (!refItem) return;
-  if (!("provider_mappings" in refItem)) {
-    // resolve itemmapping
-    refItem = await api.getItem(
-      refItem.media_type,
-      refItem.item_id,
-      refItem.provider,
-    );
-  }
+  if (!selected) return;
+  // an itemmapping carries no provider mappings, resolve it to the full item
+  const refItem =
+    "provider_mappings" in selected
+      ? selected
+      : await api.getItem(
+          selected.media_type,
+          selected.item_id,
+          selected.provider,
+        );
+  // a browse folder has no provider mappings and can not be added to a playlist
+  if (!("provider_mappings" in refItem)) return;
 
   for (const playlist of playlistResults) {
     // skip unavailable playlists

--- a/src/layouts/default/ItemContextMenu.vue
+++ b/src/layouts/default/ItemContextMenu.vue
@@ -206,7 +206,7 @@ import router from "@/plugins/router";
 import {
   getShortcutMoveAvailability,
   isShortcutCapReached,
-  isShortcutMediaType,
+  isShortcutItem,
   isShortcutPinnedItem,
   moveShortcutStandaloneItem,
   pinShortcutStandalone,
@@ -941,11 +941,7 @@ export const getContextMenuItems = async function (
     });
   }
   // pin / unpin shortcut in sidebar (playlist, artist, album, track, radio, podcast, audiobook, genre)
-  if (
-    items.length === 1 &&
-    isShortcutMediaType(items[0].media_type) &&
-    !!items[0].uri
-  ) {
+  if (items.length === 1 && isShortcutItem(items[0]) && !!items[0].uri) {
     const shortcutItem = items[0];
     if (isShortcutPinnedItem(shortcutItem)) {
       // move up/down only make sense when the menu is opened on the

--- a/src/layouts/default/PlayerOSD/PlayerControlBtn/FavoriteBtn.vue
+++ b/src/layouts/default/PlayerOSD/PlayerControlBtn/FavoriteBtn.vue
@@ -12,11 +12,11 @@
 <script setup lang="ts">
 import Icon, { IconProps } from "@/components/Icon.vue";
 import api from "@/plugins/api";
-import { type MediaItemType } from "@/plugins/api/interfaces";
+import { type MediaItem } from "@/plugins/api/interfaces";
 
 // properties
 export interface Props {
-  item?: MediaItemType;
+  item?: MediaItem;
   isVisible?: boolean;
   icon?: IconProps;
   disabled?: boolean;

--- a/src/plugins/api/index.ts
+++ b/src/plugins/api/index.ts
@@ -22,6 +22,7 @@ import {
   type EventMessage,
   type Genre,
   type MassEvent,
+  type MediaItem,
   type MediaItemType,
   type Player,
   type PlayerOptionValueType,
@@ -1418,7 +1419,7 @@ export class MusicAssistantApi {
     });
   }
 
-  public toggleFavorite(item: MediaItemType) {
+  public toggleFavorite(item: MediaItem) {
     // Toggle favorite for a media item
     if (item.favorite) {
       this.removeItemFromFavorites(item.media_type, item.item_id);

--- a/src/plugins/api/interfaces.ts
+++ b/src/plugins/api/interfaces.ts
@@ -951,8 +951,8 @@ export interface BrowseFolder extends _MediaItemBase {
   // always FOLDER: lets TS drop the folder from the MediaItemType union on any
   // other media_type check, and makes Exclude<MediaItemType, BrowseFolder> work
   media_type: MediaType.FOLDER;
-  path?: string;
-  image?: MediaItemImage;
+  path: string;
+  image: MediaItemImage | null;
 }
 export enum RecommendationFolderType {
   DEFAULT = "default",

--- a/src/plugins/api/interfaces.ts
+++ b/src/plugins/api/interfaces.ts
@@ -945,7 +945,11 @@ export interface Genre extends MediaItem {
   content_type?: MediaType | null;
 }
 
-export interface BrowseFolder extends MediaItem {
+// a browse folder is not a library item: it has no provider mappings, metadata,
+// favorite flag or position, so it extends the bare base instead of MediaItem
+export interface BrowseFolder extends _MediaItemBase {
+  // always FOLDER, which makes it the discriminant that narrows MediaItemType
+  media_type: MediaType.FOLDER;
   path?: string;
   image?: MediaItemImage;
 }
@@ -991,6 +995,9 @@ export interface MediaCollection<M extends MediaItemType> extends MediaItem {
   items: M[];
 }
 
+// unlike the server alias of the same name this includes BrowseFolder, because
+// browse listings render folders and media items through the same components.
+// use Exclude<MediaItemType, BrowseFolder> where only real media items apply.
 export type MediaItemType =
   | Artist
   | Album

--- a/src/plugins/api/interfaces.ts
+++ b/src/plugins/api/interfaces.ts
@@ -948,7 +948,8 @@ export interface Genre extends MediaItem {
 // a browse folder is not a library item: it has no provider mappings, metadata,
 // favorite flag or position, so it extends the bare base instead of MediaItem
 export interface BrowseFolder extends _MediaItemBase {
-  // always FOLDER, which makes it the discriminant that narrows MediaItemType
+  // always FOLDER: lets TS drop the folder from the MediaItemType union on any
+  // other media_type check, and makes Exclude<MediaItemType, BrowseFolder> work
   media_type: MediaType.FOLDER;
   path?: string;
   image?: MediaItemImage;


### PR DESCRIPTION
Browse folders (the entries you click through in the Browse view) are not library items — the server sends them without provider mappings, artwork metadata, a favorite flag or a position. Our type definition said otherwise, so TypeScript believed every folder had those fields.

The practical effect: the checks that keep folder rendering working looked like pointless dead code, and a cleanup pass could have removed them and broken the Browse view. Nothing was broken for users; this makes the types match reality so the compiler protects those checks from now on.

- Declare `BrowseFolder` on the plain item base instead of the full media item, and pin its media type to `folder` so it can be told apart automatically
- Correct the folder `path` and `image` fields to match what the server actually sends
- Tighten components that only ever show real media items (info header, chapters, provider details, favorite button, lyrics viewer) to the narrower type
- Add proper checks where folders genuinely do turn up (list and panel tiles, favorites filter, add-to-playlist)
- Turn the sidebar shortcut check into a type guard so the context menu narrows correctly
