### PR TITLE
Tidy up two misleading z-index values

### DIFF
--- a/src/components/InfoHeader.vue
+++ b/src/components/InfoHeader.vue
@@ -27,7 +27,7 @@
       />
       <Toolbar
         :icon="ArrowLeft"
-        style="position: absolute; z-index: 999999"
+        style="position: absolute; z-index: 1"
         :menu-items="menuItems"
         :enforce-overflow-menu="true"
         :icon-action="backButtonClick"

--- a/src/components/InfoHeader.vue
+++ b/src/components/InfoHeader.vue
@@ -25,6 +25,8 @@
         :transition="false"
         eager
       />
+      <!-- The details layout below is transformed, which gives it a stacking
+           context, so the toolbar needs a rank to stay clickable above it. -->
       <Toolbar
         :icon="ArrowLeft"
         style="position: absolute; z-index: 1"

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -144,8 +144,8 @@ onMounted(async () => {
   position: fixed;
   right: 24px;
   top: 24px;
-  /* Only has to clear the row drag ghost, so it stays out of the global
-     stacking scale and below the app's pinned chrome. */
+  /* Only has to clear the drag ghost in HomeWidgetRows, so it stays out of the
+     global stacking scale and below the player bar and its backdrops. */
   z-index: 60;
   border-radius: 999px;
   box-shadow: 0 6px 20px rgba(0, 0, 0, 0.3);

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -144,7 +144,9 @@ onMounted(async () => {
   position: fixed;
   right: 24px;
   top: 24px;
-  z-index: 1000;
+  /* Only has to clear the row drag ghost, so it stays out of the global
+     stacking scale and below the app's pinned chrome. */
+  z-index: 60;
   border-radius: 999px;
   box-shadow: 0 6px 20px rgba(0, 0, 0, 0.3);
 }


### PR DESCRIPTION
# What does this implement/fix?

Two elements borrowed a number from the app-wide stacking scale in `src/styles/global.css` that describes something else entirely: the home screen's edit-mode "done" button sat at `1000` (the desktop player bar's band) and the info header's toolbar at `999999` (the item context menu's band). Neither needs a number anywhere near that high, and reading either one sent you looking for a conflict that isn't there.

Both now use a value that matches what they actually stack against.

One small behaviour change comes with it. Because the "done" button was ranked above the player bar's popout backdrops, opening the volume, player or group popout while editing the home screen left the button floating on top of the dimmed backdrop, still bright and clickable. It now sits behind that backdrop like the rest of the page, and clicking there closes the popout.

**Related issue (if applicable):**

- n/a

**Related backend PR (if applicable):**

- n/a

## Changes

- Home screen "done editing" button: `1000` → `60`. It only has to stay above the row drag ghost, so it drops out of the global scale and now sits below the player bar and its backdrops.
- Info header toolbar: `999999` → `1`. It lives inside the header card's own stacking context and never competed app-wide — it just has to sit above the artwork and the details below it. No visual change.
- Noted at both call sites why the value is needed, so neither reads as a number picked at random.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm lint:check` passes.
- [x] `pnpm test:run` passes, and tests have been added/updated where applicable.
- [x] `pnpm build` passes.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
