### PR TITLE
Match the player grouping icon line weight to the icons around it

### DIFF
--- a/src/components/PlayerGroupIcon.vue
+++ b/src/components/PlayerGroupIcon.vue
@@ -3,7 +3,7 @@
        grip on the speaker for every glyph size; the trigger around it carries
        the accessible name, count included -->
   <span class="relative inline-flex p-1.5" aria-hidden="true">
-    <Speaker :stroke-width="1.4" v-bind="$attrs" />
+    <Speaker v-bind="$attrs" />
     <Badge
       data-player-group-count
       as="span"

--- a/tests/components/PlayerGroupIcon.test.ts
+++ b/tests/components/PlayerGroupIcon.test.ts
@@ -9,12 +9,6 @@ describe("PlayerGroupIcon", () => {
     expect(wrapper.get("[data-player-group-count]").text()).toBe("4");
   });
 
-  it("draws the speaker with the shared stroke weight", () => {
-    const wrapper = mount(PlayerGroupIcon, { props: { count: 2 } });
-
-    expect(wrapper.get("svg").attributes("stroke-width")).toBe("1.4");
-  });
-
   it("sizes the speaker glyph rather than the badge wrapper", () => {
     const wrapper = mount(PlayerGroupIcon, {
       props: { count: 2 },


### PR DESCRIPTION
# What does this implement/fix?

The player grouping icon was drawn with a lighter line than the icons next to it,
which made it stand out in the player cards and in the player bar. It now uses the
same line weight as the icons around it.

**Related issue (if applicable):**

- n/a

**Related backend PR (if applicable):**

- n/a

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

Changes:

- The grouping icon no longer forces a thinner line, so it matches its neighbours
  in the player cards, the player bar and the mobile navigation.

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm lint:check` passes.
- [x] `pnpm test:run` passes, and tests have been added/updated where applicable.
- [x] `pnpm build` passes.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
