### PR TITLE
Announce the player list to screen readers wherever it is opened from

### DIFF
--- a/src/layouts/default/PlayerOSD/PlayerBarGroupControl.vue
+++ b/src/layouts/default/PlayerOSD/PlayerBarGroupControl.vue
@@ -36,8 +36,7 @@
           ]"
           :data-active="open"
           :data-suppress-hover="suppressHover"
-          :aria-label="$t('tooltip.group_members')"
-          :aria-pressed="open"
+          :aria-label="groupMembersLabel"
           @click.capture="handleTriggerClick"
           @pointerleave="suppressHover = false"
         >
@@ -53,8 +52,7 @@
               navigation ? 'mobile-navigation-label' : 'player-bar-action-label'
             "
           >
-            {{ memberCount }}
-            {{ memberCount === 1 ? $t("player_type.player") : $t("players") }}
+            {{ memberCountLabel }}
           </span>
         </Button>
       </PopoverTrigger>
@@ -113,6 +111,7 @@ import {
 } from "@/helpers/players";
 import { api } from "@/plugins/api";
 import { type Player, PlayerType } from "@/plugins/api/interfaces";
+import { $t } from "@/plugins/i18n";
 import { store } from "@/plugins/store";
 import { computed, ref, watch } from "vue";
 import PlayerGroupPanel from "./PlayerGroupPanel.vue";
@@ -135,6 +134,17 @@ const canEditGroup = computed(
 );
 const memberCount = computed(() =>
   player.value ? getPlayerGroupMemberCount(player.value) : 0,
+);
+const memberCountLabel = computed(
+  () =>
+    `${memberCount.value} ${
+      memberCount.value === 1 ? $t("player_type.player") : $t("players")
+    }`,
+);
+// reka-ui names the panel after this trigger, so the label carries the visible
+// member count as well as the button's purpose
+const groupMembersLabel = computed(
+  () => `${$t("tooltip.group_members")}: ${memberCountLabel.value}`,
 );
 const groupMembers = computed(() => {
   if (!player.value) return [];

--- a/src/layouts/default/PlayerOSD/PlayerBarGroupControl.vue
+++ b/src/layouts/default/PlayerOSD/PlayerBarGroupControl.vue
@@ -141,8 +141,8 @@ const memberCountLabel = computed(
       memberCount.value === 1 ? $t("player_type.player") : $t("players")
     }`,
 );
-// reka-ui names the panel after this trigger, so the label carries the visible
-// member count as well as the button's purpose
+// the spoken label has to contain the button's visible text, so it leads with
+// the purpose and keeps the member count; reka-ui names the panel after it too
 const groupMembersLabel = computed(
   () => `${$t("tooltip.group_members")}: ${memberCountLabel.value}`,
 );

--- a/src/layouts/default/PlayerOSD/PlayerBarPlayerButton.vue
+++ b/src/layouts/default/PlayerOSD/PlayerBarPlayerButton.vue
@@ -9,7 +9,7 @@
     ]"
     :data-active="store.showPlayersMenu"
     :data-suppress-hover="suppressHover"
-    :aria-label="`${$t('tooltip.select_player')}: ${playerName}`"
+    :aria-label="playerSelectLabel"
     :aria-expanded="store.showPlayersMenu"
     aria-haspopup="dialog"
     @click="togglePlayersMenu"
@@ -44,6 +44,9 @@ import { computed, ref } from "vue";
 
 const suppressHover = ref(false);
 const playerName = computed(() => store.activePlayer?.name || $t("no_player"));
+const playerSelectLabel = computed(
+  () => `${$t("tooltip.select_player")}: ${playerName.value}`,
+);
 
 withDefaults(
   defineProps<{

--- a/src/layouts/default/PlayerOSD/PlayerBarPlayerButton.vue
+++ b/src/layouts/default/PlayerOSD/PlayerBarPlayerButton.vue
@@ -9,8 +9,9 @@
     ]"
     :data-active="store.showPlayersMenu"
     :data-suppress-hover="suppressHover"
-    :aria-label="$t('tooltip.select_player')"
-    :aria-pressed="store.showPlayersMenu"
+    :aria-label="`${$t('tooltip.select_player')}: ${playerName}`"
+    :aria-expanded="store.showPlayersMenu"
+    aria-haspopup="dialog"
     @click="togglePlayersMenu"
     @pointerleave="suppressHover = false"
   >
@@ -29,7 +30,7 @@
         navigation ? 'mobile-navigation-label' : 'player-bar-action-label'
       "
     >
-      {{ store.activePlayer?.name || $t("no_player") }}
+      {{ playerName }}
     </span>
   </Button>
 </template>
@@ -37,10 +38,12 @@
 <script setup lang="ts">
 import PlayerIcon from "@/components/PlayerIcon.vue";
 import { Button } from "@/components/ui/button";
+import { $t } from "@/plugins/i18n";
 import { store } from "@/plugins/store";
-import { ref } from "vue";
+import { computed, ref } from "vue";
 
 const suppressHover = ref(false);
+const playerName = computed(() => store.activePlayer?.name || $t("no_player"));
 
 withDefaults(
   defineProps<{

--- a/src/layouts/default/PlayerOSD/PlayerFullscreen.vue
+++ b/src/layouts/default/PlayerOSD/PlayerFullscreen.vue
@@ -456,6 +456,9 @@
             variant="outline"
             size="xs"
             class="border-transparent bg-background/40 shadow-none backdrop-blur-md hover:bg-background/60 dark:border-transparent dark:bg-background/40 dark:hover:bg-background/60"
+            :aria-label="playerSelectLabel"
+            :aria-expanded="store.showPlayersMenu"
+            aria-haspopup="dialog"
             @click="store.showPlayersMenu = true"
           >
             <PlayerIcon
@@ -843,6 +846,12 @@ const subTitleFontSize = computed(() => {
   // Anchor album/artist size to the track title using the EditorialMediaCard
   // tile ratio (subtitle 12px / title 14px).
   return `${(parseFloat(titleFontSize.value) * (12 / 14)).toFixed(3)}em`;
+});
+
+const playerSelectLabel = computed(() => {
+  const selectPlayer = $t("tooltip.select_player");
+  if (!store.activePlayer) return selectPlayer;
+  return `${selectPlayer}: ${getPlayerName(store.activePlayer)}`;
 });
 
 const showExpandedPlayerSelectButton = computed(() => {

--- a/src/layouts/default/PlayerSelect.vue
+++ b/src/layouts/default/PlayerSelect.vue
@@ -27,10 +27,13 @@
     <PopoverAnchor :reference="popoutAnchor" />
     <!-- reka-ui generates the panel id and only mounts the panel while it is
          open, so the buttons that open it announce it with
-         aria-haspopup/aria-expanded rather than aria-controls -->
+         aria-haspopup/aria-expanded rather than aria-controls. It also names the
+         panel after a PopoverTrigger, which this popout has no use for, so the
+         panel carries its own label. -->
     <PopoverContent
       data-player-panel
       data-testid="player-select-sheet"
+      :aria-label="$t('players')"
       side="top"
       :align="popoutFromFullscreen ? 'center' : 'end'"
       :side-offset="

--- a/src/layouts/default/PlayerSelect.vue
+++ b/src/layouts/default/PlayerSelect.vue
@@ -25,6 +25,9 @@
 
   <Popover :open="store.showPlayersMenu" @update:open="setMenuOpen">
     <PopoverAnchor :reference="popoutAnchor" />
+    <!-- reka-ui generates the panel id and only mounts the panel while it is
+         open, so the buttons that open it announce it with
+         aria-haspopup/aria-expanded rather than aria-controls -->
     <PopoverContent
       data-player-panel
       data-testid="player-select-sheet"

--- a/tests/layouts/PlayerBarGroupControl.test.ts
+++ b/tests/layouts/PlayerBarGroupControl.test.ts
@@ -1,0 +1,61 @@
+import PlayerBarGroupControl from "@/layouts/default/PlayerOSD/PlayerBarGroupControl.vue";
+import { mount, type VueWrapper } from "@vue/test-utils";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/plugins/api", async () => {
+  const { reactive } = await vi.importActual<typeof import("vue")>("vue");
+  const api = reactive({ players: {} });
+  return { api, default: api };
+});
+
+vi.mock("@/plugins/store", async () => {
+  const { reactive } = await vi.importActual<typeof import("vue")>("vue");
+  return {
+    store: reactive({
+      activePlayer: { player_id: "kitchen", group_members: [], type: "player" },
+      mobileLayout: false,
+    }),
+  };
+});
+
+vi.mock("@/plugins/i18n", () => ({ $t: (key: string) => key }));
+
+vi.mock("@/helpers/players", () => ({
+  canEditPlayerGroup: () => true,
+  getPlayerGroupMemberCount: () => 3,
+  groupMemberPickerVisible: () => true,
+}));
+
+let wrapper: VueWrapper | undefined;
+
+describe("PlayerBarGroupControl", () => {
+  afterEach(() => {
+    wrapper?.unmount();
+    wrapper = undefined;
+  });
+
+  it("leaves the panel state to the popover trigger", () => {
+    wrapper = mount(PlayerBarGroupControl, {
+      global: { stubs: { PlayerGroupPanel: true, Teleport: true } },
+    });
+    const trigger = wrapper.get("[data-player-group-trigger]");
+
+    // reka-ui's PopoverTrigger supplies the disclosure state; a second,
+    // contradictory toggle state must not ride along with it
+    expect(trigger.attributes("aria-expanded")).toBe("false");
+    expect(trigger.attributes("aria-haspopup")).toBe("dialog");
+    expect(trigger.attributes("aria-pressed")).toBeUndefined();
+  });
+
+  it("keeps the visible member count in the accessible name", () => {
+    wrapper = mount(PlayerBarGroupControl, {
+      global: { stubs: { PlayerGroupPanel: true, Teleport: true } },
+    });
+    const trigger = wrapper.get("[data-player-group-trigger]");
+
+    expect(trigger.attributes("aria-label")).toBe(
+      "tooltip.group_members: 3 players",
+    );
+    expect(trigger.text()).toContain("3 players");
+  });
+});

--- a/tests/layouts/PlayerBarGroupControl.test.ts
+++ b/tests/layouts/PlayerBarGroupControl.test.ts
@@ -1,6 +1,8 @@
 import PlayerBarGroupControl from "@/layouts/default/PlayerOSD/PlayerBarGroupControl.vue";
 import { mount, type VueWrapper } from "@vue/test-utils";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { groupSize } = vi.hoisted(() => ({ groupSize: { value: 3 } }));
 
 vi.mock("@/plugins/api", async () => {
   const { reactive } = await vi.importActual<typeof import("vue")>("vue");
@@ -22,23 +24,31 @@ vi.mock("@/plugins/i18n", () => ({ $t: (key: string) => key }));
 
 vi.mock("@/helpers/players", () => ({
   canEditPlayerGroup: () => true,
-  getPlayerGroupMemberCount: () => 3,
+  getPlayerGroupMemberCount: () => groupSize.value,
   groupMemberPickerVisible: () => true,
 }));
 
 let wrapper: VueWrapper | undefined;
 
+function mountGroupButton() {
+  wrapper = mount(PlayerBarGroupControl, {
+    global: { stubs: { PlayerGroupPanel: true, Teleport: true } },
+  });
+  return wrapper.get("[data-player-group-trigger]");
+}
+
 describe("PlayerBarGroupControl", () => {
+  beforeEach(() => {
+    groupSize.value = 3;
+  });
+
   afterEach(() => {
     wrapper?.unmount();
     wrapper = undefined;
   });
 
   it("leaves the panel state to the popover trigger", () => {
-    wrapper = mount(PlayerBarGroupControl, {
-      global: { stubs: { PlayerGroupPanel: true, Teleport: true } },
-    });
-    const trigger = wrapper.get("[data-player-group-trigger]");
+    const trigger = mountGroupButton();
 
     // reka-ui's PopoverTrigger supplies the disclosure state; a second,
     // contradictory toggle state must not ride along with it
@@ -48,14 +58,21 @@ describe("PlayerBarGroupControl", () => {
   });
 
   it("keeps the visible member count in the accessible name", () => {
-    wrapper = mount(PlayerBarGroupControl, {
-      global: { stubs: { PlayerGroupPanel: true, Teleport: true } },
-    });
-    const trigger = wrapper.get("[data-player-group-trigger]");
+    const trigger = mountGroupButton();
 
     expect(trigger.attributes("aria-label")).toBe(
       "tooltip.group_members: 3 players",
     );
     expect(trigger.text()).toContain("3 players");
+  });
+
+  it("names a single member in the singular", () => {
+    groupSize.value = 1;
+    const trigger = mountGroupButton();
+
+    expect(trigger.attributes("aria-label")).toBe(
+      "tooltip.group_members: 1 player_type.player",
+    );
+    expect(trigger.text()).toContain("1 player_type.player");
   });
 });

--- a/tests/layouts/PlayerBarPlayerButton.test.ts
+++ b/tests/layouts/PlayerBarPlayerButton.test.ts
@@ -1,7 +1,7 @@
 import PlayerBarPlayerButton from "@/layouts/default/PlayerOSD/PlayerBarPlayerButton.vue";
 import { store } from "@/plugins/store";
-import { mount } from "@vue/test-utils";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { mount, type VueWrapper } from "@vue/test-utils";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@/plugins/store", async () => {
   const { reactive } = await vi.importActual<typeof import("vue")>("vue");
@@ -24,13 +24,13 @@ interface TestStore {
 
 const testStore = store as unknown as TestStore;
 
+let wrapper: VueWrapper | undefined;
+
 function mountPlayerButton() {
-  return mount(PlayerBarPlayerButton, {
-    global: {
-      mocks: { $t: (key: string) => key },
-      stubs: { PlayerIcon: true },
-    },
+  wrapper = mount(PlayerBarPlayerButton, {
+    global: { stubs: { PlayerIcon: true } },
   });
+  return wrapper.get("#player-select-button");
 }
 
 describe("PlayerBarPlayerButton", () => {
@@ -39,9 +39,14 @@ describe("PlayerBarPlayerButton", () => {
     testStore.showPlayersMenu = false;
   });
 
+  afterEach(() => {
+    wrapper?.unmount();
+    wrapper = undefined;
+  });
+
   it("announces the player list panel it opens", async () => {
     testStore.activePlayer = { name: "Kitchen" };
-    const button = mountPlayerButton().get("#player-select-button");
+    const button = mountPlayerButton();
 
     expect(button.attributes("aria-haspopup")).toBe("dialog");
     expect(button.attributes("aria-expanded")).toBe("false");
@@ -50,6 +55,7 @@ describe("PlayerBarPlayerButton", () => {
     );
     // a button that opens a panel reports its state through aria-expanded alone
     expect(button.attributes("aria-pressed")).toBeUndefined();
+    expect(button.text()).toContain("Kitchen");
 
     await button.trigger("click");
 
@@ -58,7 +64,7 @@ describe("PlayerBarPlayerButton", () => {
   });
 
   it("names the empty selection when no player is active", () => {
-    const button = mountPlayerButton().get("#player-select-button");
+    const button = mountPlayerButton();
 
     expect(button.attributes("aria-label")).toBe(
       "tooltip.select_player: no_player",

--- a/tests/layouts/PlayerBarPlayerButton.test.ts
+++ b/tests/layouts/PlayerBarPlayerButton.test.ts
@@ -1,0 +1,68 @@
+import PlayerBarPlayerButton from "@/layouts/default/PlayerOSD/PlayerBarPlayerButton.vue";
+import { store } from "@/plugins/store";
+import { mount } from "@vue/test-utils";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/plugins/store", async () => {
+  const { reactive } = await vi.importActual<typeof import("vue")>("vue");
+  return {
+    store: reactive({
+      activePlayer: undefined,
+      showPlayersMenu: false,
+    }),
+  };
+});
+
+vi.mock("@/plugins/i18n", () => ({
+  $t: (key: string) => key,
+}));
+
+interface TestStore {
+  activePlayer?: { name: string };
+  showPlayersMenu: boolean;
+}
+
+const testStore = store as unknown as TestStore;
+
+function mountPlayerButton() {
+  return mount(PlayerBarPlayerButton, {
+    global: {
+      mocks: { $t: (key: string) => key },
+      stubs: { PlayerIcon: true },
+    },
+  });
+}
+
+describe("PlayerBarPlayerButton", () => {
+  beforeEach(() => {
+    testStore.activePlayer = undefined;
+    testStore.showPlayersMenu = false;
+  });
+
+  it("announces the player list panel it opens", async () => {
+    testStore.activePlayer = { name: "Kitchen" };
+    const button = mountPlayerButton().get("#player-select-button");
+
+    expect(button.attributes("aria-haspopup")).toBe("dialog");
+    expect(button.attributes("aria-expanded")).toBe("false");
+    expect(button.attributes("aria-label")).toBe(
+      "tooltip.select_player: Kitchen",
+    );
+    // a button that opens a panel reports its state through aria-expanded alone
+    expect(button.attributes("aria-pressed")).toBeUndefined();
+
+    await button.trigger("click");
+
+    expect(testStore.showPlayersMenu).toBe(true);
+    expect(button.attributes("aria-expanded")).toBe("true");
+  });
+
+  it("names the empty selection when no player is active", () => {
+    const button = mountPlayerButton().get("#player-select-button");
+
+    expect(button.attributes("aria-label")).toBe(
+      "tooltip.select_player: no_player",
+    );
+    expect(button.text()).toContain("no_player");
+  });
+});

--- a/tests/layouts/PlayerFullscreen.test.ts
+++ b/tests/layouts/PlayerFullscreen.test.ts
@@ -2,6 +2,7 @@ import { EMPTY_COLOR_PALETTE } from "@/helpers/utils";
 import PlayerFullscreen from "@/layouts/default/PlayerOSD/PlayerFullscreen.vue";
 import type { MusicAssistantApi } from "@/plugins/api";
 import { PlaybackState } from "@/plugins/api/interfaces";
+import { $t } from "@/plugins/i18n";
 import { shallowMount, type VueWrapper } from "@vue/test-utils";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { nextTick } from "vue";
@@ -225,10 +226,9 @@ describe("PlayerFullscreen lyrics clock", () => {
 });
 
 describe("PlayerFullscreen player select button", () => {
-  it("opens the player list on top of the fullscreen player", async () => {
+  async function mountFullscreenDialog(): Promise<VueWrapper> {
     const { store } = await import("@/plugins/store");
-    const testStore = store as unknown as TestStore;
-    testStore.showFullscreenPlayer = true;
+    (store as unknown as TestStore).showFullscreenPlayer = true;
 
     wrapper = shallowMount(PlayerFullscreen, {
       props: { colorPalette: EMPTY_COLOR_PALETTE },
@@ -242,10 +242,36 @@ describe("PlayerFullscreen player select button", () => {
       },
     });
     await nextTick();
+    return wrapper;
+  }
 
-    await wrapper.find("#fullscreen-player-select-button").trigger("click");
+  it("opens the player list on top of the fullscreen player", async () => {
+    const { store } = await import("@/plugins/store");
+    const testStore = store as unknown as TestStore;
+    const fullscreen = await mountFullscreenDialog();
+
+    await fullscreen.find("#fullscreen-player-select-button").trigger("click");
 
     expect(testStore.showPlayersMenu).toBe(true);
     expect(testStore.showFullscreenPlayer).toBe(true);
+  });
+
+  it("announces the player list panel it opens", async () => {
+    const { store } = await import("@/plugins/store");
+    const testStore = store as unknown as TestStore;
+    const fullscreen = await mountFullscreenDialog();
+    const selectButton = fullscreen.get("#fullscreen-player-select-button");
+
+    expect(selectButton.attributes("aria-haspopup")).toBe("dialog");
+    expect(selectButton.attributes("aria-expanded")).toBe("false");
+    // no player selected, so the label carries no trailing player name
+    expect(selectButton.attributes("aria-label")).toBe(
+      $t("tooltip.select_player"),
+    );
+
+    testStore.showPlayersMenu = true;
+    await nextTick();
+
+    expect(selectButton.attributes("aria-expanded")).toBe("true");
   });
 });

--- a/tests/layouts/PlayerFullscreen.test.ts
+++ b/tests/layouts/PlayerFullscreen.test.ts
@@ -2,7 +2,6 @@ import { EMPTY_COLOR_PALETTE } from "@/helpers/utils";
 import PlayerFullscreen from "@/layouts/default/PlayerOSD/PlayerFullscreen.vue";
 import type { MusicAssistantApi } from "@/plugins/api";
 import { PlaybackState } from "@/plugins/api/interfaces";
-import { $t } from "@/plugins/i18n";
 import { shallowMount, type VueWrapper } from "@vue/test-utils";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { nextTick } from "vue";
@@ -103,7 +102,12 @@ const NOW = 1_700_000_000;
 const QUEUE_ID = "q1";
 
 interface TestStore {
-  activePlayer?: { player_id: string; active_source?: string };
+  activePlayer?: {
+    player_id: string;
+    active_source?: string;
+    name?: string;
+    group_members?: string[];
+  };
   activePlayerQueue?: {
     queue_id: string;
     state: PlaybackState;
@@ -265,13 +269,28 @@ describe("PlayerFullscreen player select button", () => {
     expect(selectButton.attributes("aria-haspopup")).toBe("dialog");
     expect(selectButton.attributes("aria-expanded")).toBe("false");
     // no player selected, so the label carries no trailing player name
-    expect(selectButton.attributes("aria-label")).toBe(
-      $t("tooltip.select_player"),
-    );
+    expect(selectButton.attributes("aria-label")).toBe("tooltip.select_player");
 
     testStore.showPlayersMenu = true;
     await nextTick();
 
     expect(selectButton.attributes("aria-expanded")).toBe("true");
+  });
+
+  it("names the selected player it opens the list from", async () => {
+    const { store } = await import("@/plugins/store");
+    const testStore = store as unknown as TestStore;
+    testStore.activePlayer = {
+      player_id: "p1",
+      name: "Kitchen",
+      group_members: [],
+    };
+    const fullscreen = await mountFullscreenDialog();
+
+    expect(
+      fullscreen
+        .get("#fullscreen-player-select-button")
+        .attributes("aria-label"),
+    ).toBe("tooltip.select_player: Kitchen");
   });
 });

--- a/tests/layouts/PlayerSelect.test.ts
+++ b/tests/layouts/PlayerSelect.test.ts
@@ -769,6 +769,17 @@ describe("PlayerSelect", () => {
     expect(store.showPlayersMenu).toBe(false);
   });
 
+  it("names the panel for assistive tech", () => {
+    // no PopoverTrigger to borrow a name from, so the panel labels itself
+    const wrapper = mountPlayerSelect();
+
+    expect(
+      wrapper
+        .find('[data-testid="player-select-sheet"]')
+        .attributes("aria-label"),
+    ).toBe("players");
+  });
+
   it("stops above the bottom navigation in mobile layout", () => {
     store.mobileLayout = true;
 

--- a/tests/layouts/PlayerSelect.test.ts
+++ b/tests/layouts/PlayerSelect.test.ts
@@ -325,6 +325,30 @@ function mountPlayerSelect() {
   });
 }
 
+// the popover components render for real here, so the panel goes through
+// reka-ui's own labelling rather than a stub that echoes whatever it is passed
+function mountPlayerSelectWithPopover() {
+  return mount(PlayerSelect, {
+    global: {
+      mocks: {
+        $t: (key: string) => key,
+      },
+      stubs: {
+        PlayerCard: PlayerCardStub,
+        PlayerRenameDialog: PlayerRenameDialogStub,
+        SearchInput: SearchInputStub,
+        DropdownMenu: passthroughStub,
+        DropdownMenuCheckboxItem: DropdownMenuCheckboxItemStub,
+        DropdownMenuContent: passthroughStub,
+        DropdownMenuItem: passthroughStub,
+        DropdownMenuLabel: passthroughStub,
+        DropdownMenuSeparator: passthroughStub,
+        DropdownMenuTrigger: passthroughStub,
+      },
+    },
+  });
+}
+
 describe("PlayerSelect", () => {
   // the store and api mocks are module singletons, so a component left mounted
   // keeps reacting to the next test's state
@@ -769,15 +793,19 @@ describe("PlayerSelect", () => {
     expect(store.showPlayersMenu).toBe(false);
   });
 
-  it("names the panel for assistive tech", () => {
-    // no PopoverTrigger to borrow a name from, so the panel labels itself
-    const wrapper = mountPlayerSelect();
+  it("names the panel for assistive tech", async () => {
+    // reka-ui names a panel after its PopoverTrigger, and this popout is
+    // anchored instead of triggered, so only a real mount shows the name lands
+    const wrapper = mountPlayerSelectWithPopover();
+    await nextTick();
 
-    expect(
-      wrapper
-        .find('[data-testid="player-select-sheet"]')
-        .attributes("aria-label"),
-    ).toBe("players");
+    const panel = document.body.querySelector(
+      '[data-testid="player-select-sheet"]',
+    );
+    expect(panel?.getAttribute("role")).toBe("dialog");
+    expect(panel?.getAttribute("aria-label")).toBe("players");
+
+    wrapper.unmount();
   });
 
   it("stops above the bottom navigation in mobile layout", () => {


### PR DESCRIPTION
# What does this implement/fix?

The buttons that open the player list told assistive tech very little about it. The fullscreen player's button said nothing at all, the player bar's button described itself as an on/off toggle rather than a button that opens a panel, and the panel itself had no name to announce. The group button next to it had the same toggle problem. All of them now describe themselves the same way, so screen readers announce the player list consistently wherever it is opened from.

**Related issue (if applicable):**

- n/a

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

Changes:

- Both player select buttons now report that they open a panel, and whether it is open.
- The player bar and group buttons no longer report themselves as pressed toggles.
- The player list panel now has a name of its own to be announced by.
- The player and group buttons keep their visible text (player name, member count) in their spoken labels.
- Added tests for the player bar player and group buttons, and extended the player list and fullscreen player tests.

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm lint:check` passes.
- [x] `pnpm test:run` passes, and tests have been added/updated where applicable.
- [x] `pnpm build` passes.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
