### PR TITLE
Remember the last selected player when opening from Home Assistant

### DIFF
--- a/src/layouts/default/PlayerSelect.vue
+++ b/src/layouts/default/PlayerSelect.vue
@@ -349,12 +349,7 @@ watch(
     // would overwrite the player the user actually selected earlier
     if (playerId === autoSelectedPlayerId) return;
     autoSelectedPlayerId = undefined;
-    const player = api.players[playerId];
-    if (!player) return;
-    void setPreference(
-      "activePlayerId",
-      isBuiltinPlayer(player) ? BUILTIN_PLAYER_PREFERENCE : playerId,
-    );
+    rememberPlayer(playerId);
   },
 );
 
@@ -364,10 +359,10 @@ watch(
   { deep: true },
 );
 
-watch(
-  () => webPlayer.player_id,
-  () => checkDefaultPlayer(),
-);
+watch([() => webPlayer.player_id, () => store.companionPlayerId], () => {
+  checkDefaultPlayer();
+  preferBuiltinPlayer();
+});
 
 onMounted(() => {
   document.addEventListener("keydown", markKeyboardInteraction, true);
@@ -442,6 +437,10 @@ function selectPlayer(player: Player) {
     store.showPlayersMenu = false;
     return;
   }
+  // remember it here as well: picking the player that was already selected
+  // automatically leaves store.activePlayerId untouched
+  autoSelectedPlayerId = undefined;
+  rememberPlayer(player.player_id);
   store.activePlayerId = player.player_id;
   store.showPlayersMenu = false;
 }
@@ -552,10 +551,38 @@ function resetPanelState() {
 function checkDefaultPlayer() {
   if (store.activePlayer) return;
   const defaultPlayerId = selectDefaultPlayer();
-  if (defaultPlayerId) {
-    autoSelectedPlayerId = defaultPlayerId;
-    store.activePlayerId = defaultPlayerId;
+  if (!defaultPlayerId) return;
+  autoSelectedPlayerId = defaultPlayerId;
+  store.activePlayerId = defaultPlayerId;
+  // a built-in player id remembered before the placeholder existed only
+  // resolves in the browser session that created it: store the placeholder
+  if (getPreference<string>("activePlayerId").value === defaultPlayerId) {
+    rememberPlayer(defaultPlayerId);
   }
+}
+
+/**
+ * Hand an automatically picked player over to the built-in player of this
+ * device, which only registers a moment after the app has started.
+ */
+function preferBuiltinPlayer() {
+  if (store.activePlayerId !== autoSelectedPlayerId) return;
+  if (getPreference<string>("activePlayerId").value) return;
+  const builtinPlayerId = selectBuiltinPlayer();
+  if (!builtinPlayerId) return;
+  autoSelectedPlayerId = builtinPlayerId;
+  store.activePlayerId = builtinPlayerId;
+}
+
+function rememberPlayer(playerId: string) {
+  const player = api.players[playerId];
+  if (!player) return;
+  const rememberedPlayer = isBuiltinPlayer(player)
+    ? BUILTIN_PLAYER_PREFERENCE
+    : playerId;
+  if (getPreference<string>("activePlayerId").value === rememberedPlayer)
+    return;
+  void setPreference("activePlayerId", rememberedPlayer);
 }
 
 function selectDefaultPlayer() {

--- a/src/layouts/default/PlayerSelect.vue
+++ b/src/layouts/default/PlayerSelect.vue
@@ -212,7 +212,7 @@ import {
   fullscreenPlayerSelectAnchor,
   playerBarEndAnchor,
 } from "@/helpers/player_bar";
-import { isPlayerActive } from "@/helpers/players";
+import { isBuiltinPlayer, isPlayerActive } from "@/helpers/players";
 import { api } from "@/plugins/api";
 import type { Player } from "@/plugins/api/interfaces";
 import { authManager } from "@/plugins/auth";
@@ -233,6 +233,9 @@ import {
 import { toast } from "vue-sonner";
 
 const SEARCH_PLAYER_THRESHOLD = 10;
+// Stored instead of a built-in player id: those are unique per browser/app
+// session, so they are meaningless on the next visit or on another device.
+const BUILTIN_PLAYER_PREFERENCE = "<builtinplayer>";
 const PLAYER_SELECT_PREFERENCES = {
   showVolumeForActivePlayersOnly: "playerSelect.showVolumeForActivePlayersOnly",
   showSelectedPlayerFirst: "playerSelect.showSelectedPlayerFirst",
@@ -266,6 +269,7 @@ const showGroupMemberNames = getPreference<boolean>(
 let menuTrigger: HTMLElement | null = null;
 let lastInteractionWasKeyboard = false;
 let restoreFocusOnClose = false;
+let autoSelectedPlayerId: string | undefined;
 
 // PlayerSelect is the only surface that lists needs_setup players: a click here
 // launches the setup flow (see selectPlayer) instead of selecting/playing them.
@@ -341,8 +345,16 @@ watch(
   () => store.activePlayerId,
   (playerId) => {
     if (!playerId) return;
-    setPreference("activePlayerId", playerId);
-    localStorage.setItem("activePlayerId", playerId);
+    // only a deliberate choice is remembered: persisting the automatic pick
+    // would overwrite the player the user actually selected earlier
+    if (playerId === autoSelectedPlayerId) return;
+    autoSelectedPlayerId = undefined;
+    const player = api.players[playerId];
+    if (!player) return;
+    void setPreference(
+      "activePlayerId",
+      isBuiltinPlayer(player) ? BUILTIN_PLAYER_PREFERENCE : playerId,
+    );
   },
 );
 
@@ -517,7 +529,6 @@ async function disablePlayer(player: Player) {
     if (store.activePlayerId === player.player_id) {
       store.activePlayerId = fallbackPlayer?.player_id;
       if (!fallbackPlayer) {
-        localStorage.removeItem("activePlayerId");
         await setPreference("activePlayerId", null);
       }
     }
@@ -542,18 +553,31 @@ function checkDefaultPlayer() {
   if (store.activePlayer) return;
   const defaultPlayerId = selectDefaultPlayer();
   if (defaultPlayerId) {
+    autoSelectedPlayerId = defaultPlayerId;
     store.activePlayerId = defaultPlayerId;
   }
 }
 
 function selectDefaultPlayer() {
-  const lastPlayerId =
-    localStorage.getItem("activePlayerId") ||
-    getPreference<string>("activePlayerId").value;
+  const lastPlayerId = getPreference<string>("activePlayerId").value;
+  // both a remembered built-in player and a remembered player that is not known
+  // (yet) register a moment after startup, so leave the selection empty until
+  // they show up instead of settling for another player
+  if (lastPlayerId === BUILTIN_PLAYER_PREFERENCE) return selectBuiltinPlayer();
   if (lastPlayerId) {
     if (!(lastPlayerId in api.players)) return;
     if (isSelectablePlayer(lastPlayerId)) return lastPlayerId;
   }
+  const builtinPlayerId = selectBuiltinPlayer();
+  if (builtinPlayerId) return builtinPlayerId;
+  const selectablePlayers = orderedPlayers.value.filter((player) =>
+    isSelectablePlayer(player.player_id),
+  );
+  return (selectablePlayers.find(isPlayerActive) ?? selectablePlayers[0])
+    ?.player_id;
+}
+
+function selectBuiltinPlayer() {
   if (isSelectablePlayer(webPlayer.player_id)) {
     return webPlayer.player_id;
   }

--- a/tests/layouts/PlayerSelect.test.ts
+++ b/tests/layouts/PlayerSelect.test.ts
@@ -46,10 +46,16 @@ vi.mock("@/plugins/api", async () => {
 });
 
 vi.mock("@/plugins/store", async () => {
-  const { reactive } = await vi.importActual<typeof import("vue")>("vue");
+  const { computed, reactive } =
+    await vi.importActual<typeof import("vue")>("vue");
+  const { api } = await import("@/plugins/api");
   return {
     store: reactive({
-      activePlayer: undefined as Player | undefined,
+      // resolved from the player list like the real store, so the guard against
+      // overriding an existing selection behaves the same
+      activePlayer: computed(() =>
+        store.activePlayerId ? api.players[store.activePlayerId] : undefined,
+      ),
       activePlayerId: undefined as string | undefined,
       companionPlayerId: undefined as string | undefined,
       dialogActive: false,
@@ -334,7 +340,6 @@ describe("PlayerSelect", () => {
     }
     api.players = {};
     savePlayerConfig.mockResolvedValue({});
-    store.activePlayer = undefined;
     store.activePlayerId = undefined;
     store.companionPlayerId = undefined;
     store.dialogActive = false;
@@ -354,7 +359,6 @@ describe("PlayerSelect", () => {
       attic: createPlayer("attic", "Attic", PlaybackState.PLAYING),
       lounge: createPlayer("lounge", "Lounge"),
     };
-    store.activePlayer = activePlayer;
     store.activePlayerId = activePlayer.player_id;
 
     const wrapper = mountPlayerSelect();
@@ -375,7 +379,6 @@ describe("PlayerSelect", () => {
       selected: selectedPlayer,
       attic: createPlayer("attic", "Attic"),
     };
-    store.activePlayer = selectedPlayer;
     store.activePlayerId = selectedPlayer.player_id;
 
     const wrapper = mountPlayerSelect();
@@ -502,6 +505,85 @@ describe("PlayerSelect", () => {
     );
   });
 
+  it("remembers the player that was already selected automatically", async () => {
+    const kitchen = createPlayer("kitchen", "Kitchen");
+    api.players = { [kitchen.player_id]: kitchen };
+    const wrapper = mountPlayerSelect();
+    expect(store.activePlayerId).toBe(kitchen.player_id);
+
+    await wrapper
+      .get('[data-player-id="kitchen"] .select-player')
+      .trigger("click");
+
+    expect(setPreference).toHaveBeenCalledWith(
+      "activePlayerId",
+      kitchen.player_id,
+    );
+  });
+
+  it("replaces a remembered built-in player id with the placeholder", async () => {
+    const builtin = createPlayer("builtin", "This device");
+    setActivePlayerPreference(builtin.player_id);
+    api.players = { [builtin.player_id]: builtin };
+
+    mountPlayerSelect();
+
+    expect(store.activePlayerId).toBe(builtin.player_id);
+    expect(setPreference).toHaveBeenCalledWith(
+      "activePlayerId",
+      "<builtinplayer>",
+    );
+  });
+
+  it("hands an automatic pick over to the built-in player registering late", async () => {
+    const attic = createPlayer("attic", "Attic");
+    const builtin = createPlayer("builtin", "This device");
+    api.players = { [attic.player_id]: attic };
+
+    mountPlayerSelect();
+    expect(store.activePlayerId).toBe(attic.player_id);
+
+    api.players[builtin.player_id] = builtin;
+    store.companionPlayerId = builtin.player_id;
+    await nextTick();
+
+    expect(store.activePlayerId).toBe(builtin.player_id);
+    expect(setPreference).not.toHaveBeenCalled();
+  });
+
+  it("keeps the remembered player when it is unavailable at startup", () => {
+    const kitchen = createPlayer("kitchen", "Kitchen");
+    kitchen.available = false;
+    const attic = createPlayer("attic", "Attic");
+    setActivePlayerPreference(kitchen.player_id);
+    api.players = {
+      [kitchen.player_id]: kitchen,
+      [attic.player_id]: attic,
+    };
+
+    mountPlayerSelect();
+
+    expect(store.activePlayerId).toBe(attic.player_id);
+    expect(setPreference).not.toHaveBeenCalled();
+  });
+
+  it("keeps a remembered player when the built-in one registers late", async () => {
+    const kitchen = createPlayer("kitchen", "Kitchen");
+    const builtin = createPlayer("builtin", "This device");
+    setActivePlayerPreference(kitchen.player_id);
+    api.players = { [kitchen.player_id]: kitchen };
+
+    mountPlayerSelect();
+    expect(store.activePlayerId).toBe(kitchen.player_id);
+
+    api.players[builtin.player_id] = builtin;
+    webPlayer.player_id = builtin.player_id;
+    await nextTick();
+
+    expect(store.activePlayerId).toBe(kitchen.player_id);
+    expect(setPreference).not.toHaveBeenCalled();
+  });
+
   it("moves a newly active player to the front", async () => {
     const kitchen = createPlayer("kitchen", "Kitchen");
     const office = createPlayer("office", "Office");
@@ -561,10 +643,14 @@ describe("PlayerSelect", () => {
 
   it("selects a player and closes the sheet from the card action", async () => {
     const player = createPlayer("kitchen", "Kitchen");
-    api.players = { [player.player_id]: player };
+    const other = createPlayer("attic", "Attic");
+    api.players = { [player.player_id]: player, [other.player_id]: other };
     const wrapper = mountPlayerSelect();
+    expect(store.activePlayerId).toBe(other.player_id);
 
-    await wrapper.find(".select-player").trigger("click");
+    await wrapper
+      .get('[data-player-id="kitchen"] .select-player')
+      .trigger("click");
 
     expect(store.activePlayerId).toBe(player.player_id);
     expect(store.showPlayersMenu).toBe(false);
@@ -904,7 +990,6 @@ describe("PlayerSelect", () => {
       attic: createPlayer("attic", "Attic"),
       selected: selectedPlayer,
     };
-    store.activePlayer = selectedPlayer;
     store.activePlayerId = selectedPlayer.player_id;
     store.showPlayersMenu = false;
 
@@ -940,7 +1025,6 @@ describe("PlayerSelect", () => {
       [fallback.player_id]: fallback,
       [setupPlayer.player_id]: setupPlayer,
     };
-    store.activePlayer = player;
     store.activePlayerId = player.player_id;
     const wrapper = mountPlayerSelect();
     const menuItems = wrapper
@@ -979,5 +1063,27 @@ describe("PlayerSelect", () => {
     });
     expect(player.enabled).toBe(false);
     expect(store.activePlayerId).toBe(fallback.player_id);
+  });
+
+  it("forgets the remembered player when the last one is disabled", async () => {
+    const player = createPlayer("kitchen", "Kitchen");
+    setActivePlayerPreference(player.player_id);
+    api.players = { [player.player_id]: player };
+    const wrapper = mountPlayerSelect();
+    expect(store.activePlayerId).toBe(player.player_id);
+
+    const menuItems = wrapper
+      .getComponent(PlayerCardStub)
+      .props("playerMenuItems") as ContextMenuItem[];
+    menuItems[1].action?.();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    const confirmation = emitEvent.mock.calls.find(
+      ([event]) => event === "deleteConfirmationDialog",
+    )?.[1];
+    await confirmation.onConfirm();
+    await flushPromises();
+
+    expect(store.activePlayerId).toBeUndefined();
+    expect(setPreference).toHaveBeenCalledWith("activePlayerId", null);
   });
 });

--- a/tests/layouts/PlayerSelect.test.ts
+++ b/tests/layouts/PlayerSelect.test.ts
@@ -13,9 +13,9 @@ import {
 } from "@/plugins/api/interfaces";
 import { store } from "@/plugins/store";
 import { webPlayer } from "@/plugins/web_player";
-import { flushPromises, mount } from "@vue/test-utils";
+import { enableAutoUnmount, flushPromises, mount } from "@vue/test-utils";
 import { nextTick } from "vue";
-import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const {
   emitEvent,
@@ -24,33 +24,17 @@ const {
   preferenceState,
   savePlayerConfig,
   setPreference,
-  storage,
-} = vi.hoisted(() => {
-  const values = new Map<string, string>();
-  const storage = {
-    clear: () => values.clear(),
-    getItem: (key: string) => values.get(key) ?? null,
-    removeItem: (key: string) => {
-      values.delete(key);
-    },
-    setItem: (key: string, value: string) => {
-      values.set(key, value);
-    },
-  };
-  vi.stubGlobal("localStorage", storage);
-  return {
-    emitEvent: vi.fn(),
-    getPreference: vi.fn(),
-    isAdmin: vi.fn(() => true),
-    preferenceState: {
-      values: {} as Record<string, unknown>,
-      reactiveValues: undefined as Record<string, unknown> | undefined,
-    },
-    savePlayerConfig: vi.fn(),
-    setPreference: vi.fn(),
-    storage,
-  };
-});
+} = vi.hoisted(() => ({
+  emitEvent: vi.fn(),
+  getPreference: vi.fn(),
+  isAdmin: vi.fn(() => true),
+  preferenceState: {
+    values: {} as Record<string, unknown>,
+    reactiveValues: undefined as Record<string, unknown> | undefined,
+  },
+  savePlayerConfig: vi.fn(),
+  setPreference: vi.fn(),
+}));
 
 vi.mock("@/plugins/api", async () => {
   const { reactive } = await vi.importActual<typeof import("vue")>("vue");
@@ -298,11 +282,15 @@ function createPlayer(
   };
 }
 
-function setPlayerSelectPreference(key: string, value: boolean) {
+function setPlayerSelectPreference(key: string, value: boolean | string) {
   if (!preferenceState.reactiveValues) {
     throw new Error("Preference mock is not initialized");
   }
   preferenceState.reactiveValues[key] = value;
+}
+
+function setActivePlayerPreference(value: string) {
+  setPlayerSelectPreference("activePlayerId", value);
 }
 
 function mountPlayerSelect() {
@@ -332,9 +320,9 @@ function mountPlayerSelect() {
 }
 
 describe("PlayerSelect", () => {
-  afterAll(() => {
-    vi.unstubAllGlobals();
-  });
+  // the store and api mocks are module singletons, so a component left mounted
+  // keeps reacting to the next test's state
+  enableAutoUnmount(afterEach);
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -354,7 +342,6 @@ describe("PlayerSelect", () => {
     store.showFullscreenPlayer = false;
     store.showPlayersMenu = true;
     webPlayer.player_id = null;
-    storage.clear();
   });
 
   it("orders the selected player, this device, then active players first", () => {
@@ -421,7 +408,7 @@ describe("PlayerSelect", () => {
   it("waits for a remembered player instead of selecting the web player", async () => {
     const web = createPlayer("web", "This device");
     const remembered = createPlayer("remembered", "Living room");
-    storage.setItem("activePlayerId", remembered.player_id);
+    setActivePlayerPreference(remembered.player_id);
     webPlayer.player_id = web.player_id;
     api.players = {
       [web.player_id]: web,
@@ -434,6 +421,85 @@ describe("PlayerSelect", () => {
     await nextTick();
 
     expect(store.activePlayerId).toBe(remembered.player_id);
+  });
+
+  it("waits for the built-in player when it is the remembered one", async () => {
+    const builtin = createPlayer("builtin", "This device");
+    const kitchen = createPlayer("kitchen", "Kitchen", PlaybackState.PLAYING);
+    setActivePlayerPreference("<builtinplayer>");
+    api.players = { [kitchen.player_id]: kitchen };
+
+    mountPlayerSelect();
+    expect(store.activePlayerId).toBeUndefined();
+
+    api.players[builtin.player_id] = builtin;
+    webPlayer.player_id = builtin.player_id;
+    await nextTick();
+
+    expect(store.activePlayerId).toBe(builtin.player_id);
+  });
+
+  it("falls back to the built-in player, then a playing one, then any", async () => {
+    const attic = createPlayer("attic", "Attic");
+    const kitchen = createPlayer("kitchen", "Kitchen", PlaybackState.PLAYING);
+    const builtin = createPlayer("builtin", "This device");
+    api.players = { [attic.player_id]: attic };
+
+    mountPlayerSelect();
+    expect(store.activePlayerId).toBe(attic.player_id);
+
+    api.players[kitchen.player_id] = kitchen;
+    store.activePlayerId = undefined;
+    await nextTick();
+    expect(store.activePlayerId).toBe(kitchen.player_id);
+
+    api.players[builtin.player_id] = builtin;
+    webPlayer.player_id = builtin.player_id;
+    store.activePlayerId = undefined;
+    await nextTick();
+    expect(store.activePlayerId).toBe(builtin.player_id);
+  });
+
+  it("remembers a selected player but not an automatic one", async () => {
+    const kitchen = createPlayer("kitchen", "Kitchen");
+    const office = createPlayer("office", "Office");
+    api.players = {
+      [kitchen.player_id]: kitchen,
+      [office.player_id]: office,
+    };
+
+    const wrapper = mountPlayerSelect();
+    expect(store.activePlayerId).toBe(kitchen.player_id);
+    expect(setPreference).not.toHaveBeenCalled();
+
+    await wrapper
+      .get('[data-player-id="office"] .select-player')
+      .trigger("click");
+
+    expect(setPreference).toHaveBeenCalledWith(
+      "activePlayerId",
+      office.player_id,
+    );
+  });
+
+  it("remembers the built-in player as a device independent placeholder", async () => {
+    const builtin = createPlayer("builtin", "This device");
+    const kitchen = createPlayer("kitchen", "Kitchen");
+    setActivePlayerPreference(kitchen.player_id);
+    api.players = {
+      [builtin.player_id]: builtin,
+      [kitchen.player_id]: kitchen,
+    };
+    const wrapper = mountPlayerSelect();
+
+    await wrapper
+      .get('[data-player-id="builtin"] .select-player')
+      .trigger("click");
+
+    expect(setPreference).toHaveBeenCalledWith(
+      "activePlayerId",
+      "<builtinplayer>",
+    );
   });
 
   it("moves a newly active player to the front", async () => {


### PR DESCRIPTION
# What does this implement/fix?

Opening Music Assistant from within Home Assistant did not remember the last selected player - often no player was selected at all.

The last selected player was kept in browser storage as well as in the (server side) user preferences, with the browser copy winning. Browser storage is not shared between opening MA directly and opening it inside Home Assistant, and the built-in player of a browser session got remembered as the last player. Since that player only exists for that one session, the remembered player pointed at something that was gone the next time, leaving the selection empty.

**Related issue (if applicable):**

- related issue `n/a`

**Related backend PR (if applicable):**

- related backend PR `n/a`

- the last selected player is now only stored in your user profile, so it follows you between Home Assistant and the app
- choosing a built-in player (this browser or the Home Assistant companion app) is remembered as "the built-in player of this device" instead of a one-off id
- when nothing is remembered, the built-in player is picked first, then a player that is already playing, then any available player
- an automatically picked player no longer overwrites the player you selected yourself

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm lint:check` passes.
- [x] `pnpm test:run` passes, and tests have been added/updated where applicable.
- [x] `pnpm build` passes.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
