### PR TITLE
Keep the mobile menu clear of phone controls

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
-    <meta name="viewport" content="width=device-width,initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width,initial-scale=1.0,viewport-fit=cover" />
     <link rel="alternate icon" href="favicon.ico" type="image/png" sizes="16x16">
     <link rel="apple-touch-icon" href="apple-touch-icon.png" sizes="180x180">
     <link rel="mask-icon" href="favicon.svg" color="#FFFFFF">

--- a/public/index.html
+++ b/public/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
-    <meta name="viewport" content="width=device-width,initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width,initial-scale=1.0,viewport-fit=cover" />
     <link rel="icon" href="assets/icon.svg" type="image/svg+xml">
     <link rel="alternate icon" href="favicon.ico" type="image/png" sizes="16x16">
     <link rel="apple-touch-icon" href="apple-touch-icon.png" sizes="180x180">

--- a/src/components/navigation/BottomNavigation.vue
+++ b/src/components/navigation/BottomNavigation.vue
@@ -102,7 +102,9 @@ function closePlayersMenu() {
   bottom: -2px !important;
   height: calc(var(--mobile-navigation-height) + 2px);
   background: var(--background);
+  padding-right: calc(0.25rem + var(--device-inset-right)) !important;
   padding-bottom: calc(var(--mobile-navigation-inset-bottom) + 2px);
+  padding-left: calc(0.25rem + var(--device-inset-left)) !important;
 }
 
 .mobile-bottom-navigation::before {

--- a/src/components/ui/sidebar/Sidebar.vue
+++ b/src/components/ui/sidebar/Sidebar.vue
@@ -49,7 +49,10 @@ const mobileSheetSide = useMobileSidebarSide();
       data-slot="sidebar"
       data-mobile="true"
       :side="mobileSheetSide"
-      class="sidebar-mobile-sheet bg-sidebar text-sidebar-foreground w-(--sidebar-width) p-0 [&>button]:hidden"
+      :class="[
+        'sidebar-mobile-sheet bg-sidebar text-sidebar-foreground w-(--sidebar-width) p-0 [&>button]:hidden',
+        `sidebar-mobile-sheet--${mobileSheetSide}`,
+      ]"
       :style="{
         '--sidebar-width': SIDEBAR_WIDTH_MOBILE,
       }"
@@ -114,9 +117,17 @@ const mobileSheetSide = useMobileSidebarSide();
 
 <style>
 .sidebar-mobile-sheet {
-  top: 0 !important;
-  bottom: 0 !important;
-  height: 100dvh !important;
+  top: var(--device-inset-top) !important;
+  bottom: var(--device-inset-bottom) !important;
+  height: auto !important;
   border-radius: 0 !important;
+}
+
+.sidebar-mobile-sheet--left {
+  left: var(--device-inset-left) !important;
+}
+
+.sidebar-mobile-sheet--right {
+  right: var(--device-inset-right) !important;
 }
 </style>

--- a/src/layouts/GuestLayout.vue
+++ b/src/layouts/GuestLayout.vue
@@ -76,7 +76,7 @@
         </DropdownMenu>
       </div>
     </header>
-    <main class="min-h-0 flex-1 overflow-y-auto">
+    <main class="guest-layout-content min-h-0 flex-1 overflow-y-auto">
       <router-view />
     </main>
   </div>
@@ -161,9 +161,15 @@ function returnToHostPanel(): void {
 
 <style scoped>
 .guest-layout-header {
-  height: calc(3rem + env(safe-area-inset-top, 0px));
-  padding: env(safe-area-inset-top, 0px)
-    calc(0.5rem + env(safe-area-inset-right, 0px)) 0
-    calc(0.5rem + env(safe-area-inset-left, 0px));
+  height: calc(3rem + var(--device-inset-top));
+  padding: var(--device-inset-top) calc(0.5rem + var(--device-inset-right)) 0
+    calc(0.5rem + var(--device-inset-left));
+}
+
+.guest-layout-content {
+  box-sizing: border-box;
+  padding-right: var(--device-inset-right);
+  padding-bottom: var(--device-inset-bottom);
+  padding-left: var(--device-inset-left);
 }
 </style>

--- a/src/layouts/default/AddToPlaylistDialog.vue
+++ b/src/layouts/default/AddToPlaylistDialog.vue
@@ -15,7 +15,7 @@
       </SheetDescription>
 
       <ScrollArea class="h-full max-h-full overflow-hidden flex-1">
-        <div class="pt-2 pb-8">
+        <div class="playlist-list pt-2">
           <button
             v-for="playlist of playlists"
             :key="playlist.item_id"
@@ -304,3 +304,9 @@ const close = function () {
   show.value = false;
 };
 </script>
+
+<style scoped>
+.playlist-list {
+  padding-bottom: calc(2rem + var(--device-inset-bottom));
+}
+</style>

--- a/src/layouts/default/Footer.vue
+++ b/src/layouts/default/Footer.vue
@@ -24,9 +24,11 @@
         ? 'mediacontrols-player-float'
         : 'mediacontrols-player-default'
     }`"
-    :style="
-      store.mobileLayout ? { bottom: 'var(--mobile-navigation-height)' } : {}
-    "
+    :style="{
+      bottom: store.mobileLayout
+        ? 'var(--mobile-navigation-height)'
+        : 'var(--device-inset-bottom)',
+    }"
   >
     <Player :use-floating-player="store.mobileLayout" />
   </v-footer>
@@ -81,9 +83,12 @@ function clearOverlay() {
 .mediacontrols-player-float {
   display: flex;
   flex-direction: column;
-  margin: 5px;
+  margin: 5px calc(5px + var(--device-inset-right)) 5px
+    calc(5px + var(--device-inset-left));
   margin-bottom: 6px;
-  width: calc(100% - 10px) !important;
+  width: calc(
+    100% - 10px - var(--device-inset-right) - var(--device-inset-left)
+  ) !important;
   border-radius: 10px !important;
 }
 
@@ -106,6 +111,11 @@ function clearOverlay() {
 
 .v-footer {
   z-index: 1000 !important;
+}
+
+.v-footer.mediacontrols-player-default {
+  padding-right: var(--device-inset-right) !important;
+  padding-left: var(--device-inset-left) !important;
 }
 
 .v-footer.mediacontrols-player-float {

--- a/src/layouts/default/PlayerOSD/PlayerBarGroupControl.vue
+++ b/src/layouts/default/PlayerOSD/PlayerBarGroupControl.vue
@@ -234,7 +234,7 @@ function handleInteractOutside(event: Event) {
 
 <style>
 .player-group-backdrop-desktop {
-  bottom: var(--player-bar-height) !important;
+  bottom: var(--bottom-bars-height) !important;
 }
 
 .player-group-backdrop-mobile {

--- a/src/layouts/default/PlayerOSD/PlayerBarVolumeControl.vue
+++ b/src/layouts/default/PlayerOSD/PlayerBarVolumeControl.vue
@@ -169,7 +169,7 @@ function adjustVolume(event: WheelEvent) {
 
 <style>
 .player-volume-backdrop-desktop {
-  bottom: var(--player-bar-height);
+  bottom: var(--bottom-bars-height);
 }
 
 /* the paired class outweighs the equally-!important z-index utility the popover

--- a/src/layouts/default/PlayerOSD/PlayerFullscreen.vue
+++ b/src/layouts/default/PlayerOSD/PlayerFullscreen.vue
@@ -1396,10 +1396,13 @@ onBeforeUnmount(() => {
 
 <style scoped>
 .fullscreen-player-card {
+  box-sizing: border-box;
   overflow: hidden;
   height: 100%;
   display: flex;
   flex-direction: column;
+  padding: var(--device-inset-top) var(--device-inset-right) 0
+    var(--device-inset-left);
   /* Containing block for the visualizer layer (z-index 0); everything else
      is lifted above it so the canvas renders strictly behind the content. */
   position: relative;
@@ -1668,7 +1671,7 @@ onBeforeUnmount(() => {
 .player-bottom {
   flex-shrink: 0;
   position: unset !important;
-  padding-bottom: max(env(safe-area-inset-bottom, 0px), min(3%, 3vh));
+  padding-bottom: max(var(--device-inset-bottom), min(3%, 3vh));
   width: 100%;
 }
 

--- a/src/layouts/default/PlayerSelect.vue
+++ b/src/layouts/default/PlayerSelect.vue
@@ -643,7 +643,7 @@ async function scrollSelectedPlayerIntoView() {
 
 <style>
 .player-select-desktop-offset {
-  bottom: var(--player-bar-height) !important;
+  bottom: var(--bottom-bars-height) !important;
 }
 
 .player-select-mobile-offset {

--- a/src/layouts/default/View.vue
+++ b/src/layouts/default/View.vue
@@ -83,13 +83,15 @@ onMounted(() => {
 
 <style scoped>
 .main-layout {
+  box-sizing: border-box;
   display: flex;
   height: 100vh;
   height: 100dvh;
   overflow: hidden;
   /* Reset Vuetify's automatic padding that accounts for drawers */
-  padding-left: 0 !important;
-  padding-right: 0 !important;
+  padding-top: var(--device-inset-top) !important;
+  padding-right: var(--device-inset-right) !important;
+  padding-left: var(--device-inset-left) !important;
 }
 
 .content-section {
@@ -97,7 +99,7 @@ onMounted(() => {
   overflow-y: auto;
   overflow-x: hidden;
   min-height: 0;
-  padding-bottom: 110px;
+  padding-bottom: calc(110px + var(--device-inset-bottom));
 }
 
 .content-section--mobile {

--- a/src/main.ts
+++ b/src/main.ts
@@ -53,7 +53,7 @@ installSendspinInterceptor();
 // Browsers disagree here anyway - Chrome reports no insets inside an iframe,
 // Safari reports the ones belonging to the page around us.
 if (window.self !== window.top) {
-  document.documentElement.style.setProperty("--device-inset-bottom", "0px");
+  document.documentElement.setAttribute("data-embedded-layout", "");
 }
 
 const app = createApp(App);

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -24,13 +24,13 @@
 }
 
 :root {
-  /* Space the OS keeps for itself at the bottom of the screen (home indicator,
-     system navigation bar). main.ts zeroes this when we are embedded, because
-     there the host sizes our viewport and browsers disagree on what to report. */
+  --device-inset-top: env(safe-area-inset-top, 0px);
+  --device-inset-right: env(safe-area-inset-right, 0px);
   --device-inset-bottom: env(safe-area-inset-bottom, 0px);
+  --device-inset-left: env(safe-area-inset-left, 0px);
   /* Room below the bottom navigation buttons, so they are never flush with the
      screen edge or the system controls. */
-  --mobile-navigation-inset-bottom: calc(10px + var(--device-inset-bottom));
+  --mobile-navigation-inset-bottom: calc(20px + var(--device-inset-bottom));
   /* Space the bottom navigation occupies. Anything anchored above it (sheets,
      popovers, the player bar, scroll padding) is positioned from this. */
   --mobile-navigation-height: calc(66px + var(--mobile-navigation-inset-bottom));
@@ -45,10 +45,19 @@
   --player-bar-height: 104px;
   /* Room the bars pinned to the bottom of the screen take up together, for
      anything that has to float clear of them. */
-  --bottom-bars-height: var(--player-bar-height);
+  --bottom-bars-height: calc(
+    var(--player-bar-height) + var(--device-inset-bottom)
+  );
   /* How far up the screen the bottom is covered, for anything that stacks below
      what covers it and still has to stay visible. */
   --bottom-obscured-height: var(--bottom-bars-height);
+}
+
+:root[data-embedded-layout] {
+  --device-inset-top: 0px;
+  --device-inset-right: 0px;
+  --device-inset-bottom: 0px;
+  --device-inset-left: 0px;
 }
 
 /* The footer sets this marker while the mobile bars are on screen. There the

--- a/src/views/Login.vue
+++ b/src/views/Login.vue
@@ -2307,6 +2307,7 @@ onMounted(() => {
   --success: #4caf50;
 
   background: var(--background);
+  box-sizing: border-box;
   min-height: 100vh;
   color: var(--fg);
   opacity: 0;
@@ -2314,6 +2315,8 @@ onMounted(() => {
   height: 100vh;
   overflow-y: auto;
   overflow-x: hidden;
+  padding: var(--device-inset-top) var(--device-inset-right)
+    var(--device-inset-bottom) var(--device-inset-left);
 }
 
 @keyframes fadeIn {

--- a/src/views/MusicQuizPlayerView.vue
+++ b/src/views/MusicQuizPlayerView.vue
@@ -344,16 +344,12 @@ async function handleReady() {
 <style scoped>
 .music-quiz-player {
   min-height: 100%;
-  padding: 0.75rem calc(0.75rem + env(safe-area-inset-right, 0px))
-    calc(1rem + env(safe-area-inset-bottom, 0px))
-    calc(0.75rem + env(safe-area-inset-left, 0px));
+  padding: 0.75rem 0.75rem 1rem;
 }
 
 @media (min-width: 768px) {
   .music-quiz-player {
-    padding: 1.25rem calc(1.25rem + env(safe-area-inset-right, 0px))
-      calc(1.25rem + env(safe-area-inset-bottom, 0px))
-      calc(1.25rem + env(safe-area-inset-left, 0px));
+    padding: 1.25rem;
   }
 }
 </style>

--- a/src/views/PartyGuestView.vue
+++ b/src/views/PartyGuestView.vue
@@ -541,7 +541,7 @@ onBeforeUnmount(() => {
   max-width: 1200px;
   margin: 0 auto;
   padding: 1.5rem;
-  padding-bottom: calc(1.5rem + env(safe-area-inset-bottom, 0));
+  padding-bottom: 1.5rem;
   height: 100%;
   max-height: 100%;
   overflow: hidden;
@@ -635,7 +635,7 @@ onBeforeUnmount(() => {
 @media (max-width: 768px) {
   .guest-view {
     padding: 0.75rem;
-    padding-bottom: calc(0.75rem + env(safe-area-inset-bottom, 0));
+    padding-bottom: 0.75rem;
   }
 
   .section-header {

--- a/tests/styles/bottomBarsHeight.test.ts
+++ b/tests/styles/bottomBarsHeight.test.ts
@@ -7,11 +7,11 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 const OVERLAY_HEIGHT = "--player-bar-overlay-height";
 const OVERLAY_MARKER = "data-player-bar-overlay";
 const BAR_HEIGHT = "120px";
-const PLAYER_BAR_HEIGHT = "104px";
+const PLAYER_BAR_HEIGHT = "calc( 104px + env(safe-area-inset-bottom, 0px) )";
 const NAVIGATION_HEIGHT =
-  "calc(66px + calc(10px + env(safe-area-inset-bottom, 0px)))";
+  "calc(66px + calc(20px + env(safe-area-inset-bottom, 0px)))";
 const SCRIM_HEIGHT =
-  "calc( 180px + calc(10px + env(safe-area-inset-bottom, 0px)) )";
+  "calc( 180px + calc(20px + env(safe-area-inset-bottom, 0px)) )";
 
 let appStyles: HTMLStyleElement;
 
@@ -53,12 +53,16 @@ describe("bottom bars height", () => {
     document.body.innerHTML = "";
     document.documentElement.removeAttribute(OVERLAY_MARKER);
     document.documentElement.style.removeProperty(OVERLAY_HEIGHT);
+    document.documentElement.style.removeProperty("--device-inset-bottom");
   });
 
   it("reserves the player bar in the desktop layout", () => {
     expect(bottomBarsHeight()).toBe(PLAYER_BAR_HEIGHT);
     // always-rendered elements offset from this, so it has to reach them
-    expect(offsetFromBars()).toBe(PLAYER_BAR_HEIGHT);
+    document.documentElement.style.setProperty("--device-inset-bottom", "0px");
+    expect(offsetFromBars().replace(/\s+/g, " ").trim()).toBe(
+      "calc( 104px + 0px )",
+    );
   });
 
   it("stacks the floating player bar onto the navigation on mobile", () => {

--- a/tests/styles/safeArea.test.ts
+++ b/tests/styles/safeArea.test.ts
@@ -1,0 +1,39 @@
+import appIndex from "../../index.html?raw";
+import publicIndex from "../../public/index.html?raw";
+import css from "@/styles/global.css?inline";
+import { afterEach, describe, expect, it } from "vitest";
+
+describe.each([
+  ["development", appIndex],
+  ["bundled", publicIndex],
+])("%s viewport", (_name, html) => {
+  it("exposes the device safe-area insets", () => {
+    expect(html).toContain(
+      'content="width=device-width,initial-scale=1.0,viewport-fit=cover"',
+    );
+  });
+});
+
+describe("embedded safe area", () => {
+  const insetProperties = ["top", "right", "bottom", "left"].map(
+    (side) => `--device-inset-${side}`,
+  );
+
+  afterEach(() => {
+    document.head.querySelector("[data-safe-area-test]")?.remove();
+    document.documentElement.removeAttribute("data-embedded-layout");
+  });
+
+  it("leaves device insets to the embedding host", () => {
+    const styles = document.createElement("style");
+    styles.dataset.safeAreaTest = "";
+    styles.textContent = css;
+    document.head.appendChild(styles);
+    document.documentElement.setAttribute("data-embedded-layout", "");
+
+    const computed = getComputedStyle(document.documentElement);
+    for (const property of insetProperties) {
+      expect(computed.getPropertyValue(property).trim()).toBe("0px");
+    }
+  });
+});


### PR DESCRIPTION
# What does this implement/fix?

The mobile menu could still sit underneath Android navigation controls or the iOS home indicator because the device safe area was not available and the added spacing was canceled out by compacting the menu.

- Reserve 20px of breathing room plus the device safe area below the menu buttons
- Keep edge-anchored controls clear in standalone mode
- Let Home Assistant manage safe-area spacing when embedded

**Related issue (if applicable):**

- Follow-up to #2396

**Related backend PR (if applicable):**

- N/A

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm lint:check` passes.
- [x] `pnpm test:run` passes, and tests have been added/updated where applicable.
- [x] `pnpm build` passes.
- [x] I have read and complied with the projects [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.