### PR TITLE
A slimmer floating player with the grouping button next to play

### DIFF
--- a/src/components/PlayerGroupIcon.vue
+++ b/src/components/PlayerGroupIcon.vue
@@ -4,13 +4,15 @@
        the accessible name, count included -->
   <span class="relative inline-flex p-1.5" aria-hidden="true">
     <Speaker v-bind="$attrs" />
+    <!-- filled with the speaker's own colour (text-inherit keeps currentColor
+         from the trigger), so the count reads on any background the bar takes -->
     <Badge
       data-player-group-count
       as="span"
       variant="outline"
-      class="border-foreground/30 bg-background text-muted-foreground absolute top-0 right-0 h-4.5 min-w-4.5 rounded-full px-1 text-[11px] font-normal shadow-none"
+      class="absolute top-0 right-0 h-4.5 min-w-4.5 rounded-full border-transparent bg-current/80 px-1 text-[11px] font-normal text-inherit shadow-none"
     >
-      {{ count }}
+      <span class="text-background">{{ count }}</span>
     </Badge>
   </span>
 </template>

--- a/src/components/PlayerGroupIcon.vue
+++ b/src/components/PlayerGroupIcon.vue
@@ -10,7 +10,7 @@
       data-player-group-count
       as="span"
       variant="outline"
-      class="absolute top-0 right-0 h-4.5 min-w-4.5 rounded-full border-transparent bg-foreground/80 px-1 text-[11px] font-normal shadow-none"
+      class="absolute top-0 right-0 h-4.5 min-w-4.5 rounded-full border-transparent bg-muted-foreground/90 px-1 text-[11px] font-normal shadow-none"
     >
       <span class="text-background">{{ count }}</span>
     </Badge>

--- a/src/components/PlayerGroupIcon.vue
+++ b/src/components/PlayerGroupIcon.vue
@@ -4,13 +4,13 @@
        the accessible name, count included -->
   <span class="relative inline-flex p-1.5" aria-hidden="true">
     <Speaker v-bind="$attrs" />
-    <!-- filled with the speaker's own colour (text-inherit keeps currentColor
-         from the trigger), so the count reads on any background the bar takes -->
+    <!-- filled from the theme rather than the trigger's colour, which turns
+         primary while hovered or open and would leave the count unreadable -->
     <Badge
       data-player-group-count
       as="span"
       variant="outline"
-      class="absolute top-0 right-0 h-4.5 min-w-4.5 rounded-full border-transparent bg-current/80 px-1 text-[11px] font-normal text-inherit shadow-none"
+      class="absolute top-0 right-0 h-4.5 min-w-4.5 rounded-full border-transparent bg-foreground/80 px-1 text-[11px] font-normal shadow-none"
     >
       <span class="text-background">{{ count }}</span>
     </Badge>

--- a/src/components/navigation/BottomNavigation.vue
+++ b/src/components/navigation/BottomNavigation.vue
@@ -33,6 +33,8 @@
       </span>
     </Button>
 
+    <PlayerBarPlayerButton navigation />
+
     <Button
       variant="ghost"
       class="player-control-button mobile-navigation-item min-w-0 flex-1 rounded-none px-1"
@@ -47,15 +49,11 @@
         {{ $t("search") }}
       </span>
     </Button>
-
-    <PlayerBarGroupControl navigation />
-    <PlayerBarPlayerButton navigation />
   </nav>
 </template>
 
 <script setup lang="ts">
 import { Button } from "@/components/ui/button";
-import PlayerBarGroupControl from "@/layouts/default/PlayerOSD/PlayerBarGroupControl.vue";
 import PlayerBarPlayerButton from "@/layouts/default/PlayerOSD/PlayerBarPlayerButton.vue";
 import { eventbus } from "@/plugins/eventbus";
 import { store } from "@/plugins/store";

--- a/src/layouts/default/Footer.vue
+++ b/src/layouts/default/Footer.vue
@@ -1,16 +1,7 @@
 <template>
-  <!-- gradient background panel to make the footer player more elevated (and hide content behind it)-->
-  <div
-    v-if="store.mobileLayout"
-    :class="$vuetify.theme.current.dark ? 'gradient-dark' : 'gradient-light'"
-    :style="`
-      position: fixed;
-      width: 100%;
-      height: var(--mobile-player-scrim-height);
-      bottom: 0px;
-      z-index: 999;
-    `"
-  ></div>
+  <!-- lifts the player off the content by blurring what scrolls under it,
+       fading out towards the top so there is no hard edge -->
+  <div v-if="store.mobileLayout" class="player-scrim"></div>
 
   <!-- bottom navigation for mobile layout -->
   <BottomNavigation v-if="store.mobileLayout" />
@@ -92,20 +83,24 @@ function clearOverlay() {
   border-radius: 10px !important;
 }
 
-.gradient-dark {
-  background: linear-gradient(
-    0deg,
-    rgba(0, 0, 0, 0.9) 0%,
-    rgba(0, 0, 0, 0.9) 75%,
-    rgba(255, 255, 255, 0) 100%
-  );
-}
-.gradient-light {
-  background: linear-gradient(
-    0deg,
-    rgba(255, 255, 255, 0.9) 0%,
-    rgba(255, 255, 255, 0.9) 75%,
-    rgba(255, 255, 255, 0) 100%
+.player-scrim {
+  position: fixed;
+  bottom: 0;
+  width: 100%;
+  height: var(--mobile-player-scrim-height);
+  /* it only exists to soften what is behind it, so it never takes a tap */
+  pointer-events: none;
+  z-index: 999;
+  backdrop-filter: blur(14px);
+  -webkit-backdrop-filter: blur(14px);
+  /* the mask is what makes the blur ramp up towards the player instead of
+     ending on a visible line */
+  mask-image: linear-gradient(to top, #000 0%, #000 45%, transparent 100%);
+  -webkit-mask-image: linear-gradient(
+    to top,
+    #000 0%,
+    #000 45%,
+    transparent 100%
   );
 }
 

--- a/src/layouts/default/PlayerOSD/Player.vue
+++ b/src/layouts/default/PlayerOSD/Player.vue
@@ -80,18 +80,16 @@
   </template>
 
   <!-- Mobile: floating player with volume slider inside container -->
-  <div
-    v-else
-    class="mediacontrols-mobile-container"
-    :data-compact="compactFloatingPlayer"
-  >
+  <div v-else class="mediacontrols-mobile-container">
     <div class="mediacontrols-bg" :data-floating="useFloatingPlayer"></div>
     <div class="mediacontrols" :data-mobile="true">
-      <div class="mediacontrols-left">
+      <!-- the whole card opens the player, so the empty space around the
+           track details is clickable too; the controls stop their own clicks -->
+      <div class="mediacontrols-left" @click="openActivePlayer">
         <PlayerTrackDetails
           :show-quality-details-btn="false"
           :show-only-artist="true"
-          :compact="compactFloatingPlayer"
+          :compact="true"
           :color-palette="coverImageColorPalette"
           :primary-color="$vuetify.theme.current.dark ? '#fff' : '#000'"
         />
@@ -99,24 +97,27 @@
       <div class="mediacontrols-bottom-right">
         <div class="flex items-center">
           <PlayerTrackMenu
-            v-if="!compactFloatingPlayer"
+            v-if="showFloatingTrackMenu"
             compact
             force-visible
             :show-favorite="true"
             :show-queue="true"
           />
+          <!-- grouping sits beside play: both act on what this bar is playing -->
+          <PlayerBarGroupControl floating />
           <!-- player mobile control buttons -->
           <PlayerControls
-            :style="[{ 'padding-right': '5px' }, playIconStyle]"
+            :style="playIconStyle"
             :visible-components="{
               repeat: { isVisible: false },
               shuffle: { isVisible: false },
               play: {
                 isVisible: true,
                 icon: {
-                  staticWidth: '48px',
-                  staticHeight: '48px',
+                  staticWidth: '40px',
+                  staticHeight: '40px',
                 },
+                size: 18,
               },
               previous: { isVisible: false },
               next: { isVisible: false },
@@ -125,23 +126,21 @@
         </div>
       </div>
     </div>
-    <template v-if="!compactFloatingPlayer">
-      <div v-if="store.activePlayer" class="volume-slider">
-        <PlayerVolume
-          :player="store.activePlayer"
-          width="100%"
-          :prefer-group-volume="true"
-          :enable-popout="false"
-          :request-expand-on-group-tap="true"
-          @toggle-group-expansion="showMobileVolumeControls = true"
-        />
-      </div>
-      <PlayerBarMobileVolumeSheet
-        v-if="store.activePlayer"
-        v-model:open="showMobileVolumeControls"
+    <div v-if="store.activePlayer" class="volume-slider">
+      <PlayerVolume
         :player="store.activePlayer"
+        width="100%"
+        :prefer-group-volume="true"
+        :enable-popout="false"
+        :request-expand-on-group-tap="true"
+        @toggle-group-expansion="showMobileVolumeControls = true"
       />
-    </template>
+    </div>
+    <PlayerBarMobileVolumeSheet
+      v-if="store.activePlayer"
+      v-model:open="showMobileVolumeControls"
+      :player="store.activePlayer"
+    />
   </div>
 </template>
 
@@ -155,7 +154,7 @@ import { store } from "@/plugins/store";
 import vuetify from "@/plugins/vuetify";
 import { Heart } from "@lucide/vue";
 import { computed, ref, watch } from "vue";
-import { useRoute } from "vue-router";
+import PlayerBarGroupControl from "./PlayerBarGroupControl.vue";
 import PlayerBarMobileVolumeSheet from "./PlayerBarMobileVolumeSheet.vue";
 import PlayerTrackMenu from "./PlayerControlBtn/PlayerTrackMenu.vue";
 import QueueBtn from "./PlayerControlBtn/QueueBtn.vue";
@@ -169,7 +168,6 @@ interface Props {
   useFloatingPlayer: boolean;
 }
 const props = defineProps<Props>();
-const route = useRoute();
 const showMobileVolumeControls = ref(false);
 const showWideCenterActions = computed(() => getBreakpointValue("bp6"));
 const favoriteItem = computed(() => {
@@ -177,13 +175,18 @@ const favoriteItem = computed(() => {
   return item?.media_type === MediaType.AUDIO_SOURCE ? undefined : item;
 });
 
-// settings and its descendants collapse the floating mobile player to a
-// single row, since the fixed save button already competes for that space
-const compactFloatingPlayer = computed(
-  () =>
-    props.useFloatingPlayer &&
-    route.matched.some((record) => record.name === "settings"),
-);
+// the floating row already carries grouping and play; the track menu only
+// joins them where there is width to spare
+const showFloatingTrackMenu = computed(() => getBreakpointValue("bp12"));
+
+/** Opens the fullscreen player, or the player picker when there is nothing to show. */
+function openActivePlayer() {
+  if (!store.activePlayer || store.activePlayer.powered === false) {
+    store.showPlayersMenu = true;
+    return;
+  }
+  store.showFullscreenPlayer = true;
+}
 
 const coverImageColorPalette = computed<ImageColorPalette>(() =>
   paletteFromServer(store.activePlayer?.current_media?.palette),
@@ -200,6 +203,15 @@ const backgroundColor = computed(() => {
   return "#CCCCCC26";
 });
 
+// this bar sits on an artwork tint rather than the app surface, so its
+// controls key off the theme contrast colour instead of the flat grey the
+// other player bars use
+const floatingControlColor = computed(() =>
+  vuetify.theme.current.value.dark
+    ? "rgba(255, 255, 255, 0.82)"
+    : "rgba(0, 0, 0, 0.72)",
+);
+
 const themeColor = computed(() =>
   vuetify.theme.current.value.dark ? "#fff" : "#000",
 );
@@ -214,12 +226,6 @@ watch(
     showMobileVolumeControls.value = false;
   },
 );
-
-// the volume sheet is unmounted while compact, but its open state is not:
-// reset it so it cannot resurface once the normal player returns
-watch(compactFloatingPlayer, (compact) => {
-  if (compact) showMobileVolumeControls.value = false;
-});
 </script>
 
 <style scoped lang="scss">
@@ -231,7 +237,6 @@ watch(compactFloatingPlayer, (compact) => {
   position: relative;
   width: 100%;
   border-radius: 10px;
-  border: 1px solid rgba(255, 255, 255, 0.1);
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.2);
   overflow: hidden;
   background-color: rgb(var(--v-theme-overlay));
@@ -254,7 +259,27 @@ watch(compactFloatingPlayer, (compact) => {
     display: flex;
     background-color: transparent;
     min-height: 0;
-    padding: 8px 10px;
+    padding: 5px 10px;
+    /* play stays the primary action but is outlined here, so the compact row
+       does not read as a solid block */
+    /* beats the global .player-control-button colour, which is tuned for the
+       app surface rather than an artwork tint */
+    :deep(.player-control-button) {
+      color: v-bind(floatingControlColor) !important;
+    }
+    /* Icon.vue rests its buttons at 0.62 and only lifts them on hover, which a
+       touch device never reaches, so play looked faded next to the grouping
+       button beside it */
+    :deep(.icon-container--button) {
+      opacity: 1;
+    }
+    :deep(.play-btn-icon) {
+      min-width: 40px;
+      min-height: 40px;
+      border: 2px solid currentColor;
+      background-color: transparent;
+      color: v-bind(floatingControlColor);
+    }
     .mediacontrols-bottom-right {
       margin-right: 0;
     }
@@ -265,6 +290,7 @@ watch(compactFloatingPlayer, (compact) => {
       flex: 1;
       min-width: 0;
       max-width: none;
+      cursor: pointer;
     }
   }
 }
@@ -275,6 +301,9 @@ watch(compactFloatingPlayer, (compact) => {
   width: 320px;
   left: 0px;
   top: 0px;
+  /* it is positioned, so it paints over the row behind it; without this it
+     takes every click that does not land on the controls or the text */
+  pointer-events: none;
   background: linear-gradient(
     to right,
     v-bind("backgroundColor") 0%,
@@ -392,9 +421,16 @@ watch(compactFloatingPlayer, (compact) => {
   }
 }
 
+/* the left offset cancels the padding inside the volume icon's column so
+   it lines up with the artwork above it */
 .volume-slider {
-  width: calc(100% - 34px);
-  margin: -4px 6px 6px 14px;
+  width: auto;
+  margin: -4px 10px 2px 10px;
+}
+
+/* the slider only needs room for its own track in the floating bar */
+.volume-slider :deep(.player-volume-container) {
+  min-height: 28px;
 }
 
 .volume-slider :deep([data-slot="slider-range"]) {

--- a/src/layouts/default/PlayerOSD/Player.vue
+++ b/src/layouts/default/PlayerOSD/Player.vue
@@ -107,7 +107,6 @@
           <PlayerBarGroupControl floating />
           <!-- player mobile control buttons -->
           <PlayerControls
-            :style="playIconStyle"
             :visible-components="{
               repeat: { isVisible: false },
               shuffle: { isVisible: false },
@@ -260,19 +259,24 @@ watch(
     background-color: transparent;
     min-height: 0;
     padding: 5px 10px;
-    /* play stays the primary action but is outlined here, so the compact row
-       does not read as a solid block */
     /* beats the global .player-control-button colour, which is tuned for the
        app surface rather than an artwork tint */
     :deep(.player-control-button) {
       color: v-bind(floatingControlColor) !important;
     }
+    :deep(.player-control-button:hover:not([data-suppress-hover="true"])),
+    :deep(.player-control-button[data-active="true"]),
+    :deep(.player-control-button[data-state="open"]) {
+      color: var(--primary) !important;
+    }
     /* Icon.vue rests its buttons at 0.62 and only lifts them on hover, which a
        touch device never reaches, so play looked faded next to the grouping
        button beside it */
-    :deep(.icon-container--button) {
+    :deep(.icon-container--button:not(.icon-container--disabled)) {
       opacity: 1;
     }
+    /* play stays the primary action but is outlined here, so the compact row
+       does not read as a solid block */
     :deep(.play-btn-icon) {
       min-width: 40px;
       min-height: 40px;
@@ -421,8 +425,6 @@ watch(
   }
 }
 
-/* the left offset cancels the padding inside the volume icon's column so
-   it lines up with the artwork above it */
 .volume-slider {
   width: auto;
   margin: -4px 10px 2px 10px;

--- a/src/layouts/default/PlayerOSD/PlayerBarGroupControl.vue
+++ b/src/layouts/default/PlayerOSD/PlayerBarGroupControl.vue
@@ -30,9 +30,10 @@
           data-player-group-trigger
           variant="ghost"
           :class="[
-            navigation
-              ? 'player-control-button mobile-navigation-item min-w-0 flex-1 rounded-none px-1'
-              : 'player-control-button player-bar-action player-bar-group-button h-20 w-[72px] rounded-none px-1',
+            'player-control-button rounded-none px-1',
+            floating
+              ? 'size-11 rounded-full me-3'
+              : 'player-bar-action player-bar-group-button h-20 w-[72px]',
           ]"
           :data-active="open"
           :data-suppress-hover="suppressHover"
@@ -40,27 +41,26 @@
           @click.capture="handleTriggerClick"
           @pointerleave="suppressHover = false"
         >
-          <span
-            :class="
-              navigation ? 'mobile-navigation-icon' : 'player-bar-action-icon'
-            "
-          >
-            <!-- the navigation bar marks the current route with the full weight,
-                 so this button takes the lighter idle weight rather than looking
-                 like the route you are on -->
+          <span v-if="floating" class="inline-flex">
+            <!-- matches the track menu beside it in the floating bar -->
             <PlayerGroupIcon
               :count="memberCount"
-              :stroke-width="navigation ? 1.6 : 1.4"
-              class="size-7"
+              :stroke-width="1.5"
+              class="size-8"
             />
           </span>
-          <span
-            :class="
-              navigation ? 'mobile-navigation-label' : 'player-bar-action-label'
-            "
-          >
-            {{ memberCountLabel }}
-          </span>
+          <template v-else>
+            <span class="player-bar-action-icon">
+              <PlayerGroupIcon
+                :count="memberCount"
+                :stroke-width="1.4"
+                class="size-7"
+              />
+            </span>
+            <span class="player-bar-action-label">
+              {{ memberCountLabel }}
+            </span>
+          </template>
         </Button>
       </PopoverTrigger>
 
@@ -125,10 +125,11 @@ import PlayerGroupPanel from "./PlayerGroupPanel.vue";
 
 withDefaults(
   defineProps<{
-    navigation?: boolean;
+    /** compact round trigger for the floating mobile player */
+    floating?: boolean;
   }>(),
   {
-    navigation: false,
+    floating: false,
   },
 );
 

--- a/src/layouts/default/PlayerOSD/PlayerControls.vue
+++ b/src/layouts/default/PlayerOSD/PlayerControls.vue
@@ -33,6 +33,7 @@
         :player-queue="store.activePlayerQueue"
         class="media-controls-item"
         :icon="visibleComponents.play.icon"
+        :size="visibleComponents.play.size"
       />
     </div>
     <!-- next button -->
@@ -86,6 +87,8 @@ export interface Props {
     play?: {
       isVisible?: boolean;
       icon?: IconProps;
+      /** glyph size in px; the button box comes from `icon` */
+      size?: number;
     };
     previous?: {
       isVisible?: boolean;

--- a/src/layouts/default/PlayerOSD/PlayerTrackDetails.vue
+++ b/src/layouts/default/PlayerOSD/PlayerTrackDetails.vue
@@ -2,14 +2,15 @@
   <!-- now playing media -->
   <v-list-item
     class="player-track-details"
+    :class="{ 'player-track-details--compact': props.compact }"
     style="height: auto; margin: 0px; padding: 0px"
-    :lines="props.compact ? 'one' : 'two'"
+    lines="two"
   >
     <template #prepend>
       <div
         class="media-thumb player-media-thumb"
         :style="`cursor: pointer; height: ${outerThumbSizePx}px; width: ${outerThumbSizePx}px;`"
-        @click="store.showFullscreenPlayer = true"
+        @click.stop="store.showFullscreenPlayer = true"
       >
         <!-- player.current_media has content loaded (will work for all sources)  -->
         <div
@@ -52,7 +53,7 @@
           color: primaryColor,
         }"
         class="d-flex align-center"
-        @click="onTitleClick"
+        @click.stop="onTitleClick"
       >
         <!-- no player selected message -->
         <div v-if="!store.activePlayer">
@@ -120,7 +121,7 @@
       </div>
     </template>
     <!-- subtitle: off state or artist(s) + album -->
-    <template v-if="!props.compact" #subtitle>
+    <template #subtitle>
       <!-- player powered off -->
       <div
         v-if="store.activePlayer?.powered == false"
@@ -128,7 +129,7 @@
           cursor: 'pointer',
           color: primaryColor,
         }"
-        @click="store.showPlayersMenu = true"
+        @click.stop="store.showPlayersMenu = true"
       >
         {{ $t("off") }}
       </div>
@@ -142,7 +143,7 @@
           cursor: 'pointer',
           color: primaryColor,
         }"
-        @click="store.showFullscreenPlayer = true"
+        @click.stop="store.showFullscreenPlayer = true"
       >
         <div class="ma-line-clamp-1">
           <MarqueeText :sync="marqueeSync">
@@ -197,7 +198,7 @@ interface Props {
   showQualityDetailsBtn?: boolean;
   colorPalette: ImageColorPalette;
   primaryColor?: string;
-  /** Use a single title line and smaller artwork. */
+  /** Smaller artwork and a shallower row, for the floating mobile player. */
   compact?: boolean;
 }
 
@@ -216,13 +217,13 @@ const streamDetails = computed(() => {
 // size of the clickable artwork area; cover art fills this via its
 // w-full h-full wrapper, so this is also the real artwork size
 const outerThumbSizePx = computed(() => {
-  if (props.compact) return 44;
+  if (props.compact) return 40;
   return getBreakpointValue({ breakpoint: "phone" }) ? 60 : 64;
 });
 
 // the icon fallback (no cover art) has its own fixed size, independent of
 // the breakpoint-driven outer container
-const fallbackThumbSizePx = computed(() => (props.compact ? 44 : 60));
+const fallbackThumbSizePx = computed(() => (props.compact ? 40 : 60));
 
 function onTitleClick() {
   if (!store.activePlayer || store.activePlayer.powered == false) {
@@ -236,6 +237,12 @@ function onTitleClick() {
 <style scoped>
 .player-media-thumb {
   margin-right: 10px;
+}
+
+/* the floating player keeps both text lines but drops below the two-line
+   height Vuetify reserves, so the bar stays shallow */
+.player-track-details.player-track-details--compact {
+  min-height: 44px;
 }
 
 .player-track-content-type {

--- a/src/layouts/default/PlayerOSD/PlayerTrackDetails.vue
+++ b/src/layouts/default/PlayerOSD/PlayerTrackDetails.vue
@@ -10,7 +10,7 @@
       <div
         class="media-thumb player-media-thumb"
         :style="`cursor: pointer; height: ${outerThumbSizePx}px; width: ${outerThumbSizePx}px;`"
-        @click.stop="store.showFullscreenPlayer = true"
+        @click.stop="openPlayer"
       >
         <!-- player.current_media has content loaded (will work for all sources)  -->
         <div
@@ -53,7 +53,7 @@
           color: primaryColor,
         }"
         class="d-flex align-center"
-        @click.stop="onTitleClick"
+        @click.stop="openPlayer"
       >
         <!-- no player selected message -->
         <div v-if="!store.activePlayer">
@@ -225,7 +225,7 @@ const outerThumbSizePx = computed(() => {
 // the breakpoint-driven outer container
 const fallbackThumbSizePx = computed(() => (props.compact ? 40 : 60));
 
-function onTitleClick() {
+function openPlayer() {
   if (!store.activePlayer || store.activePlayer.powered == false) {
     store.showPlayersMenu = true;
   } else {

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -79,12 +79,6 @@
     var(--mobile-navigation-height) + var(--mobile-player-bar-gap) +
       var(--player-bar-overlay-height)
   );
-  /* The blur reaches higher than the bars, so it sets the floor for anything
-     that wants to clear the bottom of the screen. */
-  --bottom-obscured-height: max(
-    var(--bottom-bars-height),
-    var(--mobile-player-scrim-height)
-  );
 }
 
 /* Stacking order for anything pinned to the screen, lowest first. Each value is

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -46,8 +46,8 @@
   --mobile-navigation-height: calc(
     var(--mobile-navigation-item-height) + var(--mobile-navigation-inset-bottom)
   );
-  /* Height of the gradient panel behind the floating player bar. It hides whatever
-     it covers, so anything that has to stay visible is positioned above it. */
+  /* Height of the blur behind the floating player bar. It softens what scrolls
+     under it without hiding it, and fades out towards the top. */
   --mobile-player-scrim-height: calc(
     180px + var(--mobile-navigation-inset-bottom)
   );
@@ -79,7 +79,8 @@
     var(--mobile-navigation-height) + var(--mobile-player-bar-gap) +
       var(--player-bar-overlay-height)
   );
-  /* The scrim reaches higher than the bars unless the player bar has grown. */
+  /* The blur reaches higher than the bars, so it sets the floor for anything
+     that wants to clear the bottom of the screen. */
   --bottom-obscured-height: max(
     var(--bottom-bars-height),
     var(--mobile-player-scrim-height)

--- a/tests/components/PlayerCard.test.ts
+++ b/tests/components/PlayerCard.test.ts
@@ -718,8 +718,11 @@ describe("PlayerCard", () => {
       "tooltip.more_options",
     ]);
     expect(groupControl.attributes("disabled")).toBeDefined();
-    expect(count.classes()).toContain("border-foreground/30");
-    expect(count.classes()).toContain("text-muted-foreground");
+    // the badge takes the speaker's own colour rather than an accent, so a
+    // disabled slot stays as quiet as the icon it sits on
+    expect(count.classes()).toContain("bg-current/80");
+    expect(count.classes()).toContain("text-inherit");
+    expect(count.get("span").classes()).toContain("text-background");
     expect(count.classes()).not.toContain("bg-primary");
   });
 

--- a/tests/components/PlayerCard.test.ts
+++ b/tests/components/PlayerCard.test.ts
@@ -720,7 +720,7 @@ describe("PlayerCard", () => {
     expect(groupControl.attributes("disabled")).toBeDefined();
     // the badge takes the speaker's own colour rather than an accent, so a
     // disabled slot stays as quiet as the icon it sits on
-    expect(count.classes()).toContain("bg-foreground/80");
+    expect(count.classes()).toContain("bg-muted-foreground/90");
     expect(count.get("span").classes()).toContain("text-background");
     expect(count.classes()).not.toContain("bg-primary");
   });

--- a/tests/components/PlayerCard.test.ts
+++ b/tests/components/PlayerCard.test.ts
@@ -720,8 +720,7 @@ describe("PlayerCard", () => {
     expect(groupControl.attributes("disabled")).toBeDefined();
     // the badge takes the speaker's own colour rather than an accent, so a
     // disabled slot stays as quiet as the icon it sits on
-    expect(count.classes()).toContain("bg-current/80");
-    expect(count.classes()).toContain("text-inherit");
+    expect(count.classes()).toContain("bg-foreground/80");
     expect(count.get("span").classes()).toContain("text-background");
     expect(count.classes()).not.toContain("bg-primary");
   });

--- a/tests/layouts/Player.test.ts
+++ b/tests/layouts/Player.test.ts
@@ -1,21 +1,14 @@
 import Player from "@/layouts/default/PlayerOSD/Player.vue";
+import PlayerBarGroupControl from "@/layouts/default/PlayerOSD/PlayerBarGroupControl.vue";
 import PlayerBarMobileVolumeSheet from "@/layouts/default/PlayerOSD/PlayerBarMobileVolumeSheet.vue";
 import PlayerTrackDetails from "@/layouts/default/PlayerOSD/PlayerTrackDetails.vue";
 import PlayerTrackMenu from "@/layouts/default/PlayerOSD/PlayerControlBtn/PlayerTrackMenu.vue";
 import PlayerVolume from "@/layouts/default/PlayerOSD/PlayerVolume.vue";
 import type { Player as PlayerModel } from "@/plugins/api/interfaces";
+import { store } from "@/plugins/store";
 import { shallowMount, type VueWrapper } from "@vue/test-utils";
-import { nextTick, shallowReactive } from "vue";
+import { nextTick } from "vue";
 import { afterEach, describe, expect, it, vi } from "vitest";
-
-const routeState = vi.hoisted(() => ({
-  current: null as { matched: { name?: string }[] } | null,
-}));
-
-vi.mock("vue-router", async (importOriginal) => ({
-  ...(await importOriginal<typeof import("vue-router")>()),
-  useRoute: () => routeState.current,
-}));
 
 vi.mock("@/plugins/router", () => ({ default: { push: vi.fn() } }));
 
@@ -24,10 +17,6 @@ vi.mock("@/plugins/api", () => {
   const api = { toggleFavorite: vi.fn(), providers: {}, players: {} };
   return { api, default: api };
 });
-
-vi.mock("@/plugins/breakpoint", () => ({
-  getBreakpointValue: () => false,
-}));
 
 vi.mock("@/plugins/vuetify", () => ({
   default: { theme: { current: { value: { dark: false } } } },
@@ -44,7 +33,33 @@ vi.mock("@/plugins/store", async () => {
   };
 });
 
+// the real store derives the active player from the api players map, so the
+// mock is what makes these writable per test
+const mockStore = store as unknown as {
+  activePlayer?: PlayerModel;
+  activePlayerId?: string;
+};
+
+// bp12: the width from which the floating row has room for the track menu
+const TRACK_MENU_BREAKPOINT = 415;
+
+const originalInnerWidth = Object.getOwnPropertyDescriptor(
+  window,
+  "innerWidth",
+);
+
 let wrapper: VueWrapper | undefined;
+
+// the breakpoint plugin keeps the width in a module-level reactive that only
+// the resize event refreshes
+function setViewportWidth(width: number) {
+  Object.defineProperty(window, "innerWidth", {
+    value: width,
+    writable: true,
+    configurable: true,
+  });
+  window.dispatchEvent(new Event("resize"));
+}
 
 function mountPlayer(useFloatingPlayer: boolean) {
   wrapper = shallowMount(Player, {
@@ -56,59 +71,56 @@ function mountPlayer(useFloatingPlayer: boolean) {
   return wrapper;
 }
 
-describe("Player mobile settings compaction", () => {
-  afterEach(async () => {
+describe("Player floating mobile bar", () => {
+  afterEach(() => {
     wrapper?.unmount();
     wrapper = undefined;
-    routeState.current = null;
-    const { store } = await import("@/plugins/store");
-    (store as unknown as { activePlayer?: PlayerModel }).activePlayer =
-      undefined;
+    mockStore.activePlayer = undefined;
+    mockStore.activePlayerId = undefined;
+    if (originalInnerWidth) {
+      Object.defineProperty(window, "innerWidth", originalInnerWidth);
+    }
+    window.dispatchEvent(new Event("resize"));
   });
 
-  it("renders the full floating player outside settings", async () => {
-    const { store } = await import("@/plugins/store");
-    (store as unknown as { activePlayer?: PlayerModel }).activePlayer = {
-      player_id: "p1",
-    } as PlayerModel;
-    routeState.current = shallowReactive({ matched: [{ name: "discover" }] });
+  it("carries the grouping control, the volume slider and its sheet", () => {
+    mockStore.activePlayer = { player_id: "p1" } as PlayerModel;
     const player = mountPlayer(true);
 
-    expect(
-      player.find(".mediacontrols-mobile-container").attributes("data-compact"),
-    ).toBe("false");
-    expect(player.findComponent(PlayerTrackMenu).exists()).toBe(true);
+    expect(player.findComponent(PlayerBarGroupControl).props("floating")).toBe(
+      true,
+    );
+    expect(player.find(".volume-slider").exists()).toBe(true);
     expect(player.findComponent(PlayerVolume).exists()).toBe(true);
-    expect(player.findComponent(PlayerTrackDetails).props("compact")).toBe(
-      false,
+    expect(player.findComponent(PlayerBarMobileVolumeSheet).exists()).toBe(
+      true,
     );
   });
 
-  it("collapses to a compact single row on settings and its descendants", async () => {
-    const { store } = await import("@/plugins/store");
-    (store as unknown as { activePlayer?: PlayerModel }).activePlayer = {
-      player_id: "p1",
-    } as PlayerModel;
-    routeState.current = shallowReactive({
-      matched: [{ name: "settings" }, { name: "profile" }],
-    });
+  it("sizes the track details down to fit the shallow bar", () => {
+    mockStore.activePlayer = { player_id: "p1" } as PlayerModel;
     const player = mountPlayer(true);
 
-    expect(
-      player.find(".mediacontrols-mobile-container").attributes("data-compact"),
-    ).toBe("true");
-    expect(player.findComponent(PlayerTrackMenu).exists()).toBe(false);
-    expect(player.findComponent(PlayerVolume).exists()).toBe(false);
-    expect(player.findComponent(PlayerBarMobileVolumeSheet).exists()).toBe(
-      false,
-    );
     expect(player.findComponent(PlayerTrackDetails).props("compact")).toBe(
       true,
     );
   });
 
-  it("leaves the desktop player unaffected on settings routes", () => {
-    routeState.current = shallowReactive({ matched: [{ name: "settings" }] });
+  it.each([
+    { width: TRACK_MENU_BREAKPOINT, present: true },
+    { width: TRACK_MENU_BREAKPOINT - 1, present: false },
+  ])("shows the track menu at $width px: $present", ({ width, present }) => {
+    mockStore.activePlayer = { player_id: "p1" } as PlayerModel;
+    setViewportWidth(width);
+    const player = mountPlayer(true);
+
+    expect(player.findComponent(PlayerTrackMenu).exists()).toBe(present);
+    // the menu is the only control the narrow row gives up
+    expect(player.findComponent(PlayerBarGroupControl).exists()).toBe(true);
+    expect(player.findComponent(PlayerVolume).exists()).toBe(true);
+  });
+
+  it("leaves the desktop player outside the floating container", () => {
     const player = mountPlayer(false);
 
     expect(player.find(".mediacontrols-mobile-container").exists()).toBe(false);
@@ -117,12 +129,9 @@ describe("Player mobile settings compaction", () => {
     );
   });
 
-  it("resets an open volume sheet on entering settings so it cannot resurface", async () => {
-    const { store } = await import("@/plugins/store");
-    (store as unknown as { activePlayer?: PlayerModel }).activePlayer = {
-      player_id: "p1",
-    } as PlayerModel;
-    routeState.current = shallowReactive({ matched: [{ name: "discover" }] });
+  it("closes an open volume sheet when the active player changes", async () => {
+    mockStore.activePlayer = { player_id: "p1" } as PlayerModel;
+    mockStore.activePlayerId = "p1";
     const player = mountPlayer(true);
 
     await player.findComponent(PlayerVolume).vm.$emit("toggle-group-expansion");
@@ -131,15 +140,10 @@ describe("Player mobile settings compaction", () => {
       true,
     );
 
-    // entering settings unmounts the sheet, but the open state must not
-    // survive to reopen it once the normal player returns
-    routeState.current.matched = [{ name: "settings" }];
-    await nextTick();
-    expect(player.findComponent(PlayerBarMobileVolumeSheet).exists()).toBe(
-      false,
-    );
-
-    routeState.current.matched = [{ name: "discover" }];
+    // the sheet controls the volume of the player it was opened for, so it
+    // must not stay open over a player switch
+    mockStore.activePlayer = { player_id: "p2" } as PlayerModel;
+    mockStore.activePlayerId = "p2";
     await nextTick();
     expect(player.findComponent(PlayerBarMobileVolumeSheet).props("open")).toBe(
       false,

--- a/tests/layouts/PlayerBarGroupControl.test.ts
+++ b/tests/layouts/PlayerBarGroupControl.test.ts
@@ -30,7 +30,7 @@ vi.mock("@/helpers/players", () => ({
 
 let wrapper: VueWrapper | undefined;
 
-function mountGroupButton(props: { navigation?: boolean } = {}) {
+function mountGroupButton(props: { floating?: boolean } = {}) {
   wrapper = mount(PlayerBarGroupControl, {
     props,
     global: { stubs: { PlayerGroupPanel: true, Teleport: true } },
@@ -79,13 +79,24 @@ describe("PlayerBarGroupControl", () => {
     );
     wrapper?.unmount();
 
-    // 1.6 is the navigation bar's idle weight; it keeps the full weight for
-    // the route you are on
+    // 1.5 is the weight of the track menu the floating trigger sits next to
     expect(
-      mountGroupButton({ navigation: true })
+      mountGroupButton({ floating: true })
         .get("svg")
         .attributes("stroke-width"),
-    ).toBe("1.6");
+    ).toBe("1.5");
+  });
+
+  it("drops the member count label in the floating player", () => {
+    const trigger = mountGroupButton({ floating: true });
+
+    // the round floating trigger has no room for the label, so the badge is
+    // the only place the count shows; the accessible name still spells it out
+    expect(trigger.find(".player-bar-action-label").exists()).toBe(false);
+    expect(trigger.get("[data-player-group-count]").text()).toBe("3");
+    expect(trigger.attributes("aria-label")).toBe(
+      "tooltip.group_members: 3 players",
+    );
   });
 
   it("names a single member in the singular", () => {

--- a/tests/layouts/PlayerTrackDetails.test.ts
+++ b/tests/layouts/PlayerTrackDetails.test.ts
@@ -1,3 +1,4 @@
+import PlayerIcon from "@/components/PlayerIcon.vue";
 import PlayerTrackDetails from "@/layouts/default/PlayerOSD/PlayerTrackDetails.vue";
 import { store } from "@/plugins/store";
 import { EMPTY_COLOR_PALETTE } from "@/helpers/utils";
@@ -80,31 +81,39 @@ describe("PlayerTrackDetails compact mode", () => {
   });
 
   it.each([
-    { compact: false, lines: "two", size: 60, containerSize: 64 },
-    { compact: true, lines: "one", size: 44, containerSize: 44 },
+    { compact: false, size: 60, iconSize: 32, containerSize: 64 },
+    { compact: true, size: 40, iconSize: 22, containerSize: 40 },
   ])(
-    "falls back to a $size px icon with lines=$lines when compact=$compact",
-    ({ compact, lines, size, containerSize }) => {
+    "falls back to a $size px icon and keeps both text lines when compact=$compact",
+    ({ compact, size, iconSize, containerSize }) => {
       const details = mountDetails(compact);
 
+      // compact only shrinks the row, so the subtitle line stays either way
       expect(details.findComponent({ name: "VListItem" }).props("lines")).toBe(
-        lines,
+        "two",
       );
+      expect(details.text()).toContain("Artist");
+      // the shallower row height rides on this class
+      expect(
+        details
+          .get(".player-track-details")
+          .classes("player-track-details--compact"),
+      ).toBe(compact);
       const iconThumb = details.get(".icon-thumb");
       expect(iconThumb.attributes("style")).toContain(`height: ${size}px`);
       expect(iconThumb.attributes("style")).toContain(`width: ${size}px`);
+      expect(details.findComponent(PlayerIcon).props("size")).toBe(iconSize);
       // the wider non-phone container still grows to 64px outside compact
       // mode, independent of the fallback icon's own content size
       expect(details.get(".player-media-thumb").attributes("style")).toContain(
         `height: ${containerSize}px`,
       );
-      expect(details.text().includes("Artist")).toBe(!compact);
     },
   );
 
   it.each([
     { compact: false, containerSize: 64 },
-    { compact: true, containerSize: 44 },
+    { compact: true, containerSize: 40 },
   ])(
     "renders cover art sized to its $containerSize px wrapper when compact=$compact",
     ({ compact, containerSize }) => {

--- a/tests/styles/bottomBarsHeight.test.ts
+++ b/tests/styles/bottomBarsHeight.test.ts
@@ -11,7 +11,6 @@ const PLAYER_BAR_HEIGHT = "calc( 104px + env(safe-area-inset-bottom, 0px) )";
 const NAVIGATION_INSET =
   "max( 6px, calc(env(safe-area-inset-bottom, 0px) * 0.65) )";
 const NAVIGATION_HEIGHT = `calc( 64px + ${NAVIGATION_INSET} )`;
-const SCRIM_HEIGHT = `calc( 180px + ${NAVIGATION_INSET} )`;
 
 let appStyles: HTMLStyleElement;
 
@@ -80,12 +79,14 @@ describe("bottom bars height", () => {
     expect(bottomObscuredHeight()).toBe(PLAYER_BAR_HEIGHT);
   });
 
-  it("reaches over the gradient scrim on mobile", () => {
+  it("reaches no further than the bars on mobile either", () => {
     document.documentElement.setAttribute(OVERLAY_MARKER, "");
     document.documentElement.style.setProperty(OVERLAY_HEIGHT, BAR_HEIGHT);
 
+    // the blur behind the bars softens what scrolls under it without hiding
+    // it, so nothing has to clear more than the bars themselves
     expect(bottomObscuredHeight()).toBe(
-      `max( calc( ${NAVIGATION_HEIGHT} + 4px + ${BAR_HEIGHT} ), ${SCRIM_HEIGHT} )`,
+      `calc( ${NAVIGATION_HEIGHT} + 4px + ${BAR_HEIGHT} )`,
     );
   });
 });


### PR DESCRIPTION
# What does this implement/fix?

The floating player on mobile took up a lot of room, and the button that picks
which players play the music sat in the bottom menu, away from the music it
applies to.

The player is now considerably slimmer, the grouping button sits next to play
where it belongs, and the bottom menu has the space to show the full player name.

**Related issue (if applicable):**

- n/a

**Related backend PR (if applicable):**

- n/a

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

Changes:

- The floating player is about a third shorter: smaller artwork, a shallower
  row and a slimmer volume slider.
- The grouping button moved out of the bottom menu into the player, next to
  play, and the play button is smaller and outlined.
- The bottom menu is now Menu / Discover / Player / Search, so the player name
  gets more room before it is cut off.
- Tapping anywhere on the player card opens the fullscreen player.
- The blurred wash behind the player is replaced by a gradual blur of the
  content underneath.
- The player no longer collapses to a different layout on the settings pages.

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm lint:check` passes.
- [x] `pnpm test:run` passes, and tests have been added/updated where applicable.
- [x] `pnpm build` passes.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
