### PR TITLE
No more keyboard popping up over short filter lists

### DIFF
--- a/src/components/FacetedFilter.vue
+++ b/src/components/FacetedFilter.vue
@@ -48,9 +48,14 @@
         </Button>
       </slot>
     </PopoverTrigger>
-    <PopoverContent class="w-[220px] p-0" align="start">
+    <PopoverContent
+      class="w-[220px] p-0"
+      align="start"
+      @open-auto-focus="preventOnScreenKeyboardOnOpen"
+    >
       <div class="faceted-filter-content">
         <Input
+          v-if="showSearch"
           v-model="search"
           :placeholder="title"
           :aria-label="`Search ${title}`"
@@ -108,6 +113,7 @@ import {
   PopoverTrigger,
 } from "@/components/ui/popover";
 import { Separator } from "@/components/ui/separator";
+import { preventOnScreenKeyboardOnOpen } from "@/helpers/dialog_focus";
 
 interface FacetedOption {
   label: string;
@@ -125,7 +131,15 @@ const emit = defineEmits<{
   (e: "update:modelValue", value: TValue[]): void;
 }>();
 
+// a list this short is quicker to scan than to search - and on a touch device
+// a search field opens the on-screen keyboard on top of the options
+const MAX_OPTIONS_WITHOUT_SEARCH = 8;
+
 const search = ref("");
+
+const showSearch = computed(
+  () => props.options.length > MAX_OPTIONS_WITHOUT_SEARCH,
+);
 
 const selectedSet = computed(() => new Set(props.modelValue || []));
 
@@ -136,7 +150,7 @@ const selectedOptionLabels = computed(() =>
 );
 
 const filteredOptions = computed(() => {
-  const term = search.value.toLowerCase().trim();
+  const term = showSearch.value ? search.value.toLowerCase().trim() : "";
   if (!term) return props.options;
   return props.options.filter((opt) => opt.label.toLowerCase().includes(term));
 });

--- a/src/helpers/dialog_focus.ts
+++ b/src/helpers/dialog_focus.ts
@@ -1,22 +1,27 @@
 import { store } from "@/plugins/store";
 
+const LAYER_SELECTOR = "[data-dismissable-layer]";
+
 /**
- * Handler for a reka-ui `@open-auto-focus` event that keeps a dialog from
- * focusing its first field on a touch device.
+ * Handler for a reka-ui `@open-auto-focus` event that keeps a dialog or a
+ * popover from focusing its first field on a touch device.
  *
- * Use it on any dialog that opens with a search or text field: focusing that
- * field raises the on-screen keyboard, which then covers most of the dialog.
- * Focus moves to the dialog itself instead, so the focus trap and the screen
- * reader announcement stay intact. Devices without a touchscreen keep the
- * default behaviour and land in the field.
- *
- * Dialogs only. A popover is not focus trapped, so moving focus to its content
- * root dismisses it; use `@open-auto-focus.prevent` there instead.
+ * Use it on anything that opens with a search or text field: focusing that
+ * field raises the on-screen keyboard, which then covers most of the content.
+ * Focus moves to the dialog or popover itself instead, so the focus handling
+ * and the screen reader announcement stay intact. Devices without a
+ * touchscreen keep the default behaviour and land in the field.
  */
 export function preventOnScreenKeyboardOnOpen(event: Event) {
   if (!store.isTouchscreen) return;
+  if (!(event.target instanceof HTMLElement)) return;
+  // a popover reports the event on its positioning wrapper, which sits outside
+  // the dismissable layer: focusing it counts as a focus outside and closes the
+  // popover, so aim for the layer itself. A dialog is that layer already.
+  const layer = event.target.matches(LAYER_SELECTOR)
+    ? event.target
+    : event.target.querySelector<HTMLElement>(LAYER_SELECTOR);
+  if (!layer) return;
   event.preventDefault();
-  if (event.target instanceof HTMLElement) {
-    event.target.focus({ preventScroll: true });
-  }
+  layer.focus({ preventScroll: true });
 }

--- a/tests/components/FacetedFilter.test.ts
+++ b/tests/components/FacetedFilter.test.ts
@@ -1,6 +1,17 @@
 import FacetedFilter from "@/components/FacetedFilter.vue";
-import { mount } from "@vue/test-utils";
-import { describe, expect, it } from "vitest";
+import {
+  enableAutoUnmount,
+  flushPromises,
+  mount,
+  type VueWrapper,
+} from "@vue/test-utils";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { storeMock } = vi.hoisted(() => ({
+  storeMock: { isTouchscreen: false },
+}));
+
+vi.mock("@/plugins/store", () => ({ store: storeMock }));
 
 const stubs = {
   Popover: { template: "<div><slot /></div>" },
@@ -10,10 +21,74 @@ const stubs = {
   Badge: { template: "<span><slot /></span>" },
   Separator: { template: "<span />" },
   Checkbox: { template: '<input type="checkbox" />' },
-  Input: { template: "<input />" },
 };
 
+const STAGE_OPTIONS = [
+  { label: "Stable", value: "stable" },
+  { label: "Beta", value: "beta" },
+  { label: "Alpha", value: "alpha" },
+  { label: "Experimental", value: "experimental" },
+  { label: "Unmaintained", value: "unmaintained" },
+  { label: "Deprecated", value: "deprecated" },
+];
+
+const manyOptions = (count: number) =>
+  Array.from({ length: count }, (_, i) => ({
+    label: `Provider ${i}`,
+    value: `provider-${i}`,
+  }));
+
+const mountFilter = (options: { label: string; value: string }[]) =>
+  mount(FacetedFilter, {
+    props: { title: "Providers", options, modelValue: [] },
+    global: { stubs },
+  });
+
+// reka opens the popover on pointerdown + click, and settles focus on a timer
+// rather than a microtask
+const toggleTrigger = async (wrapper: VueWrapper) => {
+  const trigger = wrapper.get("button");
+  await trigger.trigger("pointerdown", { button: 0, pointerType: "mouse" });
+  await trigger.trigger("click");
+  await flushPromises();
+};
+
+// resolves with the popover content once it has settled its focus
+const openPopover = async (wrapper: VueWrapper) => {
+  await toggleTrigger(wrapper);
+  return await vi.waitFor(() => {
+    const content = document.querySelector("[data-slot='popover-content']");
+    expect(content).not.toBeNull();
+    expect(content!.contains(document.activeElement)).toBe(true);
+    return content!;
+  });
+};
+
+const closePopover = async (wrapper: VueWrapper) => {
+  await toggleTrigger(wrapper);
+  await vi.waitFor(() =>
+    expect(document.querySelector("[data-slot='popover-content']")).toBeNull(),
+  );
+};
+
+const mountAndOpen = async (options: { label: string; value: string }[]) => {
+  const wrapper = mount(FacetedFilter, {
+    props: { title: "Providers", options, modelValue: [] },
+    attachTo: document.body,
+  });
+  return { wrapper, content: await openPopover(wrapper) };
+};
+
+// an open popover keeps document-level listeners, so tear it down even when an
+// assertion fails
+enableAutoUnmount(afterEach);
+
 describe("FacetedFilter", () => {
+  beforeEach(() => {
+    storeMock.isTouchscreen = false;
+    document.body.innerHTML = "";
+  });
+
   it("toggles a focused option with Enter", async () => {
     const wrapper = mount(FacetedFilter, {
       props: {
@@ -27,5 +102,82 @@ describe("FacetedFilter", () => {
     await wrapper.get(".faceted-filter-item").trigger("keydown.enter");
 
     expect(wrapper.emitted("update:modelValue")).toEqual([[["album"]]]);
+  });
+
+  it("omits the search field until the list is long enough to need it", () => {
+    const short = mountFilter(STAGE_OPTIONS);
+    expect(short.find("input[data-slot='input']").exists()).toBe(false);
+    expect(short.findAll(".faceted-filter-item")).toHaveLength(
+      STAGE_OPTIONS.length,
+    );
+
+    expect(
+      mountFilter(manyOptions(8)).find("input[data-slot='input']").exists(),
+    ).toBe(false);
+    expect(
+      mountFilter(manyOptions(9)).find("input[data-slot='input']").exists(),
+    ).toBe(true);
+  });
+
+  it("filters the options with the search field", async () => {
+    const wrapper = mountFilter(manyOptions(12));
+
+    await wrapper.get("input[data-slot='input']").setValue("Provider 1");
+
+    // "Provider 1" plus "Provider 10" and "Provider 11"
+    expect(wrapper.findAll(".faceted-filter-item")).toHaveLength(3);
+
+    // a term left behind must not keep filtering a list that lost its field
+    await wrapper.setProps({ options: STAGE_OPTIONS });
+
+    expect(wrapper.find("input[data-slot='input']").exists()).toBe(false);
+    expect(wrapper.findAll(".faceted-filter-item")).toHaveLength(
+      STAGE_OPTIONS.length,
+    );
+  });
+
+  it("focuses the first option of a short list when it opens", async () => {
+    const { content } = await mountAndOpen(STAGE_OPTIONS);
+
+    expect(content.querySelector("input[data-slot='input']")).toBeNull();
+    expect(document.activeElement).toBe(
+      content.querySelector(".faceted-filter-item"),
+    );
+  });
+
+  it("skips the search field of a long list on a touch device", async () => {
+    storeMock.isTouchscreen = true;
+
+    const { content } = await mountAndOpen(manyOptions(12));
+
+    expect(content.querySelector("input[data-slot='input']")).not.toBeNull();
+    expect(document.activeElement).toBe(content);
+  });
+
+  it("skips the search field on a touch device with nothing left to show", async () => {
+    storeMock.isTouchscreen = true;
+    const { wrapper, content } = await mountAndOpen(manyOptions(12));
+
+    const field = content.querySelector<HTMLInputElement>(
+      "input[data-slot='input']",
+    )!;
+    field.value = "no such provider";
+    field.dispatchEvent(new Event("input"));
+    await flushPromises();
+    expect(content.querySelectorAll(".faceted-filter-item")).toHaveLength(0);
+
+    // the term outlives the popover, so it reopens on an empty list
+    await closePopover(wrapper);
+    const reopened = await openPopover(wrapper);
+
+    expect(document.activeElement).toBe(reopened);
+  });
+
+  it("focuses the search field of a long list on a desktop", async () => {
+    const { content } = await mountAndOpen(manyOptions(12));
+
+    expect(document.activeElement).toBe(
+      content.querySelector("input[data-slot='input']"),
+    );
   });
 });


### PR DESCRIPTION
# What does this implement/fix?

The filter dropdowns (like "Phase" in the Add music source dialog) always
showed a search box at the top. The dropdown puts the cursor in that box as
soon as it opens, so on a phone the on-screen keyboard pops up and covers the
options you were about to pick.

- The search box now only appears when the list is long enough to scroll -
  most of these lists are short, like the six entries in the phase filter.
- On a phone, the longer lists that keep their search box now open on the
  dropdown itself, so the keyboard stays down until you tap the box.
- On a computer nothing changes: the search box still gets the cursor.
- The shared touch handler now works for dropdowns as well as dialogs. It
  aims for the panel itself rather than the event's element, which for a
  dropdown is the invisible positioning wrapper - focusing that one counted
  as clicking outside and closed the dropdown again.

**Related issue (if applicable):**

- related issue `<link to issue>`

**Related backend PR (if applicable):**

- related backend PR `<link to PR>`

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm lint:check` passes.
- [x] `pnpm test:run` passes, and tests have been added/updated where applicable.
- [x] `pnpm build` passes.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
