### PR TITLE
Apply the mobile sidebar side setting right away

### DIFF
--- a/src/components/ui/sidebar/Sidebar.vue
+++ b/src/components/ui/sidebar/Sidebar.vue
@@ -3,8 +3,8 @@ import { Sheet, SheetContent } from "@/components/ui/sheet";
 import SheetDescription from "@/components/ui/sheet/SheetDescription.vue";
 import SheetHeader from "@/components/ui/sheet/SheetHeader.vue";
 import SheetTitle from "@/components/ui/sheet/SheetTitle.vue";
+import { useMobileSidebarSide } from "@/composables/useMobileSidebarSide";
 import { cn } from "@/lib/utils";
-import { computed } from "vue";
 import type { SidebarProps } from ".";
 import { SIDEBAR_WIDTH_MOBILE, useSidebar } from "./utils";
 
@@ -20,12 +20,7 @@ const props = withDefaults(defineProps<SidebarProps>(), {
 
 const { isMobile, state, openMobile, setOpenMobile } = useSidebar();
 
-const mobileSheetSide = computed<"left" | "right">(() => {
-  if (typeof localStorage === "undefined") return "left";
-  const stored = localStorage.getItem("frontend.settings.mobile_sidebar_side");
-
-  return stored === "right" ? "right" : "left";
-});
+const mobileSheetSide = useMobileSidebarSide();
 </script>
 
 <template>

--- a/src/components/ui/sidebar/SidebarInset.vue
+++ b/src/components/ui/sidebar/SidebarInset.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { useMobileSidebarSide } from "@/composables/useMobileSidebarSide";
 import { cn } from "@/lib/utils";
 import type { HTMLAttributes } from "vue";
 import { ref } from "vue";
@@ -10,12 +11,7 @@ const props = defineProps<{
 
 const { isMobile, openMobile, setOpenMobile } = useSidebar();
 
-const mobileSidebarSide = ref<"left" | "right">("left");
-
-if (typeof window !== "undefined" && typeof localStorage !== "undefined") {
-  const stored = localStorage.getItem("frontend.settings.mobile_sidebar_side");
-  mobileSidebarSide.value = stored === "right" ? "right" : "left";
-}
+const mobileSidebarSide = useMobileSidebarSide();
 
 const touchStartX = ref(0);
 const touchStartY = ref(0);

--- a/src/composables/useMobileSidebarSide.ts
+++ b/src/composables/useMobileSidebarSide.ts
@@ -1,14 +1,15 @@
-import { readonly, ref, type DeepReadonly, type Ref } from "vue";
 import {
-  MOBILE_SIDEBAR_SIDE_KEY,
+  MOBILE_SIDEBAR_SIDE,
+  readDeviceSetting,
   subscribeToDeviceSetting,
 } from "@/helpers/device_settings";
+import { readonly, ref, type DeepReadonly, type Ref } from "vue";
 
 export type MobileSidebarSide = "left" | "right";
 
 const mobileSidebarSide = ref<MobileSidebarSide>(readStoredSide());
 
-subscribeToDeviceSetting(MOBILE_SIDEBAR_SIDE_KEY, () => {
+subscribeToDeviceSetting(MOBILE_SIDEBAR_SIDE, () => {
   mobileSidebarSide.value = readStoredSide();
 });
 
@@ -22,13 +23,5 @@ export function useMobileSidebarSide(): DeepReadonly<Ref<MobileSidebarSide>> {
 }
 
 function readStoredSide(): MobileSidebarSide {
-  // this runs while the module loads, and reading storage throws when site data
-  // is blocked (a cross-origin iframe, for one): keep that off the import path
-  try {
-    return localStorage.getItem(MOBILE_SIDEBAR_SIDE_KEY) === "right"
-      ? "right"
-      : "left";
-  } catch {
-    return "left";
-  }
+  return readDeviceSetting(MOBILE_SIDEBAR_SIDE) === "right" ? "right" : "left";
 }

--- a/src/composables/useMobileSidebarSide.ts
+++ b/src/composables/useMobileSidebarSide.ts
@@ -22,8 +22,13 @@ export function useMobileSidebarSide(): DeepReadonly<Ref<MobileSidebarSide>> {
 }
 
 function readStoredSide(): MobileSidebarSide {
-  if (typeof localStorage === "undefined") return "left";
-  return localStorage.getItem(MOBILE_SIDEBAR_SIDE_KEY) === "right"
-    ? "right"
-    : "left";
+  // this runs while the module loads, and reading storage throws when site data
+  // is blocked (a cross-origin iframe, for one): keep that off the import path
+  try {
+    return localStorage.getItem(MOBILE_SIDEBAR_SIDE_KEY) === "right"
+      ? "right"
+      : "left";
+  } catch {
+    return "left";
+  }
 }

--- a/src/composables/useMobileSidebarSide.ts
+++ b/src/composables/useMobileSidebarSide.ts
@@ -1,0 +1,29 @@
+import { readonly, ref, type DeepReadonly, type Ref } from "vue";
+import {
+  MOBILE_SIDEBAR_SIDE_KEY,
+  subscribeToDeviceSetting,
+} from "@/helpers/device_settings";
+
+export type MobileSidebarSide = "left" | "right";
+
+const mobileSidebarSide = ref<MobileSidebarSide>(readStoredSide());
+
+subscribeToDeviceSetting(MOBILE_SIDEBAR_SIDE_KEY, () => {
+  mobileSidebarSide.value = readStoredSide();
+});
+
+/**
+ * The side the navigation sheet opens from on mobile.
+ *
+ * Shared by every consumer so changing the setting applies without a reload.
+ */
+export function useMobileSidebarSide(): DeepReadonly<Ref<MobileSidebarSide>> {
+  return readonly(mobileSidebarSide);
+}
+
+function readStoredSide(): MobileSidebarSide {
+  if (typeof localStorage === "undefined") return "left";
+  return localStorage.getItem(MOBILE_SIDEBAR_SIDE_KEY) === "right"
+    ? "right"
+    : "left";
+}

--- a/src/helpers/device_settings.ts
+++ b/src/helpers/device_settings.ts
@@ -1,15 +1,29 @@
 // Per-device frontend settings (see DEVICE_SETTING_KEYS) live in localStorage
-// instead of the server side user preferences.
+// instead of the server side user preferences. Every function here takes the
+// bare setting key and owns the storage key it maps to.
 
-export const MOBILE_SIDEBAR_SIDE_KEY = "frontend.settings.mobile_sidebar_side";
+const STORAGE_KEY_PREFIX = "frontend.settings.";
+
+export const MOBILE_SIDEBAR_SIDE = "mobile_sidebar_side";
 
 /**
- * Store a per-device setting under its `frontend.settings.` key.
+ * Read a per-device setting, or null when it is unset.
  *
- * Pass null to clear it.
+ * Also null when site data is blocked, as it is in a cross-origin iframe.
+ */
+export function readDeviceSetting(key: string): string | null {
+  try {
+    return localStorage.getItem(STORAGE_KEY_PREFIX + key);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Store a per-device setting. Pass null to clear it.
  */
 export function saveDeviceSetting(key: string, value: string | null) {
-  const storageKey = `frontend.settings.${key}`;
+  const storageKey = STORAGE_KEY_PREFIX + key;
   if (value === null) {
     localStorage.removeItem(storageKey);
   } else {
@@ -25,10 +39,8 @@ export function saveDeviceSetting(key: string, value: string | null) {
 /**
  * Run the callback whenever a per-device setting changes, in this tab or another.
  */
-export function subscribeToDeviceSetting(
-  storageKey: string,
-  onChange: () => void,
-) {
+export function subscribeToDeviceSetting(key: string, onChange: () => void) {
+  const storageKey = STORAGE_KEY_PREFIX + key;
   window.addEventListener("storage", (event) => {
     // a null key means the whole storage was cleared
     if (event.key !== null && event.key !== storageKey) return;

--- a/src/helpers/device_settings.ts
+++ b/src/helpers/device_settings.ts
@@ -1,0 +1,37 @@
+// Per-device frontend settings (see DEVICE_SETTING_KEYS) live in localStorage
+// instead of the server side user preferences.
+
+export const MOBILE_SIDEBAR_SIDE_KEY = "frontend.settings.mobile_sidebar_side";
+
+/**
+ * Store a per-device setting under its `frontend.settings.` key.
+ *
+ * Pass null to clear it.
+ */
+export function saveDeviceSetting(key: string, value: string | null) {
+  const storageKey = `frontend.settings.${key}`;
+  if (value === null) {
+    localStorage.removeItem(storageKey);
+  } else {
+    localStorage.setItem(storageKey, value);
+  }
+  // localStorage only notifies other tabs by itself, so announce the change to
+  // this one as well to save consumers a reload
+  window.dispatchEvent(
+    new StorageEvent("storage", { key: storageKey, newValue: value }),
+  );
+}
+
+/**
+ * Run the callback whenever a per-device setting changes, in this tab or another.
+ */
+export function subscribeToDeviceSetting(
+  storageKey: string,
+  onChange: () => void,
+) {
+  window.addEventListener("storage", (event) => {
+    // a null key means the whole storage was cleared
+    if (event.key !== null && event.key !== storageKey) return;
+    onChange();
+  });
+}

--- a/src/views/settings/FrontendConfig.vue
+++ b/src/views/settings/FrontendConfig.vue
@@ -43,7 +43,11 @@ import { Spinner } from "@/components/ui/spinner";
 import { useUserPreferences } from "@/composables/userPreferences";
 import { DEVICE_SETTING_KEYS } from "@/constants";
 import { hasAdvancedEntries } from "@/helpers/config_entry_ui";
-import { saveDeviceSetting } from "@/helpers/device_settings";
+import {
+  MOBILE_SIDEBAR_SIDE,
+  readDeviceSetting,
+  saveDeviceSetting,
+} from "@/helpers/device_settings";
 import {
   ConfigEntry,
   ConfigEntryType,
@@ -171,8 +175,7 @@ onMounted(() => {
       ],
       multi_value: false,
       category: "display_settings",
-      value:
-        localStorage.getItem("frontend.settings.mobile_sidebar_side") || "left",
+      value: readDeviceSetting(MOBILE_SIDEBAR_SIDE) || "left",
     },
   ];
 
@@ -281,7 +284,7 @@ const onAction = async function (
 
 const onImmediateApply = function (values: Record<string, ConfigValueType>) {
   for (const key in values) {
-    localStorage.setItem(`frontend.settings.${key}`, String(values[key]));
+    saveDeviceSetting(key, String(values[key]));
   }
 };
 </script>

--- a/src/views/settings/FrontendConfig.vue
+++ b/src/views/settings/FrontendConfig.vue
@@ -43,6 +43,7 @@ import { Spinner } from "@/components/ui/spinner";
 import { useUserPreferences } from "@/composables/userPreferences";
 import { DEVICE_SETTING_KEYS } from "@/constants";
 import { hasAdvancedEntries } from "@/helpers/config_entry_ui";
+import { saveDeviceSetting } from "@/helpers/device_settings";
 import {
   ConfigEntry,
   ConfigEntryType,
@@ -239,13 +240,8 @@ const saveValues = async function (values: Record<string, ConfigValueType>) {
 
       if (DEVICE_SETTING_KEYS.has(key)) {
         // Save to localStorage (per-device settings)
-        const storageKey = `frontend.settings.${key}`;
         const value = values[key];
-        if (value != null) {
-          localStorage.setItem(storageKey, value.toString());
-        } else {
-          localStorage.removeItem(storageKey);
-        }
+        saveDeviceSetting(key, value != null ? value.toString() : null);
       } else {
         // Save to backend via user preferences
         await setPreference(key, values[key]);

--- a/tests/composables/useMobileSidebarSide.test.ts
+++ b/tests/composables/useMobileSidebarSide.test.ts
@@ -1,0 +1,75 @@
+import { saveDeviceSetting } from "@/helpers/device_settings";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const STORAGE_KEY = "frontend.settings.mobile_sidebar_side";
+
+const createLocalStorageMock = (): Storage => {
+  const store = new Map<string, string>();
+  return {
+    get length() {
+      return store.size;
+    },
+    clear() {
+      store.clear();
+    },
+    getItem(key: string) {
+      return store.get(key) ?? null;
+    },
+    key(index: number) {
+      return Array.from(store.keys())[index] ?? null;
+    },
+    removeItem(key: string) {
+      store.delete(key);
+    },
+    setItem(key: string, value: string) {
+      store.set(key, value);
+    },
+  };
+};
+
+// the composable keeps one shared value, read when its module first loads
+async function loadMobileSidebarSide() {
+  vi.resetModules();
+  const { useMobileSidebarSide } =
+    await import("@/composables/useMobileSidebarSide");
+  return useMobileSidebarSide();
+}
+
+describe("useMobileSidebarSide", () => {
+  beforeEach(() => {
+    vi.stubGlobal("localStorage", createLocalStorageMock());
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("opens from the left by default", async () => {
+    expect((await loadMobileSidebarSide()).value).toBe("left");
+  });
+
+  it("uses the stored side", async () => {
+    localStorage.setItem(STORAGE_KEY, "right");
+
+    expect((await loadMobileSidebarSide()).value).toBe("right");
+  });
+
+  it("follows the setting without a reload", async () => {
+    const side = await loadMobileSidebarSide();
+
+    saveDeviceSetting("mobile_sidebar_side", "right");
+    expect(side.value).toBe("right");
+
+    saveDeviceSetting("mobile_sidebar_side", null);
+    expect(side.value).toBe("left");
+  });
+
+  it("ignores other device settings", async () => {
+    const side = await loadMobileSidebarSide();
+    localStorage.setItem(STORAGE_KEY, "right");
+
+    saveDeviceSetting("force_mobile_layout", "true");
+
+    expect(side.value).toBe("left");
+  });
+});

--- a/tests/composables/useMobileSidebarSide.test.ts
+++ b/tests/composables/useMobileSidebarSide.test.ts
@@ -64,6 +64,19 @@ describe("useMobileSidebarSide", () => {
     expect(side.value).toBe("left");
   });
 
+  it("loads when site data is blocked", async () => {
+    vi.stubGlobal("localStorage", {
+      getItem: () => {
+        throw new DOMException("Access denied", "SecurityError");
+      },
+    });
+
+    await expect(loadMobileSidebarSide()).resolves.toHaveProperty(
+      "value",
+      "left",
+    );
+  });
+
   it("ignores other device settings", async () => {
     const side = await loadMobileSidebarSide();
     localStorage.setItem(STORAGE_KEY, "right");


### PR DESCRIPTION
# What does this implement/fix?

Changing "Mobile sidebar side" in the frontend settings appeared to do nothing: the navigation menu kept opening from the old side until the page was refreshed by hand. Both sidebar components read the setting once when they are created, and the settings screen only reloads the page when a setting from your user profile changed in the same save - so changing just this one left the old value on screen.

**Related issue (if applicable):**

- related issue `n/a`

**Related backend PR (if applicable):**

- related backend PR `n/a`

- the setting now applies straight away, no refresh needed
- both sidebar components share one source of truth instead of each reading the stored value themselves
- a per-device setting change is announced to the current tab as well, so other device settings can pick this up too

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm lint:check` passes.
- [x] `pnpm test:run` passes, and tests have been added/updated where applicable.
- [x] `pnpm build` passes.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
