### PR TITLE
Keep the fullscreen player open when picking a player

### DIFF
--- a/src/helpers/player_bar.ts
+++ b/src/helpers/player_bar.ts
@@ -14,3 +14,18 @@ export const playerBarEndAnchor = {
     );
   },
 };
+
+// the fullscreen player covers the player bar, so popouts opened from there
+// align to its own player select button instead
+export const fullscreenPlayerSelectAnchor = {
+  getBoundingClientRect: () => {
+    const triggerRect = document
+      .getElementById("fullscreen-player-select-button")
+      ?.getBoundingClientRect();
+    // the button is hidden on very short screens; fall back to the bottom center
+    return (
+      triggerRect ??
+      new DOMRect(window.innerWidth / 2, window.innerHeight, 0, 0)
+    );
+  },
+};

--- a/src/layouts/default/PlayerOSD/PlayerFullscreen.vue
+++ b/src/layouts/default/PlayerOSD/PlayerFullscreen.vue
@@ -452,15 +452,11 @@
           "
         >
           <Button
+            id="fullscreen-player-select-button"
             variant="outline"
             size="xs"
             class="border-transparent bg-background/40 shadow-none backdrop-blur-md hover:bg-background/60 dark:border-transparent dark:bg-background/40 dark:hover:bg-background/60"
-            @click="
-              () => {
-                store.showPlayersMenu = true;
-                store.showFullscreenPlayer = false;
-              }
-            "
+            @click="store.showPlayersMenu = true"
           >
             <PlayerIcon
               :icon="store.activePlayer?.icon"

--- a/src/layouts/default/PlayerSelect.vue
+++ b/src/layouts/default/PlayerSelect.vue
@@ -597,9 +597,9 @@ async function scrollSelectedPlayerIntoView() {
   z-index: 998 !important;
 }
 
-/* the fullscreen player is a dialog at z-index 9000: both the panel and its
-   backdrop have to clear it, and there is no player bar left to keep visible.
-   Both rules pair up their class to outweigh the utility they override. */
+/* the fullscreen player is a dialog at z-index 9000, so both the panel and its
+   backdrop have to clear it; each rule pairs up its class to outweigh the
+   utility it overrides */
 .player-select-backdrop.player-select-fullscreen-backdrop {
   bottom: 0 !important;
   z-index: 9001 !important;
@@ -607,6 +607,12 @@ async function scrollSelectedPlayerIntoView() {
 
 .player-bar-popout.player-select-popover-fullscreen {
   z-index: 9002 !important;
+}
+
+/* the fullscreen player covers the mobile player bar, so this popout has no
+   floating bar to stay clear of */
+:root[data-player-bar-overlay]
+  .player-bar-popout.player-select-popover-fullscreen {
   padding-bottom: 0 !important;
 }
 </style>

--- a/src/layouts/default/PlayerSelect.vue
+++ b/src/layouts/default/PlayerSelect.vue
@@ -280,7 +280,7 @@ const showSearch = computed(
   () => orderedPlayers.value.length > SEARCH_PLAYER_THRESHOLD,
 );
 
-// the fullscreen player hides the player bar, so the panel pops out of the
+// the fullscreen player covers the player bar, so the panel pops out of the
 // player select button in there and stays on top of it
 const popoutFromFullscreen = computed(() => store.showFullscreenPlayer);
 
@@ -598,13 +598,14 @@ async function scrollSelectedPlayerIntoView() {
 }
 
 /* the fullscreen player is a dialog at z-index 9000: both the panel and its
-   backdrop have to clear it, and there is no player bar left to keep visible */
-.player-select-fullscreen-backdrop {
+   backdrop have to clear it, and there is no player bar left to keep visible.
+   Both rules pair up their class to outweigh the utility they override. */
+.player-select-backdrop.player-select-fullscreen-backdrop {
   bottom: 0 !important;
   z-index: 9001 !important;
 }
 
-.player-select-popover-fullscreen {
+.player-bar-popout.player-select-popover-fullscreen {
   z-index: 9002 !important;
   padding-bottom: 0 !important;
 }

--- a/src/layouts/default/PlayerSelect.vue
+++ b/src/layouts/default/PlayerSelect.vue
@@ -11,9 +11,11 @@
         type="button"
         :class="[
           'modal-backdrop player-select-backdrop fixed inset-x-0 top-0 z-[997]',
-          store.mobileLayout
-            ? 'player-select-mobile-offset'
-            : 'player-select-desktop-offset',
+          popoutFromFullscreen
+            ? 'player-select-fullscreen-backdrop'
+            : store.mobileLayout
+              ? 'player-select-mobile-offset'
+              : 'player-select-desktop-offset',
         ]"
         :aria-label="$t('close')"
         @click="setMenuOpen(false)"
@@ -22,12 +24,12 @@
   </Teleport>
 
   <Popover :open="store.showPlayersMenu" @update:open="setMenuOpen">
-    <PopoverAnchor :reference="playerBarEndAnchor" />
+    <PopoverAnchor :reference="popoutAnchor" />
     <PopoverContent
       data-player-panel
       data-testid="player-select-sheet"
       side="top"
-      align="end"
+      :align="popoutFromFullscreen ? 'center' : 'end'"
       :side-offset="
         store.mobileLayout
           ? MOBILE_PLAYER_BAR_POPOUT_GAP
@@ -36,6 +38,7 @@
       :collision-padding="8"
       :class="[
         'player-bar-popout player-select-popover flex flex-col gap-0 overflow-hidden p-0',
+        popoutFromFullscreen && 'player-select-popover-fullscreen',
         store.mobileLayout
           ? 'max-h-[78dvh] w-[calc(100vw-1rem)]'
           : 'max-h-[min(82dvh,780px)] w-[400px] max-w-[calc(100vw-1rem)]',
@@ -206,6 +209,7 @@ import type { ContextMenuItem } from "@/helpers/context_menu_item";
 import {
   DESKTOP_PLAYER_BAR_POPOUT_GAP,
   MOBILE_PLAYER_BAR_POPOUT_GAP,
+  fullscreenPlayerSelectAnchor,
   playerBarEndAnchor,
 } from "@/helpers/player_bar";
 import { isPlayerActive } from "@/helpers/players";
@@ -274,6 +278,16 @@ const orderedPlayers = useOrderedPlayers({
 
 const showSearch = computed(
   () => orderedPlayers.value.length > SEARCH_PLAYER_THRESHOLD,
+);
+
+// the fullscreen player hides the player bar, so the panel pops out of the
+// player select button in there and stays on top of it
+const popoutFromFullscreen = computed(() => store.showFullscreenPlayer);
+
+const popoutAnchor = computed(() =>
+  popoutFromFullscreen.value
+    ? fullscreenPlayerSelectAnchor
+    : playerBarEndAnchor,
 );
 
 const filteredPlayers = computed(() => {
@@ -581,5 +595,17 @@ async function scrollSelectedPlayerIntoView() {
 
 .player-select-popover {
   z-index: 998 !important;
+}
+
+/* the fullscreen player is a dialog at z-index 9000: both the panel and its
+   backdrop have to clear it, and there is no player bar left to keep visible */
+.player-select-fullscreen-backdrop {
+  bottom: 0 !important;
+  z-index: 9001 !important;
+}
+
+.player-select-popover-fullscreen {
+  z-index: 9002 !important;
+  padding-bottom: 0 !important;
 }
 </style>

--- a/tests/helpers/player_bar.test.ts
+++ b/tests/helpers/player_bar.test.ts
@@ -1,0 +1,37 @@
+import { fullscreenPlayerSelectAnchor } from "@/helpers/player_bar";
+import { afterEach, describe, expect, it } from "vitest";
+
+const BUTTON_ID = "fullscreen-player-select-button";
+
+function addTrigger(rect: Partial<DOMRect>) {
+  const trigger = document.createElement("button");
+  trigger.id = BUTTON_ID;
+  trigger.getBoundingClientRect = () => rect as DOMRect;
+  document.body.appendChild(trigger);
+  return trigger;
+}
+
+describe("fullscreenPlayerSelectAnchor", () => {
+  afterEach(() => {
+    document.getElementById(BUTTON_ID)?.remove();
+  });
+
+  it("anchors to the player select button of the fullscreen player", () => {
+    addTrigger({ top: 700, left: 120, width: 150, height: 26 });
+
+    expect(fullscreenPlayerSelectAnchor.getBoundingClientRect()).toMatchObject({
+      top: 700,
+      left: 120,
+      width: 150,
+      height: 26,
+    });
+  });
+
+  it("falls back to the bottom of the screen without that button", () => {
+    const rect = fullscreenPlayerSelectAnchor.getBoundingClientRect();
+
+    expect(rect.x).toBe(window.innerWidth / 2);
+    expect(rect.y).toBe(window.innerHeight);
+    expect(rect.height).toBe(0);
+  });
+});

--- a/tests/layouts/PlayerFullscreen.test.ts
+++ b/tests/layouts/PlayerFullscreen.test.ts
@@ -28,6 +28,7 @@ vi.mock("@/plugins/store", async () => {
       activePlayerQueue: undefined,
       curQueueItem: undefined,
       showFullscreenPlayer: false,
+      showPlayersMenu: false,
       showQueueItems: false,
     }),
   };
@@ -108,6 +109,7 @@ interface TestStore {
     active: boolean;
   };
   showFullscreenPlayer: boolean;
+  showPlayersMenu: boolean;
   showQueueItems: boolean;
 }
 
@@ -183,6 +185,7 @@ afterEach(async () => {
   testStore.activePlayer = undefined;
   testStore.activePlayerQueue = undefined;
   testStore.showFullscreenPlayer = false;
+  testStore.showPlayersMenu = false;
   testStore.showQueueItems = false;
   testApi.queues = {};
   testApi.queueElapsedTime = {};
@@ -218,5 +221,31 @@ describe("PlayerFullscreen lyrics clock", () => {
     testStore.showFullscreenPlayer = false;
     await nextTick();
     expect(pendingFrames.size).toBe(0);
+  });
+});
+
+describe("PlayerFullscreen player select button", () => {
+  it("opens the player list on top of the fullscreen player", async () => {
+    const { store } = await import("@/plugins/store");
+    const testStore = store as unknown as TestStore;
+    testStore.showFullscreenPlayer = true;
+
+    wrapper = shallowMount(PlayerFullscreen, {
+      props: { colorPalette: EMPTY_COLOR_PALETTE },
+      global: {
+        mocks: { $vuetify: { display: { height: 900, mdAndUp: true } } },
+        // the button lives inside the dialog, which a shallow mount leaves empty
+        stubs: {
+          "v-dialog": { template: "<div><slot /></div>" },
+          "v-card": { template: "<div><slot /></div>" },
+        },
+      },
+    });
+    await nextTick();
+
+    await wrapper.find("#fullscreen-player-select-button").trigger("click");
+
+    expect(testStore.showPlayersMenu).toBe(true);
+    expect(testStore.showFullscreenPlayer).toBe(true);
   });
 });

--- a/tests/layouts/PlayerSelect.test.ts
+++ b/tests/layouts/PlayerSelect.test.ts
@@ -1,5 +1,9 @@
 import PlayerSelect from "@/layouts/default/PlayerSelect.vue";
 import type { ContextMenuItem } from "@/helpers/context_menu_item";
+import {
+  fullscreenPlayerSelectAnchor,
+  playerBarEndAnchor,
+} from "@/helpers/player_bar";
 import { api } from "@/plugins/api";
 import {
   IdentifierType,
@@ -66,6 +70,7 @@ vi.mock("@/plugins/store", async () => {
       companionPlayerId: undefined as string | undefined,
       dialogActive: false,
       mobileLayout: false,
+      showFullscreenPlayer: false,
       showPlayersMenu: true,
     }),
   };
@@ -205,6 +210,11 @@ const DropdownMenuCheckboxItemStub = {
     </button>
   `,
 };
+const PopoverAnchorStub = {
+  name: "PopoverAnchor",
+  props: ["reference"],
+  template: `<div><slot /></div>`,
+};
 const PopoverContentStub = {
   name: "PopoverContent",
   emits: ["interact-outside", "open-auto-focus"],
@@ -313,7 +323,7 @@ function mountPlayerSelect() {
         DropdownMenuSeparator: passthroughStub,
         DropdownMenuTrigger: passthroughStub,
         Popover: passthroughStub,
-        PopoverAnchor: passthroughStub,
+        PopoverAnchor: PopoverAnchorStub,
         PopoverContent: PopoverContentStub,
         Teleport: true,
       },
@@ -341,6 +351,7 @@ describe("PlayerSelect", () => {
     store.companionPlayerId = undefined;
     store.dialogActive = false;
     store.mobileLayout = false;
+    store.showFullscreenPlayer = false;
     store.showPlayersMenu = true;
     webPlayer.player_id = null;
     storage.clear();
@@ -617,6 +628,26 @@ describe("PlayerSelect", () => {
     expect(
       wrapper.find('[data-testid="player-select-sheet"]').classes(),
     ).toContain("player-select-popover");
+    expect(wrapper.findComponent(PopoverAnchorStub).props("reference")).toBe(
+      playerBarEndAnchor,
+    );
+  });
+
+  it("pops out of the fullscreen player instead of behind it", () => {
+    store.mobileLayout = true;
+    store.showFullscreenPlayer = true;
+
+    const wrapper = mountPlayerSelect();
+
+    expect(wrapper.find(".player-select-backdrop").classes()).toContain(
+      "player-select-fullscreen-backdrop",
+    );
+    expect(
+      wrapper.find('[data-testid="player-select-sheet"]').classes(),
+    ).toContain("player-select-popover-fullscreen");
+    expect(wrapper.findComponent(PopoverAnchorStub).props("reference")).toBe(
+      fullscreenPlayerSelectAnchor,
+    );
   });
 
   it("focuses the sheet instead of opening the mobile keyboard", () => {

--- a/tests/layouts/PlayerSelect.test.ts
+++ b/tests/layouts/PlayerSelect.test.ts
@@ -625,9 +625,9 @@ describe("PlayerSelect", () => {
     expect(wrapper.find(".player-select-backdrop").classes()).toContain(
       "player-select-mobile-offset",
     );
-    expect(
-      wrapper.find('[data-testid="player-select-sheet"]').classes(),
-    ).toContain("player-select-popover");
+    const sheet = wrapper.find('[data-testid="player-select-sheet"]');
+    expect(sheet.classes()).toContain("player-select-popover");
+    expect(sheet.attributes("align")).toBe("end");
     expect(wrapper.findComponent(PopoverAnchorStub).props("reference")).toBe(
       playerBarEndAnchor,
     );
@@ -639,12 +639,13 @@ describe("PlayerSelect", () => {
 
     const wrapper = mountPlayerSelect();
 
-    expect(wrapper.find(".player-select-backdrop").classes()).toContain(
-      "player-select-fullscreen-backdrop",
-    );
-    expect(
-      wrapper.find('[data-testid="player-select-sheet"]').classes(),
-    ).toContain("player-select-popover-fullscreen");
+    const backdrop = wrapper.find(".player-select-backdrop");
+    expect(backdrop.classes()).toContain("player-select-fullscreen-backdrop");
+    // the fullscreen offset replaces the layout ones instead of stacking on them
+    expect(backdrop.classes()).not.toContain("player-select-mobile-offset");
+    const sheet = wrapper.find('[data-testid="player-select-sheet"]');
+    expect(sheet.classes()).toContain("player-select-popover-fullscreen");
+    expect(sheet.attributes("align")).toBe("center");
     expect(wrapper.findComponent(PopoverAnchorStub).props("reference")).toBe(
       fullscreenPlayerSelectAnchor,
     );


### PR DESCRIPTION
# What does this implement/fix?

Opening the player list from the fullscreen player closed the fullscreen player and dropped you back on the page behind it. Now that the player list is a popout instead of a full sheet, it can simply open on top of the fullscreen player, popping out of the player select button at the bottom.

**Related issue (if applicable):**

- n/a

**Related backend PR (if applicable):**

- n/a

Changes:

- The fullscreen player stays open when the player list is opened from it.
- The player list pops out of the fullscreen player's own player select button and is layered above it, with the usual dimmed backdrop.
- No dead space at the bottom of the panel there, since the floating player bar is hidden behind the fullscreen player.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm lint:check` passes.
- [x] `pnpm test:run` passes, and tests have been added/updated where applicable.
- [x] `pnpm build` passes.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
