### PR TITLE
Use the shared artist fixture in the guest artist tracks tests

### DIFF
--- a/tests/composables/useGuestArtistTracks.test.ts
+++ b/tests/composables/useGuestArtistTracks.test.ts
@@ -1,4 +1,4 @@
-import type { Track } from "@/plugins/api/interfaces";
+import type { Artist, Track } from "@/plugins/api/interfaces";
 import type { MusicAssistantApi } from "@/plugins/api";
 import { artist } from "../fixtures/artist";
 import { track } from "../fixtures/track";
@@ -42,7 +42,7 @@ describe("useGuestArtistTracks", () => {
     const { selectedArtist, artistTracks, loadingArtistTracks, selectArtist } =
       useGuestArtistTracks();
 
-    const libraryArtist = artist({ item_id: "artist-id" });
+    const libraryArtist = artistFixture("artist-id");
 
     await selectArtist(libraryArtist);
 
@@ -124,8 +124,8 @@ describe("useGuestArtistTracks", () => {
     const { selectedArtist, artistTracks, selectArtist } =
       useGuestArtistTracks();
 
-    const first = selectArtist(artist({ item_id: "a1", name: "First" }));
-    const second = selectArtist(artist({ item_id: "a2", name: "Second" }));
+    const first = selectArtist(artistFixture("a1", "First"));
+    const second = selectArtist(artistFixture("a2", "Second"));
     await second;
     resolveFirst([trackFixture("first-track")]);
     await first;
@@ -134,6 +134,14 @@ describe("useGuestArtistTracks", () => {
     expect(artistTracks.value).toEqual(secondTracks);
   });
 });
+
+function artistFixture(itemId: string, name = itemId): Artist {
+  return artist({
+    item_id: itemId,
+    name,
+    uri: `library://artist/${itemId}`,
+  });
+}
 
 function trackFixture(itemId: string): Track {
   return track({

--- a/tests/composables/useGuestArtistTracks.test.ts
+++ b/tests/composables/useGuestArtistTracks.test.ts
@@ -1,6 +1,6 @@
-import type { Artist, Track } from "@/plugins/api/interfaces";
+import type { Track } from "@/plugins/api/interfaces";
 import type { MusicAssistantApi } from "@/plugins/api";
-import { providerMapping } from "../fixtures/providerMapping";
+import { artist } from "../fixtures/artist";
 import { track } from "../fixtures/track";
 import { $t } from "@/plugins/i18n";
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -42,21 +42,12 @@ describe("useGuestArtistTracks", () => {
     const { selectedArtist, artistTracks, loadingArtistTracks, selectArtist } =
       useGuestArtistTracks();
 
-    const artist = {
-      item_id: "artist-id",
-      provider: "library",
-      provider_mappings: [
-        providerMapping({
-          item_id: "mapping-id",
-          provider_instance: "provider-1",
-        }),
-      ],
-    } as unknown as Artist;
+    const libraryArtist = artist({ item_id: "artist-id" });
 
-    await selectArtist(artist);
+    await selectArtist(libraryArtist);
 
     expect(loadingArtistTracks.value).toBe(false);
-    expect(selectedArtist.value).toStrictEqual(artist);
+    expect(selectedArtist.value).toStrictEqual(libraryArtist);
     expect(mockGetArtistTracks).toHaveBeenCalledWith("artist-id", "library");
     expect(artistTracks.value).toEqual(tracks);
   });
@@ -69,12 +60,7 @@ describe("useGuestArtistTracks", () => {
     const { selectedArtist, artistTracks, loadingArtistTracks, selectArtist } =
       useGuestArtistTracks();
 
-    const artist = {
-      item_id: "artist-id",
-      provider: "library",
-    } as unknown as Artist;
-
-    await selectArtist(artist);
+    await selectArtist(artist());
 
     expect(loadingArtistTracks.value).toBe(false);
     expect(selectedArtist.value).toBeNull();
@@ -90,10 +76,7 @@ describe("useGuestArtistTracks", () => {
     const { selectedArtist, artistTracks, selectArtist, clearArtistSelection } =
       useGuestArtistTracks();
 
-    await selectArtist({
-      item_id: "artist-id",
-      provider: "library",
-    } as unknown as Artist);
+    await selectArtist(artist());
     clearArtistSelection();
 
     expect(selectedArtist.value).toBeNull();
@@ -116,10 +99,7 @@ describe("useGuestArtistTracks", () => {
       clearArtistSelection,
     } = useGuestArtistTracks();
 
-    const pending = selectArtist({
-      item_id: "artist-id",
-      provider: "library",
-    } as unknown as Artist);
+    const pending = selectArtist(artist());
     clearArtistSelection();
     expect(loadingArtistTracks.value).toBe(false);
 
@@ -144,23 +124,13 @@ describe("useGuestArtistTracks", () => {
     const { selectedArtist, artistTracks, selectArtist } =
       useGuestArtistTracks();
 
-    const first = selectArtist({
-      name: "First",
-      item_id: "a1",
-      provider: "library",
-    } as unknown as Artist);
-    const second = selectArtist({
-      name: "Second",
-      item_id: "a2",
-      provider: "library",
-    } as unknown as Artist);
+    const first = selectArtist(artist({ item_id: "a1", name: "First" }));
+    const second = selectArtist(artist({ item_id: "a2", name: "Second" }));
     await second;
     resolveFirst([trackFixture("first-track")]);
     await first;
 
-    expect((selectedArtist.value as unknown as { name: string }).name).toBe(
-      "Second",
-    );
+    expect(selectedArtist.value?.name).toBe("Second");
     expect(artistTracks.value).toEqual(secondTracks);
   });
 });


### PR DESCRIPTION
The guest artist tracks tests built their `Artist` objects as partial literals cast with `as unknown as Artist`, so they could not catch a mismatch between the tests and the real interface. The shared `artist()` fixture already returns a complete, server-realistic artist.

- Replace the cast literals with the shared `artist()` fixture, keeping only the fields the tests actually assert on
- Drop the last `as unknown as { name: string }` cast, since the selected artist is now properly typed
- Add a small local helper that keeps the artist uri in sync with the item id, matching the track helper already in the file