### PR TITLE
Less empty space below the mobile menu

### DIFF
--- a/src/components/navigation/BottomNavigation.vue
+++ b/src/components/navigation/BottomNavigation.vue
@@ -119,20 +119,20 @@ function closePlayersMenu() {
 
 .mobile-navigation-item {
   display: grid !important;
-  height: 66px !important;
-  grid-template-rows: 38px 16px;
+  height: var(--mobile-navigation-item-height) !important;
+  grid-template-rows: 34px 16px;
   align-content: center;
   justify-items: center;
   row-gap: 4px !important;
   /* tight, so the buttons sit close to the player bar; the room that keeps them
      clear of the screen edge comes from the bar's own bottom inset */
-  padding-top: 4px !important;
-  padding-bottom: 4px !important;
+  padding-top: 2px !important;
+  padding-bottom: 2px !important;
 }
 
 .mobile-navigation-icon {
   display: flex;
-  height: 38px;
+  height: 34px;
   align-items: center;
   justify-content: center;
 }

--- a/src/layouts/default/Footer.vue
+++ b/src/layouts/default/Footer.vue
@@ -85,7 +85,7 @@ function clearOverlay() {
   flex-direction: column;
   margin: 5px calc(5px + var(--device-inset-right)) 5px
     calc(5px + var(--device-inset-left));
-  margin-bottom: 6px;
+  margin-bottom: var(--mobile-player-bar-gap);
   width: calc(
     100% - 10px - var(--device-inset-right) - var(--device-inset-left)
   ) !important;

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -28,13 +28,22 @@
   --device-inset-right: env(safe-area-inset-right, 0px);
   --device-inset-bottom: env(safe-area-inset-bottom, 0px);
   --device-inset-left: env(safe-area-inset-left, 0px);
-  /* Room below the bottom navigation buttons. The device inset already clears
-     the system controls, so the fixed value is only a floor keeping the buttons
-     off the screen edge where nothing reports an inset. */
-  --mobile-navigation-inset-bottom: max(6px, var(--device-inset-bottom));
+  /* Room below the bottom navigation buttons. The home indicator and the
+     gesture bar sit well inside the inset reserved around them, so the buttons
+     take a share of it instead of all of it. The fixed value is the floor for
+     everywhere that reports no inset at all. */
+  --mobile-navigation-inset-bottom: max(
+    6px,
+    calc(var(--device-inset-bottom) * 0.6)
+  );
+  /* Size of a single bottom navigation button, which the bar sizes itself from,
+     so the two can never drift apart. */
+  --mobile-navigation-item-height: 58px;
   /* Space the bottom navigation occupies. Anything anchored above it (sheets,
      popovers, the player bar, scroll padding) is positioned from this. */
-  --mobile-navigation-height: calc(66px + var(--mobile-navigation-inset-bottom));
+  --mobile-navigation-height: calc(
+    var(--mobile-navigation-item-height) + var(--mobile-navigation-inset-bottom)
+  );
   /* Height of the gradient panel behind the floating player bar. It hides whatever
      it covers, so anything that has to stay visible is positioned above it. */
   --mobile-player-scrim-height: calc(

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -30,8 +30,7 @@
   --device-inset-left: env(safe-area-inset-left, 0px);
   /* Room below the bottom navigation buttons. The home indicator and the
      gesture bar sit well inside the inset reserved around them, so the buttons
-     take a share of it instead of all of it. The fixed value is the floor for
-     everywhere that reports no inset at all. */
+     take a share of it instead of all of it, never dropping below the floor. */
   --mobile-navigation-inset-bottom: max(
     6px,
     calc(var(--device-inset-bottom) * 0.65)

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -28,9 +28,10 @@
   --device-inset-right: env(safe-area-inset-right, 0px);
   --device-inset-bottom: env(safe-area-inset-bottom, 0px);
   --device-inset-left: env(safe-area-inset-left, 0px);
-  /* Room below the bottom navigation buttons, so they are never flush with the
-     screen edge or the system controls. */
-  --mobile-navigation-inset-bottom: calc(20px + var(--device-inset-bottom));
+  /* Room below the bottom navigation buttons. The device inset already clears
+     the system controls, so the fixed value is only a floor keeping the buttons
+     off the screen edge where nothing reports an inset. */
+  --mobile-navigation-inset-bottom: max(6px, var(--device-inset-bottom));
   /* Space the bottom navigation occupies. Anything anchored above it (sheets,
      popovers, the player bar, scroll padding) is positioned from this. */
   --mobile-navigation-height: calc(66px + var(--mobile-navigation-inset-bottom));

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -34,11 +34,14 @@
      everywhere that reports no inset at all. */
   --mobile-navigation-inset-bottom: max(
     6px,
-    calc(var(--device-inset-bottom) * 0.6)
+    calc(var(--device-inset-bottom) * 0.65)
   );
   /* Size of a single bottom navigation button, which the bar sizes itself from,
      so the two can never drift apart. */
-  --mobile-navigation-item-height: 58px;
+  --mobile-navigation-item-height: 64px;
+  /* Gap the floating mobile player bar keeps above the navigation. The bar sets
+     it as its own margin, and anything stacking on top of the bar adds it. */
+  --mobile-player-bar-gap: 4px;
   /* Space the bottom navigation occupies. Anything anchored above it (sheets,
      popovers, the player bar, scroll padding) is positioned from this. */
   --mobile-navigation-height: calc(
@@ -71,10 +74,11 @@
 }
 
 /* The footer sets this marker while the mobile bars are on screen. There the
-   player bar floats above the navigation, keeping a 6px gap from it. */
+   player bar floats above the navigation, keeping its gap from it. */
 :root[data-player-bar-overlay] {
   --bottom-bars-height: calc(
-    var(--mobile-navigation-height) + 6px + var(--player-bar-overlay-height)
+    var(--mobile-navigation-height) + var(--mobile-player-bar-gap) +
+      var(--player-bar-overlay-height)
   );
   /* The scrim reaches higher than the bars unless the player bar has grown. */
   --bottom-obscured-height: max(

--- a/tests/styles/bottomBarsHeight.test.ts
+++ b/tests/styles/bottomBarsHeight.test.ts
@@ -9,8 +9,8 @@ const OVERLAY_MARKER = "data-player-bar-overlay";
 const BAR_HEIGHT = "120px";
 const PLAYER_BAR_HEIGHT = "calc( 104px + env(safe-area-inset-bottom, 0px) )";
 const NAVIGATION_INSET =
-  "max( 6px, calc(env(safe-area-inset-bottom, 0px) * 0.6) )";
-const NAVIGATION_HEIGHT = `calc( 58px + ${NAVIGATION_INSET} )`;
+  "max( 6px, calc(env(safe-area-inset-bottom, 0px) * 0.65) )";
+const NAVIGATION_HEIGHT = `calc( 64px + ${NAVIGATION_INSET} )`;
 const SCRIM_HEIGHT = `calc( 180px + ${NAVIGATION_INSET} )`;
 
 let appStyles: HTMLStyleElement;
@@ -70,7 +70,7 @@ describe("bottom bars height", () => {
     document.documentElement.style.setProperty(OVERLAY_HEIGHT, BAR_HEIGHT);
 
     expect(bottomBarsHeight()).toBe(
-      `calc( ${NAVIGATION_HEIGHT} + 6px + ${BAR_HEIGHT} )`,
+      `calc( ${NAVIGATION_HEIGHT} + 4px + ${BAR_HEIGHT} )`,
     );
   });
 
@@ -85,7 +85,7 @@ describe("bottom bars height", () => {
     document.documentElement.style.setProperty(OVERLAY_HEIGHT, BAR_HEIGHT);
 
     expect(bottomObscuredHeight()).toBe(
-      `max( calc( ${NAVIGATION_HEIGHT} + 6px + ${BAR_HEIGHT} ), ${SCRIM_HEIGHT} )`,
+      `max( calc( ${NAVIGATION_HEIGHT} + 4px + ${BAR_HEIGHT} ), ${SCRIM_HEIGHT} )`,
     );
   });
 });

--- a/tests/styles/bottomBarsHeight.test.ts
+++ b/tests/styles/bottomBarsHeight.test.ts
@@ -8,10 +8,10 @@ const OVERLAY_HEIGHT = "--player-bar-overlay-height";
 const OVERLAY_MARKER = "data-player-bar-overlay";
 const BAR_HEIGHT = "120px";
 const PLAYER_BAR_HEIGHT = "calc( 104px + env(safe-area-inset-bottom, 0px) )";
-const NAVIGATION_HEIGHT =
-  "calc(66px + max(6px, env(safe-area-inset-bottom, 0px)))";
-const SCRIM_HEIGHT =
-  "calc( 180px + max(6px, env(safe-area-inset-bottom, 0px)) )";
+const NAVIGATION_INSET =
+  "max( 6px, calc(env(safe-area-inset-bottom, 0px) * 0.6) )";
+const NAVIGATION_HEIGHT = `calc( 58px + ${NAVIGATION_INSET} )`;
+const SCRIM_HEIGHT = `calc( 180px + ${NAVIGATION_INSET} )`;
 
 let appStyles: HTMLStyleElement;
 

--- a/tests/styles/bottomBarsHeight.test.ts
+++ b/tests/styles/bottomBarsHeight.test.ts
@@ -9,9 +9,9 @@ const OVERLAY_MARKER = "data-player-bar-overlay";
 const BAR_HEIGHT = "120px";
 const PLAYER_BAR_HEIGHT = "calc( 104px + env(safe-area-inset-bottom, 0px) )";
 const NAVIGATION_HEIGHT =
-  "calc(66px + calc(20px + env(safe-area-inset-bottom, 0px)))";
+  "calc(66px + max(6px, env(safe-area-inset-bottom, 0px)))";
 const SCRIM_HEIGHT =
-  "calc( 180px + calc(20px + env(safe-area-inset-bottom, 0px)) )";
+  "calc( 180px + max(6px, env(safe-area-inset-bottom, 0px)) )";
 
 let appStyles: HTMLStyleElement;
 

--- a/tests/styles/safeArea.test.ts
+++ b/tests/styles/safeArea.test.ts
@@ -37,7 +37,7 @@ describe("bottom navigation", () => {
         .getPropertyValue("--mobile-navigation-inset-bottom")
         .replace(/\s+/g, " ")
         .trim(),
-    ).toBe("max( 6px, calc(env(safe-area-inset-bottom, 0px) * 0.6) )");
+    ).toBe("max( 6px, calc(env(safe-area-inset-bottom, 0px) * 0.65) )");
   });
 });
 

--- a/tests/styles/safeArea.test.ts
+++ b/tests/styles/safeArea.test.ts
@@ -37,7 +37,7 @@ describe("bottom navigation", () => {
         .getPropertyValue("--mobile-navigation-inset-bottom")
         .replace(/\s+/g, " ")
         .trim(),
-    ).toBe("max(6px, env(safe-area-inset-bottom, 0px))");
+    ).toBe("max( 6px, calc(env(safe-area-inset-bottom, 0px) * 0.6) )");
   });
 });
 

--- a/tests/styles/safeArea.test.ts
+++ b/tests/styles/safeArea.test.ts
@@ -3,6 +3,20 @@ import publicIndex from "../../public/index.html?raw";
 import css from "@/styles/global.css?inline";
 import { afterEach, describe, expect, it } from "vitest";
 
+// happy-dom substitutes every var() but does not evaluate calc() or max(), so
+// the insets are only observable as the expression they compose
+function applyGlobalStyles() {
+  const styles = document.createElement("style");
+  styles.dataset.safeAreaTest = "";
+  styles.textContent = css;
+  document.head.appendChild(styles);
+}
+
+afterEach(() => {
+  document.head.querySelector("[data-safe-area-test]")?.remove();
+  document.documentElement.removeAttribute("data-embedded-layout");
+});
+
 describe.each([
   ["development", appIndex],
   ["bundled", publicIndex],
@@ -14,21 +28,26 @@ describe.each([
   });
 });
 
+describe("bottom navigation", () => {
+  it("takes its clearance from the device inset rather than adding to it", () => {
+    applyGlobalStyles();
+
+    expect(
+      getComputedStyle(document.documentElement)
+        .getPropertyValue("--mobile-navigation-inset-bottom")
+        .replace(/\s+/g, " ")
+        .trim(),
+    ).toBe("max(6px, env(safe-area-inset-bottom, 0px))");
+  });
+});
+
 describe("embedded safe area", () => {
   const insetProperties = ["top", "right", "bottom", "left"].map(
     (side) => `--device-inset-${side}`,
   );
 
-  afterEach(() => {
-    document.head.querySelector("[data-safe-area-test]")?.remove();
-    document.documentElement.removeAttribute("data-embedded-layout");
-  });
-
   it("leaves device insets to the embedding host", () => {
-    const styles = document.createElement("style");
-    styles.dataset.safeAreaTest = "";
-    styles.textContent = css;
-    document.head.appendChild(styles);
+    applyGlobalStyles();
     document.documentElement.setAttribute("data-embedded-layout", "");
 
     const computed = getComputedStyle(document.documentElement);


### PR DESCRIPTION
# What does this implement/fix?

The mobile menu left far too much empty space below its buttons. The room the
phone reserves for its own controls was being added on top of a fixed 20px pad,
so the two stacked instead of one covering the other. It was most obvious in the
Home Assistant panel, where Home Assistant's own spacing showed up as a second,
white band underneath the menu's grey one.

The space a phone reserves is generous on purpose — the home indicator and the
gesture bar sit well inside it — so the menu now takes a share of that space
instead of adding its own on top, and the buttons themselves sit a little
tighter. On an iPhone that is 22px below the buttons where it used to be 58px,
and the whole bar is 34px shorter.

- Take the room below the menu from the phone's own reserved space instead of adding to it
- Trim the buttons' padding and icon row, and close the gap to the floating player
- Values settled by testing on a device

**Related issue (if applicable):**

- Follow-up to #2427

**Related backend PR (if applicable):**

- N/A

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm lint:check` passes.
- [x] `pnpm test:run` passes, and tests have been added/updated where applicable.
- [x] `pnpm build` passes.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
