### PR TITLE
Compact the mobile player in settings

### DIFF
--- a/src/layouts/default/PlayerOSD/Player.vue
+++ b/src/layouts/default/PlayerOSD/Player.vue
@@ -80,13 +80,18 @@
   </template>
 
   <!-- Mobile: floating player with volume slider inside container -->
-  <div v-else class="mediacontrols-mobile-container">
+  <div
+    v-else
+    class="mediacontrols-mobile-container"
+    :data-compact="compactFloatingPlayer"
+  >
     <div class="mediacontrols-bg" :data-floating="useFloatingPlayer"></div>
     <div class="mediacontrols" :data-mobile="true">
       <div class="mediacontrols-left">
         <PlayerTrackDetails
           :show-quality-details-btn="false"
           :show-only-artist="true"
+          :compact="compactFloatingPlayer"
           :color-palette="coverImageColorPalette"
           :primary-color="$vuetify.theme.current.dark ? '#fff' : '#000'"
         />
@@ -94,6 +99,7 @@
       <div class="mediacontrols-bottom-right">
         <div class="flex items-center">
           <PlayerTrackMenu
+            v-if="!compactFloatingPlayer"
             compact
             force-visible
             :show-favorite="true"
@@ -119,21 +125,23 @@
         </div>
       </div>
     </div>
-    <div v-if="store.activePlayer" class="volume-slider">
-      <PlayerVolume
+    <template v-if="!compactFloatingPlayer">
+      <div v-if="store.activePlayer" class="volume-slider">
+        <PlayerVolume
+          :player="store.activePlayer"
+          width="100%"
+          :prefer-group-volume="true"
+          :enable-popout="false"
+          :request-expand-on-group-tap="true"
+          @toggle-group-expansion="showMobileVolumeControls = true"
+        />
+      </div>
+      <PlayerBarMobileVolumeSheet
+        v-if="store.activePlayer"
+        v-model:open="showMobileVolumeControls"
         :player="store.activePlayer"
-        width="100%"
-        :prefer-group-volume="true"
-        :enable-popout="false"
-        :request-expand-on-group-tap="true"
-        @toggle-group-expansion="showMobileVolumeControls = true"
       />
-    </div>
-    <PlayerBarMobileVolumeSheet
-      v-if="store.activePlayer"
-      v-model:open="showMobileVolumeControls"
-      :player="store.activePlayer"
-    />
+    </template>
   </div>
 </template>
 
@@ -147,6 +155,7 @@ import { store } from "@/plugins/store";
 import vuetify from "@/plugins/vuetify";
 import { Heart } from "@lucide/vue";
 import { computed, ref, watch } from "vue";
+import { useRoute } from "vue-router";
 import PlayerBarMobileVolumeSheet from "./PlayerBarMobileVolumeSheet.vue";
 import PlayerTrackMenu from "./PlayerControlBtn/PlayerTrackMenu.vue";
 import QueueBtn from "./PlayerControlBtn/QueueBtn.vue";
@@ -160,12 +169,21 @@ interface Props {
   useFloatingPlayer: boolean;
 }
 const props = defineProps<Props>();
+const route = useRoute();
 const showMobileVolumeControls = ref(false);
 const showWideCenterActions = computed(() => getBreakpointValue("bp6"));
 const favoriteItem = computed(() => {
   const item = store.curQueueItem?.media_item;
   return item?.media_type === MediaType.AUDIO_SOURCE ? undefined : item;
 });
+
+// settings and its descendants collapse the floating mobile player to a
+// single row, since the fixed save button already competes for that space
+const compactFloatingPlayer = computed(
+  () =>
+    props.useFloatingPlayer &&
+    route.matched.some((record) => record.name === "settings"),
+);
 
 const coverImageColorPalette = computed<ImageColorPalette>(() =>
   paletteFromServer(store.activePlayer?.current_media?.palette),
@@ -196,6 +214,12 @@ watch(
     showMobileVolumeControls.value = false;
   },
 );
+
+// the volume sheet is unmounted while compact, but its open state is not:
+// reset it so it cannot resurface once the normal player returns
+watch(compactFloatingPlayer, (compact) => {
+  if (compact) showMobileVolumeControls.value = false;
+});
 </script>
 
 <style scoped lang="scss">

--- a/src/layouts/default/PlayerOSD/PlayerTrackDetails.vue
+++ b/src/layouts/default/PlayerOSD/PlayerTrackDetails.vue
@@ -8,7 +8,7 @@
     <template #prepend>
       <div
         class="media-thumb player-media-thumb"
-        :style="`cursor: pointer; height: ${thumbSizePx}px; width: ${thumbSizePx}px;`"
+        :style="`cursor: pointer; height: ${outerThumbSizePx}px; width: ${outerThumbSizePx}px;`"
         @click="store.showFullscreenPlayer = true"
       >
         <!-- player.current_media has content loaded (will work for all sources)  -->
@@ -22,7 +22,7 @@
           <v-img
             class="media-thumb"
             style="border-radius: 4px"
-            :size="thumbSizePx"
+            :size="innerThumbSizePx"
             :src="getMediaImageUrl(store.activePlayer.current_media.image_url)"
             :alt="$t('tooltip.artwork')"
           />
@@ -31,7 +31,7 @@
         <div
           v-else
           class="icon-thumb"
-          :style="`height: ${thumbSizePx}px; width: ${thumbSizePx}px;`"
+          :style="`height: ${innerThumbSizePx}px; width: ${innerThumbSizePx}px;`"
         >
           <PlayerIcon
             :icon="store.activePlayer?.icon"
@@ -198,7 +198,7 @@ interface Props {
   showQualityDetailsBtn?: boolean;
   colorPalette: ImageColorPalette;
   primaryColor?: string;
-  /** Single title line and a smaller thumbnail: for the compact settings-route mobile player. */
+  /** Use a single title line and smaller artwork. */
   compact?: boolean;
 }
 
@@ -214,10 +214,14 @@ const streamDetails = computed(() => {
   return store.activePlayerQueue?.current_item?.streamdetails;
 });
 
-const thumbSizePx = computed(() => {
+// clickable area around the artwork; matches the artwork size, except it
+// also grows on wider non-compact layouts to keep a comfortable tap target
+const outerThumbSizePx = computed(() => {
   if (props.compact) return 44;
   return getBreakpointValue({ breakpoint: "phone" }) ? 60 : 64;
 });
+
+const innerThumbSizePx = computed(() => (props.compact ? 44 : 60));
 
 function onTitleClick() {
   if (!store.activePlayer || store.activePlayer.powered == false) {

--- a/src/layouts/default/PlayerOSD/PlayerTrackDetails.vue
+++ b/src/layouts/default/PlayerOSD/PlayerTrackDetails.vue
@@ -22,7 +22,6 @@
           <v-img
             class="media-thumb"
             style="border-radius: 4px"
-            :size="innerThumbSizePx"
             :src="getMediaImageUrl(store.activePlayer.current_media.image_url)"
             :alt="$t('tooltip.artwork')"
           />
@@ -31,7 +30,7 @@
         <div
           v-else
           class="icon-thumb"
-          :style="`height: ${innerThumbSizePx}px; width: ${innerThumbSizePx}px;`"
+          :style="`height: ${fallbackThumbSizePx}px; width: ${fallbackThumbSizePx}px;`"
         >
           <PlayerIcon
             :icon="store.activePlayer?.icon"
@@ -214,14 +213,16 @@ const streamDetails = computed(() => {
   return store.activePlayerQueue?.current_item?.streamdetails;
 });
 
-// clickable area around the artwork; matches the artwork size, except it
-// also grows on wider non-compact layouts to keep a comfortable tap target
+// size of the clickable artwork area; cover art fills this via its
+// w-full h-full wrapper, so this is also the real artwork size
 const outerThumbSizePx = computed(() => {
   if (props.compact) return 44;
   return getBreakpointValue({ breakpoint: "phone" }) ? 60 : 64;
 });
 
-const innerThumbSizePx = computed(() => (props.compact ? 44 : 60));
+// the icon fallback (no cover art) has its own fixed size, independent of
+// the breakpoint-driven outer container
+const fallbackThumbSizePx = computed(() => (props.compact ? 44 : 60));
 
 function onTitleClick() {
   if (!store.activePlayer || store.activePlayer.powered == false) {

--- a/src/layouts/default/PlayerOSD/PlayerTrackDetails.vue
+++ b/src/layouts/default/PlayerOSD/PlayerTrackDetails.vue
@@ -3,16 +3,12 @@
   <v-list-item
     class="player-track-details"
     style="height: auto; margin: 0px; padding: 0px"
-    lines="two"
+    :lines="props.compact ? 'one' : 'two'"
   >
     <template #prepend>
       <div
         class="media-thumb player-media-thumb"
-        :style="`cursor: pointer;height: ${
-          getBreakpointValue({ breakpoint: 'phone' }) ? 60 : 64
-        }px; width: ${
-          getBreakpointValue({ breakpoint: 'phone' }) ? 60 : 64
-        }px; `"
+        :style="`cursor: pointer; height: ${thumbSizePx}px; width: ${thumbSizePx}px;`"
         @click="store.showFullscreenPlayer = true"
       >
         <!-- player.current_media has content loaded (will work for all sources)  -->
@@ -26,20 +22,24 @@
           <v-img
             class="media-thumb"
             style="border-radius: 4px"
-            size="60"
+            :size="thumbSizePx"
             :src="getMediaImageUrl(store.activePlayer.current_media.image_url)"
             :alt="$t('tooltip.artwork')"
           />
         </div>
         <!-- fallback: display player icon -->
-        <div v-else class="icon-thumb">
+        <div
+          v-else
+          class="icon-thumb"
+          :style="`height: ${thumbSizePx}px; width: ${thumbSizePx}px;`"
+        >
           <PlayerIcon
             :icon="store.activePlayer?.icon"
             :grouped="
               store.activePlayer?.type == PlayerType.PLAYER &&
               !!store.activePlayer?.group_members.length
             "
-            :size="32"
+            :size="props.compact ? 22 : 32"
           />
         </div>
       </div>
@@ -121,7 +121,7 @@
       </div>
     </template>
     <!-- subtitle: off state or artist(s) + album -->
-    <template #subtitle>
+    <template v-if="!props.compact" #subtitle>
       <!-- player powered off -->
       <div
         v-if="store.activePlayer?.powered == false"
@@ -198,17 +198,25 @@ interface Props {
   showQualityDetailsBtn?: boolean;
   colorPalette: ImageColorPalette;
   primaryColor?: string;
+  /** Single title line and a smaller thumbnail: for the compact settings-route mobile player. */
+  compact?: boolean;
 }
 
 const props = withDefaults(defineProps<Props>(), {
   showOnlyArtist: false,
   showQualityDetailsBtn: true,
   primaryColor: "",
+  compact: false,
 });
 
 // computed properties
 const streamDetails = computed(() => {
   return store.activePlayerQueue?.current_item?.streamdetails;
+});
+
+const thumbSizePx = computed(() => {
+  if (props.compact) return 44;
+  return getBreakpointValue({ breakpoint: "phone" }) ? 60 : 64;
 });
 
 function onTitleClick() {

--- a/tests/layouts/Player.test.ts
+++ b/tests/layouts/Player.test.ts
@@ -1,0 +1,146 @@
+import Player from "@/layouts/default/PlayerOSD/Player.vue";
+import PlayerBarMobileVolumeSheet from "@/layouts/default/PlayerOSD/PlayerBarMobileVolumeSheet.vue";
+import PlayerTrackDetails from "@/layouts/default/PlayerOSD/PlayerTrackDetails.vue";
+import PlayerTrackMenu from "@/layouts/default/PlayerOSD/PlayerControlBtn/PlayerTrackMenu.vue";
+import PlayerVolume from "@/layouts/default/PlayerOSD/PlayerVolume.vue";
+import type { Player as PlayerModel } from "@/plugins/api/interfaces";
+import { shallowMount, type VueWrapper } from "@vue/test-utils";
+import { nextTick, shallowReactive } from "vue";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const routeState = vi.hoisted(() => ({
+  current: null as { matched: { name?: string }[] } | null,
+}));
+
+vi.mock("vue-router", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("vue-router")>()),
+  useRoute: () => routeState.current,
+}));
+
+vi.mock("@/plugins/router", () => ({ default: { push: vi.fn() } }));
+
+vi.mock("@/plugins/api", () => ({
+  default: { toggleFavorite: vi.fn() },
+}));
+
+vi.mock("@/plugins/breakpoint", () => ({
+  getBreakpointValue: () => false,
+}));
+
+vi.mock("@/plugins/vuetify", () => ({
+  default: { theme: { current: { value: { dark: false } } } },
+}));
+
+vi.mock("@/plugins/store", async () => {
+  const { reactive } = await vi.importActual<typeof import("vue")>("vue");
+  return {
+    store: reactive({
+      activePlayer: undefined,
+      activePlayerId: undefined,
+      curQueueItem: undefined,
+    }),
+  };
+});
+
+let wrapper: VueWrapper | undefined;
+
+function mountPlayer(useFloatingPlayer: boolean) {
+  wrapper = shallowMount(Player, {
+    props: { useFloatingPlayer },
+    global: {
+      mocks: { $vuetify: { theme: { current: { dark: false } } } },
+    },
+  });
+  return wrapper;
+}
+
+describe("Player mobile settings compaction", () => {
+  afterEach(async () => {
+    wrapper?.unmount();
+    wrapper = undefined;
+    routeState.current = null;
+    const { store } = await import("@/plugins/store");
+    (store as unknown as { activePlayer?: PlayerModel }).activePlayer =
+      undefined;
+  });
+
+  it("renders the full floating player outside settings", async () => {
+    const { store } = await import("@/plugins/store");
+    (store as unknown as { activePlayer?: PlayerModel }).activePlayer = {
+      player_id: "p1",
+    } as PlayerModel;
+    routeState.current = shallowReactive({ matched: [{ name: "discover" }] });
+    const player = mountPlayer(true);
+
+    expect(
+      player.find(".mediacontrols-mobile-container").attributes("data-compact"),
+    ).toBe("false");
+    expect(player.findComponent(PlayerTrackMenu).exists()).toBe(true);
+    expect(player.findComponent(PlayerVolume).exists()).toBe(true);
+    expect(player.findComponent(PlayerTrackDetails).props("compact")).toBe(
+      false,
+    );
+  });
+
+  it("collapses to a compact single row on settings and its descendants", async () => {
+    const { store } = await import("@/plugins/store");
+    (store as unknown as { activePlayer?: PlayerModel }).activePlayer = {
+      player_id: "p1",
+    } as PlayerModel;
+    routeState.current = shallowReactive({
+      matched: [{ name: "settings" }, { name: "profile" }],
+    });
+    const player = mountPlayer(true);
+
+    expect(
+      player.find(".mediacontrols-mobile-container").attributes("data-compact"),
+    ).toBe("true");
+    expect(player.findComponent(PlayerTrackMenu).exists()).toBe(false);
+    expect(player.findComponent(PlayerVolume).exists()).toBe(false);
+    expect(player.findComponent(PlayerBarMobileVolumeSheet).exists()).toBe(
+      false,
+    );
+    expect(player.findComponent(PlayerTrackDetails).props("compact")).toBe(
+      true,
+    );
+  });
+
+  it("leaves the desktop player unaffected on settings routes", () => {
+    routeState.current = shallowReactive({ matched: [{ name: "settings" }] });
+    const player = mountPlayer(false);
+
+    expect(player.find(".mediacontrols-mobile-container").exists()).toBe(false);
+    expect(player.find(".mediacontrols-bg").attributes("data-floating")).toBe(
+      "false",
+    );
+  });
+
+  it("resets an open volume sheet on entering settings so it cannot resurface", async () => {
+    const { store } = await import("@/plugins/store");
+    (store as unknown as { activePlayer?: PlayerModel }).activePlayer = {
+      player_id: "p1",
+    } as PlayerModel;
+    routeState.current = shallowReactive({ matched: [{ name: "discover" }] });
+    const player = mountPlayer(true);
+
+    await player.findComponent(PlayerVolume).vm.$emit("toggle-group-expansion");
+    await nextTick();
+    expect(player.findComponent(PlayerBarMobileVolumeSheet).props("open")).toBe(
+      true,
+    );
+
+    // entering settings unmounts the sheet, but the open state must not
+    // survive to reopen it once the normal player returns
+    routeState.current.matched = [{ name: "settings" }];
+    await nextTick();
+    expect(player.findComponent(PlayerBarMobileVolumeSheet).exists()).toBe(
+      false,
+    );
+
+    routeState.current.matched = [{ name: "discover" }];
+    await nextTick();
+    expect(player.findComponent(PlayerBarMobileVolumeSheet).props("open")).toBe(
+      false,
+    );
+  });
+});

--- a/tests/layouts/PlayerTrackDetails.test.ts
+++ b/tests/layouts/PlayerTrackDetails.test.ts
@@ -1,0 +1,111 @@
+import PlayerTrackDetails from "@/layouts/default/PlayerOSD/PlayerTrackDetails.vue";
+import { EMPTY_COLOR_PALETTE } from "@/helpers/utils";
+import { mount, type VueWrapper } from "@vue/test-utils";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createVuetify } from "vuetify";
+import * as components from "vuetify/components";
+import * as directives from "vuetify/directives";
+
+// Non-phone, so the non-compact outer thumb container uses its wider 64px
+// size; the artwork/fallback content size is asserted independently of it.
+vi.mock("@/plugins/breakpoint", () => ({
+  getBreakpointValue: () => false,
+}));
+
+// Pulls in the fullscreen dialog's own player/queue/waveform machinery,
+// unrelated to the track details compact layout under test here.
+vi.mock("@/layouts/default/PlayerOSD/PlayerFullscreen.vue", () => ({
+  default: { template: "<div />" },
+}));
+
+// QualityDetailsBtn's audio-processing chain imports ProviderIcon, which
+// needs the real api singleton; stub it since it is never shown here
+// (showQualityDetailsBtn is false in every test below).
+vi.mock("@/plugins/api", () => {
+  const api = { players: {}, queues: {} };
+  return { api, default: api };
+});
+
+vi.mock("@/plugins/store", async () => {
+  const { reactive } = await vi.importActual<typeof import("vue")>("vue");
+  return {
+    store: reactive({
+      activePlayer: {
+        powered: true,
+        icon: undefined,
+        type: "player",
+        group_members: [],
+        current_media: {
+          title: "Song title",
+          artist: "Artist",
+          album: "Album",
+        },
+      },
+      activePlayerQueue: undefined,
+      showFullscreenPlayer: false,
+      showPlayersMenu: false,
+    }),
+  };
+});
+
+const vuetify = createVuetify({ components, directives });
+
+let wrapper: VueWrapper | undefined;
+
+// MarqueeText pulls in resize/intersection observers unrelated to this test.
+function mountDetails(compact: boolean) {
+  wrapper = mount(PlayerTrackDetails, {
+    props: {
+      compact,
+      showQualityDetailsBtn: false,
+      colorPalette: EMPTY_COLOR_PALETTE,
+    },
+    global: {
+      plugins: [vuetify],
+      mocks: { $t: (key: string) => key },
+      stubs: {
+        MarqueeText: { template: "<span><slot /></span>" },
+      },
+    },
+  });
+  return wrapper;
+}
+
+describe("PlayerTrackDetails compact mode", () => {
+  afterEach(() => {
+    wrapper?.unmount();
+    wrapper = undefined;
+  });
+
+  it("keeps the existing two-line layout and 60px artwork outside compact mode", () => {
+    const details = mountDetails(false);
+
+    expect(details.findComponent({ name: "VListItem" }).props("lines")).toBe(
+      "two",
+    );
+    const iconThumb = details.get(".icon-thumb");
+    expect(iconThumb.attributes("style")).toContain("height: 60px");
+    expect(iconThumb.attributes("style")).toContain("width: 60px");
+    // the wider non-phone container still grows to 64px, independent of the
+    // 60px artwork/fallback content size
+    expect(details.get(".player-media-thumb").attributes("style")).toContain(
+      "height: 64px",
+    );
+    expect(details.text()).toContain("Artist");
+  });
+
+  it("collapses to one line, 44px artwork, and no subtitle in compact mode", () => {
+    const details = mountDetails(true);
+
+    expect(details.findComponent({ name: "VListItem" }).props("lines")).toBe(
+      "one",
+    );
+    const iconThumb = details.get(".icon-thumb");
+    expect(iconThumb.attributes("style")).toContain("height: 44px");
+    expect(iconThumb.attributes("style")).toContain("width: 44px");
+    expect(details.get(".player-media-thumb").attributes("style")).toContain(
+      "height: 44px",
+    );
+    expect(details.text()).not.toContain("Artist");
+  });
+});

--- a/tests/layouts/PlayerTrackDetails.test.ts
+++ b/tests/layouts/PlayerTrackDetails.test.ts
@@ -1,4 +1,5 @@
 import PlayerTrackDetails from "@/layouts/default/PlayerOSD/PlayerTrackDetails.vue";
+import { store } from "@/plugins/store";
 import { EMPTY_COLOR_PALETTE } from "@/helpers/utils";
 import { mount, type VueWrapper } from "@vue/test-utils";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -75,37 +76,48 @@ describe("PlayerTrackDetails compact mode", () => {
   afterEach(() => {
     wrapper?.unmount();
     wrapper = undefined;
+    store.activePlayer.current_media.image_url = undefined;
   });
 
-  it("keeps the existing two-line layout and 60px artwork outside compact mode", () => {
-    const details = mountDetails(false);
+  it.each([
+    { compact: false, lines: "two", size: 60, containerSize: 64 },
+    { compact: true, lines: "one", size: 44, containerSize: 44 },
+  ])(
+    "falls back to a $size px icon with lines=$lines when compact=$compact",
+    ({ compact, lines, size, containerSize }) => {
+      const details = mountDetails(compact);
 
-    expect(details.findComponent({ name: "VListItem" }).props("lines")).toBe(
-      "two",
-    );
-    const iconThumb = details.get(".icon-thumb");
-    expect(iconThumb.attributes("style")).toContain("height: 60px");
-    expect(iconThumb.attributes("style")).toContain("width: 60px");
-    // the wider non-phone container still grows to 64px, independent of the
-    // 60px artwork/fallback content size
-    expect(details.get(".player-media-thumb").attributes("style")).toContain(
-      "height: 64px",
-    );
-    expect(details.text()).toContain("Artist");
-  });
+      expect(details.findComponent({ name: "VListItem" }).props("lines")).toBe(
+        lines,
+      );
+      const iconThumb = details.get(".icon-thumb");
+      expect(iconThumb.attributes("style")).toContain(`height: ${size}px`);
+      expect(iconThumb.attributes("style")).toContain(`width: ${size}px`);
+      // the wider non-phone container still grows to 64px outside compact
+      // mode, independent of the fallback icon's own content size
+      expect(details.get(".player-media-thumb").attributes("style")).toContain(
+        `height: ${containerSize}px`,
+      );
+      expect(details.text().includes("Artist")).toBe(!compact);
+    },
+  );
 
-  it("collapses to one line, 44px artwork, and no subtitle in compact mode", () => {
-    const details = mountDetails(true);
+  it.each([
+    { compact: false, size: 60 },
+    { compact: true, size: 44 },
+  ])(
+    "renders cover art via VImg at $size px when compact=$compact",
+    ({ compact, size }) => {
+      store.activePlayer.current_media.image_url =
+        "https://example.com/art.jpg";
+      const details = mountDetails(compact);
 
-    expect(details.findComponent({ name: "VListItem" }).props("lines")).toBe(
-      "one",
-    );
-    const iconThumb = details.get(".icon-thumb");
-    expect(iconThumb.attributes("style")).toContain("height: 44px");
-    expect(iconThumb.attributes("style")).toContain("width: 44px");
-    expect(details.get(".player-media-thumb").attributes("style")).toContain(
-      "height: 44px",
-    );
-    expect(details.text()).not.toContain("Artist");
-  });
+      expect(details.find(".icon-thumb").exists()).toBe(false);
+      const artwork = details.findComponent({ name: "VImg" });
+      expect(artwork.exists()).toBe(true);
+      // VImg has no dedicated "size" prop, so the bound value falls through
+      // as a plain DOM attribute on the component's root element
+      expect(artwork.attributes("size")).toBe(String(size));
+    },
+  );
 });

--- a/tests/layouts/PlayerTrackDetails.test.ts
+++ b/tests/layouts/PlayerTrackDetails.test.ts
@@ -76,7 +76,7 @@ describe("PlayerTrackDetails compact mode", () => {
   afterEach(() => {
     wrapper?.unmount();
     wrapper = undefined;
-    store.activePlayer.current_media.image_url = undefined;
+    store.activePlayer!.current_media!.image_url = null;
   });
 
   it.each([
@@ -103,21 +103,22 @@ describe("PlayerTrackDetails compact mode", () => {
   );
 
   it.each([
-    { compact: false, size: 60 },
-    { compact: true, size: 44 },
+    { compact: false, containerSize: 64 },
+    { compact: true, containerSize: 44 },
   ])(
-    "renders cover art via VImg at $size px when compact=$compact",
-    ({ compact, size }) => {
-      store.activePlayer.current_media.image_url =
+    "renders cover art sized to its $containerSize px wrapper when compact=$compact",
+    ({ compact, containerSize }) => {
+      store.activePlayer!.current_media!.image_url =
         "https://example.com/art.jpg";
       const details = mountDetails(compact);
 
       expect(details.find(".icon-thumb").exists()).toBe(false);
-      const artwork = details.findComponent({ name: "VImg" });
-      expect(artwork.exists()).toBe(true);
-      // VImg has no dedicated "size" prop, so the bound value falls through
-      // as a plain DOM attribute on the component's root element
-      expect(artwork.attributes("size")).toBe(String(size));
+      expect(details.findComponent({ name: "VImg" }).exists()).toBe(true);
+      // cover art fills its w-full h-full wrapper, so the outer container
+      // is what actually controls the rendered artwork size
+      expect(details.get(".player-media-thumb").attributes("style")).toContain(
+        `height: ${containerSize}px`,
+      );
     },
   );
 });


### PR DESCRIPTION
# What does this implement/fix?

The floating mobile player takes up valuable space on settings screens.

- Show a compact row with artwork, title, and play/pause in mobile settings
- Hide secondary player and volume controls there
- Keep the full player everywhere else

**Related issue (if applicable):**

- N/A

**Related backend PR (if applicable):**

- N/A

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm lint:check` passes.
- [x] `pnpm test:run` passes, and tests have been added/updated where applicable.
- [x] `pnpm build` passes.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.