### PR TITLE
Share a player queue test fixture

### DIFF
--- a/tests/components/QualityDetailsBtn.test.ts
+++ b/tests/components/QualityDetailsBtn.test.ts
@@ -6,7 +6,6 @@ import {
   AudioQuality,
   PlaybackState,
   type PlayerQueue,
-  RepeatMode,
   type StreamDetails,
 } from "@/plugins/api/interfaces";
 import { i18n } from "@/plugins/i18n";
@@ -15,6 +14,7 @@ import {
   audioOutputDetails,
   audioProcessingChain,
 } from "../fixtures/audioProcessing";
+import { playerQueue } from "../fixtures/playerQueue";
 import { queueItem } from "../fixtures/queueItem";
 import { streamDetails } from "../fixtures/streamDetails";
 
@@ -157,30 +157,10 @@ function makeStreamDetails(): StreamDetails {
 }
 
 function makeQueue(streamdetails: StreamDetails): PlayerQueue {
-  return {
-    queue_id: "queue-1",
-    active: true,
-    display_name: "Queue",
-    available: true,
+  return playerQueue({
+    // the button stays hidden for an empty queue
     items: 1,
-    shuffle_enabled: false,
-    smart_shuffle_active: false,
-    autoplay_enabled: false,
-    repeat_mode: RepeatMode.OFF,
-    crossfade_enabled: false,
-    smart_fades_active: false,
-    overlay_enabled: false,
-    overlay_source: null,
-    overlay_volume: 100,
-    current_index: null,
-    index_in_buffer: null,
-    ended: false,
-    elapsed_time: 0,
-    elapsed_time_last_updated: 0,
     state: PlaybackState.PLAYING,
     current_item: queueItem({ name: "Track", duration: 180, streamdetails }),
-    next_item: null,
-    sources: [],
-    is_dynamic: false,
-  };
+  });
 }

--- a/tests/composables/useGuestQueue.test.ts
+++ b/tests/composables/useGuestQueue.test.ts
@@ -8,6 +8,7 @@ import {
 import { BEFORE_FIRST_INDEX } from "@/helpers/queue_position";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { MusicAssistantApi } from "@/plugins/api";
+import { playerQueue } from "../fixtures/playerQueue";
 import { queueItem } from "../fixtures/queueItem";
 
 const { mockSendCommand, mockGetPlayerQueueItems, mockSubscribe } = vi.hoisted(
@@ -45,11 +46,11 @@ describe("useGuestQueue", () => {
   });
 
   it("fetches queue items for the party queue", async () => {
-    const queue = {
+    const queue = playerQueue({
       queue_id: "queue1",
       current_index: 5,
       items: 20,
-    };
+    });
     const items = [queueItemFixture("item1"), queueItemFixture("item2")];
 
     mockSendCommand.mockResolvedValueOnce(queue);
@@ -87,11 +88,11 @@ describe("useGuestQueue", () => {
   });
 
   it("loads more items when scrolling near the bottom and more items are available", async () => {
-    const queue = {
+    const queue = playerQueue({
       queue_id: "queue1",
       current_index: 0,
       items: 100,
-    };
+    });
     const initialItems = Array.from({ length: 50 }, (_, i) =>
       queueItemFixture(`item-${i}`),
     );
@@ -133,16 +134,16 @@ describe("useGuestQueue", () => {
   });
 
   it("exposes the party queue and its index from the same queue", () => {
-    api.queues["party-player"] = {
+    api.queues["party-player"] = playerQueue({
       queue_id: "party-player",
       current_index: 3,
       state: PlaybackState.PLAYING,
-    } as PlayerQueue;
-    api.queues["queue1"] = {
+    });
+    api.queues["queue1"] = playerQueue({
       queue_id: "queue1",
       current_index: 7,
       state: PlaybackState.PAUSED,
-    } as PlayerQueue;
+    });
 
     const { partyQueueId, currentQueue, currentQueueIndex } = useGuestQueue();
     partyQueueId.value = "party-player";
@@ -153,11 +154,11 @@ describe("useGuestQueue", () => {
   });
 
   it("exposes no queue when no party queue id is set", () => {
-    api.queues["queue1"] = {
+    api.queues["queue1"] = playerQueue({
       queue_id: "queue1",
       current_index: 7,
       state: PlaybackState.PAUSED,
-    } as PlayerQueue;
+    });
 
     const { currentQueue, currentQueueIndex } = useGuestQueue();
 
@@ -198,11 +199,9 @@ describe("useGuestQueue", () => {
     ["QUEUE_UPDATED", 1],
   ])("only refetches for %s events targeting the party queue", (_name, i) => {
     mockSubscribe.mockReturnValue(vi.fn());
-    mockSendCommand.mockResolvedValue({
-      queue_id: "party-player",
-      current_index: 0,
-      items: 1,
-    });
+    mockSendCommand.mockResolvedValue(
+      playerQueue({ queue_id: "party-player", current_index: 0, items: 1 }),
+    );
     mockGetPlayerQueueItems.mockResolvedValue([queueItemFixture("item1")]);
 
     const { partyQueueId, subscribeToEvents } = useGuestQueue();

--- a/tests/fixtures/playerQueue.ts
+++ b/tests/fixtures/playerQueue.ts
@@ -1,0 +1,39 @@
+import {
+  PlaybackState,
+  type PlayerQueue,
+  RepeatMode,
+} from "@/plugins/api/interfaces";
+
+/**
+ * A complete player queue, for tests that only care about a few of its fields
+ * but should still model a payload the server can send.
+ */
+export function playerQueue(overrides: Partial<PlayerQueue> = {}): PlayerQueue {
+  return {
+    queue_id: "queue-1",
+    active: true,
+    display_name: "Queue",
+    available: true,
+    items: 0,
+    shuffle_enabled: false,
+    smart_shuffle_active: false,
+    autoplay_enabled: false,
+    repeat_mode: RepeatMode.OFF,
+    crossfade_enabled: false,
+    smart_fades_active: false,
+    overlay_enabled: false,
+    overlay_source: null,
+    overlay_volume: 100,
+    current_index: null,
+    index_in_buffer: null,
+    ended: false,
+    elapsed_time: 0,
+    elapsed_time_last_updated: 0,
+    state: PlaybackState.IDLE,
+    current_item: null,
+    next_item: null,
+    sources: [],
+    is_dynamic: false,
+    ...overrides,
+  };
+}

--- a/tests/helpers/player_menu_items.test.ts
+++ b/tests/helpers/player_menu_items.test.ts
@@ -9,6 +9,7 @@ import {
   type PlayerQueue,
 } from "@/plugins/api/interfaces";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { playerQueue } from "../fixtures/playerQueue";
 
 const { emitEvent, isAdmin, routerPush, storeMock } = vi.hoisted(() => ({
   emitEvent: vi.fn(),
@@ -74,12 +75,7 @@ function makePlayer(overrides: Partial<Player> = {}): Player {
 }
 
 function makeQueue(overrides: Partial<PlayerQueue> = {}): PlayerQueue {
-  return {
-    queue_id: "kitchen",
-    active: true,
-    items: 0,
-    ...overrides,
-  } as PlayerQueue;
+  return playerQueue({ queue_id: "kitchen", ...overrides });
 }
 
 describe("getPlayerSetupMenuItem", () => {

--- a/tests/helpers/queue_position.test.ts
+++ b/tests/helpers/queue_position.test.ts
@@ -5,17 +5,10 @@ import {
 } from "@/helpers/queue_position";
 import { type PlayerQueue } from "@/plugins/api/interfaces";
 import { describe, expect, it } from "vitest";
+import { playerQueue } from "../fixtures/playerQueue";
 
 function makeQueue(overrides: Partial<PlayerQueue> = {}): PlayerQueue {
-  return {
-    queue_id: "queue-1",
-    active: true,
-    display_name: "Queue",
-    available: true,
-    items: 5,
-    ended: false,
-    ...overrides,
-  } as PlayerQueue;
+  return playerQueue({ items: 5, ...overrides });
 }
 
 describe("currentQueueIndex", () => {

--- a/tests/helpers/useMediaBrowserMetaData.test.ts
+++ b/tests/helpers/useMediaBrowserMetaData.test.ts
@@ -9,6 +9,7 @@ import {
 } from "@/plugins/api/interfaces";
 import { nextTick } from "vue";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { playerQueue } from "../fixtures/playerQueue";
 import { queueItem } from "../fixtures/queueItem";
 
 // Reactive api mock so mutating a queue fires the composable's watchers.
@@ -72,7 +73,7 @@ function makeQueue(
     elapsed_time: 30,
     elapsed_time_last_updated: ANCHOR,
   };
-  apiMock.queues[QUEUE_ID] = {
+  apiMock.queues[QUEUE_ID] = playerQueue({
     queue_id: QUEUE_ID,
     active: true,
     state: PlaybackState.PLAYING,
@@ -84,7 +85,7 @@ function makeQueue(
       ...currentItem,
     }),
     ...queue,
-  } as PlayerQueue;
+  });
   return apiMock.queues[QUEUE_ID];
 }
 

--- a/tests/plugins/api/helpers.test.ts
+++ b/tests/plugins/api/helpers.test.ts
@@ -31,9 +31,11 @@ import {
 import { MediaType } from "@/plugins/api/interfaces";
 import type {
   MediaItemType,
+  PlayableMediaItemType,
   Player,
-  PlayerQueue,
 } from "@/plugins/api/interfaces";
+import { playerQueue } from "../../fixtures/playerQueue";
+import { queueItem } from "../../fixtures/queueItem";
 
 describe("isAudioSource", () => {
   it("returns true for AUDIO_SOURCE media type", () => {
@@ -61,11 +63,13 @@ describe("isAudioSource", () => {
 
 describe("isQueueInfiniteStream", () => {
   const makeQueue = (mediaType: MediaType | undefined) =>
-    ({
+    playerQueue({
       current_item: mediaType
-        ? { media_item: { media_type: mediaType } }
-        : undefined,
-    }) as unknown as PlayerQueue;
+        ? queueItem({
+            media_item: { media_type: mediaType } as PlayableMediaItemType,
+          })
+        : null,
+    });
 
   it("returns true when the current item is a radio", () => {
     expect(isQueueInfiniteStream(makeQueue(MediaType.RADIO))).toBe(true);
@@ -100,7 +104,7 @@ describe("resolvePlayerQueue", () => {
   });
 
   it("returns the queue of the source the player is attached to", () => {
-    api.queues["source-q"] = { queue_id: "source-q" } as PlayerQueue;
+    api.queues["source-q"] = playerQueue({ queue_id: "source-q" });
 
     expect(
       resolvePlayerQueue(player({ active_source: "source-q" }))?.queue_id,
@@ -108,13 +112,13 @@ describe("resolvePlayerQueue", () => {
   });
 
   it("returns the player's own active queue when it has no source", () => {
-    api.queues["p1"] = { queue_id: "p1", active: true } as PlayerQueue;
+    api.queues["p1"] = playerQueue({ queue_id: "p1", active: true });
 
     expect(resolvePlayerQueue(player({}))?.queue_id).toBe("p1");
   });
 
   it("returns the player's own queue reached through its source while inactive", () => {
-    api.queues["p1"] = { queue_id: "p1", active: false } as PlayerQueue;
+    api.queues["p1"] = playerQueue({ queue_id: "p1", active: false });
 
     expect(resolvePlayerQueue(player({ active_source: "p1" }))?.queue_id).toBe(
       "p1",
@@ -122,7 +126,7 @@ describe("resolvePlayerQueue", () => {
   });
 
   it("ignores the player's own queue while it is inactive", () => {
-    api.queues["p1"] = { queue_id: "p1", active: false } as PlayerQueue;
+    api.queues["p1"] = playerQueue({ queue_id: "p1", active: false });
 
     expect(resolvePlayerQueue(player({}))).toBeUndefined();
   });


### PR DESCRIPTION
The tests each built their own `PlayerQueue` object by hand — the biggest one spelled out all 24 fields — so every change to the queue model meant touching a handful of test files.

- Added a shared `playerQueue()` test fixture, alongside the existing ones for tracks, albums, queue items, stream details, etc.
- Pointed the queue tests at it (quality details button, media browser metadata, player menu items, queue position, guest queue, api helpers), keeping the values each test actually asserts on explicit.