### PR TITLE
Music Quiz dashboard for TVs and casting

### DIFF
--- a/src/components/music-quiz/MusicQuizQrCard.vue
+++ b/src/components/music-quiz/MusicQuizQrCard.vue
@@ -19,6 +19,7 @@
         {{ $t("providers.music_quiz.qr_unavailable") }}
       </p>
       <InvitationShareActions
+        v-if="!hideShareActions"
         :join-link="joinLink"
         :title="$t('providers.music_quiz.share_title')"
         :description="$t('providers.music_quiz.share_description')"
@@ -45,8 +46,10 @@ const props = withDefaults(
     joinLink: string;
     size?: number;
     caption?: string;
+    // a cast TV or kiosk has no way to copy or share the link
+    hideShareActions?: boolean;
   }>(),
-  { size: 220, caption: undefined },
+  { size: 220, caption: undefined, hideShareActions: false },
 );
 
 const qrCanvas = ref<HTMLCanvasElement | null>(null);

--- a/src/components/music-quiz/adapter_contracts.ts
+++ b/src/components/music-quiz/adapter_contracts.ts
@@ -5,6 +5,7 @@ import type {
   MusicQuizRoundBase,
   MusicQuizSupportedHostState,
   MusicQuizSupportedPersonalizedState,
+  MusicQuizSupportedPublicState,
   MusicQuizSupportedRound,
 } from "@/composables/music-quiz/useMusicQuiz";
 import type { MusicQuizLeaderboardRow } from "@/components/music-quiz/MusicQuizLeaderboard.vue";
@@ -54,13 +55,18 @@ export interface MusicQuizHostGameAdapterProps<
   currentRound: TRound;
 }
 
-export type MusicQuizPresentGameAdapterProps<
-  TState extends MusicQuizSupportedHostState = MusicQuizSupportedHostState,
+// Present adapters render the guest-safe public state: the dashboard feeds them
+// music_quiz/public_state, and host state is a superset so host callers still fit.
+export interface MusicQuizPresentGameAdapterProps<
+  TState extends MusicQuizSupportedPublicState = MusicQuizSupportedPublicState,
   TRound extends MusicQuizRoundBase = MusicQuizSupportedRound,
-> = MusicQuizHostGameAdapterProps<TState, TRound>;
+> {
+  state: TState;
+  currentRound: TRound;
+}
 
 export interface MusicQuizPresentBodyAdapterProps<
-  TState extends MusicQuizSupportedHostState = MusicQuizSupportedHostState,
+  TState extends MusicQuizSupportedPublicState = MusicQuizSupportedPublicState,
   TRound extends MusicQuizRoundBase = MusicQuizSupportedRound,
 > {
   state: TState;
@@ -92,10 +98,13 @@ export interface MusicQuizHostAnswerAdapterProps<
   currentRound: TRound;
 }
 
-export type MusicQuizPresentAnswerAdapterProps<
-  TState extends MusicQuizSupportedHostState = MusicQuizSupportedHostState,
+export interface MusicQuizPresentAnswerAdapterProps<
+  TState extends MusicQuizSupportedPublicState = MusicQuizSupportedPublicState,
   TRound extends MusicQuizRoundBase = MusicQuizSupportedRound,
-> = MusicQuizHostAnswerAdapterProps<TState, TRound>;
+> {
+  state: TState;
+  currentRound: TRound;
+}
 
 export interface MusicQuizAnswerAdapterSlots {
   leaderboard: () => VNode[];

--- a/src/components/music-quiz/answer-types/multiple-choice/MultipleChoicePresentAnswer.vue
+++ b/src/components/music-quiz/answer-types/multiple-choice/MultipleChoicePresentAnswer.vue
@@ -43,7 +43,7 @@ import MultipleChoiceGrid from "@/components/music-quiz/answer-types/multiple-ch
 import MultipleChoiceProgress from "@/components/music-quiz/answer-types/multiple-choice/MultipleChoiceProgress.vue";
 import MusicQuizCountdown from "@/components/music-quiz/MusicQuizCountdown.vue";
 import type {
-  MusicQuizMultipleChoiceHostState,
+  MusicQuizMultipleChoicePublicState,
   MusicQuizMultipleChoiceRound,
 } from "@/composables/music-quiz/useMusicQuiz";
 import { useMusicQuizAnswerDeadline } from "@/composables/music-quiz/useMusicQuizAnswerDeadline";
@@ -53,7 +53,7 @@ import { computed } from "vue";
 const props =
   defineProps<
     MusicQuizPresentAnswerAdapterProps<
-      MusicQuizMultipleChoiceHostState,
+      MusicQuizMultipleChoicePublicState,
       MusicQuizMultipleChoiceRound
     >
   >();

--- a/src/components/music-quiz/answer-types/timeline/TimelineAudienceAnswer.vue
+++ b/src/components/music-quiz/answer-types/timeline/TimelineAudienceAnswer.vue
@@ -123,7 +123,7 @@ import TimelineProgress from "@/components/music-quiz/answer-types/timeline/Time
 import MusicQuizCountdown from "@/components/music-quiz/MusicQuizCountdown.vue";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import type {
-  MusicQuizTimelineHostState,
+  MusicQuizTimelinePublicState,
   MusicQuizTimelineRound,
 } from "@/composables/music-quiz/useMusicQuiz";
 import { useMusicQuizAnswerDeadline } from "@/composables/music-quiz/useMusicQuizAnswerDeadline";
@@ -134,7 +134,7 @@ import { computed, type VNode } from "vue";
 
 const props = withDefaults(
   defineProps<{
-    state: MusicQuizTimelineHostState;
+    state: MusicQuizTimelinePublicState;
     currentRound: MusicQuizTimelineRound;
     present?: boolean;
     showTimeline?: boolean;

--- a/src/components/music-quiz/answer-types/timeline/TimelinePresentAnswer.vue
+++ b/src/components/music-quiz/answer-types/timeline/TimelinePresentAnswer.vue
@@ -17,13 +17,13 @@ import type {
   MusicQuizPresentAnswerAdapterProps,
 } from "@/components/music-quiz/adapter_contracts";
 import type {
-  MusicQuizTimelineHostState,
+  MusicQuizTimelinePublicState,
   MusicQuizTimelineRound,
 } from "@/composables/music-quiz/useMusicQuiz";
 
 defineProps<
   MusicQuizPresentAnswerAdapterProps<
-    MusicQuizTimelineHostState,
+    MusicQuizTimelinePublicState,
     MusicQuizTimelineRound
   >
 >();

--- a/src/components/music-quiz/game-types/guess-the-song/GuessTheSongPresentRound.vue
+++ b/src/components/music-quiz/game-types/guess-the-song/GuessTheSongPresentRound.vue
@@ -23,7 +23,7 @@
 import type { MusicQuizPresentGameAdapterProps } from "@/components/music-quiz/adapter_contracts";
 import GuessTheSongReveal from "@/components/music-quiz/game-types/guess-the-song/GuessTheSongReveal.vue";
 import type {
-  MusicQuizGuessTheSongHostState,
+  MusicQuizGuessTheSongPublicState,
   MusicQuizGuessTheSongRound,
 } from "@/composables/music-quiz/useMusicQuiz";
 import { getMediaImageUrl } from "@/helpers/utils";
@@ -33,7 +33,7 @@ import { computed } from "vue";
 const props =
   defineProps<
     MusicQuizPresentGameAdapterProps<
-      MusicQuizGuessTheSongHostState,
+      MusicQuizGuessTheSongPublicState,
       MusicQuizGuessTheSongRound
     >
   >();

--- a/src/components/music-quiz/game-types/music-timeline/MusicTimelinePresentBody.vue
+++ b/src/components/music-quiz/game-types/music-timeline/MusicTimelinePresentBody.vue
@@ -44,13 +44,13 @@ import type { MusicQuizPresentBodyAdapterProps } from "@/components/music-quiz/a
 import MusicTimelinePresentRound from "@/components/music-quiz/game-types/music-timeline/MusicTimelinePresentRound.vue";
 import MusicQuizLeaderboard from "@/components/music-quiz/MusicQuizLeaderboard.vue";
 import type {
-  MusicQuizTimelineHostState,
+  MusicQuizTimelinePublicState,
   MusicQuizTimelineRound,
 } from "@/composables/music-quiz/useMusicQuiz";
 
 defineProps<
   MusicQuizPresentBodyAdapterProps<
-    MusicQuizTimelineHostState,
+    MusicQuizTimelinePublicState,
     MusicQuizTimelineRound
   >
 >();

--- a/src/components/music-quiz/game-types/music-timeline/MusicTimelinePresentRound.vue
+++ b/src/components/music-quiz/game-types/music-timeline/MusicTimelinePresentRound.vue
@@ -11,14 +11,14 @@
 import type { MusicQuizPresentGameAdapterProps } from "@/components/music-quiz/adapter_contracts";
 import MusicTimelineRound from "@/components/music-quiz/game-types/music-timeline/MusicTimelineRound.vue";
 import type {
-  MusicQuizTimelineHostState,
+  MusicQuizTimelinePublicState,
   MusicQuizTimelineRound,
 } from "@/composables/music-quiz/useMusicQuiz";
 
 withDefaults(
   defineProps<
     MusicQuizPresentGameAdapterProps<
-      MusicQuizTimelineHostState,
+      MusicQuizTimelinePublicState,
       MusicQuizTimelineRound
     > & {
       compact?: boolean;

--- a/src/components/music-quiz/game-types/trivia/TriviaPresentRound.vue
+++ b/src/components/music-quiz/game-types/trivia/TriviaPresentRound.vue
@@ -18,7 +18,7 @@
 import type { MusicQuizPresentGameAdapterProps } from "@/components/music-quiz/adapter_contracts";
 import TriviaQuestion from "@/components/music-quiz/game-types/trivia/TriviaQuestion.vue";
 import type {
-  MusicQuizTriviaHostState,
+  MusicQuizTriviaPublicState,
   MusicQuizTriviaRound,
 } from "@/composables/music-quiz/useMusicQuiz";
 import { useMusicQuizRevealCountdown } from "@/composables/music-quiz/useMusicQuizRevealCountdown";
@@ -29,7 +29,7 @@ import { computed } from "vue";
 const props =
   defineProps<
     MusicQuizPresentGameAdapterProps<
-      MusicQuizTriviaHostState,
+      MusicQuizTriviaPublicState,
       MusicQuizTriviaRound
     >
   >();

--- a/src/components/music-quiz/game_types.ts
+++ b/src/components/music-quiz/game_types.ts
@@ -50,6 +50,9 @@ export interface MusicQuizGameDefinition<
   supportsListenIn: MusicQuizStateCapability;
   usesRevealCountdown?: boolean;
   revealPhaseLabelKey: string;
+  // shown by the dashboard while answering, for games whose present adapter
+  // renders nothing then (audio-only guessing)
+  answeringPromptKey?: string;
   adapters: {
     setup: Component;
     player: Component;
@@ -74,6 +77,7 @@ const MUSIC_QUIZ_GAME_TYPE_REGISTRY = {
     requiresBackendAvailability: false,
     supportsListenIn: true,
     revealPhaseLabelKey: "providers.music_quiz.phase_enjoy_track",
+    answeringPromptKey: "providers.music_quiz.name_that_track",
     adapters: {
       setup: markRaw(GuessTheSongSetup),
       player: markRaw(GuessTheSongPlayerRound),

--- a/src/composables/music-quiz/useMusicQuiz.ts
+++ b/src/composables/music-quiz/useMusicQuiz.ts
@@ -101,6 +101,9 @@ interface MusicQuizStateIdentity<
   name: string | null;
   include_similar_music?: boolean;
   auto_start_at?: number | null;
+  // public and host state only, and only once the server resolved it: servers
+  // before the dashboard feature omit it, and then a display hides its join QR
+  join_url?: string;
 }
 
 interface MusicQuizGuessTheSongStateBase extends MusicQuizStateIdentity {
@@ -226,6 +229,10 @@ export interface MusicQuizTriviaHostState extends MusicQuizTriviaStateBase {
   rounds: MusicQuizTriviaHostRound[];
   playback?: MusicQuizHostPlayback;
 }
+
+export type MusicQuizMultipleChoicePublicState =
+  | MusicQuizGuessTheSongPublicState
+  | MusicQuizTriviaPublicState;
 
 export type MusicQuizMultipleChoiceHostState =
   | MusicQuizGuessTheSongHostState
@@ -733,6 +740,21 @@ export function getMusicQuizInfo(): Promise<MusicQuizInfo | null> {
   return api.sendCommand<MusicQuizInfo | null>("music_quiz/info", undefined, {
     suppressGlobalError: true,
   });
+}
+
+export function getMusicQuizPublicState(): Promise<MusicQuizPublicState | null> {
+  // Without the music_quiz provider loaded the command isn't registered, and there
+  // can be no active quiz either — so don't bother the server.
+  const hasMusicQuiz = Object.values(api.providers).some(
+    (provider) => provider.domain === "music_quiz",
+  );
+  if (!hasMusicQuiz) return Promise.resolve(null);
+  // A kiosk display has nowhere to show a toast; callers handle failures locally.
+  return api.sendCommand<MusicQuizPublicState | null>(
+    "music_quiz/public_state",
+    undefined,
+    { suppressGlobalError: true },
+  );
 }
 
 export function joinMusicQuiz(name: string) {

--- a/src/composables/music-quiz/useMusicQuizDashboard.ts
+++ b/src/composables/music-quiz/useMusicQuizDashboard.ts
@@ -5,10 +5,10 @@ import {
   type MusicQuizCurrentRound,
   type MusicQuizPublicState,
 } from "@/composables/music-quiz/useMusicQuiz";
-import api from "@/plugins/api";
+import api, { ConnectionState } from "@/plugins/api";
 import { waitForApiInitialization } from "@/plugins/api/helpers";
 import { EventType } from "@/plugins/api/interfaces";
-import { computed, onBeforeUnmount, onMounted, ref } from "vue";
+import { computed, onBeforeUnmount, onMounted, ref, watch } from "vue";
 
 /**
  * Viewer-only Music Quiz state for the cast/kiosk dashboard.
@@ -71,6 +71,18 @@ export function useMusicQuizDashboard() {
     stateRequestId += 1;
     unsubscribeProviderEvent?.();
   });
+
+  // A TV that drops its socket only gets a fresh game_updated once something
+  // changes in the game; refetch on reconnect so it isn't stuck showing stale
+  // state until then. Not immediate, so it only fires on an actual transition
+  // and doesn't duplicate the mount's own fetch; any edge-case overlap is
+  // harmless since fetchState()'s stateRequestId guard already dedupes it.
+  watch(
+    () => api.state.value,
+    (newState) => {
+      if (newState === ConnectionState.INITIALIZED) void fetchState();
+    },
+  );
 
   return { state, loading, currentRound, joinLink, fetchState };
 

--- a/src/composables/music-quiz/useMusicQuizDashboard.ts
+++ b/src/composables/music-quiz/useMusicQuizDashboard.ts
@@ -1,0 +1,98 @@
+import {
+  getMusicQuizPublicState,
+  isMusicQuizProviderEvent,
+  isSupportedMusicQuiz,
+  type MusicQuizCurrentRound,
+  type MusicQuizPublicState,
+} from "@/composables/music-quiz/useMusicQuiz";
+import api from "@/plugins/api";
+import { waitForApiInitialization } from "@/plugins/api/helpers";
+import { EventType } from "@/plugins/api/interfaces";
+import { computed, onBeforeUnmount, onMounted, ref } from "vue";
+
+/**
+ * Viewer-only Music Quiz state for the cast/kiosk dashboard.
+ *
+ * Fetches the guest-safe public state once on mount, then follows the provider's
+ * game_updated broadcasts. Their payload already IS the public state, so unlike
+ * the host composable this never re-fetches; game_removed clears the state.
+ */
+export function useMusicQuizDashboard() {
+  const state = ref<MusicQuizPublicState | null>(null);
+  const loading = ref(true);
+  const providerInstanceId = ref<string | null>(null);
+
+  let unsubscribeProviderEvent: (() => void) | undefined;
+  let stateRequestId = 0;
+  let disposed = false;
+
+  const currentRound = computed<MusicQuizCurrentRound | null>(() => {
+    const currentState = state.value;
+    return currentState && isSupportedMusicQuiz(currentState)
+      ? (currentState.current_round ?? null)
+      : null;
+  });
+
+  const joinLink = computed(() => state.value?.join_url ?? "");
+
+  async function fetchState() {
+    const requestId = ++stateRequestId;
+    loading.value = true;
+    try {
+      const nextState = await getMusicQuizPublicState();
+      if (disposed || requestId !== stateRequestId) return;
+      state.value = nextState;
+    } catch (err) {
+      if (disposed || requestId !== stateRequestId) return;
+      // a kiosk display has nowhere to surface an error: fall back to waiting
+      console.warn("Could not load the Music Quiz public state", err);
+      state.value = null;
+    } finally {
+      if (requestId === stateRequestId) loading.value = false;
+    }
+  }
+
+  onMounted(() => {
+    void (async () => {
+      // On a hard refresh this can mount before the provider registry is known,
+      // which would resolve to a wrong "no quiz" answer.
+      await waitForApiInitialization();
+      if (disposed) return;
+      await fetchState();
+    })();
+    unsubscribeProviderEvent = api.subscribe(
+      EventType.PROVIDER_EVENT,
+      handleProviderEvent,
+    );
+  });
+
+  onBeforeUnmount(() => {
+    disposed = true;
+    stateRequestId += 1;
+    unsubscribeProviderEvent?.();
+  });
+
+  return { state, loading, currentRound, joinLink, fetchState };
+
+  function handleProviderEvent(event: { object_id?: string; data?: unknown }) {
+    if (!isMusicQuizProviderEvent(event.data)) return;
+    const payload = event.data;
+    if (!isScopedProviderEvent(event.object_id)) return;
+    applyState(payload.event === "game_updated" ? payload.state : null);
+  }
+
+  function isScopedProviderEvent(objectId?: string) {
+    if (!objectId) return false;
+    if (!providerInstanceId.value) {
+      providerInstanceId.value = objectId;
+      return true;
+    }
+    return providerInstanceId.value === objectId;
+  }
+
+  function applyState(nextState: MusicQuizPublicState | null) {
+    stateRequestId += 1;
+    state.value = nextState;
+    loading.value = false;
+  }
+}

--- a/src/helpers/dashboard_viewer_access.ts
+++ b/src/helpers/dashboard_viewer_access.ts
@@ -1,7 +1,9 @@
 // Routes a dashboard viewer may be pinned to (else falls back to /party); matched by pathname only since a pinned route can carry a query string.
 const DASHBOARD_VIEWER_ROUTES = new Set([
   "/party",
+  // kept alongside the kiosk view: an older server still pins viewers here
   "/music-quiz",
+  "/music-quiz/dashboard",
   "/now-playing",
 ]);
 

--- a/src/plugins/router.ts
+++ b/src/plugins/router.ts
@@ -109,6 +109,21 @@ export const routes: RouteRecordRaw[] = [
       },
     ],
   },
+  // Viewer-only Music Quiz kiosk route; top-level like /now-playing so it renders without nav/player chrome, and unlike /music-quiz it needs no host scope.
+  {
+    path: "/music-quiz/dashboard",
+    component: () => import("@/layouts/default/Default.vue"),
+    children: [
+      {
+        path: "",
+        name: "music-quiz-dashboard",
+        component: () =>
+          import(
+            /* webpackChunkName: "music-quiz" */ "@/views/MusicQuizDashboardStageView.vue"
+          ),
+      },
+    ],
+  },
   // All other routes go through default layout with navigation/player controls
   {
     path: "/",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1612,6 +1612,8 @@
             "leaderboard": "Leaderboard",
             "invite_players": "Invite players",
             "qr_unavailable": "Could not render QR code",
+            "dashboard_waiting": "Waiting for the quiz to start",
+            "name_that_track": "Name that track",
             "copied": "Copied",
             "copy_link": "Copy link",
             "join_link_copied": "Join link copied",

--- a/src/views/MusicQuizDashboardStageView.vue
+++ b/src/views/MusicQuizDashboardStageView.vue
@@ -1,0 +1,5 @@
+<template>
+  <div></div>
+</template>
+
+<script setup lang="ts"></script>

--- a/src/views/MusicQuizDashboardStageView.vue
+++ b/src/views/MusicQuizDashboardStageView.vue
@@ -382,7 +382,8 @@ watch(
    50% opacity with muted text they turn unreadable on the black TV canvas. */
 .music-quiz-dashboard
   :deep([data-testid="music-quiz-dashboard-round-body"] button:disabled) {
-  opacity: 1;
+  /* !important because the tailwind build emits utilities with !important */
+  opacity: 1 !important;
   color: var(--color-white);
 }
 

--- a/src/views/MusicQuizDashboardStageView.vue
+++ b/src/views/MusicQuizDashboardStageView.vue
@@ -97,6 +97,31 @@
             :current-round="currentRound"
             :leaderboard-rows="visibleLeaderboardRows"
           />
+          <template v-else-if="activeState.phase === 'reveal'">
+            <div
+              data-testid="music-quiz-dashboard-reveal-layout"
+              class="grid min-h-0 flex-1 gap-[2vh] lg:grid-cols-[minmax(0,1fr)_minmax(0,22rem)] lg:gap-[2vw]"
+            >
+              <component
+                :is="resolvedDefinition.game.adapters.present"
+                :state="activeState"
+                :current-round="currentRound"
+              />
+              <component
+                :is="resolvedDefinition.answer.adapters.present"
+                :state="activeState"
+                :current-round="currentRound"
+              >
+                <template #leaderboard>
+                  <MusicQuizLeaderboard
+                    class="min-h-0 flex-1"
+                    :rows="visibleLeaderboardRows"
+                    scrollable
+                  />
+                </template>
+              </component>
+            </div>
+          </template>
           <template v-else>
             <p
               v-if="answeringPrompt"
@@ -155,7 +180,7 @@
       </template>
 
       <div
-        v-else
+        v-else-if="!loading"
         data-testid="music-quiz-dashboard-waiting"
         class="flex min-h-0 flex-1 flex-col items-center justify-center gap-[2vh] text-center"
       >
@@ -197,7 +222,7 @@ import { $t } from "@/plugins/i18n";
 import { Disc3 } from "@lucide/vue";
 import { computed, watch } from "vue";
 
-const { state, currentRound, joinLink } = useMusicQuizDashboard();
+const { state, currentRound, joinLink, loading } = useMusicQuizDashboard();
 
 const resolvedDefinition = computed(() => {
   const currentState = state.value;

--- a/src/views/MusicQuizDashboardStageView.vue
+++ b/src/views/MusicQuizDashboardStageView.vue
@@ -23,6 +23,9 @@
               {{ activeState.name || $t("providers.music_quiz.title") }}
             </h1>
             <p
+              role="status"
+              aria-live="polite"
+              aria-atomic="true"
               class="mt-1 text-[clamp(0.95rem,1.5vw,1.6rem)] font-semibold tracking-[0.15em] text-white/45 uppercase"
             >
               {{ phaseLabel }}
@@ -55,7 +58,7 @@
             hide-share-actions
             :caption="$t('providers.music_quiz.invite_players')"
           />
-          <div class="flex min-w-0 flex-col gap-[2vh]">
+          <div class="flex min-h-0 min-w-0 flex-col gap-[2vh] self-stretch">
             <h2
               class="text-[clamp(1.4rem,2.6vw,2.4rem)] font-bold text-white/90"
             >
@@ -70,7 +73,8 @@
             />
             <div
               v-if="activeState.players.length"
-              class="grid grid-cols-[repeat(auto-fill,minmax(11rem,1fr))] gap-3"
+              data-testid="music-quiz-dashboard-player-grid"
+              class="grid min-h-0 flex-1 grid-cols-[repeat(auto-fill,minmax(11rem,1fr))] gap-3 overflow-y-auto"
             >
               <MusicQuizPlayerTile
                 v-for="player in sortedPlayers"

--- a/src/views/MusicQuizDashboardStageView.vue
+++ b/src/views/MusicQuizDashboardStageView.vue
@@ -139,19 +139,32 @@
               :state="activeState"
               :current-round="currentRound"
             />
-            <component
-              :is="resolvedDefinition.answer.adapters.present"
-              :state="activeState"
-              :current-round="currentRound"
+            <div class="flex justify-center py-[1vh]">
+              <MusicQuizCountdown
+                :size="160"
+                :fraction="answerFraction"
+                :label="answerLabel || '…'"
+              />
+            </div>
+            <div
+              v-if="answerOptions.length"
+              data-testid="music-quiz-dashboard-options"
+              class="grid min-h-0 content-start gap-[1.5vh] sm:grid-cols-2 lg:gap-[1.5vw]"
             >
-              <template #leaderboard>
-                <MusicQuizLeaderboard
-                  class="min-h-0 flex-1"
-                  :rows="visibleLeaderboardRows"
-                  scrollable
-                />
-              </template>
-            </component>
+              <div
+                v-for="(option, index) in answerOptions"
+                :key="option.suggestion_id"
+                class="flex items-center gap-[0.9em] rounded-2xl bg-white/5 px-[1.1em] py-[0.9em] text-[clamp(1.1rem,2vw,2rem)] font-medium text-white/90"
+              >
+                <span
+                  class="grid size-[1.9em] shrink-0 place-items-center rounded-full bg-white/10 text-[0.75em] font-bold text-white/80"
+                  aria-hidden="true"
+                >
+                  {{ optionLetter(index) }}
+                </span>
+                <span class="min-w-0 break-words">{{ option.label }}</span>
+              </div>
+            </div>
           </template>
           <p
             v-if="revealCountdownText"
@@ -200,6 +213,7 @@
 <script setup lang="ts">
 import MusicQuizAutoStartStatus from "@/components/music-quiz/MusicQuizAutoStartStatus.vue";
 import MusicQuizConnectionBanners from "@/components/music-quiz/MusicQuizConnectionBanners.vue";
+import MusicQuizCountdown from "@/components/music-quiz/MusicQuizCountdown.vue";
 import MusicQuizLeaderboard, {
   type MusicQuizLeaderboardRow,
 } from "@/components/music-quiz/MusicQuizLeaderboard.vue";
@@ -211,7 +225,11 @@ import {
   getMusicQuizPhaseLabelKey,
   resolveMusicQuizDefinition,
 } from "@/components/music-quiz/game_types";
-import { isSupportedMusicQuiz } from "@/composables/music-quiz/useMusicQuiz";
+import {
+  isSupportedMusicQuiz,
+  type MusicQuizSuggestion,
+} from "@/composables/music-quiz/useMusicQuiz";
+import { useMusicQuizAnswerDeadline } from "@/composables/music-quiz/useMusicQuizAnswerDeadline";
 import { useMusicQuizCelebration } from "@/composables/music-quiz/useMusicQuizCelebration";
 import { useMusicQuizDashboard } from "@/composables/music-quiz/useMusicQuizDashboard";
 import { useMusicQuizRevealCountdown } from "@/composables/music-quiz/useMusicQuizRevealCountdown";
@@ -270,10 +288,7 @@ const leaderboardRows = computed<MusicQuizLeaderboardRow[]>(() => {
 
 // A TV is read from across the room: only the head of the board stays legible.
 const visibleLeaderboardRows = computed(() =>
-  leaderboardRows.value.slice(
-    0,
-    activeState.value?.phase === "answering" ? 6 : 8,
-  ),
+  leaderboardRows.value.slice(0, 8),
 );
 
 const winnerText = computed(() => getMusicQuizWinnerText(rankedPlayers.value));
@@ -303,6 +318,26 @@ const answeringPrompt = computed(() => {
     ? $t(promptKey)
     : "";
 });
+
+const OPTION_LETTERS = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+
+function optionLetter(index: number): string {
+  return OPTION_LETTERS[index] ?? String(index + 1);
+}
+
+const answerOptions = computed<MusicQuizSuggestion[]>(() => {
+  const round = currentRound.value;
+  return round && "suggestions" in round && Array.isArray(round.suggestions)
+    ? round.suggestions
+    : [];
+});
+
+const { remainingLabel: answerLabel, remainingFraction: answerFraction } =
+  useMusicQuizAnswerDeadline({
+    active: () => activeState.value?.phase === "answering",
+    deadline: () => currentRound.value?.deadline,
+    duration: () => activeState.value?.answer_duration,
+  });
 
 const backdropUrl = computed(() => {
   const phase = activeState.value?.phase;
@@ -376,15 +411,6 @@ watch(
   .music-quiz-dashboard {
     height: 100dvh;
   }
-}
-
-/* The answer tiles are the guest picker's buttons in their disabled state; at
-   50% opacity with muted text they turn unreadable on the black TV canvas. */
-.music-quiz-dashboard
-  :deep([data-testid="music-quiz-dashboard-round-body"] button:disabled) {
-  /* !important because the tailwind build emits utilities with !important */
-  opacity: 1 !important;
-  color: var(--color-white);
 }
 
 .music-quiz-dashboard-backdrop {

--- a/src/views/MusicQuizDashboardStageView.vue
+++ b/src/views/MusicQuizDashboardStageView.vue
@@ -74,7 +74,7 @@
             <div
               v-if="activeState.players.length"
               data-testid="music-quiz-dashboard-player-grid"
-              class="grid min-h-0 flex-1 grid-cols-[repeat(auto-fill,minmax(11rem,1fr))] gap-3 overflow-y-auto"
+              class="grid min-h-0 flex-1 content-start grid-cols-[repeat(auto-fill,minmax(11rem,1fr))] gap-3 overflow-y-auto"
             >
               <MusicQuizPlayerTile
                 v-for="player in sortedPlayers"

--- a/src/views/MusicQuizDashboardStageView.vue
+++ b/src/views/MusicQuizDashboardStageView.vue
@@ -378,6 +378,14 @@ watch(
   }
 }
 
+/* The answer tiles are the guest picker's buttons in their disabled state; at
+   50% opacity with muted text they turn unreadable on the black TV canvas. */
+.music-quiz-dashboard
+  :deep([data-testid="music-quiz-dashboard-round-body"] button:disabled) {
+  opacity: 1;
+  color: var(--color-white);
+}
+
 .music-quiz-dashboard-backdrop {
   position: absolute;
   /* overscanned so the blur has material to sample at every edge */

--- a/src/views/MusicQuizDashboardStageView.vue
+++ b/src/views/MusicQuizDashboardStageView.vue
@@ -1,5 +1,388 @@
 <template>
-  <div></div>
+  <div
+    class="music-quiz-dashboard dark text-white"
+    data-testid="music-quiz-dashboard-stage"
+  >
+    <div
+      v-if="backdropUrl"
+      class="music-quiz-dashboard-backdrop"
+      :style="{ backgroundImage: `url(${backdropUrl})` }"
+      data-testid="music-quiz-dashboard-backdrop"
+    ></div>
+    <div class="music-quiz-dashboard-scrim"></div>
+
+    <div class="music-quiz-dashboard-content">
+      <MusicQuizConnectionBanners :degraded="isConnectionDegraded" />
+
+      <template v-if="activeState && resolvedDefinition">
+        <header class="flex items-start justify-between gap-6">
+          <div class="min-w-0">
+            <h1
+              class="truncate text-[clamp(1.75rem,3.4vw,3rem)] leading-tight font-bold text-white/95"
+            >
+              {{ activeState.name || $t("providers.music_quiz.title") }}
+            </h1>
+            <p
+              class="mt-1 text-[clamp(0.95rem,1.5vw,1.6rem)] font-semibold tracking-[0.15em] text-white/45 uppercase"
+            >
+              {{ phaseLabel }}
+            </p>
+          </div>
+          <p
+            v-if="roundLabel"
+            class="shrink-0 rounded-full bg-white/10 px-[1.2em] py-[0.45em] text-[clamp(1rem,1.7vw,1.9rem)] font-semibold text-white/70"
+            data-testid="music-quiz-dashboard-round"
+          >
+            {{ roundLabel }}
+          </p>
+        </header>
+
+        <MusicQuizPreparingState
+          v-if="activeState.preparing"
+          class="min-h-0 flex-1"
+        />
+
+        <div
+          v-else-if="activeState.phase === 'lobby'"
+          data-testid="music-quiz-dashboard-lobby"
+          class="grid min-h-0 flex-1 items-center gap-[4vh] lg:grid-cols-[auto_minmax(0,1fr)] lg:gap-[4vw]"
+        >
+          <MusicQuizQrCard
+            v-if="joinLink"
+            class="mx-auto w-full max-w-sm lg:w-[22rem]"
+            :join-link="joinLink"
+            :size="300"
+            hide-share-actions
+            :caption="$t('providers.music_quiz.invite_players')"
+          />
+          <div class="flex min-w-0 flex-col gap-[2vh]">
+            <h2
+              class="text-[clamp(1.4rem,2.6vw,2.4rem)] font-bold text-white/90"
+            >
+              {{ $t("providers.music_quiz.players") }}
+              <span class="text-white/50">
+                ({{ activeState.players.length }})
+              </span>
+            </h2>
+            <MusicQuizAutoStartStatus
+              :state="activeState"
+              class="w-fit rounded-full bg-white/10 px-[1.1em] py-[0.4em] text-[clamp(1rem,1.7vw,1.75rem)] font-semibold text-white/75"
+            />
+            <div
+              v-if="activeState.players.length"
+              class="grid grid-cols-[repeat(auto-fill,minmax(11rem,1fr))] gap-3"
+            >
+              <MusicQuizPlayerTile
+                v-for="player in sortedPlayers"
+                :key="player.name"
+                :name="player.name"
+                class="border-white/10 bg-white/10 text-[clamp(1rem,1.4vw,1.5rem)]"
+              />
+            </div>
+            <p v-else class="text-[clamp(1rem,1.7vw,1.75rem)] text-white/60">
+              {{ $t("providers.music_quiz.waiting_for_start") }}
+            </p>
+          </div>
+        </div>
+
+        <div
+          v-else-if="isRoundPhase && currentRound"
+          data-testid="music-quiz-dashboard-round-body"
+          class="flex min-h-0 flex-1 flex-col gap-[2vh]"
+        >
+          <component
+            :is="resolvedDefinition.game.adapters.presentBody"
+            v-if="resolvedDefinition.game.adapters.presentBody"
+            :state="activeState"
+            :current-round="currentRound"
+            :leaderboard-rows="visibleLeaderboardRows"
+          />
+          <template v-else>
+            <p
+              v-if="answeringPrompt"
+              data-testid="music-quiz-dashboard-listening"
+              class="text-[clamp(1.5rem,3vw,2.8rem)] font-bold text-white/90"
+            >
+              {{ answeringPrompt }}
+            </p>
+            <component
+              :is="resolvedDefinition.game.adapters.present"
+              :state="activeState"
+              :current-round="currentRound"
+            />
+            <component
+              :is="resolvedDefinition.answer.adapters.present"
+              :state="activeState"
+              :current-round="currentRound"
+            >
+              <template #leaderboard>
+                <MusicQuizLeaderboard
+                  class="min-h-0 flex-1"
+                  :rows="visibleLeaderboardRows"
+                  scrollable
+                />
+              </template>
+            </component>
+          </template>
+          <p
+            v-if="revealCountdownText"
+            data-testid="music-quiz-dashboard-next-round"
+            role="timer"
+            class="mx-auto w-fit rounded-full bg-white/10 px-[1.2em] py-[0.45em] text-[clamp(1rem,1.7vw,1.9rem)] font-semibold text-white/75"
+          >
+            {{ revealCountdownText }}
+          </p>
+        </div>
+
+        <div
+          v-else-if="activeState.phase === 'finished'"
+          data-testid="music-quiz-dashboard-finished"
+          class="flex min-h-0 flex-1 flex-col items-center justify-center gap-[3vh]"
+        >
+          <p
+            class="text-center text-[clamp(1.6rem,3vw,3rem)] font-bold text-white/95"
+          >
+            {{ winnerText }}
+          </p>
+          <MusicQuizPodium
+            v-if="leaderboardRows.length"
+            :rows="leaderboardRows"
+          />
+          <div v-if="leaderboardRows.length > 3" class="w-full max-w-3xl">
+            <MusicQuizLeaderboard :rows="visibleLeaderboardRows" />
+          </div>
+        </div>
+      </template>
+
+      <div
+        v-else
+        data-testid="music-quiz-dashboard-waiting"
+        class="flex min-h-0 flex-1 flex-col items-center justify-center gap-[2vh] text-center"
+      >
+        <Disc3 class="size-[12vh] text-white/25" aria-hidden="true" />
+        <p class="text-[clamp(1.25rem,2.4vw,2.25rem)] text-white/60">
+          {{ $t("providers.music_quiz.dashboard_waiting") }}
+        </p>
+      </div>
+    </div>
+  </div>
 </template>
 
-<script setup lang="ts"></script>
+<script setup lang="ts">
+import MusicQuizAutoStartStatus from "@/components/music-quiz/MusicQuizAutoStartStatus.vue";
+import MusicQuizConnectionBanners from "@/components/music-quiz/MusicQuizConnectionBanners.vue";
+import MusicQuizLeaderboard, {
+  type MusicQuizLeaderboardRow,
+} from "@/components/music-quiz/MusicQuizLeaderboard.vue";
+import MusicQuizPlayerTile from "@/components/music-quiz/MusicQuizPlayerTile.vue";
+import MusicQuizPodium from "@/components/music-quiz/MusicQuizPodium.vue";
+import MusicQuizPreparingState from "@/components/music-quiz/MusicQuizPreparingState.vue";
+import MusicQuizQrCard from "@/components/music-quiz/MusicQuizQrCard.vue";
+import {
+  getMusicQuizPhaseLabelKey,
+  resolveMusicQuizDefinition,
+} from "@/components/music-quiz/game_types";
+import { isSupportedMusicQuiz } from "@/composables/music-quiz/useMusicQuiz";
+import { useMusicQuizCelebration } from "@/composables/music-quiz/useMusicQuizCelebration";
+import { useMusicQuizDashboard } from "@/composables/music-quiz/useMusicQuizDashboard";
+import { useMusicQuizRevealCountdown } from "@/composables/music-quiz/useMusicQuizRevealCountdown";
+import {
+  getMusicQuizRoundScoreLabel,
+  getMusicQuizWinnerText,
+  rankMusicQuizPlayers,
+} from "@/helpers/music_quiz";
+import { getMediaImageUrl } from "@/helpers/utils";
+import api, { ConnectionState } from "@/plugins/api";
+import { $t } from "@/plugins/i18n";
+import { Disc3 } from "@lucide/vue";
+import { computed, watch } from "vue";
+
+const { state, currentRound, joinLink } = useMusicQuizDashboard();
+
+const resolvedDefinition = computed(() => {
+  const currentState = state.value;
+  return currentState
+    ? resolveMusicQuizDefinition(
+        currentState.quiz_type,
+        currentState.answer_type,
+      )
+    : undefined;
+});
+
+const activeState = computed(() => {
+  const currentState = state.value;
+  return currentState &&
+    resolvedDefinition.value &&
+    isSupportedMusicQuiz(currentState)
+    ? currentState
+    : null;
+});
+
+const sortedPlayers = computed(() =>
+  activeState.value
+    ? [...activeState.value.players].sort((a, b) =>
+        a.name.localeCompare(b.name),
+      )
+    : [],
+);
+
+const rankedPlayers = computed(() =>
+  activeState.value ? rankMusicQuizPlayers(activeState.value.players) : [],
+);
+
+const leaderboardRows = computed<MusicQuizLeaderboardRow[]>(() => {
+  const currentState = activeState.value;
+  if (!currentState) return [];
+  return rankedPlayers.value.map((player) => ({
+    ...player,
+    roundScoreLabel: getMusicQuizRoundScoreLabel(currentState, player.name),
+  }));
+});
+
+// A TV is read from across the room: only the head of the board stays legible.
+const visibleLeaderboardRows = computed(() =>
+  leaderboardRows.value.slice(
+    0,
+    activeState.value?.phase === "answering" ? 6 : 8,
+  ),
+);
+
+const winnerText = computed(() => getMusicQuizWinnerText(rankedPlayers.value));
+
+const phaseLabel = computed(() => {
+  const currentState = activeState.value;
+  const definition = resolvedDefinition.value;
+  return currentState && definition
+    ? $t(getMusicQuizPhaseLabelKey(definition.game, currentState.phase))
+    : "";
+});
+
+const roundLabel = computed(() => {
+  if (!activeState.value || !currentRound.value) return "";
+  return `${$t("providers.music_quiz.round_label")} ${currentRound.value.round_index + 1} / ${activeState.value.round_count}`;
+});
+
+const isRoundPhase = computed(
+  () =>
+    activeState.value?.phase === "answering" ||
+    activeState.value?.phase === "reveal",
+);
+
+const answeringPrompt = computed(() => {
+  const promptKey = resolvedDefinition.value?.game.answeringPromptKey;
+  return activeState.value?.phase === "answering" && promptKey
+    ? $t(promptKey)
+    : "";
+});
+
+const backdropUrl = computed(() => {
+  const phase = activeState.value?.phase;
+  if (phase !== "reveal" && phase !== "finished") return "";
+  return getMediaImageUrl(currentRound.value?.image_url ?? "");
+});
+
+const isFinalRound = computed(
+  () =>
+    !!activeState.value &&
+    !!currentRound.value &&
+    currentRound.value.round_index + 1 >= activeState.value.round_count,
+);
+
+const { hasElapsed, isScheduled, remainingLabel } = useMusicQuizRevealCountdown(
+  {
+    active: () => activeState.value?.phase === "reveal",
+    autoAdvanceAt: () => currentRound.value?.auto_advance_at,
+  },
+);
+
+const revealCountdownText = computed(() => {
+  // some game types (Trivia) render this countdown in their own present adapter
+  if (resolvedDefinition.value?.game.usesRevealCountdown) return "";
+  if (activeState.value?.phase !== "reveal" || !isScheduled.value) return "";
+  if (hasElapsed.value) {
+    return $t(
+      isFinalRound.value
+        ? "providers.music_quiz.waiting_for_final_results"
+        : "providers.music_quiz.waiting_for_next",
+    );
+  }
+  return $t(
+    isFinalRound.value
+      ? "providers.music_quiz.final_results_in"
+      : "providers.music_quiz.next_round_in",
+    [remainingLabel.value],
+  );
+});
+
+const isConnectionDegraded = computed(
+  () =>
+    api.state.value === ConnectionState.RECONNECTING ||
+    api.state.value === ConnectionState.DISCONNECTED,
+);
+
+const { celebrate } = useMusicQuizCelebration();
+
+watch(
+  () => activeState.value?.phase,
+  (phase) => {
+    if (phase === "finished") void celebrate();
+  },
+  { immediate: true },
+);
+</script>
+
+<style scoped>
+.music-quiz-dashboard {
+  position: relative;
+  width: 100%;
+  height: 100vh;
+  /* also crops the backdrop's blurred edges, which bleed past the viewport */
+  overflow: hidden;
+  background: #000;
+}
+
+/* Keep the vh fallback in a separate rule: the minifier collapses duplicate
+   declarations, which would drop it and leave Android TV without a height. */
+@supports (height: 100dvh) {
+  .music-quiz-dashboard {
+    height: 100dvh;
+  }
+}
+
+.music-quiz-dashboard-backdrop {
+  position: absolute;
+  /* overscanned so the blur has material to sample at every edge */
+  inset: -10%;
+  background-position: center;
+  background-size: cover;
+  filter: blur(80px);
+  opacity: 0.35;
+  transition: opacity 1s ease;
+}
+
+.music-quiz-dashboard-scrim {
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(
+    to bottom,
+    rgba(0, 0, 0, 0.35),
+    rgba(0, 0, 0, 0.75)
+  );
+}
+
+.music-quiz-dashboard-content {
+  position: relative;
+  display: flex;
+  height: 100%;
+  flex-direction: column;
+  gap: 3vh;
+  padding: 4vh 4vw;
+  box-sizing: border-box;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .music-quiz-dashboard-backdrop {
+    transition: none;
+  }
+}
+</style>

--- a/tests/components/music-quiz/MusicQuizQrCard.test.ts
+++ b/tests/components/music-quiz/MusicQuizQrCard.test.ts
@@ -172,6 +172,22 @@ describe("MusicQuizQrCard", () => {
     );
     wrapper.unmount();
   });
+
+  it("drops the share actions on a display that cannot use them", async () => {
+    const wrapper = mount(MusicQuizQrCard, {
+      props: {
+        joinLink: "https://example.com/quiz/one",
+        hideShareActions: true,
+      },
+    });
+    await flushPromises();
+
+    expect(wrapper.find("canvas").exists()).toBe(true);
+    expect(
+      wrapper.find('[data-testid="invitation-share-primary"]').exists(),
+    ).toBe(false);
+    wrapper.unmount();
+  });
 });
 
 function setNavigatorProperty(property: "share" | "canShare", value: unknown) {

--- a/tests/components/music-quiz/registry.test.ts
+++ b/tests/components/music-quiz/registry.test.ts
@@ -345,6 +345,18 @@ describe("Music Quiz registries", () => {
     expect(trivia && isMusicQuizGameAvailable(trivia, ["trivia"])).toBe(true);
   });
 
+  it("declares an answering prompt only where the game renders none itself", () => {
+    const prompts = Object.fromEntries(
+      MUSIC_QUIZ_GAME_TYPES.map((game) => [game.id, game.answeringPromptKey]),
+    );
+
+    expect(prompts).toEqual({
+      guess_the_song: "providers.music_quiz.name_that_track",
+      music_timeline: undefined,
+      trivia: undefined,
+    });
+  });
+
   it.each(MUSIC_QUIZ_GAME_TYPES)("mounts every $id game adapter", (game) => {
     const fixture = GAME_MOUNT_FIXTURES[game.id];
     const wrappers = [

--- a/tests/composables/useMusicQuiz.test.ts
+++ b/tests/composables/useMusicQuiz.test.ts
@@ -18,6 +18,7 @@ import {
   getAvailableMusicQuizTypes,
   getMusicQuizInfo,
   getMusicQuizPlaybackOptions,
+  getMusicQuizPublicState,
   heartbeatMusicQuiz,
   isMusicQuizProviderEvent,
   isSupportedMusicQuiz,
@@ -74,6 +75,26 @@ describe("useMusicQuiz commands", () => {
       await expect(getMusicQuizInfo()).resolves.toBe(info);
       expect(mockSendCommand).toHaveBeenCalledWith(
         "music_quiz/info",
+        undefined,
+        { suppressGlobalError: true },
+      );
+    });
+  });
+
+  describe("getMusicQuizPublicState", () => {
+    it("resolves null without a server round-trip when the provider is absent", async () => {
+      await expect(getMusicQuizPublicState()).resolves.toBeNull();
+      expect(mockSendCommand).not.toHaveBeenCalled();
+    });
+
+    it("fetches the guest-safe state as a best-effort command", async () => {
+      mockProviders.music_quiz = { domain: "music_quiz" };
+      const state = { phase: "lobby", join_url: "http://ma/join" };
+      mockSendCommand.mockResolvedValue(state);
+
+      await expect(getMusicQuizPublicState()).resolves.toBe(state);
+      expect(mockSendCommand).toHaveBeenCalledWith(
+        "music_quiz/public_state",
         undefined,
         { suppressGlobalError: true },
       );

--- a/tests/composables/useMusicQuizDashboard.test.ts
+++ b/tests/composables/useMusicQuizDashboard.test.ts
@@ -1,0 +1,209 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockGetMusicQuizPublicState, mockSubscribe, providerHandlers } =
+  vi.hoisted(() => ({
+    mockGetMusicQuizPublicState: vi.fn(),
+    mockSubscribe: vi.fn(),
+    providerHandlers: [] as Array<
+      (event: { object_id?: string; data?: unknown }) => void
+    >,
+  }));
+
+vi.mock("vue", async () => {
+  const actual = await vi.importActual<typeof import("vue")>("vue");
+  return {
+    ...actual,
+    onMounted: (fn: () => void) => fn(),
+    onBeforeUnmount: () => {},
+  };
+});
+
+vi.mock("@/composables/music-quiz/useMusicQuiz", () => ({
+  getMusicQuizPublicState: mockGetMusicQuizPublicState,
+  isSupportedMusicQuiz: (value: { quiz_type?: string; answer_type?: string }) =>
+    value.quiz_type === "guess_the_song" &&
+    value.answer_type === "multiple_choice",
+  isMusicQuizProviderEvent: (value: unknown) => {
+    if (!value || typeof value !== "object" || !("event" in value))
+      return false;
+    return (
+      value.event === "game_removed" ||
+      (value.event === "game_updated" && "state" in value)
+    );
+  },
+}));
+
+vi.mock("@/plugins/api", () => ({
+  default: {
+    subscribe: mockSubscribe,
+  },
+}));
+
+vi.mock("@/plugins/api/helpers", () => ({
+  waitForApiInitialization: () => Promise.resolve(),
+}));
+
+import { EventType } from "@/plugins/api/interfaces";
+import { useMusicQuizDashboard } from "@/composables/music-quiz/useMusicQuizDashboard";
+
+const LOBBY_STATE = {
+  quiz_type: "guess_the_song",
+  answer_type: "multiple_choice",
+  phase: "lobby",
+  name: "Quiz",
+  round_count: 3,
+  suggestion_count: 4,
+  answer_duration: 30,
+  mode: "venue",
+  players: [],
+  current_round: null,
+  join_url: "http://ma/join",
+} as const;
+
+const ANSWERING_STATE = {
+  ...LOBBY_STATE,
+  phase: "answering",
+  players: [
+    {
+      name: "Alice",
+      score: 0,
+      ready: false,
+      answered: false,
+      active_from_round: 0,
+    },
+  ],
+  current_round: {
+    round_index: 1,
+    started_at: 10,
+    deadline: 40,
+    auto_advance_at: null,
+    question: null,
+    suggestions: [{ suggestion_id: "one", label: "One" }],
+  },
+} as const;
+
+async function flushPromises() {
+  await Promise.resolve();
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((promiseResolve) => {
+    resolve = promiseResolve;
+  });
+  return { promise, resolve };
+}
+
+describe("useMusicQuizDashboard", () => {
+  beforeEach(() => {
+    providerHandlers.length = 0;
+    mockGetMusicQuizPublicState.mockReset();
+    mockSubscribe.mockReset();
+    mockGetMusicQuizPublicState.mockResolvedValue({ ...LOBBY_STATE });
+    mockSubscribe.mockImplementation(
+      (
+        _event: EventType,
+        handler: (event: { object_id?: string; data?: unknown }) => void,
+      ) => {
+        providerHandlers.push(handler);
+        return () => {};
+      },
+    );
+  });
+
+  it("cold-starts from the guest-safe public state", async () => {
+    const dashboard = useMusicQuizDashboard();
+    await flushPromises();
+
+    expect(mockGetMusicQuizPublicState).toHaveBeenCalledOnce();
+    expect(mockSubscribe).toHaveBeenCalledWith(
+      EventType.PROVIDER_EVENT,
+      expect.any(Function),
+    );
+    expect(dashboard.state.value?.phase).toBe("lobby");
+    expect(dashboard.joinLink.value).toBe("http://ma/join");
+    expect(dashboard.loading.value).toBe(false);
+  });
+
+  it("consumes the game_updated payload directly instead of re-fetching", async () => {
+    const dashboard = useMusicQuizDashboard();
+    await flushPromises();
+    const handler = providerHandlers[0];
+    expect(handler).toBeTypeOf("function");
+
+    handler({
+      object_id: "quiz-instance",
+      data: { event: "game_updated", state: ANSWERING_STATE },
+    });
+    await flushPromises();
+
+    expect(dashboard.state.value?.phase).toBe("answering");
+    expect(dashboard.currentRound.value?.round_index).toBe(1);
+    // the payload already IS the public state: a re-fetch would only add latency
+    expect(mockGetMusicQuizPublicState).toHaveBeenCalledOnce();
+  });
+
+  it("ignores events from another provider instance", async () => {
+    const dashboard = useMusicQuizDashboard();
+    await flushPromises();
+    const handler = providerHandlers[0];
+
+    handler({
+      object_id: "quiz-instance",
+      data: { event: "game_updated", state: LOBBY_STATE },
+    });
+    handler({
+      object_id: "other-instance",
+      data: { event: "game_updated", state: ANSWERING_STATE },
+    });
+    await flushPromises();
+
+    expect(dashboard.state.value?.phase).toBe("lobby");
+
+    handler({ object_id: "other-instance", data: { event: "game_removed" } });
+    expect(dashboard.state.value).not.toBeNull();
+  });
+
+  it("falls back to the waiting screen when the game is removed", async () => {
+    const dashboard = useMusicQuizDashboard();
+    await flushPromises();
+    const handler = providerHandlers[0];
+
+    handler({ object_id: "quiz-instance", data: { event: "game_removed" } });
+
+    expect(dashboard.state.value).toBeNull();
+    expect(dashboard.joinLink.value).toBe("");
+    expect(dashboard.currentRound.value).toBeNull();
+  });
+
+  it("never lets a late cold-start response overwrite a newer event payload", async () => {
+    const pending = deferred<typeof LOBBY_STATE>();
+    mockGetMusicQuizPublicState.mockReturnValue(pending.promise);
+    const dashboard = useMusicQuizDashboard();
+    await flushPromises();
+    const handler = providerHandlers[0];
+
+    handler({
+      object_id: "quiz-instance",
+      data: { event: "game_updated", state: ANSWERING_STATE },
+    });
+    pending.resolve({ ...LOBBY_STATE });
+    await flushPromises();
+
+    expect(dashboard.state.value?.phase).toBe("answering");
+  });
+
+  it("shows the waiting screen when the cold start fails", async () => {
+    mockGetMusicQuizPublicState.mockRejectedValue(new Error("Unavailable"));
+    const consoleWarn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const dashboard = useMusicQuizDashboard();
+    await flushPromises();
+
+    expect(dashboard.state.value).toBeNull();
+    expect(dashboard.loading.value).toBe(false);
+    expect(consoleWarn).toHaveBeenCalledOnce();
+    consoleWarn.mockRestore();
+  });
+});

--- a/tests/composables/useMusicQuizDashboard.test.ts
+++ b/tests/composables/useMusicQuizDashboard.test.ts
@@ -1,13 +1,28 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const { mockGetMusicQuizPublicState, mockSubscribe, providerHandlers } =
-  vi.hoisted(() => ({
-    mockGetMusicQuizPublicState: vi.fn(),
-    mockSubscribe: vi.fn(),
-    providerHandlers: [] as Array<
-      (event: { object_id?: string; data?: unknown }) => void
-    >,
-  }));
+const {
+  mockGetMusicQuizPublicState,
+  mockSubscribe,
+  providerHandlers,
+  apiMock,
+} = vi.hoisted(() => ({
+  mockGetMusicQuizPublicState: vi.fn(),
+  mockSubscribe: vi.fn(),
+  providerHandlers: [] as Array<
+    (event: { object_id?: string; data?: unknown }) => void
+  >,
+  // A stable object identity: "@/plugins/api"'s default export. Its .state
+  // property gets replaced with a fresh ref per test so a prior test's
+  // reconnect watcher (never unmounted, since onBeforeUnmount is a no-op
+  // below) is left watching an orphaned ref instead of bleeding into the
+  // next test.
+  apiMock: {
+    default: {
+      subscribe: undefined as unknown,
+      state: { value: "initialized" as string },
+    },
+  },
+}));
 
 vi.mock("vue", async () => {
   const actual = await vi.importActual<typeof import("vue")>("vue");
@@ -33,11 +48,21 @@ vi.mock("@/composables/music-quiz/useMusicQuiz", () => ({
   },
 }));
 
-vi.mock("@/plugins/api", () => ({
-  default: {
-    subscribe: mockSubscribe,
-  },
-}));
+vi.mock("@/plugins/api", async () => {
+  // The reconnect watcher needs a real ref: assignments to a plain { value }
+  // would never reach the composable's watch callback.
+  const { ref } = await vi.importActual<typeof import("vue")>("vue");
+  apiMock.default.subscribe = mockSubscribe;
+  apiMock.default.state = ref(apiMock.default.state.value);
+  return {
+    default: apiMock.default,
+    ConnectionState: {
+      INITIALIZED: "initialized",
+      RECONNECTING: "reconnecting",
+      DISCONNECTED: "disconnected",
+    },
+  };
+});
 
 vi.mock("@/plugins/api/helpers", () => ({
   waitForApiInitialization: () => Promise.resolve(),
@@ -45,6 +70,7 @@ vi.mock("@/plugins/api/helpers", () => ({
 
 import { EventType } from "@/plugins/api/interfaces";
 import { useMusicQuizDashboard } from "@/composables/music-quiz/useMusicQuizDashboard";
+import { ref } from "vue";
 
 const LOBBY_STATE = {
   quiz_type: "guess_the_song",
@@ -99,6 +125,7 @@ function deferred<T>() {
 describe("useMusicQuizDashboard", () => {
   beforeEach(() => {
     providerHandlers.length = 0;
+    apiMock.default.state = ref("initialized");
     mockGetMusicQuizPublicState.mockReset();
     mockSubscribe.mockReset();
     mockGetMusicQuizPublicState.mockResolvedValue({ ...LOBBY_STATE });
@@ -205,5 +232,21 @@ describe("useMusicQuizDashboard", () => {
     expect(dashboard.loading.value).toBe(false);
     expect(consoleWarn).toHaveBeenCalledOnce();
     consoleWarn.mockRestore();
+  });
+
+  it("refetches the public state once the connection re-initializes after a drop", async () => {
+    const dashboard = useMusicQuizDashboard();
+    await flushPromises();
+    expect(mockGetMusicQuizPublicState).toHaveBeenCalledOnce();
+
+    apiMock.default.state.value = "reconnecting";
+    await flushPromises();
+    expect(mockGetMusicQuizPublicState).toHaveBeenCalledOnce();
+
+    apiMock.default.state.value = "initialized";
+    await flushPromises();
+
+    expect(mockGetMusicQuizPublicState).toHaveBeenCalledTimes(2);
+    expect(dashboard.loading.value).toBe(false);
   });
 });

--- a/tests/helpers/dashboard_viewer_access.test.ts
+++ b/tests/helpers/dashboard_viewer_access.test.ts
@@ -5,7 +5,7 @@ import {
 import { describe, expect, it } from "vitest";
 
 describe("dashboard viewer dashboard path", () => {
-  it.each(["/party", "/music-quiz", "/now-playing"])(
+  it.each(["/party", "/music-quiz", "/music-quiz/dashboard", "/now-playing"])(
     "keeps a known dashboard route %s",
     (path) => {
       expect(sanitizeDashboardViewerPath(path)).toBe(path);
@@ -27,6 +27,10 @@ describe("dashboard viewer dashboard path", () => {
 
   it("falls back to /party when the pathname isn't allowed, query string included", () => {
     expect(sanitizeDashboardViewerPath("/settings?tab=general")).toBe("/party");
+  });
+
+  it("keeps the host route allowed for viewers pinned there by an older server", () => {
+    expect(sanitizeDashboardViewerPath("/music-quiz")).toBe("/music-quiz");
   });
 });
 

--- a/tests/plugins/router.test.ts
+++ b/tests/plugins/router.test.ts
@@ -134,6 +134,25 @@ describe("guest routes", () => {
   });
 });
 
+describe("music quiz dashboard route", () => {
+  it("is a top-level kiosk route in the music-quiz chunk", () => {
+    const dashboardRoute = routes.find(
+      (route) => route.path === "/music-quiz/dashboard",
+    );
+
+    expect(dashboardRoute).toBeDefined();
+    expect(dashboardRoute?.children?.map((route) => route.name)).toEqual([
+      "music-quiz-dashboard",
+    ]);
+  });
+
+  it("resolves without the app chrome routes' guards", () => {
+    expect(resolveRoute("/music-quiz/dashboard").name).toBe(
+      "music-quiz-dashboard",
+    );
+  });
+});
+
 describe("party dashboard guard", () => {
   it("redirects to Discover when the party plugin is disabled", async () => {
     await expect(
@@ -274,6 +293,22 @@ describe("global navigation guard", () => {
     await expect(
       invokeGuard(globalGuard, resolveRoute("/now-playing?player=kitchen")),
     ).resolves.toBeUndefined();
+    expect(mocks.store.frameless).toBe(true);
+  });
+
+  it("keeps a dashboard viewer on the pinned Music Quiz dashboard", async () => {
+    mocks.isDashboardViewer.mockReturnValue(true);
+    sessionStorage.setItem(
+      DASHBOARD_VIEWER_PATH_STORAGE_KEY,
+      "/music-quiz/dashboard",
+    );
+
+    await expect(
+      invokeGuard(globalGuard, resolveRoute("/music-quiz/dashboard")),
+    ).resolves.toBeUndefined();
+    await expect(
+      invokeGuard(globalGuard, resolveRoute("/music-quiz")),
+    ).resolves.toBe("/music-quiz/dashboard");
     expect(mocks.store.frameless).toBe(true);
   });
 

--- a/tests/views/MusicQuizDashboardStageView.test.ts
+++ b/tests/views/MusicQuizDashboardStageView.test.ts
@@ -1,0 +1,385 @@
+import MusicQuizDashboardStageView from "@/views/MusicQuizDashboardStageView.vue";
+import type { MusicQuizPublicState } from "@/composables/music-quiz/useMusicQuiz";
+import { flushPromises, mount } from "@vue/test-utils";
+import { nextTick } from "vue";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const {
+  apiMock,
+  dashboardMock,
+  mockCelebrate,
+  mockResolveMusicQuizDefinition,
+} = vi.hoisted(() => ({
+  apiMock: { state: { value: "connected" as string } },
+  dashboardMock: {
+    state: { value: null } as { value: MusicQuizPublicState | null },
+  },
+  mockCelebrate: vi.fn(),
+  mockResolveMusicQuizDefinition: vi.fn(),
+}));
+
+vi.mock("@/plugins/api", async () => {
+  // The connection banner re-renders on api.state, so the mock has to carry a
+  // real ref: assignments to a plain { value } would never reach the computed.
+  const { ref } = await vi.importActual<typeof import("vue")>("vue");
+  apiMock.state = ref(apiMock.state.value);
+  const api = { state: apiMock.state };
+  return {
+    api,
+    default: api,
+    ConnectionState: {
+      RECONNECTING: "reconnecting",
+      DISCONNECTED: "disconnected",
+    },
+  };
+});
+
+vi.mock("@/composables/music-quiz/useMusicQuizDashboard", async () => {
+  const { computed, ref } = await vi.importActual<typeof import("vue")>("vue");
+  const state = ref<MusicQuizPublicState | null>(null);
+  dashboardMock.state = state;
+  const currentRound = computed(() =>
+    state.value && "current_round" in state.value
+      ? (state.value.current_round ?? null)
+      : null,
+  );
+  const joinLink = computed(() => state.value?.join_url ?? "");
+  return {
+    useMusicQuizDashboard: () => ({
+      state,
+      loading: ref(false),
+      currentRound,
+      joinLink,
+      fetchState: vi.fn(),
+    }),
+  };
+});
+
+vi.mock("@/composables/music-quiz/useMusicQuizCelebration", () => ({
+  useMusicQuizCelebration: () => ({ celebrate: mockCelebrate }),
+}));
+
+vi.mock("@/components/music-quiz/game_types", () => ({
+  getMusicQuizPhaseLabelKey: (_game: unknown, phase: string) =>
+    `providers.music_quiz.phase_${phase}`,
+  resolveMusicQuizDefinition: mockResolveMusicQuizDefinition,
+}));
+
+// Stubbing a component does not stop the view from importing it: MusicQuizQrCard
+// still pulls in the share sheet, so its helpers need mocks too.
+vi.mock("@/helpers/utils", () => ({
+  copyToClipboard: vi.fn(),
+  getMediaImageUrl: (url: string) => url,
+}));
+
+vi.mock("@/helpers/qr", () => ({
+  renderQrCode: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("@/helpers/invitation_share", () => ({
+  createInvitationFile: vi.fn(),
+}));
+
+vi.mock("vue-sonner", () => ({
+  toast: { error: vi.fn() },
+}));
+
+vi.mock("@/plugins/i18n", () => ({
+  $t: (key: string, values: unknown[] = []) =>
+    values.length ? `${key}:${String(values[0])}` : key,
+  canonicalizeLocale: (locale: string) => locale,
+  i18n: { global: { locale: { value: "en" } } },
+}));
+
+const guessTheSongRound = {
+  round_index: 2,
+  started_at: 10,
+  deadline: 40,
+  auto_advance_at: null,
+  question: null,
+  suggestions: [{ suggestion_id: "one", label: "One" }],
+};
+
+function lobbyState(
+  overrides: Record<string, unknown> = {},
+): MusicQuizPublicState {
+  return {
+    quiz_type: "guess_the_song",
+    answer_type: "multiple_choice",
+    phase: "lobby",
+    name: "Friday Quiz",
+    round_count: 10,
+    suggestion_count: 4,
+    answer_duration: 30,
+    mode: "venue",
+    players: [],
+    current_round: null,
+    join_url: "http://ma/join",
+    ...overrides,
+  } as MusicQuizPublicState;
+}
+
+function player(name: string, score: number, answered = false) {
+  return {
+    name,
+    score,
+    ready: false,
+    answered,
+    active_from_round: 0,
+    ...(score > 0
+      ? { last_answer: { suggestion_id: "one", points: score } }
+      : {}),
+  };
+}
+
+function createDefinition(
+  overrides: {
+    answeringPromptKey?: string;
+    usesRevealCountdown?: boolean;
+  } = {},
+) {
+  return {
+    game: {
+      id: "guess_the_song",
+      answeringPromptKey: overrides.answeringPromptKey,
+      usesRevealCountdown: overrides.usesRevealCountdown ?? false,
+      adapters: {
+        present: {
+          props: { state: Object, currentRound: Object },
+          template: '<div data-testid="game-adapter" />',
+        },
+      },
+    },
+    answer: {
+      adapters: {
+        present: {
+          props: { state: Object, currentRound: Object },
+          template:
+            '<div data-testid="answer-adapter"><slot name="leaderboard" /></div>',
+        },
+      },
+    },
+  };
+}
+
+function mountView() {
+  return mount(MusicQuizDashboardStageView, {
+    global: {
+      stubs: {
+        MusicQuizAutoStartStatus: true,
+        MusicQuizConnectionBanners: true,
+        MusicQuizPreparingState: true,
+        MusicQuizLeaderboard: {
+          props: ["rows"],
+          template:
+            '<div data-testid="leaderboard" :data-rows="rows.length" />',
+        },
+        MusicQuizPlayerTile: {
+          props: ["name"],
+          template: '<div data-testid="player-tile">{{ name }}</div>',
+        },
+        MusicQuizPodium: {
+          props: ["rows"],
+          template: '<div data-testid="podium" :data-rows="rows.length" />',
+        },
+        MusicQuizQrCard: {
+          // Boolean must be typed explicitly: the untyped array form leaves
+          // the `hide-share-actions` shorthand as the literal string "".
+          props: { joinLink: String, hideShareActions: Boolean },
+          template:
+            '<div data-testid="qr-card" :data-join-link="joinLink" :data-hide-share="String(hideShareActions)" />',
+        },
+      },
+    },
+  });
+}
+
+describe("MusicQuizDashboardStageView", () => {
+  beforeEach(() => {
+    apiMock.state.value = "connected";
+    dashboardMock.state.value = null;
+    mockCelebrate.mockReset();
+    mockResolveMusicQuizDefinition.mockReset();
+    mockResolveMusicQuizDefinition.mockReturnValue(createDefinition());
+  });
+
+  it("shows the waiting screen without an active game", () => {
+    const wrapper = mountView();
+
+    expect(
+      wrapper.get('[data-testid="music-quiz-dashboard-waiting"]').text(),
+    ).toContain("providers.music_quiz.dashboard_waiting");
+    expect(
+      wrapper.find('[data-testid="music-quiz-dashboard-lobby"]').exists(),
+    ).toBe(false);
+    wrapper.unmount();
+  });
+
+  it("falls back to the waiting screen for an unsupported game type", () => {
+    mockResolveMusicQuizDefinition.mockReturnValue(undefined);
+    dashboardMock.state.value = lobbyState({ quiz_type: "future_game" });
+    const wrapper = mountView();
+
+    expect(
+      wrapper.find('[data-testid="music-quiz-dashboard-waiting"]').exists(),
+    ).toBe(true);
+    wrapper.unmount();
+  });
+
+  it("renders the lobby with a share-free join QR and the joined players", () => {
+    dashboardMock.state.value = lobbyState({
+      players: [player("Bob", 0), player("Alice", 0)],
+    });
+    const wrapper = mountView();
+
+    const qr = wrapper.get('[data-testid="qr-card"]');
+    expect(qr.attributes("data-join-link")).toBe("http://ma/join");
+    expect(qr.attributes("data-hide-share")).toBe("true");
+    expect(
+      wrapper.findAll('[data-testid="player-tile"]').map((tile) => tile.text()),
+    ).toEqual(["Alice", "Bob"]);
+    expect(wrapper.text()).toContain("Friday Quiz");
+    expect(wrapper.text()).toContain("providers.music_quiz.phase_lobby");
+    expect(
+      wrapper.find('[data-testid="music-quiz-dashboard-round"]').exists(),
+    ).toBe(false);
+    wrapper.unmount();
+  });
+
+  it("hides the join QR when the server does not report a join url", () => {
+    dashboardMock.state.value = lobbyState({ join_url: undefined });
+    const wrapper = mountView();
+
+    expect(wrapper.find('[data-testid="qr-card"]').exists()).toBe(false);
+    expect(
+      wrapper.find('[data-testid="music-quiz-dashboard-lobby"]').exists(),
+    ).toBe(true);
+    wrapper.unmount();
+  });
+
+  it("drives answering through the present adapters and caps the board at six", () => {
+    dashboardMock.state.value = lobbyState({
+      phase: "answering",
+      current_round: guessTheSongRound,
+      players: Array.from({ length: 9 }, (_, index) =>
+        player(`P${index}`, 9 - index),
+      ),
+    });
+    mockResolveMusicQuizDefinition.mockReturnValue(
+      createDefinition({
+        answeringPromptKey: "providers.music_quiz.name_that_track",
+      }),
+    );
+    const wrapper = mountView();
+
+    expect(wrapper.find('[data-testid="game-adapter"]').exists()).toBe(true);
+    expect(wrapper.find('[data-testid="answer-adapter"]').exists()).toBe(true);
+    expect(
+      wrapper.get('[data-testid="leaderboard"]').attributes("data-rows"),
+    ).toBe("6");
+    expect(
+      wrapper.get('[data-testid="music-quiz-dashboard-listening"]').text(),
+    ).toBe("providers.music_quiz.name_that_track");
+    expect(
+      wrapper.get('[data-testid="music-quiz-dashboard-round"]').text(),
+    ).toBe("providers.music_quiz.round_label 3 / 10");
+    wrapper.unmount();
+  });
+
+  it("washes the reveal artwork behind the stage and counts to the next round", () => {
+    dashboardMock.state.value = lobbyState({
+      phase: "reveal",
+      current_round: {
+        ...guessTheSongRound,
+        auto_advance_at: Date.now() / 1000 + 8,
+        answer_label: "Song - Artist",
+        image_url: "http://example.com/art.jpg",
+      },
+      players: [player("Alice", 100)],
+    });
+    const wrapper = mountView();
+
+    const backdrop = wrapper.get(
+      '[data-testid="music-quiz-dashboard-backdrop"]',
+    );
+    expect(backdrop.attributes("style")).toContain(
+      "http://example.com/art.jpg",
+    );
+    expect(
+      wrapper.get('[data-testid="music-quiz-dashboard-next-round"]').text(),
+    ).toContain("providers.music_quiz.next_round_in");
+    expect(
+      wrapper.get('[data-testid="leaderboard"]').attributes("data-rows"),
+    ).toBe("1");
+    wrapper.unmount();
+  });
+
+  it("leaves the reveal countdown to game types that render their own", () => {
+    mockResolveMusicQuizDefinition.mockReturnValue(
+      createDefinition({ usesRevealCountdown: true }),
+    );
+    dashboardMock.state.value = lobbyState({
+      phase: "reveal",
+      current_round: {
+        ...guessTheSongRound,
+        auto_advance_at: Date.now() / 1000 + 8,
+      },
+      players: [player("Alice", 100)],
+    });
+    const wrapper = mountView();
+
+    expect(
+      wrapper.find('[data-testid="music-quiz-dashboard-next-round"]').exists(),
+    ).toBe(false);
+    wrapper.unmount();
+  });
+
+  it("celebrates the finale with a podium and the winner text", async () => {
+    dashboardMock.state.value = lobbyState({
+      phase: "finished",
+      current_round: { ...guessTheSongRound, image_url: null },
+      players: [player("Alice", 300), player("Bob", 100)],
+    });
+    const wrapper = mountView();
+    await flushPromises();
+
+    expect(
+      wrapper.find('[data-testid="music-quiz-dashboard-finished"]').exists(),
+    ).toBe(true);
+    expect(wrapper.get('[data-testid="podium"]').attributes("data-rows")).toBe(
+      "2",
+    );
+    expect(wrapper.text()).toContain("providers.music_quiz.winner_single");
+    expect(mockCelebrate).toHaveBeenCalledOnce();
+    wrapper.unmount();
+  });
+
+  it("returns to the waiting screen when the game is removed mid-cast", async () => {
+    dashboardMock.state.value = lobbyState();
+    const wrapper = mountView();
+    expect(wrapper.find('[data-testid="qr-card"]').exists()).toBe(true);
+
+    dashboardMock.state.value = null;
+    await nextTick();
+
+    expect(
+      wrapper.find('[data-testid="music-quiz-dashboard-waiting"]').exists(),
+    ).toBe(true);
+    wrapper.unmount();
+  });
+
+  it("warns the room when the connection degrades", async () => {
+    dashboardMock.state.value = lobbyState();
+    const wrapper = mountView();
+    const banner = wrapper.findComponent({
+      name: "MusicQuizConnectionBanners",
+    });
+    expect(banner.props("degraded")).toBe(false);
+
+    apiMock.state.value = "reconnecting";
+    await nextTick();
+
+    expect(banner.props("degraded")).toBe(true);
+    wrapper.unmount();
+  });
+});

--- a/tests/views/MusicQuizDashboardStageView.test.ts
+++ b/tests/views/MusicQuizDashboardStageView.test.ts
@@ -260,6 +260,28 @@ describe("MusicQuizDashboardStageView", () => {
     wrapper.unmount();
   });
 
+  it("keeps the player grid scrollable so extra players don't clip off-screen", () => {
+    dashboardMock.state.value = lobbyState({
+      players: [player("Bob", 0), player("Alice", 0)],
+    });
+    const wrapper = mountView();
+
+    expect(
+      wrapper.get('[data-testid="music-quiz-dashboard-player-grid"]').classes(),
+    ).toContain("overflow-y-auto");
+    wrapper.unmount();
+  });
+
+  it("marks the phase label as a live region for screen readers", () => {
+    dashboardMock.state.value = lobbyState();
+    const wrapper = mountView();
+
+    const phaseLabel = wrapper.get('[role="status"]');
+    expect(phaseLabel.attributes("aria-live")).toBe("polite");
+    expect(phaseLabel.attributes("aria-atomic")).toBe("true");
+    wrapper.unmount();
+  });
+
   it("hides the join QR when the server does not report a join url", () => {
     dashboardMock.state.value = lobbyState({ join_url: undefined });
     const wrapper = mountView();

--- a/tests/views/MusicQuizDashboardStageView.test.ts
+++ b/tests/views/MusicQuizDashboardStageView.test.ts
@@ -13,6 +13,7 @@ const {
   apiMock: { state: { value: "connected" as string } },
   dashboardMock: {
     state: { value: null } as { value: MusicQuizPublicState | null },
+    loading: { value: false },
   },
   mockCelebrate: vi.fn(),
   mockResolveMusicQuizDefinition: vi.fn(),
@@ -37,7 +38,9 @@ vi.mock("@/plugins/api", async () => {
 vi.mock("@/composables/music-quiz/useMusicQuizDashboard", async () => {
   const { computed, ref } = await vi.importActual<typeof import("vue")>("vue");
   const state = ref<MusicQuizPublicState | null>(null);
+  const loading = ref(dashboardMock.loading.value);
   dashboardMock.state = state;
+  dashboardMock.loading = loading;
   const currentRound = computed(() =>
     state.value && "current_round" in state.value
       ? (state.value.current_round ?? null)
@@ -47,7 +50,7 @@ vi.mock("@/composables/music-quiz/useMusicQuizDashboard", async () => {
   return {
     useMusicQuizDashboard: () => ({
       state,
-      loading: ref(false),
+      loading,
       currentRound,
       joinLink,
       fetchState: vi.fn(),
@@ -198,6 +201,7 @@ describe("MusicQuizDashboardStageView", () => {
   beforeEach(() => {
     apiMock.state.value = "connected";
     dashboardMock.state.value = null;
+    dashboardMock.loading.value = false;
     mockCelebrate.mockReset();
     mockResolveMusicQuizDefinition.mockReset();
     mockResolveMusicQuizDefinition.mockReturnValue(createDefinition());
@@ -211,6 +215,16 @@ describe("MusicQuizDashboardStageView", () => {
     ).toContain("providers.music_quiz.dashboard_waiting");
     expect(
       wrapper.find('[data-testid="music-quiz-dashboard-lobby"]').exists(),
+    ).toBe(false);
+    wrapper.unmount();
+  });
+
+  it("hides the waiting screen while the cold fetch is still in flight", () => {
+    dashboardMock.loading.value = true;
+    const wrapper = mountView();
+
+    expect(
+      wrapper.find('[data-testid="music-quiz-dashboard-waiting"]').exists(),
     ).toBe(false);
     wrapper.unmount();
   });
@@ -311,6 +325,16 @@ describe("MusicQuizDashboardStageView", () => {
     expect(
       wrapper.get('[data-testid="leaderboard"]').attributes("data-rows"),
     ).toBe("1");
+    // reveal puts the answer/leaderboard column next to the game adapter,
+    // mirroring the host present stage's two-column layout
+    const layout = wrapper.get(
+      '[data-testid="music-quiz-dashboard-reveal-layout"]',
+    );
+    expect(layout.find('[data-testid="game-adapter"]').exists()).toBe(true);
+    expect(layout.find('[data-testid="answer-adapter"]').exists()).toBe(true);
+    expect(layout.classes()).toContain(
+      "lg:grid-cols-[minmax(0,1fr)_minmax(0,22rem)]",
+    );
     wrapper.unmount();
   });
 

--- a/tests/views/MusicQuizDashboardStageView.test.ts
+++ b/tests/views/MusicQuizDashboardStageView.test.ts
@@ -293,7 +293,7 @@ describe("MusicQuizDashboardStageView", () => {
     wrapper.unmount();
   });
 
-  it("drives answering through the present adapters and caps the board at six", () => {
+  it("shows only the countdown and answer options while answering", () => {
     dashboardMock.state.value = lobbyState({
       phase: "answering",
       current_round: guessTheSongRound,
@@ -309,10 +309,11 @@ describe("MusicQuizDashboardStageView", () => {
     const wrapper = mountView();
 
     expect(wrapper.find('[data-testid="game-adapter"]').exists()).toBe(true);
-    expect(wrapper.find('[data-testid="answer-adapter"]').exists()).toBe(true);
-    expect(
-      wrapper.get('[data-testid="leaderboard"]').attributes("data-rows"),
-    ).toBe("6");
+    const options = wrapper.get('[data-testid="music-quiz-dashboard-options"]');
+    expect(options.text()).toContain("One");
+    // the board and the answered-progress panel wait until the reveal
+    expect(wrapper.find('[data-testid="answer-adapter"]').exists()).toBe(false);
+    expect(wrapper.find('[data-testid="leaderboard"]').exists()).toBe(false);
     expect(
       wrapper.get('[data-testid="music-quiz-dashboard-listening"]').text(),
     ).toBe("providers.music_quiz.name_that_track");


### PR DESCRIPTION
Adds a TV-style Music Quiz dashboard at `/music-quiz/dashboard`: a viewer-only page that shows the quiz on a big screen — cast it to a Chromecast or open it on a wall tablet. The existing quiz page is the host's; guest viewer sessions could not load it, so casting the quiz showed nothing useful.

The page follows the game live: lobby with a join QR code and joined players, the question with answer options and countdown during a round, the answer with artwork on reveal, and a podium with celebration at the end. It works for any signed-in user and for cast viewer sessions, and renders purely from the guest-safe public game state (answers stay hidden until reveal).

Changes:
- New `/music-quiz/dashboard` route (viewer allow-listed) and `MusicQuizDashboardStageView` with per-phase tests
- New `useMusicQuizDashboard` composable: fetches `music_quiz/public_state`, then follows the broadcast game state directly; recovers after reconnects
- Present adapters retyped from host state to public state (host present mode unchanged)
- QR card gains a `hideShareActions` prop for kiosk use; two new translation keys

Companion server PR: music-assistant/server#5535 (adds `join_url` to public state for the lobby QR and points quiz casts at the new route). Without it the dashboard still works; only the QR is hidden.
