### PR TITLE
Keep the selection bar and playback speed dialog clear of the player bar

### DIFF
--- a/src/components/ItemsListing.vue
+++ b/src/components/ItemsListing.vue
@@ -216,7 +216,7 @@
       <v-snackbar
         :model-value="selectedItems.length > 1"
         :timeout="-1"
-        style="margin-bottom: calc(120px + var(--device-inset-bottom))"
+        style="margin-bottom: calc(var(--bottom-bars-height) + 16px)"
       >
         <span>{{ $t("items_selected", [selectedItems.length]) }}</span>
         <template #actions>

--- a/src/components/ui/sheet/SheetOverlay.vue
+++ b/src/components/ui/sheet/SheetOverlay.vue
@@ -17,7 +17,7 @@ const delegatedProps = reactiveOmit(props, "class");
     data-slot="sheet-overlay"
     :class="
       cn(
-        'modal-backdrop data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed top-0 left-0 right-0 bottom-[var(--mobile-navigation-height)] z-[100000]',
+        'modal-backdrop data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-[100000]',
         props.class,
       )
     "

--- a/src/components/ui/sidebar/Sidebar.vue
+++ b/src/components/ui/sidebar/Sidebar.vue
@@ -55,7 +55,6 @@ const mobileSheetSide = computed<"left" | "right">(() => {
       data-mobile="true"
       :side="mobileSheetSide"
       class="sidebar-mobile-sheet bg-sidebar text-sidebar-foreground w-(--sidebar-width) p-0 [&>button]:hidden"
-      overlay-class="sidebar-mobile-overlay"
       :style="{
         '--sidebar-width': SIDEBAR_WIDTH_MOBILE,
       }"
@@ -124,9 +123,5 @@ const mobileSheetSide = computed<"left" | "right">(() => {
   bottom: 0 !important;
   height: 100dvh !important;
   border-radius: 0 !important;
-}
-
-.sidebar-mobile-overlay {
-  bottom: 0 !important;
 }
 </style>

--- a/src/layouts/default/PlayerOSD/Player.vue
+++ b/src/layouts/default/PlayerOSD/Player.vue
@@ -218,7 +218,7 @@ watch(
   grid-template-columns: minmax(0, 1fr) minmax(280px, 40%) minmax(0, 1fr);
   align-items: center;
   width: 100%;
-  min-height: 104px;
+  min-height: var(--player-bar-height);
   padding: 8px 15px;
   background-color: rgb(var(--v-theme-overlay));
   .mediacontrols-bottom-center {

--- a/src/layouts/default/PlayerOSD/PlayerBarGroupControl.vue
+++ b/src/layouts/default/PlayerOSD/PlayerBarGroupControl.vue
@@ -224,7 +224,7 @@ function handleInteractOutside(event: Event) {
 
 <style>
 .player-group-backdrop-desktop {
-  bottom: 104px !important;
+  bottom: var(--player-bar-height) !important;
 }
 
 .player-group-backdrop-mobile {

--- a/src/layouts/default/PlayerOSD/PlayerBarMobileVolumeSheet.vue
+++ b/src/layouts/default/PlayerOSD/PlayerBarMobileVolumeSheet.vue
@@ -58,7 +58,8 @@ function preventAutoFocus(event: Event) {
   max-height: calc(100dvh - var(--mobile-navigation-height) - 16px);
 }
 
-.mobile-group-volume-overlay {
+/* :root lifts this above the equally-!important inset-0 the backdrop carries */
+:root .mobile-group-volume-overlay {
   bottom: var(--mobile-navigation-height) !important;
 }
 

--- a/src/layouts/default/PlayerOSD/PlayerBarVolumeControl.vue
+++ b/src/layouts/default/PlayerOSD/PlayerBarVolumeControl.vue
@@ -169,7 +169,7 @@ function adjustVolume(event: WheelEvent) {
 
 <style>
 .player-volume-backdrop-desktop {
-  bottom: 104px;
+  bottom: var(--player-bar-height);
 }
 
 .player-volume-popover {

--- a/src/layouts/default/PlayerOSD/PlayerControlBtn/PlayerTrackMenu.vue
+++ b/src/layouts/default/PlayerOSD/PlayerControlBtn/PlayerTrackMenu.vue
@@ -332,7 +332,7 @@ onBeforeUnmount(flushPendingSpeed);
   top: auto !important;
   left: auto !important;
   right: 1rem !important;
-  bottom: calc(var(--mobile-navigation-height) + 8px) !important;
+  bottom: calc(var(--bottom-bars-height) + 8px) !important;
   transform: none !important;
 }
 

--- a/src/layouts/default/PlayerSelect.vue
+++ b/src/layouts/default/PlayerSelect.vue
@@ -586,7 +586,7 @@ async function scrollSelectedPlayerIntoView() {
 
 <style>
 .player-select-desktop-offset {
-  bottom: 104px !important;
+  bottom: var(--player-bar-height) !important;
 }
 
 .player-select-mobile-offset {

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -39,6 +39,21 @@
   --mobile-player-scrim-height: calc(
     180px + var(--mobile-navigation-inset-bottom)
   );
+  /* Space the player bar occupies in the desktop layout, where it sits flush
+     against the bottom of the screen. The mobile player bar floats and varies
+     with its contents, so it is measured at runtime instead. */
+  --player-bar-height: 104px;
+  /* Room the bars pinned to the bottom of the screen take up together, for
+     anything that has to float clear of them. */
+  --bottom-bars-height: var(--player-bar-height);
+}
+
+/* The footer sets this marker while the mobile bars are on screen. There the
+   player bar floats above the navigation, keeping a 6px gap from it. */
+:root[data-player-bar-overlay] {
+  --bottom-bars-height: calc(
+    var(--mobile-navigation-height) + 6px + var(--player-bar-overlay-height)
+  );
 }
 
 html {

--- a/src/views/settings/EditConfig.vue
+++ b/src/views/settings/EditConfig.vue
@@ -594,7 +594,7 @@ const getCategoryIcon = function (category: string): Component {
 .floating-save {
   position: fixed;
   right: 24px;
-  bottom: calc(var(--v-layout-bottom, 104px) + 16px);
+  bottom: calc(var(--v-layout-bottom, var(--player-bar-height)) + 16px);
   z-index: 20;
 }
 

--- a/src/views/settings/EditConfig.vue
+++ b/src/views/settings/EditConfig.vue
@@ -600,14 +600,11 @@ const getCategoryIcon = function (category: string): Component {
 
 :global(.content-section--mobile) .floating-save {
   right: 16px;
-  /* Stay clear of whatever reaches highest above the bottom navigation: the player
-     bar, which grows by its volume row and clears the navigation by its own 6px
-     margin, or the gradient scrim behind it, which hides everything it covers. */
+  /* Stay clear of whatever reaches highest above the bottom navigation: the
+     bottom bars, or the gradient scrim behind them, which hides what it covers
+     and outlasts the player bar when that has no volume row to grow by. */
   bottom: max(
-    calc(
-      var(--mobile-navigation-height) + var(--player-bar-overlay-height, 0px) +
-        6px + 16px
-    ),
+    calc(var(--bottom-bars-height) + 16px),
     calc(var(--mobile-player-scrim-height) + 16px)
   );
 }

--- a/tests/styles/bottomBarsHeight.test.ts
+++ b/tests/styles/bottomBarsHeight.test.ts
@@ -1,0 +1,62 @@
+// jsdom leaves var() unresolved in computed styles, so this cascade is only
+// observable under happy-dom
+// @vitest-environment happy-dom
+import css from "@/styles/global.css?inline";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+const OVERLAY_HEIGHT = "--player-bar-overlay-height";
+const OVERLAY_MARKER = "data-player-bar-overlay";
+const BAR_HEIGHT = "120px";
+const PLAYER_BAR_HEIGHT = "104px";
+const NAVIGATION_HEIGHT =
+  "calc(66px + calc(10px + env(safe-area-inset-bottom, 0px)))";
+
+let appStyles: HTMLStyleElement;
+
+// happy-dom substitutes every var() but does not evaluate calc(), so the mobile
+// branch is only observable as the expression it composes
+function bottomBarsHeight() {
+  return getComputedStyle(document.documentElement)
+    .getPropertyValue("--bottom-bars-height")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+// happy-dom caches an element's computed style from its first read, so this
+// builds its probe after the document state it measures is in place
+function offsetFromBars() {
+  const probe = document.createElement("div");
+  probe.style.bottom = "var(--bottom-bars-height)";
+  document.body.appendChild(probe);
+  return getComputedStyle(probe).bottom;
+}
+
+describe("bottom bars height", () => {
+  beforeEach(() => {
+    appStyles = document.createElement("style");
+    appStyles.textContent = css;
+    document.head.appendChild(appStyles);
+  });
+
+  afterEach(() => {
+    appStyles.remove();
+    document.body.innerHTML = "";
+    document.documentElement.removeAttribute(OVERLAY_MARKER);
+    document.documentElement.style.removeProperty(OVERLAY_HEIGHT);
+  });
+
+  it("reserves the player bar in the desktop layout", () => {
+    expect(bottomBarsHeight()).toBe(PLAYER_BAR_HEIGHT);
+    // always-rendered elements offset from this, so it has to reach them
+    expect(offsetFromBars()).toBe(PLAYER_BAR_HEIGHT);
+  });
+
+  it("stacks the floating player bar onto the navigation on mobile", () => {
+    document.documentElement.setAttribute(OVERLAY_MARKER, "");
+    document.documentElement.style.setProperty(OVERLAY_HEIGHT, BAR_HEIGHT);
+
+    expect(bottomBarsHeight()).toBe(
+      `calc( ${NAVIGATION_HEIGHT} + 6px + ${BAR_HEIGHT} )`,
+    );
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -14,7 +14,7 @@ export default mergeConfig(
       // The popout inset test asserts a real cascade result, so the app
       // stylesheet has to be compiled instead of stubbed out. Component styles
       // stay unprocessed, so the rest of the suite is unaffected.
-      css: { include: [/src\/styles\/style\.css/] },
+      css: { include: [/src\/styles\/(style|global)\.css/] },
       setupFiles: ["./tests/setup/failOnUnhandledErrors.ts"],
       // Errors that escape a test must never be silently dropped; the setup
       // file above additionally surfaces them in the pass/fail tally.


### PR DESCRIPTION
# What does this implement/fix?

A few things that float above the player bar were positioned using the mobile bottom navigation's height, even though they also show up on desktop where there is no bottom navigation at all. As a result the multi-select selection bar and the playback speed dialog ended up sitting on top of the player bar instead of above it.

There is now a single shared value for "how much room the bars at the bottom of the screen take up", which resolves to the player bar on desktop and to the navigation plus the floating player bar on mobile.

**Related issue (if applicable):**

- related issue `n/a`

**Related backend PR (if applicable):**

- related backend PR `n/a`

### Changes

- The "x items selected" bar now clears the floating player bar on mobile (it used to cover it); unchanged on desktop.
- The playback speed dialog now sits just above the player bar in both layouts, instead of behind it.
- The player bar height is defined once and reused by the popouts, the settings save button and the player bar itself, instead of being repeated as a hardcoded value.
- The settings save button now reuses the same shared value instead of spelling the calculation out again.
- Removed a mobile-only cut-out from the shared sheet backdrop that had no effect anywhere; the one sheet that needs it already sets it itself.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm lint:check` passes.
- [x] `pnpm test:run` passes, and tests have been added/updated where applicable.
- [x] `pnpm build` passes.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
