### PR TITLE
Give the player list, group and volume panels more room

### DIFF
--- a/src/layouts/default/PlayerOSD/PlayerBarGroupControl.vue
+++ b/src/layouts/default/PlayerOSD/PlayerBarGroupControl.vue
@@ -70,7 +70,7 @@
         "
         :collision-padding="8"
         :class="[
-          'player-bar-popout player-group-popover flex max-h-[var(--reka-popover-content-available-height,100dvh)] flex-col gap-0 overflow-hidden p-0',
+          'player-bar-popout player-group-popover flex flex-col gap-0 overflow-hidden p-0',
           store.mobileLayout
             ? 'w-[calc(100vw-1rem)]'
             : 'w-[400px] max-w-[calc(100vw-1rem)]',

--- a/src/layouts/default/PlayerOSD/PlayerBarGroupControl.vue
+++ b/src/layouts/default/PlayerOSD/PlayerBarGroupControl.vue
@@ -70,10 +70,10 @@
         "
         :collision-padding="8"
         :class="[
-          'player-bar-popout player-group-popover flex flex-col gap-0 overflow-hidden p-0',
+          'player-bar-popout player-group-popover flex max-h-[var(--reka-popover-content-available-height,100dvh)] flex-col gap-0 overflow-hidden p-0',
           store.mobileLayout
-            ? 'max-h-[75dvh] w-[calc(100vw-1rem)]'
-            : 'max-h-[min(70dvh,600px)] w-[400px] max-w-[calc(100vw-1rem)]',
+            ? 'w-[calc(100vw-1rem)]'
+            : 'w-[400px] max-w-[calc(100vw-1rem)]',
         ]"
         @open-auto-focus="preventAutoFocus"
         @interact-outside="handleInteractOutside"

--- a/src/layouts/default/PlayerOSD/PlayerBarMobileVolumeSheet.vue
+++ b/src/layouts/default/PlayerOSD/PlayerBarMobileVolumeSheet.vue
@@ -4,7 +4,7 @@
       data-player-panel
       side="bottom"
       :show-close="false"
-      class="player-bar-popout mobile-group-volume-sheet z-[998] max-h-[70dvh] gap-0 overflow-hidden rounded-xl p-0"
+      class="player-bar-popout mobile-group-volume-sheet z-[998] gap-0 overflow-hidden rounded-xl p-0"
       overlay-class="mobile-group-volume-overlay z-[997]"
       @open-auto-focus="preventAutoFocus"
     >
@@ -49,6 +49,8 @@ function preventAutoFocus(event: Event) {
   right: 8px !important;
   bottom: calc(var(--mobile-navigation-height) + 8px) !important;
   left: 8px !important;
+  /* grows with the group it shows, up to the room left above the navigation */
+  max-height: calc(100dvh - var(--mobile-navigation-height) - 16px);
   width: auto !important;
 }
 

--- a/src/layouts/default/PlayerOSD/PlayerBarMobileVolumeSheet.vue
+++ b/src/layouts/default/PlayerOSD/PlayerBarMobileVolumeSheet.vue
@@ -49,9 +49,13 @@ function preventAutoFocus(event: Event) {
   right: 8px !important;
   bottom: calc(var(--mobile-navigation-height) + 8px) !important;
   left: 8px !important;
-  /* grows with the group it shows, up to the room left above the navigation */
-  max-height: calc(100dvh - var(--mobile-navigation-height) - 16px);
   width: auto !important;
+}
+
+/* a sheet has no popper measuring the free space for it, so it grows with the
+   group it shows up to the room left above the navigation instead */
+.player-bar-popout.mobile-group-volume-sheet {
+  max-height: calc(100dvh - var(--mobile-navigation-height) - 16px);
 }
 
 .mobile-group-volume-overlay {

--- a/src/layouts/default/PlayerOSD/PlayerBarVolumeControl.vue
+++ b/src/layouts/default/PlayerOSD/PlayerBarVolumeControl.vue
@@ -55,7 +55,7 @@
       align="end"
       :side-offset="DESKTOP_PLAYER_BAR_POPOUT_GAP"
       :collision-padding="8"
-      class="player-bar-popout player-volume-popover w-[340px] max-w-[calc(100vw-1rem)] p-0"
+      class="player-bar-popout player-volume-popover flex max-h-[var(--reka-popover-content-available-height,100dvh)] w-[340px] max-w-[calc(100vw-1rem)] flex-col overflow-hidden p-0"
       @open-auto-focus="preventAutoFocus"
       @interact-outside="handleInteractOutside"
     >

--- a/src/layouts/default/PlayerOSD/PlayerBarVolumeControl.vue
+++ b/src/layouts/default/PlayerOSD/PlayerBarVolumeControl.vue
@@ -55,7 +55,7 @@
       align="end"
       :side-offset="DESKTOP_PLAYER_BAR_POPOUT_GAP"
       :collision-padding="8"
-      class="player-bar-popout player-volume-popover flex max-h-[var(--reka-popover-content-available-height,100dvh)] w-[340px] max-w-[calc(100vw-1rem)] flex-col overflow-hidden p-0"
+      class="player-bar-popout player-volume-popover flex w-[340px] max-w-[calc(100vw-1rem)] flex-col overflow-hidden p-0"
       @open-auto-focus="preventAutoFocus"
       @interact-outside="handleInteractOutside"
     >

--- a/src/layouts/default/PlayerSelect.vue
+++ b/src/layouts/default/PlayerSelect.vue
@@ -37,11 +37,11 @@
       "
       :collision-padding="8"
       :class="[
-        'player-bar-popout player-select-popover flex flex-col gap-0 overflow-hidden p-0',
+        'player-bar-popout player-select-popover flex max-h-[var(--reka-popover-content-available-height,100dvh)] flex-col gap-0 overflow-hidden p-0',
         popoutFromFullscreen && 'player-select-popover-fullscreen',
         store.mobileLayout
-          ? 'max-h-[78dvh] w-[calc(100vw-1rem)]'
-          : 'max-h-[min(82dvh,780px)] w-[400px] max-w-[calc(100vw-1rem)]',
+          ? 'w-[calc(100vw-1rem)]'
+          : 'w-[400px] max-w-[calc(100vw-1rem)]',
       ]"
       @keydown="handleSheetKeydown"
       @close-auto-focus="preventAutoFocus"

--- a/src/layouts/default/PlayerSelect.vue
+++ b/src/layouts/default/PlayerSelect.vue
@@ -37,7 +37,7 @@
       "
       :collision-padding="8"
       :class="[
-        'player-bar-popout player-select-popover flex max-h-[var(--reka-popover-content-available-height,100dvh)] flex-col gap-0 overflow-hidden p-0',
+        'player-bar-popout player-select-popover flex flex-col gap-0 overflow-hidden p-0',
         popoutFromFullscreen && 'player-select-popover-fullscreen',
         store.mobileLayout
           ? 'w-[calc(100vw-1rem)]'

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -134,6 +134,12 @@
   backdrop-filter: blur(4px);
 }
 
+/* the popouts grow with their content, up to the room the popper measured
+   between the player bar and the top of the screen */
+.player-bar-popout {
+  max-height: var(--reka-popover-content-available-height, calc(100dvh - 16px));
+}
+
 /* the popouts extend behind the floating mobile player bar, so their content is
    inset to stay scrollable past it; the marker keeps desktop popouts untouched
    and lifts this above the equally-!important p-0 utility they carry */

--- a/tests/layouts/PlayerSelect.test.ts
+++ b/tests/layouts/PlayerSelect.test.ts
@@ -651,21 +651,6 @@ describe("PlayerSelect", () => {
     );
   });
 
-  it("grows into the room left above the player bar", () => {
-    const cap = "max-h-[var(--reka-popover-content-available-height,100dvh)]";
-
-    const desktop = mountPlayerSelect();
-    store.mobileLayout = true;
-    const mobile = mountPlayerSelect();
-
-    expect(
-      desktop.find('[data-testid="player-select-sheet"]').classes(),
-    ).toContain(cap);
-    expect(
-      mobile.find('[data-testid="player-select-sheet"]').classes(),
-    ).toContain(cap);
-  });
-
   it("focuses the sheet instead of opening the mobile keyboard", () => {
     store.mobileLayout = true;
     api.players = Object.fromEntries(

--- a/tests/layouts/PlayerSelect.test.ts
+++ b/tests/layouts/PlayerSelect.test.ts
@@ -651,6 +651,21 @@ describe("PlayerSelect", () => {
     );
   });
 
+  it("grows into the room left above the player bar", () => {
+    const cap = "max-h-[var(--reka-popover-content-available-height,100dvh)]";
+
+    const desktop = mountPlayerSelect();
+    store.mobileLayout = true;
+    const mobile = mountPlayerSelect();
+
+    expect(
+      desktop.find('[data-testid="player-select-sheet"]').classes(),
+    ).toContain(cap);
+    expect(
+      mobile.find('[data-testid="player-select-sheet"]').classes(),
+    ).toContain(cap);
+  });
+
   it("focuses the sheet instead of opening the mobile keyboard", () => {
     store.mobileLayout = true;
     api.players = Object.fromEntries(


### PR DESCRIPTION
# What does this implement/fix?

The player list, group members and volume panels were capped at a fixed slice of
the screen (70-82%), no matter how much room was actually free. With a lot of
players that meant a small panel and a lot of scrolling, especially on a phone.

They now grow with their content up to the space that is really available above
the player bar, so long lists show a lot more at once.

**Related issue (if applicable):**

- n/a

**Related backend PR (if applicable):**

- n/a

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Changes

- the player list, group members and volume panels size to the room that is
  actually available instead of a fixed percentage of the screen
- the mobile volume sheet grows up to the space above the bottom navigation
- the volume panel scrolls when a group has many players, instead of growing
  past the edge of the screen

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm lint:check` passes.
- [x] `pnpm test:run` passes, and tests have been added/updated where applicable.
- [x] `pnpm build` passes.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
