### PR TITLE
Add a test for the popout spacing above the mobile player bar

### DIFF
--- a/tests/styles/playerBarPopout.test.ts
+++ b/tests/styles/playerBarPopout.test.ts
@@ -1,0 +1,59 @@
+// jsdom leaves var() unresolved in computed styles, so this cascade is only
+// observable under happy-dom, which in turn ignores @layer: the comparison
+// holds because both rules are unlayered in the compiled stylesheet
+// @vitest-environment happy-dom
+import css from "@/styles/style.css?inline";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+const OVERLAY_HEIGHT = "--player-bar-overlay-height";
+const OVERLAY_MARKER = "data-player-bar-overlay";
+const BAR_HEIGHT = "72px";
+
+let appStyles: HTMLStyleElement;
+
+// happy-dom caches an element's computed style from its first read, so every
+// case builds its popout after the document state it measures is in place
+function popoutInset() {
+  const popout = document.createElement("div");
+  // the p-0 every popout passes compiles to an !important padding reset
+  popout.className = "player-bar-popout p-0";
+  document.body.appendChild(popout);
+  return getComputedStyle(popout).paddingBottom;
+}
+
+function utilityPaddingPriority() {
+  const rules = [...(appStyles.sheet?.cssRules ?? [])] as CSSStyleRule[];
+  return rules
+    .find((rule) => rule.selectorText === ".p-0")
+    ?.style.getPropertyPriority("padding");
+}
+
+describe("player bar popout inset", () => {
+  beforeEach(() => {
+    appStyles = document.createElement("style");
+    appStyles.textContent = css;
+    document.head.appendChild(appStyles);
+  });
+
+  afterEach(() => {
+    appStyles.remove();
+    document.body.innerHTML = "";
+    document.documentElement.removeAttribute(OVERLAY_MARKER);
+    document.documentElement.style.removeProperty(OVERLAY_HEIGHT);
+  });
+
+  it("clears the player bar while the mobile bar is on screen", () => {
+    // the inset only proves anything while it still has to out-rank the
+    // utility, which the important-flagged Tailwind import makes a real contest
+    expect(utilityPaddingPriority()).toBe("important");
+
+    document.documentElement.setAttribute(OVERLAY_MARKER, "");
+    document.documentElement.style.setProperty(OVERLAY_HEIGHT, BAR_HEIGHT);
+
+    expect(popoutInset()).toBe(BAR_HEIGHT);
+  });
+
+  it("leaves popouts untouched without the player bar", () => {
+    expect(popoutInset()).toBe("0px");
+  });
+});

--- a/tests/styles/playerBarPopout.test.ts
+++ b/tests/styles/playerBarPopout.test.ts
@@ -22,8 +22,8 @@ function popoutInset() {
 }
 
 function utilityPaddingPriority() {
-  const rules = [...(appStyles.sheet?.cssRules ?? [])] as CSSStyleRule[];
-  return rules
+  return [...(appStyles.sheet?.cssRules ?? [])]
+    .filter((rule) => rule instanceof CSSStyleRule)
     .find((rule) => rule.selectorText === ".p-0")
     ?.style.getPropertyPriority("padding");
 }
@@ -43,9 +43,12 @@ describe("player bar popout inset", () => {
   });
 
   it("clears the player bar while the mobile bar is on screen", () => {
-    // the inset only proves anything while it still has to out-rank the
-    // utility, which the important-flagged Tailwind import makes a real contest
-    expect(utilityPaddingPriority()).toBe("important");
+    // the inset only proves anything while the utility it has to out-rank is
+    // itself !important
+    expect(
+      utilityPaddingPriority(),
+      "the Tailwind utilities import must stay `important` and unlayered",
+    ).toBe("important");
 
     document.documentElement.setAttribute(OVERLAY_MARKER, "");
     document.documentElement.style.setProperty(OVERLAY_HEIGHT, BAR_HEIGHT);

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -11,7 +11,10 @@ export default mergeConfig(
       // markdown pin themselves to jsdom with an @vitest-environment docblock.
       environment: "happy-dom",
       globals: true,
-      css: false,
+      // the popout inset test asserts a real cascade result, so the app
+      // stylesheet has to be compiled instead of stubbed out; component styles
+      // stay unprocessed so the rest of the suite is unaffected
+      css: { include: [/src\/styles\/style\.css/] },
       setupFiles: ["./tests/setup/failOnUnhandledErrors.ts"],
       // Errors that escape a test must never be silently dropped; the setup
       // file above additionally surfaces them in the pass/fail tally.

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -11,9 +11,9 @@ export default mergeConfig(
       // markdown pin themselves to jsdom with an @vitest-environment docblock.
       environment: "happy-dom",
       globals: true,
-      // the popout inset test asserts a real cascade result, so the app
-      // stylesheet has to be compiled instead of stubbed out; component styles
-      // stay unprocessed so the rest of the suite is unaffected
+      // The popout inset test asserts a real cascade result, so the app
+      // stylesheet has to be compiled instead of stubbed out. Component styles
+      // stay unprocessed, so the rest of the suite is unaffected.
       css: { include: [/src\/styles\/style\.css/] },
       setupFiles: ["./tests/setup/failOnUnhandledErrors.ts"],
       // Errors that escape a test must never be silently dropped; the setup


### PR DESCRIPTION
# What does this implement/fix?

Keeping the player bar popouts clear of the floating mobile player bar takes two
halves that have to agree: the footer marks the page while the bar is on screen,
and a style rule turns that marker into spacing at the bottom of every popout.
Only the footer half was tested, so a typo in the marker name, a lost
`!important` or a weaker selector would quietly drop the spacing on mobile while
the whole test suite stayed green.

- Adds a test that compiles the real stylesheet and checks a popout is spaced
  clear of the bar while it is on screen, and left alone without it.
- Lets Vitest process `src/styles/style.css` so that test sees the compiled CSS.
  Component styles stay unprocessed, so the rest of the suite is unaffected.

**Related issue (if applicable):**

- n/a

**Related backend PR (if applicable):**

- n/a

## Types of changes

<!--
Tick exactly one box below. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm lint:check` passes.
- [x] `pnpm test:run` passes, and tests have been added/updated where applicable.
- [x] `pnpm build` passes.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
