### PR TITLE
Share one advanced settings toggle across the settings screens

### DIFF
--- a/src/views/settings/AdvancedSettingsToggle.vue
+++ b/src/views/settings/AdvancedSettingsToggle.vue
@@ -1,0 +1,33 @@
+<template>
+  <div class="flex w-full items-center gap-2 sm:ml-auto sm:w-auto">
+    <Switch
+      :id="switchId"
+      v-model="showAdvancedSettings"
+      :data-testid="testId"
+    />
+    <Label :for="switchId" class="cursor-pointer">
+      {{ $t("settings.show_advanced_settings") }}
+    </Label>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { Label } from "@/components/ui/label";
+import { Switch } from "@/components/ui/switch";
+import { useId } from "vue";
+
+/**
+ * Reveals the advanced entries of a settings form, sized to sit at the end of the
+ * header row of a settings screen.
+ */
+defineProps<{
+  /** Names the toggle of this settings screen, so tests can address it. */
+  testId: string;
+}>();
+
+const showAdvancedSettings = defineModel<boolean>("showAdvancedSettings", {
+  default: false,
+});
+
+const switchId = useId();
+</script>

--- a/src/views/settings/EditPlayer.vue
+++ b/src/views/settings/EditPlayer.vue
@@ -187,19 +187,11 @@
             <RefreshCw class="size-4" />
             {{ $t(playerSetupLabel) }}
           </Button>
-          <div
+          <AdvancedSettingsToggle
             v-if="showAdvancedToggle"
-            class="flex w-full items-center gap-2 sm:ml-auto sm:w-auto"
-          >
-            <Switch
-              id="player-advanced-settings"
-              v-model="showAdvancedSettings"
-              data-testid="player-advanced-settings"
-            />
-            <Label for="player-advanced-settings" class="cursor-pointer">
-              {{ $t("settings.show_advanced_settings") }}
-            </Label>
-          </div>
+            v-model:show-advanced-settings="showAdvancedSettings"
+            test-id="player-advanced-settings"
+          />
         </CardContent>
       </Card>
     </div>
@@ -328,8 +320,6 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
-import { Label } from "@/components/ui/label";
-import { Switch } from "@/components/ui/switch";
 import { api } from "@/plugins/api";
 import {
   ConfigEntryType,
@@ -341,6 +331,7 @@ import {
   PlayerType,
   IdentifierType,
 } from "@/plugins/api/interfaces";
+import AdvancedSettingsToggle from "./AdvancedSettingsToggle.vue";
 import EditConfig from "./EditConfig.vue";
 import ProviderIcon from "@/components/ProviderIcon.vue";
 import PlayerIcon from "@/components/PlayerIcon.vue";

--- a/src/views/settings/EditProvider.vue
+++ b/src/views/settings/EditProvider.vue
@@ -209,19 +209,11 @@
             <CircleAlert class="size-4" />
             {{ $t("settings.known_issues") }}
           </Button>
-          <div
+          <AdvancedSettingsToggle
             v-if="config.enabled && hasAdvancedEntries(allConfigEntries)"
-            class="flex w-full items-center gap-2 sm:ml-auto sm:w-auto"
-          >
-            <Switch
-              id="provider-advanced-settings"
-              v-model="showAdvancedSettings"
-              data-testid="provider-advanced-settings"
-            />
-            <Label for="provider-advanced-settings" class="cursor-pointer">
-              {{ $t("settings.show_advanced_settings") }}
-            </Label>
-          </div>
+            v-model:show-advanced-settings="showAdvancedSettings"
+            test-id="provider-advanced-settings"
+          />
         </CardContent>
       </Card>
     </div>
@@ -303,8 +295,6 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
-import { Label } from "@/components/ui/label";
-import { Switch } from "@/components/ui/switch";
 import { useConfigAction } from "@/composables/useConfigAction";
 import {
   hasAdvancedEntries,
@@ -339,6 +329,7 @@ import { computed, onBeforeUnmount, onMounted, ref, watch } from "vue";
 import { useI18n } from "vue-i18n";
 import { useRouter } from "vue-router";
 import { toast } from "vue-sonner";
+import AdvancedSettingsToggle from "./AdvancedSettingsToggle.vue";
 import EditConfig from "./EditConfig.vue";
 
 // global refs

--- a/src/views/settings/SettingsHeaderCard.vue
+++ b/src/views/settings/SettingsHeaderCard.vue
@@ -44,16 +44,12 @@
     </CardHeader>
     <CardContent
       v-if="showAdvancedToggle"
-      class="flex items-center gap-2 border-t bg-muted/20 px-6 py-4 sm:justify-end"
+      class="flex items-center border-t bg-muted/20 px-6 py-4"
     >
-      <Switch
-        :id="advancedToggleId"
-        v-model="showAdvancedSettings"
-        data-testid="settings-advanced-settings"
+      <AdvancedSettingsToggle
+        v-model:show-advanced-settings="showAdvancedSettings"
+        test-id="settings-advanced-settings"
       />
-      <Label :for="advancedToggleId" class="cursor-pointer">
-        {{ $t("settings.show_advanced_settings") }}
-      </Label>
     </CardContent>
   </Card>
 </template>
@@ -73,11 +69,10 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
-import { Label } from "@/components/ui/label";
-import { Switch } from "@/components/ui/switch";
 import { cn } from "@/lib/utils";
 import { MoreVertical, RotateCcw } from "@lucide/vue";
-import { useId, type Component } from "vue";
+import type { Component } from "vue";
+import AdvancedSettingsToggle from "./AdvancedSettingsToggle.vue";
 
 /**
  * Header card shared by the settings screens that edit a plain config: it names what
@@ -100,6 +95,4 @@ const emit = defineEmits<{
 const showAdvancedSettings = defineModel<boolean>("showAdvancedSettings", {
   default: false,
 });
-
-const advancedToggleId = useId();
 </script>

--- a/tests/views/AdvancedSettingsToggle.test.ts
+++ b/tests/views/AdvancedSettingsToggle.test.ts
@@ -12,27 +12,45 @@ const TwoToggles = {
 
 describe("AdvancedSettingsToggle", () => {
   it("reports the toggle being flipped", async () => {
-    const wrapper = mount(AdvancedSettingsToggle, {
-      props: { testId: "advanced-settings" },
-      global: { mocks: { $t: (key: string) => key } },
-    });
+    const wrapper = mountToggle();
 
     await wrapper.get('[data-testid="advanced-settings"]').trigger("click");
 
     expect(wrapper.emitted("update:showAdvancedSettings")).toEqual([[true]]);
   });
 
+  it("follows the state its screen hands it", async () => {
+    const wrapper = mountToggle();
+    const toggle = wrapper.get('[data-testid="advanced-settings"]');
+    expect(toggle.attributes("data-state")).toBe("unchecked");
+
+    await wrapper.setProps({ showAdvancedSettings: true });
+
+    expect(toggle.attributes("data-state")).toBe("checked");
+  });
+
   it("labels every toggle on a screen with an id of its own", () => {
     const wrapper = mount(TwoToggles, {
       global: { mocks: { $t: (key: string) => key } },
     });
+    const labels = wrapper.findAll("label");
 
-    const ids = ["first-toggle", "second-toggle"].map((testId, index) => {
-      const id = wrapper.get(`[data-testid="${testId}"]`).attributes("id");
-      expect(wrapper.findAll("label")[index].attributes("for")).toBe(id);
-      return id;
-    });
+    const firstId = wrapper
+      .get('[data-testid="first-toggle"]')
+      .attributes("id");
+    const secondId = wrapper
+      .get('[data-testid="second-toggle"]')
+      .attributes("id");
 
-    expect(ids[0]).not.toBe(ids[1]);
+    expect(labels[0].attributes("for")).toBe(firstId);
+    expect(labels[1].attributes("for")).toBe(secondId);
+    expect(firstId).not.toBe(secondId);
   });
 });
+
+function mountToggle() {
+  return mount(AdvancedSettingsToggle, {
+    props: { testId: "advanced-settings" },
+    global: { mocks: { $t: (key: string) => key } },
+  });
+}

--- a/tests/views/AdvancedSettingsToggle.test.ts
+++ b/tests/views/AdvancedSettingsToggle.test.ts
@@ -1,0 +1,38 @@
+import { mount } from "@vue/test-utils";
+import { describe, expect, it } from "vitest";
+import AdvancedSettingsToggle from "@/views/settings/AdvancedSettingsToggle.vue";
+
+const TwoToggles = {
+  components: { AdvancedSettingsToggle },
+  template: `
+    <AdvancedSettingsToggle test-id="first-toggle" />
+    <AdvancedSettingsToggle test-id="second-toggle" />
+  `,
+};
+
+describe("AdvancedSettingsToggle", () => {
+  it("reports the toggle being flipped", async () => {
+    const wrapper = mount(AdvancedSettingsToggle, {
+      props: { testId: "advanced-settings" },
+      global: { mocks: { $t: (key: string) => key } },
+    });
+
+    await wrapper.get('[data-testid="advanced-settings"]').trigger("click");
+
+    expect(wrapper.emitted("update:showAdvancedSettings")).toEqual([[true]]);
+  });
+
+  it("labels every toggle on a screen with an id of its own", () => {
+    const wrapper = mount(TwoToggles, {
+      global: { mocks: { $t: (key: string) => key } },
+    });
+
+    const ids = ["first-toggle", "second-toggle"].map((testId, index) => {
+      const id = wrapper.get(`[data-testid="${testId}"]`).attributes("id");
+      expect(wrapper.findAll("label")[index].attributes("for")).toBe(id);
+      return id;
+    });
+
+    expect(ids[0]).not.toBe(ids[1]);
+  });
+});

--- a/tests/views/EditPlayer.test.ts
+++ b/tests/views/EditPlayer.test.ts
@@ -48,6 +48,8 @@ const SlotStub = {
 };
 
 const playerDetailsStubs = {
+  // rendered for real so this screen's advanced toggle stays assertable
+  AdvancedSettingsToggle: false,
   Button: SlotStub,
   Card: SlotStub,
   CardContent: SlotStub,

--- a/tests/views/EditProvider.test.ts
+++ b/tests/views/EditProvider.test.ts
@@ -54,6 +54,8 @@ const SlotStub = {
 };
 
 const providerDetailsStubs = {
+  // rendered for real so this screen's advanced toggle stays assertable
+  AdvancedSettingsToggle: false,
   Badge: SlotStub,
   Card: SlotStub,
   CardContent: SlotStub,

--- a/tests/views/SettingsHeaderCard.test.ts
+++ b/tests/views/SettingsHeaderCard.test.ts
@@ -8,6 +8,8 @@ const SlotStub = {
 };
 
 const headerStubs = {
+  // rendered for real so this screen's advanced toggle stays assertable
+  AdvancedSettingsToggle: false,
   Button: SlotStub,
   Card: SlotStub,
   CardContent: SlotStub,


### PR DESCRIPTION
# What does this implement/fix?

The "show advanced settings" toggle was copy-pasted into three settings screens, each with its own hardcoded element id. It is now one small component, so the switch and its label always belong together and the screens stay short.

No visual or behaviour change.

- Added `AdvancedSettingsToggle`, which generates its own element id so the label always points at its own switch
- Used it in the settings header card, the provider screen and the player screen
- Each screen still names its toggle for the tests, and the new component has its own test

**Related issue (if applicable):**

- related issue `<link to issue>`

**Related backend PR (if applicable):**

- related backend PR `<link to PR>`

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm lint:check` passes.
- [x] `pnpm test:run` passes, and tests have been added/updated where applicable.
- [x] `pnpm build` passes.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
