### PR TITLE
Document the app's z-index scale

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -67,25 +67,30 @@
         998  player bar popouts
         999  scrim behind the floating mobile player bar
        1000  desktop player bar
-       2000  mobile bottom navigation
+       2000  mobile bottom navigation, and Vuetify's default overlay z-index
        2001  floating mobile player bar
        2100  settings loading overlays
-       9000  fullscreen player (9001/9002 its backdrop and popout)
+       9000  fullscreen player
+       9001  player select backdrop, opened from the fullscreen player
+       9002  player select popout, opened from the fullscreen player
        9999  dialogs
-      10000  popovers and select menus (10001 tooltips over them)
-     100000  sheets (100001 menus opened from within one)
+      10000  popovers, select menus, and their backdrops
+      10001  anything that has to clear those, whatever it is
+     100000  sheets
+     100001  menus opened from a sheet or a player bar popout
      999999  item context menu
 
-   Smaller values elsewhere in the app order elements inside a component's own
-   stacking context and are unrelated to this scale.
+   Values below this range mostly order elements inside a component's own
+   stacking context.
 
    Two Vuetify behaviours to know about before placing something in this range:
-   - VOverlay (v-menu, v-dialog, v-snackbar, ...) writes its z-index as an inline
-     style and defaults it to 2000, so an overlay lands above the player bar
-     unless its z-index prop says otherwise, and no stylesheet rule can lower it
-     without !important.
-   - VOverlay takes lastZIndex + 10 whenever another Vuetify overlay is already
-     open, which ignores the z-index prop for that activation. */
+   - VOverlay writes its z-index as an inline style, so no stylesheet rule can
+     change one without !important. It defaults to 2000, which lands an
+     unconfigured overlay on top of the player bar; v-dialog raises that to 2400.
+   - An overlay activated while another Vuetify overlay is open takes that one's
+     z-index + 10 and ignores its own prop, so it can end up either side of where
+     the prop asked for. v-snackbar and v-tooltip are bumped this way as well:
+     leaving the shared stack only stops them raising the next overlay. */
 
 html {
   overflow: hidden;

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -56,6 +56,37 @@
   );
 }
 
+/* Stacking order for anything pinned to the screen, lowest first. Each value is
+   declared at its own call site (several are component props that cannot read a
+   custom property), so this is the reference for choosing one, not the source of
+   truth. Pick the band that describes the element rather than a number that
+   happens to be free.
+
+        996  multi-select "x items selected" bar
+        997  player bar popout backdrops
+        998  player bar popouts
+        999  scrim behind the floating mobile player bar
+       1000  desktop player bar
+       2000  mobile bottom navigation
+       2001  floating mobile player bar
+       2100  settings loading overlays
+       9000  fullscreen player (9001/9002 its backdrop and popout)
+       9999  dialogs
+      10000  popovers and select menus (10001 tooltips over them)
+     100000  sheets (100001 menus opened from within one)
+     999999  item context menu
+
+   Smaller values elsewhere in the app order elements inside a component's own
+   stacking context and are unrelated to this scale.
+
+   Two Vuetify behaviours to know about before placing something in this range:
+   - VOverlay (v-menu, v-dialog, v-snackbar, ...) writes its z-index as an inline
+     style and defaults it to 2000, so an overlay lands above the player bar
+     unless its z-index prop says otherwise, and no stylesheet rule can lower it
+     without !important.
+   - VOverlay takes lastZIndex + 10 whenever another Vuetify overlay is already
+     open, which ignores the z-index prop for that activation. */
+
 html {
   overflow: hidden;
   /* iOS Safari tints the status bar from this background. Must stay set. */

--- a/tests/styles/zIndexScale.test.ts
+++ b/tests/styles/zIndexScale.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest";
+
+// Below this, a z-index only orders elements inside a component's own
+// stacking context and is unrelated to the app-wide scale in global.css.
+const GLOBAL_BAND_FLOOR = 900;
+
+// The "Stacking order for anything pinned to the screen" block in
+// src/styles/global.css.
+const DOCUMENTED_BANDS = [
+  996, 997, 998, 999, 1000, 2000, 2001, 2100, 9000, 9001, 9002, 9999, 10000,
+  10001, 100000, 100001, 999999,
+];
+
+// z-index is declared in five syntaxes across the app. Requiring `:` or `=`
+// right after the property name keeps comment prose ("the overlay z-index
+// inline", "a dialog at z-index 9000") from reading as a declaration, and the
+// lookbehind keeps `--z-index` custom properties out.
+const PATTERNS = [
+  /(?<!-)z-index\s*[:=]\s*"?(\d+)/g, // CSS declaration, template attr, bound prop
+  /!?z-\[(\d+)\]/g, // Tailwind arbitrary utility
+  /zIndex\s*:\s*(\d+)/g, // JS/TS object property
+];
+
+const sources = import.meta.glob("../../src/**/*.{vue,ts,css}", {
+  query: "?raw",
+  import: "default",
+  eager: true,
+}) as Record<string, string>;
+
+function scanGlobalBand() {
+  const offenders: { value: number; file: string }[] = [];
+  const found = new Set<number>();
+
+  for (const [path, content] of Object.entries(sources)) {
+    const file = path.replace("../../", "");
+    for (const pattern of PATTERNS) {
+      for (const match of content.matchAll(pattern)) {
+        const value = Number(match[1]);
+        if (value < GLOBAL_BAND_FLOOR) continue;
+        found.add(value);
+        if (!DOCUMENTED_BANDS.includes(value)) offenders.push({ value, file });
+      }
+    }
+  }
+
+  return { offenders, found };
+}
+
+describe("z-index global scale", () => {
+  it("documents every z-index used in the global band", () => {
+    const { offenders } = scanGlobalBand();
+
+    expect(
+      offenders,
+      offenders
+        .map(
+          ({ value, file }) =>
+            `${file} declares z-index ${value}, which isn't in the documented ` +
+            `scale. Add it to the "Stacking order" block in src/styles/global.css, ` +
+            `or reuse an existing band.`,
+        )
+        .join("\n"),
+    ).toEqual([]);
+  });
+
+  it("finds every documented band in src/", () => {
+    // also guards against a broken pattern above silently matching nothing
+    const { found } = scanGlobalBand();
+    const missing = DOCUMENTED_BANDS.filter((value) => !found.has(value));
+
+    expect(
+      missing,
+      `${missing.join(", ")} no longer occurs in src/. Drop it from the ` +
+        `"Stacking order" block in src/styles/global.css, unless the patterns ` +
+        `above stopped matching how it is declared.`,
+    ).toEqual([]);
+  });
+});

--- a/tests/styles/zIndexScale.test.ts
+++ b/tests/styles/zIndexScale.test.ts
@@ -1,34 +1,44 @@
+import globalCss from "@/styles/global.css?inline";
 import { describe, expect, it } from "vitest";
 
-// Below this, a z-index only orders elements inside a component's own
-// stacking context and is unrelated to the app-wide scale in global.css.
+// Below this, a z-index orders elements inside a component's own stacking
+// context rather than against the app-wide scale.
 const GLOBAL_BAND_FLOOR = 900;
 
-// The "Stacking order for anything pinned to the screen" block in
-// src/styles/global.css.
-const DOCUMENTED_BANDS = [
-  996, 997, 998, 999, 1000, 2000, 2001, 2100, 9000, 9001, 9002, 9999, 10000,
-  10001, 100000, 100001, 999999,
-];
-
-// z-index is declared in five syntaxes across the app. Requiring `:` or `=`
-// right after the property name keeps comment prose ("the overlay z-index
-// inline", "a dialog at z-index 9000") from reading as a declaration, and the
-// lookbehind keeps `--z-index` custom properties out.
+// z-index reaches the DOM through five syntaxes here: CSS declarations, Vue
+// attributes and bound props, JS object properties, and Tailwind's two forms
+// (`z-[998]` and the bare `z-998`, which v4 compiles just the same). Requiring
+// `:` or `=` right after the property name skips the surrounding prose that
+// mentions a band without setting it, and the lookbehind keeps the `--z-index`
+// custom properties in PartyTrackCard out.
 const PATTERNS = [
-  /(?<!-)z-index\s*[:=]\s*"?(\d+)/g, // CSS declaration, template attr, bound prop
-  /!?z-\[(\d+)\]/g, // Tailwind arbitrary utility
-  /zIndex\s*:\s*(\d+)/g, // JS/TS object property
+  /(?<!-)z-index\s*[:=]\s*"?(\d+)/g,
+  /zIndex\s*:\s*"?(\d+)/g,
+  /(?<![\w-])!?-?z-\[(\d+)\]/g,
+  /(?<![\w-])!?-?z-(\d+)(?![\w-])/g,
 ];
 
-const sources = import.meta.glob("../../src/**/*.{vue,ts,css}", {
+const sources = import.meta.glob("../../src/**/*.{vue,ts,css,scss}", {
   query: "?raw",
   import: "default",
   eager: true,
 }) as Record<string, string>;
 
-function scanGlobalBand() {
-  const offenders: { value: number; file: string }[] = [];
+// Read back from the comment block itself, so what this asserts against is the
+// documentation rather than a copy of it that could drift.
+function documentedBands() {
+  const block = globalCss.match(
+    /Stacking order for anything pinned[\s\S]*?\*\//,
+  )?.[0];
+  if (!block) throw new Error("scale block not found in src/styles/global.css");
+
+  return [...block.matchAll(/^\s*(\d{3,})\s{2,}\S/gm)].map(([, band]) =>
+    Number(band),
+  );
+}
+
+function scanGlobalBand(bands: number[]) {
+  const offenders = new Map<string, { value: number; file: string }>();
   const found = new Set<number>();
 
   for (const [path, content] of Object.entries(sources)) {
@@ -38,41 +48,44 @@ function scanGlobalBand() {
         const value = Number(match[1]);
         if (value < GLOBAL_BAND_FLOOR) continue;
         found.add(value);
-        if (!DOCUMENTED_BANDS.includes(value)) offenders.push({ value, file });
+        if (!bands.includes(value)) {
+          offenders.set(`${file}:${value}`, { value, file });
+        }
       }
     }
   }
 
-  return { offenders, found };
+  return { offenders: [...offenders.values()], found };
 }
 
 describe("z-index global scale", () => {
   it("documents every z-index used in the global band", () => {
-    const { offenders } = scanGlobalBand();
+    const { offenders } = scanGlobalBand(documentedBands());
 
     expect(
       offenders,
       offenders
         .map(
           ({ value, file }) =>
-            `${file} declares z-index ${value}, which isn't in the documented ` +
-            `scale. Add it to the "Stacking order" block in src/styles/global.css, ` +
-            `or reuse an existing band.`,
+            `${file} declares z-index ${value}, which the scale in ` +
+            `src/styles/global.css does not list. Give it a line there, or ` +
+            `reuse the band that describes it.`,
         )
         .join("\n"),
     ).toEqual([]);
   });
 
   it("finds every documented band in src/", () => {
-    // also guards against a broken pattern above silently matching nothing
-    const { found } = scanGlobalBand();
-    const missing = DOCUMENTED_BANDS.filter((value) => !found.has(value));
+    // also catches a pattern above quietly matching nothing at all
+    const bands = documentedBands();
+    const { found } = scanGlobalBand(bands);
+    const missing = bands.filter((band) => !found.has(band));
 
     expect(
       missing,
-      `${missing.join(", ")} no longer occurs in src/. Drop it from the ` +
-        `"Stacking order" block in src/styles/global.css, unless the patterns ` +
-        `above stopped matching how it is declared.`,
+      `nothing in src/ uses ${missing.join(", ")} any more. Drop it from the ` +
+        `scale in src/styles/global.css, unless the patterns above stopped ` +
+        `matching how it is written.`,
     ).toEqual([]);
   });
 });


### PR DESCRIPTION
# What does this implement/fix?

The z-index values that stack everything near the bottom of the screen — player
bar, its popouts and backdrops, the selection bar, the bottom navigation — are
raw numbers spread across a dozen files, and nothing recorded what the scale
actually was. #2412 came straight out of that: the "x items selected" bar picked
up Vuetify's default of 2000 and silently covered the player menus, with no way
to tell what it should have been instead.

This writes the scale down where someone positioning a new element will find it.

- Adds a documented stacking order to `src/styles/global.css`, next to the
  existing bottom-bar height variables
- Spells out two Vuetify overlay behaviours that make this easy to get wrong:
  overlays write their z-index inline (defaulting to 2000, so a stylesheet
  cannot lower one without `!important`), and an overlay opened on top of
  another takes the one below it + 10, ignoring its own z-index prop
- Adds a test that fails when a z-index shows up at a band the block does not
  list, so the documentation cannot quietly go stale

No behaviour change — the existing values all stay exactly where they are.

**Related issue (if applicable):**

- n/a

**Related backend PR (if applicable):**

- n/a

## Types of changes

<!--
Tick exactly one box below. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm lint:check` passes.
- [x] `pnpm test:run` passes, and tests have been added/updated where applicable.
- [x] `pnpm build` passes.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
