### PR TITLE
Remove unused PWA mode flag

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -400,13 +400,6 @@ const completeInitialization = async () => {
 onMounted(async () => {
   initGlobalShortcutsSync();
 
-  // Detect if running as installed PWA (works across iOS, Android, and desktop)
-  const nav = window.navigator as Navigator & { standalone?: boolean };
-  store.isInPWAMode =
-    nav.standalone === true ||
-    window.matchMedia("(display-mode: standalone)").matches ||
-    window.matchMedia("(display-mode: fullscreen)").matches;
-
   // TODO: Remove localStorage fallback once migration period is over (language moved to user preferences)
   const langPref =
     (store.currentUser?.preferences?.language as string | undefined) ||

--- a/src/plugins/store.ts
+++ b/src/plugins/store.ts
@@ -23,7 +23,6 @@ import { getBreakpointValue } from "./breakpoint";
 
 interface Store {
   activePlayerId?: string;
-  isInPWAMode: boolean;
   showPlayersMenu: boolean;
   showFullscreenPlayer: boolean;
   frameless: boolean;
@@ -63,7 +62,6 @@ interface Store {
 
 export const store: Store = reactive({
   activePlayerId: undefined,
-  isInPWAMode: false,
   showPlayersMenu: false,
   showFullscreenPlayer: false,
   frameless: false,

--- a/tests/App.test.ts
+++ b/tests/App.test.ts
@@ -114,7 +114,6 @@ const {
         | undefined,
       enabledPlugins: new Set<string>(),
       forceMobileLayout: false,
-      isInPWAMode: false,
       isIngressSession: false,
       isOnboarding: false,
       serverInfo: undefined as unknown,


### PR DESCRIPTION
# What does this implement/fix?

On every startup the app detected whether it was running as an installed app and
stored that in a flag, but nothing in the app ever looked at that flag. So the
check ran on each load for nothing.

- Removed the unused installed-app flag and the startup detection that set it.

No behaviour change: nothing read the flag. The separate check that labels your
session in the device list (as "PWA" or "Web") is untouched and still works.

**Related issue (if applicable):**

- n/a

**Related backend PR (if applicable):**

- n/a

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm lint:check` passes.
- [x] `pnpm test:run` passes, and tests have been added/updated where applicable.
- [x] `pnpm build` passes.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
