### PR TITLE
Don't open the on-screen keyboard when a search list opens

### DIFF
--- a/src/components/genre/LinkGenreDialog.vue
+++ b/src/components/genre/LinkGenreDialog.vue
@@ -20,7 +20,10 @@
               <ChevronsUpDown class="ml-2 h-4 w-4 shrink-0 opacity-50" />
             </Button>
           </PopoverTrigger>
-          <PopoverContent class="w-[--reka-popover-trigger-width] p-0">
+          <PopoverContent
+            class="w-[--reka-popover-trigger-width] p-0"
+            @open-auto-focus.prevent
+          >
             <Command>
               <CommandInput :placeholder="t('search')" />
               <CommandList class="max-h-[250px] overflow-y-auto">

--- a/src/components/genre/MergeGenreDialog.vue
+++ b/src/components/genre/MergeGenreDialog.vue
@@ -23,7 +23,10 @@
               <ChevronsUpDown class="ml-2 h-4 w-4 shrink-0 opacity-50" />
             </Button>
           </PopoverTrigger>
-          <PopoverContent class="w-[--reka-popover-trigger-width] p-0">
+          <PopoverContent
+            class="w-[--reka-popover-trigger-width] p-0"
+            @open-auto-focus.prevent
+          >
             <Command>
               <CommandInput :placeholder="t('search')" />
               <CommandList class="max-h-[250px] overflow-y-auto">

--- a/src/components/ui/command/CommandDialog.vue
+++ b/src/components/ui/command/CommandDialog.vue
@@ -6,6 +6,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
+import { preventOnScreenKeyboardOnOpen } from "@/helpers/dialog_focus";
 import type { DialogRootEmits, DialogRootProps } from "reka-ui";
 import { useForwardPropsEmits } from "reka-ui";
 import Command from "./Command.vue";
@@ -29,7 +30,10 @@ const forwarded = useForwardPropsEmits(props, emits);
 
 <template>
   <Dialog v-slot="slotProps" v-bind="forwarded">
-    <DialogContent class="overflow-hidden p-0">
+    <DialogContent
+      class="overflow-hidden p-0"
+      @open-auto-focus="preventOnScreenKeyboardOnOpen"
+    >
       <DialogHeader class="sr-only">
         <DialogTitle>{{ title }}</DialogTitle>
         <DialogDescription>{{ description }}</DialogDescription>

--- a/src/components/ui/command/CommandInput.vue
+++ b/src/components/ui/command/CommandInput.vue
@@ -33,8 +33,9 @@ const { filterState } = useCommand();
     <Search class="size-4 shrink-0 opacity-50" />
     <!--
       Focusing this field on a touch device raises the on-screen keyboard over
-      the list it filters. A popover hosting a Command also has to prevent its
-      own open auto-focus, which would land on this field regardless.
+      the list it filters. A popover or dialog hosting a Command also has to
+      prevent its own open auto-focus, which would land on this field
+      regardless.
     -->
     <ListboxFilter
       v-bind="{ ...forwardedProps, ...$attrs }"

--- a/src/components/ui/command/CommandInput.vue
+++ b/src/components/ui/command/CommandInput.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { cn } from "@/lib/utils";
+import { store } from "@/plugins/store";
 import { Search } from "@lucide/vue";
 import { reactiveOmit } from "@vueuse/core";
 import type { ListboxFilterProps } from "reka-ui";
@@ -30,11 +31,16 @@ const { filterState } = useCommand();
     class="flex h-9 items-center gap-2 border-b px-3"
   >
     <Search class="size-4 shrink-0 opacity-50" />
+    <!--
+      Focusing this field on a touch device raises the on-screen keyboard over
+      the list it filters. A popover hosting a Command also has to prevent its
+      own open auto-focus, which would land on this field regardless.
+    -->
     <ListboxFilter
       v-bind="{ ...forwardedProps, ...$attrs }"
       v-model="filterState.search"
       data-slot="command-input"
-      auto-focus
+      :auto-focus="!store.isTouchscreen"
       :class="
         cn(
           'placeholder:text-muted-foreground flex h-10 w-full rounded-md bg-transparent py-3 text-sm outline-hidden disabled:cursor-not-allowed disabled:opacity-50',

--- a/src/helpers/dialog_focus.ts
+++ b/src/helpers/dialog_focus.ts
@@ -10,8 +10,8 @@ import { store } from "@/plugins/store";
  * reader announcement stay intact. Devices without a touchscreen keep the
  * default behaviour and land in the field.
  *
- * Dialogs only. A popover is not focus trapped, so focusing its content counts
- * as a focus outside and dismisses it; use `@open-auto-focus.prevent` there.
+ * Dialogs only. A popover is not focus trapped, so moving focus to its content
+ * root dismisses it; use `@open-auto-focus.prevent` there instead.
  */
 export function preventOnScreenKeyboardOnOpen(event: Event) {
   if (!store.isTouchscreen) return;

--- a/src/helpers/dialog_focus.ts
+++ b/src/helpers/dialog_focus.ts
@@ -9,6 +9,9 @@ import { store } from "@/plugins/store";
  * Focus moves to the dialog itself instead, so the focus trap and the screen
  * reader announcement stay intact. Devices without a touchscreen keep the
  * default behaviour and land in the field.
+ *
+ * Dialogs only. A popover is not focus trapped, so focusing its content counts
+ * as a focus outside and dismisses it; use `@open-auto-focus.prevent` there.
  */
 export function preventOnScreenKeyboardOnOpen(event: Event) {
   if (!store.isTouchscreen) return;

--- a/tests/components/genre/GenreDialogs.test.ts
+++ b/tests/components/genre/GenreDialogs.test.ts
@@ -1,0 +1,111 @@
+import LinkGenreDialog from "@/components/genre/LinkGenreDialog.vue";
+import MergeGenreDialog from "@/components/genre/MergeGenreDialog.vue";
+import { eventbus } from "@/plugins/eventbus";
+import {
+  enableAutoUnmount,
+  flushPromises,
+  mount,
+  type VueWrapper,
+} from "@vue/test-utils";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { Component } from "vue";
+import { genre } from "../../fixtures/genre";
+
+const { apiMock, storeMock } = vi.hoisted(() => ({
+  apiMock: {
+    getLibraryGenres: vi.fn(),
+    addGenreMediaMapping: vi.fn(),
+    mergeGenres: vi.fn(),
+  },
+  storeMock: {
+    isTouchscreen: false,
+    dialogActive: false,
+  },
+}));
+
+vi.mock("@/plugins/api", () => ({ api: apiMock, default: apiMock }));
+vi.mock("@/plugins/store", () => ({ store: storeMock }));
+vi.mock("vue-i18n", () => ({ useI18n: () => ({ t: (key: string) => key }) }));
+vi.mock("vue-router", () => ({ useRouter: () => ({ push: vi.fn() }) }));
+vi.mock("vue-sonner", () => ({ toast: { error: vi.fn(), success: vi.fn() } }));
+
+// an open dialog keeps document-level focus trap listeners, so tear it down
+// even when an assertion fails
+enableAutoUnmount(afterEach);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  storeMock.isTouchscreen = false;
+  storeMock.dialogActive = false;
+  apiMock.getLibraryGenres.mockResolvedValue([
+    genre({ item_id: "1", name: "Ambient" }),
+    genre({ item_id: "2", name: "Jazz" }),
+  ]);
+  document.body.innerHTML = "";
+});
+
+const dialogs: Array<[string, Component, () => void]> = [
+  [
+    "LinkGenreDialog",
+    LinkGenreDialog,
+    () => eventbus.emit("linkGenreDialog", { items: [] }),
+  ],
+  [
+    "MergeGenreDialog",
+    MergeGenreDialog,
+    () =>
+      eventbus.emit("mergeGenreDialog", {
+        genreIds: ["3"],
+        genreNames: ["Downtempo"],
+        genreContentTypes: [null],
+      }),
+  ],
+];
+
+describe.each(dialogs)("%s", (_name, component, open) => {
+  it("focuses the genre search field on a non-touch device", async () => {
+    await openGenrePicker(component, open);
+
+    expect(document.activeElement).toBe(searchField());
+  });
+
+  it("leaves the genre search field alone on a touch device", async () => {
+    storeMock.isTouchscreen = true;
+
+    await openGenrePicker(component, open);
+
+    // focusing the search field would open the on-screen keyboard over the
+    // genre list
+    expect(document.activeElement).not.toBe(searchField());
+    // and the list has to stay up: focusing the popover itself would dismiss it
+    expect(genreList()).not.toBeNull();
+  });
+});
+
+function searchField() {
+  return document.querySelector("[data-slot='command-input']");
+}
+
+function genreList() {
+  return document.querySelector("[data-slot='popover-content']");
+}
+
+async function openGenrePicker(
+  component: Component,
+  open: () => void,
+): Promise<VueWrapper> {
+  const wrapper = mount(component, {
+    attachTo: document.body,
+    global: { mocks: { $t: (key: string) => key } },
+  });
+  open();
+  await flushPromises();
+
+  // the dialog is teleported out of the wrapper, so it is only in the document
+  document.querySelector<HTMLElement>("[role='combobox']")!.click();
+  await flushPromises();
+  // reka-ui focuses the command input from a 1ms timer, so a flush is not
+  // enough to observe where focus ends up
+  await new Promise((resolve) => setTimeout(resolve, 20));
+  return wrapper;
+}

--- a/tests/components/genre/GenreDialogs.test.ts
+++ b/tests/components/genre/GenreDialogs.test.ts
@@ -77,13 +77,19 @@ describe.each(dialogs)("%s", (_name, component, open) => {
     // focusing the search field would open the on-screen keyboard over the
     // genre list
     expect(document.activeElement).not.toBe(searchField());
-    // and the list has to stay up: focusing the popover itself would dismiss it
+    // focus stays on the button that opened the list; moving it into the
+    // popover would count as a focus outside and dismiss the list
+    expect(document.activeElement).toBe(trigger());
     expect(genreList()).not.toBeNull();
   });
 });
 
 function searchField() {
   return document.querySelector("[data-slot='command-input']");
+}
+
+function trigger() {
+  return document.querySelector<HTMLElement>("[role='combobox']");
 }
 
 function genreList() {
@@ -102,7 +108,9 @@ async function openGenrePicker(
   await flushPromises();
 
   // the dialog is teleported out of the wrapper, so it is only in the document
-  document.querySelector<HTMLElement>("[role='combobox']")!.click();
+  // and a real click leaves the button focused
+  trigger()!.focus();
+  trigger()!.click();
   await flushPromises();
   // reka-ui focuses the command input from a 1ms timer, so a flush is not
   // enough to observe where focus ends up

--- a/tests/components/users/MultiSelect.test.ts
+++ b/tests/components/users/MultiSelect.test.ts
@@ -1,0 +1,77 @@
+import MultiSelect from "@/components/users/MultiSelect.vue";
+import {
+  enableAutoUnmount,
+  flushPromises,
+  mount,
+  type VueWrapper,
+} from "@vue/test-utils";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { storeMock } = vi.hoisted(() => ({
+  storeMock: {
+    isTouchscreen: false,
+  },
+}));
+
+vi.mock("@/plugins/store", () => ({ store: storeMock }));
+
+vi.mock("vue-i18n", () => ({
+  useI18n: () => ({ t: (key: string) => key }),
+}));
+
+// an open popover keeps document-level dismiss listeners, so tear it down even
+// when an assertion fails
+enableAutoUnmount(afterEach);
+
+beforeEach(() => {
+  storeMock.isTouchscreen = false;
+  document.body.innerHTML = "";
+});
+
+describe("MultiSelect", () => {
+  it("focuses the search field on a non-touch device", async () => {
+    await openOptions();
+
+    expect(document.activeElement).toBe(searchField());
+  });
+
+  it("leaves the search field alone on a touch device", async () => {
+    storeMock.isTouchscreen = true;
+
+    await openOptions();
+
+    expect(document.activeElement).not.toBe(searchField());
+    // the options stay reachable: the popover keeps focus instead of handing it
+    // back outside and dismissing itself
+    expect(optionsList()).not.toBeNull();
+  });
+});
+
+function searchField() {
+  return document.querySelector("[data-slot='command-input']");
+}
+
+function optionsList() {
+  return document.querySelector("[data-slot='popover-content']");
+}
+
+async function openOptions(): Promise<VueWrapper> {
+  const wrapper = mount(MultiSelect, {
+    props: {
+      modelValue: [],
+      options: [
+        { label: "Albums", value: "album" },
+        { label: "Tracks", value: "track" },
+      ],
+    },
+    attachTo: document.body,
+    global: { mocks: { $t: (key: string) => key } },
+  });
+
+  await wrapper.get("button").trigger("click");
+  await flushPromises();
+  // reka-ui focuses the command input from a 1ms timer, so a flush is not
+  // enough to observe where focus ends up
+  await new Promise((resolve) => setTimeout(resolve, 20));
+  return wrapper;
+}

--- a/tests/components/users/MultiSelect.test.ts
+++ b/tests/components/users/MultiSelect.test.ts
@@ -41,8 +41,9 @@ describe("MultiSelect", () => {
     await openOptions();
 
     expect(document.activeElement).not.toBe(searchField());
-    // the options stay reachable: the popover keeps focus instead of handing it
-    // back outside and dismissing itself
+    // focus stays on the button that opened the list; moving it into the
+    // popover would count as a focus outside and dismiss the list
+    expect(document.activeElement).toBe(trigger());
     expect(optionsList()).not.toBeNull();
   });
 });
@@ -53,6 +54,10 @@ function searchField() {
 
 function optionsList() {
   return document.querySelector("[data-slot='popover-content']");
+}
+
+function trigger() {
+  return document.querySelector<HTMLElement>("[data-slot='popover-trigger']");
 }
 
 async function openOptions(): Promise<VueWrapper> {
@@ -68,7 +73,9 @@ async function openOptions(): Promise<VueWrapper> {
     global: { mocks: { $t: (key: string) => key } },
   });
 
-  await wrapper.get("button").trigger("click");
+  // a real click leaves the button focused, which a synthetic one does not
+  trigger()!.focus();
+  trigger()!.click();
   await flushPromises();
   // reka-ui focuses the command input from a 1ms timer, so a flush is not
   // enough to observe where focus ends up


### PR DESCRIPTION
# What does this implement/fix?

Opening a dropdown with a searchable list (link/merge genre, the user multi-select) auto-focused the search field, so on a phone or tablet the on-screen keyboard popped up over the options you were trying to pick from. The search field is now only focused on devices without a touchscreen.

This is the same problem as #2411, but a different cause: the search field focuses itself on a timer rather than through the dialog's focus event, so the earlier fix did not cover it.

- Only focus the shared command search field when the device has no touchscreen
- Stop the genre link/merge dropdowns and the (currently unused) command dialog from focusing that field themselves
- Add tests for both genre dropdowns and the multi-select, on touch and non-touch devices

Notes for reviewers:

- `CommandInput.vue` lives in the vendored `src/components/ui/` folder, so this is a local change to a generated shadcn component (as `SidebarProvider.vue` already does). Regenerating it would drop the fix.
- The dropdowns keep focus on the button that opened them rather than moving it inside, because a popover is not focus trapped and focusing its content makes it dismiss itself. Same trade-off as #2411: a laptop with a touchscreen counts as a touch device, so a keyboard-only user there has to click into the list instead of tabbing into it.

**Related issue (if applicable):**

- related issue `<link to issue>`

**Related backend PR (if applicable):**

- related backend PR `<link to PR>`

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm lint:check` passes.
- [x] `pnpm test:run` passes, and tests have been added/updated where applicable.
- [x] `pnpm build` passes.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
