### PR TITLE
Check the fake server data in our tests against the real models

### DIFF
--- a/tests/App.test.ts
+++ b/tests/App.test.ts
@@ -1,4 +1,13 @@
-import { EventType, ProviderType } from "@/plugins/api/interfaces";
+import {
+  EventType,
+  ProviderStage,
+  ProviderStatus,
+  ProviderType,
+  UserRole,
+  type ProviderConfig,
+  type User,
+} from "@/plugins/api/interfaces";
+import type { MusicAssistantApi } from "@/plugins/api";
 import { flushPromises, shallowMount, type VueWrapper } from "@vue/test-utils";
 import { nextTick } from "vue";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -23,23 +32,27 @@ const {
 } = vi.hoisted(() => {
   const guestType = { value: null as "party" | "music_quiz" | null };
   const apiMock = {
-    authenticateWithToken: vi.fn(),
+    authenticateWithToken: vi.fn<MusicAssistantApi["authenticateWithToken"]>(),
     baseUrl: "http://music-assistant.test",
-    fetchState: vi.fn(),
-    fetchProviders: vi.fn(),
-    getCurrentUserInfo: vi.fn(),
-    getLibraryAlbumsCount: vi.fn(),
-    getLibraryArtistsCount: vi.fn(),
-    getLibraryAudiobooksCount: vi.fn(),
-    getLibraryGenresCount: vi.fn(),
-    getLibraryPlaylistsCount: vi.fn(),
-    getLibraryPodcastsCount: vi.fn(),
-    getLibraryRadiosCount: vi.fn(),
-    getLibraryTracksCount: vi.fn(),
-    getProviderConfigs: vi.fn(),
-    initialize: vi.fn(),
+    fetchState: vi.fn<MusicAssistantApi["fetchState"]>(),
+    fetchProviders: vi.fn<MusicAssistantApi["fetchProviders"]>(),
+    getCurrentUserInfo: vi.fn<MusicAssistantApi["getCurrentUserInfo"]>(),
+    getLibraryAlbumsCount: vi.fn<MusicAssistantApi["getLibraryAlbumsCount"]>(),
+    getLibraryArtistsCount:
+      vi.fn<MusicAssistantApi["getLibraryArtistsCount"]>(),
+    getLibraryAudiobooksCount:
+      vi.fn<MusicAssistantApi["getLibraryAudiobooksCount"]>(),
+    getLibraryGenresCount: vi.fn<MusicAssistantApi["getLibraryGenresCount"]>(),
+    getLibraryPlaylistsCount:
+      vi.fn<MusicAssistantApi["getLibraryPlaylistsCount"]>(),
+    getLibraryPodcastsCount:
+      vi.fn<MusicAssistantApi["getLibraryPodcastsCount"]>(),
+    getLibraryRadiosCount: vi.fn<MusicAssistantApi["getLibraryRadiosCount"]>(),
+    getLibraryTracksCount: vi.fn<MusicAssistantApi["getLibraryTracksCount"]>(),
+    getProviderConfigs: vi.fn<MusicAssistantApi["getProviderConfigs"]>(),
+    initialize: vi.fn<MusicAssistantApi["initialize"]>(),
     isRemoteConnection: { value: false },
-    requireAuthentication: vi.fn(),
+    requireAuthentication: vi.fn<MusicAssistantApi["requireAuthentication"]>(),
     serverInfo: {
       value: {
         onboard_done: true,
@@ -47,7 +60,7 @@ const {
         status: "running",
       },
     },
-    setLocale: vi.fn(),
+    setLocale: vi.fn<MusicAssistantApi["setLocale"]>(),
     state: { value: "authenticated" },
     subscribe: vi.fn((_event: string, _callback: CallableFunction) => () => {}),
     supportsServerSideTranslations: false,
@@ -271,16 +284,17 @@ describe("App initialization", () => {
       server_id: "server-id",
       status: "running",
     };
-    apiMock.getCurrentUserInfo.mockResolvedValue({
-      preferences: {},
-      role: "user",
-      user_id: "user-id",
-      username: "regular-user",
-    });
+    apiMock.getCurrentUserInfo.mockResolvedValue(
+      userFixture({
+        role: UserRole.USER,
+        user_id: "user-id",
+        username: "regular-user",
+      }),
+    );
     apiMock.fetchState.mockResolvedValue(undefined);
     apiMock.fetchProviders.mockResolvedValue(undefined);
     apiMock.initialize.mockResolvedValue(undefined);
-    apiMock.getProviderConfigs.mockResolvedValue([{ enabled: true }]);
+    apiMock.getProviderConfigs.mockResolvedValue([providerConfigFixture()]);
     for (const method of [
       apiMock.getLibraryAlbumsCount,
       apiMock.getLibraryArtistsCount,
@@ -343,12 +357,13 @@ describe("App initialization", () => {
     "avoids regular-user commands for a %s guest while initializing audio",
     async (type) => {
       guestType.value = type;
-      apiMock.getCurrentUserInfo.mockResolvedValue({
-        preferences: {},
-        role: "guest",
-        user_id: "guest-id",
-        username: type === "party" ? "party_guest" : "music_quiz_guest",
-      });
+      apiMock.getCurrentUserInfo.mockResolvedValue(
+        userFixture({
+          role: UserRole.GUEST,
+          user_id: "guest-id",
+          username: type === "party" ? "party_guest" : "music_quiz_guest",
+        }),
+      );
 
       wrapper = await mountApp();
 
@@ -406,7 +421,7 @@ describe("App initialization", () => {
 
   it("waits for the startup data before revealing the main app", async () => {
     const serverState = createDeferred<void>();
-    const pluginConfigs = createDeferred<Array<{ enabled: boolean }>>();
+    const pluginConfigs = createDeferred<ProviderConfig[]>();
     apiMock.fetchState.mockReturnValue(serverState.promise);
     apiMock.getProviderConfigs.mockReturnValue(pluginConfigs.promise);
     wrapper = await mountAppWithoutSettling();
@@ -427,7 +442,7 @@ describe("App initialization", () => {
     expect(mockInitializeWebPlayerModeSync).not.toHaveBeenCalled();
     expect(wrapper.find("router-view-stub").exists()).toBe(false);
 
-    pluginConfigs.resolve([{ enabled: true }]);
+    pluginConfigs.resolve([providerConfigFixture()]);
     await flushPromises();
     expect(apiMock.state.value).toBe("initialized");
     expect(wrapper.find("router-view-stub").exists()).toBe(true);
@@ -438,12 +453,13 @@ describe("App initialization", () => {
     "does not mount browser media controls for a %s guest fallback tab",
     async (type) => {
       guestType.value = type;
-      apiMock.getCurrentUserInfo.mockResolvedValue({
-        preferences: {},
-        role: "guest",
-        user_id: "guest-id",
-        username: type === "party" ? "party_guest" : "music_quiz_guest",
-      });
+      apiMock.getCurrentUserInfo.mockResolvedValue(
+        userFixture({
+          role: UserRole.GUEST,
+          user_id: "guest-id",
+          username: type === "party" ? "party_guest" : "music_quiz_guest",
+        }),
+      );
       webPlayerMock.audioSource = "controls_only";
       webPlayerMock.interacted = true;
       webPlayerMock.tabMode = "controls_only";
@@ -633,12 +649,11 @@ describe("App initialization", () => {
   it("re-authenticates an ingress session through the proxy on reconnect", async () => {
     storeMock.isIngressSession = true;
     wrapper = await mountApp();
-    const ingressUser = {
-      preferences: {},
-      role: "admin",
+    const ingressUser = userFixture({
+      role: UserRole.ADMIN,
       user_id: "ingress-user",
       username: "ingress-user",
-    };
+    });
     apiMock.getCurrentUserInfo.mockResolvedValue(ingressUser);
 
     await startReconnect();
@@ -875,5 +890,47 @@ function createStorage(): Storage {
     setItem(key, value) {
       values.set(key, value);
     },
+  };
+}
+
+function userFixture(
+  overrides: Partial<User> & Pick<User, "role" | "user_id" | "username">,
+): User {
+  return {
+    created_at: "2024-01-01T00:00:00Z",
+    enabled: true,
+    player_filter: [],
+    preferences: {},
+    provider_filter: [],
+    ...overrides,
+  };
+}
+
+function providerConfigFixture(
+  overrides: Partial<ProviderConfig> = {},
+): ProviderConfig {
+  return {
+    domain: "party",
+    enabled: true,
+    instance_id: "party--test",
+    manifest: {
+      allow_disable: true,
+      builtin: false,
+      codeowners: [],
+      credits: [],
+      description: "",
+      domain: "party",
+      icon_images: [],
+      multi_instance: true,
+      name: "Party",
+      requirements: [],
+      stage: ProviderStage.STABLE,
+      type: ProviderType.PLUGIN,
+    },
+    name: "Party",
+    status: ProviderStatus.LOADED,
+    type: ProviderType.PLUGIN,
+    values: {},
+    ...overrides,
   };
 }

--- a/tests/components/AudioProcessingDetails.test.ts
+++ b/tests/components/AudioProcessingDetails.test.ts
@@ -3,6 +3,7 @@ import { nextTick, type Ref } from "vue";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import AudioProcessingDetails from "@/components/AudioProcessingDetails.vue";
 import type { AudioProcessingDisplayPlayer } from "@/composables/useAudioProcessingDetails";
+import type { MusicAssistantApi } from "@/plugins/api";
 import { i18n } from "@/plugins/i18n";
 import {
   AudioChannel,
@@ -15,18 +16,35 @@ import {
   DSPFilterType,
   DSPState,
   MediaType,
+  ProviderStage,
+  ProviderType,
   type StreamDetails,
   VolumeNormalizationMode,
 } from "@/plugins/api/interfaces";
 
 const apiMock = vi.hoisted(() => ({
-  getProviderName: vi.fn(() => "Test provider"),
-  getProviderManifest: vi.fn((providerId: string) => ({
-    domain: providerId.split("--", 1)[0],
-  })),
+  getProviderName: vi.fn<MusicAssistantApi["getProviderName"]>(
+    () => "Test provider",
+  ),
+  getProviderManifest: vi.fn<MusicAssistantApi["getProviderManifest"]>(
+    (providerId: string) => ({
+      allow_disable: true,
+      builtin: false,
+      codeowners: [],
+      credits: [],
+      description: "",
+      domain: providerId.split("--", 1)[0],
+      icon_images: [],
+      multi_instance: true,
+      name: providerId,
+      requirements: [],
+      stage: ProviderStage.STABLE,
+      type: ProviderType.MUSIC,
+    }),
+  ),
   // useDSPIRs (via useAudioProcessingDetails) fetches the IR list and
   // subscribes to config updates on mount; subscribe hands back an unsubscribe.
-  getDSPIRs: vi.fn(() => Promise.resolve([])),
+  getDSPIRs: vi.fn<MusicAssistantApi["getDSPIRs"]>(() => Promise.resolve([])),
   subscribe: vi.fn(() => vi.fn()),
   players: {} as Record<string, AudioProcessingDisplayPlayer>,
 }));

--- a/tests/components/MediaSearch.test.ts
+++ b/tests/components/MediaSearch.test.ts
@@ -272,6 +272,13 @@ describe("MediaSearch", () => {
   });
 });
 
+// keep the fixture's provider in step with its uri, so the dedupe cases really
+// do carry results from two different providers
+function providerOf(uri: string): string {
+  const [scheme] = uri.split("://");
+  return scheme === uri ? "library" : scheme;
+}
+
 function artistRef(name: string): ItemMapping {
   return {
     available: true,
@@ -299,7 +306,7 @@ function trackFixture(overrides: {
     media_type: MediaType.TRACK,
     metadata: {},
     name: overrides.name,
-    provider: "library",
+    provider: providerOf(overrides.uri),
     provider_mappings: [],
     uri: overrides.uri,
   };
@@ -316,7 +323,7 @@ function playlistFixture(overrides: { uri: string; name: string }): Playlist {
     metadata: {},
     name: overrides.name,
     owner: "library",
-    provider: "library",
+    provider: providerOf(overrides.uri),
     provider_mappings: [],
     supported_mediatypes: [MediaType.TRACK],
     uri: overrides.uri,
@@ -333,7 +340,7 @@ function albumFixture(overrides: { uri: string; name: string }): Album {
     media_type: MediaType.ALBUM,
     metadata: {},
     name: overrides.name,
-    provider: "library",
+    provider: providerOf(overrides.uri),
     provider_mappings: [],
     uri: overrides.uri,
   };
@@ -347,7 +354,7 @@ function artistFixture(overrides: { uri: string; name: string }): Artist {
     media_type: MediaType.ARTIST,
     metadata: {},
     name: overrides.name,
-    provider: "library",
+    provider: providerOf(overrides.uri),
     provider_mappings: [],
     uri: overrides.uri,
   };
@@ -357,12 +364,12 @@ function genreFixture(overrides: { uri: string; name: string }): Genre {
   return {
     favorite: false,
     genre_aliases: null,
-    is_playable: true,
+    is_playable: false,
     item_id: overrides.uri,
     media_type: MediaType.GENRE,
     metadata: {},
     name: overrides.name,
-    provider: "library",
+    provider: providerOf(overrides.uri),
     provider_mappings: [],
     uri: overrides.uri,
   };

--- a/tests/components/MediaSearch.test.ts
+++ b/tests/components/MediaSearch.test.ts
@@ -1,12 +1,23 @@
 import MediaSearch from "@/components/MediaSearch.vue";
-import { MediaType } from "@/plugins/api/interfaces";
+import {
+  AlbumType,
+  MediaType,
+  type Album,
+  type Artist,
+  type Genre,
+  type ItemMapping,
+  type Playlist,
+  type SearchResults,
+  type Track,
+} from "@/plugins/api/interfaces";
+import type { MusicAssistantApi } from "@/plugins/api";
 import { mount } from "@vue/test-utils";
 import { nextTick } from "vue";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const { mockSearch, mockGetLibraryGenres } = vi.hoisted(() => ({
-  mockSearch: vi.fn(),
-  mockGetLibraryGenres: vi.fn(),
+  mockSearch: vi.fn<MusicAssistantApi["search"]>(),
+  mockGetLibraryGenres: vi.fn<MusicAssistantApi["getLibraryGenres"]>(),
 }));
 
 vi.mock("@/plugins/api", () => ({
@@ -57,7 +68,7 @@ function mountSearch(
 
 // api.search always returns every result list, so fill the ones a case does not
 // exercise rather than letting a partial mock stand in for a server response
-const searchResults = <T extends Record<string, unknown>>(lists: T) => ({
+const searchResults = (lists: Partial<SearchResults> = {}): SearchResults => ({
   artists: [],
   albums: [],
   tracks: [],
@@ -106,15 +117,13 @@ describe("MediaSearch", () => {
   it("renders a result for each allowed media type", async () => {
     mockSearch.mockResolvedValue(
       searchResults({
-        tracks: [{ uri: "track:1", name: "Some track", media_type: "track" }],
+        tracks: [trackFixture({ uri: "track:1", name: "Some track" })],
         playlists: [
-          { uri: "playlist:1", name: "Some playlist", media_type: "playlist" },
+          playlistFixture({ uri: "playlist:1", name: "Some playlist" }),
         ],
-        albums: [{ uri: "album:1", name: "Some album", media_type: "album" }],
-        artists: [
-          { uri: "artist:1", name: "Some artist", media_type: "artist" },
-        ],
-        genres: [{ uri: "genre:1", name: "Some genre", media_type: "genre" }],
+        albums: [albumFixture({ uri: "album:1", name: "Some album" })],
+        artists: [artistFixture({ uri: "artist:1", name: "Some artist" })],
+        genres: [genreFixture({ uri: "genre:1", name: "Some genre" })],
       }),
     );
     const wrapper = mountSearch({
@@ -145,7 +154,7 @@ describe("MediaSearch", () => {
       searchResults({
         tracks: [],
         playlists: [
-          { uri: "playlist:1", name: "Some playlist", media_type: "playlist" },
+          playlistFixture({ uri: "playlist:1", name: "Some playlist" }),
         ],
       }),
     );
@@ -171,7 +180,7 @@ describe("MediaSearch", () => {
       searchResults({
         tracks: [],
         playlists: [
-          { uri: "playlist:1", name: "Some playlist", media_type: "playlist" },
+          playlistFixture({ uri: "playlist:1", name: "Some playlist" }),
         ],
       }),
     );
@@ -193,30 +202,26 @@ describe("MediaSearch", () => {
     mockSearch.mockResolvedValue(
       searchResults({
         tracks: [
-          {
+          trackFixture({
             uri: "library://track/1",
             name: "Song",
-            media_type: "track",
-            artists: [{ name: "Band" }],
-          },
-          {
+            artists: [artistRef("Band")],
+          }),
+          trackFixture({
             uri: "spotify://track/9",
             name: "Song",
-            media_type: "track",
-            artists: [{ name: "Band" }],
-          },
+            artists: [artistRef("Band")],
+          }),
         ],
         playlists: [
-          {
+          playlistFixture({
             uri: "library://playlist/1",
             name: "Party",
-            media_type: "playlist",
-          },
-          {
+          }),
+          playlistFixture({
             uri: "spotify://playlist/9",
             name: "Party",
-            media_type: "playlist",
-          },
+          }),
         ],
       }),
     );
@@ -239,18 +244,16 @@ describe("MediaSearch", () => {
     mockSearch.mockResolvedValue(
       searchResults({
         tracks: [
-          {
+          trackFixture({
             uri: "library://track/1",
             name: "Untitled",
-            media_type: "track",
             artists: [],
-          },
-          {
+          }),
+          trackFixture({
             uri: "spotify://track/9",
             name: "Untitled",
-            media_type: "track",
             artists: [],
-          },
+          }),
         ],
       }),
     );
@@ -268,3 +271,99 @@ describe("MediaSearch", () => {
     vi.useRealTimers();
   });
 });
+
+function artistRef(name: string): ItemMapping {
+  return {
+    available: true,
+    is_playable: true,
+    item_id: name,
+    media_type: MediaType.ARTIST,
+    name,
+    provider: "library",
+    uri: `library://artist/${name}`,
+  };
+}
+
+function trackFixture(overrides: {
+  uri: string;
+  name: string;
+  artists?: Array<ItemMapping | Artist>;
+}): Track {
+  return {
+    album: null,
+    artists: overrides.artists ?? [],
+    duration: 180,
+    favorite: false,
+    is_playable: true,
+    item_id: overrides.uri,
+    media_type: MediaType.TRACK,
+    metadata: {},
+    name: overrides.name,
+    provider: "library",
+    provider_mappings: [],
+    uri: overrides.uri,
+  };
+}
+
+function playlistFixture(overrides: { uri: string; name: string }): Playlist {
+  return {
+    favorite: false,
+    is_dynamic: false,
+    is_editable: false,
+    is_playable: true,
+    item_id: overrides.uri,
+    media_type: MediaType.PLAYLIST,
+    metadata: {},
+    name: overrides.name,
+    owner: "library",
+    provider: "library",
+    provider_mappings: [],
+    supported_mediatypes: [MediaType.TRACK],
+    uri: overrides.uri,
+  };
+}
+
+function albumFixture(overrides: { uri: string; name: string }): Album {
+  return {
+    album_type: AlbumType.ALBUM,
+    artists: [],
+    favorite: false,
+    is_playable: true,
+    item_id: overrides.uri,
+    media_type: MediaType.ALBUM,
+    metadata: {},
+    name: overrides.name,
+    provider: "library",
+    provider_mappings: [],
+    uri: overrides.uri,
+  };
+}
+
+function artistFixture(overrides: { uri: string; name: string }): Artist {
+  return {
+    favorite: false,
+    is_playable: true,
+    item_id: overrides.uri,
+    media_type: MediaType.ARTIST,
+    metadata: {},
+    name: overrides.name,
+    provider: "library",
+    provider_mappings: [],
+    uri: overrides.uri,
+  };
+}
+
+function genreFixture(overrides: { uri: string; name: string }): Genre {
+  return {
+    favorite: false,
+    genre_aliases: null,
+    is_playable: true,
+    item_id: overrides.uri,
+    media_type: MediaType.GENRE,
+    metadata: {},
+    name: overrides.name,
+    provider: "library",
+    provider_mappings: [],
+    uri: overrides.uri,
+  };
+}

--- a/tests/components/PlayerCard.test.ts
+++ b/tests/components/PlayerCard.test.ts
@@ -7,6 +7,7 @@ import {
   PlayerFeature,
   PlayerType,
 } from "@/plugins/api/interfaces";
+import type { MusicAssistantApi } from "@/plugins/api";
 import { store } from "@/plugins/store";
 import { mount } from "@vue/test-utils";
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -23,8 +24,10 @@ const { apiMock, emitContextMenu } = vi.hoisted(() => ({
         items?: number;
       }
     >,
-    playerCommandPlayPause: vi.fn(),
-    playerCommandPowerToggle: vi.fn(),
+    playerCommandPlayPause:
+      vi.fn<MusicAssistantApi["playerCommandPlayPause"]>(),
+    playerCommandPowerToggle:
+      vi.fn<MusicAssistantApi["playerCommandPowerToggle"]>(),
   },
   emitContextMenu: vi.fn(),
 }));

--- a/tests/components/PlayerGroupMembers.test.ts
+++ b/tests/components/PlayerGroupMembers.test.ts
@@ -1,5 +1,5 @@
 import PlayerGroupMembers from "@/components/PlayerGroupMembers.vue";
-import { api } from "@/plugins/api";
+import { api, type MusicAssistantApi } from "@/plugins/api";
 import {
   IdentifierType,
   PlaybackState,
@@ -14,8 +14,10 @@ vi.mock("@/plugins/api", async () => {
   const { reactive } = await vi.importActual<typeof import("vue")>("vue");
   const api = reactive({
     players: {} as Record<string, Player>,
-    getPlayer: vi.fn(),
-    playerCommandSetMembers: vi.fn(() => Promise.resolve()),
+    getPlayer: vi.fn<MusicAssistantApi["getPlayer"]>(),
+    playerCommandSetMembers: vi.fn<
+      MusicAssistantApi["playerCommandSetMembers"]
+    >(() => Promise.resolve()),
   });
   return { api, default: api };
 });

--- a/tests/components/SendspinPlayer.test.ts
+++ b/tests/components/SendspinPlayer.test.ts
@@ -1,4 +1,5 @@
 import SendspinPlayer from "@/components/SendspinPlayer.vue";
+import type { MusicAssistantApi } from "@/plugins/api";
 import { PlaybackState } from "@/plugins/api/interfaces";
 import { webPlayer, WebPlayerMode } from "@/plugins/web_player";
 import { flushPromises, mount } from "@vue/test-utils";
@@ -64,11 +65,13 @@ const {
   mockUseMediaBrowserMetaData,
   routeState,
 } = vi.hoisted(() => {
-  const mockPlayerCommandNext = vi.fn();
-  const mockPlayerCommandPause = vi.fn();
-  const mockPlayerCommandPlay = vi.fn();
-  const mockPlayerCommandPrevious = vi.fn();
-  const mockPlayerCommandSeek = vi.fn();
+  const mockPlayerCommandNext = vi.fn<MusicAssistantApi["playerCommandNext"]>();
+  const mockPlayerCommandPause =
+    vi.fn<MusicAssistantApi["playerCommandPause"]>();
+  const mockPlayerCommandPlay = vi.fn<MusicAssistantApi["playerCommandPlay"]>();
+  const mockPlayerCommandPrevious =
+    vi.fn<MusicAssistantApi["playerCommandPrevious"]>();
+  const mockPlayerCommandSeek = vi.fn<MusicAssistantApi["playerCommandSeek"]>();
   return {
     authState: {
       guest: null as "music_quiz" | "party" | null,

--- a/tests/components/SetupFlowDialog.test.ts
+++ b/tests/components/SetupFlowDialog.test.ts
@@ -6,12 +6,13 @@ import {
   type ConfigEntry,
   type SetupFlowStep,
 } from "@/plugins/api/interfaces";
+import type { MusicAssistantApi } from "@/plugins/api";
 import SetupFlowDialog from "@/components/SetupFlowDialog.vue";
 
 const { apiMock, eventbusMock, routerMock, storeMock, toastMock } = vi.hoisted(
   () => ({
     apiMock: {
-      abortSetupFlow: vi.fn(),
+      abortSetupFlow: vi.fn<MusicAssistantApi["abortSetupFlow"]>(),
       players: {},
       providerManifests: {},
       providers: {
@@ -19,12 +20,12 @@ const { apiMock, eventbusMock, routerMock, storeMock, toastMock } = vi.hoisted(
           domain: "spotify",
         },
       },
-      reconfigureProvider: vi.fn(),
+      reconfigureProvider: vi.fn<MusicAssistantApi["reconfigureProvider"]>(),
       state: {
         value: "authenticated",
       },
-      submitSetupFlow: vi.fn(),
-      subscribeSetupFlow: vi.fn(),
+      submitSetupFlow: vi.fn<MusicAssistantApi["submitSetupFlow"]>(),
+      subscribeSetupFlow: vi.fn<MusicAssistantApi["subscribeSetupFlow"]>(),
     },
     eventbusMock: {
       off: vi.fn(),

--- a/tests/components/VolumeControl.test.ts
+++ b/tests/components/VolumeControl.test.ts
@@ -1,5 +1,5 @@
 import VolumeControl from "@/components/VolumeControl.vue";
-import { api } from "@/plugins/api";
+import { api, type MusicAssistantApi } from "@/plugins/api";
 import {
   IdentifierType,
   PlaybackState,
@@ -14,8 +14,10 @@ vi.mock("@/plugins/api", async () => {
   const { reactive } = await vi.importActual<typeof import("vue")>("vue");
   const api = reactive({
     players: {} as Record<string, Player>,
-    getPlayer: vi.fn(),
-    playerCommandSetMembers: vi.fn(() => Promise.resolve()),
+    getPlayer: vi.fn<MusicAssistantApi["getPlayer"]>(),
+    playerCommandSetMembers: vi.fn<
+      MusicAssistantApi["playerCommandSetMembers"]
+    >(() => Promise.resolve()),
   });
   return { api, default: api };
 });

--- a/tests/components/ai-radio/ShowCard.test.ts
+++ b/tests/components/ai-radio/ShowCard.test.ts
@@ -1,5 +1,6 @@
 import ShowCard from "@/components/ai-radio/ShowCard.vue";
 import { useShows } from "@/composables/ai-radio/useShows";
+import type { MusicAssistantApi } from "@/plugins/api";
 import { i18n } from "@/plugins/i18n";
 import type { AIRadioSession, AIRadioStation } from "@/plugins/api/interfaces";
 import { mount } from "@vue/test-utils";
@@ -9,7 +10,9 @@ vi.mock("@/plugins/api", () => ({
   default: {
     players: {},
     sendCommand: vi.fn(async () => []),
-    getLibraryPlaylists: vi.fn(async () => []),
+    getLibraryPlaylists: vi.fn<MusicAssistantApi["getLibraryPlaylists"]>(
+      async () => [],
+    ),
   },
 }));
 

--- a/tests/components/music-quiz/GuessTheSongPlayerRound.test.ts
+++ b/tests/components/music-quiz/GuessTheSongPlayerRound.test.ts
@@ -4,7 +4,12 @@ import type {
   MusicQuizGuessTheSongPersonalizedState,
   MusicQuizGuessTheSongRound,
 } from "@/composables/music-quiz/useMusicQuiz";
-import { MediaType } from "@/plugins/api/interfaces";
+import type { MusicAssistantApi } from "@/plugins/api";
+import {
+  MediaType,
+  type MediaItemType,
+  type Track,
+} from "@/plugins/api/interfaces";
 import { shallowMount } from "@vue/test-utils";
 import { ref } from "vue";
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -17,8 +22,8 @@ const {
   mockUseGuessTheSongPlaybackPosition,
 } = vi.hoisted(() => ({
   mockCopyToClipboard: vi.fn(),
-  mockGetItemByUri: vi.fn(),
-  mockGetTrackLyrics: vi.fn(),
+  mockGetItemByUri: vi.fn<MusicAssistantApi["getItemByUri"]>(),
+  mockGetTrackLyrics: vi.fn<MusicAssistantApi["getTrackLyrics"]>(),
   mockToastError: vi.fn(),
   mockUseGuessTheSongPlaybackPosition: vi.fn(),
 }));
@@ -87,7 +92,7 @@ describe("GuessTheSongPlayerRound", () => {
   });
 
   it("passes loaded lyrics and playback position to the reveal", async () => {
-    mockGetItemByUri.mockResolvedValue({ media_type: MediaType.TRACK });
+    mockGetItemByUri.mockResolvedValue(trackItem("library://track/1"));
     mockGetTrackLyrics.mockResolvedValue(["Plain lyrics", "Synced lyrics"]);
     const wrapper = mountRound(createState("reveal"));
 
@@ -103,7 +108,7 @@ describe("GuessTheSongPlayerRound", () => {
   });
 
   it("prefers audio_started_at as the playback anchor when present", () => {
-    mockGetItemByUri.mockReturnValue(new Promise(() => {}));
+    mockGetItemByUri.mockReturnValue(new Promise<MediaItemType>(() => {}));
     const wrapper = mountRound(createState("reveal"), {
       ...currentRound,
       audio_started_at: 55,
@@ -115,7 +120,7 @@ describe("GuessTheSongPlayerRound", () => {
   });
 
   it("falls back to started_at when the round omits audio_started_at", () => {
-    mockGetItemByUri.mockReturnValue(new Promise(() => {}));
+    mockGetItemByUri.mockReturnValue(new Promise<MediaItemType>(() => {}));
     const wrapper = mountRound(createState("reveal"));
 
     const options = mockUseGuessTheSongPlaybackPosition.mock.calls.at(-1)?.[0];
@@ -124,7 +129,7 @@ describe("GuessTheSongPlayerRound", () => {
   });
 
   it("falls back to started_at when audio_started_at is null", () => {
-    mockGetItemByUri.mockReturnValue(new Promise(() => {}));
+    mockGetItemByUri.mockReturnValue(new Promise<MediaItemType>(() => {}));
     const wrapper = mountRound(createState("reveal"), {
       ...currentRound,
       audio_started_at: null,
@@ -136,7 +141,7 @@ describe("GuessTheSongPlayerRound", () => {
   });
 
   it("keeps the loading state until the lyrics request completes", () => {
-    mockGetItemByUri.mockReturnValue(new Promise(() => {}));
+    mockGetItemByUri.mockReturnValue(new Promise<MediaItemType>(() => {}));
     const wrapper = mountRound(createState("reveal"));
 
     expect(
@@ -146,7 +151,7 @@ describe("GuessTheSongPlayerRound", () => {
   });
 
   it("keeps copy failures inside the game adapter", async () => {
-    mockGetItemByUri.mockReturnValue(new Promise(() => {}));
+    mockGetItemByUri.mockReturnValue(new Promise<MediaItemType>(() => {}));
     mockCopyToClipboard.mockResolvedValue(false);
     const wrapper = mountRound(createState("reveal"));
 
@@ -161,7 +166,7 @@ describe("GuessTheSongPlayerRound", () => {
   });
 
   it("forwards the shared ready action", () => {
-    mockGetItemByUri.mockReturnValue(new Promise(() => {}));
+    mockGetItemByUri.mockReturnValue(new Promise<MediaItemType>(() => {}));
     const wrapper = mountRound(createState("reveal"));
 
     wrapper.getComponent(GuessTheSongReveal).vm.$emit("ready");
@@ -172,7 +177,7 @@ describe("GuessTheSongPlayerRound", () => {
 
   it("ignores lyrics returned for an older round", async () => {
     const firstLyrics = deferred<[string | null, string | null]>();
-    mockGetItemByUri.mockResolvedValue({ media_type: MediaType.TRACK });
+    mockGetItemByUri.mockResolvedValue(trackItem("library://track/1"));
     mockGetTrackLyrics
       .mockReturnValueOnce(firstLyrics.promise)
       .mockResolvedValueOnce(["Second lyrics", null]);
@@ -243,4 +248,21 @@ function deferred<T>() {
     resolve = promiseResolve;
   });
   return { promise, resolve };
+}
+
+function trackItem(uri: string): Track {
+  return {
+    item_id: uri,
+    provider: "library",
+    name: "Track",
+    uri,
+    is_playable: true,
+    media_type: MediaType.TRACK,
+    provider_mappings: [],
+    metadata: {},
+    favorite: false,
+    duration: 120,
+    artists: [],
+    album: null,
+  };
 }

--- a/tests/components/music-quiz/GuessTheSongSetup.test.ts
+++ b/tests/components/music-quiz/GuessTheSongSetup.test.ts
@@ -1,12 +1,18 @@
 import GuessTheSongSetup from "@/components/music-quiz/game-types/guess-the-song/GuessTheSongSetup.vue";
-import { MediaType } from "@/plugins/api/interfaces";
+import type { MusicAssistantApi } from "@/plugins/api";
+import {
+  MediaType,
+  type Genre,
+  type Playlist,
+  type SearchResults,
+} from "@/plugins/api/interfaces";
 import { mount } from "@vue/test-utils";
 import { nextTick } from "vue";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const { mockSearch, mockGetLibraryGenres } = vi.hoisted(() => ({
-  mockSearch: vi.fn(),
-  mockGetLibraryGenres: vi.fn(),
+  mockSearch: vi.fn<MusicAssistantApi["search"]>(),
+  mockGetLibraryGenres: vi.fn<MusicAssistantApi["getLibraryGenres"]>(),
 }));
 
 vi.mock("@/plugins/api", () => ({
@@ -36,24 +42,14 @@ vi.mock("@/components/MediaItemThumb.vue", () => ({
   },
 }));
 
-type ResultItem = { uri: string; name: string; media_type: MediaType };
-
-type SearchResult = {
-  tracks: ResultItem[];
-  playlists: ResultItem[];
-  albums?: ResultItem[];
-  artists?: ResultItem[];
-  genres?: ResultItem[];
-};
-
 type DeferredSearch = {
-  promise: Promise<SearchResult>;
-  resolve: (value: SearchResult) => void;
+  promise: Promise<SearchResults>;
+  resolve: (value: SearchResults) => void;
 };
 
 function deferredSearch(): DeferredSearch {
-  let resolvePromise: (value: SearchResult) => void = () => {};
-  const promise = new Promise<SearchResult>((resolve) => {
+  let resolvePromise: (value: SearchResults) => void = () => {};
+  const promise = new Promise<SearchResults>((resolve) => {
     resolvePromise = resolve;
   });
   return {
@@ -80,7 +76,7 @@ function mountConfig(includeSimilarMusic = false, sharedConfigValid = true) {
 
 // api.search always returns every result list, so fill the ones a case does not
 // exercise rather than letting a partial mock stand in for a server response
-const searchResults = <T extends Record<string, unknown>>(lists: T) => ({
+const searchResults = (lists: Partial<SearchResults> = {}): SearchResults => ({
   artists: [],
   albums: [],
   tracks: [],
@@ -91,6 +87,39 @@ const searchResults = <T extends Record<string, unknown>>(lists: T) => ({
   genres: [],
   ...lists,
 });
+
+function playlistResult(uri: string, name: string): Playlist {
+  return {
+    item_id: uri,
+    provider: "library",
+    name,
+    uri,
+    is_playable: true,
+    media_type: MediaType.PLAYLIST,
+    provider_mappings: [],
+    metadata: {},
+    favorite: false,
+    owner: "",
+    is_editable: false,
+    supported_mediatypes: [],
+    is_dynamic: false,
+  };
+}
+
+function genreResult(uri: string, name: string): Genre {
+  return {
+    item_id: uri,
+    provider: "library",
+    name,
+    uri,
+    is_playable: false,
+    media_type: MediaType.GENRE,
+    provider_mappings: [],
+    metadata: {},
+    favorite: false,
+    genre_aliases: null,
+  };
+}
 
 describe("GuessTheSongSetup", () => {
   beforeEach(() => {
@@ -137,13 +166,7 @@ describe("GuessTheSongSetup", () => {
     newSearch.resolve(
       searchResults({
         tracks: [],
-        playlists: [
-          {
-            uri: "playlist:new",
-            name: "Newest result",
-            media_type: MediaType.PLAYLIST,
-          },
-        ],
+        playlists: [playlistResult("playlist:new", "Newest result")],
       }),
     );
     await flushPromises();
@@ -152,13 +175,7 @@ describe("GuessTheSongSetup", () => {
     oldSearch.resolve(
       searchResults({
         tracks: [],
-        playlists: [
-          {
-            uri: "playlist:old",
-            name: "Older result",
-            media_type: MediaType.PLAYLIST,
-          },
-        ],
+        playlists: [playlistResult("playlist:old", "Older result")],
       }),
     );
     await flushPromises();
@@ -171,13 +188,7 @@ describe("GuessTheSongSetup", () => {
     mockSearch.mockResolvedValue(
       searchResults({
         tracks: [],
-        playlists: [
-          {
-            uri: "playlist:test",
-            name: "Test playlist",
-            media_type: MediaType.PLAYLIST,
-          },
-        ],
+        playlists: [playlistResult("playlist:test", "Test playlist")],
       }),
     );
 
@@ -216,13 +227,7 @@ describe("GuessTheSongSetup", () => {
     mockSearch.mockResolvedValue(
       searchResults({
         tracks: [],
-        playlists: [
-          {
-            uri: "playlist:test",
-            name: "Test playlist",
-            media_type: MediaType.PLAYLIST,
-          },
-        ],
+        playlists: [playlistResult("playlist:test", "Test playlist")],
       }),
     );
     const wrapper = mountConfig(false, false);
@@ -249,13 +254,7 @@ describe("GuessTheSongSetup", () => {
     mockSearch.mockResolvedValue(
       searchResults({
         tracks: [],
-        playlists: [
-          {
-            uri: "playlist:test",
-            name: "Test playlist",
-            media_type: MediaType.PLAYLIST,
-          },
-        ],
+        playlists: [playlistResult("playlist:test", "Test playlist")],
       }),
     );
     const wrapper = mountConfig();
@@ -283,16 +282,8 @@ describe("GuessTheSongSetup", () => {
     mockSearch.mockResolvedValue(
       searchResults({
         tracks: [],
-        playlists: [
-          {
-            uri: "playlist:test",
-            name: "Test playlist",
-            media_type: MediaType.PLAYLIST,
-          },
-        ],
-        genres: [
-          { uri: "genre:rock", name: "Rock", media_type: MediaType.GENRE },
-        ],
+        playlists: [playlistResult("playlist:test", "Test playlist")],
+        genres: [genreResult("genre:rock", "Rock")],
       }),
     );
     const wrapper = mountConfig(true);
@@ -332,13 +323,7 @@ describe("GuessTheSongSetup", () => {
     mockSearch.mockResolvedValue(
       searchResults({
         tracks: [],
-        playlists: [
-          {
-            uri: "playlist:test",
-            name: "Test playlist",
-            media_type: MediaType.PLAYLIST,
-          },
-        ],
+        playlists: [playlistResult("playlist:test", "Test playlist")],
       }),
     );
     const wrapper = mountConfig();

--- a/tests/components/music-quiz/MusicTimelineAdapters.test.ts
+++ b/tests/components/music-quiz/MusicTimelineAdapters.test.ts
@@ -9,11 +9,12 @@ import type {
   MusicQuizTimelinePersonalizedState,
   MusicQuizTimelineRound,
 } from "@/composables/music-quiz/useMusicQuiz";
+import type { MusicAssistantApi } from "@/plugins/api";
 import { mount, shallowMount } from "@vue/test-utils";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const { mockGetTrackLyrics } = vi.hoisted(() => ({
-  mockGetTrackLyrics: vi.fn(),
+  mockGetTrackLyrics: vi.fn<MusicAssistantApi["getTrackLyrics"]>(),
 }));
 
 vi.mock("@/plugins/api", () => ({

--- a/tests/components/music-quiz/MusicTimelineSetup.test.ts
+++ b/tests/components/music-quiz/MusicTimelineSetup.test.ts
@@ -1,12 +1,17 @@
 import MusicTimelineSetup from "@/components/music-quiz/game-types/music-timeline/MusicTimelineSetup.vue";
-import { MediaType } from "@/plugins/api/interfaces";
+import type { MusicAssistantApi } from "@/plugins/api";
+import {
+  MediaType,
+  type Playlist,
+  type SearchResults,
+} from "@/plugins/api/interfaces";
 import { mount } from "@vue/test-utils";
 import { nextTick } from "vue";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const { mockSearch, mockGetLibraryGenres } = vi.hoisted(() => ({
-  mockSearch: vi.fn(),
-  mockGetLibraryGenres: vi.fn(),
+  mockSearch: vi.fn<MusicAssistantApi["search"]>(),
+  mockGetLibraryGenres: vi.fn<MusicAssistantApi["getLibraryGenres"]>(),
 }));
 
 vi.mock("@/plugins/api", () => ({
@@ -43,7 +48,7 @@ async function flushPromises() {
 
 // api.search always returns every result list, so fill the ones a case does not
 // exercise rather than letting a partial mock stand in for a server response
-const searchResults = <T extends Record<string, unknown>>(lists: T) => ({
+const searchResults = (lists: Partial<SearchResults> = {}): SearchResults => ({
   artists: [],
   albums: [],
   tracks: [],
@@ -55,6 +60,24 @@ const searchResults = <T extends Record<string, unknown>>(lists: T) => ({
   ...lists,
 });
 
+function playlistResult(uri: string, name: string): Playlist {
+  return {
+    item_id: uri,
+    provider: "library",
+    name,
+    uri,
+    is_playable: true,
+    media_type: MediaType.PLAYLIST,
+    provider_mappings: [],
+    metadata: {},
+    favorite: false,
+    owner: "",
+    is_editable: false,
+    supported_mediatypes: [],
+    is_dynamic: false,
+  };
+}
+
 describe("MusicTimelineSetup", () => {
   beforeEach(() => {
     vi.useFakeTimers();
@@ -64,13 +87,7 @@ describe("MusicTimelineSetup", () => {
     mockSearch.mockResolvedValue(
       searchResults({
         tracks: [],
-        playlists: [
-          {
-            uri: "playlist:test",
-            name: "Test playlist",
-            media_type: MediaType.PLAYLIST,
-          },
-        ],
+        playlists: [playlistResult("playlist:test", "Test playlist")],
       }),
     );
   });

--- a/tests/components/music-quiz/TriviaSetup.test.ts
+++ b/tests/components/music-quiz/TriviaSetup.test.ts
@@ -1,4 +1,5 @@
 import TriviaSetup from "@/components/music-quiz/game-types/trivia/TriviaSetup.vue";
+import type { MusicAssistantApi } from "@/plugins/api";
 import { mount } from "@vue/test-utils";
 import { nextTick } from "vue";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -16,8 +17,8 @@ vi.mock("@/plugins/api", () => ({
   api: {
     providers: {},
     providerManifests: {},
-    search: vi.fn(),
-    getLibraryGenres: vi.fn(),
+    search: vi.fn<MusicAssistantApi["search"]>(),
+    getLibraryGenres: vi.fn<MusicAssistantApi["getLibraryGenres"]>(),
   },
 }));
 

--- a/tests/components/music-quiz/registry.test.ts
+++ b/tests/components/music-quiz/registry.test.ts
@@ -23,6 +23,7 @@ import type {
   MusicQuizTriviaRound,
   MusicQuizType,
 } from "@/composables/music-quiz/useMusicQuiz";
+import type { MusicAssistantApi } from "@/plugins/api";
 import { shallowMount } from "@vue/test-utils";
 import { describe, expect, it, vi } from "vitest";
 
@@ -50,9 +51,9 @@ vi.mock("@/helpers/utils", () => ({
 
 vi.mock("@/plugins/api", () => ({
   default: {
-    getItemByUri: vi.fn(),
-    getTrackLyrics: vi.fn(),
-    search: vi.fn(),
+    getItemByUri: vi.fn<MusicAssistantApi["getItemByUri"]>(),
+    getTrackLyrics: vi.fn<MusicAssistantApi["getTrackLyrics"]>(),
+    search: vi.fn<MusicAssistantApi["search"]>(),
   },
 }));
 

--- a/tests/composables/smart_playlist/useSmartPlaylistGenres.test.ts
+++ b/tests/composables/smart_playlist/useSmartPlaylistGenres.test.ts
@@ -1,4 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
+import { MediaType, type Genre } from "@/plugins/api/interfaces";
+import type { MusicAssistantApi } from "@/plugins/api";
 
 vi.mock("vue", async () => {
   const actual = await vi.importActual<typeof import("vue")>("vue");
@@ -12,16 +14,22 @@ vi.mock("vue-i18n", () => ({
   useI18n: () => ({ t: (k: string) => k, te: () => false }),
 }));
 
-vi.mock("@/plugins/api", () => ({
-  default: {
-    getLibraryGenres: vi.fn().mockResolvedValue([
-      { item_id: "9", name: "Synthwave" },
-      { item_id: "2", name: "Rock" },
-    ]),
+const { apiMock } = vi.hoisted(() => ({
+  apiMock: {
+    getLibraryGenres: vi.fn<MusicAssistantApi["getLibraryGenres"]>(),
   },
 }));
 
+vi.mock("@/plugins/api", () => ({
+  default: apiMock,
+}));
+
 import { useSmartPlaylistGenres } from "@/composables/smart-playlist/useSmartPlaylistGenres";
+
+apiMock.getLibraryGenres.mockResolvedValue([
+  genreFixture("9", "Synthwave"),
+  genreFixture("2", "Rock"),
+]);
 
 describe("useSmartPlaylistGenres", () => {
   it("loads the genre list on mount and exposes options", async () => {
@@ -31,12 +39,8 @@ describe("useSmartPlaylistGenres", () => {
     await Promise.resolve();
     expect(genres.value.length).toBe(2);
     expect(genreOptions.value).toEqual([
-      {
-        id: 9,
-        name: "Synthwave",
-        item: { item_id: "9", name: "Synthwave" },
-      },
-      { id: 2, name: "Rock", item: { item_id: "2", name: "Rock" } },
+      { id: 9, name: "Synthwave", item: genreFixture("9", "Synthwave") },
+      { id: 2, name: "Rock", item: genreFixture("2", "Rock") },
     ]);
   });
 
@@ -49,3 +53,18 @@ describe("useSmartPlaylistGenres", () => {
     expect(genreName(42)).toBe("42");
   });
 });
+
+function genreFixture(item_id: string, name: string): Genre {
+  return {
+    item_id,
+    provider: "library",
+    name,
+    uri: `library://genre/${item_id}`,
+    is_playable: false,
+    media_type: MediaType.GENRE,
+    provider_mappings: [],
+    metadata: {},
+    favorite: false,
+    genre_aliases: null,
+  };
+}

--- a/tests/composables/smart_playlist/useSmartPlaylistGenres.test.ts
+++ b/tests/composables/smart_playlist/useSmartPlaylistGenres.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { MediaType, type Genre } from "@/plugins/api/interfaces";
 import type { MusicAssistantApi } from "@/plugins/api";
 
@@ -26,12 +26,14 @@ vi.mock("@/plugins/api", () => ({
 
 import { useSmartPlaylistGenres } from "@/composables/smart-playlist/useSmartPlaylistGenres";
 
-apiMock.getLibraryGenres.mockResolvedValue([
-  genreFixture("9", "Synthwave"),
-  genreFixture("2", "Rock"),
-]);
-
 describe("useSmartPlaylistGenres", () => {
+  beforeEach(() => {
+    apiMock.getLibraryGenres.mockResolvedValue([
+      genreFixture("9", "Synthwave"),
+      genreFixture("2", "Rock"),
+    ]);
+  });
+
   it("loads the genre list on mount and exposes options", async () => {
     const { genres, genreOptions } = useSmartPlaylistGenres();
     // wait a microtask for onMounted's promise resolution

--- a/tests/composables/smart_playlist/useSmartPlaylistSeedItems.test.ts
+++ b/tests/composables/smart_playlist/useSmartPlaylistSeedItems.test.ts
@@ -38,13 +38,14 @@ vi.mock("@/plugins/api", () => ({
         supported_features: [],
       },
     },
-    search: vi.fn(),
+    search: vi.fn<MusicAssistantApi["search"]>(),
   },
 }));
 
 import api from "@/plugins/api";
+import type { MusicAssistantApi } from "@/plugins/api";
 import { useSmartPlaylistSeedItems } from "@/composables/smart-playlist/useSmartPlaylistSeedItems";
-import type { Album, Track } from "@/plugins/api/interfaces";
+import { MediaType, type Album, type Track } from "@/plugins/api/interfaces";
 import { providerMapping } from "../../fixtures/providerMapping";
 
 interface SearchFnArg {
@@ -195,7 +196,7 @@ describe("useSmartPlaylistSeedItems", () => {
 
       vi.mocked(api.search).mockResolvedValueOnce({
         tracks: [
-          {
+          trackFixture({
             item_id: "lib-1",
             name: "Library Track",
             provider_mappings: [
@@ -208,7 +209,7 @@ describe("useSmartPlaylistSeedItems", () => {
                 provider_domain: "filesystem_local",
               }),
             ],
-          },
+          }),
         ],
         artists: [],
         albums: [],
@@ -216,7 +217,8 @@ describe("useSmartPlaylistSeedItems", () => {
         radio: [],
         audiobooks: [],
         podcasts: [],
-      } as never);
+        genres: [],
+      });
 
       const results = await trackSearchFn("anything");
 
@@ -243,3 +245,21 @@ describe("useSmartPlaylistSeedItems", () => {
     });
   });
 });
+
+function trackFixture(overrides: Partial<Track> = {}): Track {
+  return {
+    item_id: "1",
+    provider: "library",
+    name: "Track",
+    uri: "library://track/1",
+    is_playable: true,
+    media_type: MediaType.TRACK,
+    provider_mappings: [],
+    metadata: {},
+    favorite: false,
+    duration: 200,
+    artists: [],
+    album: null,
+    ...overrides,
+  };
+}

--- a/tests/composables/useActiveTrackWaveform.test.ts
+++ b/tests/composables/useActiveTrackWaveform.test.ts
@@ -1,12 +1,13 @@
 import { effectScope, nextTick, reactive, type EffectScope } from "vue";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { MusicAssistantApi } from "@/plugins/api";
 
 // ---------------------------------------------------------------------------
 // Hoisted mocks
 // ---------------------------------------------------------------------------
 
 const { mockGetWaveForm } = vi.hoisted(() => ({
-  mockGetWaveForm: vi.fn(),
+  mockGetWaveForm: vi.fn<MusicAssistantApi["getWaveForm"]>(),
 }));
 
 vi.mock("@/plugins/api", () => ({

--- a/tests/composables/useAudioAnalysisFailures.test.ts
+++ b/tests/composables/useAudioAnalysisFailures.test.ts
@@ -1,9 +1,15 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { MusicAssistantApi } from "@/plugins/api";
+import {
+  MediaType,
+  type ItemMapping,
+  type Track,
+} from "@/plugins/api/interfaces";
 
 const { mockSendCommand, mockGetTrack } = vi.hoisted(() => {
   return {
     mockSendCommand: vi.fn(),
-    mockGetTrack: vi.fn(),
+    mockGetTrack: vi.fn<MusicAssistantApi["getTrack"]>(),
   };
 });
 
@@ -57,7 +63,12 @@ beforeEach(() => {
   mockSendCommand.mockReset();
   mockGetTrack.mockReset();
   mockGetTrack.mockImplementation((itemId: string) =>
-    Promise.resolve({ name: `Track ${itemId}`, artists: [{ name: "Artist" }] }),
+    Promise.resolve(
+      trackFixture({
+        name: `Track ${itemId}`,
+        artists: [artistMapping("Artist")],
+      }),
+    ),
   );
 });
 
@@ -208,10 +219,9 @@ describe("useAudioAnalysisFailures", () => {
 
   it("resolves the track name + artist for the current page", async () => {
     mockFailures([serverFailure({ item_id: "1", provider: "tidal" })]);
-    mockGetTrack.mockResolvedValueOnce({
-      name: "Creep",
-      artists: [{ name: "Radiohead" }],
-    });
+    mockGetTrack.mockResolvedValueOnce(
+      trackFixture({ name: "Creep", artists: [artistMapping("Radiohead")] }),
+    );
 
     const f = useAudioAnalysisFailures();
     await f.refresh();
@@ -228,7 +238,9 @@ describe("useAudioAnalysisFailures", () => {
     ]);
     mockGetTrack.mockImplementation((itemId: string) => {
       if (itemId === "gone") return Promise.reject(new Error("not found"));
-      return Promise.resolve({ name: "Fine", artists: [{ name: "Band" }] });
+      return Promise.resolve(
+        trackFixture({ name: "Fine", artists: [artistMapping("Band")] }),
+      );
     });
 
     const f = useAudioAnalysisFailures();
@@ -338,10 +350,11 @@ describe("useAudioAnalysisFailures", () => {
       serverFailure({ item_id: "1", provider: "qobuz" }),
     ]);
     mockGetTrack.mockImplementation((_itemId: string, provider: string) =>
-      Promise.resolve({
-        name: provider === "tidal" ? "Tidal Track" : "Qobuz Track",
-        artists: [],
-      }),
+      Promise.resolve(
+        trackFixture({
+          name: provider === "tidal" ? "Tidal Track" : "Qobuz Track",
+        }),
+      ),
     );
 
     const f = useAudioAnalysisFailures();
@@ -378,7 +391,7 @@ describe("useAudioAnalysisFailures", () => {
     mockGetTrack.mockImplementation((itemId: string) =>
       itemId === "1"
         ? Promise.reject(new Error("not found"))
-        : Promise.resolve({ name: "Two", artists: [] }),
+        : Promise.resolve(trackFixture({ name: "Two" })),
     );
 
     const f = useAudioAnalysisFailures({ pageSize: 1 });
@@ -553,3 +566,33 @@ describe("useAudioAnalysisFailures", () => {
 // Keep the RawFailure import meaningful so the public type is part of the contract.
 const _typecheck: RawFailure | undefined = undefined;
 void _typecheck;
+
+function trackFixture(overrides: Partial<Track> = {}): Track {
+  return {
+    item_id: "1",
+    provider: "tidal",
+    name: "Track",
+    uri: "tidal://track/1",
+    is_playable: true,
+    media_type: MediaType.TRACK,
+    provider_mappings: [],
+    metadata: {},
+    favorite: false,
+    duration: 200,
+    artists: [],
+    album: null,
+    ...overrides,
+  };
+}
+
+function artistMapping(name: string): ItemMapping {
+  return {
+    item_id: name,
+    provider: "tidal",
+    name,
+    uri: `tidal://artist/${name}`,
+    is_playable: true,
+    media_type: MediaType.ARTIST,
+    available: true,
+  };
+}

--- a/tests/composables/useAudioProcessingDetails.test.ts
+++ b/tests/composables/useAudioProcessingDetails.test.ts
@@ -8,6 +8,7 @@ import {
   useAudioProcessingDetails,
 } from "@/composables/useAudioProcessingDetails";
 import { $t, i18n } from "@/plugins/i18n";
+import type { MusicAssistantApi } from "@/plugins/api";
 import {
   AudioChannel,
   type AudioFormat,
@@ -18,16 +19,31 @@ import {
   DSPState,
   MediaType,
   type OutputProtocol,
+  ProviderStage,
+  ProviderType,
   type StreamDetails,
   VolumeNormalizationMode,
 } from "@/plugins/api/interfaces";
 
 vi.mock("@/plugins/api", () => ({
   default: {
-    getProviderName: vi.fn(),
-    getProviderManifest: vi.fn((providerId: string) => ({
-      domain: providerId,
-    })),
+    getProviderName: vi.fn<MusicAssistantApi["getProviderName"]>(),
+    getProviderManifest: vi.fn<MusicAssistantApi["getProviderManifest"]>(
+      (providerId: string) => ({
+        allow_disable: true,
+        builtin: false,
+        codeowners: [],
+        credits: [],
+        description: "",
+        domain: providerId,
+        icon_images: [],
+        multi_instance: true,
+        name: providerId,
+        requirements: [],
+        stage: ProviderStage.STABLE,
+        type: ProviderType.MUSIC,
+      }),
+    ),
     players: {},
   },
 }));

--- a/tests/composables/useDSPPresets.test.ts
+++ b/tests/composables/useDSPPresets.test.ts
@@ -2,12 +2,13 @@ import { flushPromises, mount } from "@vue/test-utils";
 import { defineComponent, nextTick } from "vue";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { DSPConfigPreset } from "@/plugins/api/interfaces";
+import type { MusicAssistantApi } from "@/plugins/api";
 
 const apiMock = vi.hoisted(() => ({
   eventCallback: undefined as
     | ((event: { data: DSPConfigPreset[] }) => void)
     | undefined,
-  getDSPPresets: vi.fn(),
+  getDSPPresets: vi.fn<MusicAssistantApi["getDSPPresets"]>(),
   subscribe: vi.fn(),
   unsubscribe: vi.fn(),
 }));

--- a/tests/composables/useGuestArtistTracks.test.ts
+++ b/tests/composables/useGuestArtistTracks.test.ts
@@ -1,11 +1,12 @@
-import type { Artist } from "@/plugins/api/interfaces";
+import { MediaType, type Artist, type Track } from "@/plugins/api/interfaces";
+import type { MusicAssistantApi } from "@/plugins/api";
 import { providerMapping } from "../fixtures/providerMapping";
 import { $t } from "@/plugins/i18n";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const { mockGetArtistTracks, mockToast } = vi.hoisted(() => {
   return {
-    mockGetArtistTracks: vi.fn(),
+    mockGetArtistTracks: vi.fn<MusicAssistantApi["getArtistTracks"]>(),
     mockToast: {
       success: vi.fn(),
       error: vi.fn(),
@@ -34,7 +35,7 @@ describe("useGuestArtistTracks", () => {
   });
 
   it("selects artist and loads tracks", async () => {
-    const tracks = [{ id: "track1" }, { id: "track2" }];
+    const tracks = [trackFixture("track1"), trackFixture("track2")];
     mockGetArtistTracks.mockResolvedValueOnce(tracks);
 
     const { selectedArtist, artistTracks, loadingArtistTracks, selectArtist } =
@@ -83,7 +84,7 @@ describe("useGuestArtistTracks", () => {
   });
 
   it("clears the artist selection", async () => {
-    mockGetArtistTracks.mockResolvedValueOnce([{ id: "track1" }]);
+    mockGetArtistTracks.mockResolvedValueOnce([trackFixture("track1")]);
 
     const { selectedArtist, artistTracks, selectArtist, clearArtistSelection } =
       useGuestArtistTracks();
@@ -99,7 +100,7 @@ describe("useGuestArtistTracks", () => {
   });
 
   it("ignores the response of a selection that was cleared meanwhile", async () => {
-    let resolveTracks!: (tracks: unknown[]) => void;
+    let resolveTracks!: (tracks: Track[]) => void;
     mockGetArtistTracks.mockReturnValueOnce(
       new Promise((resolve) => {
         resolveTracks = resolve;
@@ -121,7 +122,7 @@ describe("useGuestArtistTracks", () => {
     clearArtistSelection();
     expect(loadingArtistTracks.value).toBe(false);
 
-    resolveTracks([{ id: "track1" }]);
+    resolveTracks([trackFixture("track1")]);
     await pending;
 
     expect(selectedArtist.value).toBeNull();
@@ -130,11 +131,11 @@ describe("useGuestArtistTracks", () => {
   });
 
   it("keeps only the latest selection when artists are picked rapidly", async () => {
-    let resolveFirst!: (tracks: unknown[]) => void;
-    const firstTracks = new Promise((resolve) => {
+    let resolveFirst!: (tracks: Track[]) => void;
+    const firstTracks = new Promise<Track[]>((resolve) => {
       resolveFirst = resolve;
     });
-    const secondTracks = [{ id: "second-track" }];
+    const secondTracks = [trackFixture("second-track")];
     mockGetArtistTracks
       .mockReturnValueOnce(firstTracks)
       .mockResolvedValueOnce(secondTracks);
@@ -153,7 +154,7 @@ describe("useGuestArtistTracks", () => {
       provider: "library",
     } as unknown as Artist);
     await second;
-    resolveFirst([{ id: "first-track" }]);
+    resolveFirst([trackFixture("first-track")]);
     await first;
 
     expect((selectedArtist.value as unknown as { name: string }).name).toBe(
@@ -162,3 +163,20 @@ describe("useGuestArtistTracks", () => {
     expect(artistTracks.value).toEqual(secondTracks);
   });
 });
+
+function trackFixture(itemId: string): Track {
+  return {
+    item_id: itemId,
+    provider: "library",
+    name: itemId,
+    uri: `library://track/${itemId}`,
+    is_playable: true,
+    media_type: MediaType.TRACK,
+    provider_mappings: [],
+    metadata: {},
+    favorite: false,
+    duration: 200,
+    artists: [],
+    album: null,
+  };
+}

--- a/tests/composables/useGuestQueue.test.ts
+++ b/tests/composables/useGuestQueue.test.ts
@@ -3,15 +3,18 @@ import {
   PlaybackState,
   type EventMessage,
   type PlayerQueue,
+  type QueueItem,
 } from "@/plugins/api/interfaces";
 import { BEFORE_FIRST_INDEX } from "@/helpers/queue_position";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { MusicAssistantApi } from "@/plugins/api";
 
 const { mockSendCommand, mockGetPlayerQueueItems, mockSubscribe } = vi.hoisted(
   () => {
     return {
       mockSendCommand: vi.fn(),
-      mockGetPlayerQueueItems: vi.fn(),
+      mockGetPlayerQueueItems:
+        vi.fn<MusicAssistantApi["getPlayerQueueItems"]>(),
       mockSubscribe: vi.fn(),
     };
   },
@@ -46,7 +49,7 @@ describe("useGuestQueue", () => {
       current_index: 5,
       items: 20,
     };
-    const items = [{ queue_item_id: "item1" }, { queue_item_id: "item2" }];
+    const items = [queueItemFixture("item1"), queueItemFixture("item2")];
 
     mockSendCommand.mockResolvedValueOnce(queue);
     mockGetPlayerQueueItems.mockResolvedValueOnce(items);
@@ -88,12 +91,12 @@ describe("useGuestQueue", () => {
       current_index: 0,
       items: 100,
     };
-    const initialItems = Array.from({ length: 50 }, (_, i) => ({
-      queue_item_id: `item-${i}`,
-    }));
-    const moreItems = Array.from({ length: 10 }, (_, i) => ({
-      queue_item_id: `item-${50 + i}`,
-    }));
+    const initialItems = Array.from({ length: 50 }, (_, i) =>
+      queueItemFixture(`item-${i}`),
+    );
+    const moreItems = Array.from({ length: 10 }, (_, i) =>
+      queueItemFixture(`item-${50 + i}`),
+    );
 
     mockSendCommand.mockResolvedValue(queue);
     mockGetPlayerQueueItems
@@ -199,7 +202,7 @@ describe("useGuestQueue", () => {
       current_index: 0,
       items: 1,
     });
-    mockGetPlayerQueueItems.mockResolvedValue([{ queue_item_id: "item1" }]);
+    mockGetPlayerQueueItems.mockResolvedValue([queueItemFixture("item1")]);
 
     const { partyQueueId, subscribeToEvents } = useGuestQueue();
     subscribeToEvents();
@@ -224,3 +227,14 @@ describe("useGuestQueue", () => {
     });
   });
 });
+
+function queueItemFixture(queueItemId: string): QueueItem {
+  return {
+    queue_id: "queue1",
+    queue_item_id: queueItemId,
+    name: queueItemId,
+    duration: 200,
+    sort_index: 0,
+    available: true,
+  };
+}

--- a/tests/composables/useProgressiveSearch.test.ts
+++ b/tests/composables/useProgressiveSearch.test.ts
@@ -1,17 +1,19 @@
 import {
   MediaType,
   ProviderFeature,
+  type Genre,
   type SearchResults,
   type Track,
 } from "@/plugins/api/interfaces";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { effectScope, nextTick, ref, type EffectScope } from "vue";
+import type { MusicAssistantApi } from "@/plugins/api";
 
 const { mockSearch, mockGetLibraryGenres, mockProviders, mockManifests } =
   vi.hoisted(() => {
     return {
-      mockSearch: vi.fn(),
-      mockGetLibraryGenres: vi.fn(),
+      mockSearch: vi.fn<MusicAssistantApi["search"]>(),
+      mockGetLibraryGenres: vi.fn<MusicAssistantApi["getLibraryGenres"]>(),
       mockProviders: {} as Record<string, unknown>,
       mockManifests: {} as Record<string, unknown>,
     };
@@ -48,13 +50,33 @@ const results = (partial: Partial<SearchResults>): SearchResults => ({
   ...partial,
 });
 
-const track = (itemId: string, name: string): Track =>
-  ({
-    item_id: itemId,
-    name,
-    uri: `test://track/${itemId}`,
-    media_type: MediaType.TRACK,
-  }) as Track;
+const track = (itemId: string, name: string): Track => ({
+  item_id: itemId,
+  provider: "library",
+  name,
+  uri: `test://track/${itemId}`,
+  is_playable: true,
+  media_type: MediaType.TRACK,
+  provider_mappings: [],
+  metadata: {},
+  favorite: false,
+  duration: 200,
+  artists: [],
+  album: null,
+});
+
+const genre = (itemId: string, name: string): Genre => ({
+  item_id: itemId,
+  provider: "library",
+  name,
+  uri: `test://genre/${itemId}`,
+  is_playable: false,
+  media_type: MediaType.GENRE,
+  provider_mappings: [],
+  metadata: {},
+  favorite: false,
+  genre_aliases: null,
+});
 
 const provider = (
   instanceId: string,
@@ -131,7 +153,7 @@ describe("useProgressiveSearch", () => {
 
   it("fires one request per target and merges results library first", async () => {
     mockSearch.mockImplementation(
-      (_query, _mediaTypes, _limit, providers: string[]) => {
+      (_query, _mediaTypes, _limit, providers: string[] = []) => {
         if (providers[0] === LIBRARY_SEARCH_TARGET)
           return Promise.resolve(results({ tracks: [track("l1", "Lib hit")] }));
         if (providers[0] === "spotify")
@@ -161,7 +183,7 @@ describe("useProgressiveSearch", () => {
 
   it("floats exact name matches above earlier fuzzy results", async () => {
     mockSearch.mockImplementation(
-      (_query, _mediaTypes, _limit, providers: string[]) => {
+      (_query, _mediaTypes, _limit, providers: string[] = []) => {
         if (providers[0] === LIBRARY_SEARCH_TARGET)
           return Promise.resolve(
             results({ tracks: [track("l1", "Queen tribute")] }),
@@ -247,7 +269,7 @@ describe("useProgressiveSearch", () => {
     vi.useFakeTimers();
     let spotifyCalls = 0;
     mockSearch.mockImplementation(
-      (_query, _mediaTypes, _limit, providers: string[]) => {
+      (_query, _mediaTypes, _limit, providers: string[] = []) => {
         if (providers[0] !== "spotify") return Promise.resolve(emptyResults());
         spotifyCalls += 1;
         if (spotifyCalls === 1) {
@@ -275,7 +297,7 @@ describe("useProgressiveSearch", () => {
   });
 
   it("searches only the library for a genre-only search", async () => {
-    const genres = [{ item_id: "g1", name: "Rock" }];
+    const genres = [genre("g1", "Rock")];
     mockGetLibraryGenres.mockResolvedValue(genres);
     const mediaTypes = ref<MediaType[]>([MediaType.GENRE]);
     const { search, searchResult } = setup({ mediaTypes });

--- a/tests/composables/useProgressiveSearch.test.ts
+++ b/tests/composables/useProgressiveSearch.test.ts
@@ -50,9 +50,9 @@ const results = (partial: Partial<SearchResults>): SearchResults => ({
   ...partial,
 });
 
-const track = (itemId: string, name: string): Track => ({
+const track = (itemId: string, name: string, provider = "library"): Track => ({
   item_id: itemId,
-  provider: "library",
+  provider,
   name,
   uri: `test://track/${itemId}`,
   is_playable: true,
@@ -158,7 +158,7 @@ describe("useProgressiveSearch", () => {
           return Promise.resolve(results({ tracks: [track("l1", "Lib hit")] }));
         if (providers[0] === "spotify")
           return Promise.resolve(
-            results({ tracks: [track("s1", "Spotify hit")] }),
+            results({ tracks: [track("s1", "Spotify hit", "spotify")] }),
           );
         return Promise.resolve(emptyResults());
       },
@@ -189,7 +189,9 @@ describe("useProgressiveSearch", () => {
             results({ tracks: [track("l1", "Queen tribute")] }),
           );
         if (providers[0] === "spotify")
-          return Promise.resolve(results({ tracks: [track("s1", "Queen")] }));
+          return Promise.resolve(
+            results({ tracks: [track("s1", "Queen", "spotify")] }),
+          );
         return Promise.resolve(emptyResults());
       },
     );
@@ -278,7 +280,9 @@ describe("useProgressiveSearch", () => {
             setTimeout(() => resolve(emptyResults()), 8000),
           );
         }
-        return Promise.resolve(results({ tracks: [track("s1", "Late")] }));
+        return Promise.resolve(
+          results({ tracks: [track("s1", "Late", "spotify")] }),
+        );
       },
     );
     const { search, searchResult, loading } = setup();

--- a/tests/composables/useShortcuts.test.ts
+++ b/tests/composables/useShortcuts.test.ts
@@ -1,9 +1,10 @@
 import { MediaType } from "@/plugins/api/interfaces";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { MusicAssistantApi } from "@/plugins/api";
 
 const { mockUpdateUser, storeMock } = vi.hoisted(() => {
   return {
-    mockUpdateUser: vi.fn(),
+    mockUpdateUser: vi.fn<MusicAssistantApi["updateUser"]>(),
     storeMock: {
       currentUser: {
         user_id: "user-1",

--- a/tests/composables/userPreferences.test.ts
+++ b/tests/composables/userPreferences.test.ts
@@ -1,8 +1,10 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { MusicAssistantApi } from "@/plugins/api";
+import { UserRole, type User } from "@/plugins/api/interfaces";
 
 const { mockUpdateUser, storeMock } = vi.hoisted(() => {
   return {
-    mockUpdateUser: vi.fn(),
+    mockUpdateUser: vi.fn<MusicAssistantApi["updateUser"]>(),
     storeMock: {
       currentUser: null as {
         user_id: string;
@@ -34,7 +36,7 @@ function readPrefs(path: string, itemtype: string) {
 describe("userPreferences - itemsListing", () => {
   beforeEach(() => {
     mockUpdateUser.mockReset();
-    mockUpdateUser.mockResolvedValue(undefined);
+    mockUpdateUser.mockResolvedValue(userFixture());
     storeMock.currentUser = { user_id: "u1", preferences: {} };
   });
 
@@ -111,3 +113,16 @@ describe("userPreferences - itemsListing", () => {
     expect(readPrefs("librarygenres", "genres").favoriteFilter).toBeUndefined();
   });
 });
+
+function userFixture(): User {
+  return {
+    user_id: "u1",
+    username: "u1",
+    role: UserRole.USER,
+    enabled: true,
+    created_at: "2024-01-01T00:00:00Z",
+    preferences: {},
+    provider_filter: [],
+    player_filter: [],
+  };
+}

--- a/tests/helpers/hass_controls.test.ts
+++ b/tests/helpers/hass_controls.test.ts
@@ -58,7 +58,7 @@ describe("getHassProviderInstance", () => {
 describe("addHassControlEntity", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    apiMock.saveProviderConfig.mockResolvedValue(providerConfig(null));
+    apiMock.saveProviderConfig.mockResolvedValue(providerConfig(["switch.tv"]));
   });
 
   it("appends the entity to the list the provider already holds", async () => {

--- a/tests/helpers/hass_controls.test.ts
+++ b/tests/helpers/hass_controls.test.ts
@@ -2,6 +2,13 @@ import {
   addHassControlEntity,
   getHassProviderInstance,
 } from "@/helpers/hass_controls";
+import type { MusicAssistantApi } from "@/plugins/api";
+import {
+  ConfigEntryType,
+  ProviderStage,
+  ProviderType,
+  type ProviderConfig,
+} from "@/plugins/api/interfaces";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const { apiMock } = vi.hoisted(() => ({
@@ -10,8 +17,8 @@ const { apiMock } = vi.hoisted(() => ({
       string,
       { instance_id: string; domain: string; available: boolean }
     >,
-    getProviderConfig: vi.fn(),
-    saveProviderConfig: vi.fn(),
+    getProviderConfig: vi.fn<MusicAssistantApi["getProviderConfig"]>(),
+    saveProviderConfig: vi.fn<MusicAssistantApi["saveProviderConfig"]>(),
   },
 }));
 
@@ -51,7 +58,7 @@ describe("getHassProviderInstance", () => {
 describe("addHassControlEntity", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    apiMock.saveProviderConfig.mockResolvedValue({});
+    apiMock.saveProviderConfig.mockResolvedValue(providerConfig(null));
   });
 
   it("appends the entity to the list the provider already holds", async () => {
@@ -88,9 +95,41 @@ describe("addHassControlEntity", () => {
 });
 
 function givenControls(value: string[] | null) {
-  apiMock.getProviderConfig.mockResolvedValue({
+  apiMock.getProviderConfig.mockResolvedValue(providerConfig(value));
+}
+
+function providerConfig(value: string[] | null): ProviderConfig {
+  return {
+    type: ProviderType.PLUGIN,
     domain: "hass",
     instance_id: "hass--1",
-    values: { power_controls: { key: "power_controls", value } },
-  });
+    enabled: true,
+    manifest: {
+      type: ProviderType.PLUGIN,
+      domain: "hass",
+      name: "Home Assistant",
+      description: "Home Assistant integration",
+      codeowners: [],
+      credits: [],
+      requirements: [],
+      multi_instance: false,
+      builtin: false,
+      allow_disable: true,
+      stage: ProviderStage.STABLE,
+      icon_images: [],
+    },
+    values: {
+      power_controls: {
+        key: "power_controls",
+        type: ConfigEntryType.STRING,
+        label: "Power controls",
+        default_value: [],
+        required: false,
+        options: [],
+        category: "generic",
+        multi_value: true,
+        value,
+      },
+    },
+  };
 }

--- a/tests/helpers/playBtnErrorFeedback.test.ts
+++ b/tests/helpers/playBtnErrorFeedback.test.ts
@@ -4,11 +4,12 @@
  * failures were swallowed, leaving the play button a silent no-op
  * (e.g. while the API connection is re-establishing after a server restart).
  */
+import type { MusicAssistantApi } from "@/plugins/api";
 import { describe, expect, it, vi, beforeEach } from "vitest";
 
 const { mockPlayMedia, mockShowPlayMenu, mockToastError, mockStore } =
   vi.hoisted(() => ({
-    mockPlayMedia: vi.fn(),
+    mockPlayMedia: vi.fn<MusicAssistantApi["playMedia"]>(),
     mockShowPlayMenu: vi.fn(),
     mockToastError: vi.fn(),
     mockStore: {

--- a/tests/helpers/playFromHereSort.test.ts
+++ b/tests/helpers/playFromHereSort.test.ts
@@ -2,11 +2,12 @@
  * Tests that "play from here" actions correctly pass the sortBy parameter
  * through handlePlayBtnClick and handleMenuBtnClick to the API / context menu.
  */
+import type { MusicAssistantApi } from "@/plugins/api";
 import { describe, expect, it, vi, beforeEach } from "vitest";
 
 const { mockPlayMedia, mockShowContextMenu, mockShowPlayMenu } = vi.hoisted(
   () => ({
-    mockPlayMedia: vi.fn(),
+    mockPlayMedia: vi.fn<MusicAssistantApi["playMedia"]>(),
     mockShowContextMenu: vi.fn(),
     mockShowPlayMenu: vi.fn(),
   }),

--- a/tests/layouts/PlayerBrowserMediaControls.test.ts
+++ b/tests/layouts/PlayerBrowserMediaControls.test.ts
@@ -1,4 +1,5 @@
 import PlayerBrowserMediaControls from "@/layouts/default/PlayerOSD/PlayerBrowserMediaControls.vue";
+import type { MusicAssistantApi } from "@/plugins/api";
 import { PlaybackState } from "@/plugins/api/interfaces";
 import { mount } from "@vue/test-utils";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -23,7 +24,7 @@ const {
   mockPlayerCommandSeek,
   mockUseMediaBrowserMetaData,
 } = vi.hoisted(() => {
-  const mockPlayerCommandSeek = vi.fn();
+  const mockPlayerCommandSeek = vi.fn<MusicAssistantApi["playerCommandSeek"]>();
   return {
     apiMock: {
       players: {} as Record<string, MockPlayer>,
@@ -32,10 +33,11 @@ const {
         string,
         { elapsed_time?: number; elapsed_time_last_updated?: number }
       >,
-      playerCommandPlay: vi.fn(),
-      playerCommandPause: vi.fn(),
-      playerCommandNext: vi.fn(),
-      playerCommandPrevious: vi.fn(),
+      playerCommandPlay: vi.fn<MusicAssistantApi["playerCommandPlay"]>(),
+      playerCommandPause: vi.fn<MusicAssistantApi["playerCommandPause"]>(),
+      playerCommandNext: vi.fn<MusicAssistantApi["playerCommandNext"]>(),
+      playerCommandPrevious:
+        vi.fn<MusicAssistantApi["playerCommandPrevious"]>(),
       playerCommandSeek: mockPlayerCommandSeek,
     },
     storeMock: {

--- a/tests/layouts/PlayerFullscreen.test.ts
+++ b/tests/layouts/PlayerFullscreen.test.ts
@@ -1,5 +1,6 @@
 import { EMPTY_COLOR_PALETTE } from "@/helpers/utils";
 import PlayerFullscreen from "@/layouts/default/PlayerOSD/PlayerFullscreen.vue";
+import type { MusicAssistantApi } from "@/plugins/api";
 import { PlaybackState } from "@/plugins/api/interfaces";
 import { shallowMount, type VueWrapper } from "@vue/test-utils";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -14,7 +15,7 @@ vi.mock("@/plugins/api", async () => {
     queues: {},
     queueElapsedTime: {},
     subscribe: vi.fn(() => vi.fn()),
-    getTrackLyrics: vi.fn(),
+    getTrackLyrics: vi.fn<MusicAssistantApi["getTrackLyrics"]>(),
   });
   return { api, default: api };
 });

--- a/tests/layouts/PlayerTimeline.test.ts
+++ b/tests/layouts/PlayerTimeline.test.ts
@@ -1,5 +1,5 @@
 import PlayerTimeline from "@/layouts/default/PlayerOSD/PlayerTimeline.vue";
-import apiDefault from "@/plugins/api";
+import apiDefault, { type MusicAssistantApi } from "@/plugins/api";
 import { PlaybackState } from "@/plugins/api/interfaces";
 import { store as storeModule } from "@/plugins/store";
 import { mount, type VueWrapper } from "@vue/test-utils";
@@ -13,8 +13,8 @@ vi.mock("@/plugins/api", async () => {
   const api = reactive({
     queues: {},
     queueElapsedTime: {},
-    playerCommandSeek: vi.fn(),
-    playMedia: vi.fn(),
+    playerCommandSeek: vi.fn<MusicAssistantApi["playerCommandSeek"]>(),
+    playMedia: vi.fn<MusicAssistantApi["playMedia"]>(),
   });
   return { api, default: api };
 });

--- a/tests/layouts/PlayerVolume.test.ts
+++ b/tests/layouts/PlayerVolume.test.ts
@@ -1,5 +1,5 @@
 import PlayerVolume from "@/layouts/default/PlayerOSD/PlayerVolume.vue";
-import { api } from "@/plugins/api";
+import { api, type MusicAssistantApi } from "@/plugins/api";
 import {
   IdentifierType,
   PlaybackState,
@@ -18,14 +18,21 @@ vi.mock("@/plugins/api", async () => {
   const { reactive } = await vi.importActual<typeof import("vue")>("vue");
   const api = reactive({
     players: {} as Record<string, Player>,
-    playerCommandGroupVolume: vi.fn(),
-    playerCommandGroupVolumeDown: vi.fn(),
-    playerCommandGroupVolumeMute: vi.fn(),
-    playerCommandGroupVolumeUp: vi.fn(),
-    playerCommandMuteToggle: vi.fn(),
-    playerCommandVolumeDown: vi.fn(),
-    playerCommandVolumeSet: vi.fn(),
-    playerCommandVolumeUp: vi.fn(),
+    playerCommandGroupVolume:
+      vi.fn<MusicAssistantApi["playerCommandGroupVolume"]>(),
+    playerCommandGroupVolumeDown:
+      vi.fn<MusicAssistantApi["playerCommandGroupVolumeDown"]>(),
+    playerCommandGroupVolumeMute:
+      vi.fn<MusicAssistantApi["playerCommandGroupVolumeMute"]>(),
+    playerCommandGroupVolumeUp:
+      vi.fn<MusicAssistantApi["playerCommandGroupVolumeUp"]>(),
+    playerCommandMuteToggle:
+      vi.fn<MusicAssistantApi["playerCommandMuteToggle"]>(),
+    playerCommandVolumeDown:
+      vi.fn<MusicAssistantApi["playerCommandVolumeDown"]>(),
+    playerCommandVolumeSet:
+      vi.fn<MusicAssistantApi["playerCommandVolumeSet"]>(),
+    playerCommandVolumeUp: vi.fn<MusicAssistantApi["playerCommandVolumeUp"]>(),
   });
   return { api, default: api };
 });

--- a/tests/views/EditCoreConfig.test.ts
+++ b/tests/views/EditCoreConfig.test.ts
@@ -11,7 +11,7 @@ import EditCoreConfig from "@/views/settings/EditCoreConfig.vue";
 
 const { apiMock, routerMock, toastMock } = vi.hoisted(() => ({
   apiMock: {
-    getCoreConfig: vi.fn(),
+    getCoreConfig: vi.fn<MusicAssistantApi["getCoreConfig"]>(),
     invokeCoreConfigAction:
       vi.fn<MusicAssistantApi["invokeCoreConfigAction"]>(),
     providerManifests: {
@@ -23,7 +23,7 @@ const { apiMock, routerMock, toastMock } = vi.hoisted(() => ({
         name: "Cache",
       },
     },
-    saveCoreConfig: vi.fn(),
+    saveCoreConfig: vi.fn<MusicAssistantApi["saveCoreConfig"]>(),
   },
   routerMock: {
     push: vi.fn(),

--- a/tests/views/EditPlayer.test.ts
+++ b/tests/views/EditPlayer.test.ts
@@ -5,24 +5,29 @@ import {
 import {
   ConfigEntryType,
   PlayerType,
+  ProviderStage,
+  ProviderType,
   type ConfigEntry,
   type PlayerConfig,
+  type ProviderInstance,
+  type ProviderManifest,
 } from "@/plugins/api/interfaces";
+import type { MusicAssistantApi } from "@/plugins/api";
 import EditPlayer from "@/views/settings/EditPlayer.vue";
 import { flushPromises, shallowMount } from "@vue/test-utils";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const { apiMock, eventbusMock, routerMock, toastMock } = vi.hoisted(() => ({
   apiMock: {
-    getDSPConfig: vi.fn(),
-    getPlayerConfig: vi.fn(),
-    getProvider: vi.fn(),
-    getProviderManifest: vi.fn(),
+    getDSPConfig: vi.fn<MusicAssistantApi["getDSPConfig"]>(),
+    getPlayerConfig: vi.fn<MusicAssistantApi["getPlayerConfig"]>(),
+    getProvider: vi.fn<MusicAssistantApi["getProvider"]>(),
+    getProviderManifest: vi.fn<MusicAssistantApi["getProviderManifest"]>(),
     players: {} as Record<string, unknown>,
     providerManifests: {} as Record<string, unknown>,
     providers: {} as Record<string, unknown>,
-    reloadProvider: vi.fn(),
-    savePlayerConfig: vi.fn(),
+    reloadProvider: vi.fn<MusicAssistantApi["reloadProvider"]>(),
+    savePlayerConfig: vi.fn<MusicAssistantApi["savePlayerConfig"]>(),
     subscribe: vi.fn(),
   },
   eventbusMock: {
@@ -81,16 +86,15 @@ describe("EditPlayer", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     apiMock.subscribe.mockReturnValue(vi.fn());
-    apiMock.getDSPConfig.mockResolvedValue({ enabled: false });
-    apiMock.getPlayerConfig.mockResolvedValue(playerConfig());
-    apiMock.getProvider.mockReturnValue({
-      available: true,
-      domain: "chromecast",
-      instance_id: "chromecast--1",
-      name: "Chromecast",
-      supported_features: [],
+    apiMock.getDSPConfig.mockResolvedValue({
+      enabled: false,
+      filters: [],
+      input_gain: 0,
+      output_gain: 0,
     });
-    apiMock.getProviderManifest.mockReturnValue({ domain: "chromecast" });
+    apiMock.getPlayerConfig.mockResolvedValue(playerConfig());
+    apiMock.getProvider.mockReturnValue(providerInstance());
+    apiMock.getProviderManifest.mockReturnValue(providerManifest());
     apiMock.reloadProvider.mockResolvedValue(undefined);
     apiMock.savePlayerConfig.mockResolvedValue(playerConfig());
     apiMock.providerManifests = { chromecast: { name: "Chromecast" } };
@@ -469,6 +473,34 @@ function controlEntry(key: string): ConfigEntry {
     default_value: "none",
     value: "none",
     options: [{ title: "none", value: "none" }],
+  };
+}
+
+function providerManifest(): ProviderManifest {
+  return {
+    type: ProviderType.PLAYER,
+    domain: "chromecast",
+    name: "Chromecast",
+    description: "",
+    codeowners: [],
+    credits: [],
+    requirements: [],
+    multi_instance: false,
+    builtin: false,
+    allow_disable: true,
+    stage: ProviderStage.STABLE,
+    icon_images: [],
+  };
+}
+
+function providerInstance(): ProviderInstance {
+  return {
+    type: ProviderType.PLAYER,
+    domain: "chromecast",
+    instance_id: "chromecast--1",
+    name: "Chromecast",
+    available: true,
+    supported_features: [],
   };
 }
 

--- a/tests/views/EditPlayerDsp.test.ts
+++ b/tests/views/EditPlayerDsp.test.ts
@@ -7,18 +7,19 @@ import type {
   ToneControlFilter,
 } from "@/plugins/api/interfaces";
 import { DSPFilterType, EventType } from "@/plugins/api/interfaces";
+import type { MusicAssistantApi } from "@/plugins/api";
 import EditPlayerDsp from "@/views/settings/EditPlayerDsp.vue";
 
 const apiMock = vi.hoisted(() => ({
-  applyDSPPreset: vi.fn(),
-  getDSPConfig: vi.fn(),
+  applyDSPPreset: vi.fn<MusicAssistantApi["applyDSPPreset"]>(),
+  getDSPConfig: vi.fn<MusicAssistantApi["getDSPConfig"]>(),
   playerDSPCallback: undefined as
     | ((event: { data: DSPConfig }) => void)
     | undefined,
   players: { "player-1": {} },
-  removeDSPPreset: vi.fn(),
-  saveDSPConfig: vi.fn(),
-  saveDSPPreset: vi.fn(),
+  removeDSPPreset: vi.fn<MusicAssistantApi["removeDSPPreset"]>(),
+  saveDSPConfig: vi.fn<MusicAssistantApi["saveDSPConfig"]>(),
+  saveDSPPreset: vi.fn<MusicAssistantApi["saveDSPPreset"]>(),
   subscribe: vi.fn(),
   unsubscribe: vi.fn(),
 }));

--- a/tests/views/EditProvider.test.ts
+++ b/tests/views/EditProvider.test.ts
@@ -6,24 +6,19 @@ import {
   ProviderStage,
   ProviderStatus,
   ProviderType,
-  type ConfigActionResult,
   type ConfigEntry,
   type ProviderConfig,
 } from "@/plugins/api/interfaces";
+import type { MusicAssistantApi } from "@/plugins/api";
 import EditProvider from "@/views/settings/EditProvider.vue";
 
 const { apiMock, eventbusMock, routerMock, toastMock, unsubscribeMock } =
   vi.hoisted(() => ({
     apiMock: {
-      getProvider: vi.fn(),
-      getProviderConfig: vi.fn(),
+      getProvider: vi.fn<MusicAssistantApi["getProvider"]>(),
+      getProviderConfig: vi.fn<MusicAssistantApi["getProviderConfig"]>(),
       invokeProviderConfigAction:
-        vi.fn<
-          (
-            instanceId: string,
-            action: string,
-          ) => Promise<ConfigEntry[] | ConfigActionResult>
-        >(),
+        vi.fn<MusicAssistantApi["invokeProviderConfigAction"]>(),
       providerManifests: {
         spotify: {
           allow_disable: true,
@@ -36,9 +31,9 @@ const { apiMock, eventbusMock, routerMock, toastMock, unsubscribeMock } =
         },
       },
       providers: {},
-      reloadProvider: vi.fn(),
-      removeProviderConfig: vi.fn(),
-      saveProviderConfig: vi.fn(),
+      reloadProvider: vi.fn<MusicAssistantApi["reloadProvider"]>(),
+      removeProviderConfig: vi.fn<MusicAssistantApi["removeProviderConfig"]>(),
+      saveProviderConfig: vi.fn<MusicAssistantApi["saveProviderConfig"]>(),
       subscribe: vi.fn(),
     },
     eventbusMock: {

--- a/tests/views/HassControlFields.test.ts
+++ b/tests/views/HassControlFields.test.ts
@@ -4,7 +4,13 @@ import type {
 } from "@/helpers/config_entry_ui";
 import { UI_ENTRY_TYPE } from "@/helpers/config_entry_ui";
 import type { HassControlEntity } from "@/helpers/hass_controls";
-import { ConfigEntryType } from "@/plugins/api/interfaces";
+import {
+  ConfigEntryType,
+  ProviderStage,
+  ProviderType,
+  type ProviderConfig,
+} from "@/plugins/api/interfaces";
+import type { MusicAssistantApi } from "@/plugins/api";
 import HassControlPickerField from "@/views/settings/fields/HassControlPickerField.vue";
 import HassControlsField from "@/views/settings/fields/HassControlsField.vue";
 import { flushPromises, mount } from "@vue/test-utils";
@@ -15,9 +21,9 @@ import * as directives from "vuetify/directives";
 
 const { apiMock } = vi.hoisted(() => ({
   apiMock: {
-    getProviderConfig: vi.fn(),
-    saveProviderConfig: vi.fn(),
-    savePlayerConfig: vi.fn(),
+    getProviderConfig: vi.fn<MusicAssistantApi["getProviderConfig"]>(),
+    saveProviderConfig: vi.fn<MusicAssistantApi["saveProviderConfig"]>(),
+    savePlayerConfig: vi.fn<MusicAssistantApi["savePlayerConfig"]>(),
   },
 }));
 
@@ -50,14 +56,8 @@ const PICKED_ENTITY: HassControlEntity = {
 describe("HassControlPickerField", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    apiMock.getProviderConfig.mockResolvedValue({
-      domain: "hass",
-      instance_id: "hass--1",
-      values: {
-        power_controls: { key: "power_controls", value: ["switch.tv"] },
-      },
-    });
-    apiMock.saveProviderConfig.mockResolvedValue({});
+    apiMock.getProviderConfig.mockResolvedValue(hassProviderConfig());
+    apiMock.saveProviderConfig.mockResolvedValue(hassProviderConfig());
   });
 
   it("registers the picked entity with the Home Assistant provider and fills in the player entry", async () => {
@@ -145,6 +145,44 @@ describe("HassControlsField", () => {
     ).toEqual(["switch.tv"]);
   });
 });
+
+function hassProviderConfig(
+  powerControls: string[] = ["switch.tv"],
+): ProviderConfig {
+  return {
+    type: ProviderType.PLUGIN,
+    domain: "hass",
+    instance_id: "hass--1",
+    enabled: true,
+    manifest: {
+      type: ProviderType.PLUGIN,
+      domain: "hass",
+      name: "Home Assistant",
+      description: "Home Assistant integration",
+      codeowners: [],
+      credits: [],
+      requirements: [],
+      multi_instance: false,
+      builtin: false,
+      allow_disable: true,
+      stage: ProviderStage.STABLE,
+      icon_images: [],
+    },
+    values: {
+      power_controls: {
+        key: "power_controls",
+        type: ConfigEntryType.STRING,
+        label: "Power controls",
+        default_value: [],
+        required: false,
+        options: [],
+        category: "generic",
+        multi_value: true,
+        value: powerControls,
+      },
+    },
+  };
+}
 
 function pickerEntry(): HassControlPickerEntry {
   return {

--- a/tests/views/HassControlFields.test.ts
+++ b/tests/views/HassControlFields.test.ts
@@ -146,9 +146,7 @@ describe("HassControlsField", () => {
   });
 });
 
-function hassProviderConfig(
-  powerControls: string[] = ["switch.tv"],
-): ProviderConfig {
+function hassProviderConfig(): ProviderConfig {
   return {
     type: ProviderType.PLUGIN,
     domain: "hass",
@@ -178,7 +176,7 @@ function hassProviderConfig(
         options: [],
         category: "generic",
         multi_value: true,
-        value: powerControls,
+        value: ["switch.tv"],
       },
     },
   };

--- a/tests/views/Login.test.ts
+++ b/tests/views/Login.test.ts
@@ -1,16 +1,18 @@
 import Login from "@/views/Login.vue";
+import type { MusicAssistantApi } from "@/plugins/api";
+import { UserRole, type User } from "@/plugins/api/interfaces";
 import { flushPromises, mount, type VueWrapper } from "@vue/test-utils";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
   apiState: { value: "disconnected" as string },
-  authenticateWithToken: vi.fn(),
+  authenticateWithToken: vi.fn<MusicAssistantApi["authenticateWithToken"]>(),
   clearAuth: vi.fn(),
   clearGuestSession: vi.fn(),
   connectRemote: vi.fn(),
   disconnectRemote: vi.fn(),
   endRejectedGuestSession: vi.fn(),
-  getCurrentUserInfo: vi.fn(),
+  getCurrentUserInfo: vi.fn<MusicAssistantApi["getCurrentUserInfo"]>(),
   getPersistentToken: vi.fn(),
   getToken: vi.fn(),
   getStoredRemoteId: vi.fn(),
@@ -45,7 +47,7 @@ vi.mock("@/plugins/api", async () => {
     },
     api: {
       authenticateWithToken: mocks.authenticateWithToken,
-      disconnect: vi.fn(),
+      disconnect: vi.fn<MusicAssistantApi["disconnect"]>(),
       getCurrentUserInfo: mocks.getCurrentUserInfo,
       sendCommand: mocks.sendCommand,
       serverInfo: mocks.serverInfo,
@@ -200,7 +202,11 @@ function mockHostedFrontend() {
 }
 
 function mockSuccessfulGuest(username = "party_guest") {
-  const guestUser = { user_id: "guest-id", username, role: "guest" };
+  const guestUser = testUser({
+    user_id: "guest-id",
+    username,
+    role: UserRole.GUEST,
+  });
   mocks.sendCommand.mockImplementation((command: string) => {
     if (command === "auth/join_code/exchange") {
       return Promise.resolve({
@@ -216,13 +222,27 @@ function mockSuccessfulGuest(username = "party_guest") {
       user:
         token === "guest-token"
           ? guestUser
-          : {
+          : testUser({
               user_id: "regular-id",
               username: "regular-user",
-              role: "admin",
-            },
+              role: UserRole.ADMIN,
+            }),
     }),
   );
+}
+
+function testUser(overrides: Partial<User> = {}): User {
+  return {
+    user_id: "user-id",
+    username: "user",
+    role: UserRole.USER,
+    enabled: true,
+    created_at: "2024-01-01T00:00:00Z",
+    preferences: {},
+    provider_filter: [],
+    player_filter: [],
+    ...overrides,
+  };
 }
 
 beforeEach(() => {
@@ -276,11 +296,13 @@ beforeEach(() => {
       ? localStorage.getItem("ma_access_token")
       : null,
   );
-  mocks.getCurrentUserInfo.mockResolvedValue({
-    user_id: "ingress-user",
-    username: "ingress-user",
-    role: "admin",
-  });
+  mocks.getCurrentUserInfo.mockResolvedValue(
+    testUser({
+      user_id: "ingress-user",
+      username: "ingress-user",
+      role: UserRole.ADMIN,
+    }),
+  );
   mocks.serverInfo.value = {
     homeassistant_addon: false,
     server_id: "server-id",
@@ -317,7 +339,11 @@ describe("guest join login", () => {
         [
           {
             token: "guest-token",
-            user: { user_id: "guest-id", username, role: "guest" },
+            user: testUser({
+              user_id: "guest-id",
+              username,
+              role: UserRole.GUEST,
+            }),
           },
         ],
       ]);
@@ -411,11 +437,11 @@ describe("guest join login", () => {
     await flushPromises();
     expect(wrapper.emitted("authenticated")?.[0]?.[0]).toEqual({
       token: "admin-token",
-      user: {
+      user: testUser({
         user_id: "regular-id",
         username: "regular-user",
-        role: "admin",
-      },
+        role: UserRole.ADMIN,
+      }),
     });
     expect(mocks.clearAuth).not.toHaveBeenCalled();
     expect(localStorage.getItem("ma_access_token")).toBe("admin-token");
@@ -541,11 +567,11 @@ describe("guest join login", () => {
     await flushPromises();
     expect(wrapper.emitted("authenticated")?.[0]?.[0]).toEqual({
       token: "admin-token",
-      user: {
+      user: testUser({
         user_id: "regular-id",
         username: "regular-user",
-        role: "admin",
-      },
+        role: UserRole.ADMIN,
+      }),
     });
     expect(mocks.authenticateWithToken).toHaveBeenCalledWith("admin-token");
     expect(mocks.sendCommand).not.toHaveBeenCalledWith(
@@ -572,11 +598,11 @@ describe("guest join login", () => {
     await flushPromises();
     expect(wrapper.emitted("authenticated")?.[0]?.[0]).toEqual({
       token: "guest-token",
-      user: {
+      user: testUser({
         user_id: "guest-id",
         username: "party_guest",
-        role: "guest",
-      },
+        role: UserRole.GUEST,
+      }),
     });
     expect(mocks.authenticateWithToken).not.toHaveBeenCalledWith("admin-token");
     expect(mocks.sendCommand).toHaveBeenCalledWith("auth/join_code/exchange", {
@@ -634,11 +660,11 @@ describe("guest join login", () => {
 
     await flushPromises();
     expect(wrapper.emitted("authenticated")?.[0]?.[0]).toEqual({
-      user: {
+      user: testUser({
         user_id: "ingress-user",
         username: "ingress-user",
-        role: "admin",
-      },
+        role: UserRole.ADMIN,
+      }),
     });
 
     expect(mocks.getCurrentUserInfo).toHaveBeenCalledOnce();
@@ -789,11 +815,11 @@ describe("ingress login", () => {
 
     await flushPromises();
     expect(wrapper.emitted("authenticated")?.[0]?.[0]).toEqual({
-      user: {
-        role: "admin",
+      user: testUser({
+        role: UserRole.ADMIN,
         user_id: "ingress-user",
         username: "ingress-user",
-      },
+      }),
     });
     expect(mocks.getCurrentUserInfo).toHaveBeenCalledOnce();
     expect(mocks.authenticateWithToken).not.toHaveBeenCalled();
@@ -809,11 +835,11 @@ describe("ingress login", () => {
     await flushPromises();
     expect(wrapper.emitted("authenticated")?.[0]?.[0]).toEqual({
       token: "admin-token",
-      user: {
-        role: "admin",
+      user: testUser({
+        role: UserRole.ADMIN,
         user_id: "regular-id",
         username: "regular-user",
-      },
+      }),
     });
     expect(mocks.authenticateWithToken).toHaveBeenCalledWith("admin-token");
     expect(mocks.getCurrentUserInfo).not.toHaveBeenCalled();

--- a/tests/views/MusicQuizDashboardView.test.ts
+++ b/tests/views/MusicQuizDashboardView.test.ts
@@ -1,5 +1,10 @@
 import MusicQuizDashboardView from "@/views/MusicQuizDashboardView.vue";
-import { ProviderType } from "@/plugins/api/interfaces";
+import {
+  ProviderStage,
+  ProviderType,
+  type ProviderConfig,
+} from "@/plugins/api/interfaces";
+import type { MusicAssistantApi } from "@/plugins/api";
 import { flushPromises, mount } from "@vue/test-utils";
 import { nextTick } from "vue";
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -18,7 +23,7 @@ const {
   mockAdminState: {
     current: undefined as { value: boolean } | undefined,
   },
-  mockGetProviderConfigs: vi.fn(),
+  mockGetProviderConfigs: vi.fn<MusicAssistantApi["getProviderConfigs"]>(),
   mockResolveMusicQuizDefinition: vi.fn(),
   mockRouterPush: vi.fn(),
   mockSendCommand: vi.fn(),
@@ -197,7 +202,7 @@ describe("MusicQuizDashboardView", () => {
   it("resolves the admin settings shortcut and routes to its provider config", async () => {
     if (mockAdminState.current) mockAdminState.current.value = true;
     mockGetProviderConfigs.mockResolvedValue([
-      { instance_id: "music_quiz--instance" },
+      musicQuizProviderConfig("music_quiz--instance"),
     ]);
     const wrapper = mountDashboard();
     await flushPromises();
@@ -239,7 +244,7 @@ describe("MusicQuizDashboardView", () => {
 
   it("resolves the settings shortcut when admin access arrives after mount", async () => {
     mockGetProviderConfigs.mockResolvedValue([
-      { instance_id: "music_quiz--instance" },
+      musicQuizProviderConfig("music_quiz--instance"),
     ]);
     const wrapper = mountDashboard();
     await flushPromises();
@@ -295,6 +300,30 @@ describe("MusicQuizDashboardView", () => {
     expect(mockRouterPush).toHaveBeenCalledWith({ name: "guest-quiz" });
   });
 });
+
+function musicQuizProviderConfig(instanceId: string): ProviderConfig {
+  return {
+    type: ProviderType.PLUGIN,
+    domain: "music_quiz",
+    instance_id: instanceId,
+    enabled: true,
+    manifest: {
+      type: ProviderType.PLUGIN,
+      domain: "music_quiz",
+      name: "Music Quiz",
+      description: "Music Quiz plugin provider",
+      codeowners: [],
+      credits: [],
+      requirements: [],
+      multi_instance: false,
+      builtin: false,
+      allow_disable: true,
+      stage: ProviderStage.STABLE,
+      icon_images: [],
+    },
+    values: {},
+  };
+}
 
 function mountDashboard() {
   return mount(MusicQuizDashboardView, {

--- a/tests/views/MusicQuizPlayerView.test.ts
+++ b/tests/views/MusicQuizPlayerView.test.ts
@@ -1,5 +1,6 @@
 import MusicQuizPlayerView from "@/views/MusicQuizPlayerView.vue";
 import MusicQuizJoinForm from "@/components/music-quiz/MusicQuizJoinForm.vue";
+import type { MusicAssistantApi } from "@/plugins/api";
 import { webPlayer } from "@/plugins/web_player";
 import { flushPromises, mount } from "@vue/test-utils";
 import { h, nextTick, ref } from "vue";
@@ -20,7 +21,7 @@ const {
   apiMock: { state: { value: "connected" as string } },
   mockGameAdapterSetup: vi.fn(),
   mockGetMusicQuizRoundScore: vi.fn(),
-  mockGetTrackLyrics: vi.fn(),
+  mockGetTrackLyrics: vi.fn<MusicAssistantApi["getTrackLyrics"]>(),
   mockListenInSetup: vi.fn(),
   mockPrimeAudio: vi.fn(),
   mockResolveMusicQuizDefinition: vi.fn(),

--- a/tests/views/Players.test.ts
+++ b/tests/views/Players.test.ts
@@ -1,13 +1,15 @@
 import Players from "@/views/settings/Players.vue";
+import type { MusicAssistantApi } from "@/plugins/api";
+import { ProviderStage, ProviderType } from "@/plugins/api/interfaces";
 import { flushPromises, mount } from "@vue/test-utils";
 import { ref } from "vue";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const { apiMock, emitEvent, routerPush } = vi.hoisted(() => ({
   apiMock: {
-    getPlayerConfigs: vi.fn(),
-    getProvider: vi.fn(),
-    getProviderManifest: vi.fn(),
+    getPlayerConfigs: vi.fn<MusicAssistantApi["getPlayerConfigs"]>(),
+    getProvider: vi.fn<MusicAssistantApi["getProvider"]>(),
+    getProviderManifest: vi.fn<MusicAssistantApi["getProviderManifest"]>(),
     playerManifests: {},
     players: {} as Record<
       string,
@@ -98,11 +100,26 @@ describe("Players", () => {
     };
     apiMock.getPlayerConfigs.mockResolvedValue([playerConfig]);
     apiMock.getProvider.mockReturnValue({
+      type: ProviderType.PLAYER,
       domain: "test",
+      name: "Test",
+      instance_id: "test",
       supported_features: [],
+      available: true,
     });
     apiMock.getProviderManifest.mockReturnValue({
+      type: ProviderType.PLAYER,
+      domain: "test",
       name: "Test",
+      description: "Test player provider",
+      codeowners: [],
+      credits: [],
+      requirements: [],
+      multi_instance: false,
+      builtin: false,
+      allow_disable: true,
+      stage: ProviderStage.STABLE,
+      icon_images: [],
     });
     apiMock.subscribe_multi.mockReturnValue(vi.fn());
   });

--- a/tests/views/Providers.test.ts
+++ b/tests/views/Providers.test.ts
@@ -1,13 +1,18 @@
 import { flushPromises, shallowMount } from "@vue/test-utils";
 import { ref } from "vue";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { ProviderStatus, ProviderType } from "@/plugins/api/interfaces";
+import {
+  ProviderStage,
+  ProviderStatus,
+  ProviderType,
+} from "@/plugins/api/interfaces";
+import type { MusicAssistantApi } from "@/plugins/api";
 import Providers from "@/views/settings/Providers.vue";
 
 const { apiMock, eventbusMock, routeMock, routerMock } = vi.hoisted(() => ({
   apiMock: {
-    getProvider: vi.fn(),
-    getProviderConfigs: vi.fn(),
+    getProvider: vi.fn<MusicAssistantApi["getProvider"]>(),
+    getProviderConfigs: vi.fn<MusicAssistantApi["getProviderConfigs"]>(),
     providerManifests: {
       spotify: {
         allow_disable: true,
@@ -20,10 +25,10 @@ const { apiMock, eventbusMock, routeMock, routerMock } = vi.hoisted(() => ({
       },
     },
     providers: {},
-    reloadProvider: vi.fn(),
-    removeProviderConfig: vi.fn(),
-    saveProviderConfig: vi.fn(),
-    startSync: vi.fn(),
+    reloadProvider: vi.fn<MusicAssistantApi["reloadProvider"]>(),
+    removeProviderConfig: vi.fn<MusicAssistantApi["removeProviderConfig"]>(),
+    saveProviderConfig: vi.fn<MusicAssistantApi["saveProviderConfig"]>(),
+    startSync: vi.fn<MusicAssistantApi["startSync"]>(),
     subscribe: vi.fn(),
   },
   eventbusMock: {
@@ -273,9 +278,26 @@ async function mountProviders(
         error_code: 1,
         message: "Authentication required",
       },
+      manifest: {
+        allow_disable: true,
+        builtin: false,
+        codeowners: [],
+        credits: [],
+        description: "Spotify music provider",
+        documentation: "https://example.com",
+        domain: "spotify",
+        has_setup_flow: hasSetupFlow,
+        icon_images: [],
+        multi_instance: true,
+        name: "Spotify",
+        requirements: [],
+        stage: ProviderStage.STABLE,
+        type: ProviderType.MUSIC,
+      },
       name: "Spotify",
       status,
       type: ProviderType.MUSIC,
+      values: {},
     },
   ]);
 


### PR DESCRIPTION
Our tests mock the server API with untyped stubs, so the fake payloads they hand back were never checked against the real models. A fixture could leave out a required field (or use a value that isn't valid at all) and nothing would complain until it broke at runtime.

This types every mocked API method against the real one, so the compiler now checks the fake data. Doing that turned up a fair number of fixtures that didn't match what the server actually sends.

- Typed the mocked API methods in 43 test files against the real API
- Filled in the fields the newly checked fixtures turned out to be missing
- Fixed fixtures using plain text where a proper value was required (user roles, media types)
- Removed two spots that were bypassing the type checks entirely
- Left generic/callback-style methods and plain data properties alone, where typing adds nothing

Same 1508 tests, all still passing. A handful of assertions were updated to match the richer fixtures (they compare against the same fixture, so they're still exact).
