### PR TITLE
Remove unused mobile code from the player bar volume control

### DIFF
--- a/src/layouts/default/PlayerOSD/PlayerBarVolumeControl.vue
+++ b/src/layouts/default/PlayerOSD/PlayerBarVolumeControl.vue
@@ -10,12 +10,7 @@
         v-if="open"
         data-player-volume-backdrop
         type="button"
-        :class="[
-          'modal-backdrop player-volume-backdrop fixed inset-x-0 top-0 z-[997]',
-          store.mobileLayout
-            ? 'player-volume-backdrop-mobile'
-            : 'player-volume-backdrop-desktop',
-        ]"
+        class="modal-backdrop player-volume-backdrop player-volume-backdrop-desktop fixed inset-x-0 top-0 z-[997]"
         :aria-label="$t('close')"
         @click.stop.prevent="close"
       ></button>
@@ -58,18 +53,9 @@
       data-player-panel
       side="top"
       align="end"
-      :side-offset="
-        store.mobileLayout
-          ? MOBILE_PLAYER_BAR_POPOUT_GAP
-          : DESKTOP_PLAYER_BAR_POPOUT_GAP
-      "
+      :side-offset="DESKTOP_PLAYER_BAR_POPOUT_GAP"
       :collision-padding="8"
-      :class="[
-        'player-bar-popout player-volume-popover p-0',
-        store.mobileLayout
-          ? 'w-[calc(100vw-1rem)]'
-          : 'w-[340px] max-w-[calc(100vw-1rem)]',
-      ]"
+      class="player-bar-popout player-volume-popover w-[340px] max-w-[calc(100vw-1rem)] p-0"
       @open-auto-focus="preventAutoFocus"
       @interact-outside="handleInteractOutside"
     >
@@ -90,14 +76,12 @@ import {
 } from "@/components/ui/popover";
 import {
   DESKTOP_PLAYER_BAR_POPOUT_GAP,
-  MOBILE_PLAYER_BAR_POPOUT_GAP,
   playerBarEndAnchor,
 } from "@/helpers/player_bar";
 import { isPlayerGrouped } from "@/helpers/players";
 import { getVolumeIconComponent } from "@/helpers/utils";
 import { api } from "@/plugins/api";
 import { type Player, PlayerFeature } from "@/plugins/api/interfaces";
-import { store } from "@/plugins/store";
 import { computed, ref } from "vue";
 import PlayerVolumePanel from "./PlayerVolumePanel.vue";
 
@@ -165,12 +149,7 @@ function close() {
 }
 
 function adjustVolume(event: WheelEvent) {
-  if (
-    store.mobileLayout ||
-    disabled.value ||
-    muted.value ||
-    event.deltaY === 0
-  ) {
+  if (disabled.value || muted.value || event.deltaY === 0) {
     return;
   }
   event.preventDefault();
@@ -191,10 +170,6 @@ function adjustVolume(event: WheelEvent) {
 <style>
 .player-volume-backdrop-desktop {
   bottom: 104px;
-}
-
-.player-volume-backdrop-mobile {
-  bottom: var(--mobile-navigation-height);
 }
 
 .player-volume-popover {


### PR DESCRIPTION
# What does this implement/fix?

The volume button in the player bar carried a second set of mobile-specific sizes, spacing and backdrop styles that could never be reached. This control is only ever shown in the desktop player bar — on mobile the volume UI is a separate slider plus sheet, so the mobile styling in this component was never applied.

Removing it keeps the component honest about where it actually runs. Nothing changes for users.

- Always use the desktop popout gap, width and backdrop instead of picking between a mobile and desktop variant
- Drop the unused mobile backdrop style and the now-unneeded imports

**Related issue (if applicable):**

- n/a

**Related backend PR (if applicable):**

- n/a

## Types of changes

<!--
Tick exactly one box below. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm lint:check` passes.
- [x] `pnpm test:run` passes, and tests have been added/updated where applicable.
- [x] `pnpm build` passes.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
