### PR TITLE
Show the full list again when a filter dropdown reopens

### DIFF
--- a/src/components/FacetedFilter.vue
+++ b/src/components/FacetedFilter.vue
@@ -1,5 +1,5 @@
 <template>
-  <Popover>
+  <Popover @update:open="onOpenChange">
     <PopoverTrigger as-child>
       <!-- custom trigger (e.g. a compact icon button inside an input) -->
       <slot name="trigger">
@@ -173,6 +173,13 @@ const removeFilter = (value: TValue) => {
 
 const clear = () => {
   emit("update:modelValue", []);
+};
+
+// only the popover content unmounts on close, so a term left in the field has to
+// be dropped by hand - on open, to leave the closing animation on the list the
+// user last saw
+const onOpenChange = (open: boolean) => {
+  if (open) search.value = "";
 };
 </script>
 

--- a/tests/components/FacetedFilter.test.ts
+++ b/tests/components/FacetedFilter.test.ts
@@ -71,6 +71,16 @@ const closePopover = async (wrapper: VueWrapper) => {
   );
 };
 
+// the field is portalled out of the wrapper, so drive the native input directly
+const typeSearch = async (content: Element, term: string) => {
+  const field = content.querySelector<HTMLInputElement>(
+    "input[data-slot='input']",
+  )!;
+  field.value = term;
+  field.dispatchEvent(new Event("input"));
+  await flushPromises();
+};
+
 const mountAndOpen = async (options: { label: string; value: string }[]) => {
   const wrapper = mount(FacetedFilter, {
     props: { title: "Providers", options, modelValue: [] },
@@ -154,23 +164,31 @@ describe("FacetedFilter", () => {
     expect(document.activeElement).toBe(content);
   });
 
-  it("skips the search field on a touch device with nothing left to show", async () => {
+  it("skips the search field of a long list on a touch device when it reopens", async () => {
     storeMock.isTouchscreen = true;
     const { wrapper, content } = await mountAndOpen(manyOptions(12));
 
-    const field = content.querySelector<HTMLInputElement>(
-      "input[data-slot='input']",
-    )!;
-    field.value = "no such provider";
-    field.dispatchEvent(new Event("input"));
-    await flushPromises();
-    expect(content.querySelectorAll(".faceted-filter-item")).toHaveLength(0);
-
-    // the term outlives the popover, so it reopens on an empty list
+    await typeSearch(content, "no such provider");
     await closePopover(wrapper);
     const reopened = await openPopover(wrapper);
 
     expect(document.activeElement).toBe(reopened);
+  });
+
+  it("reopens on the full list after a search", async () => {
+    const { wrapper, content } = await mountAndOpen(manyOptions(12));
+
+    await typeSearch(content, "no such provider");
+    expect(content.querySelectorAll(".faceted-filter-item")).toHaveLength(0);
+
+    await closePopover(wrapper);
+    const reopened = await openPopover(wrapper);
+
+    expect(
+      reopened.querySelector<HTMLInputElement>("input[data-slot='input']")!
+        .value,
+    ).toBe("");
+    expect(reopened.querySelectorAll(".faceted-filter-item")).toHaveLength(12);
   });
 
   it("focuses the search field of a long list on a desktop", async () => {


### PR DESCRIPTION
# What does this implement/fix?

A filter dropdown (media type, provider, player type, provider stage) held on to whatever you typed in its search box after you closed it. Reopening it showed the same filtered list as before, and with a term that matched nothing you got an empty dropdown with no obvious cause.

The search box is now emptied each time the dropdown opens, so it always starts on the full list.

**Related issue (if applicable):**

- n/a

**Related backend PR (if applicable):**

- n/a

## Changes

- Clear the search term each time the filter dropdown opens.
- Added a test for the close/reopen cycle; the touch-device focus test now covers the same cycle.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm lint:check` passes.
- [x] `pnpm test:run` passes, and tests have been added/updated where applicable.
- [x] `pnpm build` passes.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
