### PR TITLE
Remove an unused style rule from the mobile player bar

### DIFF
--- a/src/layouts/default/Footer.vue
+++ b/src/layouts/default/Footer.vue
@@ -24,12 +24,9 @@
         ? 'mediacontrols-player-float'
         : 'mediacontrols-player-default'
     }`"
-    :style="[
-      store.mobileLayout ? { bottom: 'var(--mobile-navigation-height)' } : {},
-      store.mobileLayout && store.showPlayersMenu
-        ? 'z-index: 999 !important;'
-        : '',
-    ]"
+    :style="
+      store.mobileLayout ? { bottom: 'var(--mobile-navigation-height)' } : {}
+    "
   >
     <Player :use-floating-player="store.mobileLayout" />
   </v-footer>


### PR DESCRIPTION
# What does this implement/fix?

The mobile player bar had a leftover style rule that lowered it in the stacking
order while the players menu was open. It was added back when that menu dimmed
the screen behind it, so that the dimming overlay would cover the bar too.

The menu has since been rebuilt as a popout whose backdrop sits below the bar,
so the rule no longer does what it was written for. All it still did was make
the bar's stacking depend on whether a menu happened to be open.

Checked on a mobile viewport:

- The bar and the bottom navigation never overlap (they are positioned from the
  same variable), so nothing changes there.
- The players menu and its backdrop are drawn below the bar either way.
- One narrow case does change, for the better: with several items selected, the
  "x items selected" bar no longer draws over the player bar while the players
  menu is open. That already was the behaviour with the menu closed, so the two
  now match.

**Related issue (if applicable):**

- n/a

**Related backend PR (if applicable):**

- n/a

## Types of changes

<!--
Tick exactly one box below. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm lint:check` passes.
- [x] `pnpm test:run` passes, and tests have been added/updated where applicable.
- [x] `pnpm build` passes.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
