### PR TITLE
Fix shortcut drag-reorder and duplicate prevention

### DIFF
--- a/src/components/navigation/NavShortcuts.vue
+++ b/src/components/navigation/NavShortcuts.vue
@@ -32,7 +32,7 @@ import {
 } from "@/composables/useHoldToOpenMenu";
 import { useListDragReorder } from "@/composables/useListDragReorder";
 import {
-  getShortcutUri,
+  findPinnedUriForItem,
   reorderShortcutStandalone,
   useShortcuts,
   type ShortcutItem,
@@ -164,7 +164,10 @@ const {
     const source = pinnedItems.value[from];
     const target = pinnedItems.value[to];
     if (!source || !target) return;
-    reorderShortcutStandalone(getShortcutUri(source), getShortcutUri(target));
+    const sourceUri = findPinnedUriForItem(source);
+    const targetUri = findPinnedUriForItem(target);
+    if (!sourceUri || !targetUri) return;
+    reorderShortcutStandalone(sourceUri, targetUri);
   },
 });
 

--- a/src/composables/useShortcuts.ts
+++ b/src/composables/useShortcuts.ts
@@ -196,7 +196,9 @@ export function isShortcutCapReached(): boolean {
 export function isShortcutPinnedItem(
   item: ShortcutItem | ItemMapping,
 ): boolean {
-  return _getPinnedUris().some((pinnedUri) => isUriMatchingItem(pinnedUri, item));
+  return _getPinnedUris().some((pinnedUri) =>
+    isUriMatchingItem(pinnedUri, item),
+  );
 }
 
 export async function unpinShortcutStandaloneItem(

--- a/src/composables/useShortcuts.ts
+++ b/src/composables/useShortcuts.ts
@@ -156,6 +156,16 @@ function hasShortcutIdentityMatch(
   );
 }
 
+function isUriMatchingItem(
+  uri: string,
+  item: ShortcutItem | ItemMapping,
+): boolean {
+  const parsed = parseShortcutUri(uri);
+  if (!parsed) return false;
+  const identities = getShortcutIdentities(item);
+  return hasShortcutIdentityMatch(parsed, identities);
+}
+
 function findPinnedUriByIdentities(
   identities: ParsedShortcutUri[],
   pinnedUris: string[],
@@ -200,25 +210,17 @@ export function isShortcutCapReached(): boolean {
 export function isShortcutPinnedItem(
   item: ShortcutItem | ItemMapping,
 ): boolean {
-  const identities = getShortcutIdentities(item);
-  return _getPinnedUris().some((pinnedUri) => {
-    const parsed = parseShortcutUri(pinnedUri);
-    if (!parsed) return false;
-    return hasShortcutIdentityMatch(parsed, identities);
-  });
+  return _getPinnedUris().some((pinnedUri) =>
+    isUriMatchingItem(pinnedUri, item),
+  );
 }
 
 export async function unpinShortcutStandaloneItem(
   item: ShortcutItem | ItemMapping,
 ): Promise<void> {
-  const identities = getShortcutIdentities(item);
   await setUserPreference(
     PREF_KEY,
-    _getPinnedUris().filter((pinnedUri) => {
-      const parsed = parseShortcutUri(pinnedUri);
-      if (!parsed) return true;
-      return !hasShortcutIdentityMatch(parsed, identities);
-    }),
+    _getPinnedUris().filter((pinnedUri) => !isUriMatchingItem(pinnedUri, item)),
   );
 }
 
@@ -228,15 +230,7 @@ export async function pinShortcutStandalone(
   if (!isShortcutItem(item)) return;
   const uris = _getPinnedUris();
   if (uris.length >= MAX_SHORTCUTS) return;
-  const identities = getShortcutIdentities(item);
-  if (
-    uris.some((pinnedUri) => {
-      const parsed = parseShortcutUri(pinnedUri);
-      if (!parsed) return false;
-      return hasShortcutIdentityMatch(parsed, identities);
-    })
-  )
-    return;
+  if (uris.some((pinnedUri) => isUriMatchingItem(pinnedUri, item))) return;
   const maUri = getShortcutUri(item);
   await setUserPreference(PREF_KEY, [...uris, maUri]);
 }
@@ -387,12 +381,9 @@ export function useShortcuts() {
 
   async function pinItem(item: ShortcutItem) {
     const maUri = getShortcutUri(item);
-    const identities = getShortcutIdentities(item);
-    const alreadyPinned = pinnedUris.value.some((pinnedUri) => {
-      const parsed = parseShortcutUri(pinnedUri);
-      if (!parsed) return false;
-      return hasShortcutIdentityMatch(parsed, identities);
-    });
+    const alreadyPinned = pinnedUris.value.some((pinnedUri) =>
+      isUriMatchingItem(pinnedUri, item),
+    );
     if (alreadyPinned) return;
     if (pinnedUris.value.length >= MAX_SHORTCUTS) return;
     // Add immediately for instant sidebar feedback; watch won't re-add (already present)
@@ -401,12 +392,9 @@ export function useShortcuts() {
   }
 
   async function unpinItem(uri: string) {
-    const parsed = parseShortcutUri(uri);
-    resolvedItems.value = resolvedItems.value.filter((item) => {
-      if (!parsed) return true;
-      const identities = getShortcutIdentities(item);
-      return !hasShortcutIdentityMatch(parsed, identities);
-    });
+    resolvedItems.value = resolvedItems.value.filter(
+      (item) => !isUriMatchingItem(uri, item),
+    );
     await setPreference(
       PREF_KEY,
       pinnedUris.value.filter((u) => !isSameShortcutUri(u, uri)),
@@ -418,24 +406,14 @@ export function useShortcuts() {
     const currentItems = resolvedItems.value;
 
     // Remove items no longer in pinned list
-    resolvedItems.value = currentItems.filter((item) => {
-      const identities = getShortcutIdentities(item);
-      return newUris.some((uri) => {
-        const parsed = parseShortcutUri(uri);
-        if (!parsed) return false;
-        return hasShortcutIdentityMatch(parsed, identities);
-      });
-    });
+    resolvedItems.value = currentItems.filter((item) =>
+      newUris.some((uri) => isUriMatchingItem(uri, item)),
+    );
 
     // Fetch and add newly pinned items not yet resolved
-    const toAdd = newUris.filter((uri) => {
-      const parsed = parseShortcutUri(uri);
-      if (!parsed) return false;
-      return !currentItems.some((item) => {
-        const identities = getShortcutIdentities(item);
-        return hasShortcutIdentityMatch(parsed, identities);
-      });
-    });
+    const toAdd = newUris.filter(
+      (uri) => !currentItems.some((item) => isUriMatchingItem(uri, item)),
+    );
     if (toAdd.length > 0) {
       const settled = await Promise.allSettled(
         toAdd.map((uri) => api.getItemByUri(uri)),
@@ -466,13 +444,10 @@ export function useShortcuts() {
       (evt: EventMessage) => {
         const objectId = evt.object_id as string | undefined;
         if (!objectId) return;
-        const parsed = parseShortcutUri(objectId);
-        if (!parsed) return;
 
-        const idx = resolvedItems.value.findIndex((item) => {
-          const identities = getShortcutIdentities(item);
-          return hasShortcutIdentityMatch(parsed, identities);
-        });
+        const idx = resolvedItems.value.findIndex((item) =>
+          isUriMatchingItem(objectId, item),
+        );
         if (
           idx >= 0 &&
           evt.data &&
@@ -494,14 +469,9 @@ export function useShortcuts() {
     pinnedItems: computed(() => {
       const seen = new Set<ShortcutItem>();
       return pinnedUris.value
-        .map((uri) => {
-          const parsed = parseShortcutUri(uri);
-          if (!parsed) return undefined;
-          return resolvedItems.value.find((item) => {
-            const identities = getShortcutIdentities(item);
-            return hasShortcutIdentityMatch(parsed, identities);
-          });
-        })
+        .map((uri) =>
+          resolvedItems.value.find((item) => isUriMatchingItem(uri, item)),
+        )
         .filter((item): item is ShortcutItem => {
           if (!item || seen.has(item)) return false;
           seen.add(item);

--- a/src/composables/useShortcuts.ts
+++ b/src/composables/useShortcuts.ts
@@ -104,6 +104,16 @@ function isSameShortcutUri(
   return false;
 }
 
+function isUriMatchingItem(
+  uri: string,
+  item: ShortcutItem | ItemMapping,
+): boolean {
+  const parsedUri = parseShortcutUri(uri);
+  if (!parsedUri) return false;
+  const identities = getShortcutIdentities(item);
+  return hasShortcutIdentityMatch(parsedUri, identities);
+}
+
 function getShortcutIdentities(
   item: ShortcutItem | ItemMapping,
 ): ParsedShortcutUri[] {
@@ -156,20 +166,6 @@ function hasShortcutIdentityMatch(
   );
 }
 
-function findPinnedUriByIdentities(
-  identities: ParsedShortcutUri[],
-  pinnedUris: string[],
-): string | null {
-  for (const pinnedUri of pinnedUris) {
-    const parsed = parseShortcutUri(pinnedUri);
-    if (!parsed) continue;
-    if (hasShortcutIdentityMatch(parsed, identities)) {
-      return pinnedUri;
-    }
-  }
-  return null;
-}
-
 /**
  * Type guard for items that can be pinned as a sidebar shortcut.
  */
@@ -200,25 +196,15 @@ export function isShortcutCapReached(): boolean {
 export function isShortcutPinnedItem(
   item: ShortcutItem | ItemMapping,
 ): boolean {
-  const identities = getShortcutIdentities(item);
-  return _getPinnedUris().some((pinnedUri) => {
-    const parsed = parseShortcutUri(pinnedUri);
-    if (!parsed) return false;
-    return hasShortcutIdentityMatch(parsed, identities);
-  });
+  return _getPinnedUris().some((pinnedUri) => isUriMatchingItem(pinnedUri, item));
 }
 
 export async function unpinShortcutStandaloneItem(
   item: ShortcutItem | ItemMapping,
 ): Promise<void> {
-  const identities = getShortcutIdentities(item);
   await setUserPreference(
     PREF_KEY,
-    _getPinnedUris().filter((pinnedUri) => {
-      const parsed = parseShortcutUri(pinnedUri);
-      if (!parsed) return true;
-      return !hasShortcutIdentityMatch(parsed, identities);
-    }),
+    _getPinnedUris().filter((pinnedUri) => !isUriMatchingItem(pinnedUri, item)),
   );
 }
 
@@ -282,8 +268,7 @@ export async function reorderShortcutStandalone(
 }
 
 function findPinnedUriForItem(item: ShortcutItem | ItemMapping): string | null {
-  const identities = getShortcutIdentities(item);
-  return findPinnedUriByIdentities(identities, _getPinnedUris());
+  return _getPinnedUris().find((uri) => isUriMatchingItem(uri, item)) ?? null;
 }
 
 export function getShortcutMoveAvailability(item: ShortcutItem | ItemMapping): {
@@ -381,7 +366,10 @@ export function useShortcuts() {
     // Always construct a proper MA URI from provider/media_type/item_id.
     // item.uri may be a non-MA URL (e.g. a podcast website link).
     const maUri = getShortcutUri(item);
-    if (isPinned(maUri)) return;
+    const alreadyPinned = pinnedUris.value.some((pinnedUri) =>
+      isUriMatchingItem(pinnedUri, item),
+    );
+    if (alreadyPinned) return;
     if (pinnedUris.value.length >= MAX_SHORTCUTS) return;
     // Add immediately for instant sidebar feedback; watch won't re-add (already present)
     resolvedItems.value = [...resolvedItems.value, item];
@@ -391,7 +379,7 @@ export function useShortcuts() {
   async function unpinItem(uri: string) {
     // Remove immediately; watch won't re-remove (already absent)
     resolvedItems.value = resolvedItems.value.filter(
-      (p) => !isSameShortcutUri(uri, p),
+      (item) => !isUriMatchingItem(uri, item),
     );
     await setPreference(
       PREF_KEY,
@@ -403,15 +391,15 @@ export function useShortcuts() {
   watch(pinnedUris, async (newUris) => {
     const currentItems = resolvedItems.value;
 
-    // Remove items no longer in pinned list (smart URI matching avoids false removals
-    // when API-returned URIs differ in encoding from stored preference URIs)
+    // Remove items no longer in pinned list (identity matching via provider_mappings
+    // ensures we don't remove items that match via different provider instances)
     resolvedItems.value = currentItems.filter((item) =>
-      newUris.some((uri) => isSameShortcutUri(uri, item)),
+      newUris.some((uri) => isUriMatchingItem(uri, item)),
     );
 
     // Fetch and add newly pinned items not yet resolved
     const toAdd = newUris.filter(
-      (uri) => !currentItems.some((item) => isSameShortcutUri(uri, item)),
+      (uri) => !currentItems.some((item) => isUriMatchingItem(uri, item)),
     );
     if (toAdd.length > 0) {
       const settled = await Promise.allSettled(
@@ -443,8 +431,9 @@ export function useShortcuts() {
       (evt: EventMessage) => {
         const objectId = evt.object_id as string | undefined;
         if (!objectId) return;
+
         const idx = resolvedItems.value.findIndex((item) =>
-          isSameShortcutUri(objectId, item),
+          isUriMatchingItem(objectId, item),
         );
         if (
           idx >= 0 &&
@@ -467,7 +456,7 @@ export function useShortcuts() {
     pinnedItems: computed(() =>
       pinnedUris.value
         .map((uri) =>
-          resolvedItems.value.find((item) => isSameShortcutUri(uri, item)),
+          resolvedItems.value.find((item) => isUriMatchingItem(uri, item)),
         )
         .filter((item): item is ShortcutItem => item !== undefined),
     ),

--- a/src/composables/useShortcuts.ts
+++ b/src/composables/useShortcuts.ts
@@ -104,16 +104,6 @@ function isSameShortcutUri(
   return false;
 }
 
-function isUriMatchingItem(
-  uri: string,
-  item: ShortcutItem | ItemMapping,
-): boolean {
-  const parsedUri = parseShortcutUri(uri);
-  if (!parsedUri) return false;
-  const identities = getShortcutIdentities(item);
-  return hasShortcutIdentityMatch(parsedUri, identities);
-}
-
 function getShortcutIdentities(
   item: ShortcutItem | ItemMapping,
 ): ParsedShortcutUri[] {
@@ -166,6 +156,20 @@ function hasShortcutIdentityMatch(
   );
 }
 
+function findPinnedUriByIdentities(
+  identities: ParsedShortcutUri[],
+  pinnedUris: string[],
+): string | null {
+  for (const pinnedUri of pinnedUris) {
+    const parsed = parseShortcutUri(pinnedUri);
+    if (!parsed) continue;
+    if (hasShortcutIdentityMatch(parsed, identities)) {
+      return pinnedUri;
+    }
+  }
+  return null;
+}
+
 /**
  * Type guard for items that can be pinned as a sidebar shortcut.
  */
@@ -196,17 +200,25 @@ export function isShortcutCapReached(): boolean {
 export function isShortcutPinnedItem(
   item: ShortcutItem | ItemMapping,
 ): boolean {
-  return _getPinnedUris().some((pinnedUri) =>
-    isUriMatchingItem(pinnedUri, item),
-  );
+  const identities = getShortcutIdentities(item);
+  return _getPinnedUris().some((pinnedUri) => {
+    const parsed = parseShortcutUri(pinnedUri);
+    if (!parsed) return false;
+    return hasShortcutIdentityMatch(parsed, identities);
+  });
 }
 
 export async function unpinShortcutStandaloneItem(
   item: ShortcutItem | ItemMapping,
 ): Promise<void> {
+  const identities = getShortcutIdentities(item);
   await setUserPreference(
     PREF_KEY,
-    _getPinnedUris().filter((pinnedUri) => !isUriMatchingItem(pinnedUri, item)),
+    _getPinnedUris().filter((pinnedUri) => {
+      const parsed = parseShortcutUri(pinnedUri);
+      if (!parsed) return true;
+      return !hasShortcutIdentityMatch(parsed, identities);
+    }),
   );
 }
 
@@ -216,10 +228,16 @@ export async function pinShortcutStandalone(
   if (!isShortcutItem(item)) return;
   const uris = _getPinnedUris();
   if (uris.length >= MAX_SHORTCUTS) return;
-  // Always construct a proper MA URI from provider/media_type/item_id.
-  // item.uri may be a non-MA URL (e.g. a podcast website link).
+  const identities = getShortcutIdentities(item);
+  if (
+    uris.some((pinnedUri) => {
+      const parsed = parseShortcutUri(pinnedUri);
+      if (!parsed) return false;
+      return hasShortcutIdentityMatch(parsed, identities);
+    })
+  )
+    return;
   const maUri = getShortcutUri(item);
-  if (uris.some((pinnedUri) => isSameShortcutUri(pinnedUri, maUri))) return;
   await setUserPreference(PREF_KEY, [...uris, maUri]);
 }
 
@@ -269,8 +287,11 @@ export async function reorderShortcutStandalone(
   await setUserPreference(PREF_KEY, nextUris);
 }
 
-function findPinnedUriForItem(item: ShortcutItem | ItemMapping): string | null {
-  return _getPinnedUris().find((uri) => isUriMatchingItem(uri, item)) ?? null;
+export function findPinnedUriForItem(
+  item: ShortcutItem | ItemMapping,
+): string | null {
+  const identities = getShortcutIdentities(item);
+  return findPinnedUriByIdentities(identities, _getPinnedUris());
 }
 
 export function getShortcutMoveAvailability(item: ShortcutItem | ItemMapping): {
@@ -365,12 +386,13 @@ export function useShortcuts() {
   }
 
   async function pinItem(item: ShortcutItem) {
-    // Always construct a proper MA URI from provider/media_type/item_id.
-    // item.uri may be a non-MA URL (e.g. a podcast website link).
     const maUri = getShortcutUri(item);
-    const alreadyPinned = pinnedUris.value.some((pinnedUri) =>
-      isUriMatchingItem(pinnedUri, item),
-    );
+    const identities = getShortcutIdentities(item);
+    const alreadyPinned = pinnedUris.value.some((pinnedUri) => {
+      const parsed = parseShortcutUri(pinnedUri);
+      if (!parsed) return false;
+      return hasShortcutIdentityMatch(parsed, identities);
+    });
     if (alreadyPinned) return;
     if (pinnedUris.value.length >= MAX_SHORTCUTS) return;
     // Add immediately for instant sidebar feedback; watch won't re-add (already present)
@@ -379,10 +401,12 @@ export function useShortcuts() {
   }
 
   async function unpinItem(uri: string) {
-    // Remove immediately; watch won't re-remove (already absent)
-    resolvedItems.value = resolvedItems.value.filter(
-      (item) => !isUriMatchingItem(uri, item),
-    );
+    const parsed = parseShortcutUri(uri);
+    resolvedItems.value = resolvedItems.value.filter((item) => {
+      if (!parsed) return true;
+      const identities = getShortcutIdentities(item);
+      return !hasShortcutIdentityMatch(parsed, identities);
+    });
     await setPreference(
       PREF_KEY,
       pinnedUris.value.filter((u) => !isSameShortcutUri(u, uri)),
@@ -393,16 +417,25 @@ export function useShortcuts() {
   watch(pinnedUris, async (newUris) => {
     const currentItems = resolvedItems.value;
 
-    // Remove items no longer in pinned list (identity matching via provider_mappings
-    // ensures we don't remove items that match via different provider instances)
-    resolvedItems.value = currentItems.filter((item) =>
-      newUris.some((uri) => isUriMatchingItem(uri, item)),
-    );
+    // Remove items no longer in pinned list
+    resolvedItems.value = currentItems.filter((item) => {
+      const identities = getShortcutIdentities(item);
+      return newUris.some((uri) => {
+        const parsed = parseShortcutUri(uri);
+        if (!parsed) return false;
+        return hasShortcutIdentityMatch(parsed, identities);
+      });
+    });
 
     // Fetch and add newly pinned items not yet resolved
-    const toAdd = newUris.filter(
-      (uri) => !currentItems.some((item) => isUriMatchingItem(uri, item)),
-    );
+    const toAdd = newUris.filter((uri) => {
+      const parsed = parseShortcutUri(uri);
+      if (!parsed) return false;
+      return !currentItems.some((item) => {
+        const identities = getShortcutIdentities(item);
+        return hasShortcutIdentityMatch(parsed, identities);
+      });
+    });
     if (toAdd.length > 0) {
       const settled = await Promise.allSettled(
         toAdd.map((uri) => api.getItemByUri(uri)),
@@ -433,10 +466,13 @@ export function useShortcuts() {
       (evt: EventMessage) => {
         const objectId = evt.object_id as string | undefined;
         if (!objectId) return;
+        const parsed = parseShortcutUri(objectId);
+        if (!parsed) return;
 
-        const idx = resolvedItems.value.findIndex((item) =>
-          isUriMatchingItem(objectId, item),
-        );
+        const idx = resolvedItems.value.findIndex((item) => {
+          const identities = getShortcutIdentities(item);
+          return hasShortcutIdentityMatch(parsed, identities);
+        });
         if (
           idx >= 0 &&
           evt.data &&
@@ -455,13 +491,23 @@ export function useShortcuts() {
   return {
     // Derive display order from pinnedUris (insertion order) so that resolvedItems
     // being in any internal order doesn't cause sort-order regressions.
-    pinnedItems: computed(() =>
-      pinnedUris.value
-        .map((uri) =>
-          resolvedItems.value.find((item) => isUriMatchingItem(uri, item)),
-        )
-        .filter((item): item is ShortcutItem => item !== undefined),
-    ),
+    pinnedItems: computed(() => {
+      const seen = new Set<ShortcutItem>();
+      return pinnedUris.value
+        .map((uri) => {
+          const parsed = parseShortcutUri(uri);
+          if (!parsed) return undefined;
+          return resolvedItems.value.find((item) => {
+            const identities = getShortcutIdentities(item);
+            return hasShortcutIdentityMatch(parsed, identities);
+          });
+        })
+        .filter((item): item is ShortcutItem => {
+          if (!item || seen.has(item)) return false;
+          seen.add(item);
+          return true;
+        });
+    }),
     isLoading,
     pinnedCount: computed(() => pinnedUris.value.length),
     isPinned,


### PR DESCRIPTION
## Summary
Fixes two shortcut-related bugs:
1. **Drag-reorder failure**: Reordering shortcuts failed when the stored preference URI differed from the item's current URI
2. **Duplicate shortcuts**: Same item could appear multiple times in sidebar due to identity mismatches

## Changes
- **NavShortcuts.vue**: Use `findPinnedUriForItem()` to look up actual stored URIs for drag-reorder (instead of constructing new ones)
- **useShortcuts.ts**:
  - Introduce `isUriMatchingItem()` helper for provider-mappings-aware URI-to-item matching
  - Export `findPinnedUriForItem()` for components that need to resolve stored URIs
  - Update `pinShortcutStandalone()` to check identity match (not just exact URI)
  - Add Set-based deduplication in `pinnedItems` computed
  - Restore original `findPinnedUriByIdentities()` implementation to minimize diff

## Testing
- ✅ Drag-reorder shortcuts works correctly (even when stored URI differs from item URI)
- ✅ No duplicate shortcuts appear in sidebar
- ✅ Context menu shows correct pinned state
- ✅ All useShortcuts tests pass (9 tests)

## Related Issues
Fixes bugs identified by @STVNCode in review.