### PR TITLE
Make test fixtures match the real API models

### DIFF
--- a/src/helpers/openActionUrlEntries.test.ts
+++ b/src/helpers/openActionUrlEntries.test.ts
@@ -1,22 +1,32 @@
 import { describe, it, expect, vi, afterEach } from "vitest";
 import { openActionResultUrl, openActionUrlEntries } from "./utils";
-import { type ConfigEntry, ConfigEntryType } from "@/plugins/api/interfaces";
+import {
+  type ConfigEntry,
+  ConfigEntryType,
+  type ConfigValueType,
+} from "@/plugins/api/interfaces";
 
-const urlEntry = (value: unknown, key = "wizard"): ConfigEntry =>
-  ({
-    key,
-    type: ConfigEntryType.URL,
-    label: key,
-    value,
-  }) as ConfigEntry;
+const urlEntry = (value: ConfigValueType, key = "wizard"): ConfigEntry => ({
+  key,
+  type: ConfigEntryType.URL,
+  label: key,
+  category: "generic",
+  default_value: null,
+  options: [],
+  required: false,
+  value,
+});
 
-const stringEntry = (key = "server_url"): ConfigEntry =>
-  ({
-    key,
-    type: ConfigEntryType.STRING,
-    label: key,
-    value: "abc",
-  }) as ConfigEntry;
+const stringEntry = (key = "server_url"): ConfigEntry => ({
+  key,
+  type: ConfigEntryType.STRING,
+  label: key,
+  category: "generic",
+  default_value: null,
+  options: [],
+  required: false,
+  value: "abc",
+});
 
 describe("openActionUrlEntries", () => {
   afterEach(() => {
@@ -55,12 +65,10 @@ describe("openActionUrlEntries", () => {
     const click = vi
       .spyOn(HTMLAnchorElement.prototype, "click")
       .mockImplementation(() => undefined);
-    const entry = {
-      key: "wizard",
-      type: ConfigEntryType.URL,
-      label: "wizard",
+    const entry: ConfigEntry = {
+      ...urlEntry(null),
       default_value: "https://example.com/from-default",
-    } as ConfigEntry;
+    };
     const result = openActionUrlEntries([entry, stringEntry()]);
     expect(click).toHaveBeenCalledTimes(1);
     expect(result.map((e) => e.key)).toEqual(["server_url"]);

--- a/tests/components/SetupFlowDialog.test.ts
+++ b/tests/components/SetupFlowDialog.test.ts
@@ -342,7 +342,7 @@ function entry(
     options: [],
     value: null,
     ...overrides,
-  } as ConfigEntry;
+  };
 }
 
 function progressStep(progressText: string): SetupFlowStep {

--- a/tests/composables/smart_playlist/useSmartPlaylistSeedItems.test.ts
+++ b/tests/composables/smart_playlist/useSmartPlaylistSeedItems.test.ts
@@ -45,6 +45,7 @@ vi.mock("@/plugins/api", () => ({
 import api from "@/plugins/api";
 import { useSmartPlaylistSeedItems } from "@/composables/smart-playlist/useSmartPlaylistSeedItems";
 import type { Album, Track } from "@/plugins/api/interfaces";
+import { providerMapping } from "../../fixtures/providerMapping";
 
 interface SearchFnArg {
   searchFn: (q: string) => Promise<unknown[]>;
@@ -72,16 +73,16 @@ describe("useSmartPlaylistSeedItems", () => {
       {
         item_id: "fallback-track-id",
         provider_mappings: [
-          {
+          providerMapping({
             item_id: "lib-1",
             provider_instance: "library",
             provider_domain: "library",
-          },
-          {
+          }),
+          providerMapping({
             item_id: "sp-track-1",
             provider_instance: "spotify_instance",
             provider_domain: "spotify",
-          },
+          }),
         ],
         artists: [{ name: "Artist" }],
         name: "Song",
@@ -109,11 +110,11 @@ describe("useSmartPlaylistSeedItems", () => {
       {
         item_id: "62",
         provider_mappings: [
-          {
+          providerMapping({
             item_id: "tidal-album",
             provider_instance: "tidal_instance",
             provider_domain: "tidal",
-          },
+          }),
         ],
         artists: [{ name: "RAM" }],
         name: "One Last Call",
@@ -198,11 +199,14 @@ describe("useSmartPlaylistSeedItems", () => {
             item_id: "lib-1",
             name: "Library Track",
             provider_mappings: [
-              { provider_instance: "library", provider_domain: "library" },
-              {
+              providerMapping({
+                provider_instance: "library",
+                provider_domain: "library",
+              }),
+              providerMapping({
                 provider_instance: "filesystem_local",
                 provider_domain: "filesystem_local",
-              },
+              }),
             ],
           },
         ],

--- a/tests/composables/useConfigAction.test.ts
+++ b/tests/composables/useConfigAction.test.ts
@@ -204,9 +204,10 @@ function entry(overrides: Partial<ConfigEntry> = {}): ConfigEntry {
     default_value: null,
     key: "existing",
     label: "Existing",
+    options: [],
     required: false,
     type: ConfigEntryType.STRING,
     value: "current",
     ...overrides,
-  } as ConfigEntry;
+  };
 }

--- a/tests/composables/useGuestArtistTracks.test.ts
+++ b/tests/composables/useGuestArtistTracks.test.ts
@@ -68,12 +68,8 @@ describe("useGuestArtistTracks", () => {
       useGuestArtistTracks();
 
     const artist = {
-      provider_mappings: [
-        providerMapping({
-          item_id: "artist-id",
-          provider_instance: "provider-1",
-        }),
-      ],
+      item_id: "artist-id",
+      provider: "library",
     } as unknown as Artist;
 
     await selectArtist(artist);
@@ -93,12 +89,8 @@ describe("useGuestArtistTracks", () => {
       useGuestArtistTracks();
 
     await selectArtist({
-      provider_mappings: [
-        providerMapping({
-          item_id: "artist-id",
-          provider_instance: "provider-1",
-        }),
-      ],
+      item_id: "artist-id",
+      provider: "library",
     } as unknown as Artist);
     clearArtistSelection();
 
@@ -123,12 +115,8 @@ describe("useGuestArtistTracks", () => {
     } = useGuestArtistTracks();
 
     const pending = selectArtist({
-      provider_mappings: [
-        providerMapping({
-          item_id: "artist-id",
-          provider_instance: "provider-1",
-        }),
-      ],
+      item_id: "artist-id",
+      provider: "library",
     } as unknown as Artist);
     clearArtistSelection();
     expect(loadingArtistTracks.value).toBe(false);
@@ -156,15 +144,13 @@ describe("useGuestArtistTracks", () => {
 
     const first = selectArtist({
       name: "First",
-      provider_mappings: [
-        providerMapping({ item_id: "a1", provider_instance: "provider-1" }),
-      ],
+      item_id: "a1",
+      provider: "library",
     } as unknown as Artist);
     const second = selectArtist({
       name: "Second",
-      provider_mappings: [
-        providerMapping({ item_id: "a2", provider_instance: "provider-1" }),
-      ],
+      item_id: "a2",
+      provider: "library",
     } as unknown as Artist);
     await second;
     resolveFirst([{ id: "first-track" }]);

--- a/tests/composables/useGuestArtistTracks.test.ts
+++ b/tests/composables/useGuestArtistTracks.test.ts
@@ -1,4 +1,5 @@
 import type { Artist } from "@/plugins/api/interfaces";
+import { providerMapping } from "../fixtures/providerMapping";
 import { $t } from "@/plugins/i18n";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -43,7 +44,10 @@ describe("useGuestArtistTracks", () => {
       item_id: "artist-id",
       provider: "library",
       provider_mappings: [
-        { item_id: "mapping-id", provider_instance: "provider-1" },
+        providerMapping({
+          item_id: "mapping-id",
+          provider_instance: "provider-1",
+        }),
       ],
     } as unknown as Artist;
 
@@ -65,7 +69,10 @@ describe("useGuestArtistTracks", () => {
 
     const artist = {
       provider_mappings: [
-        { item_id: "artist-id", provider_instance: "provider-1" },
+        providerMapping({
+          item_id: "artist-id",
+          provider_instance: "provider-1",
+        }),
       ],
     } as unknown as Artist;
 
@@ -87,7 +94,10 @@ describe("useGuestArtistTracks", () => {
 
     await selectArtist({
       provider_mappings: [
-        { item_id: "artist-id", provider_instance: "provider-1" },
+        providerMapping({
+          item_id: "artist-id",
+          provider_instance: "provider-1",
+        }),
       ],
     } as unknown as Artist);
     clearArtistSelection();
@@ -114,7 +124,10 @@ describe("useGuestArtistTracks", () => {
 
     const pending = selectArtist({
       provider_mappings: [
-        { item_id: "artist-id", provider_instance: "provider-1" },
+        providerMapping({
+          item_id: "artist-id",
+          provider_instance: "provider-1",
+        }),
       ],
     } as unknown as Artist);
     clearArtistSelection();
@@ -143,11 +156,15 @@ describe("useGuestArtistTracks", () => {
 
     const first = selectArtist({
       name: "First",
-      provider_mappings: [{ item_id: "a1", provider_instance: "provider-1" }],
+      provider_mappings: [
+        providerMapping({ item_id: "a1", provider_instance: "provider-1" }),
+      ],
     } as unknown as Artist);
     const second = selectArtist({
       name: "Second",
-      provider_mappings: [{ item_id: "a2", provider_instance: "provider-1" }],
+      provider_mappings: [
+        providerMapping({ item_id: "a2", provider_instance: "provider-1" }),
+      ],
     } as unknown as Artist);
     await second;
     resolveFirst([{ id: "first-track" }]);

--- a/tests/composables/useShortcuts.test.ts
+++ b/tests/composables/useShortcuts.test.ts
@@ -33,6 +33,7 @@ import {
   type ShortcutItem,
   unpinShortcutStandaloneItem,
 } from "@/composables/useShortcuts";
+import { providerMapping } from "../fixtures/providerMapping";
 
 const PODCAST_FEED = "https://ronzheimer.podigee.io/feed/mp3";
 const ENCODED_PODCAST_URI = `itunes_podcasts://podcast/${encodeURIComponent(PODCAST_FEED)}`;
@@ -66,12 +67,12 @@ describe("useShortcuts standalone helpers", () => {
       media_type: MediaType.PODCAST,
       item_id: "42",
       provider_mappings: [
-        {
+        providerMapping({
           item_id: PODCAST_FEED,
           provider_instance: "itunes_podcasts--abc123",
           provider_domain: "itunes_podcasts",
           available: true,
-        },
+        }),
       ],
     };
 
@@ -91,12 +92,12 @@ describe("useShortcuts standalone helpers", () => {
       media_type: MediaType.PODCAST,
       item_id: "42",
       provider_mappings: [
-        {
+        providerMapping({
           item_id: PODCAST_FEED,
           provider_instance: "itunes_podcasts--abc123",
           provider_domain: "itunes_podcasts",
           available: true,
-        },
+        }),
       ],
     };
 

--- a/tests/fixtures/providerMapping.ts
+++ b/tests/fixtures/providerMapping.ts
@@ -1,10 +1,12 @@
 import { ContentType, type ProviderMapping } from "@/plugins/api/interfaces";
 
+/**
+ * A complete provider mapping, for fixtures that only care about a few of its
+ * fields but should still model a payload the server can send.
+ */
 export function providerMapping(
   overrides: Partial<ProviderMapping> = {},
 ): ProviderMapping {
-  // Provider mapping with every field the server always sends, so tests that
-  // only care about a few of them still model a payload that can exist.
   return {
     item_id: "item-1",
     provider_domain: "test_provider",

--- a/tests/fixtures/providerMapping.ts
+++ b/tests/fixtures/providerMapping.ts
@@ -1,0 +1,24 @@
+import { ContentType, type ProviderMapping } from "@/plugins/api/interfaces";
+
+export function providerMapping(
+  overrides: Partial<ProviderMapping> = {},
+): ProviderMapping {
+  // Provider mapping with every field the server always sends, so tests that
+  // only care about a few of them still model a payload that can exist.
+  return {
+    item_id: "item-1",
+    provider_domain: "test_provider",
+    provider_instance: "test_provider--1",
+    available: true,
+    audio_format: {
+      content_type: ContentType.FLAC,
+      codec_type: ContentType.FLAC,
+      sample_rate: 44100,
+      bit_depth: 16,
+      channels: 2,
+      output_format_str: "flac",
+      bit_rate: 0,
+    },
+    ...overrides,
+  };
+}

--- a/tests/views/ConfigEntryField.test.ts
+++ b/tests/views/ConfigEntryField.test.ts
@@ -5,6 +5,7 @@ import * as components from "vuetify/components";
 import * as directives from "vuetify/directives";
 import {
   ConfigEntryType,
+  type ConfigEntry,
   type ConfigValueType,
 } from "@/plugins/api/interfaces";
 import {
@@ -210,15 +211,17 @@ function entry(
     type: ConfigEntryUIType;
   },
 ): ConfigEntryUI {
-  return {
+  // typed without key/type so the defaults stay checked against the server
+  // model, while the cast only covers the UI-only entry types
+  const base: Omit<ConfigEntry, "key" | "type"> = {
     category: "generic",
     default_value: null,
     label: overrides.key,
     required: false,
     options: [],
     value: null as ConfigValueType,
-    ...overrides,
-  } as ConfigEntryUI;
+  };
+  return { ...base, ...overrides } as ConfigEntryUI;
 }
 
 function rangedEntry(type: ConfigEntryType): ConfigEntryUI {

--- a/tests/views/ConfigEntryField.test.ts
+++ b/tests/views/ConfigEntryField.test.ts
@@ -3,11 +3,7 @@ import { describe, expect, it, vi } from "vitest";
 import { createVuetify } from "vuetify";
 import * as components from "vuetify/components";
 import * as directives from "vuetify/directives";
-import {
-  ConfigEntryType,
-  type ConfigEntry,
-  type ConfigValueType,
-} from "@/plugins/api/interfaces";
+import { ConfigEntryType, type ConfigEntry } from "@/plugins/api/interfaces";
 import {
   NON_INTERACTIVE_ENTRY_TYPES,
   UI_ENTRY_TYPE,
@@ -219,7 +215,7 @@ function entry(
     label: overrides.key,
     required: false,
     options: [],
-    value: null as ConfigValueType,
+    value: null,
   };
   return { ...base, ...overrides } as ConfigEntryUI;
 }

--- a/tests/views/EditConfig.test.ts
+++ b/tests/views/EditConfig.test.ts
@@ -263,7 +263,7 @@ function entry(
     options: [],
     value: null as ConfigValueType,
     ...overrides,
-  } as ConfigEntry;
+  };
 }
 
 function dependentEntry(

--- a/tests/views/EditConfig.test.ts
+++ b/tests/views/EditConfig.test.ts
@@ -1,11 +1,7 @@
 import { shallowMount, type VueWrapper } from "@vue/test-utils";
 import { describe, expect, it, vi } from "vitest";
 import { nextTick } from "vue";
-import {
-  ConfigEntryType,
-  type ConfigEntry,
-  type ConfigValueType,
-} from "@/plugins/api/interfaces";
+import { ConfigEntryType, type ConfigEntry } from "@/plugins/api/interfaces";
 import EditConfig from "@/views/settings/EditConfig.vue";
 
 const { apiMock, routerMock } = vi.hoisted(() => ({
@@ -261,7 +257,7 @@ function entry(
     label: overrides.key,
     required: false,
     options: [],
-    value: null as ConfigValueType,
+    value: null,
     ...overrides,
   };
 }

--- a/tests/views/EditCoreConfig.test.ts
+++ b/tests/views/EditCoreConfig.test.ts
@@ -4,6 +4,8 @@ import {
   ConfigEntryType,
   ProviderStage,
   ProviderType,
+  type ConfigActionResult,
+  type ConfigEntry,
   type CoreConfig,
 } from "@/plugins/api/interfaces";
 import EditCoreConfig from "@/views/settings/EditCoreConfig.vue";
@@ -11,7 +13,13 @@ import EditCoreConfig from "@/views/settings/EditCoreConfig.vue";
 const { apiMock, routerMock, toastMock } = vi.hoisted(() => ({
   apiMock: {
     getCoreConfig: vi.fn(),
-    invokeCoreConfigAction: vi.fn(),
+    invokeCoreConfigAction:
+      vi.fn<
+        (
+          domain: string,
+          action: string,
+        ) => Promise<ConfigEntry[] | ConfigActionResult>
+      >(),
     providerManifests: {
       cache: {
         codeowners: [],
@@ -120,6 +128,7 @@ describe("EditCoreConfig", () => {
         default_value: null,
         key: "new_field",
         label: "New field",
+        options: [],
         required: false,
         type: ConfigEntryType.STRING,
         value: "server value",

--- a/tests/views/EditCoreConfig.test.ts
+++ b/tests/views/EditCoreConfig.test.ts
@@ -4,22 +4,16 @@ import {
   ConfigEntryType,
   ProviderStage,
   ProviderType,
-  type ConfigActionResult,
-  type ConfigEntry,
   type CoreConfig,
 } from "@/plugins/api/interfaces";
+import type { MusicAssistantApi } from "@/plugins/api";
 import EditCoreConfig from "@/views/settings/EditCoreConfig.vue";
 
 const { apiMock, routerMock, toastMock } = vi.hoisted(() => ({
   apiMock: {
     getCoreConfig: vi.fn(),
     invokeCoreConfigAction:
-      vi.fn<
-        (
-          domain: string,
-          action: string,
-        ) => Promise<ConfigEntry[] | ConfigActionResult>
-      >(),
+      vi.fn<MusicAssistantApi["invokeCoreConfigAction"]>(),
     providerManifests: {
       cache: {
         codeowners: [],

--- a/tests/views/EditPlayer.test.ts
+++ b/tests/views/EditPlayer.test.ts
@@ -123,7 +123,7 @@ function controlEntry(key: string): ConfigEntry {
     default_value: "none",
     value: "none",
     options: [{ title: "none", value: "none" }],
-  } as ConfigEntry;
+  };
 }
 
 function playerConfig() {

--- a/tests/views/EditPlayer.test.ts
+++ b/tests/views/EditPlayer.test.ts
@@ -6,6 +6,7 @@ import {
   ConfigEntryType,
   PlayerType,
   type ConfigEntry,
+  type PlayerConfig,
 } from "@/plugins/api/interfaces";
 import EditPlayer from "@/views/settings/EditPlayer.vue";
 import { flushPromises, shallowMount } from "@vue/test-utils";
@@ -126,7 +127,7 @@ function controlEntry(key: string): ConfigEntry {
   };
 }
 
-function playerConfig() {
+function playerConfig(): PlayerConfig {
   return {
     player_id: "player-1",
     provider: "chromecast--1",
@@ -137,6 +138,7 @@ function playerConfig() {
         type: ConfigEntryType.BOOLEAN,
         label: "volume_normalization",
         category: "audio",
+        options: [],
         required: false,
         default_value: true,
         value: true,

--- a/tests/views/EditProvider.test.ts
+++ b/tests/views/EditProvider.test.ts
@@ -6,6 +6,8 @@ import {
   ProviderStage,
   ProviderStatus,
   ProviderType,
+  type ConfigActionResult,
+  type ConfigEntry,
   type ProviderConfig,
 } from "@/plugins/api/interfaces";
 import EditProvider from "@/views/settings/EditProvider.vue";
@@ -15,7 +17,13 @@ const { apiMock, eventbusMock, routerMock, toastMock, unsubscribeMock } =
     apiMock: {
       getProvider: vi.fn(),
       getProviderConfig: vi.fn(),
-      invokeProviderConfigAction: vi.fn(),
+      invokeProviderConfigAction:
+        vi.fn<
+          (
+            instanceId: string,
+            action: string,
+          ) => Promise<ConfigEntry[] | ConfigActionResult>
+        >(),
       providerManifests: {
         spotify: {
           codeowners: [],
@@ -195,6 +203,7 @@ describe("EditProvider", () => {
         default_value: null,
         key: "account",
         label: "Account",
+        options: [],
         required: false,
         type: ConfigEntryType.STRING,
       },
@@ -330,6 +339,7 @@ describe("EditProvider", () => {
         default_value: null,
         key: "new_field",
         label: "New field",
+        options: [],
         required: false,
         type: ConfigEntryType.STRING,
         value: "server value",

--- a/tests/views/HassControlFields.test.ts
+++ b/tests/views/HassControlFields.test.ts
@@ -176,7 +176,7 @@ function controlsEntry(
     default_value: [],
     value,
     options: options ?? [],
-  } as ConfigEntryUI;
+  };
 }
 
 function mountPickerField() {


### PR DESCRIPTION
Several test fixtures faked their config and media objects with a type cast, which silences TypeScript's check for missing fields. That let tests model server data that can never actually arrive - and it only showed up as a runtime crash later, as happened in #2335 when `options` became a required field.

Changes:
- Dropped the unnecessary casts so the compiler now checks these fixtures in full
- Filled in the fields that were missing (`options`, provider mapping details)
- Typed the config action mocks in the provider/core settings tests, so their responses are checked too
- Gave the guest artist fixtures the fields the code under test actually reads
- Added one shared provider mapping fixture for the tests that need a partial media item

No behaviour change - tests only.
