### PR TITLE
Share the queue item and stream details test fixtures

### DIFF
--- a/tests/components/AudioProcessingDetails.test.ts
+++ b/tests/components/AudioProcessingDetails.test.ts
@@ -15,7 +15,6 @@ import {
   CrossfadeMode,
   DSPFilterType,
   DSPState,
-  MediaType,
   type StreamDetails,
   VolumeNormalizationMode,
 } from "@/plugins/api/interfaces";
@@ -29,6 +28,7 @@ import {
 } from "../fixtures/audioProcessing";
 import { audioFormat } from "../fixtures/audioFormat";
 import { providerManifest } from "../fixtures/providerManifest";
+import { streamDetails } from "../fixtures/streamDetails";
 
 const apiMock = vi.hoisted(() => ({
   getProviderName: vi.fn<MusicAssistantApi["getProviderName"]>(
@@ -937,15 +937,11 @@ function makeFormat(overrides: Partial<AudioFormat> = {}): AudioFormat {
 }
 
 function makeStreamDetails(format = makeFormat()): StreamDetails {
-  return {
+  return streamDetails({
     provider: "filesystem--music",
     item_id: "track-1",
     audio_format: format,
-    media_type: MediaType.TRACK,
-    stream_metadata: null,
-    duration: null,
-    audio_processing: null,
-  };
+  });
 }
 
 function makeFullChain(): AudioProcessingChain {

--- a/tests/components/QualityDetailsBtn.test.ts
+++ b/tests/components/QualityDetailsBtn.test.ts
@@ -4,7 +4,6 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import QualityDetailsBtn from "@/components/QualityDetailsBtn.vue";
 import {
   AudioQuality,
-  MediaType,
   PlaybackState,
   type PlayerQueue,
   RepeatMode,
@@ -16,7 +15,8 @@ import {
   audioOutputDetails,
   audioProcessingChain,
 } from "../fixtures/audioProcessing";
-import { audioFormat } from "../fixtures/audioFormat";
+import { queueItem } from "../fixtures/queueItem";
+import { streamDetails } from "../fixtures/streamDetails";
 
 const storeMock = vi.hoisted(() => ({
   activePlayerQueue: undefined as PlayerQueue | undefined,
@@ -153,15 +153,7 @@ function outputWithQuality(quality: AudioQuality) {
 }
 
 function makeStreamDetails(): StreamDetails {
-  return {
-    provider: "test",
-    item_id: "track-1",
-    audio_format: audioFormat(),
-    media_type: MediaType.TRACK,
-    stream_metadata: null,
-    duration: null,
-    audio_processing: null,
-  };
+  return streamDetails({ provider: "test", item_id: "track-1" });
 }
 
 function makeQueue(streamdetails: StreamDetails): PlayerQueue {
@@ -186,17 +178,7 @@ function makeQueue(streamdetails: StreamDetails): PlayerQueue {
     elapsed_time: 0,
     elapsed_time_last_updated: 0,
     state: PlaybackState.PLAYING,
-    current_item: {
-      queue_id: "queue-1",
-      queue_item_id: "item-1",
-      name: "Track",
-      duration: 180,
-      sort_index: 0,
-      streamdetails,
-      media_item: null,
-      image: null,
-      available: true,
-    },
+    current_item: queueItem({ name: "Track", duration: 180, streamdetails }),
     next_item: null,
     sources: [],
     is_dynamic: false,

--- a/tests/composables/useActiveTrackWaveform.test.ts
+++ b/tests/composables/useActiveTrackWaveform.test.ts
@@ -1,6 +1,11 @@
 import { effectScope, nextTick, reactive, type EffectScope } from "vue";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { MusicAssistantApi } from "@/plugins/api";
+import type { QueueItem } from "@/plugins/api/interfaces";
+import { queueItem } from "../fixtures/queueItem";
+import { radio } from "../fixtures/radio";
+import { streamDetails } from "../fixtures/streamDetails";
+import { track } from "../fixtures/track";
 
 // ---------------------------------------------------------------------------
 // Hoisted mocks
@@ -34,21 +39,14 @@ vi.mock("@/plugins/api/interfaces", async (importOriginal) => {
 // Helpers
 // ---------------------------------------------------------------------------
 
-function makeQueueItem(overrides: Record<string, unknown> = {}) {
-  return {
+function makeQueueItem(overrides: Partial<QueueItem> = {}): QueueItem {
+  return queueItem({
     queue_item_id: "qi-1",
     duration: 240,
-    media_item: {
-      item_id: "track-1",
-      provider: "spotify",
-      media_type: "track",
-    },
-    streamdetails: {
-      item_id: "stream-1",
-      provider: "spotify",
-    },
+    media_item: track({ item_id: "track-1", provider: "spotify" }),
+    streamdetails: streamDetails({ item_id: "stream-1", provider: "spotify" }),
     ...overrides,
-  };
+  });
 }
 
 type UseActiveTrackWaveform =
@@ -115,7 +113,7 @@ describe("useActiveTrackWaveform", () => {
     const { waveformBins } = addConsumer(await importComposable());
 
     storeMock.curQueueItem = makeQueueItem({
-      media_item: { item_id: "r-1", provider: "spotify", media_type: "radio" },
+      media_item: radio({ item_id: "r-1", provider: "spotify" }),
     });
     await nextTick();
     await nextTick();
@@ -127,7 +125,7 @@ describe("useActiveTrackWaveform", () => {
   it("does not fetch when streamdetails are absent", async () => {
     const { waveformBins } = addConsumer(await importComposable());
 
-    storeMock.curQueueItem = makeQueueItem({ streamdetails: undefined });
+    storeMock.curQueueItem = makeQueueItem({ streamdetails: null });
     await nextTick();
     await nextTick();
 
@@ -175,7 +173,10 @@ describe("useActiveTrackWaveform", () => {
     // Switch to second track before first resolves.
     storeMock.curQueueItem = makeQueueItem({
       queue_item_id: "qi-2",
-      streamdetails: { item_id: "stream-2", provider: "spotify" },
+      streamdetails: streamDetails({
+        item_id: "stream-2",
+        provider: "spotify",
+      }),
     });
     await nextTick();
     await nextTick(); // second fetch resolves
@@ -230,7 +231,10 @@ describe("useActiveTrackWaveform", () => {
 
     storeMock.curQueueItem = makeQueueItem({
       queue_item_id: "qi-2",
-      streamdetails: { item_id: "stream-2", provider: "spotify" },
+      streamdetails: streamDetails({
+        item_id: "stream-2",
+        provider: "spotify",
+      }),
     });
     await nextTick();
     await nextTick();
@@ -280,7 +284,7 @@ describe("useActiveTrackWaveform", () => {
     await nextTick();
 
     storeMock.curQueueItem = makeQueueItem({
-      streamdetails: { item_id: "stream-1", provider: "qobuz" },
+      streamdetails: streamDetails({ item_id: "stream-1", provider: "qobuz" }),
     });
     await nextTick();
     await nextTick();
@@ -337,7 +341,10 @@ describe("useActiveTrackWaveform", () => {
 
     storeMock.curQueueItem = makeQueueItem({
       queue_item_id: "qi-2",
-      streamdetails: { item_id: "stream-2", provider: "spotify" },
+      streamdetails: streamDetails({
+        item_id: "stream-2",
+        provider: "spotify",
+      }),
     });
 
     const second = addConsumer(useActiveTrackWaveform);
@@ -360,7 +367,10 @@ describe("useActiveTrackWaveform", () => {
     const trackA = makeQueueItem();
     const trackB = makeQueueItem({
       queue_item_id: "qi-2",
-      streamdetails: { item_id: "stream-2", provider: "spotify" },
+      streamdetails: streamDetails({
+        item_id: "stream-2",
+        provider: "spotify",
+      }),
     });
 
     // Track A's fetch hangs, then track B plays and resolves.

--- a/tests/composables/useAudioProcessingDetails.test.ts
+++ b/tests/composables/useAudioProcessingDetails.test.ts
@@ -17,7 +17,6 @@ import {
   ContentType,
   CrossfadeMode,
   DSPState,
-  MediaType,
   type OutputProtocol,
   type StreamDetails,
   VolumeNormalizationMode,
@@ -31,6 +30,7 @@ import {
   audioQueueProcessing,
 } from "../fixtures/audioProcessing";
 import { audioFormat } from "../fixtures/audioFormat";
+import { streamDetails } from "../fixtures/streamDetails";
 
 vi.mock("@/plugins/api", async () => {
   const { providerManifest } = await import("../fixtures/providerManifest");
@@ -557,21 +557,16 @@ describe("buildAudioProcessingDetailsDisplay", () => {
         queue_processing: audioQueueProcessing({ playback_speed: 1.25 }),
       }),
     );
-    const streamDetails = ref<StreamDetails>({
-      provider: "test",
-      item_id: "track-1",
-      audio_format: makeFormat(),
-      media_type: MediaType.TRACK,
-      stream_metadata: null,
-      duration: null,
-      audio_processing: null,
-    });
+    const details = ref<StreamDetails>(
+      streamDetails({
+        provider: "test",
+        item_id: "track-1",
+        audio_format: makeFormat(),
+      }),
+    );
     const harness = defineComponent({
       setup() {
-        const { processingStages } = useAudioProcessingDetails(
-          chain,
-          streamDetails,
-        );
+        const { processingStages } = useAudioProcessingDetails(chain, details);
         return () =>
           h(
             "span",
@@ -600,18 +595,13 @@ function buildDisplay(
   chain: Partial<AudioProcessingChain> = {},
   format = makeFormat(),
 ) {
-  const streamDetails: StreamDetails = {
-    provider: "test--instance",
-    item_id: "track-1",
-    audio_format: format,
-    media_type: MediaType.TRACK,
-    stream_metadata: null,
-    duration: null,
-    audio_processing: null,
-  };
   return buildAudioProcessingDetailsDisplay(
     audioProcessingChain(chain),
-    streamDetails,
+    streamDetails({
+      provider: "test--instance",
+      item_id: "track-1",
+      audio_format: format,
+    }),
     dependencies,
   );
 }

--- a/tests/composables/useGuestQueue.test.ts
+++ b/tests/composables/useGuestQueue.test.ts
@@ -8,6 +8,7 @@ import {
 import { BEFORE_FIRST_INDEX } from "@/helpers/queue_position";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { MusicAssistantApi } from "@/plugins/api";
+import { queueItem } from "../fixtures/queueItem";
 
 const { mockSendCommand, mockGetPlayerQueueItems, mockSubscribe } = vi.hoisted(
   () => {
@@ -229,15 +230,9 @@ describe("useGuestQueue", () => {
 });
 
 function queueItemFixture(queueItemId: string): QueueItem {
-  return {
+  return queueItem({
     queue_id: "queue1",
     queue_item_id: queueItemId,
     name: queueItemId,
-    duration: 200,
-    sort_index: 0,
-    streamdetails: null,
-    media_item: null,
-    image: null,
-    available: true,
-  };
+  });
 }

--- a/tests/fixtures/queueItem.ts
+++ b/tests/fixtures/queueItem.ts
@@ -1,0 +1,20 @@
+import type { QueueItem } from "@/plugins/api/interfaces";
+
+/**
+ * A complete queue item, for tests that only care about a few of its fields but
+ * should still model a payload the server can send.
+ */
+export function queueItem(overrides: Partial<QueueItem> = {}): QueueItem {
+  return {
+    queue_id: "queue-1",
+    queue_item_id: "item-1",
+    name: "Queue item",
+    duration: 200,
+    sort_index: 0,
+    streamdetails: null,
+    media_item: null,
+    image: null,
+    available: true,
+    ...overrides,
+  };
+}

--- a/tests/fixtures/radio.ts
+++ b/tests/fixtures/radio.ts
@@ -1,0 +1,20 @@
+import { MediaType, type Radio } from "@/plugins/api/interfaces";
+
+/**
+ * A complete radio station, for tests that only care about a few of its fields
+ * but should still model a payload the server can send.
+ */
+export function radio(overrides: Partial<Radio> = {}): Radio {
+  return {
+    item_id: "1",
+    provider: "library",
+    name: "Radio",
+    uri: "library://radio/1",
+    is_playable: true,
+    media_type: MediaType.RADIO,
+    provider_mappings: [],
+    metadata: {},
+    favorite: false,
+    ...overrides,
+  };
+}

--- a/tests/fixtures/streamDetails.ts
+++ b/tests/fixtures/streamDetails.ts
@@ -1,0 +1,21 @@
+import { MediaType, type StreamDetails } from "@/plugins/api/interfaces";
+import { audioFormat } from "./audioFormat";
+
+/**
+ * Complete stream details, for tests that only care about a few of its fields
+ * but should still model a payload the server can send.
+ */
+export function streamDetails(
+  overrides: Partial<StreamDetails> = {},
+): StreamDetails {
+  return {
+    provider: "test_provider--1",
+    item_id: "item-1",
+    audio_format: audioFormat(),
+    media_type: MediaType.TRACK,
+    stream_metadata: null,
+    duration: null,
+    audio_processing: null,
+    ...overrides,
+  };
+}

--- a/tests/fixtures/streamDetails.ts
+++ b/tests/fixtures/streamDetails.ts
@@ -14,7 +14,7 @@ export function streamDetails(
     audio_format: audioFormat(),
     media_type: MediaType.TRACK,
     stream_metadata: null,
-    duration: null,
+    duration: 200,
     audio_processing: null,
     ...overrides,
   };

--- a/tests/helpers/useMediaBrowserMetaData.test.ts
+++ b/tests/helpers/useMediaBrowserMetaData.test.ts
@@ -9,6 +9,7 @@ import {
 } from "@/plugins/api/interfaces";
 import { nextTick } from "vue";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { queueItem } from "../fixtures/queueItem";
 
 // Reactive api mock so mutating a queue fires the composable's watchers.
 const { apiMock } = await vi.hoisted(async () => {
@@ -75,16 +76,13 @@ function makeQueue(
     queue_id: QUEUE_ID,
     active: true,
     state: PlaybackState.PLAYING,
-    current_item: {
+    current_item: queueItem({
       queue_id: QUEUE_ID,
       queue_item_id: "queue-item-1",
       name: "Item",
-      duration: 200,
-      sort_index: 0,
-      available: true,
       media_item: { media_type: MediaType.TRACK } as PlayableMediaItemType,
       ...currentItem,
-    },
+    }),
     ...queue,
   } as PlayerQueue;
   return apiMock.queues[QUEUE_ID];


### PR DESCRIPTION
Queue items and stream details were still built by hand in each test file that needed one, so every change to those types meant updating the same object in several places. Other models already have a single definition in `tests/fixtures/`.

- Added `tests/fixtures/queueItem.ts`, `tests/fixtures/streamDetails.ts` and `tests/fixtures/radio.ts`
- Pointed the queue, waveform, media browser and audio quality tests at them

Follows on from #2350.

Maintenance - no user visible change.
