### PR TITLE
Let the group volume popout scroll instead of running off screen

### DIFF
--- a/src/layouts/default/PlayerOSD/PlayerVolume.vue
+++ b/src/layouts/default/PlayerOSD/PlayerVolume.vue
@@ -74,7 +74,7 @@
       @pointermove.capture="onPointerMove"
       @pointerup="onPointerUp"
       @pointercancel="onPointerCancel"
-      @wheel.prevent="onWheel"
+      @wheel="onWheel"
       @touchstart="onTouchStart"
       @touchmove="onTouchMove"
       @touchend="onTouchEnd"
@@ -129,7 +129,7 @@ import {
   PlayerType,
 } from "@/plugins/api/interfaces";
 import { store } from "@/plugins/store";
-import { computed, onUnmounted, ref, watch } from "vue";
+import { computed, nextTick, onUnmounted, ref, watch } from "vue";
 
 export interface Props {
   /** The player to control — component handles all volume logic internally */
@@ -322,6 +322,13 @@ const updatePopoutPosition = () => {
 const toggleGroupPopout = () => {
   if (!showGroupPopout.value) {
     updatePopoutPosition();
+    // The group slider is the last row, so a capped list has to open scrolled
+    // to the bottom to keep it over the slider that was tapped
+    nextTick(() => {
+      if (popoutRef.value) {
+        popoutRef.value.scrollTop = popoutRef.value.scrollHeight;
+      }
+    });
   }
   showGroupPopout.value = !showGroupPopout.value;
   lastPopoutToggleTime = Date.now();
@@ -722,7 +729,10 @@ const onTouchCancel = () => {
 };
 
 const onWheel = (event: WheelEvent) => {
+  // Only claim the wheel when it changes volume, so sliders inside a scrollable
+  // container (the group popout) still scroll it
   if (!props.allowWheel || isSliderDisabled.value) return;
+  event.preventDefault();
 
   if (event.deltaY < 0) {
     volumeUp();
@@ -892,7 +902,7 @@ watch(
   box-shadow:
     0 -4px 16px rgba(0, 0, 0, 0.15),
     0 -1px 4px rgba(0, 0, 0, 0.08);
-  /* the max-height is set inline from the room measured above the slider */
+  /* Max-height is set inline: the room above the slider, less POPOUT_MARGIN */
   overflow-y: auto;
   overscroll-behavior: contain;
   z-index: 10001;

--- a/src/layouts/default/PlayerOSD/PlayerVolume.vue
+++ b/src/layouts/default/PlayerOSD/PlayerVolume.vue
@@ -284,12 +284,15 @@ const updatePopoutPosition = () => {
   const rect = wrapperRef.value.getBoundingClientRect();
   // Align popout bottom with wrapper bottom so the group volume slider overlaps the main one
   const bottom = `${window.innerHeight - rect.bottom}px`;
+  // It grows upwards from there, so a large group is capped at the room above
+  const maxHeight = `${rect.bottom - POPOUT_MARGIN}px`;
 
   if (store.mobileLayout) {
     // Full width with padding on mobile
     popoutStyle.value = {
       position: "fixed",
       bottom,
+      maxHeight,
       left: `${POPOUT_MARGIN}px`,
       right: `${POPOUT_MARGIN}px`,
     };
@@ -309,6 +312,7 @@ const updatePopoutPosition = () => {
     popoutStyle.value = {
       position: "fixed",
       bottom,
+      maxHeight,
       left: `${left}px`,
       width: `${popoutWidth}px`,
     };
@@ -888,6 +892,9 @@ watch(
   box-shadow:
     0 -4px 16px rgba(0, 0, 0, 0.15),
     0 -1px 4px rgba(0, 0, 0, 0.08);
+  /* the max-height is set inline from the room measured above the slider */
+  overflow-y: auto;
+  overscroll-behavior: contain;
   z-index: 10001;
 }
 

--- a/tests/layouts/PlayerVolume.test.ts
+++ b/tests/layouts/PlayerVolume.test.ts
@@ -7,8 +7,9 @@ import {
   PlayerFeature,
   PlayerType,
 } from "@/plugins/api/interfaces";
+import { store } from "@/plugins/store";
 import { mount } from "@vue/test-utils";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const { getVolumeIconComponent } = vi.hoisted(() => ({
   getVolumeIconComponent: vi.fn(() => "span"),
@@ -105,6 +106,19 @@ function createPlayer(overrides: Partial<Player> = {}): Player {
   };
 }
 
+const sliderStub = {
+  Slider: {
+    emits: ["update:modelValue"],
+    template: `
+      <div
+        data-slot="slider"
+        role="slider"
+        @pointerdown="$emit('update:modelValue', [80])"
+      />
+    `,
+  },
+};
+
 function mountGroupVolume(player: Player) {
   return mount(PlayerVolume, {
     props: {
@@ -114,18 +128,19 @@ function mountGroupVolume(player: Player) {
       requestExpandOnGroupTap: true,
     },
     global: {
-      stubs: {
-        Slider: {
-          emits: ["update:modelValue"],
-          template: `
-            <div
-              data-slot="slider"
-              role="slider"
-              @pointerdown="$emit('update:modelValue', [80])"
-            />
-          `,
-        },
-      },
+      stubs: sliderStub,
+    },
+  });
+}
+
+function mountPopoutVolume(player: Player) {
+  return mount(PlayerVolume, {
+    props: {
+      player,
+      preferGroupVolume: true,
+    },
+    global: {
+      stubs: sliderStub,
     },
   });
 }
@@ -341,5 +356,68 @@ describe("PlayerVolume group expansion", () => {
 
     expect(wrapper.emitted("toggle-group-expansion")).toBeUndefined();
     expect(api.playerCommandGroupVolume).not.toHaveBeenCalled();
+  });
+});
+
+describe("PlayerVolume group popout", () => {
+  // the popout is anchored to the bottom of the slider, so this is both the
+  // room it has above it and the point it grows up from
+  const SLIDER_BOTTOM = 700;
+
+  function mountLargeGroup() {
+    const children = ["Office", "Kitchen", "Bedroom", "Bathroom", "Study"].map(
+      (name) => createPlayer({ player_id: name.toLowerCase(), name }),
+    );
+    const parent = createPlayer({
+      type: PlayerType.GROUP,
+      group_members: children.map((child) => child.player_id),
+    });
+    api.players = Object.fromEntries(
+      [parent, ...children].map((player) => [player.player_id, player]),
+    );
+    return { children, wrapper: mountPopoutVolume(parent) };
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    api.players = {};
+    store.mobileLayout = false;
+    vi.spyOn(window, "innerHeight", "get").mockReturnValue(768);
+    vi.spyOn(Element.prototype, "getBoundingClientRect").mockReturnValue({
+      top: SLIDER_BOTTOM - 40,
+      bottom: SLIDER_BOTTOM,
+      left: 100,
+      right: 300,
+      width: 200,
+      height: 40,
+    } as DOMRect);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    document.body.innerHTML = "";
+  });
+
+  it("caps the popout at the room above the slider", async () => {
+    const { children, wrapper } = mountLargeGroup();
+
+    await wrapper.find(".player-volume-container").trigger("click");
+
+    const popout = document.body.querySelector<HTMLElement>(".group-popout");
+    expect(popout).not.toBeNull();
+    expect(popout!.querySelectorAll(".group-popout-label")).toHaveLength(
+      children.length,
+    );
+    expect(popout!.style.maxHeight).toBe("692px");
+  });
+
+  it("caps the popout at the room above the slider on mobile", async () => {
+    store.mobileLayout = true;
+    const { wrapper } = mountLargeGroup();
+
+    await wrapper.find(".player-volume-container").trigger("click");
+
+    const popout = document.body.querySelector<HTMLElement>(".group-popout");
+    expect(popout!.style.maxHeight).toBe("692px");
   });
 });

--- a/tests/layouts/PlayerVolume.test.ts
+++ b/tests/layouts/PlayerVolume.test.ts
@@ -10,6 +10,7 @@ import {
 import { store } from "@/plugins/store";
 import { mount } from "@vue/test-utils";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { nextTick } from "vue";
 
 const { getVolumeIconComponent } = vi.hoisted(() => ({
   getVolumeIconComponent: vi.fn(() => "span"),
@@ -395,29 +396,82 @@ describe("PlayerVolume group popout", () => {
 
   afterEach(() => {
     vi.restoreAllMocks();
+    store.mobileLayout = false;
     document.body.innerHTML = "";
   });
+
+  async function openPopout(wrapper: ReturnType<typeof mountPopoutVolume>) {
+    await wrapper.find(".player-volume-container").trigger("click");
+    return document.body.querySelector<HTMLElement>(".group-popout")!;
+  }
 
   it("caps the popout at the room above the slider", async () => {
     const { children, wrapper } = mountLargeGroup();
 
-    await wrapper.find(".player-volume-container").trigger("click");
+    const popout = await openPopout(wrapper);
 
-    const popout = document.body.querySelector<HTMLElement>(".group-popout");
     expect(popout).not.toBeNull();
-    expect(popout!.querySelectorAll(".group-popout-label")).toHaveLength(
+    expect(popout.querySelectorAll(".group-popout-label")).toHaveLength(
       children.length,
     );
-    expect(popout!.style.maxHeight).toBe("692px");
+    expect(popout.style.maxHeight).toBe("692px");
+    // pins the desktop branch, which the shared cap alone cannot tell apart
+    expect(popout.style.width).toBe("300px");
+    expect(popout.style.right).toBe("");
   });
 
   it("caps the popout at the room above the slider on mobile", async () => {
     store.mobileLayout = true;
     const { wrapper } = mountLargeGroup();
 
-    await wrapper.find(".player-volume-container").trigger("click");
+    const popout = await openPopout(wrapper);
 
-    const popout = document.body.querySelector<HTMLElement>(".group-popout");
-    expect(popout!.style.maxHeight).toBe("692px");
+    expect(popout.style.maxHeight).toBe("692px");
+    expect(popout.style.right).toBe("8px");
+    expect(popout.style.width).toBe("");
+  });
+
+  it("opens at the group slider so it still overlaps the tapped one", async () => {
+    vi.spyOn(HTMLElement.prototype, "scrollHeight", "get").mockReturnValue(900);
+    const { wrapper } = mountLargeGroup();
+
+    const popout = await openPopout(wrapper);
+    await nextTick();
+
+    expect(popout.scrollTop).toBe(900);
+  });
+
+  it("leaves the wheel to scroll the popout rows", async () => {
+    const { wrapper } = mountLargeGroup();
+    const popout = await openPopout(wrapper);
+    const row = popout.querySelector<HTMLElement>(".player-volume-container")!;
+
+    const event = new WheelEvent("wheel", {
+      deltaY: 120,
+      bubbles: true,
+      cancelable: true,
+    });
+    row.dispatchEvent(event);
+
+    expect(event.defaultPrevented).toBe(false);
+  });
+
+  it("still claims the wheel where it changes volume", async () => {
+    const player = createPlayer();
+    api.players = { [player.player_id]: player };
+    const wrapper = mount(PlayerVolume, {
+      props: { player, allowWheel: true },
+      global: { stubs: sliderStub },
+    });
+
+    const event = new WheelEvent("wheel", {
+      deltaY: -120,
+      bubbles: true,
+      cancelable: true,
+    });
+    wrapper.find(".player-volume-container").element.dispatchEvent(event);
+
+    expect(event.defaultPrevented).toBe(true);
+    expect(api.playerCommandVolumeUp).toHaveBeenCalledWith(player.player_id);
   });
 });

--- a/tests/layouts/PlayerVolume.test.ts
+++ b/tests/layouts/PlayerVolume.test.ts
@@ -379,11 +379,20 @@ describe("PlayerVolume group popout", () => {
     return { children, wrapper: mountPopoutVolume(parent) };
   }
 
+  const originalInnerHeight = Object.getOwnPropertyDescriptor(
+    window,
+    "innerHeight",
+  );
+
   beforeEach(() => {
     vi.clearAllMocks();
     api.players = {};
     store.mobileLayout = false;
-    vi.spyOn(window, "innerHeight", "get").mockReturnValue(768);
+    Object.defineProperty(window, "innerHeight", {
+      value: 768,
+      writable: true,
+      configurable: true,
+    });
     vi.spyOn(Element.prototype, "getBoundingClientRect").mockReturnValue({
       top: SLIDER_BOTTOM - 40,
       bottom: SLIDER_BOTTOM,
@@ -396,6 +405,9 @@ describe("PlayerVolume group popout", () => {
 
   afterEach(() => {
     vi.restoreAllMocks();
+    if (originalInnerHeight) {
+      Object.defineProperty(window, "innerHeight", originalInnerHeight);
+    }
     store.mobileLayout = false;
     document.body.innerHTML = "";
   });


### PR DESCRIPTION
# What does this implement/fix?

The group volume popout in the fullscreen player shows one volume slider per group member, but it had no height limit. With a large group it grew past the top of the screen and the members at the top were simply cut off, with no way to scroll to them.

It now stops at the room actually available above the volume slider it opens from, and scrolls once it runs out of space. Same idea as #2410, which fixed this for the player bar popouts.

**Related issue (if applicable):**

- n/a

**Related backend PR (if applicable):**

- n/a

## Types of changes

<!--
Tick exactly one box below. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Changes

- Cap the popout at the space between the volume slider and the top of the screen
- Scroll the member list once that cap is reached, without dragging the screen behind it
- Only claim the mouse wheel where it actually changes volume, so it can scroll the popout instead of being swallowed by the sliders in it
- Open a capped popout scrolled to the bottom, so the group slider still lines up with the one you tapped
- Add tests covering the cap, the scroll position and the wheel

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm lint:check` passes.
- [x] `pnpm test:run` passes, and tests have been added/updated where applicable.
- [x] `pnpm build` passes.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
