### PR TITLE
Don't open the on-screen keyboard when a search dialog opens

### DIFF
--- a/src/components/HassEntityPickerDialog.vue
+++ b/src/components/HassEntityPickerDialog.vue
@@ -2,6 +2,7 @@
   <Dialog v-model:open="model">
     <DialogContent
       class="flex max-h-[85vh] flex-col gap-0 p-0 sm:max-w-[560px]"
+      @open-auto-focus="preventOnScreenKeyboardOnOpen"
     >
       <DialogHeader class="border-b px-5 py-4 pr-12 text-left">
         <DialogTitle>
@@ -115,6 +116,7 @@ import {
 import { SearchInput } from "@/components/ui/search-input";
 import { Spinner } from "@/components/ui/spinner";
 import type { HassControlKey } from "@/helpers/config_entry_ui";
+import { preventOnScreenKeyboardOnOpen } from "@/helpers/dialog_focus";
 import {
   searchHassControlEntities,
   type HassControlEntity,

--- a/src/helpers/dialog_focus.ts
+++ b/src/helpers/dialog_focus.ts
@@ -7,7 +7,7 @@ import { store } from "@/plugins/store";
  * Use it on any dialog that opens with a search or text field: focusing that
  * field raises the on-screen keyboard, which then covers most of the dialog.
  * Focus moves to the dialog itself instead, so the focus trap and the screen
- * reader announcement stay intact. Devices with a hardware keyboard keep the
+ * reader announcement stay intact. Devices without a touchscreen keep the
  * default behaviour and land in the field.
  */
 export function preventOnScreenKeyboardOnOpen(event: Event) {

--- a/src/helpers/dialog_focus.ts
+++ b/src/helpers/dialog_focus.ts
@@ -1,0 +1,19 @@
+import { store } from "@/plugins/store";
+
+/**
+ * Handler for a reka-ui `@open-auto-focus` event that keeps a dialog from
+ * focusing its first field on a touch device.
+ *
+ * Use it on any dialog that opens with a search or text field: focusing that
+ * field raises the on-screen keyboard, which then covers most of the dialog.
+ * Focus moves to the dialog itself instead, so the focus trap and the screen
+ * reader announcement stay intact. Devices with a hardware keyboard keep the
+ * default behaviour and land in the field.
+ */
+export function preventOnScreenKeyboardOnOpen(event: Event) {
+  if (!store.isTouchscreen) return;
+  event.preventDefault();
+  if (event.target instanceof HTMLElement) {
+    event.target.focus({ preventScroll: true });
+  }
+}

--- a/src/views/settings/AddProviderDialog.vue
+++ b/src/views/settings/AddProviderDialog.vue
@@ -1,7 +1,7 @@
 <template>
   <Dialog :open="props.show" @update:open="handleOpenChange">
     <DialogContent
-      class="add-provider-dialog h-[85dvh] max-h-[85dvh] sm:h-[60vh] sm:max-h-[60vh] flex flex-col p-0"
+      class="h-[85dvh] max-h-[85dvh] sm:h-[60vh] sm:max-h-[60vh] flex flex-col p-0"
       @open-auto-focus="preventOnScreenKeyboardOnOpen"
     >
       <DialogHeader class="px-6 pt-6 pb-4 flex-shrink-0">
@@ -306,11 +306,6 @@ watch(
 </script>
 
 <style scoped>
-.add-provider-dialog {
-  display: flex;
-  flex-direction: column;
-}
-
 .search-field {
   width: 100%;
 }

--- a/src/views/settings/AddProviderDialog.vue
+++ b/src/views/settings/AddProviderDialog.vue
@@ -1,7 +1,8 @@
 <template>
   <Dialog :open="props.show" @update:open="handleOpenChange">
     <DialogContent
-      class="add-provider-dialog h-[60vh] max-h-[60vh] flex flex-col p-0"
+      class="add-provider-dialog h-[85dvh] max-h-[85dvh] sm:h-[60vh] sm:max-h-[60vh] flex flex-col p-0"
+      @open-auto-focus="preventOnScreenKeyboardOnOpen"
     >
       <DialogHeader class="px-6 pt-6 pb-4 flex-shrink-0">
         <DialogTitle>{{ dialogTitle }}</DialogTitle>
@@ -9,11 +10,7 @@
 
       <div class="px-6 pb-2 flex-shrink-0">
         <InputGroup class="search-field">
-          <InputGroupInput
-            ref="searchInput"
-            v-model="searchQuery"
-            :placeholder="$t('search')"
-          />
+          <InputGroupInput v-model="searchQuery" :placeholder="$t('search')" />
           <InputGroupAddon>
             <Search />
           </InputGroupAddon>
@@ -90,6 +87,7 @@ import {
   InputGroupAddon,
   InputGroupInput,
 } from "@/components/ui/input-group";
+import { preventOnScreenKeyboardOnOpen } from "@/helpers/dialog_focus";
 import { api } from "@/plugins/api";
 import {
   ProviderConfig,
@@ -102,7 +100,7 @@ import { $t } from "@/plugins/i18n";
 import { store } from "@/plugins/store";
 import { ChevronRight, Search } from "@lucide/vue";
 import { match } from "ts-pattern";
-import { computed, nextTick, ref, watch } from "vue";
+import { computed, ref, watch } from "vue";
 import { useRoute } from "vue-router";
 
 const props = defineProps<{
@@ -128,7 +126,6 @@ const route = useRoute();
 const providerConfigs = ref<ProviderConfig[]>([]);
 const searchQuery = ref("");
 const selectedProviderStages = ref<string[]>([]);
-const searchInput = ref<{ focus: () => void } | null>(null);
 
 const activeTypeFilter = computed(() => (route.query.types as string) || null);
 
@@ -303,9 +300,6 @@ watch(
     if (isOpen) {
       // Refresh provider configs when dialog opens
       loadItems();
-      nextTick(() => {
-        searchInput.value?.focus();
-      });
     }
   },
 );
@@ -414,11 +408,5 @@ watch(
   font-size: 14px;
   color: rgba(var(--v-theme-on-surface), 0.5);
   line-height: 1.4;
-}
-
-@media (max-width: 600px) {
-  .add-provider-dialog {
-    max-height: 500px;
-  }
 }
 </style>

--- a/tests/components/HassEntityPickerDialog.test.ts
+++ b/tests/components/HassEntityPickerDialog.test.ts
@@ -6,9 +6,12 @@ import type {
 import { flushPromises, mount, type VueWrapper } from "@vue/test-utils";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-const { apiMock } = vi.hoisted(() => ({
+const { apiMock, storeMock } = vi.hoisted(() => ({
   apiMock: {
     sendCommand: vi.fn(),
+  },
+  storeMock: {
+    isTouchscreen: false,
   },
 }));
 
@@ -16,6 +19,8 @@ vi.mock("@/plugins/api", () => ({
   api: apiMock,
   default: apiMock,
 }));
+
+vi.mock("@/plugins/store", () => ({ store: storeMock }));
 
 vi.mock("@/plugins/i18n", () => ({
   $t: (key: string) => key,
@@ -42,7 +47,9 @@ const ORPHAN_GROUP: HassControlEntityGroup = {
 describe("HassEntityPickerDialog", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    storeMock.isTouchscreen = false;
     apiMock.sendCommand.mockResolvedValue({ groups: [], truncated: false });
+    document.body.innerHTML = "";
   });
 
   afterEach(() => {
@@ -151,7 +158,46 @@ describe("HassEntityPickerDialog", () => {
     );
     expect(entityButton.attributes("disabled")).toBeDefined();
   });
+
+  it("focuses the search field on a non-touch device", async () => {
+    const wrapper = await openRealDialog();
+
+    expect(document.activeElement).toBe(searchField());
+
+    wrapper.unmount();
+  });
+
+  it("leaves the search field alone on a touch device", async () => {
+    storeMock.isTouchscreen = true;
+
+    const wrapper = await openRealDialog();
+
+    // focusing the search field would open the on-screen keyboard over the
+    // results, so the dialog itself takes focus instead
+    expect(document.activeElement).not.toBe(searchField());
+    expect(document.activeElement).toBe(
+      document.querySelector("[data-slot='dialog-content']"),
+    );
+
+    wrapper.unmount();
+  });
 });
+
+function searchField() {
+  return document.querySelector("[data-slot='input-group-control']");
+}
+
+// the shared mount stubs the dialog away, but auto-focus is reka-ui's own
+// behaviour, so this one renders the real thing
+async function openRealDialog(): Promise<VueWrapper> {
+  const wrapper = mount(HassEntityPickerDialog, {
+    props: { modelValue: false, controlType: "power_controls" as const },
+    attachTo: document.body,
+  });
+  await wrapper.setProps({ modelValue: true });
+  await flushPromises();
+  return wrapper;
+}
 
 function entity(overrides: Partial<HassControlEntity>): HassControlEntity {
   return {

--- a/tests/components/HassEntityPickerDialog.test.ts
+++ b/tests/components/HassEntityPickerDialog.test.ts
@@ -3,7 +3,12 @@ import type {
   HassControlEntity,
   HassControlEntityGroup,
 } from "@/helpers/hass_controls";
-import { flushPromises, mount, type VueWrapper } from "@vue/test-utils";
+import {
+  enableAutoUnmount,
+  flushPromises,
+  mount,
+  type VueWrapper,
+} from "@vue/test-utils";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const { apiMock, storeMock } = vi.hoisted(() => ({
@@ -43,6 +48,10 @@ const ORPHAN_GROUP: HassControlEntityGroup = {
   area_name: null,
   entities: [entity({ entity_id: "switch.relay", name: "Relay" })],
 };
+
+// an open dialog keeps document-level focus trap listeners, so tear it down
+// even when an assertion fails
+enableAutoUnmount(afterEach);
 
 describe("HassEntityPickerDialog", () => {
   beforeEach(() => {
@@ -160,17 +169,15 @@ describe("HassEntityPickerDialog", () => {
   });
 
   it("focuses the search field on a non-touch device", async () => {
-    const wrapper = await openRealDialog();
+    await openRealDialog();
 
     expect(document.activeElement).toBe(searchField());
-
-    wrapper.unmount();
   });
 
   it("leaves the search field alone on a touch device", async () => {
     storeMock.isTouchscreen = true;
 
-    const wrapper = await openRealDialog();
+    await openRealDialog();
 
     // focusing the search field would open the on-screen keyboard over the
     // results, so the dialog itself takes focus instead
@@ -178,8 +185,6 @@ describe("HassEntityPickerDialog", () => {
     expect(document.activeElement).toBe(
       document.querySelector("[data-slot='dialog-content']"),
     );
-
-    wrapper.unmount();
   });
 });
 

--- a/tests/views/AddProviderDialog.test.ts
+++ b/tests/views/AddProviderDialog.test.ts
@@ -1,0 +1,79 @@
+import AddProviderDialog from "@/views/settings/AddProviderDialog.vue";
+import { flushPromises, mount, type VueWrapper } from "@vue/test-utils";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { providerManifest } from "../fixtures/providerManifest";
+
+const { apiMock, storeMock } = vi.hoisted(() => ({
+  apiMock: {
+    providerManifests: {} as Record<string, unknown>,
+    providers: {},
+    getProviderConfigs: vi.fn(),
+    getProvider: vi.fn(),
+    getProviderName: vi.fn(),
+  },
+  storeMock: {
+    isTouchscreen: false,
+    dialogActive: false,
+  },
+}));
+
+vi.mock("@/plugins/api", () => ({ api: apiMock, default: apiMock }));
+vi.mock("@/plugins/store", () => ({ store: storeMock }));
+vi.mock("@/plugins/i18n", () => ({ $t: (key: string) => key }));
+vi.mock("vue-router", () => ({ useRoute: () => ({ query: {} }) }));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  storeMock.isTouchscreen = false;
+  storeMock.dialogActive = false;
+  apiMock.getProviderConfigs.mockResolvedValue([]);
+  apiMock.providerManifests = {
+    spotify: providerManifest({ domain: "spotify", name: "Spotify" }),
+  };
+  document.body.innerHTML = "";
+});
+
+describe("AddProviderDialog", () => {
+  it("focuses the search field on a non-touch device", async () => {
+    const wrapper = await openDialog();
+
+    expect(document.activeElement).toBe(searchField());
+
+    wrapper.unmount();
+  });
+
+  it("leaves the search field alone on a touch device", async () => {
+    storeMock.isTouchscreen = true;
+
+    const wrapper = await openDialog();
+
+    // focusing the search field would open the on-screen keyboard over the
+    // provider list, so the dialog itself takes focus instead
+    expect(document.activeElement).not.toBe(searchField());
+    expect(document.activeElement).toBe(
+      document.querySelector("[data-slot='dialog-content']"),
+    );
+
+    wrapper.unmount();
+  });
+});
+
+function searchField() {
+  return document.querySelector("[data-slot='input-group-control']");
+}
+
+async function openDialog(): Promise<VueWrapper> {
+  const wrapper = mount(AddProviderDialog, {
+    props: { show: false },
+    attachTo: document.body,
+    global: {
+      stubs: {
+        FacetedFilter: true,
+        ProviderIcon: true,
+      },
+    },
+  });
+  await wrapper.setProps({ show: true });
+  await flushPromises();
+  return wrapper;
+}

--- a/tests/views/AddProviderDialog.test.ts
+++ b/tests/views/AddProviderDialog.test.ts
@@ -1,6 +1,11 @@
 import AddProviderDialog from "@/views/settings/AddProviderDialog.vue";
-import { flushPromises, mount, type VueWrapper } from "@vue/test-utils";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  enableAutoUnmount,
+  flushPromises,
+  mount,
+  type VueWrapper,
+} from "@vue/test-utils";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { providerManifest } from "../fixtures/providerManifest";
 
 const { apiMock, storeMock } = vi.hoisted(() => ({
@@ -22,6 +27,10 @@ vi.mock("@/plugins/store", () => ({ store: storeMock }));
 vi.mock("@/plugins/i18n", () => ({ $t: (key: string) => key }));
 vi.mock("vue-router", () => ({ useRoute: () => ({ query: {} }) }));
 
+// an open dialog keeps document-level focus trap listeners, so tear it down
+// even when an assertion fails
+enableAutoUnmount(afterEach);
+
 beforeEach(() => {
   vi.clearAllMocks();
   storeMock.isTouchscreen = false;
@@ -35,17 +44,15 @@ beforeEach(() => {
 
 describe("AddProviderDialog", () => {
   it("focuses the search field on a non-touch device", async () => {
-    const wrapper = await openDialog();
+    await openDialog();
 
     expect(document.activeElement).toBe(searchField());
-
-    wrapper.unmount();
   });
 
   it("leaves the search field alone on a touch device", async () => {
     storeMock.isTouchscreen = true;
 
-    const wrapper = await openDialog();
+    await openDialog();
 
     // focusing the search field would open the on-screen keyboard over the
     // provider list, so the dialog itself takes focus instead
@@ -53,8 +60,6 @@ describe("AddProviderDialog", () => {
     expect(document.activeElement).toBe(
       document.querySelector("[data-slot='dialog-content']"),
     );
-
-    wrapper.unmount();
   });
 });
 


### PR DESCRIPTION
# What does this implement/fix?

On mobile, opening **Settings → Add music source** immediately popped up the on-screen keyboard, because the dialog focused its search field on open. The keyboard then covered most of the dialog, leaving about two provider rows visible, and dragging the list panned the whole app instead of scrolling.

The dialog now only focuses the search field on devices without a touchscreen. On a touch device it opens with the list ready to scroll, and the keyboard appears when you actually tap the search box. The same fix is applied to the Home Assistant entity picker, which had the identical problem.

**Related issue (if applicable):**

- related issue `<link to issue>`

**Related backend PR (if applicable):**

- related backend PR `<link to PR>`

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

### Changes

- skip the search field auto-focus on touch devices, focusing the dialog itself so the focus trap and screen reader announcement stay intact
- apply the same to the Home Assistant entity picker dialog
- give the add-provider dialog more height on phones (85% instead of 60%), and drop a mobile `max-height` rule that never took effect
- add tests covering both the touch and non-touch cases

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm lint:check` passes.
- [x] `pnpm test:run` passes, and tests have been added/updated where applicable.
- [x] `pnpm build` passes.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
