### PR TITLE
Remove unused folder handling from list view descriptions

### DIFF
--- a/src/components/ListviewItem.vue
+++ b/src/components/ListviewItem.vue
@@ -204,9 +204,7 @@
         v-else-if="
           'metadata' in item &&
           item.metadata?.description &&
-          [MediaType.RADIO, MediaType.PLAYLIST, MediaType.FOLDER].includes(
-            item.media_type,
-          )
+          [MediaType.RADIO, MediaType.PLAYLIST].includes(item.media_type)
         "
       >
         {{ truncateString(item.metadata.description, 150) }}


### PR DESCRIPTION
Browse folders never carry a description, so the list view had a leftover check for them that could never do anything.

- Drop `FOLDER` from the description subtitle check in `ListviewItem.vue`, leaving radio and playlist

A browse folder is sent by the server without a `metadata` object at all (and typed that way since #2333), so the surrounding `'metadata' in item` guard is always false for folders.

**Label:** maintenance