### PR TITLE
Handle 'stop' player command from companion apps

### DIFF
--- a/src/plugins/companion.ts
+++ b/src/plugins/companion.ts
@@ -305,6 +305,9 @@ const handlePlayerCommand = async (command: string): Promise<void> => {
       case "previous":
         await api.playerCommandPrevious(player.player_id);
         break;
+      case "stop":
+        await api.playerCommandStop(player.player_id);
+        break;
       default:
         console.warn("[Companion] Unknown player command:", command);
     }


### PR DESCRIPTION
The desktop companion app forwards OS media-control stop events (MPRIS Stop, macOS stopCommand, Windows SMTC Stop) as a 'stop' command to __COMPANION_PLAYER_COMMAND__, but handlePlayerCommand only knew play/pause/next/previous, so stop was logged as unknown and dropped. Route it to api.playerCommandStop like the others.