### PR TITLE
Keep the settings save button above the mobile player

### DIFF
--- a/src/views/settings/EditConfig.vue
+++ b/src/views/settings/EditConfig.vue
@@ -88,7 +88,16 @@
       </div>
     </div>
 
-    <div v-if="!disabled" class="floating-save">
+    <div
+      v-if="!disabled"
+      :class="[
+        'floating-save',
+        {
+          'floating-save--mobile': store.mobileLayout,
+          'floating-save--frameless': store.frameless,
+        },
+      ]"
+    >
       <Button
         data-testid="config-save"
         type="button"
@@ -166,6 +175,7 @@ import {
   SECURE_STRING_SUBSTITUTE,
 } from "@/plugins/api/interfaces";
 import { $t } from "@/plugins/i18n";
+import { store } from "@/plugins/store";
 import {
   Airplay,
   Cast,
@@ -598,7 +608,7 @@ const getCategoryIcon = function (category: string): Component {
   z-index: 20;
 }
 
-:global(.content-section--mobile) .floating-save {
+.floating-save--mobile {
   right: 16px;
   /* Stay clear of whatever reaches highest above the bottom navigation: the
      bottom bars, or the gradient scrim behind them, which hides what it covers
@@ -609,7 +619,7 @@ const getCategoryIcon = function (category: string): Component {
   );
 }
 
-:global(.content-section--frameless) .floating-save {
+.floating-save--frameless {
   bottom: 16px;
 }
 </style>

--- a/tests/views/EditConfig.test.ts
+++ b/tests/views/EditConfig.test.ts
@@ -1,16 +1,20 @@
 import { shallowMount, type VueWrapper } from "@vue/test-utils";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { nextTick } from "vue";
 import { ConfigEntryType, type ConfigEntry } from "@/plugins/api/interfaces";
 import EditConfig from "@/views/settings/EditConfig.vue";
 
-const { apiMock, routerMock } = vi.hoisted(() => ({
+const { apiMock, routerMock, storeMock } = vi.hoisted(() => ({
   apiMock: {
     players: {},
     providers: {},
   },
   routerMock: {
     push: vi.fn(),
+  },
+  storeMock: {
+    frameless: false,
+    mobileLayout: false,
   },
 }));
 
@@ -22,6 +26,7 @@ vi.mock("@/plugins/api", () => ({
 vi.mock("@/plugins/i18n", () => ({
   $t: (key: string) => key,
 }));
+vi.mock("@/plugins/store", () => ({ store: storeMock }));
 
 vi.mock("vue-router", async (importOriginal) => {
   const actual = await importOriginal<typeof import("vue-router")>();
@@ -32,6 +37,11 @@ vi.mock("vue-router", async (importOriginal) => {
 });
 
 describe("EditConfig", () => {
+  beforeEach(() => {
+    storeMock.frameless = false;
+    storeMock.mobileLayout = false;
+  });
+
   it.each([
     ConfigEntryType.DIVIDER,
     ConfigEntryType.LABEL,
@@ -293,6 +303,22 @@ describe("EditConfig", () => {
 
     expect(wrapper.find('[data-testid="config-save"]').exists()).toBe(false);
   });
+
+  it.each([
+    ["mobile", "mobileLayout", "floating-save--mobile"],
+    ["frameless", "frameless", "floating-save--frameless"],
+  ] as const)(
+    "uses the %s save position in that layout",
+    (_, layout, cssClass) => {
+      storeMock[layout] = true;
+
+      const wrapper = mountEntries([
+        entry({ key: "server", type: ConfigEntryType.STRING }),
+      ]);
+
+      expect(wrapper.get(".floating-save").classes()).toContain(cssClass);
+    },
+  );
 });
 
 function entry(


### PR DESCRIPTION
# What does this implement/fix?

The floating save button could remain behind the player bar on mobile because its layout-specific position was not applied.

- Keep the settings save button above the mobile player bar
- Preserve the correct position in frameless mode
- Add regression coverage for both layouts

**Related issue (if applicable):**

- N/A

**Related backend PR (if applicable):**

- N/A

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that causes existing functionality not to work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm lint:check` passes.
- [x] `pnpm test:run` passes, and tests have been added/updated where applicable.
- [x] `pnpm build` passes.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.