### PR TITLE
Announce the genre and options pickers on touch devices

### DIFF
--- a/src/components/genre/LinkGenreDialog.vue
+++ b/src/components/genre/LinkGenreDialog.vue
@@ -22,7 +22,7 @@
           </PopoverTrigger>
           <PopoverContent
             class="w-[--reka-popover-trigger-width] p-0"
-            @open-auto-focus.prevent
+            @open-auto-focus="preventOnScreenKeyboardOnOpen"
           >
             <Command>
               <CommandInput :placeholder="t('search')" />
@@ -81,6 +81,7 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from "@/components/ui/popover";
+import { preventOnScreenKeyboardOnOpen } from "@/helpers/dialog_focus";
 import { api } from "@/plugins/api";
 import type { Genre, MediaItemType } from "@/plugins/api/interfaces";
 import { eventbus, type LinkGenreDialogEvent } from "@/plugins/eventbus";

--- a/src/components/genre/MergeGenreDialog.vue
+++ b/src/components/genre/MergeGenreDialog.vue
@@ -25,7 +25,7 @@
           </PopoverTrigger>
           <PopoverContent
             class="w-[--reka-popover-trigger-width] p-0"
-            @open-auto-focus.prevent
+            @open-auto-focus="preventOnScreenKeyboardOnOpen"
           >
             <Command>
               <CommandInput :placeholder="t('search')" />
@@ -88,6 +88,7 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from "@/components/ui/popover";
+import { preventOnScreenKeyboardOnOpen } from "@/helpers/dialog_focus";
 import { api } from "@/plugins/api";
 import type { Genre, MediaType } from "@/plugins/api/interfaces";
 import { eventbus, type MergeGenreDialogEvent } from "@/plugins/eventbus";

--- a/src/components/users/MultiSelect.vue
+++ b/src/components/users/MultiSelect.vue
@@ -45,7 +45,7 @@
       align="start"
       :side-offset="4"
       :collision-padding="16"
-      @open-auto-focus.prevent
+      @open-auto-focus="preventOnScreenKeyboardOnOpen"
     >
       <Command>
         <CommandInput :placeholder="$t('search')" />
@@ -100,6 +100,7 @@ import {
   TagsInputItem,
   TagsInputItemDelete,
 } from "@/components/ui/tags-input";
+import { preventOnScreenKeyboardOnOpen } from "@/helpers/dialog_focus";
 import { cn } from "@/lib/utils";
 import { CheckIcon, ChevronsUpDown, X } from "@lucide/vue";
 import { TagsInputRoot } from "reka-ui";

--- a/src/helpers/dialog_focus.ts
+++ b/src/helpers/dialog_focus.ts
@@ -15,9 +15,9 @@ const LAYER_SELECTOR = "[data-dismissable-layer]";
 export function preventOnScreenKeyboardOnOpen(event: Event) {
   if (!store.isTouchscreen) return;
   if (!(event.target instanceof HTMLElement)) return;
-  // a popover reports the event on its positioning wrapper, which sits outside
-  // the dismissable layer: focusing it counts as a focus outside and closes the
-  // popover, so aim for the layer itself. A dialog is that layer already.
+  // a popover reports the event on its positioning wrapper, which carries no
+  // tabindex and so cannot take focus: aim for the layer nested inside it. A
+  // dialog is that layer already.
   const layer = event.target.matches(LAYER_SELECTOR)
     ? event.target
     : event.target.querySelector<HTMLElement>(LAYER_SELECTOR);

--- a/tests/components/genre/GenreDialogs.test.ts
+++ b/tests/components/genre/GenreDialogs.test.ts
@@ -69,7 +69,7 @@ describe.each(dialogs)("%s", (_name, component, open) => {
     expect(document.activeElement).toBe(searchField());
   });
 
-  it("leaves the genre search field alone on a touch device", async () => {
+  it("focuses the genre list itself on a touch device", async () => {
     storeMock.isTouchscreen = true;
 
     await openGenrePicker(component, open);
@@ -77,10 +77,10 @@ describe.each(dialogs)("%s", (_name, component, open) => {
     // focusing the search field would open the on-screen keyboard over the
     // genre list
     expect(document.activeElement).not.toBe(searchField());
-    // focus stays on the button that opened the list; moving it into the
-    // popover would count as a focus outside and dismiss the list
-    expect(document.activeElement).toBe(trigger());
+    // the list takes focus instead, so a screen reader announces it and the
+    // tab order continues from there
     expect(genreList()).not.toBeNull();
+    expect(document.activeElement).toBe(genreList());
   });
 });
 

--- a/tests/components/users/MultiSelect.test.ts
+++ b/tests/components/users/MultiSelect.test.ts
@@ -35,16 +35,16 @@ describe("MultiSelect", () => {
     expect(document.activeElement).toBe(searchField());
   });
 
-  it("leaves the search field alone on a touch device", async () => {
+  it("focuses the options list itself on a touch device", async () => {
     storeMock.isTouchscreen = true;
 
     await openOptions();
 
     expect(document.activeElement).not.toBe(searchField());
-    // focus stays on the button that opened the list; moving it into the
-    // popover would count as a focus outside and dismiss the list
-    expect(document.activeElement).toBe(trigger());
+    // the list takes focus instead, so a screen reader announces it and the
+    // tab order continues from there
     expect(optionsList()).not.toBeNull();
+    expect(document.activeElement).toBe(optionsList());
   });
 });
 


### PR DESCRIPTION
# What does this implement/fix?

Three popups that host a search field - the genre link and merge pickers, and the user options picker - skip the on-screen keyboard on touch devices so it does not cover the list. They did that by leaving focus behind entirely, which meant a screen reader never announced the popup that had just opened and Tab restarted at the top of the page.

They now use the shared helper the other pickers already use, which moves focus to the popup itself.

**Related issue (if applicable):**

- n/a

**Related backend PR (if applicable):**

- n/a

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

Changes:

- Genre link, genre merge and user options pickers hand focus to the popup itself on touch devices
- Tests pin the new focus target and that the popup stays open

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm lint:check` passes.
- [x] `pnpm test:run` passes, and tests have been added/updated where applicable.
- [x] `pnpm build` passes.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
