### PR TITLE
Use the shared test fixtures in the play helper tests

### DIFF
--- a/tests/helpers/playBtnErrorFeedback.test.ts
+++ b/tests/helpers/playBtnErrorFeedback.test.ts
@@ -61,23 +61,20 @@ vi.mock("vue-sonner", () => ({
 }));
 
 import { handlePlayBtnClick } from "@/helpers/media_item_actions";
-import { MediaType, type Playlist, type Track } from "@/plugins/api/interfaces";
+import { playlist } from "../fixtures/playlist";
+import { track } from "../fixtures/track";
 
-const track = {
+const playedTrack = track({
   item_id: "track1",
   uri: "library://track/track1",
-  media_type: MediaType.TRACK,
   name: "Track 1",
-  is_playable: true,
-} as unknown as Track;
+});
 
-const playlist = {
+const parentPlaylist = playlist({
   item_id: "pl1",
   uri: "library://playlist/pl1",
-  media_type: MediaType.PLAYLIST,
   name: "Playlist 1",
-  is_playable: true,
-} as unknown as Playlist;
+});
 
 const flushPromises = () => new Promise((resolve) => setTimeout(resolve, 0));
 
@@ -93,7 +90,7 @@ describe("handlePlayBtnClick error feedback", () => {
   it("shows a toast when direct play fails", async () => {
     mockPlayMedia.mockRejectedValue(new Error("Connection lost"));
 
-    handlePlayBtnClick(track, 0, 0);
+    handlePlayBtnClick(playedTrack, 0, 0);
     await flushPromises();
 
     expect(mockToastError).toHaveBeenCalledWith("play_failed");
@@ -102,7 +99,7 @@ describe("handlePlayBtnClick error feedback", () => {
   it("shows a toast when play-from-here fails", async () => {
     mockPlayMedia.mockRejectedValue(new Error("Connection lost"));
 
-    handlePlayBtnClick(track, 0, 0, playlist);
+    handlePlayBtnClick(playedTrack, 0, 0, parentPlaylist);
     await flushPromises();
 
     expect(mockToastError).toHaveBeenCalledWith("play_failed");
@@ -112,7 +109,7 @@ describe("handlePlayBtnClick error feedback", () => {
     mockStore.activePlayer = undefined;
     mockShowPlayMenu.mockRejectedValue(new Error("Connection lost"));
 
-    handlePlayBtnClick(track, 0, 0);
+    handlePlayBtnClick(playedTrack, 0, 0);
     await flushPromises();
 
     expect(mockToastError).toHaveBeenCalledWith("play_failed");
@@ -121,7 +118,7 @@ describe("handlePlayBtnClick error feedback", () => {
   it("does not show a toast when play succeeds", async () => {
     mockPlayMedia.mockResolvedValue(undefined);
 
-    handlePlayBtnClick(track, 0, 0);
+    handlePlayBtnClick(playedTrack, 0, 0);
     await flushPromises();
 
     expect(mockToastError).not.toHaveBeenCalled();

--- a/tests/helpers/playFromHereSort.test.ts
+++ b/tests/helpers/playFromHereSort.test.ts
@@ -72,39 +72,22 @@ import {
   handlePlayBtnClick,
   handleMenuBtnClick,
 } from "@/helpers/media_item_actions";
-import {
-  MediaType,
-  type Album,
-  type Playlist,
-  type Track,
-} from "@/plugins/api/interfaces";
+import { album } from "../fixtures/album";
+import { playlist } from "../fixtures/playlist";
+import { track } from "../fixtures/track";
 
 const makePlaylistTrack = (id: string) =>
-  ({
-    item_id: id,
-    uri: `library://track/${id}`,
-    media_type: MediaType.TRACK,
-    name: `Track ${id}`,
-    is_playable: true,
-  }) as unknown as Track;
+  track({ item_id: id, uri: `library://track/${id}`, name: `Track ${id}` });
 
 const makePlaylist = (id: string) =>
-  ({
+  playlist({
     item_id: id,
     uri: `library://playlist/${id}`,
-    media_type: MediaType.PLAYLIST,
     name: `Playlist ${id}`,
-    is_playable: true,
-  }) as unknown as Playlist;
+  });
 
 const makeAlbum = (id: string) =>
-  ({
-    item_id: id,
-    uri: `library://album/${id}`,
-    media_type: MediaType.ALBUM,
-    name: `Album ${id}`,
-    is_playable: true,
-  }) as unknown as Album;
+  album({ item_id: id, uri: `library://album/${id}`, name: `Album ${id}` });
 
 beforeEach(() => {
   mockPlayMedia.mockReset();
@@ -115,53 +98,53 @@ beforeEach(() => {
 
 describe("handlePlayBtnClick with sortBy", () => {
   it("passes sortBy to api.playMedia for playlist play-from-here", () => {
-    const track = makePlaylistTrack("track1");
-    const playlist = makePlaylist("pl1");
+    const playedTrack = makePlaylistTrack("track1");
+    const parentPlaylist = makePlaylist("pl1");
 
-    handlePlayBtnClick(track, 0, 0, playlist, false, "name");
+    handlePlayBtnClick(playedTrack, 0, 0, parentPlaylist, false, "name");
 
     expect(mockPlayMedia).toHaveBeenCalledWith(
-      playlist.uri,
+      parentPlaylist.uri,
       undefined,
-      track.item_id,
+      playedTrack.item_id,
       undefined,
       "name",
     );
   });
 
   it("passes undefined sortBy when not provided", () => {
-    const track = makePlaylistTrack("track1");
-    const playlist = makePlaylist("pl1");
+    const playedTrack = makePlaylistTrack("track1");
+    const parentPlaylist = makePlaylist("pl1");
 
-    handlePlayBtnClick(track, 0, 0, playlist);
+    handlePlayBtnClick(playedTrack, 0, 0, parentPlaylist);
 
     expect(mockPlayMedia).toHaveBeenCalledWith(
-      playlist.uri,
+      parentPlaylist.uri,
       undefined,
-      track.item_id,
+      playedTrack.item_id,
       undefined,
       undefined,
     );
   });
 
   it("passes sortBy for album play-from-here", () => {
-    const track = makePlaylistTrack("track1");
-    const album = makeAlbum("alb1");
+    const playedTrack = makePlaylistTrack("track1");
+    const parentAlbum = makeAlbum("alb1");
 
-    handlePlayBtnClick(track, 0, 0, album, false, "name");
+    handlePlayBtnClick(playedTrack, 0, 0, parentAlbum, false, "name");
 
     expect(mockPlayMedia).toHaveBeenCalledWith(
-      album.uri,
+      parentAlbum.uri,
       undefined,
-      track.item_id,
+      playedTrack.item_id,
       undefined,
       "name",
     );
   });
 
   it("passes different sort keys correctly", () => {
-    const track = makePlaylistTrack("track1");
-    const playlist = makePlaylist("pl1");
+    const playedTrack = makePlaylistTrack("track1");
+    const parentPlaylist = makePlaylist("pl1");
 
     for (const sortKey of [
       "artist",
@@ -171,11 +154,11 @@ describe("handlePlayBtnClick with sortBy", () => {
       "position_desc",
     ]) {
       mockPlayMedia.mockClear();
-      handlePlayBtnClick(track, 0, 0, playlist, false, sortKey);
+      handlePlayBtnClick(playedTrack, 0, 0, parentPlaylist, false, sortKey);
       expect(mockPlayMedia).toHaveBeenCalledWith(
-        playlist.uri,
+        parentPlaylist.uri,
         undefined,
-        track.item_id,
+        playedTrack.item_id,
         undefined,
         sortKey,
       );
@@ -185,14 +168,14 @@ describe("handlePlayBtnClick with sortBy", () => {
 
 describe("handleMenuBtnClick with sortBy", () => {
   it("passes sortBy to showContextMenuForMediaItem", () => {
-    const track = makePlaylistTrack("track1");
-    const playlist = makePlaylist("pl1");
+    const playedTrack = makePlaylistTrack("track1");
+    const parentPlaylist = makePlaylist("pl1");
 
-    handleMenuBtnClick(track, 100, 200, playlist, true, "duration");
+    handleMenuBtnClick(playedTrack, 100, 200, parentPlaylist, true, "duration");
 
     expect(mockShowContextMenu).toHaveBeenCalledWith(
-      [track],
-      playlist,
+      [playedTrack],
+      parentPlaylist,
       100,
       200,
       true,
@@ -202,14 +185,14 @@ describe("handleMenuBtnClick with sortBy", () => {
   });
 
   it("passes undefined sortBy when not provided", () => {
-    const track = makePlaylistTrack("track1");
-    const playlist = makePlaylist("pl1");
+    const playedTrack = makePlaylistTrack("track1");
+    const parentPlaylist = makePlaylist("pl1");
 
-    handleMenuBtnClick(track, 100, 200, playlist);
+    handleMenuBtnClick(playedTrack, 100, 200, parentPlaylist);
 
     expect(mockShowContextMenu).toHaveBeenCalledWith(
-      [track],
-      playlist,
+      [playedTrack],
+      parentPlaylist,
       100,
       200,
       true,


### PR DESCRIPTION
The two play-helper test files still built their media items by hand and cast them into shape with `as unknown as`, so a mismatch with the real server models would go unnoticed. PR #2350 added shared fixtures that make that unnecessary.

- Build the tracks, playlists and albums with the shared `track`/`playlist`/`album` fixtures instead of casting partial objects
- Rename the local test items so they no longer shadow the imported fixtures

Same tests, same assertions - they are just genuinely typed now.