### PR TITLE
Match the API error code type to the number the server sends

### DIFF
--- a/src/plugins/api/index.ts
+++ b/src/plugins/api/index.ts
@@ -2691,7 +2691,7 @@ export class MusicAssistantApi {
         console.error("[resultMessage]", msg);
 
         // Don't show toast for authentication errors - they're handled by the login UI
-        const errorMsg = msg.details || msg.error_code || "";
+        const errorMsg = msg.details || "";
         const isAuthError =
           errorMsg.includes("Invalid credentials") ||
           errorMsg.includes("Invalid username") ||
@@ -2701,7 +2701,7 @@ export class MusicAssistantApi {
           errorMsg.toLowerCase().includes("unauthorized");
 
         if (!isAuthError) {
-          toast.error(msg.details || msg.error_code);
+          toast.error(msg.details || String(msg.error_code));
         }
       }
     } else if (DEBUG) {
@@ -2728,7 +2728,7 @@ export class MusicAssistantApi {
 
     this.commands.delete(msg.message_id);
     if ("error_code" in msg) {
-      resultPromise.reject(msg.details || msg.error_code);
+      resultPromise.reject(msg.details || String(msg.error_code));
     } else {
       msg = msg as SuccessResultMessage;
       resultPromise.resolve(msg.result);

--- a/src/plugins/api/interfaces.ts
+++ b/src/plugins/api/interfaces.ts
@@ -563,7 +563,7 @@ export interface SuccessResultMessage extends ResultMessageBase {
 export interface ErrorResultMessage extends ResultMessageBase {
   // Message sent when a Command has been successfully executed.
 
-  error_code: string;
+  error_code: number;
   details: string | null;
 }
 

--- a/src/plugins/api/interfaces.ts
+++ b/src/plugins/api/interfaces.ts
@@ -561,7 +561,7 @@ export interface SuccessResultMessage extends ResultMessageBase {
 }
 
 export interface ErrorResultMessage extends ResultMessageBase {
-  // Message sent when a Command has been successfully executed.
+  // Message sent when a Command did not execute successfully.
 
   error_code: number;
   details: string | null;

--- a/tests/plugins/api/index.test.ts
+++ b/tests/plugins/api/index.test.ts
@@ -167,7 +167,7 @@ function createErrorResult(
   if (!command.message_id) throw new Error("Command has no message ID");
   return {
     message_id: command.message_id,
-    error_code: "test_error",
+    error_code: 999,
     details,
   };
 }

--- a/tests/plugins/api/server-time.test.ts
+++ b/tests/plugins/api/server-time.test.ts
@@ -48,7 +48,7 @@ class FakeTransport extends BaseTransport {
         this.failsTimeCommand
           ? {
               message_id: msg.message_id,
-              error_code: "invalid_command",
+              error_code: 12,
               details: "Invalid command: time",
             }
           : {


### PR DESCRIPTION
The API error message declared `error_code` as text, while the server actually sends a number. `ProviderError.error_code` in the same file was already typed correctly — this brings the two in line.

Nothing user-visible changes today, but the mismatch was a trap: the authentication-error check called a text operation on the code, so an error message arriving without a details text would have thrown before the pending command was ever settled, leaving it hanging.

- Type `ErrorResultMessage.error_code` as a number
- Drop the numeric code from the authentication-error text match, where it could never match anything
- Convert the code to text where it is used as a fallback for the toast and the rejection value
- Correct the description above `ErrorResultMessage`, which claimed the command had succeeded
- Use numeric codes in the two test fixtures