### PR TITLE
Limit the player bar popout spacing to mobile

### DIFF
--- a/src/layouts/default/Footer.vue
+++ b/src/layouts/default/Footer.vue
@@ -48,6 +48,7 @@ import {
 import Player from "./PlayerOSD/Player.vue";
 
 const OVERLAY_HEIGHT_PROPERTY = "--player-bar-overlay-height";
+const OVERLAY_MARKER_ATTRIBUTE = "data-player-bar-overlay";
 
 const playerBar = ref<ComponentPublicInstance>();
 const { height: playerBarHeight } = useElementSize(playerBar, undefined, {
@@ -55,19 +56,28 @@ const { height: playerBarHeight } = useElementSize(playerBar, undefined, {
 });
 
 // on mobile the player bar floats on top of the player bar popouts, which read
-// this variable to keep their content clear of it
+// this marker and height to keep their content clear of it
 watchEffect(() => {
+  if (!store.mobileLayout) {
+    clearOverlay();
+    return;
+  }
+
   document.documentElement.style.setProperty(
     OVERLAY_HEIGHT_PROPERTY,
-    store.mobileLayout ? `${Math.ceil(playerBarHeight.value)}px` : "0px",
+    `${Math.ceil(playerBarHeight.value)}px`,
   );
+  document.documentElement.setAttribute(OVERLAY_MARKER_ATTRIBUTE, "");
 });
 
 // the popouts outlive the player bar in frameless mode, so they must not keep
 // reserving room for a bar that is no longer there
-onBeforeUnmount(() => {
+onBeforeUnmount(clearOverlay);
+
+function clearOverlay() {
   document.documentElement.style.removeProperty(OVERLAY_HEIGHT_PROPERTY);
-});
+  document.documentElement.removeAttribute(OVERLAY_MARKER_ATTRIBUTE);
+}
 </script>
 
 <style>

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -135,9 +135,10 @@
 }
 
 /* the popouts extend behind the floating mobile player bar, so their content is
-   inset to stay scrollable past it */
-.player-bar-popout {
-  padding-bottom: var(--player-bar-overlay-height, 0px) !important;
+   inset to stay scrollable past it; the marker keeps desktop popouts untouched
+   and lifts this above the equally-!important p-0 utility they carry */
+:root[data-player-bar-overlay] .player-bar-popout {
+  padding-bottom: var(--player-bar-overlay-height) !important;
 }
 
 .player-bar-popout[data-state="open"] {

--- a/tests/layouts/Footer.test.ts
+++ b/tests/layouts/Footer.test.ts
@@ -40,9 +40,19 @@ vi.mock("@/plugins/store", async () => {
 const vuetify = createVuetify({ components, directives });
 
 const OVERLAY_HEIGHT = "--player-bar-overlay-height";
+const OVERLAY_MARKER = "data-player-bar-overlay";
 
 function overlayHeight() {
   return document.documentElement.style.getPropertyValue(OVERLAY_HEIGHT);
+}
+
+function overlayMarked() {
+  return document.documentElement.hasAttribute(OVERLAY_MARKER);
+}
+
+function clearOverlay() {
+  document.documentElement.style.removeProperty(OVERLAY_HEIGHT);
+  document.documentElement.removeAttribute(OVERLAY_MARKER);
 }
 
 let wrapper: VueWrapper | undefined;
@@ -67,7 +77,7 @@ describe("Footer", () => {
   beforeEach(() => {
     store.mobileLayout = false;
     playerBarHeight.value = 0;
-    document.documentElement.style.removeProperty(OVERLAY_HEIGHT);
+    clearOverlay();
   });
 
   afterEach(() => {
@@ -75,7 +85,7 @@ describe("Footer", () => {
     // test's state and republish the variable
     wrapper?.unmount();
     wrapper = undefined;
-    document.documentElement.style.removeProperty(OVERLAY_HEIGHT);
+    clearOverlay();
   });
 
   it("publishes the floating player bar height so popouts can clear it", async () => {
@@ -85,6 +95,7 @@ describe("Footer", () => {
     await nextTick();
 
     expect(overlayHeight()).toBe("119px");
+    expect(overlayMarked()).toBe(true);
   });
 
   it("tracks the player bar as it resizes", async () => {
@@ -99,12 +110,43 @@ describe("Footer", () => {
     expect(overlayHeight()).toBe("64px");
   });
 
-  it("reserves no room on desktop, where the popouts sit above the player bar", async () => {
+  it("leaves desktop popouts alone, as they sit above the player bar", async () => {
+    // seeded so the assertions fail unless mounting actively clears them
+    document.documentElement.style.setProperty(OVERLAY_HEIGHT, "118px");
+    document.documentElement.setAttribute(OVERLAY_MARKER, "");
     playerBarHeight.value = 104;
     mountFooter();
     await nextTick();
 
-    expect(overlayHeight()).toBe("0px");
+    expect(overlayMarked()).toBe(false);
+    expect(overlayHeight()).toBe("");
+  });
+
+  it("stops reserving room when the layout switches to desktop", async () => {
+    store.mobileLayout = true;
+    playerBarHeight.value = 118;
+    mountFooter();
+    await nextTick();
+
+    store.mobileLayout = false;
+    await nextTick();
+
+    expect(overlayMarked()).toBe(false);
+    expect(overlayHeight()).toBe("");
+  });
+
+  it("picks the player bar back up when the layout switches to mobile", async () => {
+    playerBarHeight.value = 104;
+    mountFooter();
+    await nextTick();
+
+    store.mobileLayout = true;
+    await nextTick();
+    playerBarHeight.value = 118;
+    await nextTick();
+
+    expect(overlayMarked()).toBe(true);
+    expect(overlayHeight()).toBe("118px");
   });
 
   it("stops reserving room once the player bar is gone", async () => {
@@ -117,6 +159,7 @@ describe("Footer", () => {
     wrapper = undefined;
     await nextTick();
 
+    expect(overlayMarked()).toBe(false);
     expect(overlayHeight()).toBe("");
   });
 


### PR DESCRIPTION
# What does this implement/fix?

The player list, group members and volume popouts reserve space at the bottom so
their content stays scrollable past the floating mobile player bar. That spacing
rule was applied to every popout, including on desktop where there is no
floating bar to clear — it forced the bottom padding to zero there.

It is harmless today because all four popouts happen to carry no padding of
their own, but any future popout would quietly lose its bottom padding on
desktop with nothing pointing at the cause.

The footer now marks the page while the mobile player bar is on screen, and the
spacing only applies while that marker is set. Nothing changes on mobile.

- footer publishes a `data-player-bar-overlay` marker alongside the bar height,
  and clears both on desktop and when the bar goes away
- the popout spacing is gated on that marker, so desktop popouts keep their own
  padding
- added tests for the marker and for switching between the two layouts

**Related issue (if applicable):**

- n/a

**Related backend PR (if applicable):**

<!--
Link the music-assistant/server PR when this change relies on new server
behaviour, so the two can be reviewed and released together.
-->

- n/a

## Types of changes

<!--
Tick exactly one box below. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm lint:check` passes.
- [x] `pnpm test:run` passes, and tests have been added/updated where applicable.
- [x] `pnpm build` passes.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
