### PR TITLE
Improve player control spacing

### DIFF
--- a/src/views/settings/ConfigEntryRow.vue
+++ b/src/views/settings/ConfigEntryRow.vue
@@ -95,7 +95,7 @@ const hasDescriptionOrHelpLink = computed(() => {
 }
 
 .config-entry:has(+ .config-entry-hass-picker) {
-  margin-bottom: 4px;
+  margin-bottom: 12px;
 }
 
 .config-entry:has(+ .config-entry-hass-picker)
@@ -104,6 +104,7 @@ const hasDescriptionOrHelpLink = computed(() => {
 }
 
 .config-entry-hass-picker {
+  margin-top: -8px;
   margin-bottom: 16px;
 }
 

--- a/src/views/settings/ConfigEntryRow.vue
+++ b/src/views/settings/ConfigEntryRow.vue
@@ -94,8 +94,16 @@ const hasDescriptionOrHelpLink = computed(() => {
   margin-bottom: 8px;
 }
 
+.config-entry:has(+ .config-entry-hass-picker) {
+  margin-bottom: 4px;
+}
+
+.config-entry:has(+ .config-entry-hass-picker)
+  :deep(.v-input__details:not(:has(.v-messages__message))) {
+  display: none;
+}
+
 .config-entry-hass-picker {
-  margin-top: -8px;
   margin-bottom: 16px;
 }
 


### PR DESCRIPTION
Player controls leave too much space between each select and its Home Assistant entity action.

- Group each entity action closely with its control
- Keep clear spacing between controls and unrelated settings