### PR TITLE
Fix Music Quiz getting stuck for non-English users

### DIFF
--- a/src/composables/music-quiz/useMusicQuizPlayer.ts
+++ b/src/composables/music-quiz/useMusicQuizPlayer.ts
@@ -25,6 +25,7 @@ import {
   getStoredMusicQuizPlayerId,
   getMusicQuizErrorMessage,
   isNoActiveGameError,
+  isUnknownPlayerError,
   storeMusicQuizPlayerId,
   storeMusicQuizPlayerName,
   type MusicQuizParticipantStorageContext,
@@ -298,12 +299,7 @@ export function useMusicQuizPlayer(options: UseMusicQuizPlayerOptions) {
         ) {
           continue;
         }
-        if (
-          isNoActiveGameError(err) ||
-          getMusicQuizErrorMessage(err)
-            .toLowerCase()
-            .includes("player not found")
-        ) {
+        if (isNoActiveGameError(err) || isUnknownPlayerError(err)) {
           await resetToJoinInfo();
         } else {
           notifyError(

--- a/src/helpers/music_quiz.ts
+++ b/src/helpers/music_quiz.ts
@@ -4,7 +4,14 @@ import type {
   MusicQuizSupportedPublicState,
 } from "@/composables/music-quiz/useMusicQuiz";
 import type { ConnectionIdentity } from "@/helpers/connection_identity";
+import { ApiCommandError } from "@/plugins/api/errors";
 import { $t, canonicalizeLocale, i18n } from "@/plugins/i18n";
+
+/** Error codes of the Music Quiz provider, as sent by the server. */
+export enum MusicQuizErrorCode {
+  NO_GAME = 1001,
+  UNKNOWN_PLAYER = 1009,
+}
 
 const MUSIC_QUIZ_PLAYER_ID_KEY = "music_quiz_player_id";
 const MUSIC_QUIZ_PLAYER_NAME_KEY = "music_quiz_player_name";
@@ -206,35 +213,21 @@ export function getMusicQuizErrorMessage(err: unknown, fallback = "") {
   return fallback;
 }
 
-// Detects the backend "no active Music Quiz game" error across its possible
-// shapes (plain string / Error / structured payload), since WS command
-// failures can arrive as strings rather than Error instances.
+/** Whether the command failed because there is no active Music Quiz game. */
 export function isNoActiveGameError(err: unknown): boolean {
-  const message = getMusicQuizErrorMessage(err).toLowerCase();
-  if (
-    message.includes("no active game") ||
-    message.includes("no active music quiz game") ||
-    (message.includes("no active") && message.includes("music quiz"))
-  ) {
-    return true;
-  }
-  if (err && typeof err === "object") {
-    const errorCode =
-      "error_code" in err && typeof err.error_code === "string"
-        ? err.error_code.toLowerCase()
-        : "";
-    const errorType =
-      "type" in err && typeof err.type === "string"
-        ? err.type.toLowerCase()
-        : "";
-    return (
-      errorCode === "musicquiznogameerror" ||
-      errorCode === "music_quiz_no_game" ||
-      errorType === "musicquiznogameerror" ||
-      errorType === "music_quiz_no_game"
-    );
-  }
-  return false;
+  return hasMusicQuizErrorCode(err, MusicQuizErrorCode.NO_GAME);
+}
+
+/** Whether the command failed because the game does not know this player. */
+export function isUnknownPlayerError(err: unknown): boolean {
+  return hasMusicQuizErrorCode(err, MusicQuizErrorCode.UNKNOWN_PLAYER);
+}
+
+function hasMusicQuizErrorCode(
+  err: unknown,
+  code: MusicQuizErrorCode,
+): boolean {
+  return err instanceof ApiCommandError && err.error_code === code;
 }
 
 function clearStoredMusicQuizPlayerName(): void {

--- a/src/plugins/api/errors.ts
+++ b/src/plugins/api/errors.ts
@@ -1,0 +1,21 @@
+/**
+ * Rejection value of a failed API command.
+ *
+ * `message` holds the server's (localized) error details, `error_code` the
+ * numeric code to branch on.
+ */
+export class ApiCommandError extends Error {
+  readonly error_code: number;
+
+  constructor(message: string, errorCode: number) {
+    super(message);
+    this.name = "ApiCommandError";
+    this.error_code = errorCode;
+  }
+
+  // callers render rejections with String(err); keep that the plain server
+  // message instead of Error's "Error: <message>" form
+  toString(): string {
+    return this.message;
+  }
+}

--- a/src/plugins/api/index.ts
+++ b/src/plugins/api/index.ts
@@ -11,6 +11,7 @@ import {
 import { $t, i18n } from "../i18n";
 import type { ITransport } from "../remote/transport";
 import { WebSocketTransport } from "../remote/websocket-transport";
+import { ApiCommandError } from "./errors";
 import { getDeviceName } from "./helpers";
 import {
   type Album,
@@ -88,6 +89,8 @@ export enum ConnectionState {
   RECONNECTING = "reconnecting", // Lost connection, attempting to reconnect
   FAILED = "failed", // Connection failed permanently
 }
+
+export { ApiCommandError };
 
 /** Rejection for in-flight commands that can never be answered because the connection dropped. */
 export class ConnectionLostError extends Error {
@@ -2728,7 +2731,12 @@ export class MusicAssistantApi {
 
     this.commands.delete(msg.message_id);
     if ("error_code" in msg) {
-      resultPromise.reject(msg.details || String(msg.error_code));
+      resultPromise.reject(
+        new ApiCommandError(
+          msg.details || String(msg.error_code),
+          msg.error_code,
+        ),
+      );
     } else {
       msg = msg as SuccessResultMessage;
       resultPromise.resolve(msg.result);

--- a/tests/composables/useMusicQuizHost.test.ts
+++ b/tests/composables/useMusicQuizHost.test.ts
@@ -70,6 +70,7 @@ vi.mock("@/plugins/i18n", () => ({
   $t: (key: string) => key,
 }));
 
+import { ApiCommandError } from "@/plugins/api/errors";
 import { EventType } from "@/plugins/api/interfaces";
 import type { MusicQuizCreateRequest } from "@/composables/music-quiz/useMusicQuiz";
 import { useMusicQuizHost } from "@/composables/music-quiz/useMusicQuizHost";
@@ -525,8 +526,10 @@ describe("useMusicQuizHost", () => {
     },
   );
 
-  it("treats a no-active-game string as an empty state without a toast", async () => {
-    mockGetMusicQuiz.mockRejectedValue("There is no active Music Quiz game");
+  it("treats a no-active-game error as an empty state without a toast", async () => {
+    mockGetMusicQuiz.mockRejectedValue(
+      new ApiCommandError("Er is geen actief Music Quiz spel.", 1001),
+    );
     const notifyError = vi.fn();
     const host = useMusicQuizHost({ notifyError });
     await flushPromises();
@@ -583,18 +586,6 @@ describe("useMusicQuizHost", () => {
 
     resolveDelete();
     await expect(deleting).resolves.toBe(true);
-    expect(host.state.value).toBeNull();
-  });
-
-  it("treats a no-active-game Error as an empty state without a toast", async () => {
-    mockGetMusicQuiz.mockRejectedValue(
-      new Error("There is no active Music Quiz game"),
-    );
-    const notifyError = vi.fn();
-    const host = useMusicQuizHost({ notifyError });
-    await flushPromises();
-
-    expect(notifyError).not.toHaveBeenCalled();
     expect(host.state.value).toBeNull();
   });
 

--- a/tests/composables/useMusicQuizPlayer.test.ts
+++ b/tests/composables/useMusicQuizPlayer.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ApiCommandError } from "@/plugins/api/errors";
 
 const {
   mockGetMusicQuizInfo,
@@ -124,16 +125,10 @@ vi.mock("@/helpers/music_quiz", () => ({
   getStoredMusicQuizPlayerName: mockGetStoredPlayerName,
   clearStoredMusicQuizPlayerId: mockClearStoredPlayerId,
   getMusicQuizErrorMessage: mockGetMusicQuizErrorMessage,
-  isNoActiveGameError: (err: unknown) => {
-    const message = (
-      err instanceof Error ? err.message : typeof err === "string" ? err : ""
-    ).toLowerCase();
-    return (
-      message.includes("no active game") ||
-      message.includes("no active music quiz game") ||
-      (message.includes("no active") && message.includes("music quiz"))
-    );
-  },
+  isNoActiveGameError: (err: unknown) =>
+    err instanceof ApiCommandError && err.error_code === 1001,
+  isUnknownPlayerError: (err: unknown) =>
+    err instanceof ApiCommandError && err.error_code === 1009,
 }));
 
 vi.mock("@/plugins/i18n", () => ({
@@ -632,7 +627,9 @@ describe("useMusicQuizPlayer", () => {
 
   it("recovers from a stale player token by returning to the join/info state", async () => {
     storedPlayerId.value = "stale-player";
-    mockGetMusicQuizState.mockRejectedValue(new Error("player not found"));
+    mockGetMusicQuizState.mockRejectedValue(
+      new ApiCommandError("Speler niet gevonden.", 1009),
+    );
     mockGetMusicQuizInfo.mockResolvedValue(QUIZ_INFO);
 
     const player = useMusicQuizPlayer({ notifyError: vi.fn() });
@@ -645,10 +642,10 @@ describe("useMusicQuizPlayer", () => {
     expect(storedPlayerId.value).toBeNull();
   });
 
-  it("recovers from a no-active-game error (string rejection) without a toast", async () => {
+  it("recovers from a no-active-game error in any locale without a toast", async () => {
     storedPlayerId.value = "some-player";
     mockGetMusicQuizState.mockRejectedValue(
-      "There is no active Music Quiz game",
+      new ApiCommandError("Er is geen actief Music Quiz spel.", 1001),
     );
     mockGetMusicQuizInfo.mockResolvedValue(QUIZ_INFO);
     const notifyError = vi.fn();

--- a/tests/helpers/music_quiz.test.ts
+++ b/tests/helpers/music_quiz.test.ts
@@ -2,10 +2,48 @@ import {
   clearStoredMusicQuizPlayerId,
   getStoredMusicQuizPlayerId,
   getStoredMusicQuizPlayerName,
+  isNoActiveGameError,
+  isUnknownPlayerError,
   storeMusicQuizPlayerId,
   storeMusicQuizPlayerName,
 } from "@/helpers/music_quiz";
+import { ApiCommandError } from "@/plugins/api/errors";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+describe("Music Quiz error detection", () => {
+  it("detects the no-game error regardless of the locale of the details", () => {
+    expect(
+      isNoActiveGameError(
+        new ApiCommandError("There is no active Music Quiz game.", 1001),
+      ),
+    ).toBe(true);
+    expect(
+      isNoActiveGameError(
+        new ApiCommandError("Er is geen actief Music Quiz spel.", 1001),
+      ),
+    ).toBe(true);
+  });
+
+  it("detects the unknown player error", () => {
+    expect(
+      isUnknownPlayerError(new ApiCommandError("Speler niet gevonden.", 1009)),
+    ).toBe(true);
+    expect(
+      isNoActiveGameError(new ApiCommandError("Speler niet gevonden.", 1009)),
+    ).toBe(false);
+  });
+
+  it("ignores other errors, including ones that merely mention no active game", () => {
+    expect(
+      isNoActiveGameError(new ApiCommandError("There is no active game", 1007)),
+    ).toBe(false);
+    expect(isNoActiveGameError("There is no active Music Quiz game.")).toBe(
+      false,
+    );
+    expect(isNoActiveGameError(new Error("boom"))).toBe(false);
+    expect(isNoActiveGameError(undefined)).toBe(false);
+  });
+});
 
 describe("Music Quiz guest name storage", () => {
   const storedValues = new Map<string, string>();

--- a/tests/plugins/api/index.test.ts
+++ b/tests/plugins/api/index.test.ts
@@ -31,7 +31,11 @@ vi.mock("@/plugins/store", () => ({
   store: {},
 }));
 
-import { ConnectionState, MusicAssistantApi } from "@/plugins/api";
+import {
+  ApiCommandError,
+  ConnectionState,
+  MusicAssistantApi,
+} from "@/plugins/api";
 
 const SERVER_INFO: ServerInfoMessage = {
   server_id: "test-server",
@@ -105,7 +109,10 @@ describe("MusicAssistantApi error handling", () => {
       transport.lastCommand,
       "Suppressed failure",
     );
-    const rejection = expect(command).rejects.toBe("Suppressed failure");
+    const rejection = expect(command).rejects.toMatchObject({
+      message: "Suppressed failure",
+      error_code: 999,
+    });
 
     transport.receive(error);
 
@@ -124,7 +131,10 @@ describe("MusicAssistantApi error handling", () => {
       .mockImplementation(() => {});
     const command = api.sendCommand("test/ordinary");
     const error = createErrorResult(transport.lastCommand, "Visible failure");
-    const rejection = expect(command).rejects.toBe("Visible failure");
+    const rejection = expect(command).rejects.toMatchObject({
+      message: "Visible failure",
+      error_code: 999,
+    });
 
     transport.receive(error);
 
@@ -132,6 +142,35 @@ describe("MusicAssistantApi error handling", () => {
     expect(consoleError).toHaveBeenCalledWith("[resultMessage]", error);
     expect(mockToastError).toHaveBeenCalledWith("Visible failure");
     expect(consoleDebug).not.toHaveBeenCalled();
+  });
+
+  it("rejects with the server error code and renders as the plain message", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    const command = api.sendCommand("test/coded");
+
+    transport.receive(createErrorResult(transport.lastCommand, "Boom"));
+
+    const err = await command.catch((reason: unknown) => reason);
+    expect(err).toBeInstanceOf(ApiCommandError);
+    expect((err as ApiCommandError).error_code).toBe(999);
+    expect(String(err)).toBe("Boom");
+    expect(`${err}`).toBe("Boom");
+  });
+
+  it("falls back to the error code when the server sends no details", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    const command = api.sendCommand("test/no-details");
+
+    transport.receive({
+      message_id: transport.lastCommand.message_id!,
+      error_code: 1001,
+      details: null,
+    });
+
+    await expect(command).rejects.toMatchObject({
+      message: "1001",
+      error_code: 1001,
+    });
   });
 
   it("applies a DSP preset through the dedicated command", async () => {


### PR DESCRIPTION
## Problem

The Music Quiz screens detect the "there is no active game" response from the server by matching on the error *text*. That text is translated to the user's language, so the check only ever worked in English. For everyone else the host screen showed a spurious error toast instead of the setup screen, and the guest screen never returned to the join screen after a game ended.

The guest screen had the same problem for a stale player token, where it looked for "player not found" — wording the server does not use in any language, so that recovery never worked at all.

## Changes

- Failed commands now reject with an error that carries the server's numeric error code, so the app can react to *which* error it is instead of guessing from the message.
- Music Quiz now uses those codes to detect "no active game" and "unknown player".
- Added tests covering both, including with translated error messages.

Error messages shown to the user are unchanged. As a side effect, a few connection failures on the login screen now show the server's actual reason instead of a generic "Unknown error occurred".