### PR TITLE
Use the shared media item fixtures in the smart playlist seed tests

### DIFF
--- a/tests/composables/smart_playlist/useSmartPlaylistSeedItems.test.ts
+++ b/tests/composables/smart_playlist/useSmartPlaylistSeedItems.test.ts
@@ -74,7 +74,6 @@ describe("useSmartPlaylistSeedItems", () => {
 
     const added = seed.addSeedFromSearch(
       track({
-        item_id: "fallback-track-id",
         provider_mappings: [
           providerMapping({
             item_id: "lib-1",
@@ -87,7 +86,7 @@ describe("useSmartPlaylistSeedItems", () => {
             provider_domain: "spotify",
           }),
         ],
-        artists: [artist()],
+        artists: [artist({ name: "Artist" })],
         name: "Song",
       }),
       "track",

--- a/tests/composables/smart_playlist/useSmartPlaylistSeedItems.test.ts
+++ b/tests/composables/smart_playlist/useSmartPlaylistSeedItems.test.ts
@@ -45,7 +45,8 @@ vi.mock("@/plugins/api", () => ({
 import api from "@/plugins/api";
 import type { MusicAssistantApi } from "@/plugins/api";
 import { useSmartPlaylistSeedItems } from "@/composables/smart-playlist/useSmartPlaylistSeedItems";
-import type { Album, Track } from "@/plugins/api/interfaces";
+import { album } from "../../fixtures/album";
+import { artist } from "../../fixtures/artist";
 import { providerMapping } from "../../fixtures/providerMapping";
 import { track } from "../../fixtures/track";
 
@@ -69,10 +70,10 @@ describe("useSmartPlaylistSeedItems", () => {
     const seed = useSmartPlaylistSeedItems();
 
     seed.trackSearch.value = "query";
-    seed.trackResults.value = [{ item_id: "x" } as unknown as Track];
+    seed.trackResults.value = [track()];
 
     const added = seed.addSeedFromSearch(
-      {
+      track({
         item_id: "fallback-track-id",
         provider_mappings: [
           providerMapping({
@@ -86,9 +87,9 @@ describe("useSmartPlaylistSeedItems", () => {
             provider_domain: "spotify",
           }),
         ],
-        artists: [{ name: "Artist" }],
+        artists: [artist()],
         name: "Song",
-      } as unknown as Track,
+      }),
       "track",
     );
 
@@ -109,7 +110,7 @@ describe("useSmartPlaylistSeedItems", () => {
     const seed = useSmartPlaylistSeedItems();
 
     const added = seed.addSeedFromSearch(
-      {
+      album({
         item_id: "62",
         provider_mappings: [
           providerMapping({
@@ -118,9 +119,9 @@ describe("useSmartPlaylistSeedItems", () => {
             provider_domain: "tidal",
           }),
         ],
-        artists: [{ name: "RAM" }],
+        artists: [artist({ name: "RAM" })],
         name: "One Last Call",
-      } as unknown as Album,
+      }),
       "album",
     );
 

--- a/tests/composables/smart_playlist/useSmartPlaylistSeedItems.test.ts
+++ b/tests/composables/smart_playlist/useSmartPlaylistSeedItems.test.ts
@@ -111,6 +111,7 @@ describe("useSmartPlaylistSeedItems", () => {
     const added = seed.addSeedFromSearch(
       album({
         item_id: "62",
+        uri: "library://album/62",
         provider_mappings: [
           providerMapping({
             item_id: "tidal-album",


### PR DESCRIPTION
The smart playlist seed tests were the last ones still building media items as
partial object literals cast with `as unknown as`, which lets them drift from
what the server actually sends. They now use the shared fixtures like the rest
of the test suite.

- Build the seed track and album with the shared `track()`, `album()` and `artist()` fixtures
- Drop the `as unknown as Track` / `as unknown as Album` casts and the now unused type imports
- Keep only the field overrides the assertions depend on
