### PR TITLE
Sort dashboard cast targets by provider and name

### DIFF
--- a/src/components/ShowDashboardButton.vue
+++ b/src/components/ShowDashboardButton.vue
@@ -28,7 +28,7 @@
         {{ $t("dashboard.no_devices") }}
       </div>
       <DropdownMenuItem
-        v-for="device in dashboards"
+        v-for="device in sortedDashboards"
         :key="device.dashboard_id"
         data-testid="cast-dashboard-device"
         @click="selectDevice(device)"
@@ -113,6 +113,10 @@ const showButton = computed(
 // Solid primary pill for the active state, matching the fullscreen player header's autoplay/crossfade toggles.
 const activePillClass =
   "border-primary bg-primary text-primary-foreground hover:bg-primary/90 hover:text-primary-foreground dark:bg-primary dark:hover:bg-primary/90";
+
+const sortedDashboards = computed(() =>
+  [...dashboards.value].sort(compareDashboards),
+);
 
 // Session (if any) showing this dashboard; now_playing also requires a matching player_id.
 const activeSession = computed(() =>
@@ -219,6 +223,20 @@ async function disconnect() {
     console.error("Failed to stop cast dashboard:", error);
     await fetchSessions(); // roll back the optimistic removal
   }
+}
+
+function compareDashboards(left: DashboardDevice, right: DashboardDevice) {
+  const leftProvider = left.provider_domain_hint ?? "";
+  const rightProvider = right.provider_domain_hint ?? "";
+  if (leftProvider !== rightProvider) {
+    // Endpoints without a known provider go last.
+    if (!leftProvider) return 1;
+    if (!rightProvider) return -1;
+    return leftProvider.localeCompare(rightProvider);
+  }
+  return left.name.localeCompare(right.name, undefined, {
+    sensitivity: "base",
+  });
 }
 
 function isActiveDevice(device: DashboardDevice): boolean {

--- a/tests/components/ShowDashboardButton.test.ts
+++ b/tests/components/ShowDashboardButton.test.ts
@@ -203,8 +203,48 @@ describe("ShowDashboardButton", () => {
     });
     const devices = wrapper.findAll('[data-testid="cast-dashboard-device"]');
     expect(devices).toHaveLength(2);
-    expect(devices[0]!.text()).toContain("Living Room TV");
-    expect(devices[1]!.text()).toContain("Bedroom TV");
+    expect(devices[0]!.text()).toContain("Bedroom TV");
+    expect(devices[1]!.text()).toContain("Living Room TV");
+  });
+
+  it("sorts devices by provider, then by name, with unknown providers last", async () => {
+    mockCommands({
+      "dashboard/dashboards": () => [
+        {
+          dashboard_id: "device-1",
+          name: "Attic",
+          supported_types: ["party"],
+        },
+        {
+          dashboard_id: "device-2",
+          name: "Study",
+          supported_types: ["party"],
+          provider_domain_hint: "chromecast",
+        },
+        {
+          dashboard_id: "device-3",
+          name: "Bedroom",
+          supported_types: ["party"],
+          provider_domain_hint: "chromecast",
+        },
+        {
+          dashboard_id: "device-4",
+          name: "Kitchen",
+          supported_types: ["party"],
+          provider_domain_hint: "airplay",
+        },
+      ],
+    });
+
+    const wrapper = mountButton();
+    await flushAsync();
+    await wrapper.get("button").trigger("click");
+    await flushAsync();
+
+    const names = wrapper
+      .findAll('[data-testid="cast-dashboard-device"]')
+      .map((device) => device.text());
+    expect(names).toEqual(["Kitchen", "Bedroom", "Study", "Attic"]);
   });
 
   it("passes each device's provider domain hint to its icon, one per device", async () => {
@@ -402,8 +442,9 @@ describe("ShowDashboardButton", () => {
     await flushAsync();
 
     const devices = wrapper.findAll('[data-testid="cast-dashboard-device"]');
-    expect(devices[0]!.findComponent(Check).exists()).toBe(true);
-    expect(devices[1]!.findComponent(Check).exists()).toBe(false);
+    expect(devices[0]!.text()).toContain("Bedroom TV");
+    expect(devices[0]!.findComponent(Check).exists()).toBe(false);
+    expect(devices[1]!.findComponent(Check).exists()).toBe(true);
 
     const disconnect = wrapper.get('[data-testid="cast-dashboard-disconnect"]');
     expect(disconnect.attributes("data-variant")).toBe("destructive");
@@ -562,7 +603,7 @@ describe("ShowDashboardButton", () => {
     await flushAsync();
 
     const devices = wrapper.findAll('[data-testid="cast-dashboard-device"]');
-    await devices[1]!.trigger("click"); // Bedroom TV, currently inactive
+    await devices[0]!.trigger("click"); // Bedroom TV, currently inactive
     await flushAsync();
 
     const commandNames = apiMock.sendCommand.mock.calls.map((call) => call[0]);


### PR DESCRIPTION
The cast menu listed dashboard endpoints in the order the server registered them, so the list looked random and shifted between reloads.

- Sort endpoints by provider domain, then by name (case-insensitive)
- Endpoints without a known provider sort last
- Cover the ordering with a unit test