### PR TITLE
Replace the DSP layout grid and breakpoint with app-native equivalents

### DIFF
--- a/src/views/settings/EditPlayerDsp.vue
+++ b/src/views/settings/EditPlayerDsp.vue
@@ -60,14 +60,16 @@
       </Button>
     </div>
 
-    <v-container fluid class="pa-4">
-      <v-row :class="{ 'justify-center': mobile }" class="flex-nowrap">
+    <div class="p-4">
+      <div
+        class="flex flex-nowrap gap-6"
+        :class="{ 'justify-center': mobileLayout }"
+      >
         <!-- Timeline Column -->
-        <v-col
-          v-if="!mobile || selectedStage === null"
-          class="flex-grow-0 flex-shrink-0"
-          :class="{ 'border-e pr-4': !mobile }"
-          align-self="start"
+        <div
+          v-if="!mobileLayout || selectedStage === null"
+          class="shrink-0 grow-0 self-start"
+          :class="{ 'border-r border-border pr-4': !mobileLayout }"
         >
           <DSPPipeline
             :dsp="dsp"
@@ -77,16 +79,16 @@
             @on-move-filter="(d) => moveFilter(d.index, d.direction)"
             @on-delete-filter="removeFilter"
           />
-        </v-col>
+        </div>
 
         <!-- Filter Settings Panel -->
-        <v-col v-if="selectedStage != null" style="min-width: 0">
+        <div v-if="selectedStage != null" class="min-w-0 flex-1">
           <!-- Toolbar of the selected item -->
           <div
             class="flex min-h-12 items-center gap-1 border-b bg-muted px-2 py-1.5"
           >
             <Button
-              v-if="mobile"
+              v-if="mobileLayout"
               variant="ghost"
               size="icon-sm"
               :aria-label="$t('back')"
@@ -100,7 +102,7 @@
             <Button
               v-if="
                 typeof selectedStage === 'number' &&
-                !mobile &&
+                !mobileLayout &&
                 selectedStage > 0
               "
               variant="ghost"
@@ -113,7 +115,7 @@
             <Button
               v-if="
                 typeof selectedStage === 'number' &&
-                !mobile &&
+                !mobileLayout &&
                 selectedStage < dsp.filters.length - 1
               "
               variant="ghost"
@@ -236,8 +238,8 @@
               v-model="dsp.filters[selectedStage] as CrossfeedFilter"
             />
           </div>
-        </v-col>
-      </v-row>
+        </div>
+      </div>
 
       <Alert v-if="!dsp.enabled" variant="warning" class="mt-5">
         <TriangleAlert />
@@ -245,7 +247,7 @@
           {{ $t("settings.dsp.disabled_message") }}
         </AlertDescription>
       </Alert>
-    </v-container>
+    </div>
 
     <!-- Save DSP Preset Dialog -->
     <Dialog v-model:open="showSavePresetDialog">
@@ -320,8 +322,8 @@
 <script setup lang="ts">
 import { ref, computed, toRaw, watch, onBeforeUnmount } from "vue";
 import { useI18n } from "vue-i18n";
-import { useDisplay } from "vuetify";
 import { api } from "@/plugins/api";
+import { store } from "@/plugins/store";
 import {
   DSPConfig,
   DSPConfigPreset,
@@ -412,7 +414,9 @@ const showAddFilterDialog = ref(false);
 const showSavePresetDialog = ref(false);
 const newFilterType = ref(DSPFilterType.PARAMETRIC_EQ);
 const newPresetName = ref("");
-const { mobile } = useDisplay();
+// The app's own definition of a mobile layout, which also covers tablets and
+// the force-mobile setting, rather than Vuetify's width-only breakpoint.
+const mobileLayout = computed(() => store.mobileLayout);
 let updatedFromServer = false;
 let localConfigGeneration = 0;
 let applyRequestId = 0;
@@ -677,9 +681,9 @@ const removePreset = async (presetId?: string | null) => {
 // Watchers
 
 watch(
-  mobile,
-  (mobile) => {
-    if (!mobile && selectedStage.value === null) {
+  mobileLayout,
+  (isMobile) => {
+    if (!isMobile && selectedStage.value === null) {
       selectStage("input");
     }
   },
@@ -698,7 +702,7 @@ watch(
     localConfigGeneration += 1;
     const loadRequestId = ++playerLoadRequestId;
     clearServerDSPConfig();
-    selectedStage.value = mobile.value ? null : "input";
+    selectedStage.value = mobileLayout.value ? null : "input";
     // Don't overwrite the config for the newly selected player
     if (val) {
       unsubPlayerDSP = api.subscribe(

--- a/tests/views/EditPlayerDsp.test.ts
+++ b/tests/views/EditPlayerDsp.test.ts
@@ -26,6 +26,11 @@ const apiMock = vi.hoisted(() => ({
 const registryMock = vi.hoisted(() => ({
   presets: undefined as Ref<DSPConfigPreset[]> | undefined,
 }));
+// The view reads only mobileLayout, and the real store calls into
+// @/helpers/utils at import time, which is mocked down to getPlayerName here.
+const storeMock = vi.hoisted(() => ({ mobileLayout: false }));
+
+vi.mock("@/plugins/store", () => ({ store: storeMock }));
 
 vi.mock("@/plugins/api", () => ({
   api: apiMock,
@@ -55,16 +60,6 @@ vi.mock("vue-i18n", async (importOriginal) => {
     }),
   };
 });
-vi.mock("vuetify", async () => {
-  const { ref } = await import("vue");
-  return {
-    useDisplay: () => ({ mobile: ref(false) }),
-    useTheme: () => ({
-      global: { current: ref({ dark: false }) },
-    }),
-  };
-});
-
 const SwitchStub = {
   name: "Switch",
   props: ["modelValue"],
@@ -650,9 +645,6 @@ async function mountEditor() {
     global: {
       mocks: {
         $t: translate,
-        $vuetify: {
-          theme: { current: { dark: false } },
-        },
       },
       stubs: {
         Badge: { template: "<span><slot /></span>" },
@@ -668,9 +660,6 @@ async function mountEditor() {
         DSPSlider: true,
         DSPToneControl: ToneControlStub,
         Switch: SwitchStub,
-        VCol: { template: "<div><slot /></div>" },
-        VContainer: { template: "<div><slot /></div>" },
-        VRow: { template: "<div><slot /></div>" },
       },
     },
   });


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes. -->

v-container, v-row and v-col become flex divs, leaving no Vuetify in the view. The mobile swap now reads store.mobileLayout instead of Vuetify's 960px width check, so it agrees with the rest of the app and honours the force-mobile setting.

The tests mock @/helpers/utils down to getPlayerName, which the real store calls at import time, so the store is mocked here too.

This follows the PEQ branch

**Related issue (if applicable):**

- related issue `<link to issue>`

**Related backend PR (if applicable):**

<!--
Link the music-assistant/server PR when this change relies on new server
behaviour, so the two can be reviewed and released together.
-->

- related backend PR `<link to PR>`

## Types of changes

<!--
Tick exactly one box below. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [X] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [X] The code change is tested and works locally.
- [X] `pnpm lint:check` passes.
- [X] `pnpm test:run` passes, and tests have been added/updated where applicable.
- [X] `pnpm build` passes.
- [X] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
