### PR TITLE
Match the mobile status bar colour to the app background

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,8 +8,8 @@
     <link rel="apple-touch-icon" href="apple-touch-icon.png" sizes="180x180">
     <link rel="mask-icon" href="favicon.svg" color="#FFFFFF">
     <link rel="manifest" href="manifest.webmanifest">
-    <meta name="theme-color" media="(prefers-color-scheme: light)" content="#ffffff">
-    <meta name="theme-color" media="(prefers-color-scheme: dark)"  content="#121212">
+    <!-- useStatusBarColor keeps this in sync with the active theme background -->
+    <meta name="theme-color" content="#181818">
     <link rel="icon" href="favicon.ico" />
     <title>Music Assistant</title>
     <meta name="description" content="Music Assistant - Music library manager for Home Assistant">

--- a/public/index.html
+++ b/public/index.html
@@ -10,8 +10,8 @@
     <link rel="mask-icon" href="favicon.svg" color="#FFFFFF">
     <link rel="manifest" href="manifest.webmanifest">
     <link rel="preload" as="font" href="./assets/JetBrainsMono-Medium.woff2" type="font/woff2" crossorigin="anonymous">
-    <meta name="theme-color" media="(prefers-color-scheme: light)" content="#ffffff">
-    <meta name="theme-color" media="(prefers-color-scheme: dark)"  content="#121212">
+    <!-- useStatusBarColor keeps this in sync with the active theme background -->
+    <meta name="theme-color" content="#181818">
     <title>Music Assistant</title>
     <meta name="description" content="Music Assistant - Music library manager for Home Assistant">
   </head>

--- a/src/composables/useStatusBarColor.ts
+++ b/src/composables/useStatusBarColor.ts
@@ -1,0 +1,33 @@
+/**
+ * Colour shown behind the mobile status bar.
+ *
+ * iOS Safari samples the `html` background, Android Chrome reads the
+ * theme-color meta, so both are kept in sync.
+ */
+
+let themeColor = "";
+let overrideColor: string | undefined;
+
+/** Sets the base colour that follows the active theme. */
+export function setStatusBarThemeColor(color: string): void {
+  themeColor = color;
+  applyStatusBarColor();
+}
+
+/** Overrides the colour for one screen. Pass undefined to drop back to the theme colour. */
+export function setStatusBarColorOverride(color: string | undefined): void {
+  overrideColor = color;
+  applyStatusBarColor();
+}
+
+function applyStatusBarColor(): void {
+  const html = document.documentElement;
+  if (overrideColor) html.style.backgroundColor = overrideColor;
+  else html.style.removeProperty("background-color");
+
+  const color = overrideColor ?? themeColor;
+  const meta = document.querySelector<HTMLMetaElement>(
+    'meta[name="theme-color"]',
+  );
+  if (meta && color) meta.content = color;
+}

--- a/src/composables/useThemePreference.ts
+++ b/src/composables/useThemePreference.ts
@@ -1,5 +1,6 @@
 import { authManager } from "@/plugins/auth";
 import { store } from "@/plugins/store";
+import { setStatusBarThemeColor } from "./useStatusBarColor";
 import { useColorMode } from "@vueuse/core";
 import { readonly, ref } from "vue";
 import { useTheme } from "vuetify";
@@ -57,6 +58,7 @@ export function useThemePreference() {
     themePreference.value = preference;
     theme.change(resolvedTheme);
     colorMode.value = preference === "auto" ? "auto" : resolvedTheme;
+    setStatusBarThemeColor(theme.themes.value[resolvedTheme].colors.background);
     syncVuetifyToSystemScheme(preference);
   }
 
@@ -65,7 +67,11 @@ export function useThemePreference() {
       if (!systemSchemeListener && typeof window.matchMedia === "function") {
         systemSchemeQuery = window.matchMedia("(prefers-color-scheme: dark)");
         systemSchemeListener = () => {
-          theme.change(systemSchemeQuery!.matches ? "dark" : "light");
+          const resolvedTheme = systemSchemeQuery!.matches ? "dark" : "light";
+          theme.change(resolvedTheme);
+          setStatusBarThemeColor(
+            theme.themes.value[resolvedTheme].colors.background,
+          );
         };
         systemSchemeQuery.addEventListener("change", systemSchemeListener);
       }

--- a/src/layouts/default/PlayerOSD/PlayerFullscreen.vue
+++ b/src/layouts/default/PlayerOSD/PlayerFullscreen.vue
@@ -478,6 +478,7 @@ import { Button } from "@/components/ui/button";
 import { useLyricsElapsedTime } from "@/composables/lyrics/useLyricsElapsedTime";
 import { useLyricsOffset } from "@/composables/lyrics/useLyricsOffset";
 import { useActiveTrackWaveform } from "@/composables/useActiveTrackWaveform";
+import { setStatusBarColorOverride } from "@/composables/useStatusBarColor";
 import { useUserPreferences } from "@/composables/userPreferences";
 import type { ContextMenuItem } from "@/helpers/context_menu_item";
 import { MarqueeTextSync } from "@/helpers/marquee_text_sync";
@@ -1322,6 +1323,13 @@ watchEffect(() => {
   const topColor = bgColor.lighten(0.25);
   const bottomColor = bgColor.darken(0.25);
   backgroundColor.value = `linear-gradient(to bottom, ${topColor.hex()}, ${bottomColor.hex()})`;
+  setStatusBarColorOverride(
+    store.showFullscreenPlayer ? topColor.hex() : undefined,
+  );
+});
+
+onBeforeUnmount(() => {
+  setStatusBarColorOverride(undefined);
 });
 </script>
 

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -25,6 +25,8 @@
 
 html {
   overflow: hidden;
+  /* iOS Safari tints the status bar from this background. Must stay set. */
+  background-color: rgb(var(--v-theme-background));
 }
 
 * {

--- a/tests/App.test.ts
+++ b/tests/App.test.ts
@@ -224,6 +224,12 @@ vi.mock("@vueuse/core", () => ({
 vi.mock("vuetify", () => ({
   useTheme: () => ({
     change: vi.fn(),
+    themes: {
+      value: {
+        light: { colors: { background: "#f5f5f5" } },
+        dark: { colors: { background: "#181818" } },
+      },
+    },
   }),
 }));
 

--- a/tests/composables/useStatusBarColor.test.ts
+++ b/tests/composables/useStatusBarColor.test.ts
@@ -1,0 +1,53 @@
+import {
+  setStatusBarColorOverride,
+  setStatusBarThemeColor,
+} from "@/composables/useStatusBarColor";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+describe("useStatusBarColor", () => {
+  let meta: HTMLMetaElement;
+
+  beforeEach(() => {
+    meta = document.createElement("meta");
+    meta.name = "theme-color";
+    document.head.appendChild(meta);
+    setStatusBarThemeColor("#181818");
+    setStatusBarColorOverride(undefined);
+  });
+
+  afterEach(() => {
+    meta.remove();
+    document.documentElement.style.removeProperty("background-color");
+  });
+
+  it("leaves the html background to the theme stylesheet without an override", () => {
+    expect(document.documentElement.style.backgroundColor).toBe("");
+    expect(meta.content).toBe("#181818");
+  });
+
+  it("paints the html background so iOS Safari tints the status bar", () => {
+    setStatusBarColorOverride("#7a2e2e");
+
+    expect(document.documentElement.style.backgroundColor).toBe("#7a2e2e");
+    expect(meta.content).toBe("#7a2e2e");
+  });
+
+  it("drops back to the theme colour when the override is cleared", () => {
+    setStatusBarColorOverride("#7a2e2e");
+    setStatusBarColorOverride(undefined);
+
+    expect(document.documentElement.style.backgroundColor).toBe("");
+    expect(meta.content).toBe("#181818");
+  });
+
+  it("keeps the override while the theme changes underneath it", () => {
+    setStatusBarColorOverride("#7a2e2e");
+    setStatusBarThemeColor("#f5f5f5");
+
+    expect(meta.content).toBe("#7a2e2e");
+
+    setStatusBarColorOverride(undefined);
+
+    expect(meta.content).toBe("#f5f5f5");
+  });
+});

--- a/tests/composables/useThemePreference.test.ts
+++ b/tests/composables/useThemePreference.test.ts
@@ -33,6 +33,12 @@ vi.mock("@vueuse/core", () => ({
 vi.mock("vuetify", () => ({
   useTheme: () => ({
     change: mocks.changeTheme,
+    themes: {
+      value: {
+        light: { colors: { background: "#f5f5f5" } },
+        dark: { colors: { background: "#181818" } },
+      },
+    },
   }),
 }));
 
@@ -49,6 +55,11 @@ describe("useThemePreference", () => {
 
   afterEach(() => {
     vi.unstubAllGlobals();
+    document.head
+      .querySelectorAll('meta[name="theme-color"]')
+      .forEach((meta) => {
+        meta.remove();
+      });
   });
 
   it("applies the regular user's preference", () => {
@@ -122,6 +133,38 @@ describe("useThemePreference", () => {
     expect(mocks.changeTheme).toHaveBeenCalledWith("dark");
     expect(mocks.colorMode.value).toBe("auto");
   });
+
+  it("matches the status bar to the resolved theme background", () => {
+    mocks.store.currentUser.preferences.theme = "light";
+    const meta = createThemeColorMeta();
+    const { applyThemePreference } = useThemePreference();
+
+    applyThemePreference();
+
+    expect(meta.content).toBe("#f5f5f5");
+  });
+
+  it("moves the status bar with the system scheme in auto mode", async () => {
+    const media = createMediaQueryMock(false);
+    stubMatchMedia(media);
+    const meta = createThemeColorMeta();
+    const { applyThemePreference } = await freshComposable();
+
+    applyThemePreference();
+    expect(meta.content).toBe("#f5f5f5");
+
+    media.matches = true;
+    media.dispatch();
+
+    expect(meta.content).toBe("#181818");
+  });
+
+  function createThemeColorMeta(): HTMLMetaElement {
+    const meta = document.createElement("meta");
+    meta.name = "theme-color";
+    document.head.appendChild(meta);
+    return meta;
+  }
 
   it("re-applies the Vuetify theme when the system scheme changes in auto mode", async () => {
     const media = createMediaQueryMock(false);

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -40,7 +40,8 @@ export default defineConfig({
         short_name: "Music Assistant",
         description:
           "Music Assistant is a free, opensource Media library manager that connects to your streaming services and a wide range of connected speakers.",
-        theme_color: "#424242",
+        theme_color: "#181818",
+        background_color: "#181818",
         icons: [
           {
             src: "pwa-192x192.png",


### PR DESCRIPTION
On iPhone the status bar was always black instead of matching the app. iOS Safari tints that area from the page background, and ours was transparent because the colour is painted by `.v-application` rather than by `html` or `body`. The `theme-color` meta tags we had were keyed on `prefers-color-scheme`, which is the system setting rather than the app's own theme preference, and iOS ignores them anyway.

- Set `html` background to the Vuetify theme background, so the bar follows light, dark and auto
- Add `useStatusBarColor`, keeping the `html` background and the `theme-color` meta in sync, since iOS reads the first and Android Chrome the second
- Let the now playing screen override the bar with the top colour of its artwork gradient, cleared on close
- Replace the two `prefers-color-scheme` `theme-color` metas with one that tracks the active theme
- Point the manifest `theme_color` and `background_color` at the dark theme background instead of `#424242` and `#ffffff`

Verified on iPhone: normal screens match the theme background, the now playing screen matches the artwork, and going back no longer leaves the bar black.