### PR TITLE
Add the Sendspin Sync view with a microphone capability probe

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -224,6 +224,7 @@ const refreshPluginEnabledStates = async () => {
     refreshPluginEnabledState("music_quiz"),
     refreshPluginEnabledState("ai_radio"),
     refreshPluginEnabledState("milkdrop_visualizer"),
+    refreshPluginEnabledState("sendspin_sync"),
   ]);
 };
 

--- a/src/composables/sendspin-sync/frameCounterProcessor.js
+++ b/src/composables/sendspin-sync/frameCounterProcessor.js
@@ -1,7 +1,7 @@
 /* global AudioWorkletProcessor, registerProcessor, currentTime */
 
 /**
- * Audio worklet that counts the frames a microphone capture actually delivers.
+ * Audio worklet that counts what a microphone capture actually delivers.
  *
  * Emitted verbatim — Vite neither transpiles nor type-checks this file, and an
  * AudioWorkletGlobalScope has neither the DOM nor dependable static-import
@@ -9,9 +9,9 @@
  * browser that ships AudioWorklet already understands.
  *
  * Each report pairs the running totals with the context's own clock so the main
- * thread can separate two unrelated faults: frames the input never delivered
- * (totals against the render clock) and a render clock that does not keep pace
- * with the system clock (its clock against `performance.now()`).
+ * thread can tell three unrelated faults apart: a render clock that does not
+ * keep pace with the system clock, stretches the microphone filled with digital
+ * silence, and a microphone that never produced any signal at all.
  */
 
 /** One report per this many render quanta — roughly every 170 ms at 48 kHz. */
@@ -21,17 +21,36 @@ class FrameCounterProcessor extends AudioWorkletProcessor {
   frames = 0;
   quanta = 0;
   silentQuanta = 0;
+  unconnectedQuanta = 0;
+  peak = 0;
 
   process(inputs) {
     const channel = inputs[0]?.[0];
-    // A quantum the device supplied nothing for arrives as an empty input
-    // rather than as silence, and counting those keeps a dropout visible.
-    if (channel) this.frames += channel.length;
-    else this.silentQuanta += 1;
     this.quanta += 1;
+    if (channel) this.inspect(channel);
+    // Only ever seen when the input has no live connection, so this staying at
+    // zero is what confirms the graph was wired up the way it was meant to be.
+    else this.unconnectedQuanta += 1;
 
     if (this.quanta % REPORT_INTERVAL_QUANTA === 0) this.report();
     return true;
+  }
+
+  /**
+   * A dropout arrives as digital silence, not as a missing channel, and any
+   * real room has a noise floor — so bit-exact zero is the signal to count.
+   * The peak across the whole run is what proves the microphone heard anything.
+   */
+  inspect(channel) {
+    this.frames += channel.length;
+
+    let peak = 0;
+    for (let i = 0; i < channel.length; i++) {
+      const level = Math.abs(channel[i]);
+      if (level > peak) peak = level;
+    }
+    if (peak === 0) this.silentQuanta += 1;
+    if (peak > this.peak) this.peak = peak;
   }
 
   report() {
@@ -39,6 +58,8 @@ class FrameCounterProcessor extends AudioWorkletProcessor {
       frames: this.frames,
       quanta: this.quanta,
       silentQuanta: this.silentQuanta,
+      unconnectedQuanta: this.unconnectedQuanta,
+      peak: this.peak,
       contextTime: currentTime,
     });
   }

--- a/src/composables/sendspin-sync/frameCounterProcessor.js
+++ b/src/composables/sendspin-sync/frameCounterProcessor.js
@@ -39,10 +39,11 @@ class FrameCounterProcessor extends AudioWorkletProcessor {
   /**
    * A dropout arrives as digital silence rather than as a missing channel, and
    * a live converter's noise floor is never bit-exact zero — so once anything
-   * has arrived, a silent quantum is a real gap. Before that it is the capture
-   * device still warming up, which phones do routinely and which must not read
-   * as a fault. The peak across the run is what proves the microphone heard
-   * anything at all.
+   * has arrived, a silent quantum means no audio reached the graph. Before that
+   * it is the capture device still warming up, which phones do routinely and
+   * which must not read as a fault. A noise gate or an OS-level mute produces
+   * the same silence, which is why the two counts are reported rather than
+   * judged here. The peak proves the microphone heard anything at all.
    */
   inspect(channel) {
     this.frames += channel.length;

--- a/src/composables/sendspin-sync/frameCounterProcessor.js
+++ b/src/composables/sendspin-sync/frameCounterProcessor.js
@@ -8,10 +8,9 @@
  * support. Keep it plain, import-free JavaScript inside the syntax every
  * browser that ships AudioWorklet already understands.
  *
- * Each report pairs the running totals with the context's own clock so the main
- * thread can tell three unrelated faults apart: a render clock that does not
- * keep pace with the system clock, stretches the microphone filled with digital
- * silence, and a microphone that never produced any signal at all.
+ * Each report pairs the running totals with the context's own clock, which is
+ * what lets the main thread weigh the audio pipeline against the system clock
+ * and tell a drifting clock apart from audio that never arrived.
  */
 
 /** One report per this many render quanta — roughly every 170 ms at 48 kHz. */
@@ -20,14 +19,15 @@ const REPORT_INTERVAL_QUANTA = 64;
 class FrameCounterProcessor extends AudioWorkletProcessor {
   frames = 0;
   quanta = 0;
-  silentQuanta = 0;
+  leadInQuanta = 0;
+  droppedQuanta = 0;
   unconnectedQuanta = 0;
   peak = 0;
 
   process(inputs) {
     const channel = inputs[0]?.[0];
     this.quanta += 1;
-    if (channel) this.inspect(channel);
+    if (channel?.length) this.inspect(channel);
     // Only ever seen when the input has no live connection, so this staying at
     // zero is what confirms the graph was wired up the way it was meant to be.
     else this.unconnectedQuanta += 1;
@@ -37,9 +37,12 @@ class FrameCounterProcessor extends AudioWorkletProcessor {
   }
 
   /**
-   * A dropout arrives as digital silence, not as a missing channel, and any
-   * real room has a noise floor — so bit-exact zero is the signal to count.
-   * The peak across the whole run is what proves the microphone heard anything.
+   * A dropout arrives as digital silence rather than as a missing channel, and
+   * a live converter's noise floor is never bit-exact zero — so once anything
+   * has arrived, a silent quantum is a real gap. Before that it is the capture
+   * device still warming up, which phones do routinely and which must not read
+   * as a fault. The peak across the run is what proves the microphone heard
+   * anything at all.
    */
   inspect(channel) {
     this.frames += channel.length;
@@ -49,15 +52,19 @@ class FrameCounterProcessor extends AudioWorkletProcessor {
       const level = Math.abs(channel[i]);
       if (level > peak) peak = level;
     }
-    if (peak === 0) this.silentQuanta += 1;
     if (peak > this.peak) this.peak = peak;
+    if (peak !== 0) return;
+
+    if (this.peak === 0) this.leadInQuanta += 1;
+    else this.droppedQuanta += 1;
   }
 
   report() {
     this.port.postMessage({
       frames: this.frames,
       quanta: this.quanta,
-      silentQuanta: this.silentQuanta,
+      leadInQuanta: this.leadInQuanta,
+      droppedQuanta: this.droppedQuanta,
       unconnectedQuanta: this.unconnectedQuanta,
       peak: this.peak,
       contextTime: currentTime,

--- a/src/composables/sendspin-sync/frameCounterProcessor.js
+++ b/src/composables/sendspin-sync/frameCounterProcessor.js
@@ -1,0 +1,56 @@
+/* global AudioWorkletProcessor, registerProcessor, currentFrame, currentTime */
+
+/**
+ * Audio worklet that counts the frames a microphone capture actually delivers.
+ *
+ * Stays plain JavaScript with no imports: Vite emits this file verbatim for
+ * `audioWorklet.addModule()`, and an AudioWorkletGlobalScope has neither the
+ * DOM nor dependable static-import support.
+ */
+
+/** One report per this many render quanta — roughly every 170 ms at 48 kHz. */
+const REPORT_INTERVAL_QUANTA = 64;
+
+/** Frames in a render quantum; used when the input hands back no channel. */
+const RENDER_QUANTUM_FRAMES = 128;
+
+class FrameCounterProcessor extends AudioWorkletProcessor {
+  frames = 0;
+  quanta = 0;
+  nextExpectedFrame = null;
+  gaps = [];
+
+  process(inputs) {
+    const channel = inputs[0]?.[0];
+    this.frames += channel?.length ?? 0;
+    this.quanta += 1;
+
+    // The context clock keeps running even when the audio thread misses its
+    // deadline, so a jump beyond one quantum is a stretch that never rendered.
+    if (
+      this.nextExpectedFrame !== null &&
+      currentFrame > this.nextExpectedFrame
+    )
+      this.gaps.push({
+        atFrame: currentFrame,
+        missingFrames: currentFrame - this.nextExpectedFrame,
+      });
+    this.nextExpectedFrame =
+      currentFrame + (channel?.length ?? RENDER_QUANTUM_FRAMES);
+
+    if (this.quanta % REPORT_INTERVAL_QUANTA === 0) this.report();
+    return true;
+  }
+
+  report() {
+    this.port.postMessage({
+      frames: this.frames,
+      quanta: this.quanta,
+      contextTime: currentTime,
+      gaps: this.gaps,
+    });
+    this.gaps = [];
+  }
+}
+
+registerProcessor("sendspin-frame-counter", FrameCounterProcessor);

--- a/src/composables/sendspin-sync/frameCounterProcessor.js
+++ b/src/composables/sendspin-sync/frameCounterProcessor.js
@@ -1,42 +1,34 @@
-/* global AudioWorkletProcessor, registerProcessor, currentFrame, currentTime */
+/* global AudioWorkletProcessor, registerProcessor, currentTime */
 
 /**
  * Audio worklet that counts the frames a microphone capture actually delivers.
  *
- * Stays plain JavaScript with no imports: Vite emits this file verbatim for
- * `audioWorklet.addModule()`, and an AudioWorkletGlobalScope has neither the
- * DOM nor dependable static-import support.
+ * Emitted verbatim — Vite neither transpiles nor type-checks this file, and an
+ * AudioWorkletGlobalScope has neither the DOM nor dependable static-import
+ * support. Keep it plain, import-free JavaScript inside the syntax every
+ * browser that ships AudioWorklet already understands.
+ *
+ * Each report pairs the running totals with the context's own clock so the main
+ * thread can separate two unrelated faults: frames the input never delivered
+ * (totals against the render clock) and a render clock that does not keep pace
+ * with the system clock (its clock against `performance.now()`).
  */
 
 /** One report per this many render quanta — roughly every 170 ms at 48 kHz. */
 const REPORT_INTERVAL_QUANTA = 64;
 
-/** Frames in a render quantum; used when the input hands back no channel. */
-const RENDER_QUANTUM_FRAMES = 128;
-
 class FrameCounterProcessor extends AudioWorkletProcessor {
   frames = 0;
   quanta = 0;
-  nextExpectedFrame = null;
-  gaps = [];
+  silentQuanta = 0;
 
   process(inputs) {
     const channel = inputs[0]?.[0];
-    this.frames += channel?.length ?? 0;
+    // A quantum the device supplied nothing for arrives as an empty input
+    // rather than as silence, and counting those keeps a dropout visible.
+    if (channel) this.frames += channel.length;
+    else this.silentQuanta += 1;
     this.quanta += 1;
-
-    // The context clock keeps running even when the audio thread misses its
-    // deadline, so a jump beyond one quantum is a stretch that never rendered.
-    if (
-      this.nextExpectedFrame !== null &&
-      currentFrame > this.nextExpectedFrame
-    )
-      this.gaps.push({
-        atFrame: currentFrame,
-        missingFrames: currentFrame - this.nextExpectedFrame,
-      });
-    this.nextExpectedFrame =
-      currentFrame + (channel?.length ?? RENDER_QUANTUM_FRAMES);
 
     if (this.quanta % REPORT_INTERVAL_QUANTA === 0) this.report();
     return true;
@@ -46,10 +38,9 @@ class FrameCounterProcessor extends AudioWorkletProcessor {
     this.port.postMessage({
       frames: this.frames,
       quanta: this.quanta,
+      silentQuanta: this.silentQuanta,
       contextTime: currentTime,
-      gaps: this.gaps,
     });
-    this.gaps = [];
   }
 }
 

--- a/src/composables/sendspin-sync/useMicrophoneProbe.ts
+++ b/src/composables/sendspin-sync/useMicrophoneProbe.ts
@@ -1,0 +1,533 @@
+/**
+ * Probes whether this browser can capture microphone audio well enough to time
+ * a Sendspin calibration chirp.
+ *
+ * Calibration measures when a chirp reaches the phone's microphone, which only
+ * works if the browser hands back raw, continuously clocked samples. Every
+ * check reports what the browser actually did rather than what was asked for,
+ * and a failing check never stops the ones after it — the point is to collect
+ * the whole picture in a single run. Checks that could not be reached stay
+ * `null` so a report never claims a failure it did not observe.
+ */
+
+import { computed, onScopeDispose, ref } from "vue";
+// `no-inline` keeps the processor a real file: `addModule()` is not reliably
+// allowed to load a `data:` URL, which is what Vite would otherwise emit for
+// an asset this small.
+import frameCounterUrl from "./frameCounterProcessor.js?url&no-inline";
+
+/** How long the continuity capture runs, in seconds. */
+export const CAPTURE_SECONDS = 30;
+
+const PROGRESS_INTERVAL_MS = 250;
+
+/**
+ * Drift beyond this is flagged.
+ *
+ * Consumer audio crystals sit inside ±100 ppm, so a tenth of a percent is far
+ * outside anything a healthy clock produces.
+ */
+const DRIFT_WARN_PPM = 1000;
+
+/** The voice processing a calibration capture needs switched off. */
+export const VOICE_PROCESSING = [
+  "echoCancellation",
+  "noiseSuppression",
+  "autoGainControl",
+] as const;
+
+export type VoiceProcessing = (typeof VOICE_PROCESSING)[number];
+
+/** Posted by the frame counter worklet every few render quanta. */
+interface FrameCounterReport {
+  frames: number;
+  quanta: number;
+  contextTime: number;
+  gaps: { atFrame: number; missingFrames: number }[];
+}
+
+export interface SecureContextCheck {
+  secure: boolean;
+  origin: string;
+  protocol: string;
+}
+
+export interface MediaApiCheck {
+  mediaDevices: boolean;
+  getUserMedia: boolean;
+}
+
+export interface ConstraintCheck {
+  /** What the capture asked for — `false` for each voice processor. */
+  requested: Record<VoiceProcessing, boolean>;
+  /** What the track reports back; a missing entry means the browser said nothing. */
+  applied: Partial<Record<VoiceProcessing, boolean>>;
+  /** Whether the browser recognises each constraint at all. */
+  supported: Record<VoiceProcessing, boolean>;
+  /** True only when all three read back as explicitly off. */
+  honoured: boolean;
+  trackSettings: MediaTrackSettings;
+  trackLabel: string;
+  error: string | null;
+}
+
+export interface AudioContextCheck {
+  sampleRate: number;
+  baseLatency: number | null;
+  outputLatency: number | null;
+}
+
+export interface CaptureCheck {
+  requestedSeconds: number;
+  /** Wall-clock seconds between the first and last worklet report. */
+  measuredSeconds: number;
+  framesDelivered: number;
+  expectedFrames: number;
+  /** Signed departure of delivered frames from the wall clock, in parts per million. */
+  discrepancyPpm: number;
+  quanta: number;
+  gapCount: number;
+  missingFrames: number;
+  error: string | null;
+}
+
+export interface WakeLockCheck {
+  supported: boolean;
+  acquired: boolean;
+  error: string | null;
+}
+
+export interface ContextStateTransition {
+  atSeconds: number;
+  state: AudioContextState;
+}
+
+export interface ContextStateCheck {
+  stayedRunning: boolean;
+  transitions: ContextStateTransition[];
+}
+
+export const PROBE_CHECKS = [
+  "secure_context",
+  "media_api",
+  "voice_processing",
+  "audio_context",
+  "capture",
+  "wake_lock",
+  "context_state",
+] as const;
+
+export type ProbeCheckId = (typeof PROBE_CHECKS)[number];
+
+export type CheckStatus = "pass" | "warn" | "fail" | "not_evaluated";
+
+/**
+ * `blocked` means the browser never let the probe start, which is a deployment
+ * problem rather than a verdict on the phone.
+ */
+export type ProbeVerdict = "ready" | "degraded" | "unsupported" | "blocked";
+
+export interface ProbeSummary {
+  verdict: ProbeVerdict;
+  checks: Record<ProbeCheckId, CheckStatus>;
+}
+
+/** The whole probe outcome, and the payload behind the copy button. */
+export interface MicrophoneProbeReport {
+  version: 1;
+  startedAt: string;
+  userAgent: string;
+  secureContext: SecureContextCheck;
+  mediaApi: MediaApiCheck;
+  constraints: ConstraintCheck | null;
+  audioContext: AudioContextCheck | null;
+  capture: CaptureCheck | null;
+  wakeLock: WakeLockCheck | null;
+  contextState: ContextStateCheck | null;
+}
+
+/**
+ * Drives one probe run and exposes its report as the checks fill in.
+ *
+ * `run` has to be called from a user gesture: it opens the `AudioContext`
+ * before its first `await` so Safari still counts the tap. Leaving the view
+ * mid-run aborts the capture and releases the microphone.
+ */
+export function useMicrophoneProbe() {
+  const running = ref(false);
+  const report = ref<MicrophoneProbeReport | null>(null);
+  const captureElapsed = ref(0);
+
+  const captureProgress = computed(() =>
+    Math.min(100, Math.round((captureElapsed.value / CAPTURE_SECONDS) * 100)),
+  );
+  const captureRemainingSeconds = computed(() =>
+    Math.max(0, Math.ceil(CAPTURE_SECONDS - captureElapsed.value)),
+  );
+  const reportJson = computed(() =>
+    report.value ? JSON.stringify(report.value, null, 2) : "",
+  );
+
+  let abort: AbortController | null = null;
+  onScopeDispose(() => abort?.abort());
+
+  async function run(): Promise<void> {
+    if (running.value) return;
+    running.value = true;
+    captureElapsed.value = 0;
+    abort = new AbortController();
+    const signal = abort.signal;
+
+    const result = startReport();
+    report.value = result;
+
+    // Opened before any await so Safari still counts the user gesture.
+    const context = result.mediaApi.getUserMedia ? new AudioContext() : null;
+    const wakeLock = await holdScreenAwake(result.secureContext.secure);
+    result.wakeLock = wakeLock.check;
+
+    try {
+      if (!context) return;
+
+      const stream = await openMicrophone(result);
+      if (!stream) return;
+      try {
+        if (signal.aborted) return;
+        await capture(context, stream, result, signal, (elapsed) => {
+          captureElapsed.value = elapsed;
+        });
+      } finally {
+        for (const track of stream.getTracks()) track.stop();
+      }
+    } finally {
+      await context?.close().catch(() => undefined);
+      await wakeLock.release();
+      running.value = false;
+    }
+  }
+
+  return {
+    running,
+    report,
+    reportJson,
+    captureProgress,
+    captureRemainingSeconds,
+    run,
+  };
+}
+
+/**
+ * Reduces a report to one status per check plus an overall verdict.
+ *
+ * `not_evaluated` is deliberately distinct from `fail`: on a plain-HTTP origin
+ * most of the probe never runs, and calling that a device failure would send
+ * people chasing the wrong problem.
+ */
+export function summariseProbe(report: MicrophoneProbeReport): ProbeSummary {
+  const constraints = report.constraints;
+  const capture = report.capture;
+
+  const checks: Record<ProbeCheckId, CheckStatus> = {
+    secure_context: report.secureContext.secure ? "pass" : "fail",
+    media_api: report.mediaApi.getUserMedia ? "pass" : "fail",
+    // An error here means the microphone never opened, so nothing was applied
+    // to judge; the verdict below calls that blocked rather than unsupported.
+    voice_processing:
+      !constraints || constraints.error
+        ? "not_evaluated"
+        : VOICE_PROCESSING.some((name) => constraints.applied[name])
+          ? "fail"
+          : constraints.honoured
+            ? "pass"
+            : "warn",
+    audio_context: report.audioContext ? "pass" : "not_evaluated",
+    capture: !capture
+      ? "not_evaluated"
+      : capture.error
+        ? "fail"
+        : capture.gapCount > 0 ||
+            Math.abs(capture.discrepancyPpm) > DRIFT_WARN_PPM
+          ? "warn"
+          : "pass",
+    wake_lock: !report.wakeLock
+      ? "not_evaluated"
+      : report.wakeLock.acquired
+        ? "pass"
+        : "warn",
+    context_state: !report.contextState
+      ? "not_evaluated"
+      : report.contextState.stayedRunning
+        ? "pass"
+        : "fail",
+  };
+
+  const failed = (id: ProbeCheckId) => checks[id] === "fail";
+  const verdict: ProbeVerdict =
+    failed("secure_context") ||
+    failed("media_api") ||
+    Boolean(constraints?.error)
+      ? "blocked"
+      : failed("voice_processing") ||
+          failed("capture") ||
+          failed("context_state")
+        ? "unsupported"
+        : Object.values(checks).includes("warn")
+          ? "degraded"
+          : "ready";
+
+  return { verdict, checks };
+}
+
+function startReport(): MicrophoneProbeReport {
+  return {
+    version: 1,
+    startedAt: new Date().toISOString(),
+    userAgent: navigator.userAgent,
+    secureContext: {
+      secure: window.isSecureContext,
+      origin: window.location.origin,
+      protocol: window.location.protocol,
+    },
+    mediaApi: {
+      mediaDevices: Boolean(navigator.mediaDevices),
+      getUserMedia: typeof navigator.mediaDevices?.getUserMedia === "function",
+    },
+    constraints: null,
+    audioContext: null,
+    capture: null,
+    wakeLock: null,
+    contextState: null,
+  };
+}
+
+/** Requests the microphone and records what the browser applied to the track. */
+async function openMicrophone(
+  result: MicrophoneProbeReport,
+): Promise<MediaStream | null> {
+  if (!result.mediaApi.getUserMedia) return null;
+
+  const requested = Object.fromEntries(
+    VOICE_PROCESSING.map((name) => [name, false]),
+  ) as Record<VoiceProcessing, boolean>;
+  const supportedConstraints = navigator.mediaDevices.getSupportedConstraints();
+  const supported = Object.fromEntries(
+    VOICE_PROCESSING.map((name) => [name, Boolean(supportedConstraints[name])]),
+  ) as Record<VoiceProcessing, boolean>;
+
+  let stream: MediaStream;
+  try {
+    stream = await navigator.mediaDevices.getUserMedia({ audio: requested });
+  } catch (error) {
+    result.constraints = {
+      requested,
+      applied: {},
+      supported,
+      honoured: false,
+      trackSettings: {},
+      trackLabel: "",
+      error: describeError(error),
+    };
+    return null;
+  }
+
+  const track = stream.getAudioTracks()[0];
+  const settings = track?.getSettings() ?? {};
+  const applied: Partial<Record<VoiceProcessing, boolean>> = {};
+  for (const name of VOICE_PROCESSING) {
+    const value = settings[name];
+    if (typeof value === "boolean") applied[name] = value;
+  }
+
+  result.constraints = {
+    requested,
+    applied,
+    supported,
+    honoured: VOICE_PROCESSING.every((name) => applied[name] === false),
+    trackSettings: settings,
+    trackLabel: track?.label ?? "",
+    error: track ? null : "No audio track in the captured stream",
+  };
+  if (track) return stream;
+
+  for (const orphan of stream.getTracks()) orphan.stop();
+  return null;
+}
+
+/**
+ * Runs the microphone through the frame counter worklet for {@link CAPTURE_SECONDS}.
+ *
+ * Frames are counted on the audio thread and anchored to `performance.now()` at
+ * the first and last report, so the ppm figure is the audio clock's drift
+ * against the system clock rather than a one-off scheduling hiccup.
+ */
+async function capture(
+  context: AudioContext,
+  stream: MediaStream,
+  result: MicrophoneProbeReport,
+  signal: AbortSignal,
+  onProgress: (elapsedSeconds: number) => void,
+): Promise<void> {
+  const transitions: ContextStateTransition[] = [];
+  let source: MediaStreamAudioSourceNode | null = null;
+  let counter: AudioWorkletNode | null = null;
+  let sink: GainNode | null = null;
+  const onStateChange = () => {
+    transitions.push({ atSeconds: context.currentTime, state: context.state });
+  };
+
+  try {
+    await context.resume();
+    result.audioContext = {
+      sampleRate: context.sampleRate,
+      baseLatency: finiteOrNull(context.baseLatency),
+      outputLatency: finiteOrNull(context.outputLatency),
+    };
+    // Attached after the resume so its own transition is not counted.
+    context.addEventListener("statechange", onStateChange);
+
+    await context.audioWorklet.addModule(frameCounterUrl);
+    source = context.createMediaStreamSource(stream);
+    counter = new AudioWorkletNode(context, "sendspin-frame-counter", {
+      numberOfInputs: 1,
+      numberOfOutputs: 1,
+      outputChannelCount: [1],
+    });
+    // The worklet emits silence; the muted sink exists only to keep the graph
+    // attached to the destination so the audio thread keeps pulling it.
+    sink = context.createGain();
+    sink.gain.value = 0;
+    source.connect(counter).connect(sink).connect(context.destination);
+
+    result.capture = await countFrames(context, counter, signal, onProgress);
+  } catch (error) {
+    result.capture = { ...emptyCapture(), error: describeError(error) };
+  } finally {
+    context.removeEventListener("statechange", onStateChange);
+    source?.disconnect();
+    counter?.disconnect();
+    counter?.port.close();
+    sink?.disconnect();
+    result.contextState = {
+      stayedRunning: transitions.every(
+        (transition) => transition.state === "running",
+      ),
+      transitions,
+    };
+  }
+}
+
+function countFrames(
+  context: AudioContext,
+  counter: AudioWorkletNode,
+  signal: AbortSignal,
+  onProgress: (elapsedSeconds: number) => void,
+): Promise<CaptureCheck> {
+  return new Promise<CaptureCheck>((resolve) => {
+    let first: { at: number; frames: number } | null = null;
+    let last: { at: number; frames: number } | null = null;
+    let quanta = 0;
+    let gapCount = 0;
+    let missingFrames = 0;
+
+    counter.port.onmessage = (event: MessageEvent<FrameCounterReport>) => {
+      const sample = { at: performance.now(), frames: event.data.frames };
+      first ??= sample;
+      last = sample;
+      quanta = event.data.quanta;
+      gapCount += event.data.gaps.length;
+      for (const gap of event.data.gaps) missingFrames += gap.missingFrames;
+    };
+
+    const startedAt = performance.now();
+    const progress = setInterval(() => {
+      onProgress((performance.now() - startedAt) / 1000);
+    }, PROGRESS_INTERVAL_MS);
+
+    const finish = () => {
+      clearInterval(progress);
+      clearTimeout(deadline);
+      signal.removeEventListener("abort", finish);
+      counter.port.onmessage = null;
+
+      const measuredSeconds = first && last ? (last.at - first.at) / 1000 : 0;
+      const framesDelivered = first && last ? last.frames - first.frames : 0;
+      const expectedFrames = context.sampleRate * measuredSeconds;
+      onProgress((performance.now() - startedAt) / 1000);
+      resolve({
+        requestedSeconds: CAPTURE_SECONDS,
+        measuredSeconds,
+        framesDelivered,
+        expectedFrames,
+        discrepancyPpm:
+          expectedFrames > 0
+            ? ((framesDelivered - expectedFrames) / expectedFrames) * 1e6
+            : 0,
+        quanta,
+        gapCount,
+        missingFrames,
+        error:
+          expectedFrames > 0
+            ? null
+            : "The worklet delivered no measurable frames",
+      });
+    };
+
+    const deadline = setTimeout(finish, CAPTURE_SECONDS * 1000);
+    signal.addEventListener("abort", finish);
+  });
+}
+
+/**
+ * Holds the screen awake for the run, and hands back the release.
+ *
+ * The API is secure-context only, so an insecure origin reports nothing rather
+ * than a failure the device is not responsible for.
+ */
+async function holdScreenAwake(secureContext: boolean): Promise<{
+  check: WakeLockCheck | null;
+  release: () => Promise<void>;
+}> {
+  const idle = { release: async () => undefined };
+  if (!secureContext) return { check: null, ...idle };
+
+  const supported = "wakeLock" in navigator;
+  if (!supported)
+    return { check: { supported, acquired: false, error: null }, ...idle };
+
+  try {
+    const sentinel = await navigator.wakeLock.request("screen");
+    return {
+      check: { supported, acquired: true, error: null },
+      release: () => sentinel.release().catch(() => undefined),
+    };
+  } catch (error) {
+    return {
+      check: { supported, acquired: false, error: describeError(error) },
+      ...idle,
+    };
+  }
+}
+
+function emptyCapture(): CaptureCheck {
+  return {
+    requestedSeconds: CAPTURE_SECONDS,
+    measuredSeconds: 0,
+    framesDelivered: 0,
+    expectedFrames: 0,
+    discrepancyPpm: 0,
+    quanta: 0,
+    gapCount: 0,
+    missingFrames: 0,
+    error: null,
+  };
+}
+
+function finiteOrNull(value: number | undefined): number | null {
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
+}
+
+function describeError(error: unknown): string {
+  if (error instanceof DOMException) return `${error.name}: ${error.message}`;
+  if (error instanceof Error) return `${error.name}: ${error.message}`;
+  return String(error);
+}

--- a/src/composables/sendspin-sync/useMicrophoneProbe.ts
+++ b/src/composables/sendspin-sync/useMicrophoneProbe.ts
@@ -43,6 +43,8 @@ interface FrameCounterReport {
   frames: number;
   quanta: number;
   silentQuanta: number;
+  unconnectedQuanta: number;
+  peak: number;
   contextTime: number;
 }
 
@@ -88,26 +90,41 @@ export interface AudioContextCheck {
   outputLatency: number | null;
 }
 
+/**
+ * What the capture observed.
+ *
+ * The rates are measured between the two least delayed reports of the run (see
+ * {@link anchors}), so they span rather less than `requestedSeconds`;
+ * `measuredSeconds` is that span. The tallies below them cover the whole
+ * capture, because a dropout in the discarded ends still happened.
+ */
 export interface CaptureCheck {
   requestedSeconds: number;
-  /** Wall-clock seconds between the first and last worklet report. */
+  /** Wall-clock seconds the rates below were measured over. */
   measuredSeconds: number;
   /** Seconds the context's own render clock advanced over the same span. */
   renderSeconds: number;
   framesDelivered: number;
-  /** What the render clock says should have arrived over `renderSeconds`. */
+  /** What the system clock says should have arrived over `measuredSeconds`. */
   expectedFrames: number;
+  /** Delivered frames against expected, in parts per million. */
+  discrepancyPpm: number;
   /**
-   * Delivered frames against expected, in parts per million.
+   * The render clock against the system clock, in parts per million.
    *
-   * Both terms come off the audio thread, so no main-thread jitter enters this.
+   * Separating this out says whether a discrepancy came from a drifting clock
+   * or from audio that never arrived.
    */
-  frameDiscrepancyPpm: number;
-  /** Render quanta the input handed back no channel at all. */
-  silentQuanta: number;
-  quanta: number;
-  /** The render clock against the system clock, in parts per million. */
   clockDriftPpm: number;
+  quanta: number;
+  /** Quanta the microphone filled with digital silence, over the whole capture. */
+  silentQuanta: number;
+  /** Quanta with no input connected at all; anything but zero means a broken graph. */
+  unconnectedQuanta: number;
+  /** Loudest sample of the whole capture. Zero means the microphone heard nothing. */
+  peakAmplitude: number;
+  /** True when the view was left before the capture could finish. */
+  aborted: boolean;
   error: ProbeError | null;
 }
 
@@ -222,7 +239,8 @@ export function useMicrophoneProbe() {
     try {
       wakeLock = await holdScreenAwake(result.secureContext.secure);
       result.wakeLock = wakeLock.check;
-      if (!context) return;
+      // Asking now would raise a permission prompt for a view that has gone.
+      if (!context || signal.aborted) return;
 
       const stream = await openMicrophone(result);
       if (!stream) return;
@@ -262,6 +280,9 @@ export function summarizeProbe(report: MicrophoneProbeReport): ProbeSummary {
   const constraints = report.constraints;
   const capture = report.capture;
   const wakeLock = report.wakeLock;
+  // No audio context means the pipeline never came up, which says nothing
+  // about the microphone — the same reasoning as a refused permission.
+  const pipelineNeverOpened = Boolean(capture?.error) && !report.audioContext;
 
   const checks: Record<ProbeCheckId, CheckStatus> = {
     secure_context: report.secureContext.secure ? "pass" : "fail",
@@ -277,15 +298,19 @@ export function summarizeProbe(report: MicrophoneProbeReport): ProbeSummary {
             ? "pass"
             : "warn",
     audio_context: report.audioContext ? "pass" : "not_evaluated",
-    capture: !capture
-      ? "not_evaluated"
-      : capture.error
-        ? "fail"
-        : capture.silentQuanta > 0 ||
-            Math.abs(capture.frameDiscrepancyPpm) > DRIFT_WARN_PPM ||
-            Math.abs(capture.clockDriftPpm) > DRIFT_WARN_PPM
-          ? "warn"
-          : "pass",
+    capture:
+      !capture || capture.aborted || pipelineNeverOpened
+        ? "not_evaluated"
+        : // A capture of pure silence is the one outcome that must never read
+          // as success: the chirp would never be found in it.
+          capture.error || capture.peakAmplitude === 0
+          ? "fail"
+          : capture.silentQuanta > 0 ||
+              capture.unconnectedQuanta > 0 ||
+              Math.abs(capture.discrepancyPpm) > DRIFT_WARN_PPM ||
+              Math.abs(capture.clockDriftPpm) > DRIFT_WARN_PPM
+            ? "warn"
+            : "pass",
     wake_lock: !wakeLock
       ? "not_evaluated"
       : wakeLock.acquired && wakeLock.heldToEnd
@@ -302,7 +327,8 @@ export function summarizeProbe(report: MicrophoneProbeReport): ProbeSummary {
   const verdict: ProbeVerdict =
     failed("secure_context") ||
     failed("media_api") ||
-    Boolean(constraints?.error)
+    Boolean(constraints?.error) ||
+    pipelineNeverOpened
       ? "blocked"
       : failed("voice_processing") ||
           failed("capture") ||
@@ -346,13 +372,12 @@ async function openMicrophone(
   const requested = Object.fromEntries(
     VOICE_PROCESSING.map((name) => [name, false]),
   ) as Record<VoiceProcessing, boolean>;
-  const supportedConstraints = navigator.mediaDevices.getSupportedConstraints();
-  const supported = Object.fromEntries(
-    VOICE_PROCESSING.map((name) => [name, Boolean(supportedConstraints[name])]),
-  ) as Record<VoiceProcessing, boolean>;
+  const supported = {} as Record<VoiceProcessing, boolean>;
 
   let stream: MediaStream;
   try {
+    const known = navigator.mediaDevices.getSupportedConstraints();
+    for (const name of VOICE_PROCESSING) supported[name] = Boolean(known[name]);
     stream = await navigator.mediaDevices.getUserMedia({ audio: requested });
   } catch (error) {
     result.constraints = {
@@ -430,7 +455,11 @@ async function capture(
       outputLatency: finiteOrNull(context.outputLatency),
     };
 
+    if (signal.aborted) return;
+
     await context.audioWorklet.addModule(frameCounterUrl);
+    if (signal.aborted) return;
+
     source = context.createMediaStreamSource(stream);
     counter = new AudioWorkletNode(context, "sendspin-frame-counter", {
       numberOfInputs: 1,
@@ -445,6 +474,10 @@ async function capture(
 
     baseline = context.currentTime;
     context.addEventListener("statechange", onStateChange);
+    // A context the browser declined to start fires no change of its own, so
+    // the state it settled on has to be recorded here or it is never reported.
+    if (context.state !== "running") onStateChange();
+
     result.capture = await countFrames(context, counter, signal, onProgress);
   } catch (error) {
     result.capture = { ...emptyCapture(), error: describeError(error) };
@@ -486,9 +519,10 @@ function countFrames(
       settled = true;
       clearInterval(progress);
       clearTimeout(deadline);
+      signal.removeEventListener("abort", finish);
       counter.port.onmessage = null;
       onProgress((performance.now() - startedAt) / 1000);
-      resolve(measure(context.sampleRate, samples));
+      resolve(measure(context.sampleRate, samples, signal.aborted));
     };
 
     const deadline = setTimeout(finish, CAPTURE_SECONDS * 1000);
@@ -499,60 +533,71 @@ function countFrames(
 }
 
 /**
- * Turns the collected reports into two independent readings.
+ * Turns the collected reports into the capture's readings.
  *
- * The frame totals and the render clock both come off the audio thread, so
- * comparing them carries no main-thread jitter at all. Comparing the render
- * clock with the system clock cannot avoid that jitter, so it is handled
- * separately in {@link clockDriftPpm}.
+ * The rates come from the anchors so scheduling jitter stays out of them; the
+ * tallies come from the last report, which carries the whole capture.
  */
-function measure(sampleRate: number, samples: CaptureSample[]): CaptureCheck {
-  const first = samples[0];
-  const last = samples[samples.length - 1];
-  const renderSeconds =
-    first && last ? last.contextTime - first.contextTime : 0;
-  if (!first || !last || renderSeconds <= 0)
+function measure(
+  sampleRate: number,
+  samples: CaptureSample[],
+  aborted: boolean,
+): CaptureCheck {
+  const latest = samples[samples.length - 1];
+  const span = anchors(samples);
+  if (!latest || !span)
     return {
       ...emptyCapture(),
-      error: {
-        name: "NoFramesError",
-        message: "The worklet delivered no measurable frames",
-      },
+      aborted,
+      error: aborted
+        ? null
+        : {
+            name: "NoFramesError",
+            message: "The worklet delivered no measurable frames",
+          },
     };
 
-  const framesDelivered = last.frames - first.frames;
-  const expectedFrames = sampleRate * renderSeconds;
+  const { start, end } = span;
+  const measuredSeconds = (end.at - start.at) / 1000;
+  const renderSeconds = end.contextTime - start.contextTime;
+  const framesDelivered = end.frames - start.frames;
+  const expectedFrames = sampleRate * measuredSeconds;
   return {
     requestedSeconds: CAPTURE_SECONDS,
-    measuredSeconds: (last.at - first.at) / 1000,
+    measuredSeconds,
     renderSeconds,
     framesDelivered,
     expectedFrames,
-    frameDiscrepancyPpm:
-      ((framesDelivered - expectedFrames) / expectedFrames) * 1e6,
-    silentQuanta: last.silentQuanta - first.silentQuanta,
-    quanta: last.quanta - first.quanta,
-    clockDriftPpm: clockDriftPpm(samples),
+    discrepancyPpm: ((framesDelivered - expectedFrames) / expectedFrames) * 1e6,
+    clockDriftPpm: ((renderSeconds - measuredSeconds) / measuredSeconds) * 1e6,
+    quanta: end.quanta - start.quanta,
+    silentQuanta: latest.silentQuanta,
+    unconnectedQuanta: latest.unconnectedQuanta,
+    peakAmplitude: latest.peak,
+    aborted,
     error: null,
   };
 }
 
 /**
- * Slope of the render clock against the system clock, in ppm.
+ * Picks the least delayed report from each end of the run.
  *
- * A report can only ever arrive late, never early, so the least delayed report
- * in a window is the closest thing to a true reading of the pair of clocks.
- * Taking one from each end of the run keeps scheduling jitter out of the slope.
+ * A report can only ever arrive late, never early, so the smallest gap between
+ * the two clocks is the closest thing to a true reading of the pair. Taking one
+ * from each end keeps main-thread scheduling jitter out of every rate measured
+ * between them. Returns null when the run was too short to span two reports.
  */
-function clockDriftPpm(samples: CaptureSample[]): number {
+function anchors(
+  samples: CaptureSample[],
+): { start: CaptureSample; end: CaptureSample } | null {
+  if (samples.length < 2) return null;
+
   const window = Math.max(1, Math.floor(samples.length / 3));
   const start = leastDelayed(samples.slice(0, window));
   const end = leastDelayed(samples.slice(-window));
-  const wallMs = end.at - start.at;
-  if (wallMs <= 0) return 0;
-
-  const renderMs = (end.contextTime - start.contextTime) * 1000;
-  return ((renderMs - wallMs) / wallMs) * 1e6;
+  return end.at > start.at && end.contextTime > start.contextTime
+    ? { start, end }
+    : null;
 }
 
 function leastDelayed(samples: CaptureSample[]): CaptureSample {
@@ -627,10 +672,13 @@ function emptyCapture(): CaptureCheck {
     renderSeconds: 0,
     framesDelivered: 0,
     expectedFrames: 0,
-    frameDiscrepancyPpm: 0,
-    silentQuanta: 0,
-    quanta: 0,
+    discrepancyPpm: 0,
     clockDriftPpm: 0,
+    quanta: 0,
+    silentQuanta: 0,
+    unconnectedQuanta: 0,
+    peakAmplitude: 0,
+    aborted: false,
     error: null,
   };
 }

--- a/src/composables/sendspin-sync/useMicrophoneProbe.ts
+++ b/src/composables/sendspin-sync/useMicrophoneProbe.ts
@@ -105,7 +105,13 @@ export interface CaptureCheck {
   requestedSeconds: number;
   /** Wall-clock seconds the discrepancy was measured over. */
   measuredSeconds: number;
-  /** Seconds the audio pipeline's own clock advanced over the same span. */
+  /**
+   * Seconds the audio pipeline's own clock advanced over the same span.
+   *
+   * Expected to match `framesDelivered / sampleRate`, since a render quantum is
+   * a fixed 128 frames. Whether a browser really derives its clock that way is
+   * implementation-defined, and this is what checks it.
+   */
   renderSeconds: number;
   measuredQuanta: number;
   framesDelivered: number;
@@ -114,16 +120,22 @@ export interface CaptureCheck {
   /**
    * Delivered frames against expected, in parts per million.
    *
-   * The frame count and the pipeline's clock advance in lockstep — a quantum is
-   * a fixed 128 frames — so this is equally the audio clock measured against
-   * the system clock. Reporting it twice under two names would say no more.
+   * The frames are counted on the audio thread and the expectation comes from
+   * the system clock, so this is the audio pipeline measured against the
+   * system — the one figure a chirp's arrival time depends on.
    */
   discrepancyPpm: number;
   /** Render quanta over the whole capture, the denominator for the counts below. */
   totalQuanta: number;
   /** Silent quanta before any signal arrived: the capture device warming up. */
   leadInQuanta: number;
-  /** Silent quanta after signal had arrived, which is a real gap in the audio. */
+  /**
+   * Silent quanta after signal had arrived: a gap in the audio.
+   *
+   * A noise gate the browser would not switch off, or an OS-level mute, also
+   * produces true silence — so read this next to the voice processing check
+   * rather than as a dropout on its own.
+   */
   droppedQuanta: number;
   /** Quanta with no input connected at all; anything but zero means a broken graph. */
   unconnectedQuanta: number;
@@ -390,11 +402,35 @@ async function openMicrophone(
   ) as Record<VoiceProcessing, boolean>;
   const supported = {} as Record<VoiceProcessing, boolean>;
 
-  let stream: MediaStream;
+  let stream: MediaStream | null = null;
   try {
     const known = navigator.mediaDevices.getSupportedConstraints();
     for (const name of VOICE_PROCESSING) supported[name] = Boolean(known[name]);
     stream = await navigator.mediaDevices.getUserMedia({ audio: requested });
+
+    const track = stream.getAudioTracks()[0];
+    const settings = track?.getSettings() ?? {};
+    const applied: Partial<Record<VoiceProcessing, boolean>> = {};
+    for (const name of VOICE_PROCESSING) {
+      const value = settings[name];
+      if (typeof value === "boolean") applied[name] = value;
+    }
+
+    result.constraints = {
+      requested,
+      applied,
+      supported,
+      honored: VOICE_PROCESSING.every((name) => applied[name] === false),
+      trackSettings: settings,
+      trackLabel: track?.label ?? "",
+      error: track
+        ? null
+        : {
+            name: "NoAudioTrackError",
+            message: "The captured stream carried no audio track",
+          },
+    };
+    if (track) return stream;
   } catch (error) {
     result.constraints = {
       requested,
@@ -405,34 +441,10 @@ async function openMicrophone(
       trackLabel: "",
       error: describeError(error),
     };
-    return null;
   }
 
-  const track = stream.getAudioTracks()[0];
-  const settings = track?.getSettings() ?? {};
-  const applied: Partial<Record<VoiceProcessing, boolean>> = {};
-  for (const name of VOICE_PROCESSING) {
-    const value = settings[name];
-    if (typeof value === "boolean") applied[name] = value;
-  }
-
-  result.constraints = {
-    requested,
-    applied,
-    supported,
-    honored: VOICE_PROCESSING.every((name) => applied[name] === false),
-    trackSettings: settings,
-    trackLabel: track?.label ?? "",
-    error: track
-      ? null
-      : {
-          name: "NoAudioTrackError",
-          message: "The captured stream carried no audio track",
-        },
-  };
-  if (track) return stream;
-
-  for (const orphan of stream.getTracks()) orphan.stop();
+  // Nothing usable came back, and nothing else will be holding this stream.
+  for (const orphan of stream?.getTracks() ?? []) orphan.stop();
   return null;
 }
 

--- a/src/composables/sendspin-sync/useMicrophoneProbe.ts
+++ b/src/composables/sendspin-sync/useMicrophoneProbe.ts
@@ -42,8 +42,19 @@ export type VoiceProcessing = (typeof VOICE_PROCESSING)[number];
 interface FrameCounterReport {
   frames: number;
   quanta: number;
+  silentQuanta: number;
   contextTime: number;
-  gaps: { atFrame: number; missingFrames: number }[];
+}
+
+/** One worklet report, stamped with the main thread's clock on arrival. */
+interface CaptureSample extends FrameCounterReport {
+  at: number;
+}
+
+/** A failure kept whole: the name is what tells the reader which one it was. */
+export interface ProbeError {
+  name: string;
+  message: string;
 }
 
 export interface SecureContextCheck {
@@ -65,10 +76,10 @@ export interface ConstraintCheck {
   /** Whether the browser recognises each constraint at all. */
   supported: Record<VoiceProcessing, boolean>;
   /** True only when all three read back as explicitly off. */
-  honoured: boolean;
+  honored: boolean;
   trackSettings: MediaTrackSettings;
   trackLabel: string;
-  error: string | null;
+  error: ProbeError | null;
 }
 
 export interface AudioContextCheck {
@@ -81,25 +92,40 @@ export interface CaptureCheck {
   requestedSeconds: number;
   /** Wall-clock seconds between the first and last worklet report. */
   measuredSeconds: number;
+  /** Seconds the context's own render clock advanced over the same span. */
+  renderSeconds: number;
   framesDelivered: number;
+  /** What the render clock says should have arrived over `renderSeconds`. */
   expectedFrames: number;
-  /** Signed departure of delivered frames from the wall clock, in parts per million. */
-  discrepancyPpm: number;
+  /**
+   * Delivered frames against expected, in parts per million.
+   *
+   * Both terms come off the audio thread, so no main-thread jitter enters this.
+   */
+  frameDiscrepancyPpm: number;
+  /** Render quanta the input handed back no channel at all. */
+  silentQuanta: number;
   quanta: number;
-  gapCount: number;
-  missingFrames: number;
-  error: string | null;
+  /** The render clock against the system clock, in parts per million. */
+  clockDriftPpm: number;
+  error: ProbeError | null;
 }
 
 export interface WakeLockCheck {
   supported: boolean;
   acquired: boolean;
-  error: string | null;
+  /** False when the browser took the lock back before the run finished. */
+  heldToEnd: boolean;
+  error: ProbeError | null;
 }
 
+/** Safari reports a non-standard `interrupted` state the DOM types omit. */
+export type ProbeContextState = AudioContextState | "interrupted";
+
 export interface ContextStateTransition {
+  /** Seconds since the capture graph was built. */
   atSeconds: number;
-  state: AudioContextState;
+  state: ProbeContextState;
 }
 
 export interface ContextStateCheck {
@@ -123,7 +149,7 @@ export type CheckStatus = "pass" | "warn" | "fail" | "not_evaluated";
 
 /**
  * `blocked` means the browser never let the probe start, which is a deployment
- * problem rather than a verdict on the phone.
+ * or permission problem rather than a verdict on the phone.
  */
 export type ProbeVerdict = "ready" | "degraded" | "unsupported" | "blocked";
 
@@ -181,12 +207,21 @@ export function useMicrophoneProbe() {
     const result = startReport();
     report.value = result;
 
-    // Opened before any await so Safari still counts the user gesture.
-    const context = result.mediaApi.getUserMedia ? new AudioContext() : null;
-    const wakeLock = await holdScreenAwake(result.secureContext.secure);
-    result.wakeLock = wakeLock.check;
+    let context: AudioContext | null = null;
+    let wakeLock: ScreenAwake | null = null;
+    if (result.mediaApi.getUserMedia)
+      try {
+        // Opened before any await so Safari still counts the user gesture.
+        context = new AudioContext();
+      } catch (error) {
+        // Safari caps how many contexts a page may hold, and refusing one is a
+        // result worth reporting rather than an exception into a click handler.
+        result.capture = { ...emptyCapture(), error: describeError(error) };
+      }
 
     try {
+      wakeLock = await holdScreenAwake(result.secureContext.secure);
+      result.wakeLock = wakeLock.check;
       if (!context) return;
 
       const stream = await openMicrophone(result);
@@ -201,7 +236,7 @@ export function useMicrophoneProbe() {
       }
     } finally {
       await context?.close().catch(() => undefined);
-      await wakeLock.release();
+      await wakeLock?.release();
       running.value = false;
     }
   }
@@ -223,9 +258,10 @@ export function useMicrophoneProbe() {
  * most of the probe never runs, and calling that a device failure would send
  * people chasing the wrong problem.
  */
-export function summariseProbe(report: MicrophoneProbeReport): ProbeSummary {
+export function summarizeProbe(report: MicrophoneProbeReport): ProbeSummary {
   const constraints = report.constraints;
   const capture = report.capture;
+  const wakeLock = report.wakeLock;
 
   const checks: Record<ProbeCheckId, CheckStatus> = {
     secure_context: report.secureContext.secure ? "pass" : "fail",
@@ -237,7 +273,7 @@ export function summariseProbe(report: MicrophoneProbeReport): ProbeSummary {
         ? "not_evaluated"
         : VOICE_PROCESSING.some((name) => constraints.applied[name])
           ? "fail"
-          : constraints.honoured
+          : constraints.honored
             ? "pass"
             : "warn",
     audio_context: report.audioContext ? "pass" : "not_evaluated",
@@ -245,13 +281,14 @@ export function summariseProbe(report: MicrophoneProbeReport): ProbeSummary {
       ? "not_evaluated"
       : capture.error
         ? "fail"
-        : capture.gapCount > 0 ||
-            Math.abs(capture.discrepancyPpm) > DRIFT_WARN_PPM
+        : capture.silentQuanta > 0 ||
+            Math.abs(capture.frameDiscrepancyPpm) > DRIFT_WARN_PPM ||
+            Math.abs(capture.clockDriftPpm) > DRIFT_WARN_PPM
           ? "warn"
           : "pass",
-    wake_lock: !report.wakeLock
+    wake_lock: !wakeLock
       ? "not_evaluated"
-      : report.wakeLock.acquired
+      : wakeLock.acquired && wakeLock.heldToEnd
         ? "pass"
         : "warn",
     context_state: !report.contextState
@@ -322,7 +359,7 @@ async function openMicrophone(
       requested,
       applied: {},
       supported,
-      honoured: false,
+      honored: false,
       trackSettings: {},
       trackLabel: "",
       error: describeError(error),
@@ -342,10 +379,15 @@ async function openMicrophone(
     requested,
     applied,
     supported,
-    honoured: VOICE_PROCESSING.every((name) => applied[name] === false),
+    honored: VOICE_PROCESSING.every((name) => applied[name] === false),
     trackSettings: settings,
     trackLabel: track?.label ?? "",
-    error: track ? null : "No audio track in the captured stream",
+    error: track
+      ? null
+      : {
+          name: "NoAudioTrackError",
+          message: "The captured stream carried no audio track",
+        },
   };
   if (track) return stream;
 
@@ -356,9 +398,10 @@ async function openMicrophone(
 /**
  * Runs the microphone through the frame counter worklet for {@link CAPTURE_SECONDS}.
  *
- * Frames are counted on the audio thread and anchored to `performance.now()` at
- * the first and last report, so the ppm figure is the audio clock's drift
- * against the system clock rather than a one-off scheduling hiccup.
+ * What this measures is the *render* clock, not the microphone's own: the
+ * source node resamples the capture device into the context's rate before the
+ * worklet ever sees it. That is still the clock a chirp's arrival time is
+ * stamped against, so its steadiness is what calibration depends on.
  */
 async function capture(
   context: AudioContext,
@@ -371,8 +414,12 @@ async function capture(
   let source: MediaStreamAudioSourceNode | null = null;
   let counter: AudioWorkletNode | null = null;
   let sink: GainNode | null = null;
+  let baseline = 0;
   const onStateChange = () => {
-    transitions.push({ atSeconds: context.currentTime, state: context.state });
+    transitions.push({
+      atSeconds: context.currentTime - baseline,
+      state: context.state,
+    });
   };
 
   try {
@@ -382,8 +429,6 @@ async function capture(
       baseLatency: finiteOrNull(context.baseLatency),
       outputLatency: finiteOrNull(context.outputLatency),
     };
-    // Attached after the resume so its own transition is not counted.
-    context.addEventListener("statechange", onStateChange);
 
     await context.audioWorklet.addModule(frameCounterUrl);
     source = context.createMediaStreamSource(stream);
@@ -398,6 +443,8 @@ async function capture(
     sink.gain.value = 0;
     source.connect(counter).connect(sink).connect(context.destination);
 
+    baseline = context.currentTime;
+    context.addEventListener("statechange", onStateChange);
     result.capture = await countFrames(context, counter, signal, onProgress);
   } catch (error) {
     result.capture = { ...emptyCapture(), error: describeError(error) };
@@ -423,19 +470,9 @@ function countFrames(
   onProgress: (elapsedSeconds: number) => void,
 ): Promise<CaptureCheck> {
   return new Promise<CaptureCheck>((resolve) => {
-    let first: { at: number; frames: number } | null = null;
-    let last: { at: number; frames: number } | null = null;
-    let quanta = 0;
-    let gapCount = 0;
-    let missingFrames = 0;
-
+    const samples: CaptureSample[] = [];
     counter.port.onmessage = (event: MessageEvent<FrameCounterReport>) => {
-      const sample = { at: performance.now(), frames: event.data.frames };
-      first ??= sample;
-      last = sample;
-      quanta = event.data.quanta;
-      gapCount += event.data.gaps.length;
-      for (const gap of event.data.gaps) missingFrames += gap.missingFrames;
+      samples.push({ ...event.data, at: performance.now() });
     };
 
     const startedAt = performance.now();
@@ -443,66 +480,141 @@ function countFrames(
       onProgress((performance.now() - startedAt) / 1000);
     }, PROGRESS_INTERVAL_MS);
 
+    let settled = false;
     const finish = () => {
+      if (settled) return;
+      settled = true;
       clearInterval(progress);
       clearTimeout(deadline);
-      signal.removeEventListener("abort", finish);
       counter.port.onmessage = null;
-
-      const measuredSeconds = first && last ? (last.at - first.at) / 1000 : 0;
-      const framesDelivered = first && last ? last.frames - first.frames : 0;
-      const expectedFrames = context.sampleRate * measuredSeconds;
       onProgress((performance.now() - startedAt) / 1000);
-      resolve({
-        requestedSeconds: CAPTURE_SECONDS,
-        measuredSeconds,
-        framesDelivered,
-        expectedFrames,
-        discrepancyPpm:
-          expectedFrames > 0
-            ? ((framesDelivered - expectedFrames) / expectedFrames) * 1e6
-            : 0,
-        quanta,
-        gapCount,
-        missingFrames,
-        error:
-          expectedFrames > 0
-            ? null
-            : "The worklet delivered no measurable frames",
-      });
+      resolve(measure(context.sampleRate, samples));
     };
 
     const deadline = setTimeout(finish, CAPTURE_SECONDS * 1000);
-    signal.addEventListener("abort", finish);
+    signal.addEventListener("abort", finish, { once: true });
+    // A signal aborted before this point never fires the event.
+    if (signal.aborted) finish();
   });
+}
+
+/**
+ * Turns the collected reports into two independent readings.
+ *
+ * The frame totals and the render clock both come off the audio thread, so
+ * comparing them carries no main-thread jitter at all. Comparing the render
+ * clock with the system clock cannot avoid that jitter, so it is handled
+ * separately in {@link clockDriftPpm}.
+ */
+function measure(sampleRate: number, samples: CaptureSample[]): CaptureCheck {
+  const first = samples[0];
+  const last = samples[samples.length - 1];
+  const renderSeconds =
+    first && last ? last.contextTime - first.contextTime : 0;
+  if (!first || !last || renderSeconds <= 0)
+    return {
+      ...emptyCapture(),
+      error: {
+        name: "NoFramesError",
+        message: "The worklet delivered no measurable frames",
+      },
+    };
+
+  const framesDelivered = last.frames - first.frames;
+  const expectedFrames = sampleRate * renderSeconds;
+  return {
+    requestedSeconds: CAPTURE_SECONDS,
+    measuredSeconds: (last.at - first.at) / 1000,
+    renderSeconds,
+    framesDelivered,
+    expectedFrames,
+    frameDiscrepancyPpm:
+      ((framesDelivered - expectedFrames) / expectedFrames) * 1e6,
+    silentQuanta: last.silentQuanta - first.silentQuanta,
+    quanta: last.quanta - first.quanta,
+    clockDriftPpm: clockDriftPpm(samples),
+    error: null,
+  };
+}
+
+/**
+ * Slope of the render clock against the system clock, in ppm.
+ *
+ * A report can only ever arrive late, never early, so the least delayed report
+ * in a window is the closest thing to a true reading of the pair of clocks.
+ * Taking one from each end of the run keeps scheduling jitter out of the slope.
+ */
+function clockDriftPpm(samples: CaptureSample[]): number {
+  const window = Math.max(1, Math.floor(samples.length / 3));
+  const start = leastDelayed(samples.slice(0, window));
+  const end = leastDelayed(samples.slice(-window));
+  const wallMs = end.at - start.at;
+  if (wallMs <= 0) return 0;
+
+  const renderMs = (end.contextTime - start.contextTime) * 1000;
+  return ((renderMs - wallMs) / wallMs) * 1e6;
+}
+
+function leastDelayed(samples: CaptureSample[]): CaptureSample {
+  const delay = (sample: CaptureSample) =>
+    sample.at - sample.contextTime * 1000;
+  return samples.reduce((best, sample) =>
+    delay(sample) < delay(best) ? sample : best,
+  );
+}
+
+/** What the caller must release once the run is over. */
+interface ScreenAwake {
+  check: WakeLockCheck | null;
+  release: () => Promise<void>;
 }
 
 /**
  * Holds the screen awake for the run, and hands back the release.
  *
  * The API is secure-context only, so an insecure origin reports nothing rather
- * than a failure the device is not responsible for.
+ * than a failure the device is not responsible for. A lock the browser takes
+ * back mid-run is recorded, because calibration needs it for several minutes.
  */
-async function holdScreenAwake(secureContext: boolean): Promise<{
-  check: WakeLockCheck | null;
-  release: () => Promise<void>;
-}> {
+async function holdScreenAwake(secureContext: boolean): Promise<ScreenAwake> {
   const idle = { release: async () => undefined };
   if (!secureContext) return { check: null, ...idle };
 
   const supported = "wakeLock" in navigator;
   if (!supported)
-    return { check: { supported, acquired: false, error: null }, ...idle };
+    return {
+      check: { supported, acquired: false, heldToEnd: false, error: null },
+      ...idle,
+    };
 
   try {
     const sentinel = await navigator.wakeLock.request("screen");
+    const check: WakeLockCheck = {
+      supported,
+      acquired: true,
+      heldToEnd: true,
+      error: null,
+    };
+    const onRelease = () => {
+      check.heldToEnd = false;
+    };
+    sentinel.addEventListener("release", onRelease);
     return {
-      check: { supported, acquired: true, error: null },
-      release: () => sentinel.release().catch(() => undefined),
+      check,
+      release: async () => {
+        // Detached first so this release is not read as the browser's.
+        sentinel.removeEventListener("release", onRelease);
+        await sentinel.release().catch(() => undefined);
+      },
     };
   } catch (error) {
     return {
-      check: { supported, acquired: false, error: describeError(error) },
+      check: {
+        supported,
+        acquired: false,
+        heldToEnd: false,
+        error: describeError(error),
+      },
       ...idle,
     };
   }
@@ -512,12 +624,13 @@ function emptyCapture(): CaptureCheck {
   return {
     requestedSeconds: CAPTURE_SECONDS,
     measuredSeconds: 0,
+    renderSeconds: 0,
     framesDelivered: 0,
     expectedFrames: 0,
-    discrepancyPpm: 0,
+    frameDiscrepancyPpm: 0,
+    silentQuanta: 0,
     quanta: 0,
-    gapCount: 0,
-    missingFrames: 0,
+    clockDriftPpm: 0,
     error: null,
   };
 }
@@ -526,8 +639,8 @@ function finiteOrNull(value: number | undefined): number | null {
   return typeof value === "number" && Number.isFinite(value) ? value : null;
 }
 
-function describeError(error: unknown): string {
-  if (error instanceof DOMException) return `${error.name}: ${error.message}`;
-  if (error instanceof Error) return `${error.name}: ${error.message}`;
-  return String(error);
+function describeError(error: unknown): ProbeError {
+  if (error instanceof Error)
+    return { name: error.name, message: error.message };
+  return { name: "Error", message: String(error) };
 }

--- a/src/composables/sendspin-sync/useMicrophoneProbe.ts
+++ b/src/composables/sendspin-sync/useMicrophoneProbe.ts
@@ -42,7 +42,8 @@ export type VoiceProcessing = (typeof VOICE_PROCESSING)[number];
 interface FrameCounterReport {
   frames: number;
   quanta: number;
-  silentQuanta: number;
+  leadInQuanta: number;
+  droppedQuanta: number;
   unconnectedQuanta: number;
   peak: number;
   contextTime: number;
@@ -93,36 +94,43 @@ export interface AudioContextCheck {
 /**
  * What the capture observed.
  *
- * The rates are measured between the two least delayed reports of the run (see
- * {@link anchors}), so they span rather less than `requestedSeconds`;
- * `measuredSeconds` is that span. The tallies below them cover the whole
- * capture, because a dropout in the discarded ends still happened.
+ * `discrepancyPpm` and the counts it is derived from are measured between the
+ * two least delayed reports of the run (see {@link anchors}), so they span
+ * rather less than `requestedSeconds` — `measuredSeconds` and `measuredQuanta`
+ * are that span. The tallies below them cover the whole capture, because a
+ * dropout in the discarded ends still happened; `totalQuanta` is their
+ * denominator.
  */
 export interface CaptureCheck {
   requestedSeconds: number;
-  /** Wall-clock seconds the rates below were measured over. */
+  /** Wall-clock seconds the discrepancy was measured over. */
   measuredSeconds: number;
-  /** Seconds the context's own render clock advanced over the same span. */
+  /** Seconds the audio pipeline's own clock advanced over the same span. */
   renderSeconds: number;
+  measuredQuanta: number;
   framesDelivered: number;
   /** What the system clock says should have arrived over `measuredSeconds`. */
   expectedFrames: number;
-  /** Delivered frames against expected, in parts per million. */
-  discrepancyPpm: number;
   /**
-   * The render clock against the system clock, in parts per million.
+   * Delivered frames against expected, in parts per million.
    *
-   * Separating this out says whether a discrepancy came from a drifting clock
-   * or from audio that never arrived.
+   * The frame count and the pipeline's clock advance in lockstep — a quantum is
+   * a fixed 128 frames — so this is equally the audio clock measured against
+   * the system clock. Reporting it twice under two names would say no more.
    */
-  clockDriftPpm: number;
-  quanta: number;
-  /** Quanta the microphone filled with digital silence, over the whole capture. */
-  silentQuanta: number;
+  discrepancyPpm: number;
+  /** Render quanta over the whole capture, the denominator for the counts below. */
+  totalQuanta: number;
+  /** Silent quanta before any signal arrived: the capture device warming up. */
+  leadInQuanta: number;
+  /** Silent quanta after signal had arrived, which is a real gap in the audio. */
+  droppedQuanta: number;
   /** Quanta with no input connected at all; anything but zero means a broken graph. */
   unconnectedQuanta: number;
   /** Loudest sample of the whole capture. Zero means the microphone heard nothing. */
   peakAmplitude: number;
+  /** False when the audio pipeline never got as far as capturing. */
+  started: boolean;
   /** True when the view was left before the capture could finish. */
   aborted: boolean;
   error: ProbeError | null;
@@ -276,13 +284,22 @@ export function useMicrophoneProbe() {
  * most of the probe never runs, and calling that a device failure would send
  * people chasing the wrong problem.
  */
+/**
+ * Whether the audio pipeline failed before it could capture anything.
+ *
+ * A context the browser refused, or a worklet that would not load, says nothing
+ * about the microphone — the same reasoning as a refused permission, and the
+ * reason both are reported as blocked rather than as a bad measurement.
+ */
+export function pipelineNeverOpened(report: MicrophoneProbeReport): boolean {
+  return Boolean(report.capture?.error) && !report.capture?.started;
+}
+
 export function summarizeProbe(report: MicrophoneProbeReport): ProbeSummary {
   const constraints = report.constraints;
   const capture = report.capture;
   const wakeLock = report.wakeLock;
-  // No audio context means the pipeline never came up, which says nothing
-  // about the microphone — the same reasoning as a refused permission.
-  const pipelineNeverOpened = Boolean(capture?.error) && !report.audioContext;
+  const blockedBeforeCapture = pipelineNeverOpened(report);
 
   const checks: Record<ProbeCheckId, CheckStatus> = {
     secure_context: report.secureContext.secure ? "pass" : "fail",
@@ -299,16 +316,15 @@ export function summarizeProbe(report: MicrophoneProbeReport): ProbeSummary {
             : "warn",
     audio_context: report.audioContext ? "pass" : "not_evaluated",
     capture:
-      !capture || capture.aborted || pipelineNeverOpened
+      !capture || capture.aborted || blockedBeforeCapture
         ? "not_evaluated"
         : // A capture of pure silence is the one outcome that must never read
           // as success: the chirp would never be found in it.
           capture.error || capture.peakAmplitude === 0
           ? "fail"
-          : capture.silentQuanta > 0 ||
+          : capture.droppedQuanta > 0 ||
               capture.unconnectedQuanta > 0 ||
-              Math.abs(capture.discrepancyPpm) > DRIFT_WARN_PPM ||
-              Math.abs(capture.clockDriftPpm) > DRIFT_WARN_PPM
+              Math.abs(capture.discrepancyPpm) > DRIFT_WARN_PPM
             ? "warn"
             : "pass",
     wake_lock: !wakeLock
@@ -328,7 +344,7 @@ export function summarizeProbe(report: MicrophoneProbeReport): ProbeSummary {
     failed("secure_context") ||
     failed("media_api") ||
     Boolean(constraints?.error) ||
-    pipelineNeverOpened
+    blockedBeforeCapture
       ? "blocked"
       : failed("voice_processing") ||
           failed("capture") ||
@@ -440,6 +456,7 @@ async function capture(
   let counter: AudioWorkletNode | null = null;
   let sink: GainNode | null = null;
   let baseline = 0;
+  let watching = false;
   const onStateChange = () => {
     transitions.push({
       atSeconds: context.currentTime - baseline,
@@ -474,25 +491,33 @@ async function capture(
 
     baseline = context.currentTime;
     context.addEventListener("statechange", onStateChange);
+    watching = true;
     // A context the browser declined to start fires no change of its own, so
     // the state it settled on has to be recorded here or it is never reported.
     if (context.state !== "running") onStateChange();
 
     result.capture = await countFrames(context, counter, signal, onProgress);
   } catch (error) {
-    result.capture = { ...emptyCapture(), error: describeError(error) };
+    result.capture = {
+      ...emptyCapture(),
+      aborted: signal.aborted,
+      error: describeError(error),
+    };
   } finally {
     context.removeEventListener("statechange", onStateChange);
     source?.disconnect();
     counter?.disconnect();
     counter?.port.close();
     sink?.disconnect();
-    result.contextState = {
-      stayedRunning: transitions.every(
-        (transition) => transition.state === "running",
-      ),
-      transitions,
-    };
+    // Left null when the graph never ran: an empty transition list would
+    // otherwise read as "it stayed running the whole time".
+    if (watching)
+      result.contextState = {
+        stayedRunning: transitions.every(
+          (transition) => transition.state === "running",
+        ),
+        transitions,
+      };
   }
 }
 
@@ -535,8 +560,8 @@ function countFrames(
 /**
  * Turns the collected reports into the capture's readings.
  *
- * The rates come from the anchors so scheduling jitter stays out of them; the
- * tallies come from the last report, which carries the whole capture.
+ * The discrepancy comes from the anchors so scheduling jitter stays out of it;
+ * the tallies come from the last report, which carries the whole capture.
  */
 function measure(
   sampleRate: number,
@@ -548,6 +573,7 @@ function measure(
   if (!latest || !span)
     return {
       ...emptyCapture(),
+      started: true,
       aborted,
       error: aborted
         ? null
@@ -559,21 +585,22 @@ function measure(
 
   const { start, end } = span;
   const measuredSeconds = (end.at - start.at) / 1000;
-  const renderSeconds = end.contextTime - start.contextTime;
   const framesDelivered = end.frames - start.frames;
   const expectedFrames = sampleRate * measuredSeconds;
   return {
     requestedSeconds: CAPTURE_SECONDS,
     measuredSeconds,
-    renderSeconds,
+    renderSeconds: end.contextTime - start.contextTime,
+    measuredQuanta: end.quanta - start.quanta,
     framesDelivered,
     expectedFrames,
     discrepancyPpm: ((framesDelivered - expectedFrames) / expectedFrames) * 1e6,
-    clockDriftPpm: ((renderSeconds - measuredSeconds) / measuredSeconds) * 1e6,
-    quanta: end.quanta - start.quanta,
-    silentQuanta: latest.silentQuanta,
+    totalQuanta: latest.quanta,
+    leadInQuanta: latest.leadInQuanta,
+    droppedQuanta: latest.droppedQuanta,
     unconnectedQuanta: latest.unconnectedQuanta,
     peakAmplitude: latest.peak,
+    started: true,
     aborted,
     error: null,
   };
@@ -670,14 +697,16 @@ function emptyCapture(): CaptureCheck {
     requestedSeconds: CAPTURE_SECONDS,
     measuredSeconds: 0,
     renderSeconds: 0,
+    measuredQuanta: 0,
     framesDelivered: 0,
     expectedFrames: 0,
     discrepancyPpm: 0,
-    clockDriftPpm: 0,
-    quanta: 0,
-    silentQuanta: 0,
+    totalQuanta: 0,
+    leadInQuanta: 0,
+    droppedQuanta: 0,
     unconnectedQuanta: 0,
     peakAmplitude: 0,
+    started: false,
     aborted: false,
     error: null,
   };

--- a/src/plugins/router.ts
+++ b/src/plugins/router.ts
@@ -179,6 +179,40 @@ export const routes: RouteRecordRaw[] = [
         },
       },
       {
+        path: "/sendspin-sync",
+        name: "sendspin-sync",
+        component: () =>
+          import(
+            /* webpackChunkName: "sendspin-sync" */ "@/views/SendspinSyncView.vue"
+          ),
+        beforeEnter: async () => {
+          if (api.state.value !== ConnectionState.INITIALIZED) {
+            // Wait for the connection, but never block navigation forever.
+            await new Promise<void>((resolve) => {
+              const timeout = setTimeout(() => {
+                unwatch();
+                resolve();
+              }, 10000);
+              const unwatch = watch(
+                () => api.state.value,
+                (newState) => {
+                  if (newState === ConnectionState.INITIALIZED) {
+                    clearTimeout(timeout);
+                    unwatch();
+                    resolve();
+                  }
+                },
+                { immediate: true },
+              );
+            });
+          }
+          if (!store.enabledPlugins.has("sendspin_sync")) {
+            toast.error($t("providers.sendspin_sync.toast.unavailable"));
+            return { name: "discover" };
+          }
+        },
+      },
+      {
         path: "/visualizer",
         name: "visualizer",
         component: () =>

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1897,8 +1897,12 @@
                         "description": "The browser does not offer getUserMedia, so no audio can be captured. Try a current version of Chrome, Safari or Firefox."
                     },
                     "refused": {
-                        "title": "The microphone was not handed over",
-                        "description": "The browser did not open the microphone, so nothing could be measured. Allow microphone access for this site and run the check again. The exact reason is on the Voice processing row below."
+                        "title": "Microphone access was refused",
+                        "description": "The browser did not grant the microphone, so nothing could be measured. Allow microphone access for this site and run the check again. The exact reason is on the Voice processing row below."
+                    },
+                    "no_device": {
+                        "title": "No usable microphone was found",
+                        "description": "Access was allowed, but no microphone could be opened. Check that one is connected and not held by another app, then run the check again. The exact reason is on the Voice processing row below."
                     }
                 },
                 "status": {
@@ -1936,11 +1940,11 @@
                     },
                     "capture": {
                         "title": "Capture continuity",
-                        "hint": "Thirty seconds of audio, counted frame by frame against the system clock."
+                        "hint": "Thirty seconds of audio. Frames delivered are compared with the audio engine\u2019s own clock, and that clock in turn with the system clock."
                     },
                     "wake_lock": {
                         "title": "Screen wake lock",
-                        "hint": "Calibration needs the screen awake while you walk between speakers."
+                        "hint": "Calibration needs the screen awake while you walk between speakers, so this also records whether the lock survived the capture."
                     },
                     "context_state": {
                         "title": "Uninterrupted recording",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1904,9 +1904,9 @@
                         "title": "No usable microphone was found",
                         "description": "Access was allowed, but no microphone could be opened. Check that one is connected and not held by another app, then run the check again. The exact reason is on the Voice processing row below."
                     },
-                    "no_audio_context": {
+                    "no_audio_pipeline": {
                         "title": "The audio engine would not start",
-                        "description": "The browser refused to open an audio pipeline, so nothing could be captured. Reload the page and try again; if it keeps happening, close other tabs playing audio. The exact reason is on the Capture continuity row below."
+                        "description": "The browser never got as far as capturing, so this says nothing about the microphone. Reload the page and try again. The exact reason is on the Capture continuity row below."
                     }
                 },
                 "status": {

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1849,6 +1849,105 @@
             "play_revealed_songs_help": "Music plays only after the answer is revealed.",
             "reveal_audio_on": "On",
             "reveal_audio_off": "Off"
+        },
+        "sendspin_sync": {
+            "title": "Sendspin Sync",
+            "toast": {
+                "unavailable": "Sendspin Sync is not enabled on this server."
+            },
+            "probe": {
+                "subtitle": "Check whether this phone can hear a calibration chirp accurately enough to sync your speakers.",
+                "idle": {
+                    "title": "Microphone check",
+                    "description": "Run this on the phone you will carry to each speaker. It listens for 30 seconds, so keep the screen on and stay still while it runs."
+                },
+                "start": "Start check",
+                "restart": "Run again",
+                "capturing": "Listening...",
+                "remaining": "{0} seconds left",
+                "copy": "Copy results as JSON",
+                "copied": "Results copied.",
+                "copy_failed": "Could not copy the results.",
+                "raw": "Raw results",
+                "verdict": {
+                    "ready": {
+                        "title": "This phone can measure",
+                        "description": "The microphone delivered unprocessed audio on a steady clock. Nothing here stands in the way of calibration."
+                    },
+                    "degraded": {
+                        "title": "Usable, with caveats",
+                        "description": "The microphone worked, but something below is worth a look before you trust a measurement. Copy the results and check the flagged rows."
+                    },
+                    "unsupported": {
+                        "title": "This phone cannot measure reliably",
+                        "description": "The browser altered or interrupted the audio it captured, which would move the measured arrival time. Try another phone or browser, and send the results along."
+                    },
+                    "blocked": {
+                        "title": "The check could not run",
+                        "description": "The browser refused microphone access before anything could be measured. That is about how Music Assistant is being served, not about this phone."
+                    }
+                },
+                "blocked": {
+                    "insecure": {
+                        "title": "Open Music Assistant over a secure connection",
+                        "description": "Browsers only offer microphone access on a secure origin, with no exception for local networks. Reach Music Assistant through the Home Assistant ingress, enable TLS in Music Assistant's own settings, or put a reverse proxy with a valid certificate in front of it."
+                    },
+                    "no_api": {
+                        "title": "This browser has no microphone API",
+                        "description": "The browser does not offer getUserMedia, so no audio can be captured. Try a current version of Chrome, Safari or Firefox."
+                    },
+                    "refused": {
+                        "title": "The microphone was not handed over",
+                        "description": "The browser did not open the microphone, so nothing could be measured. Allow microphone access for this site and run the check again. The exact reason is on the Voice processing row below."
+                    }
+                },
+                "status": {
+                    "pass": "Pass",
+                    "warn": "Check",
+                    "fail": "Fail",
+                    "not_evaluated": "Not run"
+                },
+                "values": {
+                    "yes": "yes",
+                    "no": "no",
+                    "on": "on",
+                    "off": "off",
+                    "available": "available",
+                    "unavailable": "unavailable",
+                    "not_reported": "not reported",
+                    "stayed_running": "stayed running"
+                },
+                "checks": {
+                    "secure_context": {
+                        "title": "Secure connection",
+                        "hint": "Microphone access is only offered on a secure origin."
+                    },
+                    "media_api": {
+                        "title": "Microphone API",
+                        "hint": "Whether this browser exposes audio capture at all."
+                    },
+                    "voice_processing": {
+                        "title": "Voice processing",
+                        "hint": "Echo cancellation, noise suppression and gain control were all asked to stay off. These are the values the browser actually applied."
+                    },
+                    "audio_context": {
+                        "title": "Audio pipeline",
+                        "hint": "The sample rate and the latencies this device reports for its audio path."
+                    },
+                    "capture": {
+                        "title": "Capture continuity",
+                        "hint": "Thirty seconds of audio, counted frame by frame against the system clock."
+                    },
+                    "wake_lock": {
+                        "title": "Screen wake lock",
+                        "hint": "Calibration needs the screen awake while you walk between speakers."
+                    },
+                    "context_state": {
+                        "title": "Uninterrupted recording",
+                        "hint": "Whether the audio engine kept running for the whole capture."
+                    }
+                }
+            }
         }
     },
     "no_lyrics_available": "No lyrics available",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1903,6 +1903,10 @@
                     "no_device": {
                         "title": "No usable microphone was found",
                         "description": "Access was allowed, but no microphone could be opened. Check that one is connected and not held by another app, then run the check again. The exact reason is on the Voice processing row below."
+                    },
+                    "no_audio_context": {
+                        "title": "The audio engine would not start",
+                        "description": "The browser refused to open an audio pipeline, so nothing could be captured. Reload the page and try again; if it keeps happening, close other tabs playing audio. The exact reason is on the Capture continuity row below."
                     }
                 },
                 "status": {
@@ -1940,7 +1944,8 @@
                     },
                     "capture": {
                         "title": "Capture continuity",
-                        "hint": "Thirty seconds of audio. Frames delivered are compared with the audio engine\u2019s own clock, and that clock in turn with the system clock."
+                        "hint": "Thirty seconds of audio, checked for gaps, for a steady clock, and for any signal at all.",
+                        "silent": "The microphone delivered nothing but digital silence, so it heard nothing at all. Check that it is not muted or covered and that no other app is holding it."
                     },
                     "wake_lock": {
                         "title": "Screen wake lock",

--- a/src/views/SendspinSyncView.vue
+++ b/src/views/SendspinSyncView.vue
@@ -82,6 +82,9 @@
               </template>
             </dl>
 
+            <p v-if="check.noteKey" class="mt-2 text-sm text-destructive">
+              {{ $t(check.noteKey) }}
+            </p>
             <p v-if="check.error" class="mt-2 text-sm text-destructive">
               {{ check.error }}
             </p>
@@ -165,6 +168,8 @@ interface CheckRow {
   titleKey: string;
   hintKey: string;
   details: DetailRow[];
+  /** A finding the raw numbers alone would not spell out. */
+  noteKey: string | null;
   error: string | null;
 }
 
@@ -212,9 +217,11 @@ const blocker = computed(() => {
     ? "insecure"
     : !current.mediaApi.getUserMedia
       ? "no_api"
-      : MISSING_DEVICE_ERRORS.includes(current.constraints?.error?.name ?? "")
-        ? "no_device"
-        : "refused";
+      : !current.audioContext && current.capture?.error
+        ? "no_audio_context"
+        : MISSING_DEVICE_ERRORS.includes(current.constraints?.error?.name ?? "")
+          ? "no_device"
+          : "refused";
   return `providers.sendspin_sync.probe.blocked.${reason}`;
 });
 
@@ -229,9 +236,22 @@ const checks = computed<CheckRow[]>(() => {
     titleKey: `providers.sendspin_sync.probe.checks.${id}.title`,
     hintKey: `providers.sendspin_sync.probe.checks.${id}.hint`,
     details: detailsFor(id, current),
+    noteKey: noteFor(id, current),
     error: errorFor(id, current),
   }));
 });
+
+/** Spells out a finding the numbers on the row would leave the reader to infer. */
+function noteFor(
+  id: ProbeCheckId,
+  current: MicrophoneProbeReport,
+): string | null {
+  if (id !== "capture" || !current.capture || current.capture.error)
+    return null;
+  return current.capture.peakAmplitude === 0
+    ? "providers.sendspin_sync.probe.checks.capture.silent"
+    : null;
+}
 
 function detailsFor(
   id: ProbeCheckId,
@@ -278,21 +298,23 @@ function detailsFor(
       const capture = current.capture;
       if (!capture) return [];
       return [
-        { label: "duration", value: `${capture.measuredSeconds.toFixed(1)} s` },
+        { label: "measured", value: `${capture.measuredSeconds.toFixed(1)} s` },
         { label: "framesDelivered", value: `${capture.framesDelivered}` },
         {
           label: "framesExpected",
           value: `${Math.round(capture.expectedFrames)}`,
         },
         {
-          label: "frame discrepancy",
-          value: `${capture.frameDiscrepancyPpm.toFixed(1)} ppm`,
+          label: "discrepancy",
+          value: `${capture.discrepancyPpm.toFixed(1)} ppm`,
         },
         {
           label: "clock drift",
           value: `${capture.clockDriftPpm.toFixed(1)} ppm`,
         },
+        { label: "peak", value: capture.peakAmplitude.toFixed(4) },
         { label: "silentQuanta", value: `${capture.silentQuanta}` },
+        { label: "unconnectedQuanta", value: `${capture.unconnectedQuanta}` },
         { label: "renderQuanta", value: `${capture.quanta}` },
       ];
     }

--- a/src/views/SendspinSyncView.vue
+++ b/src/views/SendspinSyncView.vue
@@ -1,0 +1,356 @@
+<template>
+  <section class="mx-auto w-full max-w-3xl space-y-6 p-4 md:p-6">
+    <header>
+      <h1
+        class="inline-flex items-center text-2xl font-semibold tracking-tight"
+      >
+        <Mic class="mr-2 h-5 w-5" aria-hidden="true" />
+        {{ $t("providers.sendspin_sync.title") }}
+      </h1>
+      <p class="text-sm text-muted-foreground">
+        {{ $t("providers.sendspin_sync.probe.subtitle") }}
+      </p>
+    </header>
+
+    <Alert v-if="blocker" variant="warning">
+      <TriangleAlert class="h-4 w-4" aria-hidden="true" />
+      <AlertTitle>{{ $t(`${blocker}.title`) }}</AlertTitle>
+      <AlertDescription>{{ $t(`${blocker}.description`) }}</AlertDescription>
+    </Alert>
+
+    <Card class="gap-4">
+      <CardHeader>
+        <CardTitle>{{ $t(`${headline}.title`) }}</CardTitle>
+        <CardDescription>{{ $t(`${headline}.description`) }}</CardDescription>
+      </CardHeader>
+
+      <CardContent class="space-y-4">
+        <Button class="w-full sm:w-auto" :disabled="running" @click="run">
+          <Spinner v-if="running" class="size-4" />
+          <Mic v-else class="size-4" aria-hidden="true" />
+          {{
+            running
+              ? $t("providers.sendspin_sync.probe.capturing")
+              : report
+                ? $t("providers.sendspin_sync.probe.restart")
+                : $t("providers.sendspin_sync.probe.start")
+          }}
+        </Button>
+
+        <div v-if="running" class="space-y-2" role="status" aria-live="polite">
+          <Progress :model-value="captureProgress" />
+          <p class="text-sm text-muted-foreground">
+            {{
+              $t("providers.sendspin_sync.probe.remaining", [
+                captureRemainingSeconds,
+              ])
+            }}
+          </p>
+        </div>
+
+        <ul v-if="checks.length" class="divide-y border-t">
+          <li v-for="check in checks" :key="check.id" class="py-3">
+            <div class="flex items-start justify-between gap-3">
+              <div class="min-w-0">
+                <p class="font-medium">{{ $t(check.titleKey) }}</p>
+                <p class="text-sm text-muted-foreground">
+                  {{ $t(check.hintKey) }}
+                </p>
+              </div>
+              <Badge :variant="statusVariant[check.status]" class="shrink-0">
+                {{ $t(`providers.sendspin_sync.probe.status.${check.status}`) }}
+              </Badge>
+            </div>
+
+            <dl
+              v-if="check.details.length"
+              class="mt-2 grid grid-cols-[minmax(0,auto)_minmax(0,1fr)] gap-x-3 gap-y-1 text-sm"
+            >
+              <template v-for="detail in check.details" :key="detail.label">
+                <dt class="font-mono text-muted-foreground">
+                  {{ detail.label }}
+                </dt>
+                <dd class="break-words font-mono">
+                  {{ detail.valueKey ? $t(detail.valueKey) : detail.value }}
+                </dd>
+              </template>
+            </dl>
+
+            <p v-if="check.error" class="mt-2 text-sm text-destructive">
+              {{ check.error }}
+            </p>
+          </li>
+        </ul>
+      </CardContent>
+
+      <CardFooter v-if="report" class="flex-col items-stretch gap-4">
+        <Button variant="outline" @click="copyReport">
+          <Copy class="size-4" aria-hidden="true" />
+          {{ $t("providers.sendspin_sync.probe.copy") }}
+        </Button>
+
+        <Accordion type="single" collapsible>
+          <AccordionItem value="raw">
+            <AccordionTrigger>
+              {{ $t("providers.sendspin_sync.probe.raw") }}
+            </AccordionTrigger>
+            <AccordionContent>
+              <pre class="overflow-x-auto rounded-md bg-muted p-3 text-xs">{{
+                reportJson
+              }}</pre>
+            </AccordionContent>
+          </AccordionItem>
+        </Accordion>
+      </CardFooter>
+    </Card>
+  </section>
+</template>
+
+<script setup lang="ts">
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+} from "@/components/ui/accordion";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { Badge, type BadgeVariants } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Progress } from "@/components/ui/progress";
+import { Spinner } from "@/components/ui/spinner";
+import {
+  PROBE_CHECKS,
+  summariseProbe,
+  useMicrophoneProbe,
+  VOICE_PROCESSING,
+  type CheckStatus,
+  type MicrophoneProbeReport,
+  type ProbeCheckId,
+} from "@/composables/sendspin-sync/useMicrophoneProbe";
+import { copyToClipboard } from "@/helpers/utils";
+import { $t } from "@/plugins/i18n";
+import { Copy, Mic, TriangleAlert } from "@lucide/vue";
+import { computed } from "vue";
+import { toast } from "vue-sonner";
+
+/** Either a literal reading or a translation key for a word like "not reported". */
+interface DetailValue {
+  value?: string;
+  valueKey?: string;
+}
+
+interface DetailRow extends DetailValue {
+  /** Web Audio and DOM identifiers stay verbatim so a pasted report is greppable. */
+  label: string;
+}
+
+interface CheckRow {
+  id: ProbeCheckId;
+  status: CheckStatus;
+  titleKey: string;
+  hintKey: string;
+  details: DetailRow[];
+  error: string | null;
+}
+
+const VALUES = "providers.sendspin_sync.probe.values";
+
+const statusVariant: Record<CheckStatus, BadgeVariants["variant"]> = {
+  pass: "default",
+  warn: "warning",
+  fail: "destructive",
+  not_evaluated: "outline",
+};
+
+const {
+  running,
+  report,
+  reportJson,
+  captureProgress,
+  captureRemainingSeconds,
+  run,
+} = useMicrophoneProbe();
+
+const summary = computed(() =>
+  report.value ? summariseProbe(report.value) : null,
+);
+
+const headline = computed(() =>
+  summary.value
+    ? `providers.sendspin_sync.probe.verdict.${summary.value.verdict}`
+    : "providers.sendspin_sync.probe.idle",
+);
+
+/** Names the reason the probe could not run, so the remedy can be spelled out. */
+const blocker = computed(() => {
+  const current = report.value;
+  if (!current || summary.value?.verdict !== "blocked") return null;
+  const reason = !current.secureContext.secure
+    ? "insecure"
+    : !current.mediaApi.getUserMedia
+      ? "no_api"
+      : "refused";
+  return `providers.sendspin_sync.probe.blocked.${reason}`;
+});
+
+const checks = computed<CheckRow[]>(() => {
+  const current = report.value;
+  const statuses = summary.value?.checks;
+  if (!current || !statuses) return [];
+
+  return PROBE_CHECKS.map((id) => ({
+    id,
+    status: statuses[id],
+    titleKey: `providers.sendspin_sync.probe.checks.${id}.title`,
+    hintKey: `providers.sendspin_sync.probe.checks.${id}.hint`,
+    details: detailsFor(id, current),
+    error: errorFor(id, current),
+  }));
+});
+
+function detailsFor(
+  id: ProbeCheckId,
+  current: MicrophoneProbeReport,
+): DetailRow[] {
+  switch (id) {
+    case "secure_context":
+      return [
+        { label: "origin", value: current.secureContext.origin },
+        { label: "isSecureContext", ...flag(current.secureContext.secure) },
+      ];
+    case "media_api":
+      return [
+        {
+          label: "navigator.mediaDevices",
+          ...presence(current.mediaApi.mediaDevices),
+        },
+        { label: "getUserMedia", ...presence(current.mediaApi.getUserMedia) },
+      ];
+    case "voice_processing": {
+      const constraints = current.constraints;
+      if (!constraints) return [];
+      return [
+        ...VOICE_PROCESSING.map((name) => ({
+          label: name,
+          ...switchState(constraints.applied[name]),
+        })),
+        { label: "device", value: constraints.trackLabel || "—" },
+      ];
+    }
+    case "audio_context":
+      return current.audioContext
+        ? [
+            {
+              label: "sampleRate",
+              value: `${current.audioContext.sampleRate} Hz`,
+            },
+            {
+              label: "baseLatency",
+              ...milliseconds(current.audioContext.baseLatency),
+            },
+            {
+              label: "outputLatency",
+              ...milliseconds(current.audioContext.outputLatency),
+            },
+          ]
+        : [];
+    case "capture":
+      return current.capture
+        ? [
+            {
+              label: "duration",
+              value: `${current.capture.measuredSeconds.toFixed(1)} s`,
+            },
+            {
+              label: "framesDelivered",
+              value: `${current.capture.framesDelivered}`,
+            },
+            {
+              label: "framesExpected",
+              value: `${Math.round(current.capture.expectedFrames)}`,
+            },
+            {
+              label: "discrepancy",
+              value: `${current.capture.discrepancyPpm.toFixed(1)} ppm`,
+            },
+            { label: "gaps", value: `${current.capture.gapCount}` },
+            {
+              label: "missingFrames",
+              value: `${current.capture.missingFrames}`,
+            },
+          ]
+        : [];
+    case "wake_lock":
+      return current.wakeLock
+        ? [
+            {
+              label: "navigator.wakeLock",
+              ...presence(current.wakeLock.supported),
+            },
+            { label: "screen lock", ...flag(current.wakeLock.acquired) },
+          ]
+        : [];
+    case "context_state":
+      return current.contextState
+        ? [
+            {
+              label: "AudioContext.state",
+              ...(current.contextState.stayedRunning
+                ? { valueKey: `${VALUES}.stayed_running` }
+                : {
+                    value: current.contextState.transitions
+                      .map((t) => `${t.state} @ ${t.atSeconds.toFixed(1)}s`)
+                      .join(", "),
+                  }),
+            },
+          ]
+        : [];
+  }
+}
+
+function errorFor(
+  id: ProbeCheckId,
+  current: MicrophoneProbeReport,
+): string | null {
+  if (id === "voice_processing") return current.constraints?.error ?? null;
+  if (id === "capture") return current.capture?.error ?? null;
+  if (id === "wake_lock") return current.wakeLock?.error ?? null;
+  return null;
+}
+
+/** A browser capability that is either there or not. */
+function presence(available: boolean): DetailValue {
+  return {
+    valueKey: available ? `${VALUES}.available` : `${VALUES}.unavailable`,
+  };
+}
+
+function flag(value: boolean): DetailValue {
+  return { valueKey: value ? `${VALUES}.yes` : `${VALUES}.no` };
+}
+
+/** Voice processing the browser may also decline to report on at all. */
+function switchState(value: boolean | undefined): DetailValue {
+  if (value === undefined) return { valueKey: `${VALUES}.not_reported` };
+  return { valueKey: value ? `${VALUES}.on` : `${VALUES}.off` };
+}
+
+function milliseconds(seconds: number | null): DetailValue {
+  if (seconds === null) return { valueKey: `${VALUES}.not_reported` };
+  return { value: `${(seconds * 1000).toFixed(2)} ms` };
+}
+
+async function copyReport(): Promise<void> {
+  const copied = await copyToClipboard(reportJson.value);
+  if (copied) toast.success($t("providers.sendspin_sync.probe.copied"));
+  else toast.error($t("providers.sendspin_sync.probe.copy_failed"));
+}
+</script>

--- a/src/views/SendspinSyncView.vue
+++ b/src/views/SendspinSyncView.vue
@@ -136,6 +136,7 @@ import {
 import { Progress } from "@/components/ui/progress";
 import { Spinner } from "@/components/ui/spinner";
 import {
+  pipelineNeverOpened,
   PROBE_CHECKS,
   summarizeProbe,
   useMicrophoneProbe,
@@ -217,8 +218,8 @@ const blocker = computed(() => {
     ? "insecure"
     : !current.mediaApi.getUserMedia
       ? "no_api"
-      : !current.audioContext && current.capture?.error
-        ? "no_audio_context"
+      : pipelineNeverOpened(current)
+        ? "no_audio_pipeline"
         : MISSING_DEVICE_ERRORS.includes(current.constraints?.error?.name ?? "")
           ? "no_device"
           : "refused";
@@ -308,14 +309,11 @@ function detailsFor(
           label: "discrepancy",
           value: `${capture.discrepancyPpm.toFixed(1)} ppm`,
         },
-        {
-          label: "clock drift",
-          value: `${capture.clockDriftPpm.toFixed(1)} ppm`,
-        },
         { label: "peak", value: capture.peakAmplitude.toFixed(4) },
-        { label: "silentQuanta", value: `${capture.silentQuanta}` },
+        { label: "droppedQuanta", value: `${capture.droppedQuanta}` },
+        { label: "leadInQuanta", value: `${capture.leadInQuanta}` },
         { label: "unconnectedQuanta", value: `${capture.unconnectedQuanta}` },
-        { label: "renderQuanta", value: `${capture.quanta}` },
+        { label: "totalQuanta", value: `${capture.totalQuanta}` },
       ];
     }
     case "wake_lock": {

--- a/src/views/SendspinSyncView.vue
+++ b/src/views/SendspinSyncView.vue
@@ -247,9 +247,10 @@ function noteFor(
   id: ProbeCheckId,
   current: MicrophoneProbeReport,
 ): string | null {
-  if (id !== "capture" || !current.capture || current.capture.error)
-    return null;
-  return current.capture.peakAmplitude === 0
+  const capture = id === "capture" ? current.capture : null;
+  // A capture that was cut short has no verdict to spell out.
+  if (!capture || capture.error || capture.aborted) return null;
+  return capture.peakAmplitude === 0
     ? "providers.sendspin_sync.probe.checks.capture.silent"
     : null;
 }

--- a/src/views/SendspinSyncView.vue
+++ b/src/views/SendspinSyncView.vue
@@ -12,21 +12,22 @@
       </p>
     </header>
 
-    <Alert v-if="blocker" variant="warning">
+    <Alert v-if="blocker" variant="destructive">
       <TriangleAlert class="h-4 w-4" aria-hidden="true" />
       <AlertTitle>{{ $t(`${blocker}.title`) }}</AlertTitle>
       <AlertDescription>{{ $t(`${blocker}.description`) }}</AlertDescription>
     </Alert>
 
     <Card class="gap-4">
-      <CardHeader>
+      <!-- The verdict is what the wait was for, so it is what gets announced. -->
+      <CardHeader role="status" aria-live="polite">
         <CardTitle>{{ $t(`${headline}.title`) }}</CardTitle>
         <CardDescription>{{ $t(`${headline}.description`) }}</CardDescription>
       </CardHeader>
 
       <CardContent class="space-y-4">
         <Button class="w-full sm:w-auto" :disabled="running" @click="run">
-          <Spinner v-if="running" class="size-4" />
+          <Spinner v-if="running" class="size-4" aria-hidden="true" />
           <Mic v-else class="size-4" aria-hidden="true" />
           {{
             running
@@ -37,8 +38,13 @@
           }}
         </Button>
 
-        <div v-if="running" class="space-y-2" role="status" aria-live="polite">
-          <Progress :model-value="captureProgress" />
+        <!-- Deliberately not a live region: a per-second countdown would talk
+             over the screen reader for the whole capture. -->
+        <div v-if="running" class="space-y-2">
+          <Progress
+            :model-value="captureProgress"
+            :aria-label="$t('providers.sendspin_sync.probe.capturing')"
+          />
           <p class="text-sm text-muted-foreground">
             {{
               $t("providers.sendspin_sync.probe.remaining", [
@@ -128,12 +134,13 @@ import { Progress } from "@/components/ui/progress";
 import { Spinner } from "@/components/ui/spinner";
 import {
   PROBE_CHECKS,
-  summariseProbe,
+  summarizeProbe,
   useMicrophoneProbe,
   VOICE_PROCESSING,
   type CheckStatus,
   type MicrophoneProbeReport,
   type ProbeCheckId,
+  type ProbeError,
 } from "@/composables/sendspin-sync/useMicrophoneProbe";
 import { copyToClipboard } from "@/helpers/utils";
 import { $t } from "@/plugins/i18n";
@@ -180,7 +187,7 @@ const {
 } = useMicrophoneProbe();
 
 const summary = computed(() =>
-  report.value ? summariseProbe(report.value) : null,
+  report.value ? summarizeProbe(report.value) : null,
 );
 
 const headline = computed(() =>
@@ -188,6 +195,14 @@ const headline = computed(() =>
     ? `providers.sendspin_sync.probe.verdict.${summary.value.verdict}`
     : "providers.sendspin_sync.probe.idle",
 );
+
+/** Errors that mean there was no usable microphone, rather than no permission. */
+const MISSING_DEVICE_ERRORS = [
+  "NotFoundError",
+  "NotReadableError",
+  "OverconstrainedError",
+  "NoAudioTrackError",
+];
 
 /** Names the reason the probe could not run, so the remedy can be spelled out. */
 const blocker = computed(() => {
@@ -197,7 +212,9 @@ const blocker = computed(() => {
     ? "insecure"
     : !current.mediaApi.getUserMedia
       ? "no_api"
-      : "refused";
+      : MISSING_DEVICE_ERRORS.includes(current.constraints?.error?.name ?? "")
+        ? "no_device"
+        : "refused";
   return `providers.sendspin_sync.probe.blocked.${reason}`;
 });
 
@@ -245,59 +262,49 @@ function detailsFor(
         { label: "device", value: constraints.trackLabel || "—" },
       ];
     }
-    case "audio_context":
-      return current.audioContext
-        ? [
-            {
-              label: "sampleRate",
-              value: `${current.audioContext.sampleRate} Hz`,
-            },
-            {
-              label: "baseLatency",
-              ...milliseconds(current.audioContext.baseLatency),
-            },
-            {
-              label: "outputLatency",
-              ...milliseconds(current.audioContext.outputLatency),
-            },
-          ]
-        : [];
-    case "capture":
-      return current.capture
-        ? [
-            {
-              label: "duration",
-              value: `${current.capture.measuredSeconds.toFixed(1)} s`,
-            },
-            {
-              label: "framesDelivered",
-              value: `${current.capture.framesDelivered}`,
-            },
-            {
-              label: "framesExpected",
-              value: `${Math.round(current.capture.expectedFrames)}`,
-            },
-            {
-              label: "discrepancy",
-              value: `${current.capture.discrepancyPpm.toFixed(1)} ppm`,
-            },
-            { label: "gaps", value: `${current.capture.gapCount}` },
-            {
-              label: "missingFrames",
-              value: `${current.capture.missingFrames}`,
-            },
-          ]
-        : [];
-    case "wake_lock":
-      return current.wakeLock
-        ? [
-            {
-              label: "navigator.wakeLock",
-              ...presence(current.wakeLock.supported),
-            },
-            { label: "screen lock", ...flag(current.wakeLock.acquired) },
-          ]
-        : [];
+    case "audio_context": {
+      const audio = current.audioContext;
+      if (!audio) return [];
+      return [
+        { label: "sampleRate", value: `${audio.sampleRate} Hz` },
+        { label: "baseLatency", ...milliseconds(audio.baseLatency) },
+        { label: "outputLatency", ...milliseconds(audio.outputLatency) },
+        // The device's own rate can differ from the context's, which is
+        // exactly the mismatch a chirp measurement has to allow for.
+        { label: "track sampleRate", ...hertz(trackSampleRate(current)) },
+      ];
+    }
+    case "capture": {
+      const capture = current.capture;
+      if (!capture) return [];
+      return [
+        { label: "duration", value: `${capture.measuredSeconds.toFixed(1)} s` },
+        { label: "framesDelivered", value: `${capture.framesDelivered}` },
+        {
+          label: "framesExpected",
+          value: `${Math.round(capture.expectedFrames)}`,
+        },
+        {
+          label: "frame discrepancy",
+          value: `${capture.frameDiscrepancyPpm.toFixed(1)} ppm`,
+        },
+        {
+          label: "clock drift",
+          value: `${capture.clockDriftPpm.toFixed(1)} ppm`,
+        },
+        { label: "silentQuanta", value: `${capture.silentQuanta}` },
+        { label: "renderQuanta", value: `${capture.quanta}` },
+      ];
+    }
+    case "wake_lock": {
+      const wakeLock = current.wakeLock;
+      if (!wakeLock) return [];
+      return [
+        { label: "navigator.wakeLock", ...presence(wakeLock.supported) },
+        { label: "screen lock", ...flag(wakeLock.acquired) },
+        { label: "held to end", ...flag(wakeLock.heldToEnd) },
+      ];
+    }
     case "context_state":
       return current.contextState
         ? [
@@ -320,10 +327,21 @@ function errorFor(
   id: ProbeCheckId,
   current: MicrophoneProbeReport,
 ): string | null {
-  if (id === "voice_processing") return current.constraints?.error ?? null;
-  if (id === "capture") return current.capture?.error ?? null;
-  if (id === "wake_lock") return current.wakeLock?.error ?? null;
-  return null;
+  const error: ProbeError | null | undefined =
+    id === "voice_processing"
+      ? current.constraints?.error
+      : id === "capture"
+        ? current.capture?.error
+        : id === "wake_lock"
+          ? current.wakeLock?.error
+          : null;
+  return error ? `${error.name}: ${error.message}` : null;
+}
+
+/** The rate the capture device itself runs at, when the browser discloses it. */
+function trackSampleRate(current: MicrophoneProbeReport): number | null {
+  const rate = current.constraints?.trackSettings.sampleRate;
+  return typeof rate === "number" ? rate : null;
 }
 
 /** A browser capability that is either there or not. */
@@ -346,6 +364,11 @@ function switchState(value: boolean | undefined): DetailValue {
 function milliseconds(seconds: number | null): DetailValue {
   if (seconds === null) return { valueKey: `${VALUES}.not_reported` };
   return { value: `${(seconds * 1000).toFixed(2)} ms` };
+}
+
+function hertz(rate: number | null): DetailValue {
+  if (rate === null) return { valueKey: `${VALUES}.not_reported` };
+  return { value: `${rate} Hz` };
 }
 
 async function copyReport(): Promise<void> {

--- a/tests/App.test.ts
+++ b/tests/App.test.ts
@@ -418,19 +418,25 @@ describe("App initialization", () => {
       ProviderType.PLUGIN,
       "milkdrop_visualizer",
     );
+    expect(apiMock.getProviderConfigs).toHaveBeenNthCalledWith(
+      5,
+      ProviderType.PLUGIN,
+      "sendspin_sync",
+    );
     expect(storeMock.enabledPlugins).toEqual(
       new Set<string>([
         "party",
         "music_quiz",
         "ai_radio",
         "milkdrop_visualizer",
+        "sendspin_sync",
       ]),
     );
     expect(mockInitializeWebPlayerModeSync).toHaveBeenCalledOnce();
     expectStartupDataRequestedBeforeReveal();
 
     await signalProvidersUpdated();
-    expect(apiMock.getProviderConfigs).toHaveBeenCalledTimes(8);
+    expect(apiMock.getProviderConfigs).toHaveBeenCalledTimes(10);
     expect(mockPruneStaleProviderFilters).toHaveBeenCalledTimes(2);
   });
 
@@ -450,7 +456,7 @@ describe("App initialization", () => {
     serverState.resolve();
     await flushPromises();
     expectLibraryCountsCalled();
-    expect(apiMock.getProviderConfigs).toHaveBeenCalledTimes(4);
+    expect(apiMock.getProviderConfigs).toHaveBeenCalledTimes(5);
     // The plugin lookups are still in flight: revealing the app here would
     // render it with an unknown set of enabled plugins.
     expect(apiMock.state.value).not.toBe("initialized");

--- a/tests/composables/sendspin-sync/frameCounterProcessor.test.ts
+++ b/tests/composables/sendspin-sync/frameCounterProcessor.test.ts
@@ -1,0 +1,121 @@
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+
+const RENDER_QUANTUM = 128;
+const REPORT_INTERVAL_QUANTA = 64;
+
+interface Report {
+  frames: number;
+  quanta: number;
+  silentQuanta: number;
+  contextTime: number;
+}
+
+let posted: Report[] = [];
+let ProcessorClass: new () => { process(inputs: Float32Array[][]): boolean };
+let registeredName = "";
+
+/**
+ * The worklet registers itself on import, so its globals have to exist first.
+ *
+ * It ships to the browser untranspiled and is never covered by the composable's
+ * tests, which drive the port directly — this is the only place its counting
+ * logic runs.
+ */
+beforeAll(async () => {
+  class FakeAudioWorkletProcessor {
+    port = { postMessage: (report: Report) => posted.push(report) };
+  }
+  vi.stubGlobal("AudioWorkletProcessor", FakeAudioWorkletProcessor);
+  vi.stubGlobal("currentTime", 0);
+  vi.stubGlobal(
+    "registerProcessor",
+    (name: string, processor: typeof ProcessorClass) => {
+      registeredName = name;
+      ProcessorClass = processor;
+    },
+  );
+
+  // The processor ships as untyped JavaScript on purpose: it is loaded by
+  // `addModule()` into a worklet scope, never through the app's type graph.
+  // @ts-expect-error -- no declarations, and none wanted
+  await import("@/composables/sendspin-sync/frameCounterProcessor.js");
+});
+
+afterAll(() => {
+  vi.unstubAllGlobals();
+});
+
+beforeEach(() => {
+  posted = [];
+  vi.stubGlobal("currentTime", 0);
+});
+
+function render(
+  processor: InstanceType<typeof ProcessorClass>,
+  quanta: number,
+  channel: Float32Array | undefined,
+): void {
+  const inputs = channel ? [[channel]] : [[]];
+  for (let i = 0; i < quanta; i++) processor.process(inputs);
+}
+
+describe("frameCounterProcessor", () => {
+  it("registers under the name the composable instantiates", () => {
+    expect(registeredName).toBe("sendspin-frame-counter");
+  });
+
+  it("reports running totals with the context clock, not every quantum", () => {
+    const processor = new ProcessorClass();
+
+    render(processor, REPORT_INTERVAL_QUANTA - 1, new Float32Array(128));
+    expect(posted).toHaveLength(0);
+
+    vi.stubGlobal("currentTime", 0.17);
+    render(processor, 1, new Float32Array(128));
+
+    expect(posted).toEqual([
+      {
+        frames: REPORT_INTERVAL_QUANTA * RENDER_QUANTUM,
+        quanta: REPORT_INTERVAL_QUANTA,
+        silentQuanta: 0,
+        contextTime: 0.17,
+      },
+    ]);
+  });
+
+  it("counts a quantum the device supplied nothing for", () => {
+    const processor = new ProcessorClass();
+    const silent = 4;
+
+    render(processor, silent, undefined);
+    render(processor, REPORT_INTERVAL_QUANTA - silent, new Float32Array(128));
+
+    expect(posted).toHaveLength(1);
+    expect(posted[0].silentQuanta).toBe(silent);
+    expect(posted[0].quanta).toBe(REPORT_INTERVAL_QUANTA);
+    // The frames those quanta would have carried are simply absent.
+    expect(posted[0].frames).toBe(
+      (REPORT_INTERVAL_QUANTA - silent) * RENDER_QUANTUM,
+    );
+  });
+
+  it("keeps the totals cumulative across reports", () => {
+    const processor = new ProcessorClass();
+
+    render(processor, REPORT_INTERVAL_QUANTA * 3, new Float32Array(128));
+
+    expect(posted.map((report) => report.quanta)).toEqual([
+      REPORT_INTERVAL_QUANTA,
+      REPORT_INTERVAL_QUANTA * 2,
+      REPORT_INTERVAL_QUANTA * 3,
+    ]);
+  });
+});

--- a/tests/composables/sendspin-sync/frameCounterProcessor.test.ts
+++ b/tests/composables/sendspin-sync/frameCounterProcessor.test.ts
@@ -15,6 +15,8 @@ interface Report {
   frames: number;
   quanta: number;
   silentQuanta: number;
+  unconnectedQuanta: number;
+  peak: number;
   contextTime: number;
 }
 
@@ -67,6 +69,14 @@ function render(
   for (let i = 0; i < quanta; i++) processor.process(inputs);
 }
 
+/** A quantum carrying a signal, so it is not counted as a dropout. */
+function tone(level = 0.5): Float32Array {
+  const channel = new Float32Array(RENDER_QUANTUM);
+  channel[0] = level;
+  channel[1] = -level;
+  return channel;
+}
+
 describe("frameCounterProcessor", () => {
   it("registers under the name the composable instantiates", () => {
     expect(registeredName).toBe("sendspin-frame-counter");
@@ -75,42 +85,71 @@ describe("frameCounterProcessor", () => {
   it("reports running totals with the context clock, not every quantum", () => {
     const processor = new ProcessorClass();
 
-    render(processor, REPORT_INTERVAL_QUANTA - 1, new Float32Array(128));
+    render(processor, REPORT_INTERVAL_QUANTA - 1, tone());
     expect(posted).toHaveLength(0);
 
     vi.stubGlobal("currentTime", 0.17);
-    render(processor, 1, new Float32Array(128));
+    render(processor, 1, tone());
 
     expect(posted).toEqual([
       {
         frames: REPORT_INTERVAL_QUANTA * RENDER_QUANTUM,
         quanta: REPORT_INTERVAL_QUANTA,
         silentQuanta: 0,
+        unconnectedQuanta: 0,
+        peak: 0.5,
         contextTime: 0.17,
       },
     ]);
   });
 
-  it("counts a quantum the device supplied nothing for", () => {
+  it("counts digital silence, which is how a dropout actually arrives", () => {
     const processor = new ProcessorClass();
-    const silent = 4;
+    const dropped = 4;
 
-    render(processor, silent, undefined);
-    render(processor, REPORT_INTERVAL_QUANTA - silent, new Float32Array(128));
+    render(processor, dropped, new Float32Array(RENDER_QUANTUM));
+    render(processor, REPORT_INTERVAL_QUANTA - dropped, tone());
 
     expect(posted).toHaveLength(1);
-    expect(posted[0].silentQuanta).toBe(silent);
-    expect(posted[0].quanta).toBe(REPORT_INTERVAL_QUANTA);
-    // The frames those quanta would have carried are simply absent.
-    expect(posted[0].frames).toBe(
-      (REPORT_INTERVAL_QUANTA - silent) * RENDER_QUANTUM,
-    );
+    expect(posted[0].silentQuanta).toBe(dropped);
+    expect(posted[0].unconnectedQuanta).toBe(0);
+    // Silence still carries frames, so the count alone would hide the gap.
+    expect(posted[0].frames).toBe(REPORT_INTERVAL_QUANTA * RENDER_QUANTUM);
+  });
+
+  it("keeps the loudest sample of the whole run", () => {
+    const processor = new ProcessorClass();
+
+    render(processor, 1, tone(0.25));
+    render(processor, 1, tone(0.75));
+    render(processor, REPORT_INTERVAL_QUANTA - 2, tone(0.1));
+
+    expect(posted[0].peak).toBe(0.75);
+  });
+
+  it("leaves the peak at zero when the microphone heard nothing", () => {
+    const processor = new ProcessorClass();
+
+    render(processor, REPORT_INTERVAL_QUANTA, new Float32Array(RENDER_QUANTUM));
+
+    expect(posted[0].peak).toBe(0);
+    expect(posted[0].silentQuanta).toBe(REPORT_INTERVAL_QUANTA);
+  });
+
+  it("separates an unconnected input from a silent one", () => {
+    const processor = new ProcessorClass();
+
+    render(processor, REPORT_INTERVAL_QUANTA, undefined);
+
+    expect(posted[0].unconnectedQuanta).toBe(REPORT_INTERVAL_QUANTA);
+    expect(posted[0].silentQuanta).toBe(0);
+    expect(posted[0].frames).toBe(0);
   });
 
   it("keeps the totals cumulative across reports", () => {
     const processor = new ProcessorClass();
 
-    render(processor, REPORT_INTERVAL_QUANTA * 3, new Float32Array(128));
+    render(processor, REPORT_INTERVAL_QUANTA * 3, tone());
 
     expect(posted.map((report) => report.quanta)).toEqual([
       REPORT_INTERVAL_QUANTA,

--- a/tests/composables/sendspin-sync/frameCounterProcessor.test.ts
+++ b/tests/composables/sendspin-sync/frameCounterProcessor.test.ts
@@ -14,7 +14,8 @@ const REPORT_INTERVAL_QUANTA = 64;
 interface Report {
   frames: number;
   quanta: number;
-  silentQuanta: number;
+  leadInQuanta: number;
+  droppedQuanta: number;
   unconnectedQuanta: number;
   peak: number;
   contextTime: number;
@@ -95,7 +96,8 @@ describe("frameCounterProcessor", () => {
       {
         frames: REPORT_INTERVAL_QUANTA * RENDER_QUANTUM,
         quanta: REPORT_INTERVAL_QUANTA,
-        silentQuanta: 0,
+        leadInQuanta: 0,
+        droppedQuanta: 0,
         unconnectedQuanta: 0,
         peak: 0.5,
         contextTime: 0.17,
@@ -107,14 +109,27 @@ describe("frameCounterProcessor", () => {
     const processor = new ProcessorClass();
     const dropped = 4;
 
+    render(processor, 1, tone());
     render(processor, dropped, new Float32Array(RENDER_QUANTUM));
-    render(processor, REPORT_INTERVAL_QUANTA - dropped, tone());
+    render(processor, REPORT_INTERVAL_QUANTA - dropped - 1, tone());
 
     expect(posted).toHaveLength(1);
-    expect(posted[0].silentQuanta).toBe(dropped);
+    expect(posted[0].droppedQuanta).toBe(dropped);
+    expect(posted[0].leadInQuanta).toBe(0);
     expect(posted[0].unconnectedQuanta).toBe(0);
     // Silence still carries frames, so the count alone would hide the gap.
     expect(posted[0].frames).toBe(REPORT_INTERVAL_QUANTA * RENDER_QUANTUM);
+  });
+
+  it("treats silence before any signal as the device warming up", () => {
+    const processor = new ProcessorClass();
+    const leadIn = 12;
+
+    render(processor, leadIn, new Float32Array(RENDER_QUANTUM));
+    render(processor, REPORT_INTERVAL_QUANTA - leadIn, tone());
+
+    expect(posted[0].leadInQuanta).toBe(leadIn);
+    expect(posted[0].droppedQuanta).toBe(0);
   });
 
   it("keeps the loudest sample of the whole run", () => {
@@ -132,8 +147,10 @@ describe("frameCounterProcessor", () => {
 
     render(processor, REPORT_INTERVAL_QUANTA, new Float32Array(RENDER_QUANTUM));
 
+    // Nothing ever arrived, so none of it counts as a gap in the audio.
     expect(posted[0].peak).toBe(0);
-    expect(posted[0].silentQuanta).toBe(REPORT_INTERVAL_QUANTA);
+    expect(posted[0].leadInQuanta).toBe(REPORT_INTERVAL_QUANTA);
+    expect(posted[0].droppedQuanta).toBe(0);
   });
 
   it("separates an unconnected input from a silent one", () => {
@@ -142,8 +159,18 @@ describe("frameCounterProcessor", () => {
     render(processor, REPORT_INTERVAL_QUANTA, undefined);
 
     expect(posted[0].unconnectedQuanta).toBe(REPORT_INTERVAL_QUANTA);
-    expect(posted[0].silentQuanta).toBe(0);
+    expect(posted[0].leadInQuanta).toBe(0);
     expect(posted[0].frames).toBe(0);
+  });
+
+  it("counts a zero-length channel as unconnected rather than as silence", () => {
+    const processor = new ProcessorClass();
+
+    render(processor, REPORT_INTERVAL_QUANTA, new Float32Array(0));
+
+    expect(posted[0].unconnectedQuanta).toBe(REPORT_INTERVAL_QUANTA);
+    expect(posted[0].leadInQuanta).toBe(0);
+    expect(posted[0].droppedQuanta).toBe(0);
   });
 
   it("keeps the totals cumulative across reports", () => {

--- a/tests/composables/sendspin-sync/useMicrophoneProbe.test.ts
+++ b/tests/composables/sendspin-sync/useMicrophoneProbe.test.ts
@@ -80,11 +80,9 @@ describe("summarizeProbe", () => {
     expect(summary.verdict).toBe("degraded");
   });
 
-  it("warns on either drift reading and on a quantum with no input", () => {
+  it("warns on either drift reading and on a quantum of silence", () => {
     const frames = summarizeProbe(
-      reportFixture({
-        capture: captureFixture({ frameDiscrepancyPpm: -2500 }),
-      }),
+      reportFixture({ capture: captureFixture({ discrepancyPpm: -2500 }) }),
     );
     const clock = summarizeProbe(
       reportFixture({ capture: captureFixture({ clockDriftPpm: 4000 }) }),
@@ -96,6 +94,26 @@ describe("summarizeProbe", () => {
     expect(frames.checks.capture).toBe("warn");
     expect(clock.checks.capture).toBe("warn");
     expect(silent.checks.capture).toBe("warn");
+  });
+
+  it("fails a capture that heard nothing at all", () => {
+    const summary = summarizeProbe(
+      reportFixture({ capture: captureFixture({ peakAmplitude: 0 }) }),
+    );
+
+    expect(summary.checks.capture).toBe("fail");
+    expect(summary.verdict).toBe("unsupported");
+  });
+
+  it("does not judge a capture the viewer walked away from", () => {
+    const summary = summarizeProbe(
+      reportFixture({
+        capture: captureFixture({ aborted: true, peakAmplitude: 0 }),
+      }),
+    );
+
+    expect(summary.checks.capture).toBe("not_evaluated");
+    expect(summary.verdict).toBe("ready");
   });
 
   it("warns when the browser took the wake lock back mid-run", () => {
@@ -170,7 +188,11 @@ describe("useMicrophoneProbe", () => {
       name: "Error",
       message: "Too many contexts",
     });
-    expect(summarizeProbe(probe.report.value!).checks.capture).toBe("fail");
+    // No pipeline ever opened, so this is a browser problem rather than a
+    // measurement that came back bad.
+    const summary = summarizeProbe(probe.report.value!);
+    expect(summary.checks.capture).toBe("not_evaluated");
+    expect(summary.verdict).toBe("blocked");
     expect(probe.running.value).toBe(false);
   });
 
@@ -190,18 +212,21 @@ describe("useMicrophoneProbe", () => {
 
     const worklet = workletNodes[0];
     expect(worklet).toBeDefined();
-    worklet.emit({ frames: 0, quanta: 0, silentQuanta: 0, contextTime: 0 });
+    worklet.emit(workletReport({}));
 
-    // Two thirds of the way in, the audio thread has delivered 1000 ppm more
-    // frames than its own clock accounts for, and that clock in turn has
-    // fallen 1000 ppm behind the wall clock.
+    // Twenty wall-clock seconds on, the render clock has advanced only 19.98 —
+    // 1000 ppm slow — and 0.18 s of what it did render arrived as silence, so
+    // the frame count is short by ten times as much.
     await vi.advanceTimersByTimeAsync(20_000);
-    worklet.emit({
-      frames: SAMPLE_RATE * 19.98 * (1 + 1e-3),
-      quanta: 7492,
-      silentQuanta: 0,
-      contextTime: 19.98,
-    });
+    worklet.emit(
+      workletReport({
+        frames: SAMPLE_RATE * 19.8,
+        quanta: 7492,
+        silentQuanta: 68,
+        peak: 0.2,
+        contextTime: 19.98,
+      }),
+    );
 
     await vi.advanceTimersByTimeAsync(CAPTURE_SECONDS * 1000 - 20_000);
     await pending;
@@ -220,10 +245,12 @@ describe("useMicrophoneProbe", () => {
     });
     expect(report?.capture?.measuredSeconds).toBeCloseTo(20, 3);
     expect(report?.capture?.renderSeconds).toBeCloseTo(19.98, 6);
-    expect(report?.capture?.frameDiscrepancyPpm).toBeCloseTo(1000, 3);
+    expect(report?.capture?.discrepancyPpm).toBeCloseTo(-10_000, 3);
     expect(report?.capture?.clockDriftPpm).toBeCloseTo(-1000, 3);
     expect(report?.capture?.quanta).toBe(7492);
-    expect(report?.capture?.silentQuanta).toBe(0);
+    expect(report?.capture?.silentQuanta).toBe(68);
+    expect(report?.capture?.unconnectedQuanta).toBe(0);
+    expect(report?.capture?.peakAmplitude).toBe(0.2);
     expect(report?.contextState?.stayedRunning).toBe(true);
     expect(summarizeProbe(report!).verdict).toBe("unsupported");
 
@@ -241,12 +268,7 @@ describe("useMicrophoneProbe", () => {
     const probe = withScope(() => useMicrophoneProbe());
     const pending = probe.run();
     await vi.advanceTimersByTimeAsync(0);
-    workletNodes[0].emit({
-      frames: 0,
-      quanta: 0,
-      silentQuanta: 0,
-      contextTime: 0,
-    });
+    workletNodes[0].emit(workletReport({}));
     await vi.advanceTimersByTimeAsync(CAPTURE_SECONDS * 1000);
     await pending;
 
@@ -277,12 +299,7 @@ describe("useMicrophoneProbe", () => {
     await vi.advanceTimersByTimeAsync(0);
 
     browser.context.setState("interrupted");
-    workletNodes[0].emit({
-      frames: 0,
-      quanta: 0,
-      silentQuanta: 0,
-      contextTime: 0,
-    });
+    workletNodes[0].emit(workletReport({}));
     await vi.advanceTimersByTimeAsync(CAPTURE_SECONDS * 1000);
     await pending;
 
@@ -336,6 +353,19 @@ function withScope<T>(factory: () => T): T {
   const value = scope.run(factory)!;
   restores.push(() => scope.stop());
   return value;
+}
+
+/** One worklet report, with the zeroed defaults a run starts from. */
+function workletReport(overrides: Record<string, number>) {
+  return {
+    frames: 0,
+    quanta: 0,
+    silentQuanta: 0,
+    unconnectedQuanta: 0,
+    peak: 0,
+    contextTime: 0,
+    ...overrides,
+  };
 }
 
 function deferred() {
@@ -536,14 +566,17 @@ function captureFixture(
 ): NonNullable<MicrophoneProbeReport["capture"]> {
   return {
     requestedSeconds: CAPTURE_SECONDS,
-    measuredSeconds: CAPTURE_SECONDS,
-    renderSeconds: CAPTURE_SECONDS,
-    framesDelivered: SAMPLE_RATE * CAPTURE_SECONDS,
-    expectedFrames: SAMPLE_RATE * CAPTURE_SECONDS,
-    frameDiscrepancyPpm: 0,
-    silentQuanta: 0,
-    quanta: 11250,
+    measuredSeconds: 20,
+    renderSeconds: 20,
+    framesDelivered: SAMPLE_RATE * 20,
+    expectedFrames: SAMPLE_RATE * 20,
+    discrepancyPpm: 0,
     clockDriftPpm: 0,
+    quanta: 7500,
+    silentQuanta: 0,
+    unconnectedQuanta: 0,
+    peakAmplitude: 0.21,
+    aborted: false,
     error: null,
     ...overrides,
   };

--- a/tests/composables/sendspin-sync/useMicrophoneProbe.test.ts
+++ b/tests/composables/sendspin-sync/useMicrophoneProbe.test.ts
@@ -24,6 +24,28 @@ afterEach(() => {
   vi.useRealTimers();
 });
 
+describe("capture fixtures", () => {
+  // Two passes of review were misled by fixtures encoding readings the worklet
+  // could not emit, so pin them to the invariants it actually holds to.
+  it("describe states the worklet could really produce", () => {
+    const capture = captureFixture({});
+
+    expect(capture.framesDelivered).toBe(capture.measuredQuanta * 128);
+    expect(capture.renderSeconds).toBeCloseTo(
+      capture.framesDelivered / SAMPLE_RATE,
+      9,
+    );
+    expect(capture.expectedFrames).toBe(SAMPLE_RATE * capture.measuredSeconds);
+    expect(capture.totalQuanta).toBeGreaterThanOrEqual(capture.measuredQuanta);
+    expect(capture.discrepancyPpm).toBeCloseTo(
+      ((capture.framesDelivered - capture.expectedFrames) /
+        capture.expectedFrames) *
+        1e6,
+      9,
+    );
+  });
+});
+
 describe("summarizeProbe", () => {
   it("calls an insecure origin blocked rather than a device failure", () => {
     const summary = summarizeProbe(
@@ -80,20 +102,29 @@ describe("summarizeProbe", () => {
     expect(summary.verdict).toBe("degraded");
   });
 
-  it("warns on either drift reading and on a quantum of silence", () => {
-    const frames = summarizeProbe(
+  it("warns on a drifting clock and on a gap in the audio", () => {
+    const drifting = summarizeProbe(
       reportFixture({ capture: captureFixture({ discrepancyPpm: -2500 }) }),
     );
-    const clock = summarizeProbe(
-      reportFixture({ capture: captureFixture({ clockDriftPpm: 4000 }) }),
+    const dropped = summarizeProbe(
+      reportFixture({ capture: captureFixture({ droppedQuanta: 3 }) }),
     );
-    const silent = summarizeProbe(
-      reportFixture({ capture: captureFixture({ silentQuanta: 3 }) }),
+    const unconnected = summarizeProbe(
+      reportFixture({ capture: captureFixture({ unconnectedQuanta: 1 }) }),
     );
 
-    expect(frames.checks.capture).toBe("warn");
-    expect(clock.checks.capture).toBe("warn");
-    expect(silent.checks.capture).toBe("warn");
+    expect(drifting.checks.capture).toBe("warn");
+    expect(dropped.checks.capture).toBe("warn");
+    expect(unconnected.checks.capture).toBe("warn");
+  });
+
+  it("passes a run that only had to wait for the microphone to wake up", () => {
+    const summary = summarizeProbe(
+      reportFixture({ capture: captureFixture({ leadInQuanta: 40 }) }),
+    );
+
+    expect(summary.checks.capture).toBe("pass");
+    expect(summary.verdict).toBe("ready");
   });
 
   it("fails a capture that heard nothing at all", () => {
@@ -113,7 +144,21 @@ describe("summarizeProbe", () => {
     );
 
     expect(summary.checks.capture).toBe("not_evaluated");
-    expect(summary.verdict).toBe("ready");
+  });
+
+  it("blames the browser, not the phone, when the pipeline never opened", () => {
+    const summary = summarizeProbe(
+      reportFixture({
+        capture: {
+          ...captureFixture({}),
+          started: false,
+          error: { name: "AbortError", message: "worklet module failed" },
+        },
+      }),
+    );
+
+    expect(summary.checks.capture).toBe("not_evaluated");
+    expect(summary.verdict).toBe("blocked");
   });
 
   it("warns when the browser took the wake lock back mid-run", () => {
@@ -190,6 +235,7 @@ describe("useMicrophoneProbe", () => {
     });
     // No pipeline ever opened, so this is a browser problem rather than a
     // measurement that came back bad.
+    expect(probe.report.value?.capture?.started).toBe(false);
     const summary = summarizeProbe(probe.report.value!);
     expect(summary.checks.capture).toBe("not_evaluated");
     expect(summary.verdict).toBe("blocked");
@@ -214,17 +260,17 @@ describe("useMicrophoneProbe", () => {
     expect(worklet).toBeDefined();
     worklet.emit(workletReport({}));
 
-    // Twenty wall-clock seconds on, the render clock has advanced only 19.98 —
-    // 1000 ppm slow — and 0.18 s of what it did render arrived as silence, so
-    // the frame count is short by ten times as much.
+    // Twenty wall-clock seconds on, the pipeline has rendered 7485 quanta of
+    // 128 frames — 19.96 s of audio where the system clock expected 20, so it
+    // is running 2000 ppm slow. Sixty-eight of those quanta were silent.
     await vi.advanceTimersByTimeAsync(20_000);
     worklet.emit(
       workletReport({
-        frames: SAMPLE_RATE * 19.8,
-        quanta: 7492,
-        silentQuanta: 68,
+        frames: 7485 * 128,
+        quanta: 7485,
+        droppedQuanta: 68,
         peak: 0.2,
-        contextTime: 19.98,
+        contextTime: (7485 * 128) / SAMPLE_RATE,
       }),
     );
 
@@ -244,11 +290,14 @@ describe("useMicrophoneProbe", () => {
       outputLatency: 0.02,
     });
     expect(report?.capture?.measuredSeconds).toBeCloseTo(20, 3);
-    expect(report?.capture?.renderSeconds).toBeCloseTo(19.98, 6);
-    expect(report?.capture?.discrepancyPpm).toBeCloseTo(-10_000, 3);
-    expect(report?.capture?.clockDriftPpm).toBeCloseTo(-1000, 3);
-    expect(report?.capture?.quanta).toBe(7492);
-    expect(report?.capture?.silentQuanta).toBe(68);
+    expect(report?.capture?.renderSeconds).toBeCloseTo(19.96, 6);
+    expect(report?.capture?.framesDelivered).toBe(7485 * 128);
+    expect(report?.capture?.expectedFrames).toBe(SAMPLE_RATE * 20);
+    expect(report?.capture?.discrepancyPpm).toBeCloseTo(-2000, 6);
+    expect(report?.capture?.measuredQuanta).toBe(7485);
+    expect(report?.capture?.totalQuanta).toBe(7485);
+    expect(report?.capture?.droppedQuanta).toBe(68);
+    expect(report?.capture?.leadInQuanta).toBe(0);
     expect(report?.capture?.unconnectedQuanta).toBe(0);
     expect(report?.capture?.peakAmplitude).toBe(0.2);
     expect(report?.contextState?.stayedRunning).toBe(true);
@@ -360,7 +409,8 @@ function workletReport(overrides: Record<string, number>) {
   return {
     frames: 0,
     quanta: 0,
-    silentQuanta: 0,
+    leadInQuanta: 0,
+    droppedQuanta: 0,
     unconnectedQuanta: 0,
     peak: 0,
     contextTime: 0,
@@ -561,6 +611,10 @@ function constraintsFixture(
   };
 }
 
+/**
+ * A clean twenty-second window: 7500 quanta of 128 frames, which is exactly
+ * what 20 s at 48 kHz should produce.
+ */
 function captureFixture(
   overrides: Partial<NonNullable<MicrophoneProbeReport["capture"]>>,
 ): NonNullable<MicrophoneProbeReport["capture"]> {
@@ -568,14 +622,16 @@ function captureFixture(
     requestedSeconds: CAPTURE_SECONDS,
     measuredSeconds: 20,
     renderSeconds: 20,
+    measuredQuanta: 7500,
     framesDelivered: SAMPLE_RATE * 20,
     expectedFrames: SAMPLE_RATE * 20,
     discrepancyPpm: 0,
-    clockDriftPpm: 0,
-    quanta: 7500,
-    silentQuanta: 0,
+    totalQuanta: 11250,
+    leadInQuanta: 0,
+    droppedQuanta: 0,
     unconnectedQuanta: 0,
     peakAmplitude: 0.21,
+    started: true,
     aborted: false,
     error: null,
     ...overrides,

--- a/tests/composables/sendspin-sync/useMicrophoneProbe.test.ts
+++ b/tests/composables/sendspin-sync/useMicrophoneProbe.test.ts
@@ -2,12 +2,22 @@ import {
   CAPTURE_SECONDS,
   summarizeProbe,
   useMicrophoneProbe,
+  type CaptureCheck,
   type MicrophoneProbeReport,
 } from "@/composables/sendspin-sync/useMicrophoneProbe";
 import { effectScope } from "vue";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const SAMPLE_RATE = 48000;
+const RENDER_QUANTUM = 128;
+
+/** Everything a capture fixture may set; the rest is derived from these. */
+type CaptureOverrides = Partial<
+  Omit<
+    CaptureCheck,
+    "framesDelivered" | "expectedFrames" | "renderSeconds" | "discrepancyPpm"
+  >
+>;
 
 /** Worklet nodes the composable created, newest last. */
 let workletNodes: FakeWorkletNode[] = [];
@@ -26,23 +36,17 @@ afterEach(() => {
 
 describe("capture fixtures", () => {
   // Two passes of review were misled by fixtures encoding readings the worklet
-  // could not emit, so pin them to the invariants it actually holds to.
-  it("describe states the worklet could really produce", () => {
-    const capture = captureFixture({});
+  // could not emit, so the derived fields are pinned to hand-worked numbers.
+  it("derive their readings the way a real capture would", () => {
+    const clean = captureFixture({});
+    expect(clean.framesDelivered).toBe(960_000);
+    expect(clean.renderSeconds).toBe(20);
+    expect(clean.discrepancyPpm).toBe(0);
 
-    expect(capture.framesDelivered).toBe(capture.measuredQuanta * 128);
-    expect(capture.renderSeconds).toBeCloseTo(
-      capture.framesDelivered / SAMPLE_RATE,
-      9,
-    );
-    expect(capture.expectedFrames).toBe(SAMPLE_RATE * capture.measuredSeconds);
-    expect(capture.totalQuanta).toBeGreaterThanOrEqual(capture.measuredQuanta);
-    expect(capture.discrepancyPpm).toBeCloseTo(
-      ((capture.framesDelivered - capture.expectedFrames) /
-        capture.expectedFrames) *
-        1e6,
-      9,
-    );
+    const short = captureFixture({ measuredQuanta: 7481 });
+    expect(short.framesDelivered).toBe(957_568);
+    expect(short.renderSeconds).toBeCloseTo(19.949_333_333, 9);
+    expect(short.discrepancyPpm).toBeCloseTo(-2533.333_333_333, 6);
   });
 });
 
@@ -103,8 +107,9 @@ describe("summarizeProbe", () => {
   });
 
   it("warns on a drifting clock and on a gap in the audio", () => {
+    // 7481 quanta where 20 s at 48 kHz calls for 7500 is a 2533 ppm shortfall.
     const drifting = summarizeProbe(
-      reportFixture({ capture: captureFixture({ discrepancyPpm: -2500 }) }),
+      reportFixture({ capture: captureFixture({ measuredQuanta: 7481 }) }),
     );
     const dropped = summarizeProbe(
       reportFixture({ capture: captureFixture({ droppedQuanta: 3 }) }),
@@ -614,18 +619,19 @@ function constraintsFixture(
 /**
  * A clean twenty-second window: 7500 quanta of 128 frames, which is exactly
  * what 20 s at 48 kHz should produce.
+ *
+ * The four derived fields are computed the way the composable computes them and
+ * cannot be overridden, so no fixture can describe a reading the worklet and
+ * the anchors could not have produced together. Drive them through
+ * `measuredQuanta` or `measuredSeconds` instead.
  */
 function captureFixture(
-  overrides: Partial<NonNullable<MicrophoneProbeReport["capture"]>>,
+  overrides: CaptureOverrides,
 ): NonNullable<MicrophoneProbeReport["capture"]> {
-  return {
+  const base = {
     requestedSeconds: CAPTURE_SECONDS,
     measuredSeconds: 20,
-    renderSeconds: 20,
     measuredQuanta: 7500,
-    framesDelivered: SAMPLE_RATE * 20,
-    expectedFrames: SAMPLE_RATE * 20,
-    discrepancyPpm: 0,
     totalQuanta: 11250,
     leadInQuanta: 0,
     droppedQuanta: 0,
@@ -635,5 +641,14 @@ function captureFixture(
     aborted: false,
     error: null,
     ...overrides,
+  };
+  const framesDelivered = base.measuredQuanta * RENDER_QUANTUM;
+  const expectedFrames = SAMPLE_RATE * base.measuredSeconds;
+  return {
+    ...base,
+    framesDelivered,
+    expectedFrames,
+    renderSeconds: framesDelivered / SAMPLE_RATE,
+    discrepancyPpm: ((framesDelivered - expectedFrames) / expectedFrames) * 1e6,
   };
 }

--- a/tests/composables/sendspin-sync/useMicrophoneProbe.test.ts
+++ b/tests/composables/sendspin-sync/useMicrophoneProbe.test.ts
@@ -1,6 +1,6 @@
 import {
   CAPTURE_SECONDS,
-  summariseProbe,
+  summarizeProbe,
   useMicrophoneProbe,
   type MicrophoneProbeReport,
 } from "@/composables/sendspin-sync/useMicrophoneProbe";
@@ -24,9 +24,9 @@ afterEach(() => {
   vi.useRealTimers();
 });
 
-describe("summariseProbe", () => {
+describe("summarizeProbe", () => {
   it("calls an insecure origin blocked rather than a device failure", () => {
-    const summary = summariseProbe(
+    const summary = summarizeProbe(
       reportFixture({
         secureContext: {
           secure: false,
@@ -49,7 +49,7 @@ describe("summariseProbe", () => {
   });
 
   it("fails the run when the browser kept a voice processor on", () => {
-    const summary = summariseProbe(
+    const summary = summarizeProbe(
       reportFixture({
         constraints: constraintsFixture({
           applied: {
@@ -57,7 +57,7 @@ describe("summariseProbe", () => {
             noiseSuppression: false,
             autoGainControl: false,
           },
-          honoured: false,
+          honored: false,
         }),
       }),
     );
@@ -67,11 +67,11 @@ describe("summariseProbe", () => {
   });
 
   it("only warns when a constraint was never reported back", () => {
-    const summary = summariseProbe(
+    const summary = summarizeProbe(
       reportFixture({
         constraints: constraintsFixture({
           applied: { noiseSuppression: false, autoGainControl: false },
-          honoured: false,
+          honored: false,
         }),
       }),
     );
@@ -80,22 +80,42 @@ describe("summariseProbe", () => {
     expect(summary.verdict).toBe("degraded");
   });
 
-  it("warns on a drifting clock and on skipped quanta", () => {
-    const drifting = summariseProbe(
-      reportFixture({ capture: captureFixture({ discrepancyPpm: -2500 }) }),
-    );
-    const gapped = summariseProbe(
+  it("warns on either drift reading and on a quantum with no input", () => {
+    const frames = summarizeProbe(
       reportFixture({
-        capture: captureFixture({ gapCount: 1, missingFrames: 256 }),
+        capture: captureFixture({ frameDiscrepancyPpm: -2500 }),
+      }),
+    );
+    const clock = summarizeProbe(
+      reportFixture({ capture: captureFixture({ clockDriftPpm: 4000 }) }),
+    );
+    const silent = summarizeProbe(
+      reportFixture({ capture: captureFixture({ silentQuanta: 3 }) }),
+    );
+
+    expect(frames.checks.capture).toBe("warn");
+    expect(clock.checks.capture).toBe("warn");
+    expect(silent.checks.capture).toBe("warn");
+  });
+
+  it("warns when the browser took the wake lock back mid-run", () => {
+    const summary = summarizeProbe(
+      reportFixture({
+        wakeLock: {
+          supported: true,
+          acquired: true,
+          heldToEnd: false,
+          error: null,
+        },
       }),
     );
 
-    expect(drifting.checks.capture).toBe("warn");
-    expect(gapped.checks.capture).toBe("warn");
+    expect(summary.checks.wake_lock).toBe("warn");
+    expect(summary.verdict).toBe("degraded");
   });
 
   it("reports a clean run as ready", () => {
-    const summary = summariseProbe(reportFixture({}));
+    const summary = summarizeProbe(reportFixture({}));
 
     expect(summary.verdict).toBe("ready");
     expect(Object.values(summary.checks)).toEqual(Array(7).fill("pass"));
@@ -126,20 +146,35 @@ describe("useMicrophoneProbe", () => {
     const probe = withScope(() => useMicrophoneProbe());
     await probe.run();
 
-    expect(probe.report.value?.constraints?.error).toBe(
-      "NotAllowedError: Denied",
-    );
+    expect(probe.report.value?.constraints?.error).toEqual({
+      name: "NotAllowedError",
+      message: "Denied",
+    });
     expect(probe.report.value?.capture).toBeNull();
     expect(browser.context.close).toHaveBeenCalled();
-    expect(browser.track.stop).toHaveBeenCalledTimes(0);
+    expect(browser.track.stop).not.toHaveBeenCalled();
 
     // A refusal is a permission problem, not a verdict on the microphone.
-    const summary = summariseProbe(probe.report.value!);
+    const summary = summarizeProbe(probe.report.value!);
     expect(summary.verdict).toBe("blocked");
     expect(summary.checks.voice_processing).toBe("not_evaluated");
   });
 
-  it("reports the applied constraints and the measured frame drift", async () => {
+  it("reports a refused audio context instead of throwing at the click", async () => {
+    stubBrowser({ audioContextThrows: true });
+
+    const probe = withScope(() => useMicrophoneProbe());
+    await expect(probe.run()).resolves.toBeUndefined();
+
+    expect(probe.report.value?.capture?.error).toEqual({
+      name: "Error",
+      message: "Too many contexts",
+    });
+    expect(summarizeProbe(probe.report.value!).checks.capture).toBe("fail");
+    expect(probe.running.value).toBe(false);
+  });
+
+  it("reports the applied constraints and both drift readings", async () => {
     vi.useFakeTimers();
     const browser = stubBrowser({
       settings: {
@@ -155,15 +190,17 @@ describe("useMicrophoneProbe", () => {
 
     const worklet = workletNodes[0];
     expect(worklet).toBeDefined();
-    worklet.emit({ frames: 0, quanta: 0, contextTime: 0, gaps: [] });
+    worklet.emit({ frames: 0, quanta: 0, silentQuanta: 0, contextTime: 0 });
 
-    // Two thirds of the way in, the audio clock is 1000 ppm ahead.
+    // Two thirds of the way in, the audio thread has delivered 1000 ppm more
+    // frames than its own clock accounts for, and that clock in turn has
+    // fallen 1000 ppm behind the wall clock.
     await vi.advanceTimersByTimeAsync(20_000);
     worklet.emit({
-      frames: SAMPLE_RATE * 20 + SAMPLE_RATE * 20 * 1e-3,
-      quanta: 7500,
-      contextTime: 20,
-      gaps: [{ atFrame: 480_000, missingFrames: 256 }],
+      frames: SAMPLE_RATE * 19.98 * (1 + 1e-3),
+      quanta: 7492,
+      silentQuanta: 0,
+      contextTime: 19.98,
     });
 
     await vi.advanceTimersByTimeAsync(CAPTURE_SECONDS * 1000 - 20_000);
@@ -175,24 +212,60 @@ describe("useMicrophoneProbe", () => {
       noiseSuppression: false,
       autoGainControl: true,
     });
-    expect(report?.constraints?.honoured).toBe(false);
+    expect(report?.constraints?.honored).toBe(false);
     expect(report?.audioContext).toEqual({
       sampleRate: SAMPLE_RATE,
       baseLatency: 0.005,
       outputLatency: 0.02,
     });
     expect(report?.capture?.measuredSeconds).toBeCloseTo(20, 3);
-    expect(report?.capture?.discrepancyPpm).toBeCloseTo(1000, 3);
-    expect(report?.capture?.gapCount).toBe(1);
-    expect(report?.capture?.missingFrames).toBe(256);
+    expect(report?.capture?.renderSeconds).toBeCloseTo(19.98, 6);
+    expect(report?.capture?.frameDiscrepancyPpm).toBeCloseTo(1000, 3);
+    expect(report?.capture?.clockDriftPpm).toBeCloseTo(-1000, 3);
+    expect(report?.capture?.quanta).toBe(7492);
+    expect(report?.capture?.silentQuanta).toBe(0);
     expect(report?.contextState?.stayedRunning).toBe(true);
-    expect(summariseProbe(report!).verdict).toBe("unsupported");
+    expect(summarizeProbe(report!).verdict).toBe("unsupported");
 
     // The microphone must never outlive the run.
     expect(browser.track.stop).toHaveBeenCalledOnce();
     expect(browser.context.close).toHaveBeenCalledOnce();
     expect(browser.wakeLockSentinel.release).toHaveBeenCalledOnce();
     expect(probe.running.value).toBe(false);
+  });
+
+  it("does not read its own wake lock release as the browser's", async () => {
+    vi.useFakeTimers();
+    const browser = stubBrowser({});
+
+    const probe = withScope(() => useMicrophoneProbe());
+    const pending = probe.run();
+    await vi.advanceTimersByTimeAsync(0);
+    workletNodes[0].emit({
+      frames: 0,
+      quanta: 0,
+      silentQuanta: 0,
+      contextTime: 0,
+    });
+    await vi.advanceTimersByTimeAsync(CAPTURE_SECONDS * 1000);
+    await pending;
+
+    expect(browser.wakeLockSentinel.release).toHaveBeenCalledOnce();
+    expect(probe.report.value?.wakeLock?.heldToEnd).toBe(true);
+  });
+
+  it("records a wake lock the browser took back during the capture", async () => {
+    vi.useFakeTimers();
+    const browser = stubBrowser({});
+
+    const probe = withScope(() => useMicrophoneProbe());
+    const pending = probe.run();
+    await vi.advanceTimersByTimeAsync(0);
+    browser.wakeLockSentinel.dispatchEvent(new Event("release"));
+    await vi.advanceTimersByTimeAsync(CAPTURE_SECONDS * 1000);
+    await pending;
+
+    expect(probe.report.value?.wakeLock?.heldToEnd).toBe(false);
   });
 
   it("flags an audio context that left the running state", async () => {
@@ -203,15 +276,21 @@ describe("useMicrophoneProbe", () => {
     const pending = probe.run();
     await vi.advanceTimersByTimeAsync(0);
 
-    browser.context.setState("interrupted" as AudioContextState);
-    workletNodes[0].emit({ frames: 0, quanta: 0, contextTime: 0, gaps: [] });
+    browser.context.setState("interrupted");
+    workletNodes[0].emit({
+      frames: 0,
+      quanta: 0,
+      silentQuanta: 0,
+      contextTime: 0,
+    });
     await vi.advanceTimersByTimeAsync(CAPTURE_SECONDS * 1000);
     await pending;
 
     expect(probe.report.value?.contextState?.stayedRunning).toBe(false);
-    expect(probe.report.value?.capture?.error).toBe(
-      "The worklet delivered no measurable frames",
-    );
+    expect(probe.report.value?.capture?.error).toEqual({
+      name: "NoFramesError",
+      message: "The worklet delivered no measurable frames",
+    });
   });
 
   it("releases the microphone when the view goes away mid-capture", async () => {
@@ -229,6 +308,26 @@ describe("useMicrophoneProbe", () => {
     expect(browser.context.close).toHaveBeenCalledOnce();
     expect(probe.running.value).toBe(false);
   });
+
+  it("releases the microphone when the view goes away while the worklet loads", async () => {
+    vi.useFakeTimers();
+    const module = deferred();
+    const browser = stubBrowser({ addModule: () => module.promise });
+    const scope = effectScope();
+    const probe = scope.run(() => useMicrophoneProbe())!;
+
+    const pending = probe.run();
+    await vi.advanceTimersByTimeAsync(0);
+    // Aborting here leaves nothing listening for the abort event yet.
+    scope.stop();
+    module.resolve();
+    await pending;
+
+    expect(browser.track.stop).toHaveBeenCalledOnce();
+    expect(browser.context.close).toHaveBeenCalledOnce();
+    expect(browser.wakeLockSentinel.release).toHaveBeenCalledOnce();
+    expect(probe.running.value).toBe(false);
+  });
 });
 
 /** Runs a composable inside a scope the test tears down for it. */
@@ -239,11 +338,21 @@ function withScope<T>(factory: () => T): T {
   return value;
 }
 
+function deferred() {
+  let resolve!: () => void;
+  const promise = new Promise<void>((settle) => {
+    resolve = settle;
+  });
+  return { promise, resolve };
+}
+
 interface BrowserStubOptions {
   secure?: boolean;
   mediaDevices?: boolean;
   getUserMedia?: () => Promise<MediaStream>;
   settings?: MediaTrackSettings;
+  addModule?: () => Promise<void>;
+  audioContextThrows?: boolean;
 }
 
 /**
@@ -276,10 +385,8 @@ function stubBrowser(options: BrowserStubOptions) {
       autoGainControl: true,
     }),
   };
-  const wakeLockSentinel = { release: vi.fn().mockResolvedValue(undefined) };
-  const wakeLock = {
-    request: vi.fn().mockResolvedValue(wakeLockSentinel),
-  };
+  const wakeLockSentinel = new FakeWakeLockSentinel();
+  const wakeLock = { request: vi.fn().mockResolvedValue(wakeLockSentinel) };
 
   defineOn(
     navigator,
@@ -290,10 +397,13 @@ function stubBrowser(options: BrowserStubOptions) {
   vi.stubGlobal("isSecureContext", options.secure ?? true);
 
   const context = new FakeAudioContext();
+  if (options.addModule)
+    context.audioWorklet.addModule = vi.fn(options.addModule);
   vi.stubGlobal(
     "AudioContext",
     class {
       constructor() {
+        if (options.audioContextThrows) throw new Error("Too many contexts");
         return context;
       }
     },
@@ -315,6 +425,10 @@ function defineOn(host: object, key: string, value: unknown): void {
     if (original) Object.defineProperty(host, key, original);
     else Reflect.deleteProperty(host, key);
   });
+}
+
+class FakeWakeLockSentinel extends EventTarget {
+  release = vi.fn().mockResolvedValue(undefined);
 }
 
 class FakeWorkletNode {
@@ -339,7 +453,7 @@ class FakeAudioContext extends EventTarget {
   baseLatency = 0.005;
   outputLatency = 0.02;
   currentTime = 0;
-  state: AudioContextState = "suspended";
+  state = "suspended";
   destination = {};
   audioWorklet = { addModule: vi.fn().mockResolvedValue(undefined) };
   resume = vi.fn(async () => {
@@ -358,7 +472,7 @@ class FakeAudioContext extends EventTarget {
     disconnect: vi.fn(),
   }));
 
-  setState(state: AudioContextState): void {
+  setState(state: string): void {
     this.state = state;
     this.dispatchEvent(new Event("statechange"));
   }
@@ -384,7 +498,7 @@ function reportFixture(
       outputLatency: 0.02,
     },
     capture: captureFixture({}),
-    wakeLock: { supported: true, acquired: true, error: null },
+    wakeLock: { supported: true, acquired: true, heldToEnd: true, error: null },
     contextState: { stayedRunning: true, transitions: [] },
     ...overrides,
   };
@@ -409,7 +523,7 @@ function constraintsFixture(
       noiseSuppression: true,
       autoGainControl: true,
     },
-    honoured: true,
+    honored: true,
     trackSettings: {},
     trackLabel: "Fake microphone",
     error: null,
@@ -423,12 +537,13 @@ function captureFixture(
   return {
     requestedSeconds: CAPTURE_SECONDS,
     measuredSeconds: CAPTURE_SECONDS,
+    renderSeconds: CAPTURE_SECONDS,
     framesDelivered: SAMPLE_RATE * CAPTURE_SECONDS,
     expectedFrames: SAMPLE_RATE * CAPTURE_SECONDS,
-    discrepancyPpm: 0,
+    frameDiscrepancyPpm: 0,
+    silentQuanta: 0,
     quanta: 11250,
-    gapCount: 0,
-    missingFrames: 0,
+    clockDriftPpm: 0,
     error: null,
     ...overrides,
   };

--- a/tests/composables/sendspin-sync/useMicrophoneProbe.test.ts
+++ b/tests/composables/sendspin-sync/useMicrophoneProbe.test.ts
@@ -1,0 +1,435 @@
+import {
+  CAPTURE_SECONDS,
+  summariseProbe,
+  useMicrophoneProbe,
+  type MicrophoneProbeReport,
+} from "@/composables/sendspin-sync/useMicrophoneProbe";
+import { effectScope } from "vue";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const SAMPLE_RATE = 48000;
+
+/** Worklet nodes the composable created, newest last. */
+let workletNodes: FakeWorkletNode[] = [];
+let restores: (() => void)[] = [];
+
+beforeEach(() => {
+  workletNodes = [];
+  restores = [];
+});
+
+afterEach(() => {
+  for (const restore of restores.reverse()) restore();
+  vi.unstubAllGlobals();
+  vi.useRealTimers();
+});
+
+describe("summariseProbe", () => {
+  it("calls an insecure origin blocked rather than a device failure", () => {
+    const summary = summariseProbe(
+      reportFixture({
+        secureContext: {
+          secure: false,
+          origin: "http://ma.local",
+          protocol: "http:",
+        },
+        mediaApi: { mediaDevices: false, getUserMedia: false },
+        constraints: null,
+        audioContext: null,
+        capture: null,
+        wakeLock: null,
+        contextState: null,
+      }),
+    );
+
+    expect(summary.verdict).toBe("blocked");
+    expect(summary.checks.secure_context).toBe("fail");
+    expect(summary.checks.voice_processing).toBe("not_evaluated");
+    expect(summary.checks.wake_lock).toBe("not_evaluated");
+  });
+
+  it("fails the run when the browser kept a voice processor on", () => {
+    const summary = summariseProbe(
+      reportFixture({
+        constraints: constraintsFixture({
+          applied: {
+            echoCancellation: true,
+            noiseSuppression: false,
+            autoGainControl: false,
+          },
+          honoured: false,
+        }),
+      }),
+    );
+
+    expect(summary.checks.voice_processing).toBe("fail");
+    expect(summary.verdict).toBe("unsupported");
+  });
+
+  it("only warns when a constraint was never reported back", () => {
+    const summary = summariseProbe(
+      reportFixture({
+        constraints: constraintsFixture({
+          applied: { noiseSuppression: false, autoGainControl: false },
+          honoured: false,
+        }),
+      }),
+    );
+
+    expect(summary.checks.voice_processing).toBe("warn");
+    expect(summary.verdict).toBe("degraded");
+  });
+
+  it("warns on a drifting clock and on skipped quanta", () => {
+    const drifting = summariseProbe(
+      reportFixture({ capture: captureFixture({ discrepancyPpm: -2500 }) }),
+    );
+    const gapped = summariseProbe(
+      reportFixture({
+        capture: captureFixture({ gapCount: 1, missingFrames: 256 }),
+      }),
+    );
+
+    expect(drifting.checks.capture).toBe("warn");
+    expect(gapped.checks.capture).toBe("warn");
+  });
+
+  it("reports a clean run as ready", () => {
+    const summary = summariseProbe(reportFixture({}));
+
+    expect(summary.verdict).toBe("ready");
+    expect(Object.values(summary.checks)).toEqual(Array(7).fill("pass"));
+  });
+});
+
+describe("useMicrophoneProbe", () => {
+  it("records the origin and stops when the browser has no capture API", async () => {
+    stubBrowser({ secure: false, mediaDevices: false });
+
+    const probe = withScope(() => useMicrophoneProbe());
+    await probe.run();
+
+    expect(probe.report.value?.secureContext.secure).toBe(false);
+    expect(probe.report.value?.mediaApi.getUserMedia).toBe(false);
+    expect(probe.report.value?.constraints).toBeNull();
+    expect(probe.report.value?.wakeLock).toBeNull();
+    expect(probe.running.value).toBe(false);
+  });
+
+  it("keeps the DOMException name when the microphone is refused", async () => {
+    const browser = stubBrowser({
+      getUserMedia: vi
+        .fn()
+        .mockRejectedValue(new DOMException("Denied", "NotAllowedError")),
+    });
+
+    const probe = withScope(() => useMicrophoneProbe());
+    await probe.run();
+
+    expect(probe.report.value?.constraints?.error).toBe(
+      "NotAllowedError: Denied",
+    );
+    expect(probe.report.value?.capture).toBeNull();
+    expect(browser.context.close).toHaveBeenCalled();
+    expect(browser.track.stop).toHaveBeenCalledTimes(0);
+
+    // A refusal is a permission problem, not a verdict on the microphone.
+    const summary = summariseProbe(probe.report.value!);
+    expect(summary.verdict).toBe("blocked");
+    expect(summary.checks.voice_processing).toBe("not_evaluated");
+  });
+
+  it("reports the applied constraints and the measured frame drift", async () => {
+    vi.useFakeTimers();
+    const browser = stubBrowser({
+      settings: {
+        echoCancellation: false,
+        noiseSuppression: false,
+        autoGainControl: true,
+      },
+    });
+
+    const probe = withScope(() => useMicrophoneProbe());
+    const pending = probe.run();
+    await vi.advanceTimersByTimeAsync(0);
+
+    const worklet = workletNodes[0];
+    expect(worklet).toBeDefined();
+    worklet.emit({ frames: 0, quanta: 0, contextTime: 0, gaps: [] });
+
+    // Two thirds of the way in, the audio clock is 1000 ppm ahead.
+    await vi.advanceTimersByTimeAsync(20_000);
+    worklet.emit({
+      frames: SAMPLE_RATE * 20 + SAMPLE_RATE * 20 * 1e-3,
+      quanta: 7500,
+      contextTime: 20,
+      gaps: [{ atFrame: 480_000, missingFrames: 256 }],
+    });
+
+    await vi.advanceTimersByTimeAsync(CAPTURE_SECONDS * 1000 - 20_000);
+    await pending;
+
+    const report = probe.report.value;
+    expect(report?.constraints?.applied).toEqual({
+      echoCancellation: false,
+      noiseSuppression: false,
+      autoGainControl: true,
+    });
+    expect(report?.constraints?.honoured).toBe(false);
+    expect(report?.audioContext).toEqual({
+      sampleRate: SAMPLE_RATE,
+      baseLatency: 0.005,
+      outputLatency: 0.02,
+    });
+    expect(report?.capture?.measuredSeconds).toBeCloseTo(20, 3);
+    expect(report?.capture?.discrepancyPpm).toBeCloseTo(1000, 3);
+    expect(report?.capture?.gapCount).toBe(1);
+    expect(report?.capture?.missingFrames).toBe(256);
+    expect(report?.contextState?.stayedRunning).toBe(true);
+    expect(summariseProbe(report!).verdict).toBe("unsupported");
+
+    // The microphone must never outlive the run.
+    expect(browser.track.stop).toHaveBeenCalledOnce();
+    expect(browser.context.close).toHaveBeenCalledOnce();
+    expect(browser.wakeLockSentinel.release).toHaveBeenCalledOnce();
+    expect(probe.running.value).toBe(false);
+  });
+
+  it("flags an audio context that left the running state", async () => {
+    vi.useFakeTimers();
+    const browser = stubBrowser({});
+
+    const probe = withScope(() => useMicrophoneProbe());
+    const pending = probe.run();
+    await vi.advanceTimersByTimeAsync(0);
+
+    browser.context.setState("interrupted" as AudioContextState);
+    workletNodes[0].emit({ frames: 0, quanta: 0, contextTime: 0, gaps: [] });
+    await vi.advanceTimersByTimeAsync(CAPTURE_SECONDS * 1000);
+    await pending;
+
+    expect(probe.report.value?.contextState?.stayedRunning).toBe(false);
+    expect(probe.report.value?.capture?.error).toBe(
+      "The worklet delivered no measurable frames",
+    );
+  });
+
+  it("releases the microphone when the view goes away mid-capture", async () => {
+    vi.useFakeTimers();
+    const browser = stubBrowser({});
+    const scope = effectScope();
+    const probe = scope.run(() => useMicrophoneProbe())!;
+
+    const pending = probe.run();
+    await vi.advanceTimersByTimeAsync(1000);
+    scope.stop();
+    await pending;
+
+    expect(browser.track.stop).toHaveBeenCalledOnce();
+    expect(browser.context.close).toHaveBeenCalledOnce();
+    expect(probe.running.value).toBe(false);
+  });
+});
+
+/** Runs a composable inside a scope the test tears down for it. */
+function withScope<T>(factory: () => T): T {
+  const scope = effectScope();
+  const value = scope.run(factory)!;
+  restores.push(() => scope.stop());
+  return value;
+}
+
+interface BrowserStubOptions {
+  secure?: boolean;
+  mediaDevices?: boolean;
+  getUserMedia?: () => Promise<MediaStream>;
+  settings?: MediaTrackSettings;
+}
+
+/**
+ * Stands in for the browser surfaces the probe touches.
+ *
+ * happy-dom has no Web Audio, so every node is a spy and the worklet is driven
+ * by the test rather than by an audio thread.
+ */
+function stubBrowser(options: BrowserStubOptions) {
+  const track = {
+    label: "Fake microphone",
+    getSettings: () =>
+      options.settings ?? {
+        echoCancellation: false,
+        noiseSuppression: false,
+        autoGainControl: false,
+      },
+    stop: vi.fn(),
+  };
+  const stream = {
+    getAudioTracks: () => [track],
+    getTracks: () => [track],
+  } as unknown as MediaStream;
+
+  const mediaDevices = {
+    getUserMedia: options.getUserMedia ?? vi.fn().mockResolvedValue(stream),
+    getSupportedConstraints: () => ({
+      echoCancellation: true,
+      noiseSuppression: true,
+      autoGainControl: true,
+    }),
+  };
+  const wakeLockSentinel = { release: vi.fn().mockResolvedValue(undefined) };
+  const wakeLock = {
+    request: vi.fn().mockResolvedValue(wakeLockSentinel),
+  };
+
+  defineOn(
+    navigator,
+    "mediaDevices",
+    options.mediaDevices === false ? undefined : mediaDevices,
+  );
+  defineOn(navigator, "wakeLock", wakeLock);
+  vi.stubGlobal("isSecureContext", options.secure ?? true);
+
+  const context = new FakeAudioContext();
+  vi.stubGlobal(
+    "AudioContext",
+    class {
+      constructor() {
+        return context;
+      }
+    },
+  );
+  vi.stubGlobal("AudioWorkletNode", FakeWorkletNode);
+
+  return { track, stream, mediaDevices, wakeLock, wakeLockSentinel, context };
+}
+
+/** Replaces a host-object property and queues its restore. */
+function defineOn(host: object, key: string, value: unknown): void {
+  const original = Object.getOwnPropertyDescriptor(host, key);
+  Object.defineProperty(host, key, {
+    configurable: true,
+    value,
+    writable: true,
+  });
+  restores.push(() => {
+    if (original) Object.defineProperty(host, key, original);
+    else Reflect.deleteProperty(host, key);
+  });
+}
+
+class FakeWorkletNode {
+  port = {
+    onmessage: null as ((event: MessageEvent) => void) | null,
+    close: vi.fn(),
+  };
+  connect = vi.fn((destination: unknown) => destination);
+  disconnect = vi.fn();
+
+  constructor() {
+    workletNodes.push(this);
+  }
+
+  emit(data: unknown): void {
+    this.port.onmessage?.({ data } as MessageEvent);
+  }
+}
+
+class FakeAudioContext extends EventTarget {
+  sampleRate = SAMPLE_RATE;
+  baseLatency = 0.005;
+  outputLatency = 0.02;
+  currentTime = 0;
+  state: AudioContextState = "suspended";
+  destination = {};
+  audioWorklet = { addModule: vi.fn().mockResolvedValue(undefined) };
+  resume = vi.fn(async () => {
+    this.setState("running");
+  });
+  close = vi.fn(async () => {
+    this.setState("closed");
+  });
+  createMediaStreamSource = vi.fn(() => ({
+    connect: vi.fn((destination: unknown) => destination),
+    disconnect: vi.fn(),
+  }));
+  createGain = vi.fn(() => ({
+    gain: { value: 1 },
+    connect: vi.fn((destination: unknown) => destination),
+    disconnect: vi.fn(),
+  }));
+
+  setState(state: AudioContextState): void {
+    this.state = state;
+    this.dispatchEvent(new Event("statechange"));
+  }
+}
+
+function reportFixture(
+  overrides: Partial<MicrophoneProbeReport>,
+): MicrophoneProbeReport {
+  return {
+    version: 1,
+    startedAt: "2026-01-01T00:00:00.000Z",
+    userAgent: "test",
+    secureContext: {
+      secure: true,
+      origin: "https://ma.local",
+      protocol: "https:",
+    },
+    mediaApi: { mediaDevices: true, getUserMedia: true },
+    constraints: constraintsFixture({}),
+    audioContext: {
+      sampleRate: SAMPLE_RATE,
+      baseLatency: 0.005,
+      outputLatency: 0.02,
+    },
+    capture: captureFixture({}),
+    wakeLock: { supported: true, acquired: true, error: null },
+    contextState: { stayedRunning: true, transitions: [] },
+    ...overrides,
+  };
+}
+
+function constraintsFixture(
+  overrides: Partial<NonNullable<MicrophoneProbeReport["constraints"]>>,
+): NonNullable<MicrophoneProbeReport["constraints"]> {
+  return {
+    requested: {
+      echoCancellation: false,
+      noiseSuppression: false,
+      autoGainControl: false,
+    },
+    applied: {
+      echoCancellation: false,
+      noiseSuppression: false,
+      autoGainControl: false,
+    },
+    supported: {
+      echoCancellation: true,
+      noiseSuppression: true,
+      autoGainControl: true,
+    },
+    honoured: true,
+    trackSettings: {},
+    trackLabel: "Fake microphone",
+    error: null,
+    ...overrides,
+  };
+}
+
+function captureFixture(
+  overrides: Partial<NonNullable<MicrophoneProbeReport["capture"]>>,
+): NonNullable<MicrophoneProbeReport["capture"]> {
+  return {
+    requestedSeconds: CAPTURE_SECONDS,
+    measuredSeconds: CAPTURE_SECONDS,
+    framesDelivered: SAMPLE_RATE * CAPTURE_SECONDS,
+    expectedFrames: SAMPLE_RATE * CAPTURE_SECONDS,
+    discrepancyPpm: 0,
+    quanta: 11250,
+    gapCount: 0,
+    missingFrames: 0,
+    error: null,
+    ...overrides,
+  };
+}

--- a/tests/plugins/router.test.ts
+++ b/tests/plugins/router.test.ts
@@ -84,6 +84,7 @@ vi.mock("vue-router", async () => {
 
 const partyGuard = beforeEnterGuard("party");
 const aiRadioGuard = beforeEnterGuard("ai-radio");
+const sendspinSyncGuard = beforeEnterGuard("sendspin-sync");
 const globalGuard = globalNavigationGuard();
 
 beforeEach(() => {
@@ -249,6 +250,44 @@ describe("AI Radio guard", () => {
     await expect(pending.result).resolves.toEqual({ name: "discover" });
     expect(mocks.toastError).toHaveBeenCalledWith(
       "providers.ai_radio.toast.unavailable",
+    );
+  });
+});
+
+describe("Sendspin Sync guard", () => {
+  it("redirects to Discover with a toast when the plugin is disabled", async () => {
+    await expect(
+      invokeGuard(sendspinSyncGuard, resolveRoute("/sendspin-sync")),
+    ).resolves.toEqual({ name: "discover" });
+    expect(mocks.toastError).toHaveBeenCalledWith(
+      "providers.sendspin_sync.toast.unavailable",
+    );
+  });
+
+  it("allows Sendspin Sync when the plugin is enabled", async () => {
+    mocks.store.enabledPlugins = new Set(["sendspin_sync"]);
+
+    await expect(
+      invokeGuard(sendspinSyncGuard, resolveRoute("/sendspin-sync")),
+    ).resolves.toBeUndefined();
+    expect(mocks.toastError).not.toHaveBeenCalled();
+  });
+
+  it("stops waiting for the server connection after ten seconds", async () => {
+    vi.useFakeTimers();
+    mocks.apiState.value = ConnectionState.AUTHENTICATED;
+    const pending = trackGuard(
+      invokeGuard(sendspinSyncGuard, resolveRoute("/sendspin-sync")),
+    );
+
+    await vi.advanceTimersByTimeAsync(9999);
+    expect(pending.isSettled()).toBe(false);
+
+    await vi.advanceTimersByTimeAsync(1);
+
+    await expect(pending.result).resolves.toEqual({ name: "discover" });
+    expect(mocks.toastError).toHaveBeenCalledWith(
+      "providers.sendspin_sync.toast.unavailable",
     );
   });
 });

--- a/tests/views/SendspinSyncView.test.ts
+++ b/tests/views/SendspinSyncView.test.ts
@@ -94,9 +94,7 @@ describe("SendspinSyncView", () => {
     expect(wrapper.text()).toContain("5.00 ms");
     // The device's own rate is worth seeing next to the context's.
     expect(wrapper.text()).toContain("44100 Hz");
-    // Both drift readings are shown, and neither is folded into the other.
-    expect(wrapper.text()).toContain("-12.0 ppm");
-    expect(wrapper.text()).toContain("31.0 ppm");
+    expect(wrapper.text()).toContain("-133.3 ppm");
     // A constraint the browser stayed silent on must not read as "off".
     expect(wrapper.text()).toContain(
       "providers.sendspin_sync.probe.values.not_reported",
@@ -197,6 +195,26 @@ describe("SendspinSyncView", () => {
   });
 });
 
+describe("SendspinSyncView fixture", () => {
+  // The rendered numbers are only meaningful if they are numbers the worklet
+  // and the composable could actually have produced together.
+  it("describes a capture the worklet could really produce", () => {
+    const capture = degradedReport().capture!;
+
+    expect(capture.framesDelivered).toBe(capture.measuredQuanta * 128);
+    expect(capture.renderSeconds).toBeCloseTo(
+      capture.framesDelivered / SAMPLE_RATE,
+      9,
+    );
+    expect(capture.discrepancyPpm).toBeCloseTo(
+      ((capture.framesDelivered - capture.expectedFrames) /
+        capture.expectedFrames) *
+        1e6,
+      9,
+    );
+  });
+});
+
 describe("SendspinSyncView translation keys", () => {
   // Keys are composed from check ids, statuses and verdict names, so a rename
   // would otherwise only surface as a missing string at runtime on a phone.
@@ -226,7 +244,7 @@ describe("SendspinSyncView translation keys", () => {
       "no_api",
       "refused",
       "no_device",
-      "no_audio_context",
+      "no_audio_pipeline",
     ].flatMap((reason) => [
       `${base}.blocked.${reason}.title`,
       `${base}.blocked.${reason}.description`,
@@ -298,18 +316,22 @@ function degradedReport(): MicrophoneProbeReport {
       baseLatency: 0.005,
       outputLatency: 0.02,
     },
+    // 7499 quanta of 128 frames is 19.99733 s of audio where the system clock
+    // expected 20, so the pipeline ran 133 ppm slow.
     capture: {
       requestedSeconds: 30,
       measuredSeconds: 20,
-      renderSeconds: 19.99976,
-      framesDelivered: 959988,
-      expectedFrames: 960000,
-      discrepancyPpm: -12,
-      clockDriftPpm: 31,
-      quanta: 7499,
-      silentQuanta: 0,
+      renderSeconds: (7499 * 128) / SAMPLE_RATE,
+      measuredQuanta: 7499,
+      framesDelivered: 7499 * 128,
+      expectedFrames: SAMPLE_RATE * 20,
+      discrepancyPpm: -133.33333333333334,
+      totalQuanta: 11250,
+      leadInQuanta: 9,
+      droppedQuanta: 0,
       unconnectedQuanta: 0,
       peakAmplitude: 0.1875,
+      started: true,
       aborted: false,
       error: null,
     },

--- a/tests/views/SendspinSyncView.test.ts
+++ b/tests/views/SendspinSyncView.test.ts
@@ -1,0 +1,194 @@
+import type { MicrophoneProbeReport } from "@/composables/sendspin-sync/useMicrophoneProbe";
+import SendspinSyncView from "@/views/SendspinSyncView.vue";
+import { mount } from "@vue/test-utils";
+import type { Ref } from "vue";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const SAMPLE_RATE = 48000;
+
+const mocks = vi.hoisted(() => ({
+  copyToClipboard: vi.fn().mockResolvedValue(true),
+  toastSuccess: vi.fn(),
+  toastError: vi.fn(),
+  // The composable mock builds the refs, so the view and the test share them.
+  running: undefined as unknown as Ref<boolean>,
+  report: undefined as unknown as Ref<MicrophoneProbeReport | null>,
+}));
+
+vi.mock("@/composables/sendspin-sync/useMicrophoneProbe", async () => {
+  const actual = await vi.importActual<
+    typeof import("@/composables/sendspin-sync/useMicrophoneProbe")
+  >("@/composables/sendspin-sync/useMicrophoneProbe");
+  const { computed, ref } = await vi.importActual<typeof import("vue")>("vue");
+  mocks.running = ref(false);
+  mocks.report = ref<MicrophoneProbeReport | null>(null);
+  const stub = {
+    running: mocks.running,
+    report: mocks.report,
+    reportJson: computed(() =>
+      mocks.report.value ? JSON.stringify(mocks.report.value, null, 2) : "",
+    ),
+    captureProgress: ref(0),
+    captureRemainingSeconds: ref(30),
+    run: vi.fn(),
+  };
+  return { ...actual, useMicrophoneProbe: () => stub };
+});
+
+vi.mock("@/helpers/utils", () => ({
+  copyToClipboard: mocks.copyToClipboard,
+}));
+
+vi.mock("vue-sonner", () => ({
+  toast: { success: mocks.toastSuccess, error: mocks.toastError },
+}));
+
+vi.mock("@/plugins/i18n", () => ({ $t: (key: string) => key }));
+
+beforeEach(() => {
+  mocks.copyToClipboard.mockClear();
+  mocks.toastSuccess.mockClear();
+  mocks.toastError.mockClear();
+  mocks.running.value = false;
+  mocks.report.value = null;
+});
+
+function mountView() {
+  return mount(SendspinSyncView, {
+    global: { mocks: { $t: (key: string) => key } },
+  });
+}
+
+describe("SendspinSyncView", () => {
+  it("offers the check without claiming a result yet", () => {
+    const wrapper = mountView();
+
+    expect(wrapper.text()).toContain(
+      "providers.sendspin_sync.probe.idle.title",
+    );
+    expect(wrapper.text()).toContain("providers.sendspin_sync.probe.start");
+    expect(wrapper.findAll("li")).toHaveLength(0);
+  });
+
+  it("shows every check with its reading once a report lands", async () => {
+    mocks.report.value = readyReport();
+    const wrapper = mountView();
+    await wrapper.vm.$nextTick();
+
+    const rows = wrapper.findAll("li");
+    expect(rows).toHaveLength(7);
+    expect(rows[0].text()).toContain(
+      "providers.sendspin_sync.probe.checks.secure_context.title",
+    );
+    expect(wrapper.text()).toContain(
+      "providers.sendspin_sync.probe.status.pass",
+    );
+    expect(wrapper.text()).toContain(`${SAMPLE_RATE} Hz`);
+    expect(wrapper.text()).toContain("5.00 ms");
+    expect(wrapper.text()).toContain("-12.0 ppm");
+    // A constraint the browser stayed silent on must not read as "off".
+    expect(wrapper.text()).toContain(
+      "providers.sendspin_sync.probe.values.not_reported",
+    );
+    expect(wrapper.text()).toContain(
+      "providers.sendspin_sync.probe.verdict.degraded.title",
+    );
+  });
+
+  it("copies the untranslated report as JSON", async () => {
+    mocks.report.value = readyReport();
+    const wrapper = mountView();
+    await wrapper.vm.$nextTick();
+
+    const copyButton = wrapper
+      .findAll("button")
+      .find((button) =>
+        button.text().includes("providers.sendspin_sync.probe.copy"),
+      );
+    await copyButton!.trigger("click");
+    await wrapper.vm.$nextTick();
+
+    const [payload] = mocks.copyToClipboard.mock.calls[0];
+    expect(JSON.parse(payload)).toEqual(readyReport());
+    expect(mocks.toastSuccess).toHaveBeenCalledWith(
+      "providers.sendspin_sync.probe.copied",
+    );
+  });
+
+  it("explains an insecure origin instead of blaming the phone", async () => {
+    mocks.report.value = {
+      ...readyReport(),
+      secureContext: {
+        secure: false,
+        origin: "http://ma.local:8095",
+        protocol: "http:",
+      },
+      mediaApi: { mediaDevices: false, getUserMedia: false },
+      constraints: null,
+      audioContext: null,
+      capture: null,
+      wakeLock: null,
+      contextState: null,
+    };
+    const wrapper = mountView();
+    await wrapper.vm.$nextTick();
+
+    expect(wrapper.text()).toContain(
+      "providers.sendspin_sync.probe.blocked.insecure.title",
+    );
+    expect(wrapper.text()).toContain("http://ma.local:8095");
+    expect(wrapper.text()).toContain(
+      "providers.sendspin_sync.probe.status.not_evaluated",
+    );
+  });
+});
+
+/** A run that measured everything but never heard back on autoGainControl. */
+function readyReport(): MicrophoneProbeReport {
+  return {
+    version: 1,
+    startedAt: "2026-01-01T00:00:00.000Z",
+    userAgent: "test",
+    secureContext: {
+      secure: true,
+      origin: "https://ma.local",
+      protocol: "https:",
+    },
+    mediaApi: { mediaDevices: true, getUserMedia: true },
+    constraints: {
+      requested: {
+        echoCancellation: false,
+        noiseSuppression: false,
+        autoGainControl: false,
+      },
+      applied: { echoCancellation: false, noiseSuppression: false },
+      supported: {
+        echoCancellation: true,
+        noiseSuppression: true,
+        autoGainControl: true,
+      },
+      honoured: false,
+      trackSettings: {},
+      trackLabel: "Fake microphone",
+      error: null,
+    },
+    audioContext: {
+      sampleRate: SAMPLE_RATE,
+      baseLatency: 0.005,
+      outputLatency: 0.02,
+    },
+    capture: {
+      requestedSeconds: 30,
+      measuredSeconds: 30,
+      framesDelivered: 1439982,
+      expectedFrames: 1440000,
+      discrepancyPpm: -12,
+      quanta: 11250,
+      gapCount: 0,
+      missingFrames: 0,
+      error: null,
+    },
+    wakeLock: { supported: true, acquired: true, error: null },
+    contextState: { stayedRunning: true, transitions: [] },
+  };
+}

--- a/tests/views/SendspinSyncView.test.ts
+++ b/tests/views/SendspinSyncView.test.ts
@@ -1,6 +1,13 @@
-import type { MicrophoneProbeReport } from "@/composables/sendspin-sync/useMicrophoneProbe";
+import {
+  PROBE_CHECKS,
+  type CheckStatus,
+  type MicrophoneProbeReport,
+  type ProbeVerdict,
+} from "@/composables/sendspin-sync/useMicrophoneProbe";
 import SendspinSyncView from "@/views/SendspinSyncView.vue";
 import { mount } from "@vue/test-utils";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
 import type { Ref } from "vue";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -71,7 +78,7 @@ describe("SendspinSyncView", () => {
   });
 
   it("shows every check with its reading once a report lands", async () => {
-    mocks.report.value = readyReport();
+    mocks.report.value = degradedReport();
     const wrapper = mountView();
     await wrapper.vm.$nextTick();
 
@@ -85,7 +92,11 @@ describe("SendspinSyncView", () => {
     );
     expect(wrapper.text()).toContain(`${SAMPLE_RATE} Hz`);
     expect(wrapper.text()).toContain("5.00 ms");
+    // The device's own rate is worth seeing next to the context's.
+    expect(wrapper.text()).toContain("44100 Hz");
+    // Both drift readings are shown, and neither is folded into the other.
     expect(wrapper.text()).toContain("-12.0 ppm");
+    expect(wrapper.text()).toContain("31.0 ppm");
     // A constraint the browser stayed silent on must not read as "off".
     expect(wrapper.text()).toContain(
       "providers.sendspin_sync.probe.values.not_reported",
@@ -96,7 +107,7 @@ describe("SendspinSyncView", () => {
   });
 
   it("copies the untranslated report as JSON", async () => {
-    mocks.report.value = readyReport();
+    mocks.report.value = degradedReport();
     const wrapper = mountView();
     await wrapper.vm.$nextTick();
 
@@ -109,7 +120,7 @@ describe("SendspinSyncView", () => {
     await wrapper.vm.$nextTick();
 
     const [payload] = mocks.copyToClipboard.mock.calls[0];
-    expect(JSON.parse(payload)).toEqual(readyReport());
+    expect(JSON.parse(payload)).toEqual(degradedReport());
     expect(mocks.toastSuccess).toHaveBeenCalledWith(
       "providers.sendspin_sync.probe.copied",
     );
@@ -117,7 +128,7 @@ describe("SendspinSyncView", () => {
 
   it("explains an insecure origin instead of blaming the phone", async () => {
     mocks.report.value = {
-      ...readyReport(),
+      ...degradedReport(),
       secureContext: {
         secure: false,
         origin: "http://ma.local:8095",
@@ -141,10 +152,96 @@ describe("SendspinSyncView", () => {
       "providers.sendspin_sync.probe.status.not_evaluated",
     );
   });
+
+  it("separates a missing microphone from a refused one", async () => {
+    const withError = (name: string): MicrophoneProbeReport => {
+      const report = degradedReport();
+      return {
+        ...report,
+        constraints: { ...report.constraints!, error: { name, message: "no" } },
+      };
+    };
+
+    mocks.report.value = withError("NotAllowedError");
+    const refused = mountView();
+    await refused.vm.$nextTick();
+    expect(refused.text()).toContain(
+      "providers.sendspin_sync.probe.blocked.refused.title",
+    );
+
+    mocks.report.value = withError("NotFoundError");
+    const missing = mountView();
+    await missing.vm.$nextTick();
+    expect(missing.text()).toContain(
+      "providers.sendspin_sync.probe.blocked.no_device.title",
+    );
+    // The raw failure stays on the row, whichever branch was taken.
+    expect(missing.text()).toContain("NotFoundError: no");
+  });
+});
+
+describe("SendspinSyncView translation keys", () => {
+  // Keys are composed from check ids, statuses and verdict names, so a rename
+  // would otherwise only surface as a missing string at runtime on a phone.
+  const base = "providers.sendspin_sync.probe";
+  const statuses: CheckStatus[] = ["pass", "warn", "fail", "not_evaluated"];
+  const verdicts: ProbeVerdict[] = [
+    "ready",
+    "degraded",
+    "unsupported",
+    "blocked",
+  ];
+  const composed = [
+    `${base}.idle.title`,
+    `${base}.idle.description`,
+    ...PROBE_CHECKS.flatMap((id) => [
+      `${base}.checks.${id}.title`,
+      `${base}.checks.${id}.hint`,
+    ]),
+    ...statuses.map((status) => `${base}.status.${status}`),
+    ...verdicts.flatMap((verdict) => [
+      `${base}.verdict.${verdict}.title`,
+      `${base}.verdict.${verdict}.description`,
+    ]),
+    ...["insecure", "no_api", "refused", "no_device"].flatMap((reason) => [
+      `${base}.blocked.${reason}.title`,
+      `${base}.blocked.${reason}.description`,
+    ]),
+    ...[
+      "yes",
+      "no",
+      "on",
+      "off",
+      "available",
+      "unavailable",
+      "not_reported",
+      "stayed_running",
+    ].map((value) => `${base}.values.${value}`),
+  ];
+
+  // Read from disk rather than imported: the i18n plugin precompiles anything
+  // under src/translations, so an import hands back message functions.
+  const en: unknown = JSON.parse(
+    readFileSync(resolve(process.cwd(), "src/translations/en.json"), "utf8"),
+  );
+
+  it.each(composed)("resolves %s in en.json", (key) => {
+    const message = key
+      .split(".")
+      .reduce<unknown>(
+        (node, part) =>
+          node && typeof node === "object"
+            ? (node as Record<string, unknown>)[part]
+            : undefined,
+        en,
+      );
+
+    expect(typeof message).toBe("string");
+  });
 });
 
 /** A run that measured everything but never heard back on autoGainControl. */
-function readyReport(): MicrophoneProbeReport {
+function degradedReport(): MicrophoneProbeReport {
   return {
     version: 1,
     startedAt: "2026-01-01T00:00:00.000Z",
@@ -167,8 +264,8 @@ function readyReport(): MicrophoneProbeReport {
         noiseSuppression: true,
         autoGainControl: true,
       },
-      honoured: false,
-      trackSettings: {},
+      honored: false,
+      trackSettings: { sampleRate: 44100 },
       trackLabel: "Fake microphone",
       error: null,
     },
@@ -180,15 +277,16 @@ function readyReport(): MicrophoneProbeReport {
     capture: {
       requestedSeconds: 30,
       measuredSeconds: 30,
-      framesDelivered: 1439982,
-      expectedFrames: 1440000,
-      discrepancyPpm: -12,
-      quanta: 11250,
-      gapCount: 0,
-      missingFrames: 0,
+      renderSeconds: 29.999,
+      framesDelivered: 1439935,
+      expectedFrames: 1439952,
+      frameDiscrepancyPpm: -12,
+      silentQuanta: 0,
+      quanta: 11249,
+      clockDriftPpm: 31,
       error: null,
     },
-    wakeLock: { supported: true, acquired: true, error: null },
+    wakeLock: { supported: true, acquired: true, heldToEnd: true, error: null },
     contextState: { stayedRunning: true, transitions: [] },
   };
 }

--- a/tests/views/SendspinSyncView.test.ts
+++ b/tests/views/SendspinSyncView.test.ts
@@ -195,26 +195,6 @@ describe("SendspinSyncView", () => {
   });
 });
 
-describe("SendspinSyncView fixture", () => {
-  // The rendered numbers are only meaningful if they are numbers the worklet
-  // and the composable could actually have produced together.
-  it("describes a capture the worklet could really produce", () => {
-    const capture = degradedReport().capture!;
-
-    expect(capture.framesDelivered).toBe(capture.measuredQuanta * 128);
-    expect(capture.renderSeconds).toBeCloseTo(
-      capture.framesDelivered / SAMPLE_RATE,
-      9,
-    );
-    expect(capture.discrepancyPpm).toBeCloseTo(
-      ((capture.framesDelivered - capture.expectedFrames) /
-        capture.expectedFrames) *
-        1e6,
-      9,
-    );
-  });
-});
-
 describe("SendspinSyncView translation keys", () => {
   // Keys are composed from check ids, statuses and verdict names, so a rename
   // would otherwise only surface as a missing string at runtime on a phone.

--- a/tests/views/SendspinSyncView.test.ts
+++ b/tests/views/SendspinSyncView.test.ts
@@ -178,6 +178,23 @@ describe("SendspinSyncView", () => {
     // The raw failure stays on the row, whichever branch was taken.
     expect(missing.text()).toContain("NotFoundError: no");
   });
+
+  it("spells out a capture that heard nothing rather than leaving a bare zero", async () => {
+    const report = degradedReport();
+    mocks.report.value = {
+      ...report,
+      capture: { ...report.capture!, peakAmplitude: 0 },
+    };
+    const wrapper = mountView();
+    await wrapper.vm.$nextTick();
+
+    expect(wrapper.text()).toContain(
+      "providers.sendspin_sync.probe.checks.capture.silent",
+    );
+    expect(wrapper.text()).toContain(
+      "providers.sendspin_sync.probe.status.fail",
+    );
+  });
 });
 
 describe("SendspinSyncView translation keys", () => {
@@ -203,7 +220,14 @@ describe("SendspinSyncView translation keys", () => {
       `${base}.verdict.${verdict}.title`,
       `${base}.verdict.${verdict}.description`,
     ]),
-    ...["insecure", "no_api", "refused", "no_device"].flatMap((reason) => [
+    `${base}.checks.capture.silent`,
+    ...[
+      "insecure",
+      "no_api",
+      "refused",
+      "no_device",
+      "no_audio_context",
+    ].flatMap((reason) => [
       `${base}.blocked.${reason}.title`,
       `${base}.blocked.${reason}.description`,
     ]),
@@ -276,14 +300,17 @@ function degradedReport(): MicrophoneProbeReport {
     },
     capture: {
       requestedSeconds: 30,
-      measuredSeconds: 30,
-      renderSeconds: 29.999,
-      framesDelivered: 1439935,
-      expectedFrames: 1439952,
-      frameDiscrepancyPpm: -12,
-      silentQuanta: 0,
-      quanta: 11249,
+      measuredSeconds: 20,
+      renderSeconds: 19.99976,
+      framesDelivered: 959988,
+      expectedFrames: 960000,
+      discrepancyPpm: -12,
       clockDriftPpm: 31,
+      quanta: 7499,
+      silentQuanta: 0,
+      unconnectedQuanta: 0,
+      peakAmplitude: 0.1875,
+      aborted: false,
       error: null,
     },
     wakeLock: { supported: true, acquired: true, heldToEnd: true, error: null },


### PR DESCRIPTION
## What

Adds `/sendspin-sync` — a view for the upcoming `sendspin_sync` plugin, which will auto-calibrate per-player audio latency for Sendspin speakers by having you walk to each speaker with your phone while it times a test chirp.

This PR is only the view, its route, and the **microphone capability probe** that fills it. The chirp, the correlation maths, the player list and applying the results are separate, later work.

## Why the probe comes first

The whole feature rests on an assumption nobody has tested on real hardware: that a phone browser can capture microphone audio with stable, unprocessed timing. Two things could sink it — `getUserMedia` needs a secure origin with no exemption for local networks, and phones apply echo cancellation, noise suppression and gain control to mic input by default. Echo cancellation is the dangerous one: it adds variable latency and may partially cancel a repeating test tone.

So this screen exists to answer "will this work at all?" before the measurement gets built. Its output is a verdict you read on your phone, plus a JSON report you can paste back to a desktop.

This is measured *in the browser* deliberately. The usual rule is that anything affecting multiple clients belongs server-side, but here we are measuring one specific phone's own audio stack, which no server-side code can observe.

## What it checks

Seven checks, each reporting what the browser **actually did** rather than what was asked for. A failing check never stops the ones after it.

1. **Secure connection** — `isSecureContext` and the origin. On a plain-HTTP origin it names the remedies (Home Assistant ingress, MA's own TLS setting, or a reverse proxy with a valid certificate). No bypass is offered.
2. **Microphone API** — whether `getUserMedia` exists at all.
3. **Voice processing** — requests all three processors off, then reads back `track.getSettings()` and shows the *applied* values. Any coming back on is the headline finding; a constraint the browser stays silent on renders as "not reported", never as "off".
4. **Audio pipeline** — `sampleRate`, `baseLatency`, `outputLatency`, plus the device's own rate from `getSettings()` (they differ on Bluetooth, which the real measurement will have to allow for).
5. **Capture continuity** — 30 s through an `AudioWorkletNode`, reported as a drift figure in ppm plus counts of silent, warming-up and unconnected render quanta.
6. **Screen wake lock** — whether it was granted *and* whether it held for the whole capture.
7. **Uninterrupted recording** — whether the `AudioContext` ever left `running`.

Then a copy-to-clipboard button emitting the whole thing as JSON. The payload is untranslated with stable keys, since it is meant to be pasted into an issue.

## Design notes worth a reviewer's time

**Distinguishing "can't run" from "your phone is unsuitable."** MA is routinely reached as `http://homeassistant.local:8095`, so for a lot of users the probe cannot start at all. Checks that were never reached stay `null` and render as "Not run" rather than as failures, and the verdict says the check could not run — an insecure origin, a refused permission, a missing device and an audio pipeline that would not open each get their own explanation. Reporting a deployment problem as a broken phone would send people chasing the wrong thing.

**One drift figure, not two.** `discrepancyPpm` compares frames counted on the audio thread against what the system clock expected, anchored on the least-delayed worklet report at each end of the run so main-thread scheduling jitter stays out of it. An earlier iteration reported this alongside a separate render-clock-vs-system-clock figure; a render quantum is a fixed 128 frames and the context clock advances in the same steps, so the two were algebraically the same number. `renderSeconds` is still reported, because whether a browser really derives its clock from rendered frames is implementation-defined and worth checking rather than assuming.

**Silence, not a missing channel, is what a dropout looks like.** An absent `inputs[0][0]` only reaches a worklet when nothing is connected to it. A microphone that underruns or gets muted delivers zeros. So the worklet scans each quantum, and the run-wide peak is what proves the microphone heard anything at all — a capture of pure silence fails, rather than sailing through and reporting the phone ready. Silence *before* any signal is counted separately as the capture device warming up, which phones do routinely and which must not read as a fault.

**Worklet delivery under Vite.** `new URL("./x.js", import.meta.url)` inlines a file this small as a base64 `data:` URI, which `addModule()` cannot be relied on to load, so it uses `?url&no-inline`. Verified both ways: the dev server serves the file verbatim, and the build emits a separate asset referenced relative to its chunk, which keeps it working under a Home Assistant ingress path prefix given `base: "./"`.

**Plugin gating.** The route guard clones `/ai-radio`'s. It also needed `refreshPluginEnabledState("sendspin_sync")` in `App.vue` — `store.enabledPlugins` is only populated for domains listed there, so without it the guard would redirect every time.

No navigation entry point yet; the route is reachable by URL, which is enough for this stage.

## Testing

`pnpm lint:check`, `pnpm test:run` and `pnpm build` all pass. 30 new tests cover the probe's state machine and teardown, the worklet's counting logic directly, the route guard, and that every dynamically composed translation key resolves in `en.json`.

The capture fixtures derive their frame counts and clock readings the way the composable does, and the type forbids overriding those, so a fixture cannot describe a reading the worklet could not emit.

Not yet run on real hardware — that is the next step, and the point of the screen.