### PR TITLE
Show formatted text and working links in provider setup steps

### DIFF
--- a/src/components/InfoHeader.vue
+++ b/src/components/InfoHeader.vue
@@ -433,9 +433,7 @@
             style="padding-bottom: 10px; cursor: pointer"
             @click="showFullInfo = !showFullInfo"
           >
-            <!-- eslint-disable vue/no-v-html -->
-            <div v-html="shortDescription"></div>
-            <!-- eslint-enable vue/no-v-html -->
+            <MarkdownText :text="shortDescription" />
           </v-card-subtitle>
 
           <!-- genres/tags -->
@@ -474,13 +472,11 @@
         <DialogHeader>
           <DialogTitle>{{ headerTitle }}</DialogTitle>
         </DialogHeader>
-        <!-- eslint-disable vue/no-v-html -->
-        <div
-          class="prose prose-sm dark:prose-invert max-w-none text-sm leading-relaxed"
+        <MarkdownText
+          :text="rawDescription"
+          class="max-w-none text-sm leading-relaxed"
           style="max-height: 60vh; overflow-y: auto"
-          v-html="fullDescription"
-        ></div>
-        <!-- eslint-enable vue/no-v-html -->
+        />
         <DialogFooter>
           <Button @click="showFullInfo = false">{{ $t("close") }}</Button>
         </DialogFooter>
@@ -496,6 +492,7 @@
 </template>
 
 <script setup lang="ts">
+import MarkdownText from "@/components/MarkdownText.vue";
 import Toolbar from "@/components/Toolbar.vue";
 import AudioAnalysisMetadata from "@/components/AudioAnalysisMetadata.vue";
 import { Button } from "@/components/ui/button";
@@ -522,7 +519,6 @@ import {
   getAuthorsNarratorsArray,
   getAudiobookCollectionArtists,
   getImageThumbForItem,
-  markdownToHtml,
   truncateString,
 } from "@/helpers/utils";
 import { getContextMenuItems } from "@/layouts/default/ItemContextMenu.vue";
@@ -749,16 +745,12 @@ const rawDescription = computed(() => {
   return "";
 });
 
-const fullDescription = computed(() => {
-  return markdownToHtml(rawDescription.value);
-});
-
 const shortDescription = computed(() => {
   const maxChars = 800;
   if (rawDescription.value.length > maxChars) {
-    return fullDescription.value.substring(0, maxChars) + "…";
+    return rawDescription.value.substring(0, maxChars) + "…";
   }
-  return fullDescription.value;
+  return rawDescription.value;
 });
 
 const artistLogo = computed(() => {

--- a/src/components/InfoHeader.vue
+++ b/src/components/InfoHeader.vue
@@ -431,7 +431,7 @@
             v-if="shortDescription"
             class="body-2 justify-left description-text"
             style="padding-bottom: 10px; cursor: pointer"
-            @click="showFullInfo = !showFullInfo"
+            @click="onDescriptionClick"
           >
             <MarkdownText :text="shortDescription" />
           </v-card-subtitle>
@@ -752,6 +752,12 @@ const shortDescription = computed(() => {
   }
   return rawDescription.value;
 });
+
+const onDescriptionClick = (event: MouseEvent) => {
+  // a link in the description opens on its own; don't also expand the text
+  if ((event.target as HTMLElement).closest("a")) return;
+  showFullInfo.value = !showFullInfo.value;
+};
 
 const artistLogo = computed(() => {
   if (!compProps.item) return undefined;

--- a/src/components/MarkdownText.vue
+++ b/src/components/MarkdownText.vue
@@ -1,0 +1,20 @@
+<script setup lang="ts">
+import { markdownToHtml } from "@/helpers/utils";
+import { computed } from "vue";
+
+const props = defineProps<{
+  /** Markdown source, rendered as sanitized HTML. */
+  text?: string | null;
+}>();
+
+const html = computed(() => (props.text ? markdownToHtml(props.text) : ""));
+</script>
+
+<template>
+  <!-- eslint-disable vue/no-v-html -->
+  <div
+    class="[&_a]:text-primary [&_code]:bg-muted break-words [&>*]:mb-2 [&>*:last-child]:mb-0 [&_a]:underline [&_a]:underline-offset-2 [&_code]:rounded [&_code]:px-1 [&_code]:py-0.5 [&_ol]:list-decimal [&_ol]:pl-5 [&_ol]:text-start [&_ul]:list-disc [&_ul]:pl-5 [&_ul]:text-start"
+    v-html="html"
+  ></div>
+  <!-- eslint-enable vue/no-v-html -->
+</template>

--- a/src/components/MarkdownText.vue
+++ b/src/components/MarkdownText.vue
@@ -13,7 +13,7 @@ const html = computed(() => (props.text ? markdownToHtml(props.text) : ""));
 <template>
   <!-- eslint-disable vue/no-v-html -->
   <div
-    class="[&_a]:text-primary [&_code]:bg-muted break-words [&>*]:mb-2 [&>*:last-child]:mb-0 [&_a]:underline [&_a]:underline-offset-2 [&_code]:rounded [&_code]:px-1 [&_code]:py-0.5 [&_ol]:list-decimal [&_ol]:pl-5 [&_ol]:text-start [&_ul]:list-disc [&_ul]:pl-5 [&_ul]:text-start"
+    class="[&_a]:text-primary [&_code]:bg-muted break-words [&>*]:mb-2 [&>*:last-child]:mb-0 [&_a]:underline [&_a]:underline-offset-2 [&_code]:rounded [&_code]:px-1 [&_code]:py-0.5 [&_li]:mb-1 [&_li>p]:mb-2 [&_li>p:last-child]:mb-0 [&_ol]:list-decimal [&_ol]:pl-5 [&_ol]:text-start [&_pre]:overflow-x-auto [&_pre_code]:bg-transparent [&_pre_code]:p-0 [&_ul]:list-disc [&_ul]:pl-5 [&_ul]:text-start"
     v-html="html"
   ></div>
   <!-- eslint-enable vue/no-v-html -->

--- a/src/components/SetupFlowDialog.vue
+++ b/src/components/SetupFlowDialog.vue
@@ -31,12 +31,11 @@
           <h3 v-if="step.title" class="mb-2 text-base font-semibold">
             {{ step.title }}
           </h3>
-          <p
+          <MarkdownText
             v-if="step.description"
-            class="text-muted-foreground mb-4 text-sm leading-relaxed whitespace-pre-wrap"
-          >
-            {{ step.description }}
-          </p>
+            :text="step.description"
+            class="text-muted-foreground mb-4 text-sm leading-relaxed"
+          />
 
           <!-- base (non-field) error -->
           <Alert
@@ -91,14 +90,13 @@
           <h3 class="mb-2 text-base font-semibold">
             {{ step.title ?? $t("settings.setup_flow.external_default_title") }}
           </h3>
-          <p
-            class="text-muted-foreground mb-4 text-sm leading-relaxed whitespace-pre-wrap"
-          >
-            {{
+          <MarkdownText
+            :text="
               step.description ??
-              $t("settings.setup_flow.external_default_text")
-            }}
-          </p>
+              $t('settings.setup_flow.external_default_text')
+            "
+            class="text-muted-foreground mb-4 text-sm leading-relaxed"
+          />
           <div
             class="flex w-full flex-col items-center justify-center gap-4 py-3 text-center"
           >
@@ -158,12 +156,11 @@
               :model-value="(step.progress || 0) * 100"
               class="w-full max-w-[320px]"
             />
-            <p
+            <MarkdownText
               v-if="step.progress_text"
-              class="text-muted-foreground text-sm leading-relaxed whitespace-pre-wrap"
-            >
-              {{ step.progress_text }}
-            </p>
+              :text="step.progress_text"
+              class="text-muted-foreground w-full text-sm leading-relaxed"
+            />
             <div
               v-if="countdownText"
               class="text-muted-foreground flex items-center justify-center gap-1.5 text-xs"
@@ -187,12 +184,11 @@
             <h3 class="text-base font-semibold">
               {{ step.title ?? $t("settings.setup_flow.success_title") }}
             </h3>
-            <p
+            <MarkdownText
               v-if="step.description"
-              class="text-muted-foreground text-sm leading-relaxed whitespace-pre-wrap"
-            >
-              {{ step.description }}
-            </p>
+              :text="step.description"
+              class="text-muted-foreground w-full text-sm leading-relaxed"
+            />
           </div>
         </template>
 
@@ -221,11 +217,10 @@
                   : $t("settings.setup_flow.aborted_title"))
               }}
             </h3>
-            <p
-              class="text-muted-foreground text-sm leading-relaxed whitespace-pre-wrap"
-            >
-              {{ step.reason || $t("settings.setup_flow.aborted_text") }}
-            </p>
+            <MarkdownText
+              :text="step.reason || $t('settings.setup_flow.aborted_text')"
+              class="text-muted-foreground w-full text-sm leading-relaxed"
+            />
           </div>
         </template>
       </div>
@@ -281,9 +276,10 @@
       <DialogHeader>
         <DialogTitle>{{ helpEntry?.label }}</DialogTitle>
       </DialogHeader>
-      <p class="text-muted-foreground text-sm whitespace-pre-wrap">
-        {{ helpEntry?.description }}
-      </p>
+      <MarkdownText
+        :text="helpEntry?.description"
+        class="text-muted-foreground text-sm"
+      />
       <DialogFooter>
         <Button
           v-if="helpEntry?.help_link"
@@ -299,6 +295,7 @@
 </template>
 
 <script setup lang="ts">
+import MarkdownText from "@/components/MarkdownText.vue";
 import ProviderIcon from "@/components/ProviderIcon.vue";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";

--- a/src/helpers/utils.ts
+++ b/src/helpers/utils.ts
@@ -652,9 +652,12 @@ export const panelViewItemResponsive = function (displaySize: number) {
   }
 };
 
-// Rendered markdown only ever links to resources outside the app, so keep the
-// current view intact and never hand the opener over to the target page.
-DOMPurify.addHook("afterSanitizeAttributes", (node) => {
+// Own instance, so the anchor rewrite below stays confined to rendered markdown
+const markdownPurifier = DOMPurify();
+
+// Send every link to a new tab (keeping the app itself loaded) and withhold the
+// opener from the target page.
+markdownPurifier.addHook("afterSanitizeAttributes", (node) => {
   if (node.nodeName === "A" && node.hasAttribute("href")) {
     node.setAttribute("target", "_blank");
     node.setAttribute("rel", "noopener noreferrer");
@@ -673,7 +676,7 @@ export const markdownToHtml = function (text: string): string {
   // some sources encode their line breaks literally; block syntax only parses on real ones
   const source = text.replaceAll("\\n", "\n").replaceAll(" \\", "\n");
   // Metadata can carry attacker-controlled HTML that reaches v-html; SANITIZE_NAMED_PROPS also blocks DOM clobbering
-  return DOMPurify.sanitize(marked(source, { breaks: true }) as string, {
+  return markdownPurifier.sanitize(marked(source, { breaks: true }) as string, {
     SANITIZE_NAMED_PROPS: true,
   });
 };

--- a/src/helpers/utils.ts
+++ b/src/helpers/utils.ts
@@ -652,13 +652,28 @@ export const panelViewItemResponsive = function (displaySize: number) {
   }
 };
 
+// Rendered markdown only ever links to resources outside the app, so keep the
+// current view intact and never hand the opener over to the target page.
+DOMPurify.addHook("afterSanitizeAttributes", (node) => {
+  if (node.nodeName === "A" && node.hasAttribute("href")) {
+    node.setAttribute("target", "_blank");
+    node.setAttribute("rel", "noopener noreferrer");
+  }
+});
+
+/**
+ * Render markdown as sanitized HTML, safe to pass to `v-html`.
+ *
+ * Supports the full block syntax (lists, paragraphs, ...) and turns single
+ * newlines into line breaks. Links always open in a new tab.
+ *
+ * @param text - Markdown source. May use escaped `\n` sequences as newlines.
+ */
 export const markdownToHtml = function (text: string): string {
-  text = text
-    .replaceAll(/\\n/g, "<br />")
-    .replaceAll("\n", "<br />")
-    .replaceAll(" \\", "<br />");
+  // some sources encode their line breaks literally; block syntax only parses on real ones
+  const source = text.replaceAll("\\n", "\n").replaceAll(" \\", "\n");
   // Metadata can carry attacker-controlled HTML that reaches v-html; SANITIZE_NAMED_PROPS also blocks DOM clobbering
-  return DOMPurify.sanitize(marked(text) as string, {
+  return DOMPurify.sanitize(marked(source, { breaks: true }) as string, {
     SANITIZE_NAMED_PROPS: true,
   });
 };

--- a/src/views/settings/EditConfig.vue
+++ b/src/views/settings/EditConfig.vue
@@ -144,11 +144,9 @@
           {{ showHelpInfo?.label || "" }}
         </h2>
       </v-card-text>
-      <!-- eslint-disable vue/no-v-html -->
-      <!-- eslint-disable vue/no-v-text-v-html-on-component -->
-      <v-card-text v-html="markdownToHtml(showHelpInfo?.description || '')" />
-      <!-- eslint-enable vue/no-v-html -->
-      <!-- eslint-enable vue/no-v-text-v-html-on-component -->
+      <v-card-text>
+        <MarkdownText :text="showHelpInfo?.description" />
+      </v-card-text>
       <v-card-actions>
         <v-btn
           v-if="showHelpInfo?.help_link"
@@ -190,8 +188,8 @@ import {
   NON_INTERACTIVE_ENTRY_TYPES,
   VALUELESS_ENTRY_TYPES,
 } from "@/helpers/config_entry_ui";
+import MarkdownText from "@/components/MarkdownText.vue";
 import { Button } from "@/components/ui/button";
-import { markdownToHtml } from "@/helpers/utils";
 import {
   ConfigEntryType,
   ConfigValueType,

--- a/src/views/settings/fields/AlertField.vue
+++ b/src/views/settings/fields/AlertField.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { TriangleAlert } from "@lucide/vue";
+import MarkdownText from "@/components/MarkdownText.vue";
 import { Alert, AlertDescription } from "@/components/ui/alert";
-import { markdownToHtml } from "@/helpers/utils";
 
 defineProps<{ text: string }>();
 </script>
@@ -9,9 +9,8 @@ defineProps<{ text: string }>();
 <template>
   <Alert variant="warning" class="mt-2 mb-4">
     <TriangleAlert />
-    <AlertDescription class="[&_a]:underline [&_p]:mb-2 [&_p:last-child]:mb-0">
-      <!-- eslint-disable-next-line vue/no-v-html -->
-      <div v-html="markdownToHtml(text)"></div>
+    <AlertDescription>
+      <MarkdownText :text="text" />
     </AlertDescription>
   </Alert>
 </template>

--- a/src/views/settings/fields/LabelField.vue
+++ b/src/views/settings/fields/LabelField.vue
@@ -1,14 +1,12 @@
 <script setup lang="ts">
-import { markdownToHtml } from "@/helpers/utils";
+import MarkdownText from "@/components/MarkdownText.vue";
 
 defineProps<{ text: string }>();
 </script>
 
 <template>
-  <div
-    class="text-muted-foreground mt-2 mb-4 rounded-md bg-muted/50 px-3 py-2 text-sm leading-relaxed [&_a]:underline [&_p]:mb-2 [&_p:last-child]:mb-0"
-  >
-    <!-- eslint-disable-next-line vue/no-v-html -->
-    <div v-html="markdownToHtml(text)"></div>
-  </div>
+  <MarkdownText
+    :text="text"
+    class="text-muted-foreground bg-muted/50 mt-2 mb-4 rounded-md px-3 py-2 text-sm leading-relaxed"
+  />
 </template>

--- a/tests/components/MarkdownText.test.ts
+++ b/tests/components/MarkdownText.test.ts
@@ -1,0 +1,38 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * DOMPurify (used by the rendered markdown) needs a spec-complete DOM; the
+ * suite's default happy-dom discards elements it should keep.
+ */
+import MarkdownText from "@/components/MarkdownText.vue";
+import { mount } from "@vue/test-utils";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@/plugins/api", () => ({ api: {} }));
+
+vi.mock("@/plugins/breakpoint", () => ({
+  getBreakpointValue: vi.fn(() => false),
+}));
+
+describe("MarkdownText", () => {
+  it("renders markdown instead of showing its syntax", () => {
+    const wrapper = mount(MarkdownText, { props: { text: "**bold**" } });
+
+    expect(wrapper.find("strong").text()).toBe("bold");
+    expect(wrapper.text()).not.toContain("*");
+  });
+
+  it("makes a link clickable and opens it in a new tab", () => {
+    const wrapper = mount(MarkdownText, {
+      props: { text: "see https://example.com/callback" },
+    });
+
+    const link = wrapper.find("a");
+    expect(link.attributes("href")).toBe("https://example.com/callback");
+    expect(link.attributes("target")).toBe("_blank");
+  });
+
+  it("renders nothing for empty text", () => {
+    expect(mount(MarkdownText, { props: { text: null } }).text()).toBe("");
+  });
+});

--- a/tests/components/SetupFlowDialog.test.ts
+++ b/tests/components/SetupFlowDialog.test.ts
@@ -4,7 +4,7 @@ import {
   shallowMount,
   type VueWrapper,
 } from "@vue/test-utils";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   ConfigEntryType,
   FlowStepType,
@@ -97,13 +97,18 @@ vi.mock("vue-sonner", () => ({
 
 // shallowMount would stub the step copy away; render it as plain text instead
 // so the assertions below keep seeing it
+const originalStubs = config.global.stubs;
 config.global.stubs = {
-  ...config.global.stubs,
+  ...originalStubs,
   MarkdownText: {
     props: ["text"],
     template: "<div>{{ text }}</div>",
   },
 };
+
+afterAll(() => {
+  config.global.stubs = originalStubs;
+});
 
 beforeEach(() => {
   vi.clearAllMocks();

--- a/tests/components/SetupFlowDialog.test.ts
+++ b/tests/components/SetupFlowDialog.test.ts
@@ -98,6 +98,7 @@ vi.mock("vue-sonner", () => ({
 // shallowMount would stub the step copy away; render it as plain text instead
 // so the assertions below keep seeing it
 config.global.stubs = {
+  ...config.global.stubs,
   MarkdownText: {
     props: ["text"],
     template: "<div>{{ text }}</div>",

--- a/tests/components/SetupFlowDialog.test.ts
+++ b/tests/components/SetupFlowDialog.test.ts
@@ -1,4 +1,9 @@
-import { flushPromises, shallowMount, type VueWrapper } from "@vue/test-utils";
+import {
+  config,
+  flushPromises,
+  shallowMount,
+  type VueWrapper,
+} from "@vue/test-utils";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   ConfigEntryType,
@@ -89,6 +94,15 @@ vi.mock("vue-router", async (importOriginal) => {
 vi.mock("vue-sonner", () => ({
   toast: toastMock,
 }));
+
+// shallowMount would stub the step copy away; render it as plain text instead
+// so the assertions below keep seeing it
+config.global.stubs = {
+  MarkdownText: {
+    props: ["text"],
+    template: "<div>{{ text }}</div>",
+  },
+};
 
 beforeEach(() => {
   vi.clearAllMocks();

--- a/tests/helpers/markdown.test.ts
+++ b/tests/helpers/markdown.test.ts
@@ -1,0 +1,75 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * DOMPurify needs a spec-complete DOM: under the suite's default happy-dom it
+ * discards elements it should keep (lists, the leading paragraph), which would
+ * make every assertion below meaningless.
+ */
+import { markdownToHtml } from "@/helpers/utils";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@/plugins/api", () => ({ api: {} }));
+
+vi.mock("@/plugins/breakpoint", () => ({
+  getBreakpointValue: vi.fn(() => false),
+}));
+
+describe("markdownToHtml", () => {
+  it("neutralizes an onerror image payload", () => {
+    const html = markdownToHtml('<img src=x onerror="alert(1)">');
+    expect(html).not.toContain("onerror");
+  });
+
+  it("strips script tags", () => {
+    const html = markdownToHtml("<script>alert(1)</script>");
+    expect(html).not.toContain("<script>");
+  });
+
+  it("drops a javascript: link", () => {
+    expect(markdownToHtml("[x](javascript:alert(1))")).not.toContain(
+      "javascript:",
+    );
+  });
+
+  it("renders legitimate markdown", () => {
+    expect(markdownToHtml("**bold**")).toContain("<strong>bold</strong>");
+    expect(markdownToHtml("*italic*")).toContain("<em>italic</em>");
+    expect(markdownToHtml("[link](https://example.com)")).toContain(
+      'href="https://example.com"',
+    );
+  });
+
+  it("converts line breaks", () => {
+    expect(markdownToHtml("line1\nline2")).toContain("<br>");
+  });
+
+  it("treats escaped newlines as real ones", () => {
+    expect(markdownToHtml("line1\\nline2")).toContain("<br>");
+    expect(markdownToHtml("- one\\n- two")).toContain("<li>two</li>");
+  });
+
+  it("renders numbered and bulleted lists", () => {
+    const ordered = markdownToHtml("1. first\n2. second");
+    expect(ordered).toContain("<ol>");
+    expect(ordered).toContain("<li>second</li>");
+    expect(markdownToHtml("- one\n- two")).toContain("<ul>");
+  });
+
+  it("keeps blank-line separated text in separate paragraphs", () => {
+    const html = markdownToHtml("first\n\nsecond");
+    expect(html).toContain("<p>first</p>");
+    expect(html).toContain("<p>second</p>");
+  });
+
+  it("opens links in a new tab without leaking the opener", () => {
+    const html = markdownToHtml("[link](https://example.com)");
+    expect(html).toContain('target="_blank"');
+    expect(html).toContain('rel="noopener noreferrer"');
+  });
+
+  it("links a bare url so it can be opened and copied", () => {
+    expect(markdownToHtml("go to https://example.com/callback")).toContain(
+      'href="https://example.com/callback"',
+    );
+  });
+});

--- a/tests/helpers/utils.test.ts
+++ b/tests/helpers/utils.test.ts
@@ -5,7 +5,6 @@ import {
   getExternalLinkUrl,
   hexToRgb,
   kebabize,
-  markdownToHtml,
   numberRange,
   openLinkInNewTab,
   paletteFromServer,
@@ -281,29 +280,6 @@ describe("formatRelativeTime", () => {
     expect(formatRelativeTime(3660)).toBe("1h 1m");
     expect(formatRelativeTime(7200)).toBe("2h");
     expect(formatRelativeTime(7380)).toBe("2h 3m");
-  });
-});
-
-describe("markdownToHtml", () => {
-  it("neutralizes an onerror image payload", () => {
-    const html = markdownToHtml('<img src=x onerror="alert(1)">');
-    expect(html).not.toContain("onerror");
-  });
-
-  it("strips script tags", () => {
-    const html = markdownToHtml("<script>alert(1)</script>");
-    expect(html).not.toContain("<script>");
-  });
-
-  it("renders legitimate markdown", () => {
-    expect(markdownToHtml("**bold**")).toContain("<strong>bold</strong>");
-    expect(markdownToHtml("[link](https://example.com)")).toContain(
-      'href="https://example.com"',
-    );
-  });
-
-  it("converts line breaks", () => {
-    expect(markdownToHtml("line1\nline2")).toContain("<br>");
   });
 });
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -6,6 +6,9 @@ export default mergeConfig(
   viteConfig,
   defineConfig({
     test: {
+      // happy-dom is not spec-complete enough for DOMPurify: it silently drops
+      // elements the sanitizer should keep. Tests that assert on rendered
+      // markdown pin themselves to jsdom with an @vitest-environment docblock.
       environment: "happy-dom",
       globals: true,
       css: false,


### PR DESCRIPTION
Setup flow steps showed their text exactly as written, so any formatting a provider used leaked through as raw characters (`**bold**` showed the asterisks) and a web address in a step was neither clickable nor selectable — in the Spotify browser approval step the address ran off the edge of the dialog and could not even be copied, which made that step impossible to complete.

Step text is now rendered as formatted text: links are clickable and open in a new tab, long addresses wrap instead of being cut off, and numbered/bulleted lists show properly. Everything is sanitized first, since these texts come from the translations.

Changes:
- render the setup step instructions, progress text and end-of-flow message as formatted text (step titles stay plain)
- new shared `MarkdownText` component so all formatted copy looks the same
- formatting now also works beyond the first line, so lists and paragraphs in provider texts render as intended (this also applies to config option help texts and artist/album info)
- links always open in a new tab, and no longer expand the artist/album description when clicked