### PR TITLE
Match queue types to the null values the server sends

### DIFF
--- a/src/components/LyricsViewer.vue
+++ b/src/components/LyricsViewer.vue
@@ -121,9 +121,9 @@ interface DisplayLine {
 }
 
 interface Props {
-  mediaItem?: PlayableMediaItemType;
+  mediaItem?: PlayableMediaItemType | null;
   position?: number;
-  streamDetails?: StreamDetails;
+  streamDetails?: StreamDetails | null;
   textColor?: string;
   lyrics?: string | null;
   lrcLyrics?: string | null;

--- a/src/helpers/activeElapsedTime.ts
+++ b/src/helpers/activeElapsedTime.ts
@@ -155,5 +155,5 @@ function resolvePlayer(player_id?: string): Player | undefined {
 
 function resolveCurrentItem(player?: Player): QueueItem | undefined {
   const queue = resolvePlayerQueue(player);
-  return (queue?.active ? queue.current_item : undefined) ?? undefined;
+  return queue?.active ? (queue.current_item ?? undefined) : undefined;
 }

--- a/src/helpers/activeElapsedTime.ts
+++ b/src/helpers/activeElapsedTime.ts
@@ -155,5 +155,5 @@ function resolvePlayer(player_id?: string): Player | undefined {
 
 function resolveCurrentItem(player?: Player): QueueItem | undefined {
   const queue = resolvePlayerQueue(player);
-  return queue?.active ? queue.current_item : undefined;
+  return (queue?.active ? queue.current_item : undefined) ?? undefined;
 }

--- a/src/helpers/elapsed.ts
+++ b/src/helpers/elapsed.ts
@@ -42,7 +42,7 @@ export function computeElapsedTime(
  * indicator, a negative value would run them backwards, and the OS media
  * session rejects such a rate outright. Anything else reads as normal speed.
  */
-export function queueItemPlaybackSpeed(item?: QueueItem): number {
+export function queueItemPlaybackSpeed(item?: QueueItem | null): number {
   const speed = item?.extra_attributes?.playback_speed;
   return typeof speed === "number" && Number.isFinite(speed) && speed > 0
     ? speed

--- a/src/layouts/default/PlayerOSD/useQueueDragReorder.ts
+++ b/src/layouts/default/PlayerOSD/useQueueDragReorder.ts
@@ -58,7 +58,7 @@ export function useQueueDragReorder(options: QueueDragReorderOptions) {
     const queue = store.activePlayerQueue;
     if (!queue) return 0;
     // a queue that never started or already ended has nothing cued, so every row is free
-    if (queue.ended || queue.current_index === undefined) return 0;
+    if (queue.ended || queue.current_index === null) return 0;
     const current = queue.current_index;
     const buffer = Math.max(queue.index_in_buffer ?? current, current);
     return buffer + 1;

--- a/src/plugins/api/helpers.ts
+++ b/src/plugins/api/helpers.ts
@@ -52,7 +52,7 @@ export const isQueueInfiniteStream = function (
  * flags drive which transport controls are surfaced when active.
  */
 export const isAudioSource = function (
-  item: MediaItemType | ItemMapping | undefined,
+  item: MediaItemType | ItemMapping | null | undefined,
 ): item is AudioSource {
   return item?.media_type === MediaType.AUDIO_SOURCE;
 };

--- a/src/plugins/api/interfaces.ts
+++ b/src/plugins/api/interfaces.ts
@@ -1097,7 +1097,7 @@ export interface AudioProcessingChain {
 export interface StreamMetadata {
   // mandatory fields
   title: string;
-  // optional fields
+  // nullable fields (always present, null when not set)
   artist: string | null;
   album: string | null;
   image_url: string | null;

--- a/src/plugins/api/interfaces.ts
+++ b/src/plugins/api/interfaces.ts
@@ -1098,11 +1098,11 @@ export interface StreamMetadata {
   // mandatory fields
   title: string;
   // optional fields
-  artist?: string;
-  album?: string;
-  image_url?: string;
-  duration?: number;
-  uri?: string;
+  artist: string | null;
+  album: string | null;
+  image_url: string | null;
+  duration: number | null;
+  uri: string | null;
 }
 
 export interface StreamDetails {
@@ -1110,9 +1110,9 @@ export interface StreamDetails {
   item_id: string;
   audio_format: AudioFormat;
   media_type: MediaType;
-  stream_metadata?: StreamMetadata;
-  duration?: number;
-  audio_processing?: AudioProcessingChain | null;
+  stream_metadata: StreamMetadata | null;
+  duration: number | null;
+  audio_processing: AudioProcessingChain | null;
 }
 
 // queue_item
@@ -1124,9 +1124,9 @@ export interface QueueItem {
   // duration: null for items without a fixed length (radio stations, live sources)
   duration: number | null;
   sort_index: number;
-  streamdetails?: StreamDetails;
-  media_item?: PlayableMediaItemType;
-  image?: MediaItemImage;
+  streamdetails: StreamDetails | null;
+  media_item: PlayableMediaItemType | null;
+  image: MediaItemImage | null;
   available: boolean;
   // Party: extra_attributes for guest-added items
   extra_attributes?: {
@@ -1165,10 +1165,10 @@ export interface PlayerQueue {
   // disabled so it can be re-enabled with the same sound), overlay_volume is
   // the overlay loudness relative to the music in percent (100 = equally loud).
   overlay_enabled: boolean;
-  overlay_source?: ItemMapping;
+  overlay_source: ItemMapping | null;
   overlay_volume: number;
-  current_index?: number;
-  index_in_buffer?: number;
+  current_index: number | null;
+  index_in_buffer: number | null;
   // ended: whether the queue played all the way to its end and is waiting to be restarted
   // (server-derived, read-only). The position stays on the last item, so this flag is what
   // tells a finished queue apart from one that is merely stopped on that item. Pressing play
@@ -1189,8 +1189,8 @@ export interface PlayerQueue {
    */
   elapsed_time_last_updated: number;
   state: PlaybackState;
-  current_item?: QueueItem;
-  next_item?: QueueItem;
+  current_item: QueueItem | null;
+  next_item: QueueItem | null;
   // The queue's enqueued parent items (its origin), present regardless of mode.
   // When one or more sources are dynamic, the queue runs in dynamic mode
   // (is_dynamic), implicitly enabling autoplay and smart shuffle.

--- a/src/plugins/store.ts
+++ b/src/plugins/store.ts
@@ -80,7 +80,7 @@ export const store: Store = reactive({
   activePlayerQueue: computed(() => resolvePlayerQueue(store.activePlayer)),
   curQueueItem: computed(() => {
     if (store.activePlayerQueue && store.activePlayerQueue.active)
-      return store.activePlayerQueue.current_item;
+      return store.activePlayerQueue.current_item ?? undefined;
     return undefined;
   }),
   globalSearchTerm: undefined,

--- a/tests/components/AudioProcessingDetails.test.ts
+++ b/tests/components/AudioProcessingDetails.test.ts
@@ -938,6 +938,9 @@ function makeStreamDetails(audioFormat = makeFormat()): StreamDetails {
     item_id: "track-1",
     audio_format: audioFormat,
     media_type: MediaType.TRACK,
+    stream_metadata: null,
+    duration: null,
+    audio_processing: null,
   };
 }
 

--- a/tests/components/QualityDetailsBtn.test.ts
+++ b/tests/components/QualityDetailsBtn.test.ts
@@ -157,6 +157,9 @@ function makeStreamDetails(): StreamDetails {
       bit_rate: 0,
     },
     media_type: MediaType.TRACK,
+    stream_metadata: null,
+    duration: null,
+    audio_processing: null,
   };
 }
 
@@ -174,7 +177,10 @@ function makeQueue(streamdetails: StreamDetails): PlayerQueue {
     crossfade_enabled: false,
     smart_fades_active: false,
     overlay_enabled: false,
+    overlay_source: null,
     overlay_volume: 100,
+    current_index: null,
+    index_in_buffer: null,
     ended: false,
     elapsed_time: 0,
     elapsed_time_last_updated: 0,
@@ -186,8 +192,11 @@ function makeQueue(streamdetails: StreamDetails): PlayerQueue {
       duration: 180,
       sort_index: 0,
       streamdetails,
+      media_item: null,
+      image: null,
       available: true,
     },
+    next_item: null,
     sources: [],
     is_dynamic: false,
   };

--- a/tests/composables/useAudioProcessingDetails.test.ts
+++ b/tests/composables/useAudioProcessingDetails.test.ts
@@ -532,6 +532,9 @@ describe("buildAudioProcessingDetailsDisplay", () => {
       item_id: "track-1",
       audio_format: makeFormat(),
       media_type: MediaType.TRACK,
+      stream_metadata: null,
+      duration: null,
+      audio_processing: null,
     });
     const harness = defineComponent({
       setup() {
@@ -569,6 +572,9 @@ function buildDisplay(chain: AudioProcessingChain, audioFormat = makeFormat()) {
     item_id: "track-1",
     audio_format: audioFormat,
     media_type: MediaType.TRACK,
+    stream_metadata: null,
+    duration: null,
+    audio_processing: null,
   };
   return buildAudioProcessingDetailsDisplay(chain, streamDetails, dependencies);
 }

--- a/tests/composables/useGuestQueue.test.ts
+++ b/tests/composables/useGuestQueue.test.ts
@@ -235,6 +235,9 @@ function queueItemFixture(queueItemId: string): QueueItem {
     name: queueItemId,
     duration: 200,
     sort_index: 0,
+    streamdetails: null,
+    media_item: null,
+    image: null,
     available: true,
   };
 }


### PR DESCRIPTION
Same problem as #2334, now for the queue types. The server always sends every field of a queue, queue item and stream details, using `null` for the ones it has no value for — it never leaves a key out. Our types said the opposite (`current_item?: QueueItem`), so code was written to expect `undefined`.

This also fixes a bug that mistake was hiding: the queue drag-and-drop guard compared `current_index` against `undefined`, which never matched, so a queue that had not started playing yet treated its first row as locked and refused a drop there.

- `PlayerQueue`, `QueueItem`, `StreamDetails` and `StreamMetadata`: optional fields are now spelled as nullable
- Fixed the drag-reorder check to compare against `null`
- Widened the helpers and the lyrics view to accept null
- Updated the queue test fixtures to build the same shape the server sends

Verified against the `music_assistant_models` dataclasses field by field. The audio processing types in the same area need a wider change and follow separately.
