### PR TITLE
Keep the mobile save button close to the player

### DIFF
--- a/src/views/settings/EditConfig.vue
+++ b/src/views/settings/EditConfig.vue
@@ -610,13 +610,9 @@ const getCategoryIcon = function (category: string): Component {
 
 .floating-save--mobile {
   right: 16px;
-  /* Stay clear of whatever reaches highest above the bottom navigation: the
-     bottom bars, or the gradient scrim behind them, which hides what it covers
-     and outlasts the player bar when that has no volume row to grow by. */
-  bottom: max(
-    calc(var(--bottom-bars-height) + 16px),
-    calc(var(--mobile-player-scrim-height) + 16px)
-  );
+  bottom: calc(var(--bottom-bars-height) + 16px);
+  /* Above the player scrim, below the mobile bars. */
+  z-index: 1000;
 }
 
 .floating-save--frameless {

--- a/tests/styles/floatingSaveMobile.test.ts
+++ b/tests/styles/floatingSaveMobile.test.ts
@@ -41,7 +41,9 @@ describe("mobile floating save position", () => {
   });
 
   it("clears the bottom bars by 16px", () => {
-    expect(getComputedStyle(saveButton).bottom).toBe("calc(158px + 16px)");
+    expect(getComputedStyle(saveButton).bottom.replace(/\s+/g, "")).toBe(
+      "calc(158px+16px)",
+    );
   });
 
   it("stacks above the player scrim, below the mobile bars", () => {

--- a/tests/styles/floatingSaveMobile.test.ts
+++ b/tests/styles/floatingSaveMobile.test.ts
@@ -1,0 +1,51 @@
+// jsdom leaves var() unresolved in computed styles, so this cascade is only
+// observable under happy-dom
+// @vitest-environment happy-dom
+import editConfigSource from "@/views/settings/EditConfig.vue?raw";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+let appStyles: HTMLStyleElement;
+let saveButton: HTMLDivElement;
+
+// Use raw selectors so the test does not depend on Vue's generated scope id.
+function extractStyle(source: string) {
+  return source.match(/<style scoped>([\s\S]*?)<\/style>/)?.[1] ?? "";
+}
+
+describe("mobile floating save position", () => {
+  beforeEach(() => {
+    appStyles = document.createElement("style");
+    appStyles.textContent = extractStyle(editConfigSource);
+    document.head.appendChild(appStyles);
+
+    document.documentElement.style.setProperty("--bottom-bars-height", "158px");
+    // Taller than the bars, so a passing test proves the fix measures the
+    // bars instead of falling back to the old max-with-scrim behavior.
+    document.documentElement.style.setProperty(
+      "--mobile-player-scrim-height",
+      "200px",
+    );
+
+    saveButton = document.createElement("div");
+    saveButton.className = "floating-save floating-save--mobile";
+    document.body.appendChild(saveButton);
+  });
+
+  afterEach(() => {
+    appStyles.remove();
+    document.body.innerHTML = "";
+    document.documentElement.style.removeProperty("--bottom-bars-height");
+    document.documentElement.style.removeProperty(
+      "--mobile-player-scrim-height",
+    );
+  });
+
+  it("clears the bottom bars by 16px", () => {
+    expect(getComputedStyle(saveButton).bottom).toBe("calc(158px + 16px)");
+  });
+
+  it("stacks above the player scrim, below the mobile bars", () => {
+    expect(Number(getComputedStyle(saveButton).zIndex)).toBeGreaterThan(999);
+    expect(Number(getComputedStyle(saveButton).zIndex)).toBeLessThan(2000);
+  });
+});


### PR DESCRIPTION
# What does this implement/fix?

The settings save button floated too far above the compact mobile player.

- Keep the save button 16px above the measured player bar
- Keep it visible over the player background gradient

**Related issue (if applicable):**

- N/A

**Related backend PR (if applicable):**

- N/A

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm lint:check` passes.
- [x] `pnpm test:run` passes, and tests have been added/updated where applicable.
- [x] `pnpm build` passes.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.