### PR TITLE
Clean up duplicate import in the player settings screen

### DIFF
--- a/src/views/settings/EditPlayer.vue
+++ b/src/views/settings/EditPlayer.vue
@@ -308,9 +308,11 @@
 </template>
 
 <script setup lang="ts">
-import { computed, onBeforeUnmount, ref } from "vue";
+import { computed, onBeforeUnmount, ref, watch } from "vue";
 import { useRouter } from "vue-router";
 import { toast } from "vue-sonner";
+import ProviderIcon from "@/components/ProviderIcon.vue";
+import PlayerIcon from "@/components/PlayerIcon.vue";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader } from "@/components/ui/card";
 import {
@@ -331,12 +333,6 @@ import {
   PlayerType,
   IdentifierType,
 } from "@/plugins/api/interfaces";
-import AdvancedSettingsToggle from "./AdvancedSettingsToggle.vue";
-import EditConfig from "./EditConfig.vue";
-import ProviderIcon from "@/components/ProviderIcon.vue";
-import PlayerIcon from "@/components/PlayerIcon.vue";
-import { watch } from "vue";
-
 import {
   ConfigEntryUI,
   HASS_CONTROL_KEY_BY_PLAYER_KEY,
@@ -361,6 +357,8 @@ import {
   RotateCcw,
   Settings,
 } from "@lucide/vue";
+import AdvancedSettingsToggle from "./AdvancedSettingsToggle.vue";
+import EditConfig from "./EditConfig.vue";
 // global refs
 const router = useRouter();
 const config = ref<PlayerConfig>();


### PR DESCRIPTION
# What does this implement/fix?

The player settings screen imported from `vue` twice: once at the top of the
file and again halfway down the list, below the component imports. Tidied that
up so the imports are easier to read and match the other settings screens.

No behaviour change.

- Merged the stray `watch` import into the main `vue` import
- Moved the two relative `./` imports to the end of the block, like the other settings screens do
- Grouped the player/provider icon imports with the other component imports
- Removed a stray blank line that split the import block in two

**Related issue (if applicable):**

- n/a

**Related backend PR (if applicable):**

- n/a

## Types of changes

<!--
Tick exactly one box below. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm lint:check` passes.
- [x] `pnpm test:run` passes, and tests have been added/updated where applicable.
- [x] `pnpm build` passes.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
