### PR TITLE
Share the common test fixtures instead of repeating them

### DIFF
--- a/tests/App.test.ts
+++ b/tests/App.test.ts
@@ -1,16 +1,16 @@
 import {
   EventType,
-  ProviderStage,
   ProviderStatus,
   ProviderType,
   UserRole,
   type ProviderConfig,
-  type User,
 } from "@/plugins/api/interfaces";
 import type { MusicAssistantApi } from "@/plugins/api";
 import { flushPromises, shallowMount, type VueWrapper } from "@vue/test-utils";
 import { nextTick } from "vue";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { providerConfig } from "./fixtures/providerConfig";
+import { user } from "./fixtures/user";
 
 const {
   apiMock,
@@ -285,7 +285,7 @@ describe("App initialization", () => {
       status: "running",
     };
     apiMock.getCurrentUserInfo.mockResolvedValue(
-      userFixture({
+      user({
         role: UserRole.USER,
         user_id: "user-id",
         username: "regular-user",
@@ -294,7 +294,7 @@ describe("App initialization", () => {
     apiMock.fetchState.mockResolvedValue(undefined);
     apiMock.fetchProviders.mockResolvedValue(undefined);
     apiMock.initialize.mockResolvedValue(undefined);
-    apiMock.getProviderConfigs.mockResolvedValue([providerConfigFixture()]);
+    apiMock.getProviderConfigs.mockResolvedValue([partyPluginConfig()]);
     for (const method of [
       apiMock.getLibraryAlbumsCount,
       apiMock.getLibraryArtistsCount,
@@ -358,7 +358,7 @@ describe("App initialization", () => {
     async (type) => {
       guestType.value = type;
       apiMock.getCurrentUserInfo.mockResolvedValue(
-        userFixture({
+        user({
           role: UserRole.GUEST,
           user_id: "guest-id",
           username: type === "party" ? "party_guest" : "music_quiz_guest",
@@ -442,7 +442,7 @@ describe("App initialization", () => {
     expect(mockInitializeWebPlayerModeSync).not.toHaveBeenCalled();
     expect(wrapper.find("router-view-stub").exists()).toBe(false);
 
-    pluginConfigs.resolve([providerConfigFixture()]);
+    pluginConfigs.resolve([partyPluginConfig()]);
     await flushPromises();
     expect(apiMock.state.value).toBe("initialized");
     expect(wrapper.find("router-view-stub").exists()).toBe(true);
@@ -454,7 +454,7 @@ describe("App initialization", () => {
     async (type) => {
       guestType.value = type;
       apiMock.getCurrentUserInfo.mockResolvedValue(
-        userFixture({
+        user({
           role: UserRole.GUEST,
           user_id: "guest-id",
           username: type === "party" ? "party_guest" : "music_quiz_guest",
@@ -649,7 +649,7 @@ describe("App initialization", () => {
   it("re-authenticates an ingress session through the proxy on reconnect", async () => {
     storeMock.isIngressSession = true;
     wrapper = await mountApp();
-    const ingressUser = userFixture({
+    const ingressUser = user({
       role: UserRole.ADMIN,
       user_id: "ingress-user",
       username: "ingress-user",
@@ -893,44 +893,14 @@ function createStorage(): Storage {
   };
 }
 
-function userFixture(
-  overrides: Partial<User> & Pick<User, "role" | "user_id" | "username">,
-): User {
-  return {
-    created_at: "2024-01-01T00:00:00Z",
-    enabled: true,
-    player_filter: [],
-    preferences: {},
-    provider_filter: [],
-    ...overrides,
-  };
-}
-
-function providerConfigFixture(
-  overrides: Partial<ProviderConfig> = {},
-): ProviderConfig {
-  return {
+/**
+ * The party plugin config, as returned for the plugin lookups App runs on init.
+ */
+function partyPluginConfig(): ProviderConfig {
+  return providerConfig({
+    type: ProviderType.PLUGIN,
     domain: "party",
-    enabled: true,
-    instance_id: "party--test",
-    manifest: {
-      allow_disable: true,
-      builtin: false,
-      codeowners: [],
-      credits: [],
-      description: "",
-      domain: "party",
-      icon_images: [],
-      multi_instance: true,
-      name: "Party",
-      requirements: [],
-      stage: ProviderStage.STABLE,
-      type: ProviderType.PLUGIN,
-    },
     name: "Party",
     status: ProviderStatus.LOADED,
-    type: ProviderType.PLUGIN,
-    values: {},
-    ...overrides,
-  };
+  });
 }

--- a/tests/components/AudioProcessingDetails.test.ts
+++ b/tests/components/AudioProcessingDetails.test.ts
@@ -16,32 +16,16 @@ import {
   DSPFilterType,
   DSPState,
   MediaType,
-  ProviderStage,
-  ProviderType,
   type StreamDetails,
   VolumeNormalizationMode,
 } from "@/plugins/api/interfaces";
+import { providerManifest } from "../fixtures/providerManifest";
 
 const apiMock = vi.hoisted(() => ({
   getProviderName: vi.fn<MusicAssistantApi["getProviderName"]>(
     () => "Test provider",
   ),
-  getProviderManifest: vi.fn<MusicAssistantApi["getProviderManifest"]>(
-    (providerId: string) => ({
-      allow_disable: true,
-      builtin: false,
-      codeowners: [],
-      credits: [],
-      description: "",
-      domain: providerId.split("--", 1)[0],
-      icon_images: [],
-      multi_instance: true,
-      name: providerId,
-      requirements: [],
-      stage: ProviderStage.STABLE,
-      type: ProviderType.MUSIC,
-    }),
-  ),
+  getProviderManifest: vi.fn<MusicAssistantApi["getProviderManifest"]>(),
   // useDSPIRs (via useAudioProcessingDetails) fetches the IR list and
   // subscribes to config updates on mount; subscribe hands back an unsubscribe.
   getDSPIRs: vi.fn<MusicAssistantApi["getDSPIRs"]>(() => Promise.resolve([])),
@@ -69,6 +53,10 @@ vi.mock("@/composables/useDSPPresets", async () => {
 
 beforeEach(() => {
   i18n.global.locale.value = "en";
+  // the provider icon domain strips the instance suffix, e.g. "squeezelite--main" -> "squeezelite"
+  apiMock.getProviderManifest.mockImplementation((providerId: string) =>
+    providerManifest({ domain: providerId.split("--", 1)[0] }),
+  );
   apiMock.players = {
     "player-1": {
       player_id: "player-1",

--- a/tests/components/MediaSearch.test.ts
+++ b/tests/components/MediaSearch.test.ts
@@ -14,6 +14,9 @@ import type { MusicAssistantApi } from "@/plugins/api";
 import { mount } from "@vue/test-utils";
 import { nextTick } from "vue";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { track } from "../fixtures/track";
+import { playlist } from "../fixtures/playlist";
+import { genre } from "../fixtures/genre";
 
 const { mockSearch, mockGetLibraryGenres } = vi.hoisted(() => ({
   mockSearch: vi.fn<MusicAssistantApi["search"]>(),
@@ -291,43 +294,22 @@ function artistRef(name: string): ItemMapping {
   };
 }
 
-function trackFixture(overrides: {
-  uri: string;
-  name: string;
-  artists?: Array<ItemMapping | Artist>;
-}): Track {
-  return {
-    album: null,
-    artists: overrides.artists ?? [],
-    duration: 180,
-    favorite: false,
-    is_playable: true,
+function trackFixture(overrides: Partial<Track> & Pick<Track, "uri">): Track {
+  return track({
+    ...overrides,
     item_id: overrides.uri,
-    media_type: MediaType.TRACK,
-    metadata: {},
-    name: overrides.name,
     provider: providerOf(overrides.uri),
-    provider_mappings: [],
-    uri: overrides.uri,
-  };
+  });
 }
 
-function playlistFixture(overrides: { uri: string; name: string }): Playlist {
-  return {
-    favorite: false,
-    is_dynamic: false,
-    is_editable: false,
-    is_playable: true,
+function playlistFixture(
+  overrides: Partial<Playlist> & Pick<Playlist, "uri">,
+): Playlist {
+  return playlist({
+    ...overrides,
     item_id: overrides.uri,
-    media_type: MediaType.PLAYLIST,
-    metadata: {},
-    name: overrides.name,
-    owner: "library",
     provider: providerOf(overrides.uri),
-    provider_mappings: [],
-    supported_mediatypes: [MediaType.TRACK],
-    uri: overrides.uri,
-  };
+  });
 }
 
 function albumFixture(overrides: { uri: string; name: string }): Album {
@@ -360,17 +342,10 @@ function artistFixture(overrides: { uri: string; name: string }): Artist {
   };
 }
 
-function genreFixture(overrides: { uri: string; name: string }): Genre {
-  return {
-    favorite: false,
-    genre_aliases: null,
-    is_playable: false,
+function genreFixture(overrides: Partial<Genre> & Pick<Genre, "uri">): Genre {
+  return genre({
+    ...overrides,
     item_id: overrides.uri,
-    media_type: MediaType.GENRE,
-    metadata: {},
-    name: overrides.name,
     provider: providerOf(overrides.uri),
-    provider_mappings: [],
-    uri: overrides.uri,
-  };
+  });
 }

--- a/tests/components/MediaSearch.test.ts
+++ b/tests/components/MediaSearch.test.ts
@@ -294,7 +294,9 @@ function artistRef(name: string): ItemMapping {
   };
 }
 
-function trackFixture(overrides: Partial<Track> & Pick<Track, "uri">): Track {
+function trackFixture(
+  overrides: Omit<Partial<Track>, "item_id" | "provider"> & Pick<Track, "uri">,
+): Track {
   return track({
     ...overrides,
     item_id: overrides.uri,
@@ -303,7 +305,8 @@ function trackFixture(overrides: Partial<Track> & Pick<Track, "uri">): Track {
 }
 
 function playlistFixture(
-  overrides: Partial<Playlist> & Pick<Playlist, "uri">,
+  overrides: Omit<Partial<Playlist>, "item_id" | "provider"> &
+    Pick<Playlist, "uri">,
 ): Playlist {
   return playlist({
     ...overrides,
@@ -342,7 +345,9 @@ function artistFixture(overrides: { uri: string; name: string }): Artist {
   };
 }
 
-function genreFixture(overrides: Partial<Genre> & Pick<Genre, "uri">): Genre {
+function genreFixture(
+  overrides: Omit<Partial<Genre>, "item_id" | "provider"> & Pick<Genre, "uri">,
+): Genre {
   return genre({
     ...overrides,
     item_id: overrides.uri,

--- a/tests/components/MediaSearch.test.ts
+++ b/tests/components/MediaSearch.test.ts
@@ -1,6 +1,5 @@
 import MediaSearch from "@/components/MediaSearch.vue";
 import {
-  AlbumType,
   MediaType,
   type Album,
   type Artist,
@@ -17,6 +16,8 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { track } from "../fixtures/track";
 import { playlist } from "../fixtures/playlist";
 import { genre } from "../fixtures/genre";
+import { album } from "../fixtures/album";
+import { artist } from "../fixtures/artist";
 
 const { mockSearch, mockGetLibraryGenres } = vi.hoisted(() => ({
   mockSearch: vi.fn<MusicAssistantApi["search"]>(),
@@ -315,34 +316,25 @@ function playlistFixture(
   });
 }
 
-function albumFixture(overrides: { uri: string; name: string }): Album {
-  return {
-    album_type: AlbumType.ALBUM,
-    artists: [],
-    favorite: false,
-    is_playable: true,
+function albumFixture(
+  overrides: Omit<Partial<Album>, "item_id" | "provider"> & Pick<Album, "uri">,
+): Album {
+  return album({
+    ...overrides,
     item_id: overrides.uri,
-    media_type: MediaType.ALBUM,
-    metadata: {},
-    name: overrides.name,
     provider: providerOf(overrides.uri),
-    provider_mappings: [],
-    uri: overrides.uri,
-  };
+  });
 }
 
-function artistFixture(overrides: { uri: string; name: string }): Artist {
-  return {
-    favorite: false,
-    is_playable: true,
+function artistFixture(
+  overrides: Omit<Partial<Artist>, "item_id" | "provider"> &
+    Pick<Artist, "uri">,
+): Artist {
+  return artist({
+    ...overrides,
     item_id: overrides.uri,
-    media_type: MediaType.ARTIST,
-    metadata: {},
-    name: overrides.name,
     provider: providerOf(overrides.uri),
-    provider_mappings: [],
-    uri: overrides.uri,
-  };
+  });
 }
 
 function genreFixture(

--- a/tests/components/music-quiz/GuessTheSongPlayerRound.test.ts
+++ b/tests/components/music-quiz/GuessTheSongPlayerRound.test.ts
@@ -5,14 +5,11 @@ import type {
   MusicQuizGuessTheSongRound,
 } from "@/composables/music-quiz/useMusicQuiz";
 import type { MusicAssistantApi } from "@/plugins/api";
-import {
-  MediaType,
-  type MediaItemType,
-  type Track,
-} from "@/plugins/api/interfaces";
+import type { MediaItemType } from "@/plugins/api/interfaces";
 import { shallowMount } from "@vue/test-utils";
 import { ref } from "vue";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { track } from "../../fixtures/track";
 
 const {
   mockCopyToClipboard,
@@ -92,7 +89,7 @@ describe("GuessTheSongPlayerRound", () => {
   });
 
   it("passes loaded lyrics and playback position to the reveal", async () => {
-    mockGetItemByUri.mockResolvedValue(trackItem("library://track/1"));
+    mockGetItemByUri.mockResolvedValue(track());
     mockGetTrackLyrics.mockResolvedValue(["Plain lyrics", "Synced lyrics"]);
     const wrapper = mountRound(createState("reveal"));
 
@@ -177,7 +174,7 @@ describe("GuessTheSongPlayerRound", () => {
 
   it("ignores lyrics returned for an older round", async () => {
     const firstLyrics = deferred<[string | null, string | null]>();
-    mockGetItemByUri.mockResolvedValue(trackItem("library://track/1"));
+    mockGetItemByUri.mockResolvedValue(track());
     mockGetTrackLyrics
       .mockReturnValueOnce(firstLyrics.promise)
       .mockResolvedValueOnce(["Second lyrics", null]);
@@ -248,21 +245,4 @@ function deferred<T>() {
     resolve = promiseResolve;
   });
   return { promise, resolve };
-}
-
-function trackItem(uri: string): Track {
-  return {
-    item_id: uri,
-    provider: "library",
-    name: "Track",
-    uri,
-    is_playable: true,
-    media_type: MediaType.TRACK,
-    provider_mappings: [],
-    metadata: {},
-    favorite: false,
-    duration: 120,
-    artists: [],
-    album: null,
-  };
 }

--- a/tests/components/music-quiz/GuessTheSongSetup.test.ts
+++ b/tests/components/music-quiz/GuessTheSongSetup.test.ts
@@ -1,14 +1,11 @@
 import GuessTheSongSetup from "@/components/music-quiz/game-types/guess-the-song/GuessTheSongSetup.vue";
 import type { MusicAssistantApi } from "@/plugins/api";
-import {
-  MediaType,
-  type Genre,
-  type Playlist,
-  type SearchResults,
-} from "@/plugins/api/interfaces";
+import { MediaType, type SearchResults } from "@/plugins/api/interfaces";
 import { mount } from "@vue/test-utils";
 import { nextTick } from "vue";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { genre } from "../../fixtures/genre";
+import { playlist } from "../../fixtures/playlist";
 
 const { mockSearch, mockGetLibraryGenres } = vi.hoisted(() => ({
   mockSearch: vi.fn<MusicAssistantApi["search"]>(),
@@ -88,39 +85,6 @@ const searchResults = (lists: Partial<SearchResults> = {}): SearchResults => ({
   ...lists,
 });
 
-function playlistResult(uri: string, name: string): Playlist {
-  return {
-    item_id: uri,
-    provider: "library",
-    name,
-    uri,
-    is_playable: true,
-    media_type: MediaType.PLAYLIST,
-    provider_mappings: [],
-    metadata: {},
-    favorite: false,
-    owner: "",
-    is_editable: false,
-    supported_mediatypes: [],
-    is_dynamic: false,
-  };
-}
-
-function genreResult(uri: string, name: string): Genre {
-  return {
-    item_id: uri,
-    provider: "library",
-    name,
-    uri,
-    is_playable: false,
-    media_type: MediaType.GENRE,
-    provider_mappings: [],
-    metadata: {},
-    favorite: false,
-    genre_aliases: null,
-  };
-}
-
 describe("GuessTheSongSetup", () => {
   beforeEach(() => {
     vi.useFakeTimers();
@@ -166,7 +130,7 @@ describe("GuessTheSongSetup", () => {
     newSearch.resolve(
       searchResults({
         tracks: [],
-        playlists: [playlistResult("playlist:new", "Newest result")],
+        playlists: [playlist({ uri: "playlist:new", name: "Newest result" })],
       }),
     );
     await flushPromises();
@@ -175,7 +139,7 @@ describe("GuessTheSongSetup", () => {
     oldSearch.resolve(
       searchResults({
         tracks: [],
-        playlists: [playlistResult("playlist:old", "Older result")],
+        playlists: [playlist({ uri: "playlist:old", name: "Older result" })],
       }),
     );
     await flushPromises();
@@ -188,7 +152,7 @@ describe("GuessTheSongSetup", () => {
     mockSearch.mockResolvedValue(
       searchResults({
         tracks: [],
-        playlists: [playlistResult("playlist:test", "Test playlist")],
+        playlists: [playlist({ uri: "playlist:test", name: "Test playlist" })],
       }),
     );
 
@@ -227,7 +191,7 @@ describe("GuessTheSongSetup", () => {
     mockSearch.mockResolvedValue(
       searchResults({
         tracks: [],
-        playlists: [playlistResult("playlist:test", "Test playlist")],
+        playlists: [playlist({ uri: "playlist:test", name: "Test playlist" })],
       }),
     );
     const wrapper = mountConfig(false, false);
@@ -254,7 +218,7 @@ describe("GuessTheSongSetup", () => {
     mockSearch.mockResolvedValue(
       searchResults({
         tracks: [],
-        playlists: [playlistResult("playlist:test", "Test playlist")],
+        playlists: [playlist({ uri: "playlist:test", name: "Test playlist" })],
       }),
     );
     const wrapper = mountConfig();
@@ -282,8 +246,8 @@ describe("GuessTheSongSetup", () => {
     mockSearch.mockResolvedValue(
       searchResults({
         tracks: [],
-        playlists: [playlistResult("playlist:test", "Test playlist")],
-        genres: [genreResult("genre:rock", "Rock")],
+        playlists: [playlist({ uri: "playlist:test", name: "Test playlist" })],
+        genres: [genre({ uri: "genre:rock", name: "Rock" })],
       }),
     );
     const wrapper = mountConfig(true);
@@ -323,7 +287,7 @@ describe("GuessTheSongSetup", () => {
     mockSearch.mockResolvedValue(
       searchResults({
         tracks: [],
-        playlists: [playlistResult("playlist:test", "Test playlist")],
+        playlists: [playlist({ uri: "playlist:test", name: "Test playlist" })],
       }),
     );
     const wrapper = mountConfig();

--- a/tests/components/music-quiz/MusicQuizSourceSelector.test.ts
+++ b/tests/components/music-quiz/MusicQuizSourceSelector.test.ts
@@ -1,6 +1,6 @@
 import MediaSearch from "@/components/MediaSearch.vue";
 import MusicQuizSourceSelector from "@/components/music-quiz/MusicQuizSourceSelector.vue";
-import { type Playlist } from "@/plugins/api/interfaces";
+import type { Playlist } from "@/plugins/api/interfaces";
 import { flushPromises, mount } from "@vue/test-utils";
 import { nextTick } from "vue";
 import { afterEach, describe, expect, it, vi } from "vitest";

--- a/tests/components/music-quiz/MusicQuizSourceSelector.test.ts
+++ b/tests/components/music-quiz/MusicQuizSourceSelector.test.ts
@@ -1,9 +1,10 @@
 import MediaSearch from "@/components/MediaSearch.vue";
 import MusicQuizSourceSelector from "@/components/music-quiz/MusicQuizSourceSelector.vue";
-import { MediaType, type Playlist } from "@/plugins/api/interfaces";
+import { type Playlist } from "@/plugins/api/interfaces";
 import { flushPromises, mount } from "@vue/test-utils";
 import { nextTick } from "vue";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { playlist } from "../../fixtures/playlist";
 
 vi.mock("@/components/MediaSearch.vue", async () => {
   const { defineComponent } = await import("vue");
@@ -131,19 +132,5 @@ function getRemoveButtons(wrapper: ReturnType<typeof mountSelector>) {
 }
 
 function createPlaylist(name: string, index: number): Playlist {
-  return {
-    item_id: String(index),
-    provider: "library",
-    name,
-    uri: `library://playlist/${index}`,
-    is_playable: true,
-    media_type: MediaType.PLAYLIST,
-    provider_mappings: [],
-    metadata: {},
-    favorite: false,
-    owner: "",
-    is_editable: false,
-    supported_mediatypes: [MediaType.TRACK],
-    is_dynamic: false,
-  };
+  return playlist({ name, uri: `library://playlist/${index}` });
 }

--- a/tests/components/music-quiz/MusicTimelineSetup.test.ts
+++ b/tests/components/music-quiz/MusicTimelineSetup.test.ts
@@ -1,13 +1,10 @@
 import MusicTimelineSetup from "@/components/music-quiz/game-types/music-timeline/MusicTimelineSetup.vue";
 import type { MusicAssistantApi } from "@/plugins/api";
-import {
-  MediaType,
-  type Playlist,
-  type SearchResults,
-} from "@/plugins/api/interfaces";
+import { MediaType, type SearchResults } from "@/plugins/api/interfaces";
 import { mount } from "@vue/test-utils";
 import { nextTick } from "vue";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { playlist } from "../../fixtures/playlist";
 
 const { mockSearch, mockGetLibraryGenres } = vi.hoisted(() => ({
   mockSearch: vi.fn<MusicAssistantApi["search"]>(),
@@ -60,24 +57,6 @@ const searchResults = (lists: Partial<SearchResults> = {}): SearchResults => ({
   ...lists,
 });
 
-function playlistResult(uri: string, name: string): Playlist {
-  return {
-    item_id: uri,
-    provider: "library",
-    name,
-    uri,
-    is_playable: true,
-    media_type: MediaType.PLAYLIST,
-    provider_mappings: [],
-    metadata: {},
-    favorite: false,
-    owner: "",
-    is_editable: false,
-    supported_mediatypes: [],
-    is_dynamic: false,
-  };
-}
-
 describe("MusicTimelineSetup", () => {
   beforeEach(() => {
     vi.useFakeTimers();
@@ -87,7 +66,7 @@ describe("MusicTimelineSetup", () => {
     mockSearch.mockResolvedValue(
       searchResults({
         tracks: [],
-        playlists: [playlistResult("playlist:test", "Test playlist")],
+        playlists: [playlist({ uri: "playlist:test", name: "Test playlist" })],
       }),
     );
   });

--- a/tests/components/music-quiz/MusicTimelineSetup.test.ts
+++ b/tests/components/music-quiz/MusicTimelineSetup.test.ts
@@ -1,6 +1,6 @@
 import MusicTimelineSetup from "@/components/music-quiz/game-types/music-timeline/MusicTimelineSetup.vue";
 import type { MusicAssistantApi } from "@/plugins/api";
-import { MediaType, type SearchResults } from "@/plugins/api/interfaces";
+import type { SearchResults } from "@/plugins/api/interfaces";
 import { mount } from "@vue/test-utils";
 import { nextTick } from "vue";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";

--- a/tests/composables/smart_playlist/useSmartPlaylistGenres.test.ts
+++ b/tests/composables/smart_playlist/useSmartPlaylistGenres.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { MediaType, type Genre } from "@/plugins/api/interfaces";
+import type { Genre } from "@/plugins/api/interfaces";
 import type { MusicAssistantApi } from "@/plugins/api";
+import { genre } from "../../fixtures/genre";
 
 vi.mock("vue", async () => {
   const actual = await vi.importActual<typeof import("vue")>("vue");
@@ -57,16 +58,5 @@ describe("useSmartPlaylistGenres", () => {
 });
 
 function genreFixture(item_id: string, name: string): Genre {
-  return {
-    item_id,
-    provider: "library",
-    name,
-    uri: `library://genre/${item_id}`,
-    is_playable: false,
-    media_type: MediaType.GENRE,
-    provider_mappings: [],
-    metadata: {},
-    favorite: false,
-    genre_aliases: null,
-  };
+  return genre({ item_id, name, uri: `library://genre/${item_id}` });
 }

--- a/tests/composables/smart_playlist/useSmartPlaylistSeedItems.test.ts
+++ b/tests/composables/smart_playlist/useSmartPlaylistSeedItems.test.ts
@@ -45,8 +45,9 @@ vi.mock("@/plugins/api", () => ({
 import api from "@/plugins/api";
 import type { MusicAssistantApi } from "@/plugins/api";
 import { useSmartPlaylistSeedItems } from "@/composables/smart-playlist/useSmartPlaylistSeedItems";
-import { MediaType, type Album, type Track } from "@/plugins/api/interfaces";
+import type { Album, Track } from "@/plugins/api/interfaces";
 import { providerMapping } from "../../fixtures/providerMapping";
+import { track } from "../../fixtures/track";
 
 interface SearchFnArg {
   searchFn: (q: string) => Promise<unknown[]>;
@@ -196,7 +197,7 @@ describe("useSmartPlaylistSeedItems", () => {
 
       vi.mocked(api.search).mockResolvedValueOnce({
         tracks: [
-          trackFixture({
+          track({
             item_id: "lib-1",
             name: "Library Track",
             provider_mappings: [
@@ -245,21 +246,3 @@ describe("useSmartPlaylistSeedItems", () => {
     });
   });
 });
-
-function trackFixture(overrides: Partial<Track> = {}): Track {
-  return {
-    item_id: "1",
-    provider: "library",
-    name: "Track",
-    uri: "library://track/1",
-    is_playable: true,
-    media_type: MediaType.TRACK,
-    provider_mappings: [],
-    metadata: {},
-    favorite: false,
-    duration: 200,
-    artists: [],
-    album: null,
-    ...overrides,
-  };
-}

--- a/tests/composables/useAudioAnalysisFailures.test.ts
+++ b/tests/composables/useAudioAnalysisFailures.test.ts
@@ -1,10 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { MusicAssistantApi } from "@/plugins/api";
-import {
-  MediaType,
-  type ItemMapping,
-  type Track,
-} from "@/plugins/api/interfaces";
+import { MediaType, type ItemMapping } from "@/plugins/api/interfaces";
+import { track } from "../fixtures/track";
 
 const { mockSendCommand, mockGetTrack } = vi.hoisted(() => {
   return {
@@ -64,7 +61,7 @@ beforeEach(() => {
   mockGetTrack.mockReset();
   mockGetTrack.mockImplementation((itemId: string) =>
     Promise.resolve(
-      trackFixture({
+      track({
         name: `Track ${itemId}`,
         artists: [artistMapping("Artist")],
       }),
@@ -220,7 +217,7 @@ describe("useAudioAnalysisFailures", () => {
   it("resolves the track name + artist for the current page", async () => {
     mockFailures([serverFailure({ item_id: "1", provider: "tidal" })]);
     mockGetTrack.mockResolvedValueOnce(
-      trackFixture({ name: "Creep", artists: [artistMapping("Radiohead")] }),
+      track({ name: "Creep", artists: [artistMapping("Radiohead")] }),
     );
 
     const f = useAudioAnalysisFailures();
@@ -239,7 +236,7 @@ describe("useAudioAnalysisFailures", () => {
     mockGetTrack.mockImplementation((itemId: string) => {
       if (itemId === "gone") return Promise.reject(new Error("not found"));
       return Promise.resolve(
-        trackFixture({ name: "Fine", artists: [artistMapping("Band")] }),
+        track({ name: "Fine", artists: [artistMapping("Band")] }),
       );
     });
 
@@ -351,7 +348,7 @@ describe("useAudioAnalysisFailures", () => {
     ]);
     mockGetTrack.mockImplementation((_itemId: string, provider: string) =>
       Promise.resolve(
-        trackFixture({
+        track({
           name: provider === "tidal" ? "Tidal Track" : "Qobuz Track",
         }),
       ),
@@ -391,7 +388,7 @@ describe("useAudioAnalysisFailures", () => {
     mockGetTrack.mockImplementation((itemId: string) =>
       itemId === "1"
         ? Promise.reject(new Error("not found"))
-        : Promise.resolve(trackFixture({ name: "Two" })),
+        : Promise.resolve(track({ name: "Two" })),
     );
 
     const f = useAudioAnalysisFailures({ pageSize: 1 });
@@ -566,24 +563,6 @@ describe("useAudioAnalysisFailures", () => {
 // Keep the RawFailure import meaningful so the public type is part of the contract.
 const _typecheck: RawFailure | undefined = undefined;
 void _typecheck;
-
-function trackFixture(overrides: Partial<Track> = {}): Track {
-  return {
-    item_id: "1",
-    provider: "tidal",
-    name: "Track",
-    uri: "tidal://track/1",
-    is_playable: true,
-    media_type: MediaType.TRACK,
-    provider_mappings: [],
-    metadata: {},
-    favorite: false,
-    duration: 200,
-    artists: [],
-    album: null,
-    ...overrides,
-  };
-}
 
 function artistMapping(name: string): ItemMapping {
   return {

--- a/tests/composables/useAudioProcessingDetails.test.ts
+++ b/tests/composables/useAudioProcessingDetails.test.ts
@@ -23,20 +23,18 @@ import {
   VolumeNormalizationMode,
 } from "@/plugins/api/interfaces";
 
-const { providerManifest } = await vi.hoisted(async () => {
+vi.mock("@/plugins/api", async () => {
   const { providerManifest } = await import("../fixtures/providerManifest");
-  return { providerManifest };
+  return {
+    default: {
+      getProviderName: vi.fn<MusicAssistantApi["getProviderName"]>(),
+      getProviderManifest: vi.fn<MusicAssistantApi["getProviderManifest"]>(
+        (providerId: string) => providerManifest({ domain: providerId }),
+      ),
+      players: {},
+    },
+  };
 });
-
-vi.mock("@/plugins/api", () => ({
-  default: {
-    getProviderName: vi.fn<MusicAssistantApi["getProviderName"]>(),
-    getProviderManifest: vi.fn<MusicAssistantApi["getProviderManifest"]>(
-      (providerId: string) => providerManifest({ domain: providerId }),
-    ),
-    players: {},
-  },
-}));
 vi.mock("@/composables/useDSPPresets", () => ({
   useDSPPresets: () => ({
     getPresetName: vi.fn(),

--- a/tests/composables/useAudioProcessingDetails.test.ts
+++ b/tests/composables/useAudioProcessingDetails.test.ts
@@ -19,30 +19,20 @@ import {
   DSPState,
   MediaType,
   type OutputProtocol,
-  ProviderStage,
-  ProviderType,
   type StreamDetails,
   VolumeNormalizationMode,
 } from "@/plugins/api/interfaces";
+
+const { providerManifest } = await vi.hoisted(async () => {
+  const { providerManifest } = await import("../fixtures/providerManifest");
+  return { providerManifest };
+});
 
 vi.mock("@/plugins/api", () => ({
   default: {
     getProviderName: vi.fn<MusicAssistantApi["getProviderName"]>(),
     getProviderManifest: vi.fn<MusicAssistantApi["getProviderManifest"]>(
-      (providerId: string) => ({
-        allow_disable: true,
-        builtin: false,
-        codeowners: [],
-        credits: [],
-        description: "",
-        domain: providerId,
-        icon_images: [],
-        multi_instance: true,
-        name: providerId,
-        requirements: [],
-        stage: ProviderStage.STABLE,
-        type: ProviderType.MUSIC,
-      }),
+      (providerId: string) => providerManifest({ domain: providerId }),
     ),
     players: {},
   },

--- a/tests/composables/useGuestArtistTracks.test.ts
+++ b/tests/composables/useGuestArtistTracks.test.ts
@@ -1,6 +1,7 @@
-import { MediaType, type Artist, type Track } from "@/plugins/api/interfaces";
+import type { Artist, Track } from "@/plugins/api/interfaces";
 import type { MusicAssistantApi } from "@/plugins/api";
 import { providerMapping } from "../fixtures/providerMapping";
+import { track } from "../fixtures/track";
 import { $t } from "@/plugins/i18n";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -165,18 +166,9 @@ describe("useGuestArtistTracks", () => {
 });
 
 function trackFixture(itemId: string): Track {
-  return {
+  return track({
     item_id: itemId,
-    provider: "library",
     name: itemId,
     uri: `library://track/${itemId}`,
-    is_playable: true,
-    media_type: MediaType.TRACK,
-    provider_mappings: [],
-    metadata: {},
-    favorite: false,
-    duration: 200,
-    artists: [],
-    album: null,
-  };
+  });
 }

--- a/tests/composables/useProgressiveSearch.test.ts
+++ b/tests/composables/useProgressiveSearch.test.ts
@@ -8,6 +8,8 @@ import {
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { effectScope, nextTick, ref, type EffectScope } from "vue";
 import type { MusicAssistantApi } from "@/plugins/api";
+import { track as trackFixture } from "../fixtures/track";
+import { genre as genreFixture } from "../fixtures/genre";
 
 const { mockSearch, mockGetLibraryGenres, mockProviders, mockManifests } =
   vi.hoisted(() => {
@@ -50,33 +52,16 @@ const results = (partial: Partial<SearchResults>): SearchResults => ({
   ...partial,
 });
 
-const track = (itemId: string, name: string, provider = "library"): Track => ({
-  item_id: itemId,
-  provider,
-  name,
-  uri: `test://track/${itemId}`,
-  is_playable: true,
-  media_type: MediaType.TRACK,
-  provider_mappings: [],
-  metadata: {},
-  favorite: false,
-  duration: 200,
-  artists: [],
-  album: null,
-});
+const track = (itemId: string, name: string, provider = "library"): Track =>
+  trackFixture({
+    item_id: itemId,
+    provider,
+    name,
+    uri: `test://track/${itemId}`,
+  });
 
-const genre = (itemId: string, name: string): Genre => ({
-  item_id: itemId,
-  provider: "library",
-  name,
-  uri: `test://genre/${itemId}`,
-  is_playable: false,
-  media_type: MediaType.GENRE,
-  provider_mappings: [],
-  metadata: {},
-  favorite: false,
-  genre_aliases: null,
-});
+const genre = (itemId: string, name: string): Genre =>
+  genreFixture({ item_id: itemId, name, uri: `test://genre/${itemId}` });
 
 const provider = (
   instanceId: string,

--- a/tests/composables/useProgressiveSearch.test.ts
+++ b/tests/composables/useProgressiveSearch.test.ts
@@ -8,8 +8,8 @@ import {
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { effectScope, nextTick, ref, type EffectScope } from "vue";
 import type { MusicAssistantApi } from "@/plugins/api";
-import { track as trackFixture } from "../fixtures/track";
-import { genre as genreFixture } from "../fixtures/genre";
+import { track } from "../fixtures/track";
+import { genre } from "../fixtures/genre";
 
 const { mockSearch, mockGetLibraryGenres, mockProviders, mockManifests } =
   vi.hoisted(() => {
@@ -52,16 +52,20 @@ const results = (partial: Partial<SearchResults>): SearchResults => ({
   ...partial,
 });
 
-const track = (itemId: string, name: string, provider = "library"): Track =>
-  trackFixture({
+const trackFixture = (
+  itemId: string,
+  name: string,
+  provider = "library",
+): Track =>
+  track({
     item_id: itemId,
     provider,
     name,
     uri: `test://track/${itemId}`,
   });
 
-const genre = (itemId: string, name: string): Genre =>
-  genreFixture({ item_id: itemId, name, uri: `test://genre/${itemId}` });
+const genreFixture = (itemId: string, name: string): Genre =>
+  genre({ item_id: itemId, name, uri: `test://genre/${itemId}` });
 
 const provider = (
   instanceId: string,
@@ -140,10 +144,12 @@ describe("useProgressiveSearch", () => {
     mockSearch.mockImplementation(
       (_query, _mediaTypes, _limit, providers: string[] = []) => {
         if (providers[0] === LIBRARY_SEARCH_TARGET)
-          return Promise.resolve(results({ tracks: [track("l1", "Lib hit")] }));
+          return Promise.resolve(
+            results({ tracks: [trackFixture("l1", "Lib hit")] }),
+          );
         if (providers[0] === "spotify")
           return Promise.resolve(
-            results({ tracks: [track("s1", "Spotify hit", "spotify")] }),
+            results({ tracks: [trackFixture("s1", "Spotify hit", "spotify")] }),
           );
         return Promise.resolve(emptyResults());
       },
@@ -171,11 +177,11 @@ describe("useProgressiveSearch", () => {
       (_query, _mediaTypes, _limit, providers: string[] = []) => {
         if (providers[0] === LIBRARY_SEARCH_TARGET)
           return Promise.resolve(
-            results({ tracks: [track("l1", "Queen tribute")] }),
+            results({ tracks: [trackFixture("l1", "Queen tribute")] }),
           );
         if (providers[0] === "spotify")
           return Promise.resolve(
-            results({ tracks: [track("s1", "Queen", "spotify")] }),
+            results({ tracks: [trackFixture("s1", "Queen", "spotify")] }),
           );
         return Promise.resolve(emptyResults());
       },
@@ -236,13 +242,15 @@ describe("useProgressiveSearch", () => {
         return new Promise<SearchResults>((resolve) => {
           resolveFirst = resolve;
         });
-      return Promise.resolve(results({ tracks: [track("t2", "Second")] }));
+      return Promise.resolve(
+        results({ tracks: [trackFixture("t2", "Second")] }),
+      );
     });
     const { search, searchResult } = setup();
 
     await search("first");
     await search("second");
-    resolveFirst(results({ tracks: [track("t1", "First")] }));
+    resolveFirst(results({ tracks: [trackFixture("t1", "First")] }));
     await flush();
 
     expect(searchResult.value?.tracks.map((item) => item.name)).toEqual([
@@ -266,7 +274,7 @@ describe("useProgressiveSearch", () => {
           );
         }
         return Promise.resolve(
-          results({ tracks: [track("s1", "Late", "spotify")] }),
+          results({ tracks: [trackFixture("s1", "Late", "spotify")] }),
         );
       },
     );
@@ -286,7 +294,7 @@ describe("useProgressiveSearch", () => {
   });
 
   it("searches only the library for a genre-only search", async () => {
-    const genres = [genre("g1", "Rock")];
+    const genres = [genreFixture("g1", "Rock")];
     mockGetLibraryGenres.mockResolvedValue(genres);
     const mediaTypes = ref<MediaType[]>([MediaType.GENRE]);
     const { search, searchResult } = setup({ mediaTypes });

--- a/tests/composables/userPreferences.test.ts
+++ b/tests/composables/userPreferences.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { MusicAssistantApi } from "@/plugins/api";
-import { UserRole, type User } from "@/plugins/api/interfaces";
+import { user } from "../fixtures/user";
 
 const { mockUpdateUser, storeMock } = vi.hoisted(() => {
   return {
@@ -36,7 +36,7 @@ function readPrefs(path: string, itemtype: string) {
 describe("userPreferences - itemsListing", () => {
   beforeEach(() => {
     mockUpdateUser.mockReset();
-    mockUpdateUser.mockResolvedValue(userFixture());
+    mockUpdateUser.mockResolvedValue(user());
     storeMock.currentUser = { user_id: "u1", preferences: {} };
   });
 
@@ -113,16 +113,3 @@ describe("userPreferences - itemsListing", () => {
     expect(readPrefs("librarygenres", "genres").favoriteFilter).toBeUndefined();
   });
 });
-
-function userFixture(): User {
-  return {
-    user_id: "u1",
-    username: "u1",
-    role: UserRole.USER,
-    enabled: true,
-    created_at: "2024-01-01T00:00:00Z",
-    preferences: {},
-    provider_filter: [],
-    player_filter: [],
-  };
-}

--- a/tests/fixtures/album.ts
+++ b/tests/fixtures/album.ts
@@ -1,0 +1,22 @@
+import { type Album, AlbumType, MediaType } from "@/plugins/api/interfaces";
+
+/**
+ * A complete album, for tests that only care about a few of its fields but
+ * should still model a payload the server can send.
+ */
+export function album(overrides: Partial<Album> = {}): Album {
+  return {
+    item_id: "1",
+    provider: "library",
+    name: "Album",
+    uri: "library://album/1",
+    is_playable: true,
+    media_type: MediaType.ALBUM,
+    provider_mappings: [],
+    metadata: {},
+    favorite: false,
+    album_type: AlbumType.ALBUM,
+    artists: [],
+    ...overrides,
+  };
+}

--- a/tests/fixtures/artist.ts
+++ b/tests/fixtures/artist.ts
@@ -1,0 +1,20 @@
+import { type Artist, MediaType } from "@/plugins/api/interfaces";
+
+/**
+ * A complete artist, for tests that only care about a few of its fields but
+ * should still model a payload the server can send.
+ */
+export function artist(overrides: Partial<Artist> = {}): Artist {
+  return {
+    item_id: "1",
+    provider: "library",
+    name: "Artist",
+    uri: "library://artist/1",
+    is_playable: true,
+    media_type: MediaType.ARTIST,
+    provider_mappings: [],
+    metadata: {},
+    favorite: false,
+    ...overrides,
+  };
+}

--- a/tests/fixtures/genre.ts
+++ b/tests/fixtures/genre.ts
@@ -1,0 +1,21 @@
+import { type Genre, MediaType } from "@/plugins/api/interfaces";
+
+/**
+ * A complete genre, for tests that only care about a few of its fields but
+ * should still model a payload the server can send.
+ */
+export function genre(overrides: Partial<Genre> = {}): Genre {
+  return {
+    item_id: "1",
+    provider: "library",
+    name: "Genre",
+    uri: "library://genre/1",
+    is_playable: false,
+    media_type: MediaType.GENRE,
+    provider_mappings: [],
+    metadata: {},
+    favorite: false,
+    genre_aliases: null,
+    ...overrides,
+  };
+}

--- a/tests/fixtures/hassProviderConfig.ts
+++ b/tests/fixtures/hassProviderConfig.ts
@@ -1,0 +1,38 @@
+import {
+  ConfigEntryType,
+  type ProviderConfig,
+  ProviderType,
+} from "@/plugins/api/interfaces";
+import { providerConfig } from "./providerConfig";
+import { providerManifest } from "./providerManifest";
+
+/**
+ * The Home Assistant provider config, carrying the given power controls.
+ */
+export function hassProviderConfig(
+  powerControls: string[] | null,
+): ProviderConfig {
+  return providerConfig({
+    type: ProviderType.PLUGIN,
+    domain: "hass",
+    manifest: providerManifest({
+      type: ProviderType.PLUGIN,
+      domain: "hass",
+      name: "Home Assistant",
+      description: "Home Assistant integration",
+    }),
+    values: {
+      power_controls: {
+        key: "power_controls",
+        type: ConfigEntryType.STRING,
+        label: "Power controls",
+        default_value: [],
+        required: false,
+        options: [],
+        category: "generic",
+        multi_value: true,
+        value: powerControls,
+      },
+    },
+  });
+}

--- a/tests/fixtures/playlist.ts
+++ b/tests/fixtures/playlist.ts
@@ -1,0 +1,24 @@
+import { MediaType, type Playlist } from "@/plugins/api/interfaces";
+
+/**
+ * A complete playlist, for tests that only care about a few of its fields but
+ * should still model a payload the server can send.
+ */
+export function playlist(overrides: Partial<Playlist> = {}): Playlist {
+  return {
+    item_id: "1",
+    provider: "library",
+    name: "Playlist",
+    uri: "library://playlist/1",
+    is_playable: true,
+    media_type: MediaType.PLAYLIST,
+    provider_mappings: [],
+    metadata: {},
+    favorite: false,
+    owner: "",
+    is_editable: false,
+    supported_mediatypes: [MediaType.TRACK],
+    is_dynamic: false,
+    ...overrides,
+  };
+}

--- a/tests/fixtures/providerConfig.ts
+++ b/tests/fixtures/providerConfig.ts
@@ -1,0 +1,24 @@
+import { type ProviderConfig, ProviderType } from "@/plugins/api/interfaces";
+import { providerManifest } from "./providerManifest";
+
+/**
+ * A complete provider config, for tests that only care about a few of its
+ * fields but should still model a payload the server can send. The default
+ * manifest follows the config's own type and domain; pass `manifest` to
+ * control the rest of it.
+ */
+export function providerConfig(
+  overrides: Partial<ProviderConfig> = {},
+): ProviderConfig {
+  const type = overrides.type ?? ProviderType.MUSIC;
+  const domain = overrides.domain ?? "test_provider";
+  return {
+    type,
+    domain,
+    instance_id: `${domain}--1`,
+    manifest: providerManifest({ type, domain }),
+    enabled: true,
+    values: {},
+    ...overrides,
+  };
+}

--- a/tests/fixtures/providerManifest.ts
+++ b/tests/fixtures/providerManifest.ts
@@ -1,0 +1,29 @@
+import {
+  type ProviderManifest,
+  ProviderStage,
+  ProviderType,
+} from "@/plugins/api/interfaces";
+
+/**
+ * A complete provider manifest, for tests that only care about a few of its
+ * fields but should still model a payload the server can send.
+ */
+export function providerManifest(
+  overrides: Partial<ProviderManifest> = {},
+): ProviderManifest {
+  return {
+    type: ProviderType.MUSIC,
+    domain: "test_provider",
+    name: "Test provider",
+    description: "",
+    codeowners: [],
+    credits: [],
+    requirements: [],
+    multi_instance: false,
+    builtin: false,
+    allow_disable: true,
+    stage: ProviderStage.STABLE,
+    icon_images: [],
+    ...overrides,
+  };
+}

--- a/tests/fixtures/track.ts
+++ b/tests/fixtures/track.ts
@@ -1,0 +1,23 @@
+import { MediaType, type Track } from "@/plugins/api/interfaces";
+
+/**
+ * A complete track, for tests that only care about a few of its fields but
+ * should still model a payload the server can send.
+ */
+export function track(overrides: Partial<Track> = {}): Track {
+  return {
+    item_id: "1",
+    provider: "library",
+    name: "Track",
+    uri: "library://track/1",
+    is_playable: true,
+    media_type: MediaType.TRACK,
+    provider_mappings: [],
+    metadata: {},
+    favorite: false,
+    duration: 200,
+    artists: [],
+    album: null,
+    ...overrides,
+  };
+}

--- a/tests/fixtures/user.ts
+++ b/tests/fixtures/user.ts
@@ -1,0 +1,19 @@
+import { type User, UserRole } from "@/plugins/api/interfaces";
+
+/**
+ * A complete user, for tests that only care about a few of its fields but
+ * should still model a payload the server can send.
+ */
+export function user(overrides: Partial<User> = {}): User {
+  return {
+    user_id: "user-id",
+    username: "user",
+    role: UserRole.USER,
+    enabled: true,
+    created_at: "2024-01-01T00:00:00Z",
+    preferences: {},
+    provider_filter: [],
+    player_filter: [],
+    ...overrides,
+  };
+}

--- a/tests/helpers/hass_controls.test.ts
+++ b/tests/helpers/hass_controls.test.ts
@@ -5,11 +5,11 @@ import {
 import type { MusicAssistantApi } from "@/plugins/api";
 import {
   ConfigEntryType,
-  ProviderStage,
   ProviderType,
   type ProviderConfig,
 } from "@/plugins/api/interfaces";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { providerConfig } from "../fixtures/providerConfig";
 
 const { apiMock } = vi.hoisted(() => ({
   apiMock: {
@@ -58,7 +58,7 @@ describe("getHassProviderInstance", () => {
 describe("addHassControlEntity", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    apiMock.saveProviderConfig.mockResolvedValue(providerConfig(["switch.tv"]));
+    apiMock.saveProviderConfig.mockResolvedValue(hassConfig(["switch.tv"]));
   });
 
   it("appends the entity to the list the provider already holds", async () => {
@@ -95,29 +95,13 @@ describe("addHassControlEntity", () => {
 });
 
 function givenControls(value: string[] | null) {
-  apiMock.getProviderConfig.mockResolvedValue(providerConfig(value));
+  apiMock.getProviderConfig.mockResolvedValue(hassConfig(value));
 }
 
-function providerConfig(value: string[] | null): ProviderConfig {
-  return {
+function hassConfig(value: string[] | null): ProviderConfig {
+  return providerConfig({
     type: ProviderType.PLUGIN,
     domain: "hass",
-    instance_id: "hass--1",
-    enabled: true,
-    manifest: {
-      type: ProviderType.PLUGIN,
-      domain: "hass",
-      name: "Home Assistant",
-      description: "Home Assistant integration",
-      codeowners: [],
-      credits: [],
-      requirements: [],
-      multi_instance: false,
-      builtin: false,
-      allow_disable: true,
-      stage: ProviderStage.STABLE,
-      icon_images: [],
-    },
     values: {
       power_controls: {
         key: "power_controls",
@@ -131,5 +115,5 @@ function providerConfig(value: string[] | null): ProviderConfig {
         value,
       },
     },
-  };
+  });
 }

--- a/tests/helpers/hass_controls.test.ts
+++ b/tests/helpers/hass_controls.test.ts
@@ -3,13 +3,8 @@ import {
   getHassProviderInstance,
 } from "@/helpers/hass_controls";
 import type { MusicAssistantApi } from "@/plugins/api";
-import {
-  ConfigEntryType,
-  ProviderType,
-  type ProviderConfig,
-} from "@/plugins/api/interfaces";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { providerConfig } from "../fixtures/providerConfig";
+import { hassProviderConfig } from "../fixtures/hassProviderConfig";
 
 const { apiMock } = vi.hoisted(() => ({
   apiMock: {
@@ -58,7 +53,9 @@ describe("getHassProviderInstance", () => {
 describe("addHassControlEntity", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    apiMock.saveProviderConfig.mockResolvedValue(hassConfig(["switch.tv"]));
+    apiMock.saveProviderConfig.mockResolvedValue(
+      hassProviderConfig(["switch.tv"]),
+    );
   });
 
   it("appends the entity to the list the provider already holds", async () => {
@@ -95,25 +92,5 @@ describe("addHassControlEntity", () => {
 });
 
 function givenControls(value: string[] | null) {
-  apiMock.getProviderConfig.mockResolvedValue(hassConfig(value));
-}
-
-function hassConfig(value: string[] | null): ProviderConfig {
-  return providerConfig({
-    type: ProviderType.PLUGIN,
-    domain: "hass",
-    values: {
-      power_controls: {
-        key: "power_controls",
-        type: ConfigEntryType.STRING,
-        label: "Power controls",
-        default_value: [],
-        required: false,
-        options: [],
-        category: "generic",
-        multi_value: true,
-        value,
-      },
-    },
-  });
+  apiMock.getProviderConfig.mockResolvedValue(hassProviderConfig(value));
 }

--- a/tests/helpers/players.test.ts
+++ b/tests/helpers/players.test.ts
@@ -13,6 +13,7 @@ import {
 } from "@/plugins/api/interfaces";
 import { store } from "@/plugins/store";
 import { webPlayer } from "@/plugins/web_player";
+import { user } from "../fixtures/user";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@/plugins/store", () => ({
@@ -79,16 +80,12 @@ function createOutputProtocol(
 }
 
 function createAdminUser(playerFilter: string[]): User {
-  return {
+  return user({
     user_id: "admin",
     username: "admin",
     role: UserRole.ADMIN,
-    enabled: true,
-    created_at: "",
-    preferences: {},
-    provider_filter: [],
     player_filter: playerFilter,
-  };
+  });
 }
 
 beforeEach(() => {

--- a/tests/views/EditCoreConfig.test.ts
+++ b/tests/views/EditCoreConfig.test.ts
@@ -1,13 +1,9 @@
 import { flushPromises, shallowMount } from "@vue/test-utils";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import {
-  ConfigEntryType,
-  ProviderStage,
-  ProviderType,
-  type CoreConfig,
-} from "@/plugins/api/interfaces";
+import { ConfigEntryType, type CoreConfig } from "@/plugins/api/interfaces";
 import type { MusicAssistantApi } from "@/plugins/api";
 import EditCoreConfig from "@/views/settings/EditCoreConfig.vue";
+import { providerManifest } from "../fixtures/providerManifest";
 
 const { apiMock, routerMock, toastMock } = vi.hoisted(() => ({
   apiMock: {
@@ -241,21 +237,14 @@ describe("EditCoreConfig", () => {
 function coreConfig(): CoreConfig {
   return {
     domain: "cache",
-    manifest: {
+    manifest: providerManifest({
       allow_disable: false,
       builtin: true,
-      codeowners: [],
-      credits: [],
       description: "Cache controller",
       domain: "cache",
-      icon_images: [],
       has_setup_flow: false,
-      multi_instance: false,
       name: "Cache",
-      requirements: [],
-      stage: ProviderStage.STABLE,
-      type: ProviderType.MUSIC,
-    },
+    }),
     values: {
       clear_on_start: {
         category: "generic",

--- a/tests/views/EditPlayer.test.ts
+++ b/tests/views/EditPlayer.test.ts
@@ -5,17 +5,16 @@ import {
 import {
   ConfigEntryType,
   PlayerType,
-  ProviderStage,
   ProviderType,
   type ConfigEntry,
   type PlayerConfig,
   type ProviderInstance,
-  type ProviderManifest,
 } from "@/plugins/api/interfaces";
 import type { MusicAssistantApi } from "@/plugins/api";
 import EditPlayer from "@/views/settings/EditPlayer.vue";
 import { flushPromises, shallowMount } from "@vue/test-utils";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { providerManifest } from "../fixtures/providerManifest";
 
 const { apiMock, eventbusMock, routerMock, toastMock } = vi.hoisted(() => ({
   apiMock: {
@@ -473,23 +472,6 @@ function controlEntry(key: string): ConfigEntry {
     default_value: "none",
     value: "none",
     options: [{ title: "none", value: "none" }],
-  };
-}
-
-function providerManifest(): ProviderManifest {
-  return {
-    type: ProviderType.PLAYER,
-    domain: "chromecast",
-    name: "Chromecast",
-    description: "",
-    codeowners: [],
-    credits: [],
-    requirements: [],
-    multi_instance: false,
-    builtin: false,
-    allow_disable: true,
-    stage: ProviderStage.STABLE,
-    icon_images: [],
   };
 }
 

--- a/tests/views/EditPlayer.test.ts
+++ b/tests/views/EditPlayer.test.ts
@@ -93,7 +93,13 @@ describe("EditPlayer", () => {
     });
     apiMock.getPlayerConfig.mockResolvedValue(playerConfig());
     apiMock.getProvider.mockReturnValue(providerInstance());
-    apiMock.getProviderManifest.mockReturnValue(providerManifest());
+    apiMock.getProviderManifest.mockReturnValue(
+      providerManifest({
+        type: ProviderType.PLAYER,
+        domain: "chromecast",
+        name: "Chromecast",
+      }),
+    );
     apiMock.reloadProvider.mockResolvedValue(undefined);
     apiMock.savePlayerConfig.mockResolvedValue(playerConfig());
     apiMock.providerManifests = { chromecast: { name: "Chromecast" } };

--- a/tests/views/EditProvider.test.ts
+++ b/tests/views/EditProvider.test.ts
@@ -4,7 +4,6 @@ import {
   ConfigEntryType,
   EventType,
   ProviderStatus,
-  type ConfigEntry,
   type ProviderConfig,
 } from "@/plugins/api/interfaces";
 import type { MusicAssistantApi } from "@/plugins/api";
@@ -765,8 +764,8 @@ describe("EditProvider", () => {
 /**
  * The spotify provider config these tests load, with a single `account` entry.
  *
- * The view reads the manifest from `api.providerManifests`, not from the
- * config, so the config's own manifest stays at the shared default.
+ * The view resolves the manifest from `api.providerManifests` first, so this
+ * config's own manifest never surfaces.
  */
 function spotifyConfig(
   status: ProviderStatus,

--- a/tests/views/EditProvider.test.ts
+++ b/tests/views/EditProvider.test.ts
@@ -3,14 +3,13 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   ConfigEntryType,
   EventType,
-  ProviderStage,
   ProviderStatus,
-  ProviderType,
   type ConfigEntry,
   type ProviderConfig,
 } from "@/plugins/api/interfaces";
 import type { MusicAssistantApi } from "@/plugins/api";
 import EditProvider from "@/views/settings/EditProvider.vue";
+import { providerConfig } from "../fixtures/providerConfig";
 
 const { apiMock, eventbusMock, routerMock, toastMock, unsubscribeMock } =
   vi.hoisted(() => ({
@@ -130,7 +129,7 @@ beforeEach(() => {
 describe("EditProvider", () => {
   it("shows provider status and direct support actions", async () => {
     apiMock.getProviderConfig.mockResolvedValue(
-      providerConfig(ProviderStatus.LOADED),
+      spotifyConfig(ProviderStatus.LOADED),
     );
 
     const wrapper = shallowMount(EditProvider, {
@@ -172,7 +171,7 @@ describe("EditProvider", () => {
   it("hides reconfiguration when the provider has no setup flow", async () => {
     apiMock.providerManifests.spotify.has_setup_flow = false;
     apiMock.getProviderConfig.mockResolvedValue(
-      providerConfig(ProviderStatus.LOADED),
+      spotifyConfig(ProviderStatus.LOADED),
     );
 
     const wrapper = shallowMount(EditProvider, {
@@ -196,7 +195,7 @@ describe("EditProvider", () => {
   it("hides documentation links with an unsafe URL", async () => {
     apiMock.providerManifests.spotify.documentation = "javascript:alert(1)";
     apiMock.getProviderConfig.mockResolvedValue(
-      providerConfig(ProviderStatus.LOADED),
+      spotifyConfig(ProviderStatus.LOADED),
     );
 
     const wrapper = shallowMount(EditProvider, {
@@ -219,15 +218,10 @@ describe("EditProvider", () => {
 
   it("disables the provider from the header menu", async () => {
     apiMock.getProviderConfig.mockResolvedValue(
-      providerConfig(ProviderStatus.LOADED),
+      spotifyConfig(ProviderStatus.LOADED),
     );
     apiMock.saveProviderConfig.mockResolvedValue(
-      providerConfig(
-        ProviderStatus.DISABLED,
-        "current value",
-        undefined,
-        false,
-      ),
+      spotifyConfig(ProviderStatus.DISABLED, "current value", undefined, false),
     );
 
     const wrapper = shallowMount(EditProvider, {
@@ -267,7 +261,7 @@ describe("EditProvider", () => {
 
   it("keeps the provider enabled when disabling fails", async () => {
     apiMock.getProviderConfig.mockResolvedValue(
-      providerConfig(ProviderStatus.LOADED),
+      spotifyConfig(ProviderStatus.LOADED),
     );
     apiMock.saveProviderConfig.mockRejectedValue(new Error("Save failed"));
 
@@ -299,14 +293,14 @@ describe("EditProvider", () => {
   it("reconciles provider state when enabling fails after being saved", async () => {
     apiMock.getProviderConfig
       .mockResolvedValueOnce(
-        providerConfig(
+        spotifyConfig(
           ProviderStatus.DISABLED,
           "current value",
           undefined,
           false,
         ),
       )
-      .mockResolvedValueOnce(providerConfig(ProviderStatus.ERROR));
+      .mockResolvedValueOnce(spotifyConfig(ProviderStatus.ERROR));
     apiMock.saveProviderConfig.mockRejectedValue(new Error("Load failed"));
 
     const wrapper = shallowMount(EditProvider, {
@@ -345,9 +339,9 @@ describe("EditProvider", () => {
   it("ignores a toggle response after navigating to another provider", async () => {
     let resolveSave: (config: ProviderConfig) => void = () => {};
     apiMock.getProviderConfig
-      .mockResolvedValueOnce(providerConfig(ProviderStatus.LOADED))
+      .mockResolvedValueOnce(spotifyConfig(ProviderStatus.LOADED))
       .mockResolvedValueOnce(
-        providerConfig(
+        spotifyConfig(
           ProviderStatus.LOADED,
           "other value",
           undefined,
@@ -382,12 +376,7 @@ describe("EditProvider", () => {
     await flushPromises();
 
     resolveSave(
-      providerConfig(
-        ProviderStatus.DISABLED,
-        "current value",
-        undefined,
-        false,
-      ),
+      spotifyConfig(ProviderStatus.DISABLED, "current value", undefined, false),
     );
     await flushPromises();
 
@@ -402,9 +391,9 @@ describe("EditProvider", () => {
   it("ignores a toggle error after navigating to another provider", async () => {
     let rejectSave: (error: Error) => void = () => {};
     apiMock.getProviderConfig
-      .mockResolvedValueOnce(providerConfig(ProviderStatus.LOADED))
+      .mockResolvedValueOnce(spotifyConfig(ProviderStatus.LOADED))
       .mockResolvedValueOnce(
-        providerConfig(
+        spotifyConfig(
           ProviderStatus.LOADED,
           "other value",
           undefined,
@@ -451,7 +440,7 @@ describe("EditProvider", () => {
   it("hides the header menu while enabled when disabling is not supported", async () => {
     apiMock.providerManifests.spotify.allow_disable = false;
     apiMock.getProviderConfig.mockResolvedValue(
-      providerConfig(ProviderStatus.LOADED),
+      spotifyConfig(ProviderStatus.LOADED),
     );
 
     const wrapper = shallowMount(EditProvider, {
@@ -473,15 +462,10 @@ describe("EditProvider", () => {
   it("enables a disabled provider when disabling is not supported", async () => {
     apiMock.providerManifests.spotify.allow_disable = false;
     apiMock.getProviderConfig.mockResolvedValue(
-      providerConfig(
-        ProviderStatus.DISABLED,
-        "current value",
-        undefined,
-        false,
-      ),
+      spotifyConfig(ProviderStatus.DISABLED, "current value", undefined, false),
     );
     apiMock.saveProviderConfig.mockResolvedValue(
-      providerConfig(ProviderStatus.LOADED),
+      spotifyConfig(ProviderStatus.LOADED),
     );
 
     const wrapper = shallowMount(EditProvider, {
@@ -516,10 +500,10 @@ describe("EditProvider", () => {
   it("refreshes provider state after a provider update", async () => {
     apiMock.getProviderConfig
       .mockResolvedValueOnce(
-        providerConfig(ProviderStatus.AUTH_REQUIRED, "current value"),
+        spotifyConfig(ProviderStatus.AUTH_REQUIRED, "current value"),
       )
       .mockResolvedValueOnce(
-        providerConfig(ProviderStatus.LOADED, "server refresh"),
+        spotifyConfig(ProviderStatus.LOADED, "server refresh"),
       );
 
     const wrapper = shallowMount(EditProvider, {
@@ -558,10 +542,10 @@ describe("EditProvider", () => {
   it("merges fresh entry definitions while keeping a pending local edit", async () => {
     apiMock.getProviderConfig
       .mockResolvedValueOnce(
-        providerConfig(ProviderStatus.LOADED, "current value", []),
+        spotifyConfig(ProviderStatus.LOADED, "current value", []),
       )
       .mockResolvedValueOnce(
-        providerConfig(ProviderStatus.LOADED, "server refresh", [
+        spotifyConfig(ProviderStatus.LOADED, "server refresh", [
           { title: "Home Assistant", value: "ha" },
         ]),
       );
@@ -598,7 +582,7 @@ describe("EditProvider", () => {
 
   it("keeps form values when an action returns entries without them", async () => {
     apiMock.getProviderConfig.mockResolvedValue(
-      providerConfig(ProviderStatus.LOADED, "current value"),
+      spotifyConfig(ProviderStatus.LOADED, "current value"),
     );
     // an action response carries entry definitions only, never the stored values
     apiMock.invokeProviderConfigAction.mockResolvedValue([
@@ -639,8 +623,8 @@ describe("EditProvider", () => {
 
   it("refreshes provider status when reconfiguration ends", async () => {
     apiMock.getProviderConfig
-      .mockResolvedValueOnce(providerConfig(ProviderStatus.AUTH_REQUIRED))
-      .mockResolvedValueOnce(providerConfig(ProviderStatus.LOADED));
+      .mockResolvedValueOnce(spotifyConfig(ProviderStatus.AUTH_REQUIRED))
+      .mockResolvedValueOnce(spotifyConfig(ProviderStatus.LOADED));
 
     const wrapper = shallowMount(EditProvider, {
       props: {
@@ -670,7 +654,7 @@ describe("EditProvider", () => {
 
   it("keeps a pending local edit and shows a toast when an action returns no entries", async () => {
     apiMock.getProviderConfig.mockResolvedValueOnce(
-      providerConfig(ProviderStatus.LOADED),
+      spotifyConfig(ProviderStatus.LOADED),
     );
     apiMock.invokeProviderConfigAction.mockResolvedValueOnce([]);
 
@@ -709,7 +693,7 @@ describe("EditProvider", () => {
 
   it("does not save when an immediate-apply action returns no entries", async () => {
     apiMock.getProviderConfig.mockResolvedValueOnce(
-      providerConfig(ProviderStatus.LOADED),
+      spotifyConfig(ProviderStatus.LOADED),
     );
     apiMock.invokeProviderConfigAction.mockResolvedValueOnce([]);
 
@@ -735,7 +719,7 @@ describe("EditProvider", () => {
 
   it("still replaces the form when an action returns entries (transitional path)", async () => {
     apiMock.getProviderConfig.mockResolvedValueOnce(
-      providerConfig(ProviderStatus.LOADED),
+      spotifyConfig(ProviderStatus.LOADED),
     );
     apiMock.invokeProviderConfigAction.mockResolvedValueOnce([
       {
@@ -778,14 +762,20 @@ describe("EditProvider", () => {
   });
 });
 
-function providerConfig(
+/**
+ * The spotify provider config these tests load, with a single `account` entry.
+ *
+ * The view reads the manifest from `api.providerManifests`, not from the
+ * config, so the config's own manifest stays at the shared default.
+ */
+function spotifyConfig(
   status: ProviderStatus,
   account: string = "current value",
   accountOptions?: { title: string; value: string }[],
   enabled: boolean = true,
   instanceId: string = "spotify--test",
 ): ProviderConfig {
-  return {
+  return providerConfig({
     domain: "spotify",
     enabled,
     instance_id: instanceId,
@@ -796,24 +786,7 @@ function providerConfig(
             message: "Authentication required",
           }
         : undefined,
-    manifest: {
-      allow_disable: true,
-      builtin: false,
-      codeowners: [],
-      credits: [],
-      description: "Spotify music provider",
-      domain: "spotify",
-      icon_images: [],
-      has_setup_flow: true,
-      multi_instance: true,
-      name: "Spotify",
-      requirements: [],
-      stage: ProviderStage.STABLE,
-      type: ProviderType.MUSIC,
-    },
-    name: "Spotify",
     status,
-    type: ProviderType.MUSIC,
     values: {
       account: {
         category: "generic",
@@ -826,5 +799,5 @@ function providerConfig(
         value: account,
       },
     },
-  };
+  });
 }

--- a/tests/views/HassControlFields.test.ts
+++ b/tests/views/HassControlFields.test.ts
@@ -4,11 +4,7 @@ import type {
 } from "@/helpers/config_entry_ui";
 import { UI_ENTRY_TYPE } from "@/helpers/config_entry_ui";
 import type { HassControlEntity } from "@/helpers/hass_controls";
-import {
-  ConfigEntryType,
-  ProviderType,
-  type ProviderConfig,
-} from "@/plugins/api/interfaces";
+import { ConfigEntryType } from "@/plugins/api/interfaces";
 import type { MusicAssistantApi } from "@/plugins/api";
 import HassControlPickerField from "@/views/settings/fields/HassControlPickerField.vue";
 import HassControlsField from "@/views/settings/fields/HassControlsField.vue";
@@ -17,7 +13,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { createVuetify } from "vuetify";
 import * as components from "vuetify/components";
 import * as directives from "vuetify/directives";
-import { providerConfig } from "../fixtures/providerConfig";
+import { hassProviderConfig } from "../fixtures/hassProviderConfig";
 
 const { apiMock } = vi.hoisted(() => ({
   apiMock: {
@@ -56,8 +52,12 @@ const PICKED_ENTITY: HassControlEntity = {
 describe("HassControlPickerField", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    apiMock.getProviderConfig.mockResolvedValue(hassProviderConfig());
-    apiMock.saveProviderConfig.mockResolvedValue(hassProviderConfig());
+    apiMock.getProviderConfig.mockResolvedValue(
+      hassProviderConfig(["switch.tv"]),
+    );
+    apiMock.saveProviderConfig.mockResolvedValue(
+      hassProviderConfig(["switch.tv"]),
+    );
   });
 
   it("registers the picked entity with the Home Assistant provider and fills in the player entry", async () => {
@@ -145,26 +145,6 @@ describe("HassControlsField", () => {
     ).toEqual(["switch.tv"]);
   });
 });
-
-function hassProviderConfig(): ProviderConfig {
-  return providerConfig({
-    type: ProviderType.PLUGIN,
-    domain: "hass",
-    values: {
-      power_controls: {
-        key: "power_controls",
-        type: ConfigEntryType.STRING,
-        label: "Power controls",
-        default_value: [],
-        required: false,
-        options: [],
-        category: "generic",
-        multi_value: true,
-        value: ["switch.tv"],
-      },
-    },
-  });
-}
 
 function pickerEntry(): HassControlPickerEntry {
   return {

--- a/tests/views/HassControlFields.test.ts
+++ b/tests/views/HassControlFields.test.ts
@@ -6,7 +6,6 @@ import { UI_ENTRY_TYPE } from "@/helpers/config_entry_ui";
 import type { HassControlEntity } from "@/helpers/hass_controls";
 import {
   ConfigEntryType,
-  ProviderStage,
   ProviderType,
   type ProviderConfig,
 } from "@/plugins/api/interfaces";
@@ -18,6 +17,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { createVuetify } from "vuetify";
 import * as components from "vuetify/components";
 import * as directives from "vuetify/directives";
+import { providerConfig } from "../fixtures/providerConfig";
 
 const { apiMock } = vi.hoisted(() => ({
   apiMock: {
@@ -147,25 +147,9 @@ describe("HassControlsField", () => {
 });
 
 function hassProviderConfig(): ProviderConfig {
-  return {
+  return providerConfig({
     type: ProviderType.PLUGIN,
     domain: "hass",
-    instance_id: "hass--1",
-    enabled: true,
-    manifest: {
-      type: ProviderType.PLUGIN,
-      domain: "hass",
-      name: "Home Assistant",
-      description: "Home Assistant integration",
-      codeowners: [],
-      credits: [],
-      requirements: [],
-      multi_instance: false,
-      builtin: false,
-      allow_disable: true,
-      stage: ProviderStage.STABLE,
-      icon_images: [],
-    },
     values: {
       power_controls: {
         key: "power_controls",
@@ -179,7 +163,7 @@ function hassProviderConfig(): ProviderConfig {
         value: ["switch.tv"],
       },
     },
-  };
+  });
 }
 
 function pickerEntry(): HassControlPickerEntry {

--- a/tests/views/Login.test.ts
+++ b/tests/views/Login.test.ts
@@ -1,8 +1,9 @@
 import Login from "@/views/Login.vue";
 import type { MusicAssistantApi } from "@/plugins/api";
-import { UserRole, type User } from "@/plugins/api/interfaces";
+import { UserRole } from "@/plugins/api/interfaces";
 import { flushPromises, mount, type VueWrapper } from "@vue/test-utils";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { user } from "../fixtures/user";
 
 const mocks = vi.hoisted(() => ({
   apiState: { value: "disconnected" as string },
@@ -202,7 +203,7 @@ function mockHostedFrontend() {
 }
 
 function mockSuccessfulGuest(username = "party_guest") {
-  const guestUser = testUser({
+  const guestUser = user({
     user_id: "guest-id",
     username,
     role: UserRole.GUEST,
@@ -222,27 +223,13 @@ function mockSuccessfulGuest(username = "party_guest") {
       user:
         token === "guest-token"
           ? guestUser
-          : testUser({
+          : user({
               user_id: "regular-id",
               username: "regular-user",
               role: UserRole.ADMIN,
             }),
     }),
   );
-}
-
-function testUser(overrides: Partial<User> = {}): User {
-  return {
-    user_id: "user-id",
-    username: "user",
-    role: UserRole.USER,
-    enabled: true,
-    created_at: "2024-01-01T00:00:00Z",
-    preferences: {},
-    provider_filter: [],
-    player_filter: [],
-    ...overrides,
-  };
 }
 
 beforeEach(() => {
@@ -297,7 +284,7 @@ beforeEach(() => {
       : null,
   );
   mocks.getCurrentUserInfo.mockResolvedValue(
-    testUser({
+    user({
       user_id: "ingress-user",
       username: "ingress-user",
       role: UserRole.ADMIN,
@@ -339,7 +326,7 @@ describe("guest join login", () => {
         [
           {
             token: "guest-token",
-            user: testUser({
+            user: user({
               user_id: "guest-id",
               username,
               role: UserRole.GUEST,
@@ -437,7 +424,7 @@ describe("guest join login", () => {
     await flushPromises();
     expect(wrapper.emitted("authenticated")?.[0]?.[0]).toEqual({
       token: "admin-token",
-      user: testUser({
+      user: user({
         user_id: "regular-id",
         username: "regular-user",
         role: UserRole.ADMIN,
@@ -567,7 +554,7 @@ describe("guest join login", () => {
     await flushPromises();
     expect(wrapper.emitted("authenticated")?.[0]?.[0]).toEqual({
       token: "admin-token",
-      user: testUser({
+      user: user({
         user_id: "regular-id",
         username: "regular-user",
         role: UserRole.ADMIN,
@@ -598,7 +585,7 @@ describe("guest join login", () => {
     await flushPromises();
     expect(wrapper.emitted("authenticated")?.[0]?.[0]).toEqual({
       token: "guest-token",
-      user: testUser({
+      user: user({
         user_id: "guest-id",
         username: "party_guest",
         role: UserRole.GUEST,
@@ -660,7 +647,7 @@ describe("guest join login", () => {
 
     await flushPromises();
     expect(wrapper.emitted("authenticated")?.[0]?.[0]).toEqual({
-      user: testUser({
+      user: user({
         user_id: "ingress-user",
         username: "ingress-user",
         role: UserRole.ADMIN,
@@ -815,7 +802,7 @@ describe("ingress login", () => {
 
     await flushPromises();
     expect(wrapper.emitted("authenticated")?.[0]?.[0]).toEqual({
-      user: testUser({
+      user: user({
         role: UserRole.ADMIN,
         user_id: "ingress-user",
         username: "ingress-user",
@@ -835,7 +822,7 @@ describe("ingress login", () => {
     await flushPromises();
     expect(wrapper.emitted("authenticated")?.[0]?.[0]).toEqual({
       token: "admin-token",
-      user: testUser({
+      user: user({
         role: UserRole.ADMIN,
         user_id: "regular-id",
         username: "regular-user",

--- a/tests/views/MusicQuizDashboardView.test.ts
+++ b/tests/views/MusicQuizDashboardView.test.ts
@@ -5,6 +5,7 @@ import { flushPromises, mount } from "@vue/test-utils";
 import { nextTick } from "vue";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { providerConfig } from "../fixtures/providerConfig";
+import { providerManifest } from "../fixtures/providerManifest";
 
 const {
   apiMock,
@@ -303,6 +304,12 @@ function musicQuizProviderConfig(instanceId: string): ProviderConfig {
     type: ProviderType.PLUGIN,
     domain: "music_quiz",
     instance_id: instanceId,
+    manifest: providerManifest({
+      type: ProviderType.PLUGIN,
+      domain: "music_quiz",
+      name: "Music Quiz",
+      description: "Music Quiz plugin provider",
+    }),
   });
 }
 

--- a/tests/views/MusicQuizDashboardView.test.ts
+++ b/tests/views/MusicQuizDashboardView.test.ts
@@ -1,13 +1,10 @@
 import MusicQuizDashboardView from "@/views/MusicQuizDashboardView.vue";
-import {
-  ProviderStage,
-  ProviderType,
-  type ProviderConfig,
-} from "@/plugins/api/interfaces";
+import { ProviderType, type ProviderConfig } from "@/plugins/api/interfaces";
 import type { MusicAssistantApi } from "@/plugins/api";
 import { flushPromises, mount } from "@vue/test-utils";
 import { nextTick } from "vue";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { providerConfig } from "../fixtures/providerConfig";
 
 const {
   apiMock,
@@ -302,27 +299,11 @@ describe("MusicQuizDashboardView", () => {
 });
 
 function musicQuizProviderConfig(instanceId: string): ProviderConfig {
-  return {
+  return providerConfig({
     type: ProviderType.PLUGIN,
     domain: "music_quiz",
     instance_id: instanceId,
-    enabled: true,
-    manifest: {
-      type: ProviderType.PLUGIN,
-      domain: "music_quiz",
-      name: "Music Quiz",
-      description: "Music Quiz plugin provider",
-      codeowners: [],
-      credits: [],
-      requirements: [],
-      multi_instance: false,
-      builtin: false,
-      allow_disable: true,
-      stage: ProviderStage.STABLE,
-      icon_images: [],
-    },
-    values: {},
-  };
+  });
 }
 
 function mountDashboard() {

--- a/tests/views/Players.test.ts
+++ b/tests/views/Players.test.ts
@@ -1,9 +1,10 @@
 import Players from "@/views/settings/Players.vue";
 import type { MusicAssistantApi } from "@/plugins/api";
-import { ProviderStage, ProviderType } from "@/plugins/api/interfaces";
+import { ProviderType } from "@/plugins/api/interfaces";
 import { flushPromises, mount } from "@vue/test-utils";
 import { ref } from "vue";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { providerManifest } from "../fixtures/providerManifest";
 
 const { apiMock, emitEvent, routerPush } = vi.hoisted(() => ({
   apiMock: {
@@ -107,20 +108,7 @@ describe("Players", () => {
       supported_features: [],
       available: true,
     });
-    apiMock.getProviderManifest.mockReturnValue({
-      type: ProviderType.PLAYER,
-      domain: "test",
-      name: "Test",
-      description: "Test player provider",
-      codeowners: [],
-      credits: [],
-      requirements: [],
-      multi_instance: false,
-      builtin: false,
-      allow_disable: true,
-      stage: ProviderStage.STABLE,
-      icon_images: [],
-    });
+    apiMock.getProviderManifest.mockReturnValue(providerManifest());
     apiMock.subscribe_multi.mockReturnValue(vi.fn());
   });
 

--- a/tests/views/Providers.test.ts
+++ b/tests/views/Providers.test.ts
@@ -1,13 +1,10 @@
 import { flushPromises, shallowMount } from "@vue/test-utils";
 import { ref } from "vue";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import {
-  ProviderStage,
-  ProviderStatus,
-  ProviderType,
-} from "@/plugins/api/interfaces";
+import { ProviderStatus } from "@/plugins/api/interfaces";
 import type { MusicAssistantApi } from "@/plugins/api";
 import Providers from "@/views/settings/Providers.vue";
+import { providerConfig } from "../fixtures/providerConfig";
 
 const { apiMock, eventbusMock, routeMock, routerMock } = vi.hoisted(() => ({
   apiMock: {
@@ -270,7 +267,7 @@ async function mountProviders(
 ) {
   apiMock.providerManifests.spotify.has_setup_flow = hasSetupFlow;
   apiMock.getProviderConfigs.mockResolvedValue([
-    {
+    providerConfig({
       domain: "spotify",
       enabled,
       instance_id: "spotify--test",
@@ -278,27 +275,9 @@ async function mountProviders(
         error_code: 1,
         message: "Authentication required",
       },
-      manifest: {
-        allow_disable: true,
-        builtin: false,
-        codeowners: [],
-        credits: [],
-        description: "Spotify music provider",
-        documentation: "https://example.com",
-        domain: "spotify",
-        has_setup_flow: hasSetupFlow,
-        icon_images: [],
-        multi_instance: true,
-        name: "Spotify",
-        requirements: [],
-        stage: ProviderStage.STABLE,
-        type: ProviderType.MUSIC,
-      },
       name: "Spotify",
       status,
-      type: ProviderType.MUSIC,
-      values: {},
-    },
+    }),
   ]);
 
   const wrapper = shallowMount(Providers, {


### PR DESCRIPTION
The recent test-typing work was split across parallel agents, which left the same full object literals copied into a lot of test files — the same provider manifest was written out nine times, and tracks, playlists, genres and users several times each. That makes the tests noisy to read and easy to drift apart.

Moved them into `tests/fixtures/`, next to the `providerMapping` fixture that was already there.

- new `track`, `playlist`, `genre`, `user`, `providerManifest` and `providerConfig` fixtures
- test files import them and drop their local copies (~570 lines removed)
- one signature everywhere: `fixture({ ...overrides })`, replacing the mix of positional arguments and one-off shapes

No test behaviour changes — same tests, same count.