### PR TITLE
Make the player bar popout stacking independent of CSS load order

### DIFF
--- a/src/layouts/default/PlayerOSD/PlayerBarGroupControl.vue
+++ b/src/layouts/default/PlayerOSD/PlayerBarGroupControl.vue
@@ -231,7 +231,9 @@ function handleInteractOutside(event: Event) {
   bottom: var(--mobile-navigation-height) !important;
 }
 
-.player-group-popover {
+/* the paired class outweighs the equally-!important z-index utility the popover
+   component carries */
+.player-bar-popout.player-group-popover {
   z-index: 998 !important;
 }
 </style>

--- a/src/layouts/default/PlayerOSD/PlayerBarVolumeControl.vue
+++ b/src/layouts/default/PlayerOSD/PlayerBarVolumeControl.vue
@@ -172,7 +172,9 @@ function adjustVolume(event: WheelEvent) {
   bottom: var(--player-bar-height);
 }
 
-.player-volume-popover {
+/* the paired class outweighs the equally-!important z-index utility the popover
+   component carries */
+.player-bar-popout.player-volume-popover {
   z-index: 998 !important;
 }
 </style>

--- a/src/layouts/default/PlayerSelect.vue
+++ b/src/layouts/default/PlayerSelect.vue
@@ -607,7 +607,7 @@ async function scrollSelectedPlayerIntoView() {
   z-index: 9001 !important;
 }
 
-.player-bar-popout.player-select-popover-fullscreen {
+.player-bar-popout.player-select-popover.player-select-popover-fullscreen {
   z-index: 9002 !important;
 }
 

--- a/src/layouts/default/PlayerSelect.vue
+++ b/src/layouts/default/PlayerSelect.vue
@@ -593,7 +593,9 @@ async function scrollSelectedPlayerIntoView() {
   bottom: var(--mobile-navigation-height) !important;
 }
 
-.player-select-popover {
+/* the paired class outweighs the equally-!important z-index utility the popover
+   component carries */
+.player-bar-popout.player-select-popover {
   z-index: 998 !important;
 }
 


### PR DESCRIPTION
# What does this implement/fix?

The three player bar popouts (player select, volume, group) each set their own
z-index to sit above the player bar, but that rule tied exactly with the z-index
the popover component already sets — same specificity, both `!important`. Which
one wins is decided purely by the order the stylesheets happen to load, so a
change in chunking or an extra import could have hidden the panels behind the
player bar. Pairing each rule with the shared popout class settles it on
specificity instead.

Verified against the production stylesheets with both load orders: the panels
resolve to 998 and the backdrops to 997 either way (before this change the
reversed order put the panels at 10000).

- pair the popout z-index rules with the shared `.player-bar-popout` class in
  PlayerSelect, PlayerBarVolumeControl and PlayerBarGroupControl
- do the same for the fullscreen player select rule, so it keeps out-ranking
  the regular one on specificity rather than on where it sits in the file

**Related issue (if applicable):**

- n/a

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm lint:check` passes.
- [x] `pnpm test:run` passes, and tests have been added/updated where applicable.
- [x] `pnpm build` passes.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
