### PR TITLE
Keep the test fixtures' item ids and uris in sync

### DIFF
--- a/tests/composables/smart_playlist/useSmartPlaylistGenres.test.ts
+++ b/tests/composables/smart_playlist/useSmartPlaylistGenres.test.ts
@@ -58,5 +58,5 @@ describe("useSmartPlaylistGenres", () => {
 });
 
 function genreFixture(item_id: string, name: string): Genre {
-  return genre({ item_id, name, uri: `library://genre/${item_id}` });
+  return genre({ item_id, name });
 }

--- a/tests/composables/useGuestArtistTracks.test.ts
+++ b/tests/composables/useGuestArtistTracks.test.ts
@@ -139,7 +139,6 @@ function artistFixture(itemId: string, name = itemId): Artist {
   return artist({
     item_id: itemId,
     name,
-    uri: `library://artist/${itemId}`,
   });
 }
 
@@ -147,6 +146,5 @@ function trackFixture(itemId: string): Track {
   return track({
     item_id: itemId,
     name: itemId,
-    uri: `library://track/${itemId}`,
   });
 }

--- a/tests/composables/useProgressiveSearch.test.ts
+++ b/tests/composables/useProgressiveSearch.test.ts
@@ -61,11 +61,10 @@ const trackFixture = (
     item_id: itemId,
     provider,
     name,
-    uri: `test://track/${itemId}`,
   });
 
 const genreFixture = (itemId: string, name: string): Genre =>
-  genre({ item_id: itemId, name, uri: `test://genre/${itemId}` });
+  genre({ item_id: itemId, name });
 
 const provider = (
   instanceId: string,

--- a/tests/fixtures/album.ts
+++ b/tests/fixtures/album.ts
@@ -1,16 +1,16 @@
 import { type Album, AlbumType, MediaType } from "@/plugins/api/interfaces";
+import { withUri } from "./mediaItem";
 
 /**
  * A complete album, for tests that only care about a few of its fields but
  * should still model a payload the server can send.
  */
 export function album(overrides: Partial<Album> = {}): Album {
-  return {
+  return withUri<Omit<Album, "uri">>({
     item_id: "1",
     provider: "library",
     name: "Album",
     version: "",
-    uri: "library://album/1",
     external_ids: [],
     is_playable: true,
     media_type: MediaType.ALBUM,
@@ -20,5 +20,5 @@ export function album(overrides: Partial<Album> = {}): Album {
     album_type: AlbumType.ALBUM,
     artists: [],
     ...overrides,
-  };
+  });
 }

--- a/tests/fixtures/artist.ts
+++ b/tests/fixtures/artist.ts
@@ -1,16 +1,16 @@
 import { type Artist, ArtistType, MediaType } from "@/plugins/api/interfaces";
+import { withUri } from "./mediaItem";
 
 /**
  * A complete artist, for tests that only care about a few of its fields but
  * should still model a payload the server can send.
  */
 export function artist(overrides: Partial<Artist> = {}): Artist {
-  return {
+  return withUri<Omit<Artist, "uri">>({
     item_id: "1",
     provider: "library",
     name: "Artist",
     version: "",
-    uri: "library://artist/1",
     external_ids: [],
     is_playable: true,
     media_type: MediaType.ARTIST,
@@ -19,5 +19,5 @@ export function artist(overrides: Partial<Artist> = {}): Artist {
     favorite: false,
     artist_type: ArtistType.SINGER,
     ...overrides,
-  };
+  });
 }

--- a/tests/fixtures/genre.ts
+++ b/tests/fixtures/genre.ts
@@ -1,16 +1,16 @@
 import { type Genre, MediaType } from "@/plugins/api/interfaces";
+import { withUri } from "./mediaItem";
 
 /**
  * A complete genre, for tests that only care about a few of its fields but
  * should still model a payload the server can send.
  */
 export function genre(overrides: Partial<Genre> = {}): Genre {
-  return {
+  return withUri<Omit<Genre, "uri">>({
     item_id: "1",
     provider: "library",
     name: "Genre",
     version: "",
-    uri: "library://genre/1",
     external_ids: [],
     is_playable: false,
     media_type: MediaType.GENRE,
@@ -19,5 +19,5 @@ export function genre(overrides: Partial<Genre> = {}): Genre {
     favorite: false,
     genre_aliases: null,
     ...overrides,
-  };
+  });
 }

--- a/tests/fixtures/mediaItem.ts
+++ b/tests/fixtures/mediaItem.ts
@@ -1,0 +1,14 @@
+import type { MediaItem } from "@/plugins/api/interfaces";
+
+/**
+ * Returns the item with the uri the server derives from its provider, media
+ * type and item id, unless the caller supplied a uri of their own.
+ */
+export function withUri<T extends Omit<MediaItem, "uri">>(
+  item: T & { uri?: string },
+): T & { uri: string } {
+  return {
+    ...item,
+    uri: item.uri ?? `${item.provider}://${item.media_type}/${item.item_id}`,
+  };
+}

--- a/tests/fixtures/playlist.ts
+++ b/tests/fixtures/playlist.ts
@@ -1,16 +1,16 @@
 import { MediaType, type Playlist } from "@/plugins/api/interfaces";
+import { withUri } from "./mediaItem";
 
 /**
  * A complete playlist, for tests that only care about a few of its fields but
  * should still model a payload the server can send.
  */
 export function playlist(overrides: Partial<Playlist> = {}): Playlist {
-  return {
+  return withUri<Omit<Playlist, "uri">>({
     item_id: "1",
     provider: "library",
     name: "Playlist",
     version: "",
-    uri: "library://playlist/1",
     external_ids: [],
     is_playable: true,
     media_type: MediaType.PLAYLIST,
@@ -22,5 +22,5 @@ export function playlist(overrides: Partial<Playlist> = {}): Playlist {
     supported_mediatypes: [MediaType.TRACK],
     is_dynamic: false,
     ...overrides,
-  };
+  });
 }

--- a/tests/fixtures/podcast.ts
+++ b/tests/fixtures/podcast.ts
@@ -1,16 +1,16 @@
 import { MediaType, type Podcast } from "@/plugins/api/interfaces";
+import { withUri } from "./mediaItem";
 
 /**
  * A complete podcast, for tests that only care about a few of its fields but
  * should still model a payload the server can send.
  */
 export function podcast(overrides: Partial<Podcast> = {}): Podcast {
-  return {
+  return withUri<Omit<Podcast, "uri">>({
     item_id: "1",
     provider: "library",
     name: "Podcast",
     version: "",
-    uri: "library://podcast/1",
     external_ids: [],
     is_playable: true,
     media_type: MediaType.PODCAST,
@@ -20,5 +20,5 @@ export function podcast(overrides: Partial<Podcast> = {}): Podcast {
     publisher: null,
     total_episodes: null,
     ...overrides,
-  };
+  });
 }

--- a/tests/fixtures/radio.ts
+++ b/tests/fixtures/radio.ts
@@ -1,16 +1,16 @@
 import { MediaType, type Radio } from "@/plugins/api/interfaces";
+import { withUri } from "./mediaItem";
 
 /**
  * A complete radio station, for tests that only care about a few of its fields
  * but should still model a payload the server can send.
  */
 export function radio(overrides: Partial<Radio> = {}): Radio {
-  return {
+  return withUri<Omit<Radio, "uri">>({
     item_id: "1",
     provider: "library",
     name: "Radio",
     version: "",
-    uri: "library://radio/1",
     external_ids: [],
     is_playable: true,
     media_type: MediaType.RADIO,
@@ -18,5 +18,5 @@ export function radio(overrides: Partial<Radio> = {}): Radio {
     metadata: {},
     favorite: false,
     ...overrides,
-  };
+  });
 }

--- a/tests/fixtures/track.ts
+++ b/tests/fixtures/track.ts
@@ -1,16 +1,16 @@
 import { MediaType, type Track } from "@/plugins/api/interfaces";
+import { withUri } from "./mediaItem";
 
 /**
  * A complete track, for tests that only care about a few of its fields but
  * should still model a payload the server can send.
  */
 export function track(overrides: Partial<Track> = {}): Track {
-  return {
+  return withUri<Omit<Track, "uri">>({
     item_id: "1",
     provider: "library",
     name: "Track",
     version: "",
-    uri: "library://track/1",
     external_ids: [],
     is_playable: true,
     media_type: MediaType.TRACK,
@@ -23,5 +23,5 @@ export function track(overrides: Partial<Track> = {}): Track {
     disc_number: 0,
     track_number: 0,
     ...overrides,
-  };
+  });
 }

--- a/tests/helpers/playBtnErrorFeedback.test.ts
+++ b/tests/helpers/playBtnErrorFeedback.test.ts
@@ -66,13 +66,11 @@ import { track } from "../fixtures/track";
 
 const playedTrack = track({
   item_id: "track1",
-  uri: "library://track/track1",
   name: "Track 1",
 });
 
 const parentPlaylist = playlist({
   item_id: "pl1",
-  uri: "library://playlist/pl1",
   name: "Playlist 1",
 });
 

--- a/tests/helpers/playFromHereSort.test.ts
+++ b/tests/helpers/playFromHereSort.test.ts
@@ -77,17 +77,15 @@ import { playlist } from "../fixtures/playlist";
 import { track } from "../fixtures/track";
 
 const makePlaylistTrack = (id: string) =>
-  track({ item_id: id, uri: `library://track/${id}`, name: `Track ${id}` });
+  track({ item_id: id, name: `Track ${id}` });
 
 const makePlaylist = (id: string) =>
   playlist({
     item_id: id,
-    uri: `library://playlist/${id}`,
     name: `Playlist ${id}`,
   });
 
-const makeAlbum = (id: string) =>
-  album({ item_id: id, uri: `library://album/${id}`, name: `Album ${id}` });
+const makeAlbum = (id: string) => album({ item_id: id, name: `Album ${id}` });
 
 beforeEach(() => {
   mockPlayMedia.mockReset();


### PR DESCRIPTION
The shared media item test fixtures hardcoded both an `item_id` and a matching `uri`, so a test that only overrode `item_id` silently got a mismatched pair (`item_id: "a1"` with `uri: "library://artist/1"`) - which is not something the server would ever send. Several test files worked around this with their own little helpers that re-built the uri by hand.

The fixtures now fill in the uri the same way the server does (`{provider}://{media_type}/{item_id}`, see `create_uri` in the models), unless a test passes a uri itself. Tests that need a provider specific uri (podcast feeds, radio streams) keep working exactly as before.

Changes:
- Added a small `withUri` fixture helper that derives the uri from provider, media type and item id
- Applied it to the artist, album, track, playlist, genre, podcast and radio fixtures
- Dropped the hand written uri lines from the test helpers that only existed to keep the two in sync

A few tests that were not touched here also get a corrected uri as a result, for example a spotify track fixture that used to carry `library://track/1`. Nothing reads those uris, so behaviour is unchanged.
