### PR TITLE
Music Quiz TV dashboard polish

### DIFF
--- a/src/components/music-quiz/adapter_contracts.ts
+++ b/src/components/music-quiz/adapter_contracts.ts
@@ -72,6 +72,8 @@ export interface MusicQuizPresentBodyAdapterProps<
   state: TState;
   currentRound: TRound;
   leaderboardRows: MusicQuizLeaderboardRow[];
+  // set by the TV dashboard; the host's present mode leaves it unset
+  dashboard?: boolean;
 }
 
 export interface MusicQuizPlayerAnswerAdapterProps<

--- a/src/components/music-quiz/answer-types/timeline/TimelineAudienceAnswer.vue
+++ b/src/components/music-quiz/answer-types/timeline/TimelineAudienceAnswer.vue
@@ -26,8 +26,10 @@
       :class="{
         'lg:min-h-0 lg:flex-1 lg:grid-cols-[minmax(0,1fr)_22rem] lg:overflow-hidden':
           present && state.phase === 'answering',
+        'lg:min-h-0 lg:flex-1 lg:grid-rows-[minmax(7rem,2fr)_minmax(9rem,3fr)] lg:overflow-hidden':
+          present && state.phase === 'reveal' && revealedResults.length,
         'lg:min-h-0 lg:flex-1 lg:grid-rows-[minmax(0,1fr)] lg:overflow-hidden':
-          present && state.phase === 'reveal',
+          present && state.phase === 'reveal' && !revealedResults.length,
         'lg:grid-cols-2': !present,
       }"
     >
@@ -36,6 +38,72 @@
         :statuses="roundPlayerStatuses"
         :scrollable="present"
       />
+
+      <Card
+        v-if="state.phase === 'reveal' && revealedResults.length && !present"
+        data-testid="timeline-round-results"
+        role="region"
+        :aria-label="$t('providers.music_quiz.timeline_round_results')"
+        :class="{
+          'lg:min-h-0 lg:gap-3 lg:overflow-hidden lg:py-3': present,
+        }"
+      >
+        <CardHeader :class="{ 'lg:px-4': present }">
+          <CardTitle class="text-base">
+            {{ $t("providers.music_quiz.timeline_round_results") }}
+          </CardTitle>
+        </CardHeader>
+        <CardContent
+          :class="{
+            'lg:min-h-0 lg:flex-1 lg:overflow-y-auto lg:overscroll-contain lg:px-4':
+              present,
+          }"
+        >
+          <ul class="flex flex-col gap-2">
+            <li
+              v-for="result in revealedResults"
+              :key="result.name"
+              class="bg-muted flex items-center justify-between gap-3 rounded-md px-3 py-2"
+            >
+              <span class="min-w-0 flex-1 truncate font-medium">
+                {{ result.name }}
+              </span>
+              <span
+                data-testid="timeline-result-score"
+                class="flex min-w-0 max-w-[45%] items-center gap-1 font-semibold tabular-nums"
+              >
+                <CircleCheck
+                  v-if="result.placementCorrect"
+                  class="size-4 text-green-600 dark:text-green-400"
+                  aria-hidden="true"
+                />
+                <CircleX
+                  v-else
+                  class="text-muted-foreground size-4"
+                  aria-hidden="true"
+                />
+                <span class="sr-only">
+                  {{
+                    result.placementCorrect
+                      ? $t("providers.music_quiz.timeline_correct_placement")
+                      : $t("providers.music_quiz.timeline_incorrect_placement")
+                  }}
+                </span>
+                <span
+                  class="min-w-0 flex-1 truncate"
+                  :class="
+                    result.points > 0
+                      ? 'text-green-600 dark:text-green-400'
+                      : 'text-muted-foreground'
+                  "
+                >
+                  +{{ result.points }}
+                </span>
+              </span>
+            </li>
+          </ul>
+        </CardContent>
+      </Card>
 
       <!-- the big screen keeps standings for the reveal; scores mid-guess spoil the race -->
       <div
@@ -54,12 +122,15 @@
 import TimelineDisplay from "@/components/music-quiz/answer-types/timeline/TimelineDisplay.vue";
 import TimelineProgress from "@/components/music-quiz/answer-types/timeline/TimelineProgress.vue";
 import MusicQuizCountdown from "@/components/music-quiz/MusicQuizCountdown.vue";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import type {
   MusicQuizTimelinePublicState,
   MusicQuizTimelineRound,
 } from "@/composables/music-quiz/useMusicQuiz";
 import { useMusicQuizAnswerDeadline } from "@/composables/music-quiz/useMusicQuizAnswerDeadline";
 import { getMusicQuizRoundPlayers } from "@/helpers/music_quiz";
+import { $t } from "@/plugins/i18n";
+import { CircleCheck, CircleX } from "@lucide/vue";
 import { computed, type VNode } from "vue";
 
 const props = withDefaults(
@@ -76,6 +147,22 @@ const props = withDefaults(
 );
 defineSlots<{ leaderboard: () => VNode[] }>();
 
+const revealedResults = computed(() =>
+  props.state.players.flatMap((player) => {
+    const answer = player.last_answer;
+    if (!answer) return [];
+    return [
+      {
+        name: player.name,
+        placementCorrect: answer.placement.correct,
+        points:
+          answer.placement.points +
+          (answer.artist?.points ?? 0) +
+          (answer.title?.points ?? 0),
+      },
+    ];
+  }),
+);
 const roundPlayerStatuses = computed(() =>
   getMusicQuizRoundPlayers(props.state.players, props.currentRound.round_index),
 );

--- a/src/components/music-quiz/answer-types/timeline/TimelineAudienceAnswer.vue
+++ b/src/components/music-quiz/answer-types/timeline/TimelineAudienceAnswer.vue
@@ -26,10 +26,8 @@
       :class="{
         'lg:min-h-0 lg:flex-1 lg:grid-cols-[minmax(0,1fr)_22rem] lg:overflow-hidden':
           present && state.phase === 'answering',
-        'lg:min-h-0 lg:flex-1 lg:grid-rows-[minmax(7rem,2fr)_minmax(9rem,3fr)] lg:overflow-hidden':
-          present && state.phase === 'reveal' && revealedResults.length,
         'lg:min-h-0 lg:flex-1 lg:grid-rows-[minmax(0,1fr)] lg:overflow-hidden':
-          present && state.phase === 'reveal' && !revealedResults.length,
+          present && state.phase === 'reveal',
         'lg:grid-cols-2': !present,
       }"
     >
@@ -38,72 +36,6 @@
         :statuses="roundPlayerStatuses"
         :scrollable="present"
       />
-
-      <Card
-        v-if="state.phase === 'reveal' && revealedResults.length && !present"
-        data-testid="timeline-round-results"
-        role="region"
-        :aria-label="$t('providers.music_quiz.timeline_round_results')"
-        :class="{
-          'lg:min-h-0 lg:gap-3 lg:overflow-hidden lg:py-3': present,
-        }"
-      >
-        <CardHeader :class="{ 'lg:px-4': present }">
-          <CardTitle class="text-base">
-            {{ $t("providers.music_quiz.timeline_round_results") }}
-          </CardTitle>
-        </CardHeader>
-        <CardContent
-          :class="{
-            'lg:min-h-0 lg:flex-1 lg:overflow-y-auto lg:overscroll-contain lg:px-4':
-              present,
-          }"
-        >
-          <ul class="flex flex-col gap-2">
-            <li
-              v-for="result in revealedResults"
-              :key="result.name"
-              class="bg-muted flex items-center justify-between gap-3 rounded-md px-3 py-2"
-            >
-              <span class="min-w-0 flex-1 truncate font-medium">
-                {{ result.name }}
-              </span>
-              <span
-                data-testid="timeline-result-score"
-                class="flex min-w-0 max-w-[45%] items-center gap-1 font-semibold tabular-nums"
-              >
-                <CircleCheck
-                  v-if="result.placementCorrect"
-                  class="size-4 text-green-600 dark:text-green-400"
-                  aria-hidden="true"
-                />
-                <CircleX
-                  v-else
-                  class="text-muted-foreground size-4"
-                  aria-hidden="true"
-                />
-                <span class="sr-only">
-                  {{
-                    result.placementCorrect
-                      ? $t("providers.music_quiz.timeline_correct_placement")
-                      : $t("providers.music_quiz.timeline_incorrect_placement")
-                  }}
-                </span>
-                <span
-                  class="min-w-0 flex-1 truncate"
-                  :class="
-                    result.points > 0
-                      ? 'text-green-600 dark:text-green-400'
-                      : 'text-muted-foreground'
-                  "
-                >
-                  +{{ result.points }}
-                </span>
-              </span>
-            </li>
-          </ul>
-        </CardContent>
-      </Card>
 
       <!-- the big screen keeps standings for the reveal; scores mid-guess spoil the race -->
       <div
@@ -122,15 +54,12 @@
 import TimelineDisplay from "@/components/music-quiz/answer-types/timeline/TimelineDisplay.vue";
 import TimelineProgress from "@/components/music-quiz/answer-types/timeline/TimelineProgress.vue";
 import MusicQuizCountdown from "@/components/music-quiz/MusicQuizCountdown.vue";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import type {
   MusicQuizTimelinePublicState,
   MusicQuizTimelineRound,
 } from "@/composables/music-quiz/useMusicQuiz";
 import { useMusicQuizAnswerDeadline } from "@/composables/music-quiz/useMusicQuizAnswerDeadline";
 import { getMusicQuizRoundPlayers } from "@/helpers/music_quiz";
-import { $t } from "@/plugins/i18n";
-import { CircleCheck, CircleX } from "@lucide/vue";
 import { computed, type VNode } from "vue";
 
 const props = withDefaults(
@@ -147,22 +76,6 @@ const props = withDefaults(
 );
 defineSlots<{ leaderboard: () => VNode[] }>();
 
-const revealedResults = computed(() =>
-  props.state.players.flatMap((player) => {
-    const answer = player.last_answer;
-    if (!answer) return [];
-    return [
-      {
-        name: player.name,
-        placementCorrect: answer.placement.correct,
-        points:
-          answer.placement.points +
-          (answer.artist?.points ?? 0) +
-          (answer.title?.points ?? 0),
-      },
-    ];
-  }),
-);
 const roundPlayerStatuses = computed(() =>
   getMusicQuizRoundPlayers(props.state.players, props.currentRound.round_index),
 );

--- a/src/components/music-quiz/answer-types/timeline/TimelineAudienceAnswer.vue
+++ b/src/components/music-quiz/answer-types/timeline/TimelineAudienceAnswer.vue
@@ -40,7 +40,7 @@
       />
 
       <Card
-        v-if="state.phase === 'reveal' && revealedResults.length"
+        v-if="state.phase === 'reveal' && revealedResults.length && !present"
         data-testid="timeline-round-results"
         role="region"
         :aria-label="$t('providers.music_quiz.timeline_round_results')"
@@ -105,14 +105,15 @@
         </CardContent>
       </Card>
 
+      <!-- the big screen keeps standings for the reveal; scores mid-guess spoil the race -->
       <div
-        v-if="present"
+        v-if="present && state.phase === 'reveal'"
         data-testid="timeline-leaderboard-region"
         class="lg:min-h-0 lg:overflow-hidden"
       >
         <slot name="leaderboard"></slot>
       </div>
-      <slot v-else name="leaderboard"></slot>
+      <slot v-else-if="!present" name="leaderboard"></slot>
     </div>
   </div>
 </template>

--- a/src/components/music-quiz/answer-types/timeline/TimelineAudienceAnswer.vue
+++ b/src/components/music-quiz/answer-types/timeline/TimelineAudienceAnswer.vue
@@ -40,7 +40,7 @@
       />
 
       <Card
-        v-if="state.phase === 'reveal' && revealedResults.length"
+        v-if="state.phase === 'reveal' && revealedResults.length && !dashboard"
         data-testid="timeline-round-results"
         role="region"
         :aria-label="$t('providers.music_quiz.timeline_round_results')"
@@ -106,13 +106,13 @@
       </Card>
 
       <div
-        v-if="present"
+        v-if="present && (!dashboard || state.phase === 'reveal')"
         data-testid="timeline-leaderboard-region"
         class="lg:min-h-0 lg:overflow-hidden"
       >
         <slot name="leaderboard"></slot>
       </div>
-      <slot v-else name="leaderboard"></slot>
+      <slot v-else-if="!present" name="leaderboard"></slot>
     </div>
   </div>
 </template>
@@ -138,10 +138,12 @@ const props = withDefaults(
     currentRound: MusicQuizTimelineRound;
     present?: boolean;
     showTimeline?: boolean;
+    dashboard?: boolean;
   }>(),
   {
     present: false,
     showTimeline: true,
+    dashboard: false,
   },
 );
 defineSlots<{ leaderboard: () => VNode[] }>();

--- a/src/components/music-quiz/answer-types/timeline/TimelineAudienceAnswer.vue
+++ b/src/components/music-quiz/answer-types/timeline/TimelineAudienceAnswer.vue
@@ -2,11 +2,19 @@
   <div
     data-testid="timeline-audience-answer"
     class="flex flex-col gap-4"
-    :class="{ 'lg:h-full lg:min-h-0 lg:overflow-hidden': present }"
+    :class="{
+      'lg:h-full lg:min-h-0 lg:overflow-hidden': present,
+      // dashboard answering: progress fills the left half, countdown sits right
+      'lg:grid lg:grid-cols-[minmax(0,1fr)_minmax(14rem,18rem)] lg:grid-rows-[minmax(0,1fr)]':
+        present && dashboard && state.phase === 'answering',
+    }"
   >
     <div
       v-if="state.phase === 'answering'"
       class="flex flex-col items-center gap-2"
+      :class="{
+        'lg:order-2 lg:justify-center': present && dashboard,
+      }"
     >
       <MusicQuizCountdown
         :size="present ? 150 : 112"
@@ -37,6 +45,8 @@
           state.phase === 'reveal' &&
           !dashboard &&
           revealedResults.length > 0,
+        'lg:order-1 lg:h-full':
+          present && dashboard && state.phase === 'answering',
         'lg:grid-cols-2': !present,
       }"
     >

--- a/src/components/music-quiz/answer-types/timeline/TimelineAudienceAnswer.vue
+++ b/src/components/music-quiz/answer-types/timeline/TimelineAudienceAnswer.vue
@@ -25,11 +25,18 @@
       class="grid gap-4"
       :class="{
         'lg:min-h-0 lg:flex-1 lg:grid-cols-[minmax(0,1fr)_22rem] lg:overflow-hidden':
-          present && state.phase === 'answering',
-        'lg:min-h-0 lg:flex-1 lg:grid-rows-[minmax(7rem,2fr)_minmax(9rem,3fr)] lg:overflow-hidden':
-          present && state.phase === 'reveal' && revealedResults.length,
+          present && state.phase === 'answering' && !dashboard,
+        // the dashboard has no side leaderboard while answering; progress gets the full row
         'lg:min-h-0 lg:flex-1 lg:grid-rows-[minmax(0,1fr)] lg:overflow-hidden':
-          present && state.phase === 'reveal' && !revealedResults.length,
+          present &&
+          ((state.phase === 'answering' && dashboard) ||
+            (state.phase === 'reveal' &&
+              (dashboard || !revealedResults.length))),
+        'lg:min-h-0 lg:flex-1 lg:grid-rows-[minmax(7rem,2fr)_minmax(9rem,3fr)] lg:overflow-hidden':
+          present &&
+          state.phase === 'reveal' &&
+          !dashboard &&
+          revealedResults.length > 0,
         'lg:grid-cols-2': !present,
       }"
     >

--- a/src/components/music-quiz/answer-types/timeline/TimelineAudienceAnswer.vue
+++ b/src/components/music-quiz/answer-types/timeline/TimelineAudienceAnswer.vue
@@ -40,7 +40,7 @@
       />
 
       <Card
-        v-if="state.phase === 'reveal' && revealedResults.length && !present"
+        v-if="state.phase === 'reveal' && revealedResults.length"
         data-testid="timeline-round-results"
         role="region"
         :aria-label="$t('providers.music_quiz.timeline_round_results')"
@@ -105,15 +105,14 @@
         </CardContent>
       </Card>
 
-      <!-- the big screen keeps standings for the reveal; scores mid-guess spoil the race -->
       <div
-        v-if="present && state.phase === 'reveal'"
+        v-if="present"
         data-testid="timeline-leaderboard-region"
         class="lg:min-h-0 lg:overflow-hidden"
       >
         <slot name="leaderboard"></slot>
       </div>
-      <slot v-else-if="!present" name="leaderboard"></slot>
+      <slot v-else name="leaderboard"></slot>
     </div>
   </div>
 </template>

--- a/src/components/music-quiz/answer-types/timeline/TimelineDisplay.vue
+++ b/src/components/music-quiz/answer-types/timeline/TimelineDisplay.vue
@@ -248,8 +248,7 @@ function scrollEntryIntoView(entryId: string) {
   const entry = Array.from(
     containerRef.value?.querySelectorAll<HTMLElement>("[data-entry-id]") ?? [],
   ).find((element) => element.dataset.entryId === entryId);
-  // scroll only the strip's own container; scrollIntoView would also drag
-  // scrollable ancestors along and shift the whole kiosk page sideways
+  // scroll only the strip: scrollIntoView also drags scrollable ancestors along
   const scrollArea = entry?.closest<HTMLElement>("[data-timeline-scroll]");
   if (!entry || !scrollArea?.scrollTo) return;
 

--- a/src/components/music-quiz/answer-types/timeline/TimelineDisplay.vue
+++ b/src/components/music-quiz/answer-types/timeline/TimelineDisplay.vue
@@ -248,15 +248,24 @@ function scrollEntryIntoView(entryId: string) {
   const entry = Array.from(
     containerRef.value?.querySelectorAll<HTMLElement>("[data-entry-id]") ?? [],
   ).find((element) => element.dataset.entryId === entryId);
-  if (!entry?.scrollIntoView) return;
+  // scroll only the strip's own container; scrollIntoView would also drag
+  // scrollable ancestors along and shift the whole kiosk page sideways
+  const scrollArea = entry?.closest<HTMLElement>("[data-timeline-scroll]");
+  if (!entry || !scrollArea?.scrollTo) return;
 
   const reduceMotion =
     typeof window !== "undefined" &&
     window.matchMedia?.("(prefers-reduced-motion: reduce)").matches === true;
-  entry.scrollIntoView({
+  const areaRect = scrollArea.getBoundingClientRect();
+  const entryRect = entry.getBoundingClientRect();
+  const entryCenter =
+    scrollArea.scrollLeft +
+    (entryRect.left - areaRect.left) +
+    entryRect.width / 2 -
+    areaRect.width / 2;
+  scrollArea.scrollTo({
+    left: Math.max(0, entryCenter),
     behavior: reduceMotion ? "auto" : "smooth",
-    block: "nearest",
-    inline: "center",
   });
 }
 </script>

--- a/src/components/music-quiz/game-types/music-timeline/MusicTimelinePresentBody.vue
+++ b/src/components/music-quiz/game-types/music-timeline/MusicTimelinePresentBody.vue
@@ -3,7 +3,10 @@
     data-testid="music-timeline-present-body"
     class="flex min-h-0 flex-col gap-3 lg:grid lg:flex-1 lg:grid-cols-[minmax(16rem,1fr)_minmax(22rem,1fr)] lg:grid-rows-[minmax(0,1fr)_auto] lg:gap-4 lg:overflow-hidden"
   >
+    <!-- the dashboard drops the listen instructions while answering; guests
+         read them on their phones and round progress takes this spot -->
     <MusicTimelinePresentRound
+      v-if="!(dashboard && state.phase === 'answering')"
       class="lg:self-start"
       :state="state"
       :current-round="currentRound"
@@ -12,6 +15,7 @@
 
     <TimelineAudienceAnswer
       class="lg:h-full"
+      :class="{ 'lg:col-span-2': dashboard && state.phase === 'answering' }"
       :state="state"
       :current-round="currentRound"
       :show-timeline="false"

--- a/src/components/music-quiz/game-types/music-timeline/MusicTimelinePresentBody.vue
+++ b/src/components/music-quiz/game-types/music-timeline/MusicTimelinePresentBody.vue
@@ -3,8 +3,7 @@
     data-testid="music-timeline-present-body"
     class="flex min-h-0 flex-col gap-3 lg:grid lg:flex-1 lg:grid-cols-[minmax(16rem,1fr)_minmax(22rem,1fr)] lg:grid-rows-[minmax(0,1fr)_auto] lg:gap-4 lg:overflow-hidden"
   >
-    <!-- the dashboard drops the listen instructions while answering; guests
-         read them on their phones and round progress takes this spot -->
+    <!-- guests read the listen instructions on their phones -->
     <MusicTimelinePresentRound
       v-if="!(dashboard && state.phase === 'answering')"
       class="lg:self-start"

--- a/src/components/music-quiz/game-types/music-timeline/MusicTimelinePresentBody.vue
+++ b/src/components/music-quiz/game-types/music-timeline/MusicTimelinePresentBody.vue
@@ -1,7 +1,7 @@
 <template>
   <div
     data-testid="music-timeline-present-body"
-    class="flex min-h-0 flex-col gap-3 lg:grid lg:flex-1 lg:grid-cols-[minmax(16rem,2fr)_minmax(22rem,3fr)] lg:grid-rows-[minmax(0,1fr)_auto] lg:gap-4 lg:overflow-hidden"
+    class="flex min-h-0 flex-col gap-3 lg:grid lg:flex-1 lg:grid-cols-[minmax(16rem,1fr)_minmax(22rem,1fr)] lg:grid-rows-[minmax(0,1fr)_auto] lg:gap-4 lg:overflow-hidden"
   >
     <MusicTimelinePresentRound
       class="lg:self-start"

--- a/src/components/music-quiz/game-types/music-timeline/MusicTimelinePresentBody.vue
+++ b/src/components/music-quiz/game-types/music-timeline/MusicTimelinePresentBody.vue
@@ -15,6 +15,7 @@
       :state="state"
       :current-round="currentRound"
       :show-timeline="false"
+      :dashboard="dashboard"
       present
     >
       <template #leaderboard>

--- a/src/components/music-quiz/game-types/music-timeline/MusicTimelinePresentBody.vue
+++ b/src/components/music-quiz/game-types/music-timeline/MusicTimelinePresentBody.vue
@@ -1,7 +1,12 @@
 <template>
   <div
     data-testid="music-timeline-present-body"
-    class="flex min-h-0 flex-col gap-3 lg:grid lg:flex-1 lg:grid-cols-[minmax(16rem,1fr)_minmax(22rem,1fr)] lg:grid-rows-[minmax(0,1fr)_auto] lg:gap-4 lg:overflow-hidden"
+    class="flex min-h-0 flex-col gap-3 lg:grid lg:flex-1 lg:grid-rows-[minmax(0,1fr)_auto] lg:gap-4 lg:overflow-hidden"
+    :class="
+      dashboard
+        ? 'lg:grid-cols-[minmax(16rem,1fr)_minmax(22rem,1fr)]'
+        : 'lg:grid-cols-[minmax(16rem,2fr)_minmax(22rem,3fr)]'
+    "
   >
     <!-- guests read the listen instructions on their phones -->
     <MusicTimelinePresentRound

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -47,7 +47,7 @@
     "mass": "Music Assistant",
     "new_playlist_name": "Enter a name for the new playlist",
     "no_content": "No items found.",
-    "no_content_filter": "No items found for the current filter/search conditions.",
+    "no_content_filter": "No items found for the current filter\/search conditions.",
     "no_player": "No player selected",
     "off": "Off",
     "on": "On",
@@ -202,7 +202,7 @@
         "no_player_providers_detail": "Configure player providers to select devices where Music Assistant can output your music.",
         "dynamic_members": {
             "label": "Dynamic group members",
-            "description": "Allow members to (temporarily) join/leave the group dynamically, so the group more or less behaves the same as manually syncing players together, with the main difference being that the group player will hold the queue."
+            "description": "Allow members to (temporarily) join\/leave the group dynamically, so the group more or less behaves the same as manually syncing players together, with the main difference being that the group player will hold the queue."
         },
         "dsp": {
             "configure_on": "Configuring DSP on: {name}",
@@ -234,7 +234,7 @@
                     "high_pass": "High Pass",
                     "notch": "Notch"
                 },
-                "import_apo": "Import APO/REW Preset",
+                "import_apo": "Import APO\/REW Preset",
                 "export_apo": "Export APO Preset",
                 "preamp": "Preamp",
                 "add_band_channel": "Add Band ({channel} only)",
@@ -308,7 +308,7 @@
                 }
             },
             "convolution": {
-                "help": "Convolution applies a recorded impulse response to the audio — used for room or speaker correction and headphone simulation. Gain should be negative or zero, as an impulse response changes overall loudness.",
+                "help": "Convolution applies a recorded impulse response to the audio \u2014 used for room or speaker correction and headphone simulation. Gain should be negative or zero, as an impulse response changes overall loudness.",
                 "impulse_response": "Impulse Response",
                 "none": "None selected",
                 "missing": "Unavailable impulse response",
@@ -415,7 +415,7 @@
                 "mute": "Mute"
             }
         },
-        "add_group_player_desc_universal": "By creating a Universal Player Group, you can group players from different providers/ecosystems together. \nThis will distribute the same audio to all member players (but not in sync).",
+        "add_group_player_desc_universal": "By creating a Universal Player Group, you can group players from different providers\/ecosystems together. \nThis will distribute the same audio to all member players (but not in sync).",
         "edit_provider": "Edit provider: {0}",
         "metadata": "Metadata",
         "metadataprovider": "Metadata provider",
@@ -510,7 +510,7 @@
         "remote_access_feature_no_port_forwarding": "No port forwarding or VPN required",
         "remote_access_mode_optimized": "Optimized Mode (HA Cloud)",
         "remote_access_mode_basic": "Running in Basic Mode",
-        "remote_access_mode_optimized_description": "Using STUN/TURN servers from Home Assistant Cloud for optimal performance. Works reliably in all network configurations.",
+        "remote_access_mode_optimized_description": "Using STUN\/TURN servers from Home Assistant Cloud for optimal performance. Works reliably in all network configurations.",
         "remote_access_mode_basic_description": "Using public STUN servers. This may not work in complex network setups. Upgrade to Home Assistant Cloud for the best experience.",
         "remote_access_upgrade_to_optimized": "Upgrade to Home Assistant Cloud",
         "remote_access_status": "Remote Access Status",
@@ -538,7 +538,7 @@
         "remote_access_disabled_success": "Remote Access has been disabled",
         "remote_access_signaling_server_description": "Signaling server in the cloud, hosted by the Open Home Foundation.",
         "remote_access_protocol_basic": "WebRTC with public STUN servers (may not work in complex network setups).",
-        "remote_access_protocol_optimized": "WebRTC with optimized STUN/TURN servers from Home Assistant Cloud (works in all network setups).",
+        "remote_access_protocol_optimized": "WebRTC with optimized STUN\/TURN servers from Home Assistant Cloud (works in all network setups).",
         "remote_access_encryption_description": "End-to-end encryption using DTLS-SRTP ensures your data remains private and secure.",
         "frontend": "User Interface",
         "players_count": "{0} player{1}",
@@ -547,7 +547,7 @@
         "players_total": "{count} total player | {count} total players",
         "api_docs": "API Documentation",
         "no_group_providers": "You currently do not have any providers that support creating groups",
-        "provider_codeowners": "This provider is contributed/maintained by",
+        "provider_codeowners": "This provider is contributed\/maintained by",
         "provider_credits": "Made possible by",
         "category": {
             "web_player": "Web Player",
@@ -579,7 +579,7 @@
         "fix_now": "Fix now",
         "web_player_enabled": {
             "label": "Enable built-in (Sendspin) Web Player",
-            "description": "Allow playback to this device/browser using the built-in Sendspin web player."
+            "description": "Allow playback to this device\/browser using the built-in Sendspin web player."
         },
         "enable_browser_controls": {
             "label": "Enable browser media controls",
@@ -802,21 +802,21 @@
         "album_artist_filter": "Toggle album-artist filter",
         "collapse_collections": "Collapse collections",
         "explicit": "Explicit",
-        "filter_library": "Toggle in-library/favorite filter",
-        "library": "Toggle in-library/favorite",
+        "filter_library": "Toggle in-library\/favorite filter",
+        "library": "Toggle in-library\/favorite",
         "linked": "This provideritem is linked to the current itemdetails",
         "refresh": "Refresh the items listing",
         "refresh_new_content": "New content is available, click to refresh the listing",
-        "search": "Show/hide search input",
+        "search": "Show\/hide search input",
         "select_items": "Select multiple items",
         "sort_options": "Sort options",
-        "toggle_view_mode": "Toggle view mode list/thumbs",
+        "toggle_view_mode": "Toggle view mode list\/thumbs",
         "filter_favorites": "Only show favorites",
-        "favorite": "Mark/unmark as a favorite",
+        "favorite": "Mark\/unmark as a favorite",
         "open_provider_link": "Open this item on the provider's website",
-        "collapse_expand": "Collapse/expand this listing",
+        "collapse_expand": "Collapse\/expand this listing",
         "back": "Back",
-        "show_menu": "Show/hide menu",
+        "show_menu": "Show\/hide menu",
         "search_filter_active": "Search is currently filtering results",
         "play_sample": "Play sample",
         "album_type": "Album type",
@@ -1187,7 +1187,7 @@
         "remote_server": "Remote",
         "remote_only_info": "Connect to your Music Assistant server remotely",
         "server_address": "Server Address",
-        "server_address_placeholder": "http://192.168.1.100:8095",
+        "server_address_placeholder": "http:\/\/192.168.1.100:8095",
         "server_address_hint": "Enter the full URL of your Music Assistant server",
         "remote_id": "Remote ID",
         "remote_id_placeholder": "e.g., MA-X7K9-P2M4",
@@ -1778,6 +1778,7 @@
             "timeline_submit_bonus": "Submit bonus",
             "timeline_correct_placement": "Correct placement",
             "timeline_incorrect_placement": "Incorrect placement",
+            "timeline_round_results": "Round results",
             "add_music_sources": "Add music sources",
             "genre": "Genre",
             "album": "Album",
@@ -1864,7 +1865,7 @@
         "on_demand": "On demand",
         "automatic_schedule": "Automatic schedule",
         "system": "System",
-        "no_value": "n/a",
+        "no_value": "n\/a",
         "loading_log": "Loading log...",
         "no_log_output": "No log output available.",
         "open": "Open background tasks",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -47,7 +47,7 @@
     "mass": "Music Assistant",
     "new_playlist_name": "Enter a name for the new playlist",
     "no_content": "No items found.",
-    "no_content_filter": "No items found for the current filter\/search conditions.",
+    "no_content_filter": "No items found for the current filter/search conditions.",
     "no_player": "No player selected",
     "off": "Off",
     "on": "On",
@@ -202,7 +202,7 @@
         "no_player_providers_detail": "Configure player providers to select devices where Music Assistant can output your music.",
         "dynamic_members": {
             "label": "Dynamic group members",
-            "description": "Allow members to (temporarily) join\/leave the group dynamically, so the group more or less behaves the same as manually syncing players together, with the main difference being that the group player will hold the queue."
+            "description": "Allow members to (temporarily) join/leave the group dynamically, so the group more or less behaves the same as manually syncing players together, with the main difference being that the group player will hold the queue."
         },
         "dsp": {
             "configure_on": "Configuring DSP on: {name}",
@@ -234,7 +234,7 @@
                     "high_pass": "High Pass",
                     "notch": "Notch"
                 },
-                "import_apo": "Import APO\/REW Preset",
+                "import_apo": "Import APO/REW Preset",
                 "export_apo": "Export APO Preset",
                 "preamp": "Preamp",
                 "add_band_channel": "Add Band ({channel} only)",
@@ -308,7 +308,7 @@
                 }
             },
             "convolution": {
-                "help": "Convolution applies a recorded impulse response to the audio \u2014 used for room or speaker correction and headphone simulation. Gain should be negative or zero, as an impulse response changes overall loudness.",
+                "help": "Convolution applies a recorded impulse response to the audio — used for room or speaker correction and headphone simulation. Gain should be negative or zero, as an impulse response changes overall loudness.",
                 "impulse_response": "Impulse Response",
                 "none": "None selected",
                 "missing": "Unavailable impulse response",
@@ -415,7 +415,7 @@
                 "mute": "Mute"
             }
         },
-        "add_group_player_desc_universal": "By creating a Universal Player Group, you can group players from different providers\/ecosystems together. \nThis will distribute the same audio to all member players (but not in sync).",
+        "add_group_player_desc_universal": "By creating a Universal Player Group, you can group players from different providers/ecosystems together. \nThis will distribute the same audio to all member players (but not in sync).",
         "edit_provider": "Edit provider: {0}",
         "metadata": "Metadata",
         "metadataprovider": "Metadata provider",
@@ -510,7 +510,7 @@
         "remote_access_feature_no_port_forwarding": "No port forwarding or VPN required",
         "remote_access_mode_optimized": "Optimized Mode (HA Cloud)",
         "remote_access_mode_basic": "Running in Basic Mode",
-        "remote_access_mode_optimized_description": "Using STUN\/TURN servers from Home Assistant Cloud for optimal performance. Works reliably in all network configurations.",
+        "remote_access_mode_optimized_description": "Using STUN/TURN servers from Home Assistant Cloud for optimal performance. Works reliably in all network configurations.",
         "remote_access_mode_basic_description": "Using public STUN servers. This may not work in complex network setups. Upgrade to Home Assistant Cloud for the best experience.",
         "remote_access_upgrade_to_optimized": "Upgrade to Home Assistant Cloud",
         "remote_access_status": "Remote Access Status",
@@ -538,7 +538,7 @@
         "remote_access_disabled_success": "Remote Access has been disabled",
         "remote_access_signaling_server_description": "Signaling server in the cloud, hosted by the Open Home Foundation.",
         "remote_access_protocol_basic": "WebRTC with public STUN servers (may not work in complex network setups).",
-        "remote_access_protocol_optimized": "WebRTC with optimized STUN\/TURN servers from Home Assistant Cloud (works in all network setups).",
+        "remote_access_protocol_optimized": "WebRTC with optimized STUN/TURN servers from Home Assistant Cloud (works in all network setups).",
         "remote_access_encryption_description": "End-to-end encryption using DTLS-SRTP ensures your data remains private and secure.",
         "frontend": "User Interface",
         "players_count": "{0} player{1}",
@@ -547,7 +547,7 @@
         "players_total": "{count} total player | {count} total players",
         "api_docs": "API Documentation",
         "no_group_providers": "You currently do not have any providers that support creating groups",
-        "provider_codeowners": "This provider is contributed\/maintained by",
+        "provider_codeowners": "This provider is contributed/maintained by",
         "provider_credits": "Made possible by",
         "category": {
             "web_player": "Web Player",
@@ -579,7 +579,7 @@
         "fix_now": "Fix now",
         "web_player_enabled": {
             "label": "Enable built-in (Sendspin) Web Player",
-            "description": "Allow playback to this device\/browser using the built-in Sendspin web player."
+            "description": "Allow playback to this device/browser using the built-in Sendspin web player."
         },
         "enable_browser_controls": {
             "label": "Enable browser media controls",
@@ -802,21 +802,21 @@
         "album_artist_filter": "Toggle album-artist filter",
         "collapse_collections": "Collapse collections",
         "explicit": "Explicit",
-        "filter_library": "Toggle in-library\/favorite filter",
-        "library": "Toggle in-library\/favorite",
+        "filter_library": "Toggle in-library/favorite filter",
+        "library": "Toggle in-library/favorite",
         "linked": "This provideritem is linked to the current itemdetails",
         "refresh": "Refresh the items listing",
         "refresh_new_content": "New content is available, click to refresh the listing",
-        "search": "Show\/hide search input",
+        "search": "Show/hide search input",
         "select_items": "Select multiple items",
         "sort_options": "Sort options",
-        "toggle_view_mode": "Toggle view mode list\/thumbs",
+        "toggle_view_mode": "Toggle view mode list/thumbs",
         "filter_favorites": "Only show favorites",
-        "favorite": "Mark\/unmark as a favorite",
+        "favorite": "Mark/unmark as a favorite",
         "open_provider_link": "Open this item on the provider's website",
-        "collapse_expand": "Collapse\/expand this listing",
+        "collapse_expand": "Collapse/expand this listing",
         "back": "Back",
-        "show_menu": "Show\/hide menu",
+        "show_menu": "Show/hide menu",
         "search_filter_active": "Search is currently filtering results",
         "play_sample": "Play sample",
         "album_type": "Album type",
@@ -1187,7 +1187,7 @@
         "remote_server": "Remote",
         "remote_only_info": "Connect to your Music Assistant server remotely",
         "server_address": "Server Address",
-        "server_address_placeholder": "http:\/\/192.168.1.100:8095",
+        "server_address_placeholder": "http://192.168.1.100:8095",
         "server_address_hint": "Enter the full URL of your Music Assistant server",
         "remote_id": "Remote ID",
         "remote_id_placeholder": "e.g., MA-X7K9-P2M4",
@@ -1778,7 +1778,6 @@
             "timeline_submit_bonus": "Submit bonus",
             "timeline_correct_placement": "Correct placement",
             "timeline_incorrect_placement": "Incorrect placement",
-            "timeline_round_results": "Round results",
             "add_music_sources": "Add music sources",
             "genre": "Genre",
             "album": "Album",
@@ -1865,7 +1864,7 @@
         "on_demand": "On demand",
         "automatic_schedule": "Automatic schedule",
         "system": "System",
-        "no_value": "n\/a",
+        "no_value": "n/a",
         "loading_log": "Loading log...",
         "no_log_output": "No log output available.",
         "open": "Open background tasks",

--- a/src/views/MusicQuizDashboardStageView.vue
+++ b/src/views/MusicQuizDashboardStageView.vue
@@ -149,7 +149,7 @@
             <div
               v-if="answerOptions.length"
               data-testid="music-quiz-dashboard-options"
-              class="grid min-h-0 content-start gap-[1.5vh] sm:grid-cols-2 lg:gap-[1.5vw]"
+              class="mt-auto grid min-h-0 gap-[1.5vh] sm:grid-cols-2 lg:gap-[1.5vw]"
             >
               <div
                 v-for="(option, index) in answerOptions"

--- a/src/views/MusicQuizDashboardStageView.vue
+++ b/src/views/MusicQuizDashboardStageView.vue
@@ -103,6 +103,7 @@
             :state="activeState"
             :current-round="currentRound"
             :leaderboard-rows="visibleLeaderboardRows"
+            dashboard
           />
           <template v-else-if="activeState.phase === 'reveal'">
             <div

--- a/src/views/MusicQuizDashboardStageView.vue
+++ b/src/views/MusicQuizDashboardStageView.vue
@@ -1,6 +1,6 @@
 <template>
   <div
-    class="music-quiz-dashboard dark text-white"
+    class="music-quiz-dashboard text-foreground"
     data-testid="music-quiz-dashboard-stage"
   >
     <div
@@ -18,7 +18,7 @@
         <header class="flex items-start justify-between gap-6">
           <div class="min-w-0">
             <h1
-              class="truncate text-[clamp(1.75rem,3.4vw,3rem)] leading-tight font-bold text-white/95"
+              class="truncate text-[clamp(1.75rem,3.4vw,3rem)] leading-tight font-bold text-foreground/95"
             >
               {{ activeState.name || $t("providers.music_quiz.title") }}
             </h1>
@@ -26,14 +26,14 @@
               role="status"
               aria-live="polite"
               aria-atomic="true"
-              class="mt-1 text-[clamp(0.95rem,1.5vw,1.6rem)] font-semibold tracking-[0.15em] text-white/45 uppercase"
+              class="mt-1 text-[clamp(0.95rem,1.5vw,1.6rem)] font-semibold tracking-[0.15em] text-foreground/45 uppercase"
             >
               {{ phaseLabel }}
             </p>
           </div>
           <p
             v-if="roundLabel"
-            class="shrink-0 rounded-full bg-white/10 px-[1.2em] py-[0.45em] text-[clamp(1rem,1.7vw,1.9rem)] font-semibold text-white/70"
+            class="shrink-0 rounded-full bg-foreground/10 px-[1.2em] py-[0.45em] text-[clamp(1rem,1.7vw,1.9rem)] font-semibold text-foreground/70"
             data-testid="music-quiz-dashboard-round"
           >
             {{ roundLabel }}
@@ -60,16 +60,16 @@
           />
           <div class="flex min-h-0 min-w-0 flex-col gap-[2vh] self-stretch">
             <h2
-              class="text-[clamp(1.4rem,2.6vw,2.4rem)] font-bold text-white/90"
+              class="text-[clamp(1.4rem,2.6vw,2.4rem)] font-bold text-foreground/90"
             >
               {{ $t("providers.music_quiz.players") }}
-              <span class="text-white/50">
+              <span class="text-foreground/50">
                 ({{ activeState.players.length }})
               </span>
             </h2>
             <MusicQuizAutoStartStatus
               :state="activeState"
-              class="w-fit rounded-full bg-white/10 px-[1.1em] py-[0.4em] text-[clamp(1rem,1.7vw,1.75rem)] font-semibold text-white/75"
+              class="w-fit rounded-full bg-foreground/10 px-[1.1em] py-[0.4em] text-[clamp(1rem,1.7vw,1.75rem)] font-semibold text-foreground/75"
             />
             <div
               v-if="activeState.players.length"
@@ -80,10 +80,13 @@
                 v-for="player in sortedPlayers"
                 :key="player.name"
                 :name="player.name"
-                class="border-white/10 bg-white/10 text-[clamp(1rem,1.4vw,1.5rem)]"
+                class="border-foreground/10 bg-foreground/10 text-[clamp(1rem,1.4vw,1.5rem)]"
               />
             </div>
-            <p v-else class="text-[clamp(1rem,1.7vw,1.75rem)] text-white/60">
+            <p
+              v-else
+              class="text-[clamp(1rem,1.7vw,1.75rem)] text-foreground/60"
+            >
               {{ $t("providers.music_quiz.waiting_for_start") }}
             </p>
           </div>
@@ -130,7 +133,7 @@
             <p
               v-if="answeringPrompt"
               data-testid="music-quiz-dashboard-listening"
-              class="text-[clamp(1.5rem,3vw,2.8rem)] font-bold text-white/90"
+              class="text-[clamp(1.5rem,3vw,2.8rem)] font-bold text-foreground/90"
             >
               {{ answeringPrompt }}
             </p>
@@ -154,10 +157,10 @@
               <div
                 v-for="(option, index) in answerOptions"
                 :key="option.suggestion_id"
-                class="flex items-center gap-[0.9em] rounded-2xl bg-white/5 px-[1.1em] py-[0.9em] text-[clamp(1.1rem,2vw,2rem)] font-medium text-white/90"
+                class="flex items-center gap-[0.9em] rounded-2xl bg-foreground/5 px-[1.1em] py-[0.9em] text-[clamp(1.1rem,2vw,2rem)] font-medium text-foreground/90"
               >
                 <span
-                  class="grid size-[1.9em] shrink-0 place-items-center rounded-full bg-white/10 text-[0.75em] font-bold text-white/80"
+                  class="grid size-[1.9em] shrink-0 place-items-center rounded-full bg-foreground/10 text-[0.75em] font-bold text-foreground/80"
                   aria-hidden="true"
                 >
                   {{ optionLetter(index) }}
@@ -170,7 +173,7 @@
             v-if="revealCountdownText"
             data-testid="music-quiz-dashboard-next-round"
             role="timer"
-            class="mx-auto w-fit rounded-full bg-white/10 px-[1.2em] py-[0.45em] text-[clamp(1rem,1.7vw,1.9rem)] font-semibold text-white/75"
+            class="mx-auto w-fit rounded-full bg-foreground/10 px-[1.2em] py-[0.45em] text-[clamp(1rem,1.7vw,1.9rem)] font-semibold text-foreground/75"
           >
             {{ revealCountdownText }}
           </p>
@@ -182,7 +185,7 @@
           class="flex min-h-0 flex-1 flex-col items-center justify-center gap-[3vh]"
         >
           <p
-            class="text-center text-[clamp(1.6rem,3vw,3rem)] font-bold text-white/95"
+            class="text-center text-[clamp(1.6rem,3vw,3rem)] font-bold text-foreground/95"
           >
             {{ winnerText }}
           </p>
@@ -201,8 +204,8 @@
         data-testid="music-quiz-dashboard-waiting"
         class="flex min-h-0 flex-1 flex-col items-center justify-center gap-[2vh] text-center"
       >
-        <Disc3 class="size-[12vh] text-white/25" aria-hidden="true" />
-        <p class="text-[clamp(1.25rem,2.4vw,2.25rem)] text-white/60">
+        <Disc3 class="size-[12vh] text-foreground/25" aria-hidden="true" />
+        <p class="text-[clamp(1.25rem,2.4vw,2.25rem)] text-foreground/60">
           {{ $t("providers.music_quiz.dashboard_waiting") }}
         </p>
       </div>
@@ -402,7 +405,7 @@ watch(
   height: 100vh;
   /* also crops the backdrop's blurred edges, which bleed past the viewport */
   overflow: hidden;
-  background: #000;
+  background: var(--background);
 }
 
 /* Keep the vh fallback in a separate rule: the minifier collapses duplicate
@@ -427,10 +430,11 @@ watch(
 .music-quiz-dashboard-scrim {
   position: absolute;
   inset: 0;
+  /* wash the blurred artwork toward the theme background so content stays readable */
   background: linear-gradient(
     to bottom,
-    rgba(0, 0, 0, 0.35),
-    rgba(0, 0, 0, 0.75)
+    color-mix(in srgb, var(--background) 35%, transparent),
+    color-mix(in srgb, var(--background) 75%, transparent)
   );
 }
 

--- a/tests/components/music-quiz/MusicTimelinePresentBody.test.ts
+++ b/tests/components/music-quiz/MusicTimelinePresentBody.test.ts
@@ -92,6 +92,21 @@ const leaderboardRows = players.map((player, index) => ({
 })) satisfies MusicQuizLeaderboardRow[];
 
 describe("MusicTimelinePresentBody", () => {
+  it("splits reveal evenly on the dashboard, keeps the host ratio elsewhere", () => {
+    for (const [dashboard, expected] of [
+      [true, "lg:grid-cols-[minmax(16rem,1fr)_minmax(22rem,1fr)]"],
+      [false, "lg:grid-cols-[minmax(16rem,2fr)_minmax(22rem,3fr)]"],
+    ] as const) {
+      const wrapper = mount(MusicTimelinePresentBody, {
+        props: { state, currentRound, leaderboardRows, dashboard },
+      });
+      expect(
+        wrapper.get('[data-testid="music-timeline-present-body"]').classes(),
+      ).toContain(expected);
+      wrapper.unmount();
+    }
+  });
+
   it("keeps song and score panels before the bottom timeline", () => {
     const wrapper = mount(MusicTimelinePresentBody, {
       props: {

--- a/tests/components/music-quiz/MusicTimelinePresentBody.test.ts
+++ b/tests/components/music-quiz/MusicTimelinePresentBody.test.ts
@@ -102,7 +102,6 @@ describe("MusicTimelinePresentBody", () => {
     });
     const body = wrapper.get('[data-testid="music-timeline-present-body"]');
     const currentSong = wrapper.get('[data-testid="music-timeline-round"]');
-    const results = wrapper.get('[data-testid="timeline-round-results"]');
     const leaderboard = wrapper.get(
       '[aria-label="providers.music_quiz.leaderboard"]',
     );
@@ -119,18 +118,21 @@ describe("MusicTimelinePresentBody", () => {
       ]),
     );
     expect(body.classes()).not.toContain("overflow-hidden");
-    for (const panel of [currentSong, results, leaderboard]) {
+    // per-player round results stay on the phones; the big screen shows the board
+    expect(
+      wrapper.find('[data-testid="timeline-round-results"]').exists(),
+    ).toBe(false);
+    for (const panel of [currentSong, leaderboard]) {
       expect(
         panel.element.compareDocumentPosition(history.element) &
           Node.DOCUMENT_POSITION_FOLLOWING,
       ).toBeTruthy();
     }
     expect(currentSong.attributes("data-compact")).toBe("true");
-    expect(results.attributes("role")).toBe("region");
     expect(leaderboard.attributes("role")).toBe("region");
   });
 
-  it("bounds many-player results and gives the leaderboard internal scroll", () => {
+  it("gives the leaderboard internal scroll", () => {
     const wrapper = mount(MusicTimelinePresentBody, {
       props: {
         state,
@@ -138,25 +140,12 @@ describe("MusicTimelinePresentBody", () => {
         leaderboardRows,
       },
     });
-    const results = wrapper.get('[data-testid="timeline-round-results"]');
-    const resultsContent = results.get('[data-slot="card-content"]');
     const leaderboardRegion = wrapper.get(
       '[data-testid="timeline-leaderboard-region"]',
     );
     const leaderboard = leaderboardRegion.get('[data-slot="card"]');
     const leaderboardContent = leaderboard.get('[data-slot="card-content"]');
 
-    expect(results.classes()).toEqual(
-      expect.arrayContaining(["lg:min-h-0", "lg:overflow-hidden"]),
-    );
-    expect(resultsContent.classes()).toEqual(
-      expect.arrayContaining(["lg:min-h-0", "lg:overflow-y-auto"]),
-    );
-    const resultScore = results.get('[data-testid="timeline-result-score"]');
-    expect(resultScore.classes()).not.toContain("shrink-0");
-    expect(resultScore.get("span.truncate").classes()).toEqual(
-      expect.arrayContaining(["min-w-0", "flex-1"]),
-    );
     expect(leaderboardRegion.classes()).toEqual(
       expect.arrayContaining(["lg:min-h-0", "lg:overflow-hidden"]),
     );
@@ -166,7 +155,6 @@ describe("MusicTimelinePresentBody", () => {
     expect(leaderboardContent.classes()).toEqual(
       expect.arrayContaining(["min-h-0", "flex-1", "overflow-y-auto"]),
     );
-    expect(results.findAll("li")).toHaveLength(players.length);
     expect(leaderboard.findAll("li")).toHaveLength(players.length);
   });
 

--- a/tests/components/music-quiz/MusicTimelinePresentBody.test.ts
+++ b/tests/components/music-quiz/MusicTimelinePresentBody.test.ts
@@ -102,6 +102,7 @@ describe("MusicTimelinePresentBody", () => {
     });
     const body = wrapper.get('[data-testid="music-timeline-present-body"]');
     const currentSong = wrapper.get('[data-testid="music-timeline-round"]');
+    const results = wrapper.get('[data-testid="timeline-round-results"]');
     const leaderboard = wrapper.get(
       '[aria-label="providers.music_quiz.leaderboard"]',
     );
@@ -118,21 +119,18 @@ describe("MusicTimelinePresentBody", () => {
       ]),
     );
     expect(body.classes()).not.toContain("overflow-hidden");
-    // per-player round results stay on the phones; the big screen shows the board
-    expect(
-      wrapper.find('[data-testid="timeline-round-results"]').exists(),
-    ).toBe(false);
-    for (const panel of [currentSong, leaderboard]) {
+    for (const panel of [currentSong, results, leaderboard]) {
       expect(
         panel.element.compareDocumentPosition(history.element) &
           Node.DOCUMENT_POSITION_FOLLOWING,
       ).toBeTruthy();
     }
     expect(currentSong.attributes("data-compact")).toBe("true");
+    expect(results.attributes("role")).toBe("region");
     expect(leaderboard.attributes("role")).toBe("region");
   });
 
-  it("gives the leaderboard internal scroll", () => {
+  it("bounds many-player results and gives the leaderboard internal scroll", () => {
     const wrapper = mount(MusicTimelinePresentBody, {
       props: {
         state,
@@ -140,12 +138,25 @@ describe("MusicTimelinePresentBody", () => {
         leaderboardRows,
       },
     });
+    const results = wrapper.get('[data-testid="timeline-round-results"]');
+    const resultsContent = results.get('[data-slot="card-content"]');
     const leaderboardRegion = wrapper.get(
       '[data-testid="timeline-leaderboard-region"]',
     );
     const leaderboard = leaderboardRegion.get('[data-slot="card"]');
     const leaderboardContent = leaderboard.get('[data-slot="card-content"]');
 
+    expect(results.classes()).toEqual(
+      expect.arrayContaining(["lg:min-h-0", "lg:overflow-hidden"]),
+    );
+    expect(resultsContent.classes()).toEqual(
+      expect.arrayContaining(["lg:min-h-0", "lg:overflow-y-auto"]),
+    );
+    const resultScore = results.get('[data-testid="timeline-result-score"]');
+    expect(resultScore.classes()).not.toContain("shrink-0");
+    expect(resultScore.get("span.truncate").classes()).toEqual(
+      expect.arrayContaining(["min-w-0", "flex-1"]),
+    );
     expect(leaderboardRegion.classes()).toEqual(
       expect.arrayContaining(["lg:min-h-0", "lg:overflow-hidden"]),
     );
@@ -155,6 +166,7 @@ describe("MusicTimelinePresentBody", () => {
     expect(leaderboardContent.classes()).toEqual(
       expect.arrayContaining(["min-h-0", "flex-1", "overflow-y-auto"]),
     );
+    expect(results.findAll("li")).toHaveLength(players.length);
     expect(leaderboard.findAll("li")).toHaveLength(players.length);
   });
 

--- a/tests/components/music-quiz/TimelineAudienceAdapters.test.ts
+++ b/tests/components/music-quiz/TimelineAudienceAdapters.test.ts
@@ -260,5 +260,52 @@ describe("timeline host and present answers", () => {
         .classes(),
     ).toContain("text-green-600");
     expect(wrapper.find('[data-testid="leaderboard"]').exists()).toBe(true);
+
+    // the TV dashboard hides the per-round results; every other surface keeps them
+    const dashboard = mount(TimelineAudienceAnswer, {
+      props: {
+        state,
+        currentRound: revealedRound,
+        present: true,
+        dashboard: true,
+      },
+      slots: {
+        leaderboard: '<div data-testid="leaderboard">Leaderboard</div>',
+      },
+      global: {
+        stubs: {
+          MusicQuizCountdown: true,
+          TimelineDisplay: true,
+          TimelineProgress: true,
+        },
+      },
+    });
+    expect(
+      dashboard.find('[data-testid="timeline-round-results"]').exists(),
+    ).toBe(false);
+    expect(dashboard.find('[data-testid="leaderboard"]').exists()).toBe(true);
+  });
+
+  it("hides the dashboard leaderboard while guessing, keeps it for the host", () => {
+    for (const [dashboard, expected] of [
+      [true, false],
+      [false, true],
+    ] as const) {
+      const wrapper = shallowMount(TimelineAudienceAnswer, {
+        props: {
+          state: hostState,
+          currentRound,
+          present: true,
+          dashboard,
+        },
+        slots: {
+          leaderboard: '<div data-testid="leaderboard">Leaderboard</div>',
+        },
+      });
+      expect(wrapper.find('[data-testid="leaderboard"]').exists()).toBe(
+        expected,
+      );
+      wrapper.unmount();
+    }
   });
 });

--- a/tests/components/music-quiz/TimelineAudienceAdapters.test.ts
+++ b/tests/components/music-quiz/TimelineAudienceAdapters.test.ts
@@ -189,7 +189,7 @@ describe("timeline host and present answers", () => {
     );
   });
 
-  it("shows aggregate reveal results and preserves the leaderboard slot", () => {
+  it("shows only the leaderboard at reveal on every surface", () => {
     const revealedEntry = {
       ...anchor,
       entry_id: "current",
@@ -249,24 +249,15 @@ describe("timeline host and present answers", () => {
         },
       });
 
-    const audience = mountVariant(false);
-    expect(audience.text()).toContain("+250");
-    expect(audience.findComponent(TimelineProgress).exists()).toBe(false);
-    expect(audience.find(".sr-only").text()).toContain(
-      "providers.music_quiz.timeline_incorrect_placement",
-    );
-    expect(
-      audience
-        .get('[data-testid="timeline-result-score"] span.truncate')
-        .classes(),
-    ).toContain("text-green-600");
-    expect(audience.find('[data-testid="leaderboard"]').exists()).toBe(true);
-
-    // the big screen leaves per-player results to the phones and keeps the board
-    const present = mountVariant(true);
-    expect(
-      present.find('[data-testid="timeline-round-results"]').exists(),
-    ).toBe(false);
-    expect(present.find('[data-testid="leaderboard"]').exists()).toBe(true);
+    // per-player results live on the phones; shared surfaces show only the board
+    for (const present of [false, true]) {
+      const wrapper = mountVariant(present);
+      expect(
+        wrapper.find('[data-testid="timeline-round-results"]').exists(),
+      ).toBe(false);
+      expect(wrapper.findComponent(TimelineProgress).exists()).toBe(false);
+      expect(wrapper.find('[data-testid="leaderboard"]').exists()).toBe(true);
+      wrapper.unmount();
+    }
   });
 });

--- a/tests/components/music-quiz/TimelineAudienceAdapters.test.ts
+++ b/tests/components/music-quiz/TimelineAudienceAdapters.test.ts
@@ -230,43 +230,35 @@ describe("timeline host and present answers", () => {
         },
       ],
     } satisfies MusicQuizTimelineHostState;
-    const mountVariant = (present: boolean) =>
-      mount(TimelineAudienceAnswer, {
-        props: {
-          state,
-          currentRound: revealedRound,
-          present,
+    const wrapper = mount(TimelineAudienceAnswer, {
+      props: {
+        state,
+        currentRound: revealedRound,
+        present: true,
+      },
+      slots: {
+        leaderboard: '<div data-testid="leaderboard">Leaderboard</div>',
+      },
+      global: {
+        stubs: {
+          MusicQuizCountdown: true,
+          TimelineDisplay: true,
+          TimelineProgress: true,
         },
-        slots: {
-          leaderboard: '<div data-testid="leaderboard">Leaderboard</div>',
-        },
-        global: {
-          stubs: {
-            MusicQuizCountdown: true,
-            TimelineDisplay: true,
-            TimelineProgress: true,
-          },
-        },
-      });
+      },
+    });
 
-    const audience = mountVariant(false);
-    expect(audience.text()).toContain("+250");
-    expect(audience.findComponent(TimelineProgress).exists()).toBe(false);
-    expect(audience.find(".sr-only").text()).toContain(
+    expect(wrapper.text()).toContain("Complete");
+    expect(wrapper.text()).toContain("+250");
+    expect(wrapper.findComponent(TimelineProgress).exists()).toBe(false);
+    expect(wrapper.find(".sr-only").text()).toContain(
       "providers.music_quiz.timeline_incorrect_placement",
     );
     expect(
-      audience
+      wrapper
         .get('[data-testid="timeline-result-score"] span.truncate')
         .classes(),
     ).toContain("text-green-600");
-    expect(audience.find('[data-testid="leaderboard"]').exists()).toBe(true);
-
-    // the big screen leaves per-player results to the phones and keeps the board
-    const present = mountVariant(true);
-    expect(
-      present.find('[data-testid="timeline-round-results"]').exists(),
-    ).toBe(false);
-    expect(present.find('[data-testid="leaderboard"]').exists()).toBe(true);
+    expect(wrapper.find('[data-testid="leaderboard"]').exists()).toBe(true);
   });
 });

--- a/tests/components/music-quiz/TimelineAudienceAdapters.test.ts
+++ b/tests/components/music-quiz/TimelineAudienceAdapters.test.ts
@@ -230,35 +230,43 @@ describe("timeline host and present answers", () => {
         },
       ],
     } satisfies MusicQuizTimelineHostState;
-    const wrapper = mount(TimelineAudienceAnswer, {
-      props: {
-        state,
-        currentRound: revealedRound,
-        present: true,
-      },
-      slots: {
-        leaderboard: '<div data-testid="leaderboard">Leaderboard</div>',
-      },
-      global: {
-        stubs: {
-          MusicQuizCountdown: true,
-          TimelineDisplay: true,
-          TimelineProgress: true,
+    const mountVariant = (present: boolean) =>
+      mount(TimelineAudienceAnswer, {
+        props: {
+          state,
+          currentRound: revealedRound,
+          present,
         },
-      },
-    });
+        slots: {
+          leaderboard: '<div data-testid="leaderboard">Leaderboard</div>',
+        },
+        global: {
+          stubs: {
+            MusicQuizCountdown: true,
+            TimelineDisplay: true,
+            TimelineProgress: true,
+          },
+        },
+      });
 
-    expect(wrapper.text()).toContain("Complete");
-    expect(wrapper.text()).toContain("+250");
-    expect(wrapper.findComponent(TimelineProgress).exists()).toBe(false);
-    expect(wrapper.find(".sr-only").text()).toContain(
+    const audience = mountVariant(false);
+    expect(audience.text()).toContain("+250");
+    expect(audience.findComponent(TimelineProgress).exists()).toBe(false);
+    expect(audience.find(".sr-only").text()).toContain(
       "providers.music_quiz.timeline_incorrect_placement",
     );
     expect(
-      wrapper
+      audience
         .get('[data-testid="timeline-result-score"] span.truncate')
         .classes(),
     ).toContain("text-green-600");
-    expect(wrapper.find('[data-testid="leaderboard"]').exists()).toBe(true);
+    expect(audience.find('[data-testid="leaderboard"]').exists()).toBe(true);
+
+    // the big screen leaves per-player results to the phones and keeps the board
+    const present = mountVariant(true);
+    expect(
+      present.find('[data-testid="timeline-round-results"]').exists(),
+    ).toBe(false);
+    expect(present.find('[data-testid="leaderboard"]').exists()).toBe(true);
   });
 });

--- a/tests/components/music-quiz/TimelineAudienceAdapters.test.ts
+++ b/tests/components/music-quiz/TimelineAudienceAdapters.test.ts
@@ -189,7 +189,7 @@ describe("timeline host and present answers", () => {
     );
   });
 
-  it("shows only the leaderboard at reveal on every surface", () => {
+  it("shows aggregate reveal results and preserves the leaderboard slot", () => {
     const revealedEntry = {
       ...anchor,
       entry_id: "current",
@@ -249,15 +249,24 @@ describe("timeline host and present answers", () => {
         },
       });
 
-    // per-player results live on the phones; shared surfaces show only the board
-    for (const present of [false, true]) {
-      const wrapper = mountVariant(present);
-      expect(
-        wrapper.find('[data-testid="timeline-round-results"]').exists(),
-      ).toBe(false);
-      expect(wrapper.findComponent(TimelineProgress).exists()).toBe(false);
-      expect(wrapper.find('[data-testid="leaderboard"]').exists()).toBe(true);
-      wrapper.unmount();
-    }
+    const audience = mountVariant(false);
+    expect(audience.text()).toContain("+250");
+    expect(audience.findComponent(TimelineProgress).exists()).toBe(false);
+    expect(audience.find(".sr-only").text()).toContain(
+      "providers.music_quiz.timeline_incorrect_placement",
+    );
+    expect(
+      audience
+        .get('[data-testid="timeline-result-score"] span.truncate')
+        .classes(),
+    ).toContain("text-green-600");
+    expect(audience.find('[data-testid="leaderboard"]').exists()).toBe(true);
+
+    // the big screen leaves per-player results to the phones and keeps the board
+    const present = mountVariant(true);
+    expect(
+      present.find('[data-testid="timeline-round-results"]').exists(),
+    ).toBe(false);
+    expect(present.find('[data-testid="leaderboard"]').exists()).toBe(true);
   });
 });

--- a/tests/components/music-quiz/TimelineDisplay.test.ts
+++ b/tests/components/music-quiz/TimelineDisplay.test.ts
@@ -49,22 +49,22 @@ const entries: MusicQuizTimelineEntry[] = [
     is_anchor: false,
   },
 ];
-const originalScrollIntoView = Object.getOwnPropertyDescriptor(
+const originalScrollTo = Object.getOwnPropertyDescriptor(
   HTMLElement.prototype,
-  "scrollIntoView",
+  "scrollTo",
 );
 const originalMatchMedia = Object.getOwnPropertyDescriptor(
   window,
   "matchMedia",
 );
-const scrollIntoView = vi.fn();
+const scrollTo = vi.fn();
 
 describe("TimelineDisplay", () => {
   beforeEach(() => {
-    scrollIntoView.mockReset();
-    Object.defineProperty(HTMLElement.prototype, "scrollIntoView", {
+    scrollTo.mockReset();
+    Object.defineProperty(HTMLElement.prototype, "scrollTo", {
       configurable: true,
-      value: scrollIntoView,
+      value: scrollTo,
     });
     Object.defineProperty(window, "matchMedia", {
       configurable: true,
@@ -83,14 +83,14 @@ describe("TimelineDisplay", () => {
   });
 
   afterAll(() => {
-    if (originalScrollIntoView) {
+    if (originalScrollTo) {
       Object.defineProperty(
         HTMLElement.prototype,
-        "scrollIntoView",
-        originalScrollIntoView,
+        "scrollTo",
+        originalScrollTo,
       );
     } else {
-      Reflect.deleteProperty(HTMLElement.prototype, "scrollIntoView");
+      Reflect.deleteProperty(HTMLElement.prototype, "scrollTo");
     }
   });
 
@@ -293,14 +293,13 @@ describe("TimelineDisplay", () => {
         .filter((item) => item.find("article").exists())
         .every((item) => item.classes().includes("shrink-0")),
     ).toBe(true);
-    expect(scrollIntoView).toHaveBeenCalledOnce();
-    expect(scrollIntoView.mock.instances[0]).toBe(
-      display.get('article[data-entry-id="same-b"]').element,
+    expect(scrollTo).toHaveBeenCalledOnce();
+    expect(scrollTo.mock.instances[0]).toBe(
+      display.get("[data-timeline-scroll]").element,
     );
-    expect(scrollIntoView).toHaveBeenCalledWith({
+    expect(scrollTo).toHaveBeenCalledWith({
+      left: expect.any(Number),
       behavior: "smooth",
-      block: "nearest",
-      inline: "center",
     });
   });
 
@@ -313,14 +312,14 @@ describe("TimelineDisplay", () => {
       },
     });
     await flushPromises();
-    scrollIntoView.mockReset();
+    scrollTo.mockReset();
 
     await wrapper.setProps({ highlightedEntryId: "same-a" });
     await flushPromises();
 
-    expect(scrollIntoView).toHaveBeenCalledOnce();
-    expect(scrollIntoView.mock.instances[0]).toBe(
-      wrapper.get('article[data-entry-id="same-a"]').element,
+    expect(scrollTo).toHaveBeenCalledOnce();
+    expect(scrollTo.mock.instances[0]).toBe(
+      wrapper.get("[data-timeline-scroll]").element,
     );
   });
 
@@ -332,11 +331,11 @@ describe("TimelineDisplay", () => {
       },
     });
     await flushPromises();
-    expect(scrollIntoView).not.toHaveBeenCalled();
+    expect(scrollTo).not.toHaveBeenCalled();
 
     await wrapper.setProps({ highlightedEntryId: "missing" });
     await flushPromises();
-    expect(scrollIntoView).not.toHaveBeenCalled();
+    expect(scrollTo).not.toHaveBeenCalled();
   });
 
   it("never scrolls vertical timelines", async () => {
@@ -351,7 +350,7 @@ describe("TimelineDisplay", () => {
     await wrapper.setProps({ highlightedEntryId: "same-a" });
     await flushPromises();
 
-    expect(scrollIntoView).not.toHaveBeenCalled();
+    expect(scrollTo).not.toHaveBeenCalled();
   });
 
   it("avoids animated scrolling when reduced motion is preferred", async () => {
@@ -368,10 +367,9 @@ describe("TimelineDisplay", () => {
     });
     await flushPromises();
 
-    expect(scrollIntoView).toHaveBeenCalledWith({
+    expect(scrollTo).toHaveBeenCalledWith({
+      left: expect.any(Number),
       behavior: "auto",
-      block: "nearest",
-      inline: "center",
     });
   });
 
@@ -391,10 +389,9 @@ describe("TimelineDisplay", () => {
     });
     await flushPromises();
 
-    expect(scrollIntoView).toHaveBeenCalledWith({
+    expect(scrollTo).toHaveBeenCalledWith({
+      left: expect.any(Number),
       behavior: "smooth",
-      block: "nearest",
-      inline: "center",
     });
   });
 


### PR DESCRIPTION
Polish for the Music Quiz TV dashboard, following live testing on a Nest Hub. The dashboard now follows the light/dark theme of the device and the question and timeline screens were decluttered so they read well from the couch.

Changes:
- Follow the light/dark theme (like the now-playing dashboard) instead of always dark
- Anchor the answer options to the bottom of the screen during a question
- Timeline reveal: song and leaderboard split the screen evenly
- Dashboard-only declutter (host and phone views unchanged): no "Round results" card, no leaderboard while guessing, and full-height round progress instead of the listen instructions
- Fix the whole page shifting sideways when the timeline centers a revealed entry
