### PR TITLE
Match player types to the null values the server sends

### DIFF
--- a/src/helpers/chapters.test.ts
+++ b/src/helpers/chapters.test.ts
@@ -10,6 +10,7 @@ const chapters: MediaItemChapter[] = [
 
 describe("computeChapterTicks", () => {
   it("returns [] when duration is missing or zero", () => {
+    expect(computeChapterTicks(chapters, null)).toEqual([]);
     expect(computeChapterTicks(chapters, undefined)).toEqual([]);
     expect(computeChapterTicks(chapters, 0)).toEqual([]);
   });

--- a/src/helpers/chapters.ts
+++ b/src/helpers/chapters.ts
@@ -11,7 +11,7 @@ export interface ChapterTick extends MediaItemChapter {
  */
 export function computeChapterTicks(
   chapters: MediaItemChapter[] | null | undefined,
-  duration: number | undefined,
+  duration: number | null | undefined,
 ): ChapterTick[] {
   if (!duration || !chapters?.length) return [];
   return chapters.map((chapter) => ({

--- a/src/helpers/useMediaBrowserMetaData.ts
+++ b/src/helpers/useMediaBrowserMetaData.ts
@@ -23,10 +23,11 @@ function playerMediaToMetadata(item: PlayerMedia) {
     },
   ];
 
+  // MediaMetadata rejects null, so unset fields are passed through as undefined
   return new MediaMetadata({
-    title: item.title,
-    artist: item.artist,
-    album: item.album,
+    title: item.title ?? undefined,
+    artist: item.artist ?? undefined,
+    album: item.album ?? undefined,
     artwork,
   });
 }

--- a/src/helpers/utils.ts
+++ b/src/helpers/utils.ts
@@ -309,7 +309,7 @@ const normalizeImageProxySize = function (size?: number): number {
  * - Otherwise return the URL as-is
  */
 export const getMediaImageUrl = function (
-  imageUrl: string | undefined,
+  imageUrl: string | null | undefined,
 ): string {
   if (!imageUrl) return "";
 

--- a/src/plugins/api/interfaces.ts
+++ b/src/plugins/api/interfaces.ts
@@ -1218,43 +1218,43 @@ export interface OutputProtocol {
   available: boolean; // Whether this output protocol is currently available
   // derived_from: for a derived transport that rides on another protocol (e.g. a Sendspin
   // bridge over an AirPlay player), the output_protocol_id of the base output; null for direct outputs
-  derived_from?: string | null;
+  derived_from: string | null;
 }
 
 export interface DeviceInfo {
   model: string;
   manufacturer: string;
-  software_version?: string;
-  model_id?: string;
-  manufacturer_id?: string;
+  software_version: string | null;
+  model_id: string | null;
+  manufacturer_id: string | null;
   // Identifiers for device identification and protocol player linking
   // Maps IdentifierType to value (e.g., MAC_ADDRESS -> "AA:BB:CC:DD:EE:FF")
   identifiers: Record<IdentifierType, string>;
 }
 
 export interface MediaItemPalette {
-  background_dark?: [number, number, number] | null;
-  background_light?: [number, number, number] | null;
-  primary?: [number, number, number] | null;
-  accent?: [number, number, number] | null;
-  on_dark?: [number, number, number] | null;
-  on_light?: [number, number, number] | null;
+  background_dark: [number, number, number] | null;
+  background_light: [number, number, number] | null;
+  primary: [number, number, number] | null;
+  accent: [number, number, number] | null;
+  on_dark: [number, number, number] | null;
+  on_light: [number, number, number] | null;
 }
 
 export interface PlayerMedia {
   uri: string; // uri or other identifier of the loaded media
   media_type: MediaType;
-  title?: string; // optional
-  artist?: string; // optional
-  album?: string; // optional
-  image_url?: string; // optional
-  palette?: MediaItemPalette | null; // optional
-  duration?: number; // optional
-  source_id?: string; // optional
-  elapsed_time?: number; // optional
-  elapsed_time_last_updated?: number; // optional
+  title: string | null;
+  artist: string | null;
+  album: string | null;
+  image_url: string | null;
+  palette: MediaItemPalette | null;
+  duration: number | null;
+  source_id: string | null;
+  elapsed_time: number | null;
+  elapsed_time_last_updated: number | null;
   queue_id?: string; // only present for requests from queue controller
-  queue_item_id?: string; // only present for requests from queue controller
+  queue_item_id: string | null; // only set for requests from the queue controller
 }
 
 export interface PlayerSource {
@@ -1290,11 +1290,11 @@ export interface PlayerOption {
   value: PlayerOptionValueType;
   read_only: boolean;
 
-  min_value?: number;
-  max_value?: number;
-  step?: number;
+  min_value: number | null;
+  max_value: number | null;
+  step: number | null;
 
-  options?: PlayerOptionEntry[];
+  options: PlayerOptionEntry[] | null;
 }
 
 export interface Player {
@@ -1308,26 +1308,26 @@ export interface Player {
   can_group_with: string[];
   enabled: boolean;
 
-  elapsed_time?: number;
-  elapsed_time_last_updated?: number;
-  current_media?: PlayerMedia;
+  elapsed_time: number | null;
+  elapsed_time_last_updated: number | null;
+  current_media: PlayerMedia | null;
   playback_state?: PlaybackState;
-  powered?: boolean;
-  volume_level?: number;
-  volume_muted?: boolean;
+  powered: boolean | null;
+  volume_level: number | null;
+  volume_muted: boolean | null;
   group_members: string[];
   static_group_members: string[];
   // active_source: id of the source the player is currently playing - its own queue_id for
   // Music Assistant playback, or an external source id. PlayerQueue.active is derived from
   // this, and PLAYER_UPDATED carries a new value before the queue is recalculated, so the
   // two can disagree for about half a second during a source handover.
-  active_source?: string;
+  active_source: string | null;
   source_list: PlayerSource[];
-  active_sound_mode?: string;
+  active_sound_mode: string | null;
   sound_mode_list: PlayerSoundMode[];
   options: PlayerOption[];
-  active_group?: string;
-  synced_to?: string;
+  active_group: string | null;
+  synced_to: string | null;
 
   group_volume: number | null;
   group_volume_muted: boolean | null;
@@ -1351,7 +1351,7 @@ export interface Player {
 
   // sleep_timer_expires_at: unix (utc) timestamp at which the active sleep timer
   // will stop playback, or null when no sleep timer is set.
-  sleep_timer_expires_at?: number | null;
+  sleep_timer_expires_at: number | null;
 }
 
 // provider

--- a/src/plugins/api/interfaces.ts
+++ b/src/plugins/api/interfaces.ts
@@ -1329,6 +1329,9 @@ export interface Player {
   active_group: string | null;
   synced_to: string | null;
 
+  // group_volume: the server currently substitutes 0 for an unset value, so null does not
+  // reach us today; it stays nullable because that substitution is a temporary shim for
+  // older Home Assistant integration versions.
   group_volume: number | null;
   group_volume_muted: boolean | null;
   hide_in_ui: boolean;

--- a/src/plugins/companion.ts
+++ b/src/plugins/companion.ts
@@ -342,8 +342,8 @@ const unregisterPlayerCommandHandler = (): void => {
  */
 interface NowPlayingSignal {
   uri?: string;
-  title?: string;
-  artist?: string;
+  title?: string | null;
+  artist?: string | null;
   state?: PlaybackState;
   playerId?: string;
   timing?: ActiveTiming;

--- a/tests/components/AudioProcessingDetails.test.ts
+++ b/tests/components/AudioProcessingDetails.test.ts
@@ -764,6 +764,7 @@ describe("AudioProcessingDetails", () => {
         protocol_domain: "airplay",
         priority: 1,
         available: true,
+        derived_from: null,
       },
     ];
     const wrapper = mountDetails({
@@ -798,6 +799,7 @@ describe("AudioProcessingDetails", () => {
         protocol_domain: "airplay",
         priority: 1,
         available: true,
+        derived_from: null,
       },
     ];
     const wrapper = mountDetails({

--- a/tests/components/PlayerCard.test.ts
+++ b/tests/components/PlayerCard.test.ts
@@ -5,6 +5,7 @@ import {
   PlaybackState,
   type Player,
   PlayerFeature,
+  type PlayerMedia,
   PlayerType,
 } from "@/plugins/api/interfaces";
 import type { MusicAssistantApi } from "@/plugins/api";
@@ -115,6 +116,25 @@ const VolumeControlStub = {
   `,
 };
 
+// the server sends every PlayerMedia key, using null for the ones it has no value for
+function createPlayerMedia(overrides: Partial<PlayerMedia> = {}): PlayerMedia {
+  return {
+    uri: "test://track",
+    media_type: MediaType.TRACK,
+    title: null,
+    artist: null,
+    album: null,
+    image_url: null,
+    palette: null,
+    duration: null,
+    source_id: null,
+    elapsed_time: null,
+    elapsed_time_last_updated: null,
+    queue_item_id: null,
+    ...overrides,
+  };
+}
+
 function createPlayer(overrides: Partial<Player> = {}): Player {
   return {
     player_id: "player",
@@ -125,6 +145,9 @@ function createPlayer(overrides: Partial<Player> = {}): Player {
     device_info: {
       model: "Test",
       manufacturer: "Test",
+      software_version: null,
+      model_id: null,
+      manufacturer_id: null,
       identifiers: {
         [IdentifierType.MAC_ADDRESS]: "",
         [IdentifierType.SERIAL_NUMBER]: "",
@@ -155,6 +178,14 @@ function createPlayer(overrides: Partial<Player> = {}): Player {
     needs_setup: false,
     output_protocols: [],
     active_output_protocol: null,
+    elapsed_time: null,
+    elapsed_time_last_updated: null,
+    current_media: null,
+    active_source: null,
+    active_sound_mode: null,
+    active_group: null,
+    synced_to: null,
+    sleep_timer_expires_at: null,
     ...overrides,
   };
 }
@@ -335,12 +366,10 @@ describe("PlayerCard", () => {
   it("stacks player identity above loaded media only when requested", () => {
     const player = createPlayer({
       playback_state: PlaybackState.PLAYING,
-      current_media: {
-        uri: "test://track",
-        media_type: MediaType.TRACK,
+      current_media: createPlayerMedia({
         title: "Hate Me Now",
         artist: "Nas",
-      },
+      }),
     });
 
     const mainCard = mountPlayerCard(player);
@@ -391,11 +420,9 @@ describe("PlayerCard", () => {
       const wrapper = mountPlayerCard(
         createPlayer({
           playback_state: playbackState,
-          current_media: {
-            uri: "test://track",
-            media_type: MediaType.TRACK,
+          current_media: createPlayerMedia({
             image_url: "https://example.test/cover.jpg",
-          },
+          }),
         }),
       );
 
@@ -408,11 +435,9 @@ describe("PlayerCard", () => {
   it("shows the player icon instead of idle artwork", () => {
     const wrapper = mountPlayerCard(
       createPlayer({
-        current_media: {
-          uri: "test://track",
-          media_type: MediaType.TRACK,
+        current_media: createPlayerMedia({
           image_url: "https://example.test/cover.jpg",
-        },
+        }),
       }),
     );
 

--- a/tests/components/PlayerGroupMembers.test.ts
+++ b/tests/components/PlayerGroupMembers.test.ts
@@ -48,6 +48,9 @@ function createPlayer(overrides: Partial<Player> = {}): Player {
     device_info: {
       model: "Test",
       manufacturer: "Test",
+      software_version: null,
+      model_id: null,
+      manufacturer_id: null,
       identifiers: {
         [IdentifierType.MAC_ADDRESS]: "",
         [IdentifierType.SERIAL_NUMBER]: "",
@@ -78,6 +81,14 @@ function createPlayer(overrides: Partial<Player> = {}): Player {
     needs_setup: false,
     output_protocols: [],
     active_output_protocol: null,
+    elapsed_time: null,
+    elapsed_time_last_updated: null,
+    current_media: null,
+    active_source: null,
+    active_sound_mode: null,
+    active_group: null,
+    synced_to: null,
+    sleep_timer_expires_at: null,
     ...overrides,
   };
 }

--- a/tests/components/VolumeControl.test.ts
+++ b/tests/components/VolumeControl.test.ts
@@ -61,6 +61,9 @@ function createPlayer(overrides: Partial<Player> = {}): Player {
     device_info: {
       model: "Test",
       manufacturer: "Test",
+      software_version: null,
+      model_id: null,
+      manufacturer_id: null,
       identifiers: {
         [IdentifierType.MAC_ADDRESS]: "",
         [IdentifierType.SERIAL_NUMBER]: "",
@@ -91,6 +94,14 @@ function createPlayer(overrides: Partial<Player> = {}): Player {
     needs_setup: false,
     output_protocols: [],
     active_output_protocol: null,
+    elapsed_time: null,
+    elapsed_time_last_updated: null,
+    current_media: null,
+    active_source: null,
+    active_sound_mode: null,
+    active_group: null,
+    synced_to: null,
+    sleep_timer_expires_at: null,
     ...overrides,
   };
 }

--- a/tests/composables/useAudioProcessingDetails.test.ts
+++ b/tests/composables/useAudioProcessingDetails.test.ts
@@ -604,6 +604,7 @@ function makeOutputProtocol(
     protocol_domain: "airplay",
     priority: 1,
     available: true,
+    derived_from: null,
     ...overrides,
   };
 }

--- a/tests/helpers/players.test.ts
+++ b/tests/helpers/players.test.ts
@@ -39,6 +39,9 @@ function createPlayer(overrides: Partial<Player> = {}): Player {
     device_info: {
       model: "Test",
       manufacturer: "Test",
+      software_version: null,
+      model_id: null,
+      manufacturer_id: null,
       identifiers: {
         [IdentifierType.MAC_ADDRESS]: "",
         [IdentifierType.SERIAL_NUMBER]: "",
@@ -65,6 +68,17 @@ function createPlayer(overrides: Partial<Player> = {}): Player {
     needs_setup: false,
     output_protocols: [],
     active_output_protocol: null,
+    elapsed_time: null,
+    elapsed_time_last_updated: null,
+    current_media: null,
+    powered: null,
+    volume_level: null,
+    volume_muted: null,
+    active_source: null,
+    active_sound_mode: null,
+    active_group: null,
+    synced_to: null,
+    sleep_timer_expires_at: null,
     ...overrides,
   };
 }
@@ -79,6 +93,7 @@ function createOutputProtocol(
     protocol_domain: "test",
     priority: 0,
     available: true,
+    derived_from: null,
     ...overrides,
   };
 }

--- a/tests/helpers/utils.test.ts
+++ b/tests/helpers/utils.test.ts
@@ -176,6 +176,19 @@ describe("color utilities", () => {
   });
 
   describe("paletteFromServer", () => {
+    // the server sends every palette key, using null for the colors it could not derive
+    const serverPalette = (
+      overrides: Partial<MediaItemPalette> = {},
+    ): MediaItemPalette => ({
+      background_dark: null,
+      background_light: null,
+      primary: null,
+      accent: null,
+      on_dark: null,
+      on_light: null,
+      ...overrides,
+    });
+
     it("returns empty palette for null", () => {
       expect(paletteFromServer(null)).toEqual({
         lightColor: "",
@@ -190,27 +203,18 @@ describe("color utilities", () => {
       });
     });
 
-    it("returns empty strings when on_dark and on_light are missing", () => {
-      const palette: MediaItemPalette = {};
-      expect(paletteFromServer(palette)).toEqual({
-        lightColor: "",
-        darkColor: "",
-      });
-    });
-
     it("returns empty strings when on_dark and on_light are null", () => {
-      const palette: MediaItemPalette = { on_dark: null, on_light: null };
-      expect(paletteFromServer(palette)).toEqual({
+      expect(paletteFromServer(serverPalette())).toEqual({
         lightColor: "",
         darkColor: "",
       });
     });
 
     it("maps on_dark to lightColor and on_light to darkColor", () => {
-      const palette: MediaItemPalette = {
+      const palette = serverPalette({
         on_dark: [255, 200, 100],
         on_light: [40, 20, 10],
-      };
+      });
       expect(paletteFromServer(palette)).toEqual({
         lightColor: "#ffc864",
         darkColor: "#28140a",
@@ -218,14 +222,18 @@ describe("color utilities", () => {
     });
 
     it("handles only one of on_dark/on_light being set", () => {
-      expect(paletteFromServer({ on_dark: [255, 255, 255] })).toEqual({
+      expect(
+        paletteFromServer(serverPalette({ on_dark: [255, 255, 255] })),
+      ).toEqual({
         lightColor: "#ffffff",
         darkColor: "",
       });
-      expect(paletteFromServer({ on_light: [0, 0, 0] })).toEqual({
-        lightColor: "",
-        darkColor: "#000000",
-      });
+      expect(paletteFromServer(serverPalette({ on_light: [0, 0, 0] }))).toEqual(
+        {
+          lightColor: "",
+          darkColor: "#000000",
+        },
+      );
     });
   });
 });

--- a/tests/layouts/PlayerBarVolumeControl.test.ts
+++ b/tests/layouts/PlayerBarVolumeControl.test.ts
@@ -96,6 +96,9 @@ function createPlayer(overrides: Partial<Player> = {}): Player {
     device_info: {
       model: "Test",
       manufacturer: "Test",
+      software_version: null,
+      model_id: null,
+      manufacturer_id: null,
       identifiers: {
         [IdentifierType.MAC_ADDRESS]: "",
         [IdentifierType.SERIAL_NUMBER]: "",
@@ -126,6 +129,14 @@ function createPlayer(overrides: Partial<Player> = {}): Player {
     needs_setup: false,
     output_protocols: [],
     active_output_protocol: null,
+    elapsed_time: null,
+    elapsed_time_last_updated: null,
+    current_media: null,
+    active_source: null,
+    active_sound_mode: null,
+    active_group: null,
+    synced_to: null,
+    sleep_timer_expires_at: null,
     ...overrides,
   };
 }

--- a/tests/layouts/PlayerSelect.test.ts
+++ b/tests/layouts/PlayerSelect.test.ts
@@ -156,6 +156,9 @@ function createPlayer(
     device_info: {
       model: "Test",
       manufacturer: "Test",
+      software_version: null,
+      model_id: null,
+      manufacturer_id: null,
       identifiers: {
         [IdentifierType.MAC_ADDRESS]: "",
         [IdentifierType.SERIAL_NUMBER]: "",
@@ -186,6 +189,14 @@ function createPlayer(
     needs_setup: false,
     output_protocols: [],
     active_output_protocol: null,
+    elapsed_time: null,
+    elapsed_time_last_updated: null,
+    current_media: null,
+    active_source: null,
+    active_sound_mode: null,
+    active_group: null,
+    synced_to: null,
+    sleep_timer_expires_at: null,
   };
 }
 

--- a/tests/layouts/PlayerVolume.test.ts
+++ b/tests/layouts/PlayerVolume.test.ts
@@ -59,6 +59,9 @@ function createPlayer(overrides: Partial<Player> = {}): Player {
     device_info: {
       model: "Test",
       manufacturer: "Test",
+      software_version: null,
+      model_id: null,
+      manufacturer_id: null,
       identifiers: {
         [IdentifierType.MAC_ADDRESS]: "",
         [IdentifierType.SERIAL_NUMBER]: "",
@@ -89,6 +92,14 @@ function createPlayer(overrides: Partial<Player> = {}): Player {
     needs_setup: false,
     output_protocols: [],
     active_output_protocol: null,
+    elapsed_time: null,
+    elapsed_time_last_updated: null,
+    current_media: null,
+    active_source: null,
+    active_sound_mode: null,
+    active_group: null,
+    synced_to: null,
+    sleep_timer_expires_at: null,
     ...overrides,
   };
 }


### PR DESCRIPTION
The server always sends every field of a player, using `null` for the ones it has no value for — it never leaves a key out. Our types said the opposite (`powered?: boolean`), so code was written to expect `undefined` and `null` slipped past unnoticed.

This corrects the player types to match what actually arrives, so the compiler now points at the places that need a null check.

- `Player`, `PlayerMedia`, `PlayerOption`, `DeviceInfo`, `OutputProtocol` and `MediaItemPalette`: optional fields are now spelled as nullable
- Widened `getMediaImageUrl`, `computeChapterTicks` and the Discord now-playing signal to accept null
- Updated the player test fixtures to build the same shape the server sends

Verified against the `music_assistant_models` dataclasses field by field. Queue, media item, config and provider types have the same problem and follow in separate PRs.

A few fields here (`playback_state`, `has_setup_flow`, `PlayerOption.translation_key`) are marked optional but are never null either — those need to become plain required fields, which is a separate change and is tracked as a follow-up.
