### PR TITLE
Stop the "items selected" box floating too far above the player bar

### DIFF
--- a/src/components/ItemsListing.vue
+++ b/src/components/ItemsListing.vue
@@ -214,12 +214,19 @@
 
       <!-- box shown when item(s) selected; vuetify writes the overlay z-index inline
            (default 2000), so it has to be lowered here to stay behind the player bar
-           popouts (998) and their backdrops (997) -->
+           popouts (998) and their backdrops (997). that also puts it below the mobile
+           scrim, so it is offset by what the scrim reaches rather than by the bars.
+           vuetify already pads the snackbar by the layout bar height, which is
+           subtracted again to keep the box the intended distance above the bars -->
       <v-snackbar
         :model-value="selectedItems.length > 1"
         :timeout="-1"
         :z-index="996"
-        style="margin-bottom: calc(var(--bottom-bars-height) + 16px)"
+        style="
+          margin-bottom: calc(
+            var(--bottom-obscured-height) + 16px - var(--v-layout-bottom, 0px)
+          );
+        "
       >
         <span>{{ $t("items_selected", [selectedItems.length]) }}</span>
         <template #actions>

--- a/src/components/ItemsListing.vue
+++ b/src/components/ItemsListing.vue
@@ -215,16 +215,19 @@
       <!-- box shown when item(s) selected; vuetify writes the overlay z-index inline
            (default 2000), so it has to be lowered here to stay behind the player bar
            popouts (998) and their backdrops (997). that also puts it below the mobile
-           scrim, so it is offset by what the scrim reaches rather than by the bars.
-           vuetify already pads the snackbar by the layout bar height, which is
-           subtracted again to keep the box the intended distance above the bars -->
+           scrim, so it clears what covers the bottom rather than just the bars.
+           vuetify pads the snackbar by the measured bar height on its own, so that
+           is taken off, with a 16px floor in case the bar outgrows the offset -->
       <v-snackbar
         :model-value="selectedItems.length > 1"
         :timeout="-1"
         :z-index="996"
         style="
-          margin-bottom: calc(
-            var(--bottom-obscured-height) + 16px - var(--v-layout-bottom, 0px)
+          margin-bottom: max(
+            16px,
+            calc(
+              var(--bottom-obscured-height) + 16px - var(--v-layout-bottom, 0px)
+            )
           );
         "
       >

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -46,8 +46,8 @@
   /* Room the bars pinned to the bottom of the screen take up together, for
      anything that has to float clear of them. */
   --bottom-bars-height: var(--player-bar-height);
-  /* How high the bottom of the screen is obscured, for anything that stacks
-     below the gradient scrim and would be faded by it. */
+  /* How far up the screen the bottom is covered, for anything that stacks below
+     what covers it and still has to stay visible. */
   --bottom-obscured-height: var(--bottom-bars-height);
 }
 

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -46,6 +46,9 @@
   /* Room the bars pinned to the bottom of the screen take up together, for
      anything that has to float clear of them. */
   --bottom-bars-height: var(--player-bar-height);
+  /* How high the bottom of the screen is obscured, for anything that stacks
+     below the gradient scrim and would be faded by it. */
+  --bottom-obscured-height: var(--bottom-bars-height);
 }
 
 /* The footer sets this marker while the mobile bars are on screen. There the
@@ -53,6 +56,11 @@
 :root[data-player-bar-overlay] {
   --bottom-bars-height: calc(
     var(--mobile-navigation-height) + 6px + var(--player-bar-overlay-height)
+  );
+  /* the scrim outreaches the bars whenever the player bar has no volume row */
+  --bottom-obscured-height: max(
+    var(--bottom-bars-height),
+    var(--mobile-player-scrim-height)
   );
 }
 

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -57,7 +57,7 @@
   --bottom-bars-height: calc(
     var(--mobile-navigation-height) + 6px + var(--player-bar-overlay-height)
   );
-  /* the scrim outreaches the bars whenever the player bar has no volume row */
+  /* The scrim reaches higher than the bars unless the player bar has grown. */
   --bottom-obscured-height: max(
     var(--bottom-bars-height),
     var(--mobile-player-scrim-height)

--- a/tests/styles/bottomBarsHeight.test.ts
+++ b/tests/styles/bottomBarsHeight.test.ts
@@ -10,14 +10,24 @@ const BAR_HEIGHT = "120px";
 const PLAYER_BAR_HEIGHT = "104px";
 const NAVIGATION_HEIGHT =
   "calc(66px + calc(10px + env(safe-area-inset-bottom, 0px)))";
+const SCRIM_HEIGHT =
+  "calc( 180px + calc(10px + env(safe-area-inset-bottom, 0px)) )";
 
 let appStyles: HTMLStyleElement;
 
 // happy-dom substitutes every var() but does not evaluate calc(), so the mobile
 // branch is only observable as the expression it composes
 function bottomBarsHeight() {
+  return customProperty("--bottom-bars-height");
+}
+
+function bottomObscuredHeight() {
+  return customProperty("--bottom-obscured-height");
+}
+
+function customProperty(name: string) {
   return getComputedStyle(document.documentElement)
-    .getPropertyValue("--bottom-bars-height")
+    .getPropertyValue(name)
     .replace(/\s+/g, " ")
     .trim();
 }
@@ -57,6 +67,21 @@ describe("bottom bars height", () => {
 
     expect(bottomBarsHeight()).toBe(
       `calc( ${NAVIGATION_HEIGHT} + 6px + ${BAR_HEIGHT} )`,
+    );
+  });
+
+  it("reaches no further than the bars in the desktop layout", () => {
+    // the scrim is mobile-only, so pulling it in here would push everything
+    // that stacks below it far above the player bar
+    expect(bottomObscuredHeight()).toBe(PLAYER_BAR_HEIGHT);
+  });
+
+  it("reaches over the gradient scrim on mobile", () => {
+    document.documentElement.setAttribute(OVERLAY_MARKER, "");
+    document.documentElement.style.setProperty(OVERLAY_HEIGHT, BAR_HEIGHT);
+
+    expect(bottomObscuredHeight()).toBe(
+      `max( calc( ${NAVIGATION_HEIGHT} + 6px + ${BAR_HEIGHT} ), ${SCRIM_HEIGHT} )`,
     );
   });
 });


### PR DESCRIPTION
# What does this implement/fix?

The "items selected" box floated far above the player bar instead of sitting just
above it — about 94px too high on mobile, and roughly a player bar's worth too high
on desktop.

Vuetify already offsets a snackbar by the height of the player bar on its own, on
top of the offset we set, so that height was counted twice. The offset now subtracts
what Vuetify adds. On mobile the box also has to clear the gradient panel behind the
player bar, which reaches higher than the bars themselves and would otherwise fade
the bottom of the box, so there it is positioned from the panel instead.

- subtract the offset Vuetify already applies to the snackbar
- keep the box above the gradient panel on mobile, matching the settings save button
- never let it sit closer than 16px above the player bar, which only has a minimum height
- add tests for the new offset in both layouts

**Related issue (if applicable):**

- n/a

**Related backend PR (if applicable):**

- n/a

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm lint:check` passes.
- [x] `pnpm test:run` passes, and tests have been added/updated where applicable.
- [x] `pnpm build` passes.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
