### PR TITLE
Make the mobile navigation and sheet layout independent of CSS load order

### DIFF
--- a/src/components/navigation/BottomNavigation.vue
+++ b/src/components/navigation/BottomNavigation.vue
@@ -120,7 +120,7 @@ function closePlayersMenu() {
 }
 
 /* the paired class outweighs the equally-!important layout utilities the button
-   variant carries */
+   brings along with its base and size */
 .player-control-button.mobile-navigation-item {
   display: grid !important;
   height: var(--mobile-navigation-item-height) !important;

--- a/src/components/navigation/BottomNavigation.vue
+++ b/src/components/navigation/BottomNavigation.vue
@@ -98,7 +98,9 @@ function closePlayersMenu() {
 </script>
 
 <style>
-.mobile-bottom-navigation {
+/* :root lifts this above the equally-!important bottom and padding utilities
+   the bar carries */
+:root .mobile-bottom-navigation {
   bottom: -2px !important;
   height: calc(var(--mobile-navigation-height) + 2px);
   background: var(--background);
@@ -117,7 +119,9 @@ function closePlayersMenu() {
   content: "";
 }
 
-.mobile-navigation-item {
+/* the paired class outweighs the equally-!important layout utilities the button
+   variant carries */
+.player-control-button.mobile-navigation-item {
   display: grid !important;
   height: var(--mobile-navigation-item-height) !important;
   grid-template-rows: 34px 16px;

--- a/src/components/ui/sidebar/Sidebar.vue
+++ b/src/components/ui/sidebar/Sidebar.vue
@@ -116,18 +116,20 @@ const mobileSheetSide = useMobileSidebarSide();
 </template>
 
 <style>
-.sidebar-mobile-sheet {
+/* :root lifts these above the equally-!important inset and radius utilities the
+   sheet carries */
+:root .sidebar-mobile-sheet {
   top: var(--device-inset-top) !important;
   bottom: var(--device-inset-bottom) !important;
   height: auto !important;
   border-radius: 0 !important;
 }
 
-.sidebar-mobile-sheet--left {
+:root .sidebar-mobile-sheet--left {
   left: var(--device-inset-left) !important;
 }
 
-.sidebar-mobile-sheet--right {
+:root .sidebar-mobile-sheet--right {
   right: var(--device-inset-right) !important;
 }
 </style>

--- a/src/layouts/default/PlayerOSD/PlayerBarMobileVolumeSheet.vue
+++ b/src/layouts/default/PlayerOSD/PlayerBarMobileVolumeSheet.vue
@@ -45,16 +45,15 @@ function preventAutoFocus(event: Event) {
 </script>
 
 <style>
-.mobile-group-volume-sheet {
+/* the paired class outweighs the equally-!important inset utilities the sheet
+   carries */
+.player-bar-popout.mobile-group-volume-sheet {
   right: 8px !important;
   bottom: calc(var(--mobile-navigation-height) + 8px) !important;
   left: 8px !important;
   width: auto !important;
-}
-
-/* a sheet has no popper measuring the free space for it, so it grows with the
-   group it shows up to the room left above the navigation instead */
-.player-bar-popout.mobile-group-volume-sheet {
+  /* a sheet has no popper measuring the free space for it, so it grows with the
+     group it shows up to the room left above the navigation instead */
   max-height: calc(100dvh - var(--mobile-navigation-height) - 16px);
 }
 


### PR DESCRIPTION
# What does this implement/fix?

Follow-up to #2413, same class of problem in the mobile layout. The bottom
navigation, its buttons, the mobile sidebar sheet and the grouped volume sheet
each override positioning and sizing that the Tailwind utilities on the same
element already set. Both sides are `!important` at the same specificity, so
which one wins is decided purely by the order the stylesheets happen to load —
a change in chunking or an extra import could have flipped them. Pairing each
rule with a second selector settles it on specificity instead.

Verified against the production stylesheets in both load orders: every value
now resolves the same either way. Before this change, reversing the order lost
the safe-area insets on the sidebar sheet, collapsed the navigation buttons to
half their height and made the volume sheet full-width against the screen edges.

- pair the bottom navigation and mobile sidebar sheet rules with `:root`
- pair the navigation button rule with the `.player-control-button` class it
  always carries
- pair the grouped volume sheet rule with `.player-bar-popout`, merging it into
  the rule that already used that pairing

**Related issue (if applicable):**

- n/a

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm lint:check` passes.
- [x] `pnpm test:run` passes, and tests have been added/updated where applicable.
- [x] `pnpm build` passes.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
