### PR TITLE
Stop the "items selected" box covering the player menus

### DIFF
--- a/src/components/ItemsListing.vue
+++ b/src/components/ItemsListing.vue
@@ -212,10 +212,13 @@
         </EmptyContent>
       </Empty>
 
-      <!-- box shown when item(s) selected -->
+      <!-- box shown when item(s) selected; vuetify writes the overlay z-index inline
+           (default 2000), so it has to be lowered here to stay behind the player bar
+           popouts (998) and their backdrops (997) -->
       <v-snackbar
         :model-value="selectedItems.length > 1"
         :timeout="-1"
+        :z-index="996"
         style="margin-bottom: calc(var(--bottom-bars-height) + 16px)"
       >
         <span>{{ $t("items_selected", [selectedItems.length]) }}</span>


### PR DESCRIPTION
# What does this implement/fix?

Selecting two or more items in a list shows an "x items selected" box at the bottom of the screen. That box was drawn on top of the menus that open from the player bar — pick players, volume or group members while items are selected and the box floated over the menu.

The box is a Vuetify overlay, and Vuetify writes the stacking order onto it directly, so it always won. It now sits behind those menus instead.

**Related issue (if applicable):**

- n/a

**Related backend PR (if applicable):**

- n/a

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm lint:check` passes.
- [x] `pnpm test:run` passes, and tests have been added/updated where applicable.
- [x] `pnpm build` passes.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
