### PR TITLE
Add missing metadata fields to the API types

### DIFF
--- a/src/plugins/api/interfaces.ts
+++ b/src/plugins/api/interfaces.ts
@@ -871,8 +871,17 @@ export interface MediaItemChapter {
   end: number | null;
 }
 
+// a collection groups related items, most commonly an audiobook series
+export interface MediaItemCollection {
+  title: string;
+  // sorts the item within the collection, e.g. the book number in a series
+  sequence: number | string | null;
+}
+
 export interface MediaItemMetadata {
   description?: string | null;
+  // ISO 639-1 language code of `description`
+  description_language?: string | null;
   review?: string | null;
   explicit?: boolean | null;
   images?: MediaItemImage[] | null;
@@ -888,7 +897,11 @@ export interface MediaItemMetadata {
   preview?: string | null;
   popularity?: number | null;
   release_date?: string | null;
+  // spoken languages of the content, mostly set for audiobooks and podcasts.
+  // the spelling is whatever the provider reports, e.g. "en", "en-us" or "English"
+  languages?: string[] | null;
   chapters?: MediaItemChapter[] | null;
+  collections?: MediaItemCollection[] | null;
   life_span?: LifeSpan | null;
   artist_entity_type?: ArtistEntityType | null;
 }


### PR DESCRIPTION
The API type definitions were missing a few metadata fields that the server does send, so anything wanting to use them had to work around the type.

Follow-up to #2359, which did the opposite: dropping fields the server never sends.

- Added `description_language`, `languages` and `collections` to the media item metadata type
- Added a `MediaItemCollection` type (title + sequence) for the collections field

Only fields the frontend could realistically use were added. Left out on purpose: the player media fields `album_artist` (never filled in by the server), `stream_duration` (the length the server hands to a speaker after a seek, which is not what the progress bar shows) and `custom_data` (internal plumbing between server and player), plus the metadata fields `grouping` and `last_refresh`.
