### PR TITLE
Consistent settings screens and a save button that stays clear of the player bar

### DIFF
--- a/src/helpers/config_entry_ui.ts
+++ b/src/helpers/config_entry_ui.ts
@@ -144,6 +144,16 @@ export const allRequiredValuesPresent = (
       !isNullOrUndefined(entry.default_value),
   );
 
+/**
+ * Whether `entries` holds anything the advanced settings toggle would reveal.
+ *
+ * A config without advanced entries has no use for the toggle, so the settings
+ * screens leave it out entirely.
+ */
+export const hasAdvancedEntries = (
+  entries: readonly Pick<ConfigEntry, "advanced" | "hidden">[],
+): boolean => entries.some((entry) => entry.advanced && !entry.hidden);
+
 export const isInjected = (e: ConfigEntryUI): e is InjectedConfigEntry =>
   (e as InjectedConfigEntry).injected === true;
 

--- a/src/layouts/default/Footer.vue
+++ b/src/layouts/default/Footer.vue
@@ -6,7 +6,7 @@
     :style="`
       position: fixed;
       width: 100%;
-      height: calc(180px + var(--mobile-navigation-inset-bottom));
+      height: var(--mobile-player-scrim-height);
       bottom: 0px;
       z-index: 999;
     `"

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -34,6 +34,11 @@
   /* Space the bottom navigation occupies. Anything anchored above it (sheets,
      popovers, the player bar, scroll padding) is positioned from this. */
   --mobile-navigation-height: calc(66px + var(--mobile-navigation-inset-bottom));
+  /* Height of the gradient panel behind the floating player bar. It hides whatever
+     it covers, so anything that has to stay visible is positioned above it. */
+  --mobile-player-scrim-height: calc(
+    180px + var(--mobile-navigation-inset-bottom)
+  );
 }
 
 html {

--- a/src/views/settings/EditConfig.vue
+++ b/src/views/settings/EditConfig.vue
@@ -88,10 +88,7 @@
       </div>
     </div>
 
-    <div
-      v-if="!disabled && actionLayout === 'floating-save'"
-      class="floating-save"
-    >
+    <div v-if="!disabled" class="floating-save">
       <Button
         data-testid="config-save"
         type="button"
@@ -103,34 +100,6 @@
         <Save class="size-4" />
         {{ $t("settings.save") }}
       </Button>
-    </div>
-    <div v-else-if="!disabled" class="config-actions">
-      <!-- Show advanced settings toggle -->
-      <div class="advanced-toggle-wrapper">
-        <v-switch
-          v-model="showAdvancedSettings"
-          color="primary"
-          hide-details
-          density="comfortable"
-          :label="$t('settings.show_advanced_settings')"
-          class="advanced-settings-switch"
-        />
-      </div>
-      <v-btn
-        block
-        color="primary"
-        size="large"
-        :disabled="!requiredValuesPresent || !hasUnsavedChanges"
-        @click="submit"
-      >
-        {{ $t("settings.save") }}
-      </v-btn>
-      <v-btn block variant="outlined" size="large" @click="handleClose">
-        {{ $t("close") }}
-      </v-btn>
-      <v-btn block variant="text" size="large" @click="resetToDefaults">
-        {{ $t("settings.reset_to_defaults") }}
-      </v-btn>
     </div>
   </v-form>
   <v-dialog
@@ -223,7 +192,6 @@ const showUnsavedDialog = ref(false);
 const allowNavigation = ref(false);
 
 export interface Props {
-  actionLayout?: "default" | "floating-save";
   configEntries: ConfigEntryUI[];
   disabled: boolean;
   // Output protocols of the player being configured; drives derived-transport labelling
@@ -440,14 +408,6 @@ const resetToDefaults = function () {
 
 defineExpose({ resetToDefaults });
 
-const handleClose = function () {
-  if (hasUnsavedChanges.value) {
-    showUnsavedDialog.value = true;
-  } else {
-    router.back();
-  }
-};
-
 const confirmDiscard = function () {
   showUnsavedDialog.value = false;
   allowNavigation.value = true;
@@ -631,20 +591,6 @@ const getCategoryIcon = function (category: string): Component {
   padding: 14px 16px;
 }
 
-/* Action buttons */
-.config-actions {
-  display: flex;
-  flex-direction: column;
-  gap: 12px;
-  margin-top: 24px;
-  padding-top: 16px;
-}
-
-.config-actions .v-btn--disabled {
-  background-color: rgba(var(--v-theme-on-surface), 0.12) !important;
-  color: rgba(var(--v-theme-on-surface), 0.38) !important;
-}
-
 .floating-save {
   position: fixed;
   right: 24px;
@@ -654,28 +600,19 @@ const getCategoryIcon = function (category: string): Component {
 
 :global(.content-section--mobile) .floating-save {
   right: 16px;
-  bottom: calc(var(--mobile-navigation-height) + 108px);
+  /* Stay clear of whatever reaches highest above the bottom navigation: the player
+     bar, which grows by its volume row and sits 6px above the navigation, or the
+     gradient scrim behind it, which hides everything it covers. */
+  bottom: max(
+    calc(
+      var(--mobile-navigation-height) + var(--player-bar-overlay-height, 0px) +
+        22px
+    ),
+    calc(var(--mobile-player-scrim-height) + 16px)
+  );
 }
 
 :global(.content-section--frameless) .floating-save {
   bottom: 16px;
-}
-
-/* Advanced settings toggle */
-.advanced-toggle-wrapper {
-  display: flex;
-  justify-content: center;
-  padding: 8px 0 16px 0;
-  margin-bottom: 8px;
-  border-bottom: 1px solid rgba(var(--v-theme-on-surface), 0.08);
-}
-
-.advanced-settings-switch {
-  opacity: 0.85;
-  transition: opacity 0.2s ease;
-}
-
-.advanced-settings-switch:hover {
-  opacity: 1;
 }
 </style>

--- a/src/views/settings/EditConfig.vue
+++ b/src/views/settings/EditConfig.vue
@@ -601,12 +601,12 @@ const getCategoryIcon = function (category: string): Component {
 :global(.content-section--mobile) .floating-save {
   right: 16px;
   /* Stay clear of whatever reaches highest above the bottom navigation: the player
-     bar, which grows by its volume row and sits 6px above the navigation, or the
-     gradient scrim behind it, which hides everything it covers. */
+     bar, which grows by its volume row and clears the navigation by its own 6px
+     margin, or the gradient scrim behind it, which hides everything it covers. */
   bottom: max(
     calc(
       var(--mobile-navigation-height) + var(--player-bar-overlay-height, 0px) +
-        22px
+        6px + 16px
     ),
     calc(var(--mobile-player-scrim-height) + 16px)
   );

--- a/src/views/settings/EditCoreConfig.vue
+++ b/src/views/settings/EditCoreConfig.vue
@@ -21,10 +21,11 @@
       @immediate-apply="onImmediateApply"
     />
 
+    <!-- z-index clears the player bar (2001), which floats above page content -->
     <div
       v-if="loading"
       data-testid="loading-overlay"
-      class="fixed inset-0 z-50 flex items-center justify-center bg-background/80"
+      class="fixed inset-0 z-[2100] flex items-center justify-center bg-background/80"
     >
       <Spinner class="size-16" />
     </div>

--- a/src/views/settings/EditCoreConfig.vue
+++ b/src/views/settings/EditCoreConfig.vue
@@ -1,28 +1,19 @@
 <template>
-  <section class="edit-core-config">
-    <div v-if="config && api.providerManifests[config.domain]">
-      <!-- Header card -->
-      <v-card class="header-card mb-4" elevation="0">
-        <div class="header-content">
-          <div class="header-icon">
-            <v-icon size="32" color="primary">{{
-              getCoreIcon(config.domain)
-            }}</v-icon>
-          </div>
-          <div class="header-info">
-            <h2 class="header-title">
-              {{ getItemTitle(config) }}
-            </h2>
-            <p class="header-description">
-              {{ getItemDescription(config) }}
-            </p>
-          </div>
-        </div>
-      </v-card>
-    </div>
+  <section class="p-4">
+    <SettingsHeaderCard
+      v-if="config && api.providerManifests[config.domain]"
+      v-model:show-advanced-settings="showAdvancedSettings"
+      :icon="getCoreIcon(config.domain)"
+      :title="getItemTitle(config)"
+      :description="getItemDescription(config)"
+      :show-advanced-toggle="hasAdvancedEntries(allConfigEntries)"
+      @reset-to-defaults="resetToDefaults"
+    />
 
     <edit-config
       v-if="config"
+      ref="editConfig"
+      v-model:show-advanced-settings="showAdvancedSettings"
       :config-entries="allConfigEntries"
       :disabled="false"
       @submit="onSubmit"
@@ -30,32 +21,45 @@
       @immediate-apply="onImmediateApply"
     />
 
-    <v-overlay
-      v-model="loading"
-      scrim="true"
-      persistent
-      class="loading-overlay"
+    <div
+      v-if="loading"
+      data-testid="loading-overlay"
+      class="fixed inset-0 z-50 flex items-center justify-center bg-background/80"
     >
-      <v-progress-circular indeterminate size="64" color="primary" />
-    </v-overlay>
+      <Spinner class="size-16" />
+    </div>
   </section>
 </template>
 
 <script setup lang="ts">
+import { Spinner } from "@/components/ui/spinner";
 import { useConfigAction } from "@/composables/useConfigAction";
+import { hasAdvancedEntries } from "@/helpers/config_entry_ui";
 import { api } from "@/plugins/api";
 import { ConfigValueType, CoreConfig } from "@/plugins/api/interfaces";
-import { computed, ref, watch } from "vue";
+import {
+  Database,
+  Globe,
+  Music,
+  RadioTower,
+  Settings2,
+  Speaker,
+  Tags,
+} from "@lucide/vue";
+import { computed, ref, watch, type Component } from "vue";
 import { useI18n } from "vue-i18n";
 import { useRouter } from "vue-router";
 import { toast } from "vue-sonner";
 import EditConfig from "./EditConfig.vue";
+import SettingsHeaderCard from "./SettingsHeaderCard.vue";
 
 // global refs
 const router = useRouter();
 const { t } = useI18n();
 const config = ref<CoreConfig>();
+const editConfig = ref<InstanceType<typeof EditConfig>>();
 const loading = ref(false);
+const showAdvancedSettings = ref(false);
 
 // props
 const props = defineProps<{
@@ -98,16 +102,20 @@ const getItemDescription = (item: CoreConfig) => {
     : api.providerManifests[item.domain].description;
 };
 
-const getCoreIcon = (domain: string): string => {
-  const iconMap: Record<string, string> = {
-    streams: "mdi-radio-tower",
-    players: "mdi-speaker-multiple",
-    metadata: "mdi-tag-multiple",
-    music: "mdi-music",
-    webserver: "mdi-web",
-    cache: "mdi-cached",
+const getCoreIcon = (domain: string): Component => {
+  const iconMap: Record<string, Component> = {
+    streams: RadioTower,
+    players: Speaker,
+    metadata: Tags,
+    music: Music,
+    webserver: Globe,
+    cache: Database,
   };
-  return iconMap[domain] || "mdi-cog";
+  return iconMap[domain] || Settings2;
+};
+
+const resetToDefaults = function () {
+  editConfig.value?.resetToDefaults();
 };
 
 const onSubmit = async function (values: Record<string, ConfigValueType>) {
@@ -145,63 +153,3 @@ const { onAction } = useConfigAction({
   saveValues: (values) => api.saveCoreConfig(config.value!.domain, values),
 });
 </script>
-
-<style scoped>
-.edit-core-config {
-  padding: 16px;
-}
-
-.header-card {
-  border: 1px solid rgba(var(--v-theme-on-surface), 0.12);
-  border-radius: 12px;
-}
-
-.header-content {
-  display: flex;
-  gap: 20px;
-  padding: 24px;
-}
-
-.header-icon {
-  flex-shrink: 0;
-  width: 56px;
-  height: 56px;
-  border-radius: 12px;
-  background: rgba(var(--v-theme-primary), 0.1);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-}
-
-.header-info {
-  flex: 1;
-  min-width: 0;
-}
-
-.header-title {
-  font-size: 1.25rem;
-  font-weight: 600;
-  margin: 0 0 8px 0;
-  color: rgb(var(--v-theme-on-surface));
-}
-
-.header-description {
-  font-size: 0.875rem;
-  color: rgba(var(--v-theme-on-surface), 0.7);
-  margin: 0;
-  line-height: 1.5;
-}
-
-.loading-overlay {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-}
-
-@media (max-width: 600px) {
-  .header-content {
-    flex-direction: column;
-    align-items: flex-start;
-  }
-}
-</style>

--- a/src/views/settings/EditPlayer.vue
+++ b/src/views/settings/EditPlayer.vue
@@ -176,7 +176,7 @@
           </DropdownMenu>
         </CardHeader>
         <CardContent
-          v-if="playerSetupLabel || config.enabled"
+          v-if="playerSetupLabel || showAdvancedToggle"
           class="flex flex-wrap items-center gap-3 border-t bg-muted/20 px-6 py-4"
         >
           <Button
@@ -188,7 +188,7 @@
             {{ $t(playerSetupLabel) }}
           </Button>
           <div
-            v-if="config.enabled"
+            v-if="showAdvancedToggle"
             class="flex w-full items-center gap-2 sm:ml-auto sm:w-auto"
           >
             <Switch
@@ -266,7 +266,6 @@
       v-if="config"
       ref="editConfig"
       v-model:show-advanced-settings="showAdvancedSettings"
-      action-layout="floating-save"
       :disabled="!config?.enabled"
       :config-entries="config_entries"
       :output-protocols="api.players[config.player_id]?.output_protocols || []"
@@ -353,6 +352,7 @@ import {
   HassControlPickerEntry,
   HassControlPlayerKey,
   UI_ENTRY_TYPE,
+  hasAdvancedEntries,
   isInjected,
   mergeConfigEntries,
 } from "@/helpers/config_entry_ui";
@@ -537,6 +537,10 @@ const config_entries = computed(() => {
   }
   return entries;
 });
+
+const showAdvancedToggle = computed(
+  () => !!config.value?.enabled && hasAdvancedEntries(config_entries.value),
+);
 
 // watchers
 

--- a/src/views/settings/EditPlayerQueue.vue
+++ b/src/views/settings/EditPlayerQueue.vue
@@ -34,10 +34,11 @@
       @immediate-apply="onImmediateApply"
     />
 
+    <!-- z-index clears the player bar (2001), which floats above page content -->
     <div
       v-if="loading"
       data-testid="loading-overlay"
-      class="fixed inset-0 z-50 flex items-center justify-center bg-background/80"
+      class="fixed inset-0 z-[2100] flex items-center justify-center bg-background/80"
     >
       <Spinner class="size-16" />
     </div>

--- a/src/views/settings/EditPlayerQueue.vue
+++ b/src/views/settings/EditPlayerQueue.vue
@@ -1,16 +1,13 @@
 <template>
-  <section class="edit-queue-config">
-    <v-card class="header-card mb-4" elevation="0">
-      <div class="header-content">
-        <div class="header-icon">
-          <v-icon size="32" color="primary">mdi-tune</v-icon>
-        </div>
-        <div class="header-info">
-          <h2 class="header-title">{{ $t("settings.queue_settings") }}</h2>
-          <p class="header-description">{{ queueName }}</p>
-        </div>
-      </div>
-    </v-card>
+  <section class="p-4">
+    <SettingsHeaderCard
+      v-model:show-advanced-settings="showAdvancedSettings"
+      :icon="SlidersHorizontal"
+      :title="$t('settings.queue_settings')"
+      :description="queueName"
+      :show-advanced-toggle="hasAdvancedEntries(allConfigEntries)"
+      @reset-to-defaults="resetToDefaults"
+    />
 
     <!-- Global queue settings hint -->
     <div
@@ -29,20 +26,21 @@
 
     <edit-config
       v-if="config"
+      ref="editConfig"
+      v-model:show-advanced-settings="showAdvancedSettings"
       :config-entries="allConfigEntries"
       :disabled="false"
       @submit="onSubmit"
       @immediate-apply="onImmediateApply"
     />
 
-    <v-overlay
-      v-model="loading"
-      scrim="true"
-      persistent
-      class="loading-overlay"
+    <div
+      v-if="loading"
+      data-testid="loading-overlay"
+      class="fixed inset-0 z-50 flex items-center justify-center bg-background/80"
     >
-      <v-progress-circular indeterminate size="64" color="primary" />
-    </v-overlay>
+      <Spinner class="size-16" />
+    </div>
   </section>
 </template>
 
@@ -50,16 +48,21 @@
 import { api } from "@/plugins/api";
 import { ConfigValueType, PlayerQueueConfig } from "@/plugins/api/interfaces";
 import { Button } from "@/components/ui/button";
-import { Info } from "@lucide/vue";
+import { Spinner } from "@/components/ui/spinner";
+import { hasAdvancedEntries } from "@/helpers/config_entry_ui";
+import { Info, SlidersHorizontal } from "@lucide/vue";
 import { computed, ref, watch } from "vue";
 import { RouterLink, useRouter } from "vue-router";
 import { toast } from "vue-sonner";
 import EditConfig from "./EditConfig.vue";
+import SettingsHeaderCard from "./SettingsHeaderCard.vue";
 
 // global refs
 const router = useRouter();
 const config = ref<PlayerQueueConfig>();
+const editConfig = ref<InstanceType<typeof EditConfig>>();
 const loading = ref(false);
+const showAdvancedSettings = ref(false);
 
 // props
 const props = defineProps<{
@@ -88,6 +91,10 @@ watch(
 );
 
 // methods
+const resetToDefaults = function () {
+  editConfig.value?.resetToDefaults();
+};
+
 const onSubmit = async function (values: Record<string, ConfigValueType>) {
   loading.value = true;
   api
@@ -119,63 +126,3 @@ const onImmediateApply = async function (
     });
 };
 </script>
-
-<style scoped>
-.edit-queue-config {
-  padding: 16px;
-}
-
-.header-card {
-  border: 1px solid rgba(var(--v-theme-on-surface), 0.12);
-  border-radius: 12px;
-}
-
-.header-content {
-  display: flex;
-  gap: 20px;
-  padding: 24px;
-}
-
-.header-icon {
-  flex-shrink: 0;
-  width: 56px;
-  height: 56px;
-  border-radius: 12px;
-  background: rgba(var(--v-theme-primary), 0.1);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-}
-
-.header-info {
-  flex: 1;
-  min-width: 0;
-}
-
-.header-title {
-  font-size: 1.25rem;
-  font-weight: 600;
-  margin: 0 0 8px 0;
-  color: rgb(var(--v-theme-on-surface));
-}
-
-.header-description {
-  font-size: 0.875rem;
-  color: rgba(var(--v-theme-on-surface), 0.7);
-  margin: 0;
-  line-height: 1.5;
-}
-
-.loading-overlay {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-}
-
-@media (max-width: 600px) {
-  .header-content {
-    flex-direction: column;
-    align-items: flex-start;
-  }
-}
-</style>

--- a/src/views/settings/EditProvider.vue
+++ b/src/views/settings/EditProvider.vue
@@ -136,7 +136,7 @@
               "
             ></div>
           </div>
-          <DropdownMenu v-if="canToggleEnabled">
+          <DropdownMenu>
             <DropdownMenuTrigger as-child>
               <Button
                 data-testid="provider-menu"
@@ -150,22 +150,33 @@
             </DropdownMenuTrigger>
             <DropdownMenuContent align="end">
               <DropdownMenuItem
-                data-testid="provider-toggle-enabled"
-                :disabled="toggleLoading"
-                @click="toggleEnabled"
+                data-testid="provider-reset-defaults"
+                :disabled="!config.enabled"
+                @click="resetToDefaults"
               >
-                <Power class="size-4" />
-                {{
-                  config.enabled
-                    ? $t("settings.disable")
-                    : $t("settings.enable")
-                }}
+                <RotateCcw class="size-4" />
+                {{ $t("settings.reset_to_defaults") }}
               </DropdownMenuItem>
+              <template v-if="canToggleEnabled">
+                <DropdownMenuSeparator />
+                <DropdownMenuItem
+                  data-testid="provider-toggle-enabled"
+                  :disabled="toggleLoading"
+                  @click="toggleEnabled"
+                >
+                  <Power class="size-4" />
+                  {{
+                    config.enabled
+                      ? $t("settings.disable")
+                      : $t("settings.enable")
+                  }}
+                </DropdownMenuItem>
+              </template>
             </DropdownMenuContent>
           </DropdownMenu>
         </CardHeader>
         <CardContent
-          class="flex flex-wrap gap-2 border-t bg-muted/20 px-6 py-4"
+          class="flex flex-wrap items-center gap-3 border-t bg-muted/20 px-6 py-4"
         >
           <Button
             v-if="canReconfigure"
@@ -198,12 +209,27 @@
             <CircleAlert class="size-4" />
             {{ $t("settings.known_issues") }}
           </Button>
+          <div
+            v-if="config.enabled && hasAdvancedEntries(allConfigEntries)"
+            class="flex w-full items-center gap-2 sm:ml-auto sm:w-auto"
+          >
+            <Switch
+              id="provider-advanced-settings"
+              v-model="showAdvancedSettings"
+              data-testid="provider-advanced-settings"
+            />
+            <Label for="provider-advanced-settings" class="cursor-pointer">
+              {{ $t("settings.show_advanced_settings") }}
+            </Label>
+          </div>
         </CardContent>
       </Card>
     </div>
 
     <edit-config
       v-if="config"
+      ref="editConfig"
+      v-model:show-advanced-settings="showAdvancedSettings"
       :config-entries="allConfigEntries"
       :disabled="!config.enabled"
       :provider-domain="config.domain"
@@ -274,10 +300,16 @@ import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
+  DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
+import { Label } from "@/components/ui/label";
+import { Switch } from "@/components/ui/switch";
 import { useConfigAction } from "@/composables/useConfigAction";
-import { mergeConfigEntries } from "@/helpers/config_entry_ui";
+import {
+  hasAdvancedEntries,
+  mergeConfigEntries,
+} from "@/helpers/config_entry_ui";
 import {
   canReconfigureProvider,
   getProviderStatusTranslationKey,
@@ -299,6 +331,7 @@ import {
   Pencil,
   Power,
   RefreshCw,
+  RotateCcw,
   Trash2,
   TriangleAlert,
 } from "@lucide/vue";
@@ -312,7 +345,9 @@ import EditConfig from "./EditConfig.vue";
 const router = useRouter();
 const { t } = useI18n();
 const config = ref<ProviderConfig>();
+const editConfig = ref<InstanceType<typeof EditConfig>>();
 const loading = ref(false);
+const showAdvancedSettings = ref(false);
 const toggleLoading = ref(false);
 const showRenameDialog = ref(false);
 const editName = ref<string | null>(null);
@@ -408,6 +443,10 @@ const backToProviders = function () {
     name: "providersettings",
     query: { types: config.value?.type },
   });
+};
+
+const resetToDefaults = function () {
+  editConfig.value?.resetToDefaults();
 };
 
 const onReload = function () {

--- a/src/views/settings/FrontendConfig.vue
+++ b/src/views/settings/FrontendConfig.vue
@@ -23,11 +23,11 @@
       @immediate-apply="onImmediateApply"
     />
 
-    <!-- Loading overlay -->
+    <!-- Loading overlay; z-index clears the player bar (2001) floating above it -->
     <div
       v-if="loading"
       data-testid="loading-overlay"
-      class="fixed inset-0 z-50 flex items-center justify-center bg-background/80"
+      class="fixed inset-0 z-[2100] flex items-center justify-center bg-background/80"
     >
       <Spinner class="size-16" />
     </div>
@@ -60,6 +60,8 @@ const router = useRouter();
 const config = ref<ConfigEntry[]>([]);
 const editConfig = ref<InstanceType<typeof EditConfig>>();
 const loading = ref(false);
+// no entry below is advanced today, so the toggle stays hidden; the wiring is what
+// makes an advanced entry reachable the moment one is added
 const showAdvancedSettings = ref(false);
 
 onMounted(() => {

--- a/src/views/settings/FrontendConfig.vue
+++ b/src/views/settings/FrontendConfig.vue
@@ -1,25 +1,21 @@
 <template>
   <div class="p-4">
     <!-- Header card -->
-    <Card class="mb-4">
-      <CardHeader class="flex flex-row items-center gap-4 pb-4">
-        <div
-          class="flex size-14 shrink-0 items-center justify-center rounded-xl bg-orange-500/10"
-        >
-          <Palette class="size-8 text-orange-500" />
-        </div>
-        <div class="flex flex-col gap-1">
-          <CardTitle>{{ $t("settings.frontend") }}</CardTitle>
-          <CardDescription>{{
-            $t("settings.frontend_description")
-          }}</CardDescription>
-        </div>
-      </CardHeader>
-    </Card>
+    <SettingsHeaderCard
+      v-model:show-advanced-settings="showAdvancedSettings"
+      :icon="Palette"
+      icon-class="text-orange-500"
+      :title="$t('settings.frontend')"
+      :description="$t('settings.frontend_description')"
+      :show-advanced-toggle="hasAdvancedEntries(config)"
+      @reset-to-defaults="resetToDefaults"
+    />
 
     <!-- Config entries -->
     <EditConfig
       v-if="config.length > 0"
+      ref="editConfig"
+      v-model:show-advanced-settings="showAdvancedSettings"
       :config-entries="config"
       :disabled="false"
       @submit="onSubmit"
@@ -30,6 +26,7 @@
     <!-- Loading overlay -->
     <div
       v-if="loading"
+      data-testid="loading-overlay"
       class="fixed inset-0 z-50 flex items-center justify-center bg-background/80"
     >
       <Spinner class="size-16" />
@@ -42,15 +39,10 @@ import { Palette } from "@lucide/vue";
 import { onMounted, ref } from "vue";
 import { useRouter } from "vue-router";
 
-import {
-  Card,
-  CardDescription,
-  CardHeader,
-  CardTitle,
-} from "@/components/ui/card";
 import { Spinner } from "@/components/ui/spinner";
 import { useUserPreferences } from "@/composables/userPreferences";
 import { DEVICE_SETTING_KEYS } from "@/constants";
+import { hasAdvancedEntries } from "@/helpers/config_entry_ui";
 import {
   ConfigEntry,
   ConfigEntryType,
@@ -61,11 +53,14 @@ import { eventbus } from "@/plugins/eventbus";
 import { $t, i18n } from "@/plugins/i18n";
 import { store } from "@/plugins/store";
 import EditConfig from "./EditConfig.vue";
+import SettingsHeaderCard from "./SettingsHeaderCard.vue";
 
 // global refs
 const router = useRouter();
 const config = ref<ConfigEntry[]>([]);
+const editConfig = ref<InstanceType<typeof EditConfig>>();
 const loading = ref(false);
+const showAdvancedSettings = ref(false);
 
 onMounted(() => {
   // TODO: Remove localStorage fallbacks below once migration period is over
@@ -223,6 +218,10 @@ onMounted(() => {
 });
 
 // methods
+const resetToDefaults = function () {
+  editConfig.value?.resetToDefaults();
+};
+
 const saveValues = async function (values: Record<string, ConfigValueType>) {
   const { setPreference } = useUserPreferences();
   loading.value = true;

--- a/src/views/settings/SettingsHeaderCard.vue
+++ b/src/views/settings/SettingsHeaderCard.vue
@@ -1,0 +1,100 @@
+<template>
+  <Card class="mb-4 gap-0 py-0">
+    <CardHeader class="relative flex flex-row items-center gap-5 p-6 pr-16">
+      <div
+        :class="
+          cn(
+            'flex size-14 shrink-0 items-center justify-center rounded-xl bg-current/10 text-primary',
+            iconClass,
+          )
+        "
+      >
+        <component :is="icon" class="size-8" />
+      </div>
+      <div class="min-w-0 flex-1">
+        <CardTitle class="text-xl leading-tight">{{ title }}</CardTitle>
+        <CardDescription v-if="description" class="mt-2 leading-relaxed">
+          {{ description }}
+        </CardDescription>
+      </div>
+      <DropdownMenu>
+        <DropdownMenuTrigger as-child>
+          <Button
+            data-testid="settings-menu"
+            variant="ghost"
+            size="icon-sm"
+            class="absolute top-4 right-4"
+            :aria-label="$t('more_options')"
+          >
+            <MoreVertical class="size-4" />
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end">
+          <DropdownMenuItem
+            data-testid="settings-reset-defaults"
+            @click="emit('resetToDefaults')"
+          >
+            <RotateCcw class="size-4" />
+            {{ $t("settings.reset_to_defaults") }}
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+    </CardHeader>
+    <CardContent
+      v-if="showAdvancedToggle"
+      class="flex items-center gap-2 border-t bg-muted/20 px-6 py-4 sm:justify-end"
+    >
+      <Switch
+        id="settings-advanced-settings"
+        v-model="showAdvancedSettings"
+        data-testid="settings-advanced-settings"
+      />
+      <Label for="settings-advanced-settings" class="cursor-pointer">
+        {{ $t("settings.show_advanced_settings") }}
+      </Label>
+    </CardContent>
+  </Card>
+</template>
+
+<script setup lang="ts">
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { Label } from "@/components/ui/label";
+import { Switch } from "@/components/ui/switch";
+import { cn } from "@/lib/utils";
+import { MoreVertical, RotateCcw } from "@lucide/vue";
+import type { Component } from "vue";
+
+/**
+ * Header card shared by the settings screens that edit a plain config: it names what
+ * is being configured and carries the controls that act on the whole form.
+ */
+defineProps<{
+  icon: Component;
+  title: string;
+  description?: string;
+  // tints the icon and its tile, e.g. "text-orange-500"; defaults to the primary colour
+  iconClass?: string;
+  showAdvancedToggle?: boolean;
+}>();
+
+const emit = defineEmits<{
+  (e: "resetToDefaults"): void;
+}>();
+
+const showAdvancedSettings = defineModel<boolean>("showAdvancedSettings", {
+  default: false,
+});
+</script>

--- a/src/views/settings/SettingsHeaderCard.vue
+++ b/src/views/settings/SettingsHeaderCard.vue
@@ -1,6 +1,8 @@
 <template>
   <Card class="mb-4 gap-0 py-0">
-    <CardHeader class="relative flex flex-row items-center gap-5 p-6 pr-16">
+    <CardHeader
+      class="relative flex flex-col gap-5 p-6 pr-16 sm:flex-row sm:items-center"
+    >
       <div
         :class="
           cn(
@@ -45,11 +47,11 @@
       class="flex items-center gap-2 border-t bg-muted/20 px-6 py-4 sm:justify-end"
     >
       <Switch
-        id="settings-advanced-settings"
+        :id="advancedToggleId"
         v-model="showAdvancedSettings"
         data-testid="settings-advanced-settings"
       />
-      <Label for="settings-advanced-settings" class="cursor-pointer">
+      <Label :for="advancedToggleId" class="cursor-pointer">
         {{ $t("settings.show_advanced_settings") }}
       </Label>
     </CardContent>
@@ -75,7 +77,7 @@ import { Label } from "@/components/ui/label";
 import { Switch } from "@/components/ui/switch";
 import { cn } from "@/lib/utils";
 import { MoreVertical, RotateCcw } from "@lucide/vue";
-import type { Component } from "vue";
+import { useId, type Component } from "vue";
 
 /**
  * Header card shared by the settings screens that edit a plain config: it names what
@@ -85,8 +87,9 @@ defineProps<{
   icon: Component;
   title: string;
   description?: string;
-  // tints the icon and its tile, e.g. "text-orange-500"; defaults to the primary colour
+  /** Tints the icon and its tile, e.g. "text-orange-500"; defaults to the primary colour. */
   iconClass?: string;
+  /** Whether the config holds advanced entries the toggle can reveal. */
   showAdvancedToggle?: boolean;
 }>();
 
@@ -97,4 +100,6 @@ const emit = defineEmits<{
 const showAdvancedSettings = defineModel<boolean>("showAdvancedSettings", {
   default: false,
 });
+
+const advancedToggleId = useId();
 </script>

--- a/tests/helpers/config_entry_ui.test.ts
+++ b/tests/helpers/config_entry_ui.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   allRequiredValuesPresent,
+  hasAdvancedEntries,
   isEntryDisabled,
   mergeActionEntries,
   mergeConfigEntries,
@@ -310,5 +311,24 @@ describe("mergeActionEntries", () => {
 
     expect(current).toEqual(currentSnapshot);
     expect(incoming).toEqual(incomingSnapshot);
+  });
+});
+
+describe("hasAdvancedEntries", () => {
+  it("finds an advanced entry", () => {
+    expect(
+      hasAdvancedEntries([entry(), entry({ key: "tweak", advanced: true })]),
+    ).toBe(true);
+  });
+
+  it("ignores an advanced entry the form never shows", () => {
+    expect(hasAdvancedEntries([entry({ advanced: true, hidden: true })])).toBe(
+      false,
+    );
+  });
+
+  it("reports nothing to reveal without advanced entries", () => {
+    expect(hasAdvancedEntries([entry()])).toBe(false);
+    expect(hasAdvancedEntries([])).toBe(false);
   });
 });

--- a/tests/views/EditConfig.test.ts
+++ b/tests/views/EditConfig.test.ts
@@ -247,12 +247,10 @@ describe("EditConfig", () => {
     expect(saveDisabled(wrapper)).toBe(true);
   });
 
-  it("renders only a floating save action when requested", async () => {
-    const wrapper = mountEntries(
-      [entry({ key: "server", type: ConfigEntryType.STRING })],
-      false,
-      { actionLayout: "floating-save" },
-    );
+  it("leaves the form-wide controls to the settings screen around it", async () => {
+    const wrapper = mountEntries([
+      entry({ key: "server", type: ConfigEntryType.STRING }),
+    ]);
 
     dirty(wrapper);
     await nextTick();
@@ -262,7 +260,15 @@ describe("EditConfig", () => {
     );
     expect(wrapper.text()).not.toContain("settings.show_advanced_settings");
     expect(wrapper.text()).not.toContain("settings.reset_to_defaults");
-    expect(wrapper.find(".config-actions").exists()).toBe(false);
+  });
+
+  it("hides the save action on a disabled form", () => {
+    const wrapper = mountEntries(
+      [entry({ key: "server", type: ConfigEntryType.STRING })],
+      true,
+    );
+
+    expect(wrapper.find('[data-testid="config-save"]').exists()).toBe(false);
   });
 });
 
@@ -290,13 +296,9 @@ function dependentEntry(
   });
 }
 
-function mountEntries(
-  configEntries: ConfigEntry[],
-  disabled = false,
-  props: { actionLayout?: "default" | "floating-save" } = {},
-) {
+function mountEntries(configEntries: ConfigEntry[], disabled = false) {
   return shallowMount(EditConfig, {
-    props: { configEntries, disabled, ...props },
+    props: { configEntries, disabled },
     global: { renderStubDefaultSlot: true },
   });
 }
@@ -316,9 +318,7 @@ function dirty(wrapper: VueWrapper) {
 }
 
 function saveDisabled(wrapper: VueWrapper) {
-  const button = wrapper
-    .findAll("v-btn-stub")
-    .find((btn) => btn.text() === "settings.save");
-  if (!button) throw new Error("save button not rendered");
+  const button = wrapper.find('[data-testid="config-save"]');
+  if (!button.exists()) throw new Error("save button not rendered");
   return button.attributes("disabled") === "true";
 }

--- a/tests/views/EditConfig.test.ts
+++ b/tests/views/EditConfig.test.ts
@@ -262,6 +262,29 @@ describe("EditConfig", () => {
     expect(wrapper.text()).not.toContain("settings.reset_to_defaults");
   });
 
+  it("puts every entry back to its default value on request", async () => {
+    const wrapper = mountEntries([
+      entry({
+        key: "server",
+        type: ConfigEntryType.STRING,
+        default_value: "localhost",
+        value: "elsewhere",
+      }),
+    ]);
+
+    wrapper.vm.resetToDefaults();
+    await nextTick();
+
+    expect(
+      (
+        wrapper
+          .findAllComponents({ name: "ConfigEntryRow" })[0]
+          .props("confEntry") as ConfigEntry
+      ).value,
+    ).toBe("localhost");
+    expect(saveDisabled(wrapper)).toBe(false);
+  });
+
   it("hides the save action on a disabled form", () => {
     const wrapper = mountEntries(
       [entry({ key: "server", type: ConfigEntryType.STRING })],

--- a/tests/views/EditCoreConfig.test.ts
+++ b/tests/views/EditCoreConfig.test.ts
@@ -104,10 +104,70 @@ describe("EditCoreConfig", () => {
     expect(entriesAfter[0].value).toBe("typed but not saved");
     expect(apiMock.saveCoreConfig).not.toHaveBeenCalled();
     expect(toastMock.success).toHaveBeenCalledWith("settings.action_completed");
-    expect(
-      wrapper.findComponent({ name: "v-overlay" }).props("modelValue"),
-    ).toBe(false);
+    expect(wrapper.find('[data-testid="loading-overlay"]').exists()).toBe(
+      false,
+    );
   });
+
+  it("resets the form to its defaults from the header menu", async () => {
+    apiMock.getCoreConfig.mockResolvedValueOnce(coreConfig());
+    const resetToDefaults = vi.fn();
+
+    const wrapper = shallowMount(EditCoreConfig, {
+      props: {
+        domain: "cache",
+      },
+      global: {
+        mocks: {
+          $t: (key: string) => key,
+        },
+        stubs: {
+          EditConfig: {
+            name: "EditConfig",
+            methods: { resetToDefaults },
+            template: "<div />",
+          },
+        },
+      },
+    });
+    await flushPromises();
+
+    await wrapper
+      .findComponent({ name: "SettingsHeaderCard" })
+      .vm.$emit("resetToDefaults");
+
+    expect(resetToDefaults).toHaveBeenCalled();
+  });
+
+  it.each([
+    { advanced: true, offered: true },
+    { advanced: false, offered: false },
+  ])(
+    "offers the advanced toggle for a config with advanced entries: $advanced",
+    async ({ advanced, offered }) => {
+      const config = coreConfig();
+      config.values.clear_on_start.advanced = advanced;
+      apiMock.getCoreConfig.mockResolvedValueOnce(config);
+
+      const wrapper = shallowMount(EditCoreConfig, {
+        props: {
+          domain: "cache",
+        },
+        global: {
+          mocks: {
+            $t: (key: string) => key,
+          },
+        },
+      });
+      await flushPromises();
+
+      expect(
+        wrapper
+          .findComponent({ name: "SettingsHeaderCard" })
+          .props("showAdvancedToggle"),
+      ).toBe(offered);
+    },
+  );
 
   it("takes the value an action did provide", async () => {
     apiMock.getCoreConfig.mockResolvedValueOnce(coreConfig());

--- a/tests/views/EditPlayer.test.ts
+++ b/tests/views/EditPlayer.test.ts
@@ -60,7 +60,6 @@ const playerDetailsStubs = {
   EditConfig: {
     name: "EditConfig",
     props: [
-      "actionLayout",
       "configEntries",
       "disabled",
       "outputProtocols",
@@ -148,9 +147,18 @@ describe("EditPlayer", () => {
     expect(
       wrapper.get('[data-testid="player-toggle-enabled"]').text(),
     ).toContain("settings.disable");
+  });
+
+  it("leaves out the advanced toggle without advanced settings to reveal", async () => {
+    const config = playerConfig();
+    delete config.values.sample_rates;
+    apiMock.getPlayerConfig.mockResolvedValue(config);
+
+    const wrapper = await mountPlayerPage();
+
     expect(
-      wrapper.findComponent({ name: "EditConfig" }).props("actionLayout"),
-    ).toBe("floating-save");
+      wrapper.find('[data-testid="player-advanced-settings"]').exists(),
+    ).toBe(false);
   });
 
   it("controls advanced settings from the header", async () => {
@@ -512,6 +520,17 @@ function playerConfig({
         required: false,
         default_value: true,
         value: true,
+      },
+      sample_rates: {
+        key: "sample_rates",
+        type: ConfigEntryType.INTEGER,
+        label: "sample_rates",
+        category: "audio",
+        advanced: true,
+        options: [],
+        required: false,
+        default_value: 44100,
+        value: 44100,
       },
       ...Object.fromEntries(
         CONTROL_KEYS.map((key) => [key, controlEntry(key)]),

--- a/tests/views/EditProvider.test.ts
+++ b/tests/views/EditProvider.test.ts
@@ -436,7 +436,7 @@ describe("EditProvider", () => {
     );
   });
 
-  it("hides the header menu while enabled when disabling is not supported", async () => {
+  it("hides the enable/disable item while enabled when disabling is not supported", async () => {
     apiMock.providerManifests.spotify.allow_disable = false;
     apiMock.getProviderConfig.mockResolvedValue(
       spotifyConfig(ProviderStatus.LOADED),
@@ -455,8 +455,75 @@ describe("EditProvider", () => {
     });
     await flushPromises();
 
-    expect(wrapper.find('[data-testid="provider-menu"]').exists()).toBe(false);
+    expect(
+      wrapper.find('[data-testid="provider-toggle-enabled"]').exists(),
+    ).toBe(false);
+    expect(
+      wrapper.get('[data-testid="provider-reset-defaults"]').text(),
+    ).toContain("settings.reset_to_defaults");
   });
+
+  it("resets the form to its defaults from the header menu", async () => {
+    apiMock.getProviderConfig.mockResolvedValue(
+      spotifyConfig(ProviderStatus.LOADED),
+    );
+    const resetToDefaults = vi.fn();
+
+    const wrapper = shallowMount(EditProvider, {
+      props: {
+        instanceId: "spotify--test",
+      },
+      global: {
+        mocks: {
+          $t: (key: string) => key,
+        },
+        stubs: {
+          ...providerDetailsStubs,
+          EditConfig: {
+            name: "EditConfig",
+            methods: { resetToDefaults },
+            template: "<div />",
+          },
+        },
+      },
+    });
+    await flushPromises();
+
+    await wrapper
+      .get('[data-testid="provider-reset-defaults"]')
+      .trigger("click");
+
+    expect(resetToDefaults).toHaveBeenCalled();
+  });
+
+  it.each([
+    { advanced: true, offered: true },
+    { advanced: false, offered: false },
+  ])(
+    "offers the advanced toggle for a config with advanced entries: $advanced",
+    async ({ advanced, offered }) => {
+      const config = spotifyConfig(ProviderStatus.LOADED);
+      config.values.account.advanced = advanced;
+      apiMock.getProviderConfig.mockResolvedValue(config);
+
+      const wrapper = shallowMount(EditProvider, {
+        props: {
+          instanceId: "spotify--test",
+        },
+        global: {
+          mocks: {
+            $t: (key: string) => key,
+          },
+          stubs: providerDetailsStubs,
+        },
+      });
+      await flushPromises();
+
+      expect(
+        wrapper.find('[data-testid="provider-advanced-settings"]').exists(),
+      ).toBe(offered);
+    },
+  );
 
   it("enables a disabled provider when disabling is not supported", async () => {
     apiMock.providerManifests.spotify.allow_disable = false;

--- a/tests/views/SettingsHeaderCard.test.ts
+++ b/tests/views/SettingsHeaderCard.test.ts
@@ -1,0 +1,66 @@
+import { shallowMount } from "@vue/test-utils";
+import { Settings2 } from "@lucide/vue";
+import { describe, expect, it } from "vitest";
+import SettingsHeaderCard from "@/views/settings/SettingsHeaderCard.vue";
+
+const SlotStub = {
+  template: "<div><slot /></div>",
+};
+
+const headerStubs = {
+  Button: SlotStub,
+  Card: SlotStub,
+  CardContent: SlotStub,
+  CardDescription: SlotStub,
+  CardHeader: SlotStub,
+  CardTitle: SlotStub,
+  DropdownMenu: SlotStub,
+  DropdownMenuContent: SlotStub,
+  DropdownMenuItem: SlotStub,
+  DropdownMenuTrigger: SlotStub,
+};
+
+describe("SettingsHeaderCard", () => {
+  it("names what is being configured", () => {
+    const wrapper = mountHeader({ description: "Everything cached" });
+
+    expect(wrapper.text()).toContain("Cache");
+    expect(wrapper.text()).toContain("Everything cached");
+  });
+
+  it("asks the settings screen to reset the form", async () => {
+    const wrapper = mountHeader();
+
+    await wrapper
+      .get('[data-testid="settings-reset-defaults"]')
+      .trigger("click");
+
+    expect(wrapper.emitted("resetToDefaults")).toHaveLength(1);
+  });
+
+  it("leaves out the advanced toggle without advanced settings to reveal", () => {
+    expect(
+      mountHeader().find('[data-testid="settings-advanced-settings"]').exists(),
+    ).toBe(false);
+  });
+
+  it("reports the advanced toggle being flipped", async () => {
+    const wrapper = mountHeader({ showAdvancedToggle: true });
+
+    await wrapper
+      .findComponent({ name: "Switch" })
+      .vm.$emit("update:modelValue", true);
+
+    expect(wrapper.emitted("update:showAdvancedSettings")).toEqual([[true]]);
+  });
+});
+
+function mountHeader(props: Record<string, unknown> = {}) {
+  return shallowMount(SettingsHeaderCard, {
+    props: { icon: Settings2, title: "Cache", ...props },
+    global: {
+      mocks: { $t: (key: string) => key },
+      stubs: headerStubs,
+    },
+  });
+}


### PR DESCRIPTION
# What does this implement/fix?

The player settings screen recently got a floating save button, an advanced settings toggle in the header and a "reset to defaults" entry in the header menu. This brings the same layout to the other settings screens, and fixes the save button being hidden behind the player bar on mobile.

- Position the floating save button above the mobile player bar and the gradient behind it, so it stays visible and tappable however tall the bar is
- Give core, provider, queue and frontend settings the same floating save button, header toggle for advanced settings and "reset to defaults" in the header menu
- Only show the advanced settings toggle when there are advanced settings to reveal
- Share one header card between the core, queue and frontend settings screens, converted to shadcn

**Related issue (if applicable):**

- related issue `<link to issue>`

**Related backend PR (if applicable):**

- related backend PR `<link to PR>`

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm lint:check` passes.
- [x] `pnpm test:run` passes, and tests have been added/updated where applicable.
- [x] `pnpm build` passes.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
