### PR TITLE
Fix scrolling to the last players in the player list

### DIFF
--- a/src/layouts/default/Footer.vue
+++ b/src/layouts/default/Footer.vue
@@ -39,8 +39,15 @@
 import BottomNavigation from "@/components/navigation/BottomNavigation.vue";
 import { store } from "@/plugins/store";
 import { useElementSize } from "@vueuse/core";
-import { type ComponentPublicInstance, ref, watchEffect } from "vue";
+import {
+  type ComponentPublicInstance,
+  onBeforeUnmount,
+  ref,
+  watchEffect,
+} from "vue";
 import Player from "./PlayerOSD/Player.vue";
+
+const OVERLAY_HEIGHT_PROPERTY = "--player-bar-overlay-height";
 
 const playerBar = ref<ComponentPublicInstance>();
 const { height: playerBarHeight } = useElementSize(playerBar, undefined, {
@@ -51,9 +58,15 @@ const { height: playerBarHeight } = useElementSize(playerBar, undefined, {
 // this to keep their content clear of it
 watchEffect(() => {
   document.documentElement.style.setProperty(
-    "--player-bar-overlay-height",
+    OVERLAY_HEIGHT_PROPERTY,
     store.mobileLayout ? `${Math.ceil(playerBarHeight.value)}px` : "0px",
   );
+});
+
+// the popouts outlive the player bar in frameless mode, so they must not keep
+// reserving room for a bar that is no longer there
+onBeforeUnmount(() => {
+  document.documentElement.style.removeProperty(OVERLAY_HEIGHT_PROPERTY);
 });
 </script>
 

--- a/src/layouts/default/Footer.vue
+++ b/src/layouts/default/Footer.vue
@@ -16,6 +16,7 @@
   <BottomNavigation v-if="store.mobileLayout" />
 
   <v-footer
+    ref="playerBar"
     app
     color="default"
     :class="`py-0 px-0 ${
@@ -37,7 +38,23 @@
 <script setup lang="ts">
 import BottomNavigation from "@/components/navigation/BottomNavigation.vue";
 import { store } from "@/plugins/store";
+import { useElementSize } from "@vueuse/core";
+import { type ComponentPublicInstance, ref, watchEffect } from "vue";
 import Player from "./PlayerOSD/Player.vue";
+
+const playerBar = ref<ComponentPublicInstance>();
+const { height: playerBarHeight } = useElementSize(playerBar, undefined, {
+  box: "border-box",
+});
+
+// on mobile the player bar floats on top of the player bar popouts, which use
+// this to keep their content clear of it
+watchEffect(() => {
+  document.documentElement.style.setProperty(
+    "--player-bar-overlay-height",
+    store.mobileLayout ? `${Math.ceil(playerBarHeight.value)}px` : "0px",
+  );
+});
 </script>
 
 <style>

--- a/src/layouts/default/Footer.vue
+++ b/src/layouts/default/Footer.vue
@@ -54,8 +54,8 @@ const { height: playerBarHeight } = useElementSize(playerBar, undefined, {
   box: "border-box",
 });
 
-// on mobile the player bar floats on top of the player bar popouts, which use
-// this to keep their content clear of it
+// on mobile the player bar floats on top of the player bar popouts, which read
+// this variable to keep their content clear of it
 watchEffect(() => {
   document.documentElement.style.setProperty(
     OVERLAY_HEIGHT_PROPERTY,

--- a/src/layouts/default/PlayerSelect.vue
+++ b/src/layouts/default/PlayerSelect.vue
@@ -122,9 +122,10 @@
       </div>
 
       <div ref="playerList" class="min-h-0 flex-1 overflow-y-auto pb-6">
+        <!-- outranks the selected player badge on the cards scrolling underneath -->
         <div
           v-if="showSearch"
-          class="bg-background sticky top-0 z-10 px-3 pt-3 pb-2"
+          class="bg-background sticky top-0 z-20 px-3 pt-3 pb-2"
         >
           <SearchInput
             v-model="playerSearchQuery"

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -134,6 +134,12 @@
   backdrop-filter: blur(4px);
 }
 
+/* the popouts extend behind the floating mobile player bar, so their content is
+   inset to stay scrollable past it */
+.player-bar-popout {
+  padding-bottom: var(--player-bar-overlay-height, 0px) !important;
+}
+
 .player-bar-popout[data-state="open"] {
   animation: player-bar-popout-in 220ms cubic-bezier(0.2, 0.8, 0.2, 1) both !important;
 }

--- a/tests/layouts/Footer.test.ts
+++ b/tests/layouts/Footer.test.ts
@@ -1,15 +1,19 @@
 import Footer from "@/layouts/default/Footer.vue";
 import { store } from "@/plugins/store";
-import { mount } from "@vue/test-utils";
+import { type VueWrapper, mount } from "@vue/test-utils";
+import { unrefElement } from "@vueuse/core";
 import { h, nextTick } from "vue";
 import { createVuetify } from "vuetify";
 import * as components from "vuetify/components";
 import * as directives from "vuetify/directives";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-const { playerBarHeight } = await vi.hoisted(async () => {
+const { measured, playerBarHeight } = await vi.hoisted(async () => {
   const { ref } = await import("vue");
-  return { playerBarHeight: ref(0) };
+  return {
+    measured: { target: undefined as unknown, options: undefined as unknown },
+    playerBarHeight: ref(0),
+  };
 });
 
 vi.mock("@vueuse/core", async () => {
@@ -18,7 +22,11 @@ vi.mock("@vueuse/core", async () => {
   const { ref } = await vi.importActual<typeof import("vue")>("vue");
   return {
     ...actual,
-    useElementSize: () => ({ width: ref(0), height: playerBarHeight }),
+    useElementSize: (target: unknown, _initial: unknown, options: unknown) => {
+      measured.target = target;
+      measured.options = options;
+      return { width: ref(0), height: playerBarHeight };
+    },
   };
 });
 
@@ -37,9 +45,11 @@ function overlayHeight() {
   return document.documentElement.style.getPropertyValue(OVERLAY_HEIGHT);
 }
 
+let wrapper: VueWrapper | undefined;
+
 // v-footer registers itself as an app layout item, so it needs a layout host
 function mountFooter() {
-  return mount(
+  wrapper = mount(
     {
       render: () => h(components.VLayout, null, { default: () => h(Footer) }),
     },
@@ -50,6 +60,7 @@ function mountFooter() {
       },
     },
   );
+  return wrapper;
 }
 
 describe("Footer", () => {
@@ -60,6 +71,10 @@ describe("Footer", () => {
   });
 
   afterEach(() => {
+    // the store is shared, so an instance left mounted would react to the next
+    // test's state and republish the variable
+    wrapper?.unmount();
+    wrapper = undefined;
     document.documentElement.style.removeProperty(OVERLAY_HEIGHT);
   });
 
@@ -95,12 +110,22 @@ describe("Footer", () => {
   it("stops reserving room once the player bar is gone", async () => {
     store.mobileLayout = true;
     playerBarHeight.value = 118;
-    const wrapper = mountFooter();
+    mountFooter();
     await nextTick();
 
-    wrapper.unmount();
+    wrapper?.unmount();
+    wrapper = undefined;
     await nextTick();
 
     expect(overlayHeight()).toBe("");
+  });
+
+  it("measures the rendered player bar, borders included", () => {
+    mountFooter();
+
+    expect(unrefElement(measured.target as never)).toBe(
+      wrapper?.find("footer").element,
+    );
+    expect(measured.options).toEqual({ box: "border-box" });
   });
 });

--- a/tests/layouts/Footer.test.ts
+++ b/tests/layouts/Footer.test.ts
@@ -1,0 +1,94 @@
+import Footer from "@/layouts/default/Footer.vue";
+import { store } from "@/plugins/store";
+import { mount } from "@vue/test-utils";
+import { h, nextTick } from "vue";
+import { createVuetify } from "vuetify";
+import * as components from "vuetify/components";
+import * as directives from "vuetify/directives";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { playerBarHeight } = await vi.hoisted(async () => {
+  const { ref } = await import("vue");
+  return { playerBarHeight: ref(0) };
+});
+
+vi.mock("@vueuse/core", async () => {
+  const actual =
+    await vi.importActual<typeof import("@vueuse/core")>("@vueuse/core");
+  const { ref } = await vi.importActual<typeof import("vue")>("vue");
+  return {
+    ...actual,
+    useElementSize: () => ({ width: ref(0), height: playerBarHeight }),
+  };
+});
+
+vi.mock("@/plugins/store", async () => {
+  const { reactive } = await vi.importActual<typeof import("vue")>("vue");
+  return {
+    store: reactive({ mobileLayout: false, showPlayersMenu: false }),
+  };
+});
+
+const vuetify = createVuetify({ components, directives });
+
+const OVERLAY_HEIGHT = "--player-bar-overlay-height";
+
+function overlayHeight() {
+  return document.documentElement.style.getPropertyValue(OVERLAY_HEIGHT);
+}
+
+// v-footer registers itself as an app layout item, so it needs a layout host
+function mountFooter() {
+  return mount(
+    {
+      render: () => h(components.VLayout, null, { default: () => h(Footer) }),
+    },
+    {
+      global: {
+        plugins: [vuetify],
+        stubs: { BottomNavigation: true, Player: true },
+      },
+    },
+  );
+}
+
+describe("Footer", () => {
+  beforeEach(() => {
+    store.mobileLayout = false;
+    playerBarHeight.value = 0;
+    document.documentElement.style.removeProperty(OVERLAY_HEIGHT);
+  });
+
+  afterEach(() => {
+    document.documentElement.style.removeProperty(OVERLAY_HEIGHT);
+  });
+
+  it("publishes the floating player bar height so popouts can clear it", async () => {
+    store.mobileLayout = true;
+    playerBarHeight.value = 118.4;
+    mountFooter();
+    await nextTick();
+
+    expect(overlayHeight()).toBe("119px");
+  });
+
+  it("tracks the player bar as it resizes", async () => {
+    store.mobileLayout = true;
+    playerBarHeight.value = 118;
+    mountFooter();
+    await nextTick();
+
+    playerBarHeight.value = 64;
+    await nextTick();
+
+    expect(overlayHeight()).toBe("64px");
+  });
+
+  it("reserves no room on desktop, where the popouts sit above the player bar", async () => {
+    playerBarHeight.value = 104;
+    mountFooter();
+    await nextTick();
+
+    expect(overlayHeight()).toBe("0px");
+  });
+});

--- a/tests/layouts/Footer.test.ts
+++ b/tests/layouts/Footer.test.ts
@@ -91,4 +91,16 @@ describe("Footer", () => {
 
     expect(overlayHeight()).toBe("0px");
   });
+
+  it("stops reserving room once the player bar is gone", async () => {
+    store.mobileLayout = true;
+    playerBarHeight.value = 118;
+    const wrapper = mountFooter();
+    await nextTick();
+
+    wrapper.unmount();
+    await nextTick();
+
+    expect(overlayHeight()).toBe("");
+  });
 });


### PR DESCRIPTION
# What does this implement/fix?

On mobile you could not scroll all the way down in the players list: the last one
or two players stayed hidden behind the floating player bar. They only flashed
into view while overscrolling and disappeared again as soon as you let go.

The players list, the group members panel and the volume sheet all extend behind
the player bar, but they did not reserve any room for it, so the bottom of their
content was permanently covered.

- The player bar now publishes its height, and the panels inset their content by
  it, so the full list can be scrolled into view.
- Also fixes the same problem in the group members panel and the volume sheet.
- Jumping to the selected player no longer parks it behind the player bar.
- The "selected player" badge no longer shows through the search bar while
  scrolling.

**Related issue (if applicable):**

- reported with a screen recording

**Related backend PR (if applicable):**

- n/a

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm lint:check` passes.
- [x] `pnpm test:run` passes, and tests have been added/updated where applicable.
- [x] `pnpm build` passes.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
