### PR TITLE
Remove API fields the server never sends

### DIFF
--- a/src/plugins/api/interfaces.ts
+++ b/src/plugins/api/interfaces.ts
@@ -746,7 +746,6 @@ export interface ProviderConfig extends Config {
   type: ProviderType;
   domain: string;
   instance_id: string;
-  manifest: ProviderManifest; // copied here for the UI only
   // enabled: boolean to indicate if the provider is enabled
   enabled: boolean;
   // name: a custom name for this provider instance/config
@@ -774,7 +773,6 @@ export interface PlayerConfig extends Config {
 export interface CoreConfig extends Config {
   // Core(controller) Configuration.
   domain: string;
-  manifest: ProviderManifest; // copied here for the UI only
   last_error: string | null;
 }
 
@@ -846,7 +844,6 @@ export interface MediaItemMetadata {
   links?: MediaItemLink[] | null;
   performers?: string[] | null;
   preview?: string | null;
-  replaygain?: number;
   popularity?: number | null;
   release_date?: string | null;
   chapters?: MediaItemChapter[] | null;
@@ -1255,7 +1252,6 @@ export interface PlayerMedia {
   source_id: string | null;
   elapsed_time: number | null;
   elapsed_time_last_updated: number | null;
-  queue_id?: string; // only present for requests from queue controller
   queue_item_id: string | null; // only set for requests from the queue controller
 }
 

--- a/src/views/settings/EditProvider.vue
+++ b/src/views/settings/EditProvider.vue
@@ -337,7 +337,7 @@ const allConfigEntries = computed(() => {
 
 const providerManifest = computed(() => {
   if (!config.value) return undefined;
-  return api.providerManifests[config.value.domain] ?? config.value.manifest;
+  return api.providerManifests[config.value.domain];
 });
 
 const providerName = computed(

--- a/tests/fixtures/hassProviderConfig.ts
+++ b/tests/fixtures/hassProviderConfig.ts
@@ -4,7 +4,6 @@ import {
   ProviderType,
 } from "@/plugins/api/interfaces";
 import { providerConfig } from "./providerConfig";
-import { providerManifest } from "./providerManifest";
 
 /**
  * The Home Assistant provider config, carrying the given power controls.
@@ -15,12 +14,6 @@ export function hassProviderConfig(
   return providerConfig({
     type: ProviderType.PLUGIN,
     domain: "hass",
-    manifest: providerManifest({
-      type: ProviderType.PLUGIN,
-      domain: "hass",
-      name: "Home Assistant",
-      description: "Home Assistant integration",
-    }),
     values: {
       power_controls: {
         key: "power_controls",

--- a/tests/fixtures/providerConfig.ts
+++ b/tests/fixtures/providerConfig.ts
@@ -1,11 +1,8 @@
 import { type ProviderConfig, ProviderType } from "@/plugins/api/interfaces";
-import { providerManifest } from "./providerManifest";
 
 /**
  * A complete provider config, for tests that only care about a few of its
- * fields but should still model a payload the server can send. The default
- * manifest follows the config's own type and domain; pass `manifest` to
- * control the rest of it.
+ * fields but should still model a payload the server can send.
  */
 export function providerConfig(
   overrides: Partial<ProviderConfig> = {},
@@ -16,7 +13,6 @@ export function providerConfig(
     type,
     domain,
     instance_id: `${domain}--1`,
-    manifest: providerManifest({ type, domain }),
     enabled: true,
     name: null,
     default_name: null,

--- a/tests/views/EditCoreConfig.test.ts
+++ b/tests/views/EditCoreConfig.test.ts
@@ -3,7 +3,6 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { ConfigEntryType, type CoreConfig } from "@/plugins/api/interfaces";
 import type { MusicAssistantApi } from "@/plugins/api";
 import EditCoreConfig from "@/views/settings/EditCoreConfig.vue";
-import { providerManifest } from "../fixtures/providerManifest";
 
 const { apiMock, routerMock, toastMock } = vi.hoisted(() => ({
   apiMock: {
@@ -238,14 +237,6 @@ function coreConfig(): CoreConfig {
   return {
     domain: "cache",
     last_error: null,
-    manifest: providerManifest({
-      allow_disable: false,
-      builtin: true,
-      description: "Cache controller",
-      domain: "cache",
-      has_setup_flow: false,
-      name: "Cache",
-    }),
     values: {
       clear_on_start: {
         category: "generic",

--- a/tests/views/EditProvider.test.ts
+++ b/tests/views/EditProvider.test.ts
@@ -763,9 +763,6 @@ describe("EditProvider", () => {
 
 /**
  * The spotify provider config these tests load, with a single `account` entry.
- *
- * The view resolves the manifest from `api.providerManifests` first, so this
- * config's own manifest never surfaces.
  */
 function spotifyConfig(
   status: ProviderStatus,

--- a/tests/views/MusicQuizDashboardView.test.ts
+++ b/tests/views/MusicQuizDashboardView.test.ts
@@ -5,7 +5,6 @@ import { flushPromises, mount } from "@vue/test-utils";
 import { nextTick } from "vue";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { providerConfig } from "../fixtures/providerConfig";
-import { providerManifest } from "../fixtures/providerManifest";
 
 const {
   apiMock,
@@ -304,12 +303,6 @@ function musicQuizProviderConfig(instanceId: string): ProviderConfig {
     type: ProviderType.PLUGIN,
     domain: "music_quiz",
     instance_id: instanceId,
-    manifest: providerManifest({
-      type: ProviderType.PLUGIN,
-      domain: "music_quiz",
-      name: "Music Quiz",
-      description: "Music Quiz plugin provider",
-    }),
   });
 }
 


### PR DESCRIPTION
Our API type definitions declared four fields that the server never actually sends: a `manifest` on the provider and core config, `replaygain` on media item metadata, and `queue_id` on player media. None of them exist in the server models, and nothing in the app reads them — the one place that did (the provider settings screen) used it only as a fallback that could never fire.

Because the manifest fields were declared as required, our test fixtures were forced to invent a fake manifest for every config they built.

Changes:
- Removed `ProviderConfig.manifest`, `CoreConfig.manifest`, `MediaItemMetadata.replaygain` and `PlayerMedia.queue_id`
- Dropped the dead manifest fallback in the provider settings screen (it always resolves through the provider manifests map)
- Simplified the config test fixtures that only existed to satisfy the removed fields
