### PR TITLE
Match the grouping icon line weight to the bar it sits in

### DIFF
--- a/src/layouts/default/PlayerOSD/PlayerBarGroupControl.vue
+++ b/src/layouts/default/PlayerOSD/PlayerBarGroupControl.vue
@@ -45,7 +45,13 @@
               navigation ? 'mobile-navigation-icon' : 'player-bar-action-icon'
             "
           >
-            <PlayerGroupIcon :count="memberCount" class="size-7" />
+            <!-- the navigation bar draws its idle items lighter and reserves the
+                 full weight for the item you are on -->
+            <PlayerGroupIcon
+              :count="memberCount"
+              :stroke-width="navigation ? 1.6 : 1.4"
+              class="size-7"
+            />
           </span>
           <span
             :class="

--- a/src/layouts/default/PlayerOSD/PlayerBarGroupControl.vue
+++ b/src/layouts/default/PlayerOSD/PlayerBarGroupControl.vue
@@ -45,8 +45,9 @@
               navigation ? 'mobile-navigation-icon' : 'player-bar-action-icon'
             "
           >
-            <!-- the navigation bar draws its idle items lighter and reserves the
-                 full weight for the item you are on -->
+            <!-- the navigation bar marks the current route with the full weight,
+                 so this button takes the lighter idle weight rather than looking
+                 like the route you are on -->
             <PlayerGroupIcon
               :count="memberCount"
               :stroke-width="navigation ? 1.6 : 1.4"

--- a/tests/components/PlayerGroupIcon.test.ts
+++ b/tests/components/PlayerGroupIcon.test.ts
@@ -18,6 +18,15 @@ describe("PlayerGroupIcon", () => {
     // the badge is anchored to the wrapper, so a caller's size must not land
     // on it or the count would be positioned against the wrong box
     expect(wrapper.get("svg").classes()).toContain("size-7");
-    expect(wrapper.element.classList.contains("size-7")).toBe(false);
+    expect(wrapper.get("span.relative").classes()).not.toContain("size-7");
+  });
+
+  it("lets a caller set the line weight of the speaker", () => {
+    const wrapper = mount(PlayerGroupIcon, {
+      props: { count: 2 },
+      attrs: { "stroke-width": 1.6 },
+    });
+
+    expect(wrapper.get("svg").attributes("stroke-width")).toBe("1.6");
   });
 });

--- a/tests/layouts/PlayerBarGroupControl.test.ts
+++ b/tests/layouts/PlayerBarGroupControl.test.ts
@@ -79,7 +79,8 @@ describe("PlayerBarGroupControl", () => {
     );
     wrapper?.unmount();
 
-    // the navigation bar keeps the heavier weight for the item you are on
+    // 1.6 is the navigation bar's idle weight; it keeps the full weight for
+    // the route you are on
     expect(
       mountGroupButton({ navigation: true })
         .get("svg")

--- a/tests/layouts/PlayerBarGroupControl.test.ts
+++ b/tests/layouts/PlayerBarGroupControl.test.ts
@@ -30,8 +30,9 @@ vi.mock("@/helpers/players", () => ({
 
 let wrapper: VueWrapper | undefined;
 
-function mountGroupButton() {
+function mountGroupButton(props: { navigation?: boolean } = {}) {
   wrapper = mount(PlayerBarGroupControl, {
+    props,
     global: { stubs: { PlayerGroupPanel: true, Teleport: true } },
   });
   return wrapper.get("[data-player-group-trigger]");
@@ -70,6 +71,20 @@ describe("PlayerBarGroupControl", () => {
     const trigger = mountGroupButton();
 
     expect(trigger.get("[data-player-group-count]").text()).toBe("3");
+  });
+
+  it("draws the speaker at the line weight of the bar it sits in", () => {
+    expect(mountGroupButton().get("svg").attributes("stroke-width")).toBe(
+      "1.4",
+    );
+    wrapper?.unmount();
+
+    // the navigation bar keeps the heavier weight for the item you are on
+    expect(
+      mountGroupButton({ navigation: true })
+        .get("svg")
+        .attributes("stroke-width"),
+    ).toBe("1.6");
   });
 
   it("names a single member in the singular", () => {


### PR DESCRIPTION
# What does this implement/fix?

The player grouping icon is drawn with a single line weight everywhere, but the bars
it sits in do not use that weight. In the player bar the volume and player buttons
next to it are lighter, and in the mobile navigation the heavier line is what marks
the item you are currently on — so the grouping button looked permanently selected.

It now follows the bar it is in, and keeps the normal weight in the player cards
where its neighbours use it.

**Related issue (if applicable):**

- n/a

**Related backend PR (if applicable):**

- n/a

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

Changes:

- The grouping icon matches the player bar (lighter) and the mobile navigation
  (idle weight) instead of always using the full weight; player cards are unchanged.
- Replaced an assertion that could never fail, and added coverage for the line
  weight in each bar.

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm lint:check` passes.
- [x] `pnpm test:run` passes, and tests have been added/updated where applicable.
- [x] `pnpm build` passes.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
