### PR TITLE
Match audio processing types to what the server sends

### DIFF
--- a/src/composables/useAudioProcessingDetails.ts
+++ b/src/composables/useAudioProcessingDetails.ts
@@ -21,6 +21,7 @@ import { dspFilterText } from "@/helpers/audioProcessing";
 import api from "@/plugins/api";
 import {
   AudioChannel,
+  type AudioDSPDetails,
   type AudioFormat,
   type AudioNormalizationDetails,
   type AudioOutputDetails,
@@ -37,7 +38,6 @@ import {
 
 type TranslationValue = string | number;
 type Translate = (key: string, values?: TranslationValue[]) => string;
-type AudioDSPDetails = NonNullable<AudioOutputDetails["dsp"]>;
 
 interface AudioProcessingDisplayStageBase {
   key: string;
@@ -186,14 +186,14 @@ export function buildAudioProcessingDetailsDisplay(
   dependencies: AudioProcessingDetailsDependencies,
 ): AudioProcessingDetailsDisplay {
   return {
-    inputQualityTier: audioQualityToTier(chain.input_fidelity?.quality),
+    inputQualityTier: audioQualityToTier(chain.input_fidelity.quality),
     inputQualityLabel: audioQualityLabel(
-      chain.input_fidelity?.quality,
+      chain.input_fidelity.quality,
       dependencies.translate,
     ),
     inputStages: buildInputStages(streamDetails, dependencies),
     processingStages: buildProcessingStages(streamDetails, chain, dependencies),
-    outputPaths: (chain.outputs ?? []).map((output, index) =>
+    outputPaths: chain.outputs.map((output, index) =>
       buildOutputDisplay(output, index, dependencies),
     ),
   };
@@ -238,10 +238,7 @@ function buildProcessingStages(
       ),
     );
   }
-  if (
-    typeof processing?.playback_speed === "number" &&
-    processing.playback_speed !== 1
-  ) {
+  if (processing && processing.playback_speed !== 1) {
     stages.push({
       key: "playback-speed",
       icon: Gauge,
@@ -250,10 +247,7 @@ function buildProcessingStages(
       ]),
     });
   }
-  if (
-    processing?.crossfade_mode &&
-    processing.crossfade_mode !== CrossfadeMode.DISABLED
-  ) {
+  if (processing && processing.crossfade_mode !== CrossfadeMode.DISABLED) {
     stages.push({
       key: "crossfade",
       icon: CrossfadeIcon,
@@ -289,59 +283,57 @@ function buildOutputDisplay(
   dependencies: AudioProcessingDetailsDependencies,
 ): AudioProcessingOutputDisplay {
   const { translate, getPresetName, getIRName } = dependencies;
-  const playerIds = output.player_ids ?? [];
+  const { dsp, player_ids: playerIds } = output;
   const stages: AudioProcessingDisplayStage[] = [];
 
-  if (output.dsp) {
-    if (shouldShowDSPState(output.dsp)) {
-      stages.push({
-        key: `dsp-state-${index}`,
-        icon: SlidersHorizontal,
-        title: dspStateLabel(output.dsp.state, translate),
-      });
-    }
-    if (output.dsp.preset_id) {
-      stages.push({
-        key: `dsp-preset-${index}`,
-        icon: SlidersHorizontal,
-        title:
-          getPresetName(output.dsp.preset_id) ??
-          translate("settings.dsp.presets.custom"),
-        subtitleParts: [
-          translate("streamdetails.audio_processing.dsp_preset_label"),
-        ],
-      });
-    }
-    if (output.dsp.input_gain) {
-      stages.push({
-        key: `dsp-input-gain-${index}`,
-        icon: SlidersHorizontal,
-        title: translate("streamdetails.input_gain", [
-          formatNumber(output.dsp.input_gain, 1, dependencies.locale),
-        ]),
-      });
-    }
-    for (const [filterIndex, filter] of (output.dsp.filters ?? []).entries()) {
-      const irName =
-        filter.type === DSPFilterType.CONVOLUTION
-          ? getIRName(filter.ir_id)
-          : undefined;
-      stages.push({
-        key: `dsp-filter-${index}-${filterIndex}`,
-        icon: SlidersHorizontal,
-        title: dspFilterText(filter),
-        subtitleParts: irName ? [irName] : undefined,
-      });
-    }
-    if (output.dsp.output_gain) {
-      stages.push({
-        key: `dsp-output-gain-${index}`,
-        icon: SlidersHorizontal,
-        title: translate("streamdetails.output_gain", [
-          formatNumber(output.dsp.output_gain, 1, dependencies.locale),
-        ]),
-      });
-    }
+  if (shouldShowDSPState(dsp)) {
+    stages.push({
+      key: `dsp-state-${index}`,
+      icon: SlidersHorizontal,
+      title: dspStateLabel(dsp.state, translate),
+    });
+  }
+  if (dsp.preset_id) {
+    stages.push({
+      key: `dsp-preset-${index}`,
+      icon: SlidersHorizontal,
+      title:
+        getPresetName(dsp.preset_id) ??
+        translate("settings.dsp.presets.custom"),
+      subtitleParts: [
+        translate("streamdetails.audio_processing.dsp_preset_label"),
+      ],
+    });
+  }
+  if (dsp.input_gain) {
+    stages.push({
+      key: `dsp-input-gain-${index}`,
+      icon: SlidersHorizontal,
+      title: translate("streamdetails.input_gain", [
+        formatNumber(dsp.input_gain, 1, dependencies.locale),
+      ]),
+    });
+  }
+  for (const [filterIndex, filter] of dsp.filters.entries()) {
+    const irName =
+      filter.type === DSPFilterType.CONVOLUTION
+        ? getIRName(filter.ir_id)
+        : undefined;
+    stages.push({
+      key: `dsp-filter-${index}-${filterIndex}`,
+      icon: SlidersHorizontal,
+      title: dspFilterText(filter),
+      subtitleParts: irName ? [irName] : undefined,
+    });
+  }
+  if (dsp.output_gain) {
+    stages.push({
+      key: `dsp-output-gain-${index}`,
+      icon: SlidersHorizontal,
+      title: translate("streamdetails.output_gain", [
+        formatNumber(dsp.output_gain, 1, dependencies.locale),
+      ]),
+    });
   }
 
   if (output.source_channel) {
@@ -363,8 +355,8 @@ function buildOutputDisplay(
   return {
     key: playerIds.join("|") || `output-${index}`,
     playerIds,
-    qualityTier: audioQualityToTier(output.fidelity?.quality),
-    qualityLabel: audioQualityLabel(output.fidelity?.quality, translate),
+    qualityTier: audioQualityToTier(output.fidelity.quality),
+    qualityLabel: audioQualityLabel(output.fidelity.quality, translate),
     stages,
     destination: destinationStage(playerIds, dependencies),
   };
@@ -631,8 +623,8 @@ function processingContextStage(
 
 function allOutputsAreBitPerfect(chain: AudioProcessingChain): boolean {
   return Boolean(
-    chain.outputs?.length &&
-    chain.outputs.every((output) => output.fidelity?.bit_perfect === true),
+    chain.outputs.length &&
+    chain.outputs.every((output) => output.fidelity.bit_perfect === true),
   );
 }
 
@@ -646,7 +638,7 @@ function finalOutputStage(
   const details = format ? audioFormatDetails(format, translate, locale) : [];
   details.push(
     outputFidelityDetail(
-      output.fidelity?.bit_perfect,
+      output.fidelity.bit_perfect,
       output.output_format,
       translate,
     ),
@@ -662,7 +654,7 @@ function finalOutputStage(
       : undefined,
     atomicSubtitleParts: true,
     badge:
-      output.fidelity?.bit_perfect === true
+      output.fidelity.bit_perfect === true
         ? translate("streamdetails.audio_processing.bit_perfect_badge")
         : undefined,
     details,
@@ -686,8 +678,8 @@ function formatStage(
 }
 
 function outputFidelityDetail(
-  bitPerfect: boolean | null | undefined,
-  format: AudioFormat | null | undefined,
+  bitPerfect: boolean | null,
+  format: AudioFormat | null,
   translate: Translate,
 ): string {
   if (bitPerfect === true) {
@@ -708,7 +700,7 @@ function shouldShowDSPState(dsp: AudioDSPDetails): boolean {
 
 function hasDSPConfiguration(dsp: AudioDSPDetails): boolean {
   return Boolean(
-    dsp.preset_id || dsp.input_gain || dsp.output_gain || dsp.filters?.length,
+    dsp.preset_id || dsp.input_gain || dsp.output_gain || dsp.filters.length,
   );
 }
 
@@ -718,7 +710,7 @@ function hasActiveDSPTransform(dsp: AudioDSPDetails): boolean {
     (dsp.preset_id ||
       dsp.input_gain ||
       dsp.output_gain ||
-      dsp.filters?.some((filter) => filter.enabled !== false)),
+      dsp.filters.some((filter) => filter.enabled !== false)),
   );
 }
 
@@ -736,25 +728,18 @@ function processingHeadroomReasons(
       translate("streamdetails.audio_processing.normalization_title"),
     );
   }
-  if (
-    typeof processing?.playback_speed === "number" &&
-    processing.playback_speed !== 1
-  ) {
+  if (processing && processing.playback_speed !== 1) {
     reasons.add(
       translate("streamdetails.audio_processing.playback_speed_title"),
     );
   }
-  if (
-    processing?.crossfade_mode &&
-    processing.crossfade_mode !== CrossfadeMode.DISABLED
-  ) {
+  if (processing && processing.crossfade_mode !== CrossfadeMode.DISABLED) {
     reasons.add(translate("streamdetails.audio_processing.crossfade_title"));
   }
   if (processing?.overlay_active) {
     reasons.add(translate("streamdetails.audio_processing.overlay_title"));
   }
-  for (const output of chain.outputs ?? []) {
-    if (!output.dsp) continue;
+  for (const output of chain.outputs) {
     if (hasActiveDSPTransform(output.dsp)) {
       reasons.add(translate("streamdetails.audio_processing.dsp_title"));
     }

--- a/src/composables/useStreamQuality.ts
+++ b/src/composables/useStreamQuality.ts
@@ -79,7 +79,7 @@ export function useStreamQuality(
 ) {
   const knownOutputQualityTiers = computed(() =>
     (toValue(audioProcessing)?.outputs ?? [])
-      .map((output) => audioQualityToTier(output.fidelity?.quality))
+      .map((output) => audioQualityToTier(output.fidelity.quality))
       .filter((tier) => tier !== QualityTier.UNKNOWN),
   );
   const minOutputQualityTier = computed(() =>

--- a/src/plugins/api/interfaces.ts
+++ b/src/plugins/api/interfaces.ts
@@ -1051,46 +1051,51 @@ export interface AudioFormat {
 }
 
 export interface AudioFidelity {
-  quality?: AudioQuality;
-  bit_perfect?: boolean | null;
+  quality: AudioQuality;
+  // null when bit-perfect status cannot be determined
+  bit_perfect: boolean | null;
 }
 
 export interface AudioNormalizationDetails {
-  mode?: VolumeNormalizationMode;
-  measurement_source?: AudioNormalizationMeasurementSource;
-  target_lufs?: number | null;
-  measured_lufs?: number | null;
-  applied_gain_db?: number | null;
+  mode: VolumeNormalizationMode;
+  measurement_source: AudioNormalizationMeasurementSource;
+  target_lufs: number | null;
+  measured_lufs: number | null;
+  applied_gain_db: number | null;
 }
 
 export interface AudioQueueProcessing {
-  pcm_format?: AudioFormat | null;
-  normalization?: AudioNormalizationDetails | null;
-  playback_speed?: number;
-  crossfade_mode?: CrossfadeMode;
-  overlay_active?: boolean;
+  // internal PCM format shared by queue processing, including F32 headroom
+  pcm_format: AudioFormat | null;
+  normalization: AudioNormalizationDetails | null;
+  playback_speed: number;
+  crossfade_mode: CrossfadeMode;
+  overlay_active: boolean;
 }
 
 export interface AudioDSPDetails {
-  state?: DSPState;
-  input_gain?: number;
-  filters?: DSPFilter[];
-  output_gain?: number;
-  preset_id?: string | null;
+  state: DSPState;
+  input_gain: number;
+  filters: DSPFilter[];
+  output_gain: number;
+  // cleared when the user changes DSP settings manually
+  preset_id: string | null;
 }
 
 export interface AudioOutputDetails {
-  player_ids?: string[];
-  dsp?: AudioDSPDetails;
-  source_channel?: AudioChannel | null;
-  output_format?: AudioFormat | null;
-  fidelity?: AudioFidelity;
+  player_ids: string[];
+  dsp: AudioDSPDetails;
+  // set only for explicit left/right routing; formats show mono/stereo conversion
+  source_channel: AudioChannel | null;
+  // furthest downstream format known to Music Assistant
+  output_format: AudioFormat | null;
+  fidelity: AudioFidelity;
 }
 
 export interface AudioProcessingChain {
-  input_fidelity?: AudioFidelity;
-  queue_processing?: AudioQueueProcessing | null;
-  outputs?: AudioOutputDetails[];
+  input_fidelity: AudioFidelity;
+  queue_processing: AudioQueueProcessing | null;
+  outputs: AudioOutputDetails[];
 }
 
 export interface StreamMetadata {

--- a/tests/components/AudioProcessingDetails.test.ts
+++ b/tests/components/AudioProcessingDetails.test.ts
@@ -22,12 +22,12 @@ import {
 import {
   audioDSPDetails,
   audioFidelity,
-  audioFormat,
   audioNormalizationDetails,
   audioOutputDetails,
   audioProcessingChain,
   audioQueueProcessing,
 } from "../fixtures/audioProcessing";
+import { audioFormat } from "../fixtures/audioFormat";
 import { providerManifest } from "../fixtures/providerManifest";
 
 const apiMock = vi.hoisted(() => ({
@@ -936,11 +936,11 @@ function makeFormat(overrides: Partial<AudioFormat> = {}): AudioFormat {
   return audioFormat({ sample_rate: 96000, bit_depth: 24, ...overrides });
 }
 
-function makeStreamDetails(audioFormat = makeFormat()): StreamDetails {
+function makeStreamDetails(format = makeFormat()): StreamDetails {
   return {
     provider: "filesystem--music",
     item_id: "track-1",
-    audio_format: audioFormat,
+    audio_format: format,
     media_type: MediaType.TRACK,
     stream_metadata: null,
     duration: null,

--- a/tests/components/AudioProcessingDetails.test.ts
+++ b/tests/components/AudioProcessingDetails.test.ts
@@ -19,6 +19,15 @@ import {
   type StreamDetails,
   VolumeNormalizationMode,
 } from "@/plugins/api/interfaces";
+import {
+  audioDSPDetails,
+  audioFidelity,
+  audioFormat,
+  audioNormalizationDetails,
+  audioOutputDetails,
+  audioProcessingChain,
+  audioQueueProcessing,
+} from "../fixtures/audioProcessing";
 import { providerManifest } from "../fixtures/providerManifest";
 
 const apiMock = vi.hoisted(() => ({
@@ -261,22 +270,22 @@ describe("AudioProcessingDetails", () => {
 
   it("renders future enum values as safe unknown states", () => {
     const wrapper = mountDetails({
-      input_fidelity: { quality: "future" as AudioQuality },
-      queue_processing: {
+      input_fidelity: audioFidelity({ quality: "future" as AudioQuality }),
+      queue_processing: audioQueueProcessing({
         pcm_format: makeFormat({
           content_type: ContentType.PCM_F32LE,
           codec_type: ContentType.PCM_F32LE,
           bit_depth: 32,
         }),
         crossfade_mode: "future" as CrossfadeMode,
-      },
+      }),
       outputs: [
-        {
+        audioOutputDetails({
           player_ids: ["player-1"],
-          dsp: { state: "future" as DSPState },
+          dsp: audioDSPDetails({ state: "future" as DSPState }),
           source_channel: "future" as AudioChannel,
-          fidelity: { quality: "future" as AudioQuality },
-        },
+          fidelity: audioFidelity({ quality: "future" as AudioQuality }),
+        }),
       ],
     });
 
@@ -297,12 +306,12 @@ describe("AudioProcessingDetails", () => {
   it("names a mono downmix instead of a selected source channel", () => {
     const wrapper = mountDetails({
       outputs: [
-        {
+        audioOutputDetails({
           player_ids: ["player-1"],
-          dsp: { state: DSPState.DISABLED },
+          dsp: audioDSPDetails({ state: DSPState.DISABLED }),
           source_channel: AudioChannel.ALL,
           output_format: makeFormat(),
-        },
+        }),
       ],
     });
 
@@ -316,19 +325,19 @@ describe("AudioProcessingDetails", () => {
 
   it("excludes disabled crossfade from component headroom reasons", () => {
     const wrapper = mountDetails({
-      queue_processing: {
+      queue_processing: audioQueueProcessing({
         pcm_format: makeFormat({
           content_type: ContentType.PCM_F32LE,
           codec_type: ContentType.PCM_F32LE,
           bit_depth: 32,
         }),
         crossfade_mode: CrossfadeMode.DISABLED,
-      },
+      }),
       outputs: [
-        {
+        audioOutputDetails({
           player_ids: ["player-1"],
-          fidelity: { bit_perfect: false },
-        },
+          fidelity: audioFidelity({ bit_perfect: false }),
+        }),
       ],
     });
 
@@ -351,28 +360,28 @@ describe("AudioProcessingDetails", () => {
     });
     const wrapper = mountDetails(
       {
-        input_fidelity: { quality: AudioQuality.STANDARD },
-        queue_processing: {
+        input_fidelity: audioFidelity({ quality: AudioQuality.STANDARD }),
+        queue_processing: audioQueueProcessing({
           pcm_format: makeFormat({
             content_type: ContentType.PCM_F32LE,
             codec_type: ContentType.PCM_F32LE,
             sample_rate: 48000,
             bit_depth: 32,
           }),
-        },
+        }),
         outputs: [
-          {
+          audioOutputDetails({
             player_ids: ["player-1"],
-            dsp: { state: DSPState.DISABLED },
+            dsp: audioDSPDetails({ state: DSPState.DISABLED }),
             output_format: makeFormat({
               sample_rate: 48000,
               bit_depth: 16,
             }),
-            fidelity: {
+            fidelity: audioFidelity({
               quality: AudioQuality.STANDARD,
               bit_perfect: false,
-            },
-          },
+            }),
+          }),
         ],
       },
       makeStreamDetails(sourceFormat),
@@ -458,17 +467,17 @@ describe("AudioProcessingDetails", () => {
     ({ contentType, codecType }) => {
       const wrapper = mountDetails({
         outputs: [
-          {
+          audioOutputDetails({
             player_ids: ["player-1"],
             output_format: makeFormat({
               content_type: contentType,
               codec_type: codecType,
             }),
-            fidelity: {
+            fidelity: audioFidelity({
               quality: AudioQuality.STANDARD,
               bit_perfect: false,
-            },
-          },
+            }),
+          }),
         ],
       });
 
@@ -499,17 +508,17 @@ describe("AudioProcessingDetails", () => {
     ({ contentType, codecType }) => {
       const wrapper = mountDetails({
         outputs: [
-          {
+          audioOutputDetails({
             player_ids: ["player-1"],
             output_format: makeFormat({
               content_type: contentType,
               codec_type: codecType,
             }),
-            fidelity: {
+            fidelity: audioFidelity({
               quality: AudioQuality.LOSSLESS,
               bit_perfect: false,
-            },
-          },
+            }),
+          }),
         ],
       });
 
@@ -527,17 +536,17 @@ describe("AudioProcessingDetails", () => {
   it("prefers a known lossless codec over a lossy container", () => {
     const wrapper = mountDetails({
       outputs: [
-        {
+        audioOutputDetails({
           player_ids: ["player-1"],
           output_format: makeFormat({
             content_type: ContentType.MP3,
             codec_type: ContentType.FLAC,
           }),
-          fidelity: {
+          fidelity: audioFidelity({
             quality: AudioQuality.LOSSLESS,
             bit_perfect: false,
-          },
-        },
+          }),
+        }),
       ],
     });
 
@@ -554,14 +563,14 @@ describe("AudioProcessingDetails", () => {
   it("explains unknown final-output fidelity in the format tooltip", () => {
     const wrapper = mountDetails({
       outputs: [
-        {
+        audioOutputDetails({
           player_ids: ["player-1"],
           output_format: makeFormat({
             sample_rate: 48000,
             bit_depth: 16,
           }),
-          fidelity: { quality: AudioQuality.STANDARD },
-        },
+          fidelity: audioFidelity({ quality: AudioQuality.STANDARD }),
+        }),
       ],
     });
 
@@ -581,29 +590,31 @@ describe("AudioProcessingDetails", () => {
     });
     const wrapper = mountDetails(
       {
-        input_fidelity: { quality: AudioQuality.LOSSLESS },
-        queue_processing: {
+        input_fidelity: audioFidelity({ quality: AudioQuality.LOSSLESS }),
+        queue_processing: audioQueueProcessing({
           pcm_format: makeFormat({
             content_type: ContentType.PCM_S16LE,
             codec_type: ContentType.PCM_S16LE,
             sample_rate: 44100,
             bit_depth: 16,
           }),
-          normalization: { mode: VolumeNormalizationMode.DISABLED },
+          normalization: audioNormalizationDetails({
+            mode: VolumeNormalizationMode.DISABLED,
+          }),
           playback_speed: 1,
           crossfade_mode: CrossfadeMode.DISABLED,
           overlay_active: false,
-        },
+        }),
         outputs: [
-          {
+          audioOutputDetails({
             player_ids: ["player-1"],
-            dsp: { state: DSPState.DISABLED },
+            dsp: audioDSPDetails({ state: DSPState.DISABLED }),
             output_format: sourceFormat,
-            fidelity: {
+            fidelity: audioFidelity({
               quality: AudioQuality.LOSSLESS,
               bit_perfect: true,
-            },
-          },
+            }),
+          }),
         ],
       },
       makeStreamDetails(sourceFormat),
@@ -644,23 +655,23 @@ describe("AudioProcessingDetails", () => {
     });
     const wrapper = mountDetails(
       {
-        queue_processing: {
+        queue_processing: audioQueueProcessing({
           pcm_format: makeFormat({
             content_type: ContentType.PCM_S16LE,
             codec_type: ContentType.PCM_S16LE,
             sample_rate: 44100,
             bit_depth: 16,
           }),
-        },
+        }),
         outputs: [
-          {
+          audioOutputDetails({
             player_ids: ["player-1"],
             output_format: sourceFormat,
-            fidelity: {
+            fidelity: audioFidelity({
               quality: AudioQuality.LOSSLESS,
               bit_perfect: false,
-            },
-          },
+            }),
+          }),
         ],
       },
       makeStreamDetails(sourceFormat),
@@ -680,11 +691,13 @@ describe("AudioProcessingDetails", () => {
   it("keeps unsupported-group DSP state visible", () => {
     const wrapper = mountDetails({
       outputs: [
-        {
+        audioOutputDetails({
           player_ids: ["player-1"],
-          dsp: { state: DSPState.DISABLED_BY_UNSUPPORTED_GROUP },
+          dsp: audioDSPDetails({
+            state: DSPState.DISABLED_BY_UNSUPPORTED_GROUP,
+          }),
           output_format: makeFormat(),
-        },
+        }),
       ],
     });
 
@@ -702,22 +715,22 @@ describe("AudioProcessingDetails", () => {
     });
     const wrapper = mountDetails(
       {
-        queue_processing: {
+        queue_processing: audioQueueProcessing({
           pcm_format: makeFormat({
             content_type: ContentType.PCM_F32LE,
             codec_type: ContentType.PCM_F32LE,
             sample_rate: 48000,
             bit_depth: 32,
           }),
-        },
+        }),
         outputs: [
-          {
+          audioOutputDetails({
             player_ids: ["player-1"],
-            dsp: {
+            dsp: audioDSPDetails({
               state: DSPState.DISABLED,
-            },
+            }),
             output_format: sourceFormat,
-          },
+          }),
         ],
       },
       makeStreamDetails(sourceFormat),
@@ -737,10 +750,10 @@ describe("AudioProcessingDetails", () => {
   it("keeps missing destination IDs visible in the grouped detail list", () => {
     const wrapper = mountDetails({
       outputs: [
-        {
+        audioOutputDetails({
           player_ids: ["missing-1", "missing-2"],
           output_format: makeFormat(),
-        },
+        }),
       ],
     });
 
@@ -769,10 +782,10 @@ describe("AudioProcessingDetails", () => {
     ];
     const wrapper = mountDetails({
       outputs: [
-        {
+        audioOutputDetails({
           player_ids: ["airplay-kitchen", "player-2"],
           output_format: makeFormat(),
-        },
+        }),
       ],
     });
 
@@ -804,10 +817,10 @@ describe("AudioProcessingDetails", () => {
     ];
     const wrapper = mountDetails({
       outputs: [
-        {
+        audioOutputDetails({
           player_ids: ["player-1"],
           output_format: makeFormat(),
-        },
+        }),
       ],
     });
 
@@ -835,10 +848,10 @@ describe("AudioProcessingDetails", () => {
     }
     const wrapper = mountDetails({
       outputs: [
-        {
+        audioOutputDetails({
           player_ids: playerIds,
           output_format: makeFormat(),
-        },
+        }),
       ],
     });
 
@@ -853,14 +866,14 @@ describe("AudioProcessingDetails", () => {
   it("keeps multiple output paths separate and terminates the final path", () => {
     const wrapper = mountDetails({
       outputs: [
-        {
+        audioOutputDetails({
           player_ids: ["player-1"],
-          fidelity: { quality: AudioQuality.LOSSLESS },
-        },
-        {
+          fidelity: audioFidelity({ quality: AudioQuality.LOSSLESS }),
+        }),
+        audioOutputDetails({
           player_ids: ["player-2"],
-          fidelity: { quality: AudioQuality.HI_RES },
-        },
+          fidelity: audioFidelity({ quality: AudioQuality.HI_RES }),
+        }),
       ],
     });
 
@@ -888,12 +901,12 @@ describe("AudioProcessingDetails", () => {
 });
 
 function mountDetails(
-  chain: AudioProcessingChain,
+  chain: Partial<AudioProcessingChain> = {},
   streamDetails = makeStreamDetails(),
 ) {
   return mount(AudioProcessingDetails, {
     props: {
-      chain,
+      chain: audioProcessingChain(chain),
       streamDetails,
     },
     global: {
@@ -920,16 +933,7 @@ function getPresetNames(): Ref<Map<string, string>> {
 }
 
 function makeFormat(overrides: Partial<AudioFormat> = {}): AudioFormat {
-  return {
-    content_type: ContentType.FLAC,
-    codec_type: ContentType.FLAC,
-    sample_rate: 96000,
-    bit_depth: 24,
-    channels: 2,
-    output_format_str: "",
-    bit_rate: 0,
-    ...overrides,
-  };
+  return audioFormat({ sample_rate: 96000, bit_depth: 24, ...overrides });
 }
 
 function makeStreamDetails(audioFormat = makeFormat()): StreamDetails {
@@ -951,25 +955,25 @@ function makeFullChain(): AudioProcessingChain {
     sample_rate: 48000,
     bit_depth: 32,
   });
-  return {
-    input_fidelity: { quality: AudioQuality.HI_RES },
-    queue_processing: {
+  return audioProcessingChain({
+    input_fidelity: audioFidelity({ quality: AudioQuality.HI_RES }),
+    queue_processing: audioQueueProcessing({
       pcm_format: floatPcm,
-      normalization: {
+      normalization: audioNormalizationDetails({
         mode: VolumeNormalizationMode.DYNAMIC,
         measurement_source: AudioNormalizationMeasurementSource.LIVE,
         target_lufs: -14,
         measured_lufs: -12.5,
         applied_gain_db: -1.5,
-      },
+      }),
       playback_speed: 1.25,
       crossfade_mode: CrossfadeMode.SMART_CROSSFADE,
       overlay_active: true,
-    },
+    }),
     outputs: [
-      {
+      audioOutputDetails({
         player_ids: ["player-1", "player-2"],
-        dsp: {
+        dsp: audioDSPDetails({
           state: DSPState.ENABLED,
           preset_id: "preset-1",
           input_gain: -1,
@@ -993,17 +997,17 @@ function makeFullChain(): AudioProcessingChain {
             },
           ],
           output_gain: 2,
-        },
+        }),
         source_channel: AudioChannel.FL,
         output_format: makeFormat({
           sample_rate: 48000,
           bit_depth: 16,
         }),
-        fidelity: {
+        fidelity: audioFidelity({
           quality: AudioQuality.LOSSLESS,
           bit_perfect: true,
-        },
-      },
+        }),
+      }),
     ],
-  };
+  });
 }

--- a/tests/components/QualityDetailsBtn.test.ts
+++ b/tests/components/QualityDetailsBtn.test.ts
@@ -4,7 +4,6 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import QualityDetailsBtn from "@/components/QualityDetailsBtn.vue";
 import {
   AudioQuality,
-  ContentType,
   MediaType,
   PlaybackState,
   type PlayerQueue,
@@ -12,6 +11,12 @@ import {
   type StreamDetails,
 } from "@/plugins/api/interfaces";
 import { i18n } from "@/plugins/i18n";
+import {
+  audioFidelity,
+  audioFormat,
+  audioOutputDetails,
+  audioProcessingChain,
+} from "../fixtures/audioProcessing";
 
 const storeMock = vi.hoisted(() => ({
   activePlayerQueue: undefined as PlayerQueue | undefined,
@@ -55,12 +60,12 @@ describe("QualityDetailsBtn", () => {
   it("renders embedded details and the authoritative quality range", () => {
     storeMock.activePlayerQueue = makeQueue({
       ...makeStreamDetails(),
-      audio_processing: {
+      audio_processing: audioProcessingChain({
         outputs: [
-          { fidelity: { quality: AudioQuality.LOW } },
-          { fidelity: { quality: AudioQuality.HI_RES } },
+          outputWithQuality(AudioQuality.LOW),
+          outputWithQuality(AudioQuality.HI_RES),
         ],
-      },
+      }),
     });
 
     const wrapper = mountButton();
@@ -81,9 +86,9 @@ describe("QualityDetailsBtn", () => {
   ])("uses the compact popover layout on the $side side", ({ pill, side }) => {
     storeMock.activePlayerQueue = makeQueue({
       ...makeStreamDetails(),
-      audio_processing: {
-        outputs: [{ fidelity: { quality: AudioQuality.STANDARD } }],
-      },
+      audio_processing: audioProcessingChain({
+        outputs: [outputWithQuality(AudioQuality.STANDARD)],
+      }),
     });
 
     const wrapper = mountButton({ pill });
@@ -101,9 +106,9 @@ describe("QualityDetailsBtn", () => {
   it("moves focus into the audio-chain popover when opened", async () => {
     storeMock.activePlayerQueue = makeQueue({
       ...makeStreamDetails(),
-      audio_processing: {
-        outputs: [{ fidelity: { quality: AudioQuality.STANDARD } }],
-      },
+      audio_processing: audioProcessingChain({
+        outputs: [outputWithQuality(AudioQuality.STANDARD)],
+      }),
     });
 
     const wrapper = mount(QualityDetailsBtn, {
@@ -143,19 +148,15 @@ function mountButton(props: { pill?: boolean } = {}) {
   });
 }
 
+function outputWithQuality(quality: AudioQuality) {
+  return audioOutputDetails({ fidelity: audioFidelity({ quality }) });
+}
+
 function makeStreamDetails(): StreamDetails {
   return {
     provider: "test",
     item_id: "track-1",
-    audio_format: {
-      content_type: ContentType.FLAC,
-      codec_type: ContentType.FLAC,
-      sample_rate: 44100,
-      bit_depth: 16,
-      channels: 2,
-      output_format_str: "",
-      bit_rate: 0,
-    },
+    audio_format: audioFormat(),
     media_type: MediaType.TRACK,
     stream_metadata: null,
     duration: null,

--- a/tests/components/QualityDetailsBtn.test.ts
+++ b/tests/components/QualityDetailsBtn.test.ts
@@ -13,10 +13,10 @@ import {
 import { i18n } from "@/plugins/i18n";
 import {
   audioFidelity,
-  audioFormat,
   audioOutputDetails,
   audioProcessingChain,
 } from "../fixtures/audioProcessing";
+import { audioFormat } from "../fixtures/audioFormat";
 
 const storeMock = vi.hoisted(() => ({
   activePlayerQueue: undefined as PlayerQueue | undefined,

--- a/tests/composables/useAudioProcessingDetails.test.ts
+++ b/tests/composables/useAudioProcessingDetails.test.ts
@@ -25,12 +25,12 @@ import {
 import {
   audioDSPDetails,
   audioFidelity,
-  audioFormat,
   audioNormalizationDetails,
   audioOutputDetails,
   audioProcessingChain,
   audioQueueProcessing,
 } from "../fixtures/audioProcessing";
+import { audioFormat } from "../fixtures/audioFormat";
 
 vi.mock("@/plugins/api", async () => {
   const { providerManifest } = await import("../fixtures/providerManifest");

--- a/tests/composables/useAudioProcessingDetails.test.ts
+++ b/tests/composables/useAudioProcessingDetails.test.ts
@@ -22,6 +22,15 @@ import {
   type StreamDetails,
   VolumeNormalizationMode,
 } from "@/plugins/api/interfaces";
+import {
+  audioDSPDetails,
+  audioFidelity,
+  audioFormat,
+  audioNormalizationDetails,
+  audioOutputDetails,
+  audioProcessingChain,
+  audioQueueProcessing,
+} from "../fixtures/audioProcessing";
 
 vi.mock("@/plugins/api", async () => {
   const { providerManifest } = await import("../fixtures/providerManifest");
@@ -96,7 +105,9 @@ describe("buildAudioProcessingDetailsDisplay", () => {
     });
     const display = buildDisplay(
       {
-        outputs: [{ player_ids: ["office"], output_format: format }],
+        outputs: [
+          audioOutputDetails({ player_ids: ["office"], output_format: format }),
+        ],
       },
       format,
     );
@@ -109,7 +120,12 @@ describe("buildAudioProcessingDetailsDisplay", () => {
 
   it("uses the native player provider for direct output", () => {
     const destination = buildDisplay({
-      outputs: [{ player_ids: ["office"], output_format: makeFormat() }],
+      outputs: [
+        audioOutputDetails({
+          player_ids: ["office"],
+          output_format: makeFormat(),
+        }),
+      ],
     }).outputPaths[0].destination;
 
     expect(destination).toMatchObject({
@@ -131,7 +147,12 @@ describe("buildAudioProcessingDetailsDisplay", () => {
       ];
 
       const destination = buildDisplay({
-        outputs: [{ player_ids: ["kitchen"], output_format: makeFormat() }],
+        outputs: [
+          audioOutputDetails({
+            player_ids: ["kitchen"],
+            output_format: makeFormat(),
+          }),
+        ],
       }).outputPaths[0].destination;
 
       expect(destination).toMatchObject({
@@ -144,10 +165,10 @@ describe("buildAudioProcessingDetailsDisplay", () => {
   it("resolves older protocol IDs to one visible parent", () => {
     const destination = buildDisplay({
       outputs: [
-        {
+        audioOutputDetails({
           player_ids: ["airplay-kitchen", "kitchen"],
           output_format: makeFormat(),
-        },
+        }),
       ],
     }).outputPaths[0].destination;
 
@@ -170,7 +191,12 @@ describe("buildAudioProcessingDetailsDisplay", () => {
     };
 
     const destination = buildDisplay({
-      outputs: [{ player_ids: ["kitchen"], output_format: makeFormat() }],
+      outputs: [
+        audioOutputDetails({
+          player_ids: ["kitchen"],
+          output_format: makeFormat(),
+        }),
+      ],
     }).outputPaths[0].destination;
 
     expect(destination).toHaveProperty("icon");
@@ -192,10 +218,10 @@ describe("buildAudioProcessingDetailsDisplay", () => {
 
       const destination = buildDisplay({
         outputs: [
-          {
+          audioOutputDetails({
             player_ids: [playerId],
             output_format: makeFormat(),
-          },
+          }),
         ],
       }).outputPaths[0].destination;
 
@@ -211,10 +237,10 @@ describe("buildAudioProcessingDetailsDisplay", () => {
 
     const destination = buildDisplay({
       outputs: [
-        {
+        audioOutputDetails({
           player_ids: ["airplay-kitchen"],
           output_format: makeFormat(),
-        },
+        }),
       ],
     }).outputPaths[0].destination;
 
@@ -228,10 +254,10 @@ describe("buildAudioProcessingDetailsDisplay", () => {
     dependencies.players.office.provider = "sonos--office";
     let destination = buildDisplay({
       outputs: [
-        {
+        audioOutputDetails({
           player_ids: ["kitchen", "office"],
           output_format: makeFormat(),
-        },
+        }),
       ],
     }).outputPaths[0].destination;
     expect(destination).toMatchObject({ providerIconDomain: "sonos" });
@@ -239,10 +265,10 @@ describe("buildAudioProcessingDetailsDisplay", () => {
     dependencies.players.office.provider = "squeezelite--office";
     destination = buildDisplay({
       outputs: [
-        {
+        audioOutputDetails({
           player_ids: ["kitchen", "office"],
           output_format: makeFormat(),
-        },
+        }),
       ],
     }).outputPaths[0].destination;
     expect(destination).toHaveProperty("icon");
@@ -256,10 +282,10 @@ describe("buildAudioProcessingDetailsDisplay", () => {
     ];
     let destination = buildDisplay({
       outputs: [
-        {
+        audioOutputDetails({
           player_ids: ["kitchen", "office"],
           output_format: makeFormat(),
-        },
+        }),
       ],
     }).outputPaths[0].destination;
     expect(destination).toMatchObject({ providerIconDomain: "airplay" });
@@ -268,10 +294,10 @@ describe("buildAudioProcessingDetailsDisplay", () => {
       "snapcast";
     destination = buildDisplay({
       outputs: [
-        {
+        audioOutputDetails({
           player_ids: ["kitchen", "office"],
           output_format: makeFormat(),
-        },
+        }),
       ],
     }).outputPaths[0].destination;
     expect(destination).toHaveProperty("icon");
@@ -285,20 +311,20 @@ describe("buildAudioProcessingDetailsDisplay", () => {
     });
     const direct = buildDisplay(
       {
-        queue_processing: {
+        queue_processing: audioQueueProcessing({
           pcm_format: makeFormat({
             content_type: ContentType.PCM_S16LE,
             codec_type: ContentType.PCM_S16LE,
             sample_rate: 44100,
             bit_depth: 16,
           }),
-        },
+        }),
         outputs: [
-          {
+          audioOutputDetails({
             player_ids: ["kitchen"],
             output_format: sourceFormat,
-            fidelity: { bit_perfect: true },
-          },
+            fidelity: audioFidelity({ bit_perfect: true }),
+          }),
         ],
       },
       sourceFormat,
@@ -309,21 +335,23 @@ describe("buildAudioProcessingDetailsDisplay", () => {
 
     const headroom = buildDisplay(
       {
-        queue_processing: {
+        queue_processing: audioQueueProcessing({
           pcm_format: makeFormat({
             content_type: ContentType.PCM_F32LE,
             codec_type: ContentType.PCM_F32LE,
             sample_rate: 48000,
             bit_depth: 32,
           }),
-          normalization: { mode: VolumeNormalizationMode.DYNAMIC },
-        },
+          normalization: audioNormalizationDetails({
+            mode: VolumeNormalizationMode.DYNAMIC,
+          }),
+        }),
         outputs: [
-          {
+          audioOutputDetails({
             player_ids: ["kitchen"],
             output_format: sourceFormat,
-            fidelity: { bit_perfect: false },
-          },
+            fidelity: audioFidelity({ bit_perfect: false }),
+          }),
         ],
       },
       sourceFormat,
@@ -340,14 +368,14 @@ describe("buildAudioProcessingDetailsDisplay", () => {
   it("uses codec-aware fidelity wording", () => {
     const lossy = buildDisplay({
       outputs: [
-        {
+        audioOutputDetails({
           player_ids: ["kitchen"],
           output_format: makeFormat({
             content_type: ContentType.M4A,
             codec_type: ContentType.AAC,
           }),
-          fidelity: { bit_perfect: false },
-        },
+          fidelity: audioFidelity({ bit_perfect: false }),
+        }),
       ],
     });
     expect(lossy.outputPaths[0].stages.at(-1)?.details).toContain(
@@ -356,11 +384,11 @@ describe("buildAudioProcessingDetailsDisplay", () => {
 
     const lossless = buildDisplay({
       outputs: [
-        {
+        audioOutputDetails({
           player_ids: ["kitchen"],
           output_format: makeFormat(),
-          fidelity: { bit_perfect: false },
-        },
+          fidelity: audioFidelity({ bit_perfect: false }),
+        }),
       ],
     });
     expect(lossless.outputPaths[0].stages.at(-1)?.details).toContain(
@@ -369,17 +397,17 @@ describe("buildAudioProcessingDetailsDisplay", () => {
   });
 
   it("resolves presets and protocol-parent destinations", () => {
-    const chain: AudioProcessingChain = {
-      input_fidelity: { quality: AudioQuality.LOSSLESS },
+    const chain: Partial<AudioProcessingChain> = {
+      input_fidelity: audioFidelity({ quality: AudioQuality.LOSSLESS }),
       outputs: [
-        {
+        audioOutputDetails({
           player_ids: ["airplay-kitchen", "office"],
-          dsp: {
+          dsp: audioDSPDetails({
             state: DSPState.ENABLED,
             preset_id: "preset-1",
-          },
+          }),
           output_format: makeFormat(),
-        },
+        }),
       ],
     };
     const display = buildDisplay(chain);
@@ -402,11 +430,11 @@ describe("buildAudioProcessingDetailsDisplay", () => {
     (sourceChannel, title, icon) => {
       const display = buildDisplay({
         outputs: [
-          {
+          audioOutputDetails({
             player_ids: ["office"],
             source_channel: sourceChannel,
             output_format: makeFormat(),
-          },
+          }),
         ],
       });
 
@@ -422,20 +450,20 @@ describe("buildAudioProcessingDetailsDisplay", () => {
     "keeps %s crossfade in headroom reasons",
     (crossfadeMode) => {
       const display = buildDisplay({
-        queue_processing: {
+        queue_processing: audioQueueProcessing({
           pcm_format: makeFormat({
             content_type: ContentType.PCM_F32LE,
             codec_type: ContentType.PCM_F32LE,
             bit_depth: 32,
           }),
           crossfade_mode: crossfadeMode,
-        },
+        }),
         outputs: [
-          {
+          audioOutputDetails({
             player_ids: ["kitchen"],
             output_format: makeFormat(),
-            fidelity: { bit_perfect: false },
-          },
+            fidelity: audioFidelity({ bit_perfect: false }),
+          }),
         ],
       });
 
@@ -450,20 +478,20 @@ describe("buildAudioProcessingDetailsDisplay", () => {
 
   it("excludes disabled crossfade from headroom reasons", () => {
     const display = buildDisplay({
-      queue_processing: {
+      queue_processing: audioQueueProcessing({
         pcm_format: makeFormat({
           content_type: ContentType.PCM_F32LE,
           codec_type: ContentType.PCM_F32LE,
           bit_depth: 32,
         }),
         crossfade_mode: CrossfadeMode.DISABLED,
-      },
+      }),
       outputs: [
-        {
+        audioOutputDetails({
           player_ids: ["kitchen"],
           output_format: makeFormat(),
-          fidelity: { bit_perfect: false },
-        },
+          fidelity: audioFidelity({ bit_perfect: false }),
+        }),
       ],
     });
 
@@ -474,34 +502,34 @@ describe("buildAudioProcessingDetailsDisplay", () => {
   });
 
   it("formats every numeric detail with the supplied locale", () => {
-    const audioFormat = makeFormat({
+    const format = makeFormat({
       content_type: ContentType.MP3,
       codec_type: ContentType.MP3,
       sample_rate: 44100,
       bit_rate: 1234,
     });
-    const chain: AudioProcessingChain = {
-      queue_processing: {
-        normalization: {
+    const chain: Partial<AudioProcessingChain> = {
+      queue_processing: audioQueueProcessing({
+        normalization: audioNormalizationDetails({
           mode: VolumeNormalizationMode.DYNAMIC,
           measured_lufs: -12.5,
-        },
+        }),
         playback_speed: 1.25,
-      },
+      }),
       outputs: [
-        {
+        audioOutputDetails({
           player_ids: ["kitchen"],
-          dsp: {
+          dsp: audioDSPDetails({
             state: DSPState.ENABLED,
             input_gain: -1.5,
             output_gain: 2.25,
-          },
-          output_format: audioFormat,
-        },
+          }),
+          output_format: format,
+        }),
       ],
     };
 
-    const english = buildDisplay(chain, audioFormat);
+    const english = buildDisplay(chain, format);
     expect(english.inputStages[1].subtitleParts).toContain("44.1 kHz");
     expect(english.inputStages[1].subtitleParts).toContain("1,234 kbps");
     expect(english.processingStages[0].details).toContain(
@@ -512,7 +540,7 @@ describe("buildAudioProcessingDetailsDisplay", () => {
     expect(english.outputPaths[0].stages[2].title).toBe("Output Gain (2.3 dB)");
 
     dependencies.locale = "de-DE";
-    const german = buildDisplay(chain, audioFormat);
+    const german = buildDisplay(chain, format);
     expect(german.inputStages[1].subtitleParts).toContain("44,1 kHz");
     expect(german.inputStages[1].subtitleParts).toContain("1.234 kbps");
     expect(german.processingStages[0].details).toContain(
@@ -524,9 +552,11 @@ describe("buildAudioProcessingDetailsDisplay", () => {
   });
 
   it("updates number formatting when the selected locale changes", async () => {
-    const chain = ref<AudioProcessingChain>({
-      queue_processing: { playback_speed: 1.25 },
-    });
+    const chain = ref<AudioProcessingChain>(
+      audioProcessingChain({
+        queue_processing: audioQueueProcessing({ playback_speed: 1.25 }),
+      }),
+    );
     const streamDetails = ref<StreamDetails>({
       provider: "test",
       item_id: "track-1",
@@ -566,17 +596,24 @@ describe("buildAudioProcessingDetailsDisplay", () => {
   });
 });
 
-function buildDisplay(chain: AudioProcessingChain, audioFormat = makeFormat()) {
+function buildDisplay(
+  chain: Partial<AudioProcessingChain> = {},
+  format = makeFormat(),
+) {
   const streamDetails: StreamDetails = {
     provider: "test--instance",
     item_id: "track-1",
-    audio_format: audioFormat,
+    audio_format: format,
     media_type: MediaType.TRACK,
     stream_metadata: null,
     duration: null,
     audio_processing: null,
   };
-  return buildAudioProcessingDetailsDisplay(chain, streamDetails, dependencies);
+  return buildAudioProcessingDetailsDisplay(
+    audioProcessingChain(chain),
+    streamDetails,
+    dependencies,
+  );
 }
 
 function makePlayers(): AudioProcessingDetailsDependencies["players"] {
@@ -616,14 +653,5 @@ function makeOutputProtocol(
 }
 
 function makeFormat(overrides: Partial<AudioFormat> = {}): AudioFormat {
-  return {
-    content_type: ContentType.FLAC,
-    codec_type: ContentType.FLAC,
-    sample_rate: 48000,
-    bit_depth: 16,
-    channels: 2,
-    output_format_str: "",
-    bit_rate: 0,
-    ...overrides,
-  };
+  return audioFormat({ sample_rate: 48000, bit_depth: 16, ...overrides });
 }

--- a/tests/composables/useStreamQuality.test.ts
+++ b/tests/composables/useStreamQuality.test.ts
@@ -7,10 +7,12 @@ import {
   qualityTierToColor,
   useStreamQuality,
 } from "@/composables/useStreamQuality";
+import { AudioQuality } from "@/plugins/api/interfaces";
 import {
-  type AudioProcessingChain,
-  AudioQuality,
-} from "@/plugins/api/interfaces";
+  audioFidelity,
+  audioOutputDetails,
+  audioProcessingChain,
+} from "../fixtures/audioProcessing";
 
 describe("stream quality presentation", () => {
   it("maps authoritative qualities, colors, and labels", () => {
@@ -28,13 +30,15 @@ describe("stream quality presentation", () => {
 
   it("takes min and max from embedded output fidelity", () => {
     const quality = useStreamQuality(
-      ref<AudioProcessingChain>({
-        outputs: [
-          { fidelity: { quality: AudioQuality.STANDARD } },
-          { fidelity: { quality: AudioQuality.HI_RES } },
-          { fidelity: { quality: AudioQuality.LOW } },
-        ],
-      }),
+      ref(
+        audioProcessingChain({
+          outputs: [
+            outputWithQuality(AudioQuality.STANDARD),
+            outputWithQuality(AudioQuality.HI_RES),
+            outputWithQuality(AudioQuality.LOW),
+          ],
+        }),
+      ),
     );
 
     expect(quality.minOutputQualityTier.value).toBe(QualityTier.LOW);
@@ -43,13 +47,15 @@ describe("stream quality presentation", () => {
 
   it("excludes unknown qualities from the known output range", () => {
     const quality = useStreamQuality(
-      ref<AudioProcessingChain>({
-        outputs: [
-          { fidelity: { quality: AudioQuality.UNKNOWN } },
-          { fidelity: { quality: AudioQuality.LOW } },
-          { fidelity: { quality: AudioQuality.HI_RES } },
-        ],
-      }),
+      ref(
+        audioProcessingChain({
+          outputs: [
+            outputWithQuality(AudioQuality.UNKNOWN),
+            outputWithQuality(AudioQuality.LOW),
+            outputWithQuality(AudioQuality.HI_RES),
+          ],
+        }),
+      ),
     );
 
     expect(quality.minOutputQualityTier.value).toBe(QualityTier.LOW);
@@ -67,20 +73,22 @@ describe("stream quality presentation", () => {
       QualityTier.UNKNOWN,
     );
     expect(
-      useStreamQuality(ref<AudioProcessingChain>({ outputs: [] }))
+      useStreamQuality(ref(audioProcessingChain({ outputs: [] })))
         .maxOutputQualityTier.value,
     ).toBe(QualityTier.UNKNOWN);
   });
 
   it("returns unknown when all output qualities are unknown", () => {
     const quality = useStreamQuality(
-      ref<AudioProcessingChain>({
-        outputs: [
-          { fidelity: { quality: AudioQuality.UNKNOWN } },
-          { fidelity: { quality: "future" as AudioQuality } },
-          {},
-        ],
-      }),
+      ref(
+        audioProcessingChain({
+          outputs: [
+            outputWithQuality(AudioQuality.UNKNOWN),
+            outputWithQuality("future" as AudioQuality),
+            audioOutputDetails(),
+          ],
+        }),
+      ),
     );
 
     expect(quality.minOutputQualityTier.value).toBe(QualityTier.UNKNOWN);
@@ -88,15 +96,21 @@ describe("stream quality presentation", () => {
   });
 
   it("recomputes when the embedded chain changes", () => {
-    const chain = ref<AudioProcessingChain>({
-      outputs: [{ fidelity: { quality: AudioQuality.LOW } }],
-    });
+    const chain = ref(
+      audioProcessingChain({
+        outputs: [outputWithQuality(AudioQuality.LOW)],
+      }),
+    );
     const quality = useStreamQuality(chain);
 
     expect(quality.maxOutputQualityTier.value).toBe(QualityTier.LOW);
-    chain.value = {
-      outputs: [{ fidelity: { quality: AudioQuality.LOSSLESS } }],
-    };
+    chain.value = audioProcessingChain({
+      outputs: [outputWithQuality(AudioQuality.LOSSLESS)],
+    });
     expect(quality.maxOutputQualityTier.value).toBe(QualityTier.LOSSLESS);
   });
 });
+
+function outputWithQuality(quality: AudioQuality) {
+  return audioOutputDetails({ fidelity: audioFidelity({ quality }) });
+}

--- a/tests/fixtures/audioFormat.ts
+++ b/tests/fixtures/audioFormat.ts
@@ -1,0 +1,25 @@
+import { type AudioFormat, ContentType } from "@/plugins/api/interfaces";
+
+/**
+ * A complete audio format, for tests that only care about a few of its fields
+ * but should still model a payload the server can send.
+ *
+ * The server derives output_format_str from the content type, so it follows
+ * any content type the caller overrides.
+ */
+export function audioFormat(overrides: Partial<AudioFormat> = {}): AudioFormat {
+  const format = {
+    content_type: ContentType.FLAC,
+    codec_type: ContentType.FLAC,
+    sample_rate: 44100,
+    bit_depth: 16,
+    channels: 2,
+    output_format_str: "",
+    bit_rate: 0,
+    ...overrides,
+  };
+  return {
+    ...format,
+    output_format_str: format.output_format_str || format.content_type,
+  };
+}

--- a/tests/fixtures/audioProcessing.ts
+++ b/tests/fixtures/audioProcessing.ts
@@ -1,35 +1,16 @@
 import {
   type AudioDSPDetails,
   type AudioFidelity,
-  type AudioFormat,
   type AudioNormalizationDetails,
   AudioNormalizationMeasurementSource,
   type AudioOutputDetails,
   type AudioProcessingChain,
   AudioQuality,
   type AudioQueueProcessing,
-  ContentType,
   CrossfadeMode,
   DSPState,
   VolumeNormalizationMode,
 } from "@/plugins/api/interfaces";
-
-/**
- * A complete audio format, for tests that only care about a few of its fields
- * but should still model a payload the server can send.
- */
-export function audioFormat(overrides: Partial<AudioFormat> = {}): AudioFormat {
-  return {
-    content_type: ContentType.FLAC,
-    codec_type: ContentType.FLAC,
-    sample_rate: 44100,
-    bit_depth: 16,
-    channels: 2,
-    output_format_str: "",
-    bit_rate: 0,
-    ...overrides,
-  };
-}
 
 /**
  * A complete audio fidelity, defaulting to an undetermined stream.

--- a/tests/fixtures/audioProcessing.ts
+++ b/tests/fixtures/audioProcessing.ts
@@ -1,0 +1,124 @@
+import {
+  type AudioDSPDetails,
+  type AudioFidelity,
+  type AudioFormat,
+  type AudioNormalizationDetails,
+  AudioNormalizationMeasurementSource,
+  type AudioOutputDetails,
+  type AudioProcessingChain,
+  AudioQuality,
+  type AudioQueueProcessing,
+  ContentType,
+  CrossfadeMode,
+  DSPState,
+  VolumeNormalizationMode,
+} from "@/plugins/api/interfaces";
+
+/**
+ * A complete audio format, for tests that only care about a few of its fields
+ * but should still model a payload the server can send.
+ */
+export function audioFormat(overrides: Partial<AudioFormat> = {}): AudioFormat {
+  return {
+    content_type: ContentType.FLAC,
+    codec_type: ContentType.FLAC,
+    sample_rate: 44100,
+    bit_depth: 16,
+    channels: 2,
+    output_format_str: "",
+    bit_rate: 0,
+    ...overrides,
+  };
+}
+
+/**
+ * A complete audio fidelity, defaulting to an undetermined stream.
+ */
+export function audioFidelity(
+  overrides: Partial<AudioFidelity> = {},
+): AudioFidelity {
+  return {
+    quality: AudioQuality.UNKNOWN,
+    bit_perfect: null,
+    ...overrides,
+  };
+}
+
+/**
+ * Complete normalization details, defaulting to normalization turned off.
+ */
+export function audioNormalizationDetails(
+  overrides: Partial<AudioNormalizationDetails> = {},
+): AudioNormalizationDetails {
+  return {
+    mode: VolumeNormalizationMode.DISABLED,
+    measurement_source: AudioNormalizationMeasurementSource.UNKNOWN,
+    target_lufs: null,
+    measured_lufs: null,
+    applied_gain_db: null,
+    ...overrides,
+  };
+}
+
+/**
+ * Complete queue processing details, defaulting to no processing applied.
+ */
+export function audioQueueProcessing(
+  overrides: Partial<AudioQueueProcessing> = {},
+): AudioQueueProcessing {
+  return {
+    pcm_format: null,
+    normalization: null,
+    playback_speed: 1,
+    crossfade_mode: CrossfadeMode.DISABLED,
+    overlay_active: false,
+    ...overrides,
+  };
+}
+
+/**
+ * Complete DSP details, defaulting to DSP turned off.
+ */
+export function audioDSPDetails(
+  overrides: Partial<AudioDSPDetails> = {},
+): AudioDSPDetails {
+  return {
+    state: DSPState.DISABLED,
+    input_gain: 0,
+    filters: [],
+    output_gain: 0,
+    preset_id: null,
+    ...overrides,
+  };
+}
+
+/**
+ * A complete output path, defaulting to an untouched stream to unnamed players.
+ */
+export function audioOutputDetails(
+  overrides: Partial<AudioOutputDetails> = {},
+): AudioOutputDetails {
+  return {
+    player_ids: [],
+    dsp: audioDSPDetails(),
+    source_channel: null,
+    output_format: null,
+    fidelity: audioFidelity(),
+    ...overrides,
+  };
+}
+
+/**
+ * A complete processing chain, defaulting to a stream that is passed through
+ * untouched and has no outputs yet.
+ */
+export function audioProcessingChain(
+  overrides: Partial<AudioProcessingChain> = {},
+): AudioProcessingChain {
+  return {
+    input_fidelity: audioFidelity(),
+    queue_processing: null,
+    outputs: [],
+    ...overrides,
+  };
+}

--- a/tests/fixtures/providerMapping.ts
+++ b/tests/fixtures/providerMapping.ts
@@ -1,4 +1,5 @@
-import { ContentType, type ProviderMapping } from "@/plugins/api/interfaces";
+import { type ProviderMapping } from "@/plugins/api/interfaces";
+import { audioFormat } from "./audioFormat";
 
 /**
  * A complete provider mapping, for fixtures that only care about a few of its
@@ -15,15 +16,7 @@ export function providerMapping(
     in_library: null,
     details: null,
     url: null,
-    audio_format: {
-      content_type: ContentType.FLAC,
-      codec_type: ContentType.FLAC,
-      sample_rate: 44100,
-      bit_depth: 16,
-      channels: 2,
-      output_format_str: "flac",
-      bit_rate: 0,
-    },
+    audio_format: audioFormat(),
     ...overrides,
   };
 }


### PR DESCRIPTION
The audio processing interfaces spelled nearly every field as optional (`foo?: X`), but the server declares them with plain defaults and always sends them - only a handful are genuinely nullable. That left consumers typed for `undefined` in places it can never appear, and guarding against it.

This is the last of the nullability clean-ups (after #2334, #2336, #2338, #2339). It was kept separate because it is mostly the "always present" case rather than the "null on the wire" case, and splitting it would have left the interfaces inconsistent with each other.

- Spell `AudioFidelity`, `AudioNormalizationDetails`, `AudioQueueProcessing`, `AudioDSPDetails`, `AudioOutputDetails` and `AudioProcessingChain` as they arrive on the wire
- Drop the guards in the audio processing composables that can no longer fire
- Move the audio fixtures the tests share into `tests/fixtures/audioProcessing.ts`

No user visible change - types and tests only.
