### PR TITLE
Show the full playlist list again when the AI radio picker reopens

### DIFF
--- a/src/components/ai-radio/AiRadioPlaylistPicker.vue
+++ b/src/components/ai-radio/AiRadioPlaylistPicker.vue
@@ -75,7 +75,7 @@ import {
 import { useShows } from "@/composables/ai-radio/useShows";
 import { $t } from "@/plugins/i18n";
 import { Loader2, Music } from "@lucide/vue";
-import { computed, onMounted, ref } from "vue";
+import { computed, onMounted, ref, watch } from "vue";
 
 /** A user-picked source playlist, kept as plain ids so it round-trips through route query and drafts. */
 export interface PlaylistSelection {
@@ -118,6 +118,12 @@ function onPick(playlist: (typeof playlists.value)[number]) {
   });
   popoverOpen.value = false;
 }
+
+// Closing only unmounts the popover content, so the term has to be dropped by
+// hand - on open, to keep the restored full list out of the closing animation.
+watch(popoverOpen, (isOpen) => {
+  if (isOpen) search.value = "";
+});
 
 onMounted(() => {
   if (playlists.value.length === 0 && !loadingPlaylists.value) {

--- a/tests/components/ai-radio/AiRadioPlaylistPicker.test.ts
+++ b/tests/components/ai-radio/AiRadioPlaylistPicker.test.ts
@@ -1,0 +1,114 @@
+import AiRadioPlaylistPicker from "@/components/ai-radio/AiRadioPlaylistPicker.vue";
+import { useShows } from "@/composables/ai-radio/useShows";
+import { playlist } from "../../fixtures/playlist";
+import {
+  enableAutoUnmount,
+  flushPromises,
+  mount,
+  type VueWrapper,
+} from "@vue/test-utils";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/plugins/api", () => ({
+  default: {
+    sendCommand: vi.fn(async () => []),
+    getLibraryPlaylists: vi.fn(async () => []),
+  },
+}));
+
+vi.mock("@/components/MediaItemThumb.vue", () => ({
+  default: {
+    name: "MediaItemThumb",
+    template: "<div />",
+  },
+}));
+
+const PLAYLISTS = [
+  playlist({ item_id: "1", name: "Jazz classics" }),
+  playlist({ item_id: "2", name: "Road trip" }),
+  playlist({ item_id: "3", name: "Sunday morning" }),
+];
+
+const mountPicker = () =>
+  mount(AiRadioPlaylistPicker, { attachTo: document.body });
+
+// reka opens the popover on pointerdown + click, and settles focus on a timer
+// rather than a microtask
+const toggleTrigger = async (wrapper: VueWrapper) => {
+  const trigger = wrapper.get("button");
+  await trigger.trigger("pointerdown", { button: 0, pointerType: "mouse" });
+  await trigger.trigger("click");
+  await flushPromises();
+};
+
+// resolves with the popover content once it has settled its focus
+const openPopover = async (wrapper: VueWrapper) => {
+  await toggleTrigger(wrapper);
+  return await vi.waitFor(() => {
+    const content = document.querySelector("[data-slot='popover-content']");
+    expect(content).not.toBeNull();
+    expect(content!.contains(document.activeElement)).toBe(true);
+    return content!;
+  });
+};
+
+const closePopover = async (wrapper: VueWrapper) => {
+  await toggleTrigger(wrapper);
+  await vi.waitFor(() =>
+    expect(document.querySelector("[data-slot='popover-content']")).toBeNull(),
+  );
+};
+
+// the field is portalled out of the wrapper, so drive the native input directly
+const typeSearch = async (content: Element, term: string) => {
+  const field = content.querySelector<HTMLInputElement>(
+    "input[data-slot='input']",
+  )!;
+  field.value = term;
+  field.dispatchEvent(new Event("input"));
+  await flushPromises();
+};
+
+// the playlist rows are the only buttons inside the popover content
+const rows = (content: Element) => content.querySelectorAll("button");
+
+// an open popover keeps document-level listeners, so tear it down even when an
+// assertion fails
+enableAutoUnmount(afterEach);
+
+describe("AiRadioPlaylistPicker", () => {
+  beforeEach(() => {
+    useShows().playlists.value = PLAYLISTS;
+    document.body.innerHTML = "";
+  });
+
+  afterEach(() => {
+    useShows().playlists.value = [];
+  });
+
+  it("filters the playlists with the search field", async () => {
+    const content = await openPopover(mountPicker());
+
+    await typeSearch(content, "jazz");
+
+    expect(rows(content)).toHaveLength(1);
+    expect(rows(content)[0].textContent).toContain("Jazz classics");
+  });
+
+  it("reopens on the full list after a search", async () => {
+    const wrapper = mountPicker();
+    const content = await openPopover(wrapper);
+
+    await typeSearch(content, "no such playlist");
+    expect(rows(content)).toHaveLength(0);
+
+    await closePopover(wrapper);
+    const reopened = await openPopover(wrapper);
+
+    expect(
+      reopened.querySelector<HTMLInputElement>("input[data-slot='input']")!
+        .value,
+    ).toBe("");
+    expect(rows(reopened)).toHaveLength(PLAYLISTS.length);
+  });
+});

--- a/tests/components/ai-radio/AiRadioPlaylistPicker.test.ts
+++ b/tests/components/ai-radio/AiRadioPlaylistPicker.test.ts
@@ -52,11 +52,14 @@ const openPopover = async (wrapper: VueWrapper) => {
   });
 };
 
-const closePopover = async (wrapper: VueWrapper) => {
-  await toggleTrigger(wrapper);
+const waitForClose = async () =>
   await vi.waitFor(() =>
     expect(document.querySelector("[data-slot='popover-content']")).toBeNull(),
   );
+
+const closePopover = async (wrapper: VueWrapper) => {
+  await toggleTrigger(wrapper);
+  await waitForClose();
 };
 
 // the field is portalled out of the wrapper, so drive the native input directly
@@ -93,6 +96,21 @@ describe("AiRadioPlaylistPicker", () => {
 
     expect(rows(content)).toHaveLength(1);
     expect(rows(content)[0].textContent).toContain("Jazz classics");
+  });
+
+  it("reopens on the full list after picking a playlist", async () => {
+    const wrapper = mountPicker();
+    const content = await openPopover(wrapper);
+
+    await typeSearch(content, "jazz");
+    rows(content)[0].click();
+    await flushPromises();
+    await waitForClose();
+
+    expect(wrapper.emitted("update:modelValue")).toEqual([
+      [{ itemId: "1", provider: "library", name: "Jazz classics" }],
+    ]);
+    expect(rows(await openPopover(wrapper))).toHaveLength(PLAYLISTS.length);
   });
 
   it("reopens on the full list after a search", async () => {


### PR DESCRIPTION
# What does this implement/fix?

Picking a source playlist for an AI radio show is done through a small search-and-pick dropdown. The search term you type there was never cleared, so after closing the picker and opening it again the list was still filtered by the old term - and if that term matched nothing, you were left staring at an empty picker with no visible reason why.

The term is now cleared when the picker opens, so it always starts on the full list.

**Related issue (if applicable):**

- related issue `<link to issue>`

**Related backend PR (if applicable):**

- related backend PR `<link to PR>`

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

Changes:

- Clear the AI radio playlist picker's search term when it opens
- Add tests covering filtering and the close/reopen case

Same fix as #2433 did for the filter dropdowns. `SmartPlaylistRuleValuePicker` resets its search on close instead of on open - that works, but it briefly shows the restored full list during the fade-out. Happy to align it in a follow-up if you want them consistent.

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm lint:check` passes.
- [x] `pnpm test:run` passes, and tests have been added/updated where applicable.
- [x] `pnpm build` passes.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
