### PR TITLE
Improve player settings controls

### DIFF
--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -127,7 +127,7 @@
         "pluginproviders": "Plugin providers",
         "provider_disabled": "This provider entry is disabled",
         "provider_name": "Custom name for this provider entry",
-        "provider_settings": "{name} settings",
+        "provider_settings": "{name} provider settings",
         "providers": "Providers",
         "reload": "Reload",
         "reload_provider": "Reload provider",

--- a/src/views/settings/EditConfig.vue
+++ b/src/views/settings/EditConfig.vue
@@ -88,7 +88,23 @@
       </div>
     </div>
 
-    <div v-if="!disabled" class="config-actions">
+    <div
+      v-if="!disabled && actionLayout === 'floating-save'"
+      class="floating-save"
+    >
+      <Button
+        data-testid="config-save"
+        type="button"
+        size="lg"
+        class="shadow-lg"
+        :disabled="!requiredValuesPresent || !hasUnsavedChanges"
+        @click="submit"
+      >
+        <Save class="size-4" />
+        {{ $t("settings.save") }}
+      </Button>
+    </div>
+    <div v-else-if="!disabled" class="config-actions">
       <!-- Show advanced settings toggle -->
       <div class="advanced-toggle-wrapper">
         <v-switch
@@ -174,6 +190,7 @@ import {
   NON_INTERACTIVE_ENTRY_TYPES,
   VALUELESS_ENTRY_TYPES,
 } from "@/helpers/config_entry_ui";
+import { Button } from "@/components/ui/button";
 import { markdownToHtml } from "@/helpers/utils";
 import {
   ConfigEntryType,
@@ -192,6 +209,7 @@ import {
   PlayCircle,
   RadioTower,
   RefreshCw,
+  Save,
   Settings2,
   SlidersHorizontal,
   Speaker,
@@ -207,6 +225,7 @@ const showUnsavedDialog = ref(false);
 const allowNavigation = ref(false);
 
 export interface Props {
+  actionLayout?: "default" | "floating-save";
   configEntries: ConfigEntryUI[];
   disabled: boolean;
   // Output protocols of the player being configured; drives derived-transport labelling
@@ -233,13 +252,15 @@ const entries = ref<ConfigEntryUI[]>();
 const valid = ref(false);
 const form = ref<InstanceType<typeof import("vuetify/components").VForm>>();
 const showPasswordValues = ref(false);
-const showAdvancedSettings = ref(false);
 const showHelpInfo = ref<ConfigEntryUI>();
 const oldValues = ref<Record<string, ConfigValueType>>({});
 const oldValuesInitialized = ref(false);
 
 // props
 const props = defineProps<Props>();
+const showAdvancedSettings = defineModel<boolean>("showAdvancedSettings", {
+  default: false,
+});
 
 // computed props
 const panels = computed(() => {
@@ -418,6 +439,8 @@ const resetToDefaults = function () {
     entry.value = entry.default_value;
   }
 };
+
+defineExpose({ resetToDefaults });
 
 const handleClose = function () {
   if (hasUnsavedChanges.value) {
@@ -622,6 +645,22 @@ const getCategoryIcon = function (category: string): Component {
 .config-actions .v-btn--disabled {
   background-color: rgba(var(--v-theme-on-surface), 0.12) !important;
   color: rgba(var(--v-theme-on-surface), 0.38) !important;
+}
+
+.floating-save {
+  position: fixed;
+  right: 24px;
+  bottom: calc(var(--v-layout-bottom, 104px) + 16px);
+  z-index: 20;
+}
+
+:global(.content-section--mobile) .floating-save {
+  right: 16px;
+  bottom: calc(196px + env(safe-area-inset-bottom, 0px));
+}
+
+:global(.content-section--frameless) .floating-save {
+  bottom: 16px;
 }
 
 /* Advanced settings toggle */

--- a/src/views/settings/EditPlayer.vue
+++ b/src/views/settings/EditPlayer.vue
@@ -140,13 +140,26 @@
             <DropdownMenuContent align="end">
               <DropdownMenuItem
                 v-if="owningProvider"
-                data-testid="player-reload-provider"
-                :disabled="toggleLoading"
-                @click="onReloadProvider"
+                data-testid="player-provider-settings"
+                @click="openProviderSettings"
               >
-                <RefreshCw class="size-4" />
-                {{ $t("settings.reload_provider") }}
+                <Settings class="size-4" />
+                {{
+                  $t("settings.provider_settings", {
+                    name: owningProvider.name,
+                  })
+                }}
               </DropdownMenuItem>
+              <DropdownMenuSeparator v-if="owningProvider" />
+              <DropdownMenuItem
+                data-testid="player-reset-defaults"
+                :disabled="!config.enabled"
+                @click="resetToDefaults"
+              >
+                <RotateCcw class="size-4" />
+                {{ $t("settings.reset_to_defaults") }}
+              </DropdownMenuItem>
+              <DropdownMenuSeparator />
               <DropdownMenuItem
                 data-testid="player-toggle-enabled"
                 :disabled="toggleLoading"
@@ -163,8 +176,8 @@
           </DropdownMenu>
         </CardHeader>
         <CardContent
-          v-if="playerSetupLabel || owningProvider"
-          class="flex flex-wrap gap-2 border-t bg-muted/20 px-6 py-4"
+          v-if="playerSetupLabel || config.enabled"
+          class="flex flex-wrap items-center gap-3 border-t bg-muted/20 px-6 py-4"
         >
           <Button
             v-if="playerSetupLabel"
@@ -174,17 +187,19 @@
             <RefreshCw class="size-4" />
             {{ $t(playerSetupLabel) }}
           </Button>
-          <Button
-            v-if="owningProvider"
-            data-testid="player-provider-settings"
-            variant="outline"
-            @click="openProviderSettings"
+          <div
+            v-if="config.enabled"
+            class="flex w-full items-center gap-2 sm:ml-auto sm:w-auto"
           >
-            <Settings class="size-4" />
-            {{
-              $t("settings.provider_settings", { name: owningProvider.name })
-            }}
-          </Button>
+            <Switch
+              id="player-advanced-settings"
+              v-model="showAdvancedSettings"
+              data-testid="player-advanced-settings"
+            />
+            <Label for="player-advanced-settings" class="cursor-pointer">
+              {{ $t("settings.show_advanced_settings") }}
+            </Label>
+          </div>
         </CardContent>
       </Card>
     </div>
@@ -249,6 +264,9 @@
 
     <edit-config
       v-if="config"
+      ref="editConfig"
+      v-model:show-advanced-settings="showAdvancedSettings"
+      action-layout="floating-save"
       :disabled="!config?.enabled"
       :config-entries="config_entries"
       :output-protocols="api.players[config.player_id]?.output_protocols || []"
@@ -308,8 +326,11 @@ import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
+  DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
+import { Label } from "@/components/ui/label";
+import { Switch } from "@/components/ui/switch";
 import { api } from "@/plugins/api";
 import {
   ConfigEntryType,
@@ -341,11 +362,20 @@ import { useConfigAction } from "@/composables/useConfigAction";
 import { openLinkInNewTab } from "@/helpers/utils";
 import { eventbus } from "@/plugins/eventbus";
 import { $t } from "@/plugins/i18n";
-import { MoreVertical, Pencil, Power, RefreshCw, Settings } from "@lucide/vue";
+import {
+  MoreVertical,
+  Pencil,
+  Power,
+  RefreshCw,
+  RotateCcw,
+  Settings,
+} from "@lucide/vue";
 // global refs
 const router = useRouter();
 const config = ref<PlayerConfig>();
+const editConfig = ref<InstanceType<typeof EditConfig>>();
 const loading = ref(false);
+const showAdvancedSettings = ref(false);
 const toggleLoading = ref(false);
 const showRenameDialog = ref(false);
 const editName = ref<string | null>(null);
@@ -558,21 +588,8 @@ const openProviderSettings = async function () {
   }
 };
 
-const onReloadProvider = function () {
-  const instanceId = owningProvider.value?.instanceId;
-  const playerId = config.value?.player_id;
-  if (!instanceId || !playerId) return;
-
-  void api
-    .reloadProvider(instanceId)
-    .then(() => {
-      if (isCurrentPlayer(playerId)) {
-        toast.success($t("settings.provider_reloading"));
-      }
-    })
-    .catch((err) => {
-      if (isCurrentPlayer(playerId)) toast.error(String(err));
-    });
+const resetToDefaults = function () {
+  editConfig.value?.resetToDefaults();
 };
 
 const toggleEnabled = async function () {
@@ -700,6 +717,7 @@ function isCurrentPlayer(playerId: string) {
 function resetPlayerState(playerId?: string) {
   if (config.value?.player_id === playerId) return;
   config.value = undefined;
+  showAdvancedSettings.value = false;
   toggleLoading.value = false;
   toggleRequestId++;
 }

--- a/src/views/settings/ProtocolConfigSection.vue
+++ b/src/views/settings/ProtocolConfigSection.vue
@@ -35,19 +35,33 @@
       />
 
       <template v-if="protocolPanels.length > 0">
-        <Accordion type="single" collapsible class="space-y-2">
-          <AccordionItem
+        <component
+          :is="hasMultipleProtocols ? Accordion : 'div'"
+          :type="hasMultipleProtocols ? 'single' : undefined"
+          :collapsible="hasMultipleProtocols || undefined"
+          class="space-y-2"
+        >
+          <component
+            :is="hasMultipleProtocols ? AccordionItem : 'div'"
             v-for="panel of protocolPanels"
             :key="panel"
-            :value="panel"
+            :value="hasMultipleProtocols ? panel : undefined"
             class="rounded-[6px] border bg-card px-4 shadow-sm"
           >
-            <AccordionTrigger class="hover:no-underline">
+            <component
+              :is="hasMultipleProtocols ? AccordionTrigger : 'div'"
+              :class="
+                hasMultipleProtocols
+                  ? 'hover:no-underline'
+                  : 'flex items-start py-4 text-left text-sm font-medium'
+              "
+            >
               <span class="flex items-center gap-2">
                 <ProviderIcon
                   v-if="getProtocolDomain(panel)"
                   :domain="getProtocolDomain(panel)!"
                   :size="22"
+                  class="!ml-0"
                 />
                 <span>{{ getProtocolConfigureTitle(panel) }}</span>
                 <Badge
@@ -57,8 +71,11 @@
                   {{ $t("settings.protocol_native_badge") }}
                 </Badge>
               </span>
-            </AccordionTrigger>
-            <AccordionContent class="border-t pt-4">
+            </component>
+            <component
+              :is="hasMultipleProtocols ? AccordionContent : 'div'"
+              :class="['border-t pt-4', { 'pb-4': !hasMultipleProtocols }]"
+            >
               <div
                 v-if="!isProtocolProviderAvailable(panel)"
                 class="protocol-empty-message"
@@ -87,9 +104,9 @@
               >
                 {{ getProtocolEmptyMessage(panel) }}
               </div>
-            </AccordionContent>
-          </AccordionItem>
-        </Accordion>
+            </component>
+          </component>
+        </component>
       </template>
     </div>
   </div>
@@ -148,6 +165,8 @@ const getCategoryTranslation = function (category: string) {
 const protocolGeneralEntries = computed(() =>
   entriesForCategory("protocol_general"),
 );
+
+const hasMultipleProtocols = computed(() => props.protocolPanels.length > 1);
 
 const getProtocolDomain = function (category: string): string | undefined {
   if (!category.startsWith("protocol_")) return undefined;

--- a/tests/views/EditConfig.test.ts
+++ b/tests/views/EditConfig.test.ts
@@ -246,6 +246,24 @@ describe("EditConfig", () => {
 
     expect(saveDisabled(wrapper)).toBe(true);
   });
+
+  it("renders only a floating save action when requested", async () => {
+    const wrapper = mountEntries(
+      [entry({ key: "server", type: ConfigEntryType.STRING })],
+      false,
+      { actionLayout: "floating-save" },
+    );
+
+    dirty(wrapper);
+    await nextTick();
+
+    expect(wrapper.get('[data-testid="config-save"]').text()).toContain(
+      "settings.save",
+    );
+    expect(wrapper.text()).not.toContain("settings.show_advanced_settings");
+    expect(wrapper.text()).not.toContain("settings.reset_to_defaults");
+    expect(wrapper.find(".config-actions").exists()).toBe(false);
+  });
 });
 
 function entry(
@@ -272,9 +290,13 @@ function dependentEntry(
   });
 }
 
-function mountEntries(configEntries: ConfigEntry[], disabled = false) {
+function mountEntries(
+  configEntries: ConfigEntry[],
+  disabled = false,
+  props: { actionLayout?: "default" | "floating-save" } = {},
+) {
   return shallowMount(EditConfig, {
-    props: { configEntries, disabled },
+    props: { configEntries, disabled, ...props },
     global: { renderStubDefaultSlot: true },
   });
 }

--- a/tests/views/EditPlayer.test.ts
+++ b/tests/views/EditPlayer.test.ts
@@ -16,31 +16,32 @@ import { flushPromises, shallowMount } from "@vue/test-utils";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { providerManifest } from "../fixtures/providerManifest";
 
-const { apiMock, eventbusMock, routerMock, toastMock } = vi.hoisted(() => ({
-  apiMock: {
-    getDSPConfig: vi.fn<MusicAssistantApi["getDSPConfig"]>(),
-    getPlayerConfig: vi.fn<MusicAssistantApi["getPlayerConfig"]>(),
-    getProvider: vi.fn<MusicAssistantApi["getProvider"]>(),
-    getProviderManifest: vi.fn<MusicAssistantApi["getProviderManifest"]>(),
-    players: {} as Record<string, unknown>,
-    providerManifests: {} as Record<string, unknown>,
-    providers: {} as Record<string, unknown>,
-    reloadProvider: vi.fn<MusicAssistantApi["reloadProvider"]>(),
-    savePlayerConfig: vi.fn<MusicAssistantApi["savePlayerConfig"]>(),
-    subscribe: vi.fn(),
-  },
-  eventbusMock: {
-    emit: vi.fn(),
-  },
-  routerMock: {
-    back: vi.fn(),
-    push: vi.fn(),
-  },
-  toastMock: {
-    error: vi.fn(),
-    success: vi.fn(),
-  },
-}));
+const { apiMock, editConfigResetMock, eventbusMock, routerMock, toastMock } =
+  vi.hoisted(() => ({
+    apiMock: {
+      getDSPConfig: vi.fn<MusicAssistantApi["getDSPConfig"]>(),
+      getPlayerConfig: vi.fn<MusicAssistantApi["getPlayerConfig"]>(),
+      getProvider: vi.fn<MusicAssistantApi["getProvider"]>(),
+      getProviderManifest: vi.fn<MusicAssistantApi["getProviderManifest"]>(),
+      players: {} as Record<string, unknown>,
+      providerManifests: {} as Record<string, unknown>,
+      providers: {} as Record<string, unknown>,
+      savePlayerConfig: vi.fn<MusicAssistantApi["savePlayerConfig"]>(),
+      subscribe: vi.fn(),
+    },
+    editConfigResetMock: vi.fn(),
+    eventbusMock: {
+      emit: vi.fn(),
+    },
+    routerMock: {
+      back: vi.fn(),
+      push: vi.fn(),
+    },
+    toastMock: {
+      error: vi.fn(),
+      success: vi.fn(),
+    },
+  }));
 
 const SlotStub = {
   template: "<div><slot /></div>",
@@ -54,7 +55,22 @@ const playerDetailsStubs = {
   DropdownMenu: SlotStub,
   DropdownMenuContent: SlotStub,
   DropdownMenuItem: SlotStub,
+  DropdownMenuSeparator: true,
   DropdownMenuTrigger: SlotStub,
+  EditConfig: {
+    name: "EditConfig",
+    props: [
+      "actionLayout",
+      "configEntries",
+      "disabled",
+      "outputProtocols",
+      "showAdvancedSettings",
+    ],
+    methods: {
+      resetToDefaults: editConfigResetMock,
+    },
+    template: "<div />",
+  },
 };
 
 vi.mock("@/plugins/api", () => ({
@@ -100,7 +116,6 @@ describe("EditPlayer", () => {
         name: "Chromecast",
       }),
     );
-    apiMock.reloadProvider.mockResolvedValue(undefined);
     apiMock.savePlayerConfig.mockResolvedValue(playerConfig());
     apiMock.providerManifests = { chromecast: { name: "Chromecast" } };
     apiMock.players = {
@@ -112,7 +127,7 @@ describe("EditPlayer", () => {
     routerMock.push.mockResolvedValue(undefined);
   });
 
-  it("shows setup, provider, reload, and enable controls in the header", async () => {
+  it("shows setup, provider, reset, advanced, and enable controls", async () => {
     const wrapper = await mountPlayerPage();
 
     expect(wrapper.get('[data-testid="player-setup"]').text()).toContain(
@@ -122,11 +137,32 @@ describe("EditPlayer", () => {
       wrapper.get('[data-testid="player-provider-settings"]').text(),
     ).toContain("settings.provider_settings");
     expect(
-      wrapper.get('[data-testid="player-reload-provider"]').text(),
-    ).toContain("settings.reload_provider");
+      wrapper.find('[data-testid="player-reload-provider"]').exists(),
+    ).toBe(false);
+    expect(
+      wrapper.get('[data-testid="player-reset-defaults"]').text(),
+    ).toContain("settings.reset_to_defaults");
+    expect(
+      wrapper.find('[data-testid="player-advanced-settings"]').exists(),
+    ).toBe(true);
     expect(
       wrapper.get('[data-testid="player-toggle-enabled"]').text(),
     ).toContain("settings.disable");
+    expect(
+      wrapper.findComponent({ name: "EditConfig" }).props("actionLayout"),
+    ).toBe("floating-save");
+  });
+
+  it("controls advanced settings from the header", async () => {
+    const wrapper = await mountPlayerPage();
+    const editConfig = wrapper.findComponent({ name: "EditConfig" });
+
+    wrapper
+      .findComponent({ name: "Switch" })
+      .vm.$emit("update:modelValue", true);
+    await wrapper.vm.$nextTick();
+
+    expect(editConfig.props("showAdvancedSettings")).toBe(true);
   });
 
   it("hides optional reconfiguration when the player has no setup flow", async () => {
@@ -214,64 +250,24 @@ describe("EditPlayer", () => {
     expect(
       wrapper.find('[data-testid="player-provider-settings"]').exists(),
     ).toBe(true);
-    expect(
-      wrapper.find('[data-testid="player-reload-provider"]').exists(),
-    ).toBe(true);
 
     await wrapper
-      .get('[data-testid="player-reload-provider"]')
+      .get('[data-testid="player-provider-settings"]')
       .trigger("click");
     await flushPromises();
 
-    expect(apiMock.reloadProvider).toHaveBeenCalledWith("chromecast--1");
+    expect(routerMock.push).toHaveBeenCalledWith({
+      name: "editprovider",
+      params: { instanceId: "chromecast--1" },
+    });
   });
 
-  it("reloads the owning provider from the header menu", async () => {
+  it("resets player settings from the header menu", async () => {
     const wrapper = await mountPlayerPage();
 
-    await wrapper
-      .get('[data-testid="player-reload-provider"]')
-      .trigger("click");
-    await flushPromises();
+    await wrapper.get('[data-testid="player-reset-defaults"]').trigger("click");
 
-    expect(apiMock.reloadProvider).toHaveBeenCalledWith("chromecast--1");
-    expect(toastMock.success).toHaveBeenCalledWith(
-      "settings.provider_reloading",
-    );
-  });
-
-  it("reports provider reload failures without navigating", async () => {
-    apiMock.reloadProvider.mockRejectedValueOnce(new Error("Reload failed"));
-    const wrapper = await mountPlayerPage();
-
-    await wrapper
-      .get('[data-testid="player-reload-provider"]')
-      .trigger("click");
-    await flushPromises();
-
-    expect(toastMock.error).toHaveBeenCalledWith("Error: Reload failed");
-    expect(routerMock.push).not.toHaveBeenCalled();
-  });
-
-  it("keeps player settings available while the provider reload is pending", async () => {
-    let resolveReload: () => void = () => {};
-    apiMock.reloadProvider.mockImplementationOnce(
-      () =>
-        new Promise<void>((resolve) => {
-          resolveReload = resolve;
-        }),
-    );
-    const wrapper = await mountPlayerPage();
-
-    await wrapper
-      .get('[data-testid="player-reload-provider"]')
-      .trigger("click");
-
-    expect(
-      wrapper.findComponent({ name: "VOverlay" }).props("modelValue"),
-    ).toBe(false);
-    resolveReload();
-    await flushPromises();
+    expect(editConfigResetMock).toHaveBeenCalledOnce();
   });
 
   it("disables the player from the header menu", async () => {

--- a/tests/views/ProtocolConfigSection.test.ts
+++ b/tests/views/ProtocolConfigSection.test.ts
@@ -70,6 +70,22 @@ describe("ProtocolConfigSection", () => {
     ]);
   });
 
+  it("renders a single protocol without an accordion", () => {
+    const wrapper = mountSection(
+      [entry("native_buffer", "protocol_sonos")],
+      [outputProtocol("native", "sonos", true)],
+    );
+
+    expect(wrapper.findComponent({ name: "Accordion" }).exists()).toBe(false);
+    expect(wrapper.findComponent({ name: "AccordionTrigger" }).exists()).toBe(
+      false,
+    );
+    expect(renderedKeys(wrapper)).toEqual(["native_buffer"]);
+    expect(wrapper.getComponent({ name: "Badge" }).text()).toBe(
+      "settings.protocol_native_badge",
+    );
+  });
+
   it("keeps a disabled protocol configurable and gates its settings", async () => {
     const disabledEntries = [
       enabledEntry("airplay-output", "protocol_airplay", false),


### PR DESCRIPTION
Player settings spread related actions across several areas, while single output protocols require an unnecessary extra click.

- Move provider and reset actions into the player menu and remove redundant reload and close actions
- Place advanced settings beside reconfigure and keep Save accessible as a floating action
- Simplify output protocol sections and show a single protocol directly