### PR TITLE
A floating dock for the player and bottom menu

### DIFF
--- a/src/components/navigation/BottomNavigation.vue
+++ b/src/components/navigation/BottomNavigation.vue
@@ -112,19 +112,24 @@ function closePlayersMenu() {
 }
 
 /* darker than the muted grey the player controls use elsewhere, so the labels
-   hold their own against the blurred content behind them. The field and the
-   heavier label carry the state instead, so nothing here turns primary - which
-   also stops a tap leaving an item stuck in its hover colour on iOS. */
-.mobile-bottom-navigation .player-control-button,
+   hold their own against the blurred content behind them. The active item is
+   left out so it keeps the primary colour, and hover is pinned here: iOS holds
+   hover after a tap, which would otherwise leave an item looking active. */
+.mobile-bottom-navigation .player-control-button:not([data-active="true"]),
 .mobile-bottom-navigation
-  .player-control-button:hover:not([data-suppress-hover="true"]),
-.mobile-bottom-navigation .player-control-button[data-active="true"],
-.mobile-bottom-navigation .player-control-button[data-state="open"] {
+  .player-control-button:not([data-active="true"]):hover:not(
+    [data-suppress-hover="true"]
+  ) {
   color: color-mix(in srgb, var(--foreground) 80%, transparent) !important;
 }
 
-/* the open picker takes the active state for itself, so the page it sits over
-   stops claiming it too */
+/* an open picker is the active item, so the page underneath gives up both the
+   colour and the weight and only one thing in the bar ever reads as active */
+.mobile-bottom-navigation[data-picker-open="true"]
+  .player-control-button[data-active="true"]:not(#player-select-button) {
+  color: color-mix(in srgb, var(--foreground) 80%, transparent) !important;
+}
+
 .mobile-bottom-navigation:not([data-picker-open="true"])
   .player-control-button[data-active="true"]:not(#player-select-button)
   .mobile-navigation-label,
@@ -132,33 +137,6 @@ function closePlayersMenu() {
   #player-select-button[data-active="true"]
   .mobile-navigation-label {
   font-weight: 600;
-}
-
-/* the active item sits on a faded field that repeats the bar's own corner
-   radius; it sits under the icon and label but over the bar's tint. An open
-   picker takes the active state for itself, so the page underneath drops it and
-   only one item is ever marked. */
-.mobile-bottom-navigation:not([data-picker-open="true"])
-  .player-control-button[data-active="true"]:not(#player-select-button),
-.mobile-bottom-navigation #player-select-button[data-active="true"] {
-  position: relative;
-}
-
-.mobile-bottom-navigation:not([data-picker-open="true"])
-  .player-control-button[data-active="true"]:not(#player-select-button)::before,
-.mobile-bottom-navigation #player-select-button[data-active="true"]::before {
-  position: absolute;
-  z-index: 0;
-  inset: 4px 0;
-  border-radius: 28px;
-  background: color-mix(in srgb, var(--primary) 22%, transparent);
-  content: "";
-}
-
-/* the player name fills its button, so its field reaches past it to keep the
-   text off the edges; the page labels are short and need no such room */
-.mobile-bottom-navigation #player-select-button[data-active="true"]::before {
-  inset: 4px -6px;
 }
 
 /* no label, so the icon takes the whole height and the button only claims the
@@ -195,7 +173,6 @@ function closePlayersMenu() {
 }
 
 .mobile-navigation-label {
-  position: relative;
   display: block;
   width: 100%;
   height: 16px;

--- a/src/components/navigation/BottomNavigation.vue
+++ b/src/components/navigation/BottomNavigation.vue
@@ -19,6 +19,7 @@
       variant="ghost"
       class="player-control-button mobile-navigation-item min-w-0 flex-1 rounded-none px-1"
       :data-active="isActive('discover')"
+      :aria-current="isActive('discover') ? 'page' : undefined"
       :aria-label="$t('discover')"
       @click="handleDiscoverClick"
     >
@@ -36,6 +37,7 @@
       variant="ghost"
       class="player-control-button mobile-navigation-item mobile-navigation-item--bare shrink-0 rounded-none px-1"
       :data-active="isActive('search')"
+      :aria-current="isActive('search') ? 'page' : undefined"
       :aria-label="$t('search')"
       @click="handleSearchClick"
     >
@@ -99,25 +101,25 @@ function closePlayersMenu() {
   /* the device insets are already covered by left/right, so this only keeps the
      two icon-only ends off the rounded corners */
   padding-inline: 12px !important;
-  border: 1px solid var(--border);
+  /* an outline rather than a border: it costs no layout, so the items still
+     get the full height and their focus ring is not clipped */
+  outline: 1px solid var(--border);
+  outline-offset: -1px;
   border-radius: 28px;
   /* only a tint: the blur comes from the scrim behind it, which ramps up from
      above the player, so the bar has no blur edge of its own */
   background: color-mix(in srgb, var(--background) 70%, transparent);
-  /* the items paint a full-height hover, which would otherwise square off the
-     rounded ends */
-  overflow: hidden;
 }
 
 /* darker than the muted grey the player controls use elsewhere, so the labels
-   hold their own against the blurred content behind them */
-.mobile-bottom-navigation .player-control-button {
-  color: color-mix(in srgb, var(--foreground) 80%, transparent) !important;
-}
-
-/* the state is carried by the dot and the heavier label, so nothing in the bar
-   switches to the primary colour */
-.mobile-bottom-navigation .player-control-button[data-active="true"] {
+   hold their own against the blurred content behind them. The field and the
+   heavier label carry the state instead, so nothing here turns primary - which
+   also stops a tap leaving an item stuck in its hover colour on iOS. */
+.mobile-bottom-navigation .player-control-button,
+.mobile-bottom-navigation
+  .player-control-button:hover:not([data-suppress-hover="true"]),
+.mobile-bottom-navigation .player-control-button[data-active="true"],
+.mobile-bottom-navigation .player-control-button[data-state="open"] {
   color: color-mix(in srgb, var(--foreground) 80%, transparent) !important;
 }
 
@@ -133,7 +135,7 @@ function closePlayersMenu() {
 }
 
 /* the active item sits on a faded field that repeats the bar's own corner
-   radius; -1 keeps it under the icon and label but over the bar's tint. An open
+   radius; it sits under the icon and label but over the bar's tint. An open
    picker takes the active state for itself, so the page underneath drops it and
    only one item is ever marked. */
 .mobile-bottom-navigation:not([data-picker-open="true"])
@@ -146,7 +148,7 @@ function closePlayersMenu() {
   .player-control-button[data-active="true"]:not(#player-select-button)::before,
 .mobile-bottom-navigation #player-select-button[data-active="true"]::before {
   position: absolute;
-  z-index: -1;
+  z-index: 0;
   inset: 4px 0;
   border-radius: 28px;
   background: color-mix(in srgb, var(--primary) 22%, transparent);
@@ -193,6 +195,7 @@ function closePlayersMenu() {
 }
 
 .mobile-navigation-label {
+  position: relative;
   display: block;
   width: 100%;
   height: 16px;

--- a/src/components/navigation/BottomNavigation.vue
+++ b/src/components/navigation/BottomNavigation.vue
@@ -1,6 +1,6 @@
 <template>
   <nav
-    class="mobile-bottom-navigation fixed inset-x-0 bottom-0 z-[2000] flex shadow-lg"
+    class="mobile-bottom-navigation fixed inset-x-0 bottom-0 z-[2000] flex"
     :data-picker-open="store.showPlayersMenu"
     aria-label="Main navigation"
   >
@@ -101,14 +101,27 @@ function closePlayersMenu() {
   /* the device insets are already covered by left/right, so this only keeps the
      two icon-only ends off the rounded corners */
   padding-inline: 12px !important;
-  /* an outline rather than a border: it costs no layout, so the items still
-     get the full height and their focus ring is not clipped */
-  outline: 1px solid var(--border);
-  outline-offset: -1px;
-  border-radius: 28px;
-  /* only a tint: the blur comes from the scrim behind it, which ramps up from
-     above the player, so the bar has no blur edge of its own */
+}
+
+/* one surface for the whole dock: it reaches up behind the player, which then
+   sits on it as its own card. The player's measured height is published by the
+   footer, so the two always meet. Only a tint - the blur comes from the scrim
+   behind it, which ramps up from above the player. */
+.mobile-bottom-navigation::before {
+  position: absolute;
+  z-index: -1;
+  top: calc(-1 * (var(--player-bar-overlay-height, 0px) + 4px));
+  right: 0;
+  bottom: 0;
+  left: 0;
+  /* the top stays concentric with the player card sitting on it; the bottom is
+     far rounder so it does not fight the screen's own corner curve */
+  border-radius: 20px 20px 32px 32px;
   background: color-mix(in srgb, var(--background) 70%, transparent);
+  box-shadow:
+    0 10px 15px -3px rgb(0 0 0 / 0.1),
+    0 4px 6px -4px rgb(0 0 0 / 0.1);
+  content: "";
 }
 
 /* darker than the muted grey the player controls use elsewhere, so the labels

--- a/src/components/navigation/BottomNavigation.vue
+++ b/src/components/navigation/BottomNavigation.vue
@@ -42,7 +42,12 @@
       @click="handleSearchClick"
     >
       <span class="mobile-navigation-icon">
-        <Search class="size-8" :stroke-width="isActive('search') ? 2.2 : 1.6" />
+        <Search
+          class="size-8"
+          :stroke-width="
+            isActive('search') && !store.showPlayersMenu ? 2.2 : 1.6
+          "
+        />
       </span>
     </Button>
   </nav>

--- a/src/components/navigation/BottomNavigation.vue
+++ b/src/components/navigation/BottomNavigation.vue
@@ -6,7 +6,7 @@
   >
     <Button
       variant="ghost"
-      class="player-control-button mobile-navigation-item mobile-navigation-item--bare shrink-0 rounded-none px-1"
+      class="player-control-button mobile-navigation-item mobile-navigation-item--bare px-1"
       aria-label="Menu"
       @click="handleMenuClick"
     >
@@ -17,7 +17,7 @@
 
     <Button
       variant="ghost"
-      class="player-control-button mobile-navigation-item min-w-0 flex-1 rounded-none px-1"
+      class="player-control-button mobile-navigation-item min-w-0 flex-1 px-1"
       :data-active="isActive('discover')"
       :aria-current="isActive('discover') ? 'page' : undefined"
       :aria-label="$t('discover')"
@@ -35,7 +35,7 @@
 
     <Button
       variant="ghost"
-      class="player-control-button mobile-navigation-item mobile-navigation-item--bare shrink-0 rounded-none px-1"
+      class="player-control-button mobile-navigation-item mobile-navigation-item--bare px-1"
       :data-active="isActive('search')"
       :aria-current="isActive('search') ? 'page' : undefined"
       :aria-label="$t('search')"

--- a/src/components/navigation/BottomNavigation.vue
+++ b/src/components/navigation/BottomNavigation.vue
@@ -1,18 +1,18 @@
 <template>
   <nav
-    class="mobile-bottom-navigation fixed inset-x-0 bottom-0 z-[2000] flex border-t px-1 shadow-lg"
+    class="mobile-bottom-navigation fixed inset-x-0 bottom-0 z-[2000] flex shadow-lg"
+    :data-picker-open="store.showPlayersMenu"
     aria-label="Main navigation"
   >
     <Button
       variant="ghost"
-      class="player-control-button mobile-navigation-item min-w-0 flex-1 rounded-none px-1"
+      class="player-control-button mobile-navigation-item mobile-navigation-item--bare shrink-0 rounded-none px-1"
       aria-label="Menu"
       @click="handleMenuClick"
     >
       <span class="mobile-navigation-icon">
-        <Menu :stroke-width="1.6" class="size-7" />
+        <Menu :stroke-width="1.6" class="size-8" />
       </span>
-      <span class="mobile-navigation-label"> Menu </span>
     </Button>
 
     <Button
@@ -23,10 +23,7 @@
       @click="handleDiscoverClick"
     >
       <span class="mobile-navigation-icon">
-        <Compass
-          class="size-7"
-          :stroke-width="isActive('discover') ? 2 : 1.6"
-        />
+        <Compass class="size-7" :stroke-width="1.6" />
       </span>
       <span class="mobile-navigation-label">
         {{ $t("discover") }}
@@ -37,16 +34,13 @@
 
     <Button
       variant="ghost"
-      class="player-control-button mobile-navigation-item min-w-0 flex-1 rounded-none px-1"
+      class="player-control-button mobile-navigation-item mobile-navigation-item--bare shrink-0 rounded-none px-1"
       :data-active="isActive('search')"
       :aria-label="$t('search')"
       @click="handleSearchClick"
     >
       <span class="mobile-navigation-icon">
-        <Search class="size-7" :stroke-width="isActive('search') ? 2 : 1.6" />
-      </span>
-      <span class="mobile-navigation-label">
-        {{ $t("search") }}
+        <Search class="size-8" :stroke-width="1.6" />
       </span>
     </Button>
   </nav>
@@ -96,36 +90,94 @@ function closePlayersMenu() {
 </script>
 
 <style>
-/* :root lifts this above the equally-!important bottom and padding utilities
-   the bar carries */
+/* :root lifts this above the equally-!important inset utilities the bar carries */
 :root .mobile-bottom-navigation {
-  bottom: -2px !important;
-  height: calc(var(--mobile-navigation-height) + 2px);
-  background: var(--background);
-  padding-right: calc(0.25rem + var(--device-inset-right)) !important;
-  padding-bottom: calc(var(--mobile-navigation-inset-bottom) + 2px);
-  padding-left: calc(0.25rem + var(--device-inset-left)) !important;
+  right: calc(12px + var(--device-inset-right)) !important;
+  bottom: var(--mobile-navigation-inset-bottom) !important;
+  left: calc(12px + var(--device-inset-left)) !important;
+  height: var(--mobile-navigation-item-height);
+  /* the device insets are already covered by left/right, so this only keeps the
+     two icon-only ends off the rounded corners */
+  padding-inline: 12px !important;
+  border: 1px solid var(--border);
+  border-radius: 28px;
+  /* only a tint: the blur comes from the scrim behind it, which ramps up from
+     above the player, so the bar has no blur edge of its own */
+  background: color-mix(in srgb, var(--background) 70%, transparent);
+  /* the items paint a full-height hover, which would otherwise square off the
+     rounded ends */
+  overflow: hidden;
 }
 
-.mobile-bottom-navigation::before {
+/* darker than the muted grey the player controls use elsewhere, so the labels
+   hold their own against the blurred content behind them */
+.mobile-bottom-navigation .player-control-button {
+  color: color-mix(in srgb, var(--foreground) 80%, transparent) !important;
+}
+
+/* the state is carried by the dot and the heavier label, so nothing in the bar
+   switches to the primary colour */
+.mobile-bottom-navigation .player-control-button[data-active="true"] {
+  color: color-mix(in srgb, var(--foreground) 80%, transparent) !important;
+}
+
+/* the open picker takes the active state for itself, so the page it sits over
+   stops claiming it too */
+.mobile-bottom-navigation:not([data-picker-open="true"])
+  .player-control-button[data-active="true"]:not(#player-select-button)
+  .mobile-navigation-label,
+.mobile-bottom-navigation
+  #player-select-button[data-active="true"]
+  .mobile-navigation-label {
+  font-weight: 600;
+}
+
+/* the active item sits on a faded field that repeats the bar's own corner
+   radius; -1 keeps it under the icon and label but over the bar's tint. An open
+   picker takes the active state for itself, so the page underneath drops it and
+   only one item is ever marked. */
+.mobile-bottom-navigation:not([data-picker-open="true"])
+  .player-control-button[data-active="true"]:not(#player-select-button),
+.mobile-bottom-navigation #player-select-button[data-active="true"] {
+  position: relative;
+}
+
+.mobile-bottom-navigation:not([data-picker-open="true"])
+  .player-control-button[data-active="true"]:not(#player-select-button)::before,
+.mobile-bottom-navigation #player-select-button[data-active="true"]::before {
   position: absolute;
-  top: -2px;
-  right: 0;
-  left: 0;
-  height: 2px;
-  background: var(--background);
+  z-index: -1;
+  inset: 4px 0;
+  border-radius: 28px;
+  background: color-mix(in srgb, var(--primary) 22%, transparent);
   content: "";
+}
+
+/* the player name fills its button, so its field reaches past it to keep the
+   text off the edges; the page labels are short and need no such room */
+.mobile-bottom-navigation #player-select-button[data-active="true"]::before {
+  inset: 4px -6px;
+}
+
+/* no label, so the icon takes the whole height and the button only claims the
+   width it needs */
+.player-control-button.mobile-navigation-item--bare {
+  width: 60px;
+  grid-template-rows: 1fr !important;
 }
 
 /* the paired class outweighs the equally-!important layout utilities the button
    brings along with its base and size */
 .player-control-button.mobile-navigation-item {
   display: grid !important;
+  /* the ring follows the bar's own shape instead of cutting hard verticals
+     across it */
+  border-radius: 24px !important;
   height: var(--mobile-navigation-item-height) !important;
-  grid-template-rows: 34px 16px;
+  grid-template-rows: 30px 16px;
   align-content: center;
   justify-items: center;
-  row-gap: 4px !important;
+  row-gap: 1px !important;
   /* tight, so the buttons sit close to the player bar; the room that keeps them
      clear of the screen edge comes from the bar's own bottom inset */
   padding-top: 2px !important;
@@ -133,8 +185,9 @@ function closePlayersMenu() {
 }
 
 .mobile-navigation-icon {
+  position: relative;
   display: flex;
-  height: 34px;
+  height: 30px;
   align-items: center;
   justify-content: center;
 }

--- a/src/components/navigation/BottomNavigation.vue
+++ b/src/components/navigation/BottomNavigation.vue
@@ -42,7 +42,7 @@
       @click="handleSearchClick"
     >
       <span class="mobile-navigation-icon">
-        <Search class="size-8" :stroke-width="1.6" />
+        <Search class="size-8" :stroke-width="isActive('search') ? 2.2 : 1.6" />
       </span>
     </Button>
   </nav>
@@ -111,6 +111,7 @@ function closePlayersMenu() {
   position: absolute;
   z-index: -1;
   top: calc(-1 * (var(--player-bar-overlay-height, 0px) + 4px));
+  pointer-events: none;
   right: 0;
   bottom: 0;
   left: 0;
@@ -152,13 +153,6 @@ function closePlayersMenu() {
   font-weight: 600;
 }
 
-/* no label, so the icon takes the whole height and the button only claims the
-   width it needs */
-.player-control-button.mobile-navigation-item--bare {
-  width: 60px;
-  grid-template-rows: 1fr !important;
-}
-
 /* the paired class outweighs the equally-!important layout utilities the button
    brings along with its base and size */
 .player-control-button.mobile-navigation-item {
@@ -177,8 +171,14 @@ function closePlayersMenu() {
   padding-bottom: 2px !important;
 }
 
+/* no label, so the icon takes the whole height and the button only claims the
+   width it needs */
+.player-control-button.mobile-navigation-item--bare {
+  width: 60px;
+  grid-template-rows: 1fr;
+}
+
 .mobile-navigation-icon {
-  position: relative;
   display: flex;
   height: 30px;
   align-items: center;

--- a/src/layouts/default/Footer.vue
+++ b/src/layouts/default/Footer.vue
@@ -74,13 +74,14 @@ function clearOverlay() {
 .mediacontrols-player-float {
   display: flex;
   flex-direction: column;
-  margin: 5px calc(5px + var(--device-inset-right)) 5px
-    calc(5px + var(--device-inset-left));
+  /* the same inset the navigation below it uses, so the two line up */
+  margin: 5px calc(12px + var(--device-inset-right)) 5px
+    calc(12px + var(--device-inset-left));
   margin-bottom: var(--mobile-player-bar-gap);
   width: calc(
-    100% - 10px - var(--device-inset-right) - var(--device-inset-left)
+    100% - 24px - var(--device-inset-right) - var(--device-inset-left)
   ) !important;
-  border-radius: 10px !important;
+  border-radius: 16px !important;
 }
 
 .player-scrim {
@@ -95,11 +96,18 @@ function clearOverlay() {
   -webkit-backdrop-filter: blur(14px);
   /* the mask is what makes the blur ramp up towards the player instead of
      ending on a visible line */
-  mask-image: linear-gradient(to top, #000 0%, #000 45%, transparent 100%);
+  mask-image: linear-gradient(
+    to top,
+    #000 0%,
+    #000 35%,
+    rgba(0, 0, 0, 0.55) 65%,
+    transparent 100%
+  );
   -webkit-mask-image: linear-gradient(
     to top,
     #000 0%,
-    #000 45%,
+    #000 35%,
+    rgba(0, 0, 0, 0.55) 65%,
     transparent 100%
   );
 }

--- a/src/layouts/default/Footer.vue
+++ b/src/layouts/default/Footer.vue
@@ -74,10 +74,10 @@ function clearOverlay() {
 .mediacontrols-player-float {
   display: flex;
   flex-direction: column;
-  /* the same inset the navigation below it uses, so the two line up */
-  margin: 5px calc(16px + var(--device-inset-right)) 5px
+  /* 4px inside the dock's own inset, so the surface shows evenly around the
+     card on every side */
+  margin: 5px calc(16px + var(--device-inset-right)) 0
     calc(16px + var(--device-inset-left));
-  margin-bottom: var(--mobile-player-bar-gap);
   width: calc(
     100% - 32px - var(--device-inset-right) - var(--device-inset-left)
   ) !important;

--- a/src/layouts/default/Footer.vue
+++ b/src/layouts/default/Footer.vue
@@ -75,13 +75,16 @@ function clearOverlay() {
   display: flex;
   flex-direction: column;
   /* the same inset the navigation below it uses, so the two line up */
-  margin: 5px calc(12px + var(--device-inset-right)) 5px
-    calc(12px + var(--device-inset-left));
+  margin: 5px calc(16px + var(--device-inset-right)) 5px
+    calc(16px + var(--device-inset-left));
   margin-bottom: var(--mobile-player-bar-gap);
   width: calc(
-    100% - 24px - var(--device-inset-right) - var(--device-inset-left)
+    100% - 32px - var(--device-inset-right) - var(--device-inset-left)
   ) !important;
   border-radius: 16px !important;
+  /* the footer only positions the player; its own surface would otherwise show
+     as opaque wedges outside the player's rounded corners */
+  background: transparent !important;
 }
 
 .player-scrim {

--- a/src/layouts/default/Footer.vue
+++ b/src/layouts/default/Footer.vue
@@ -75,16 +75,14 @@ function clearOverlay() {
   display: flex;
   flex-direction: column;
   /* 4px inside the dock's own inset, so the surface shows evenly around the
-     card on every side */
-  margin: 5px calc(16px + var(--device-inset-right)) 0
+     card on every side. The vertical margins are omitted: the bar is fixed and
+     anchored by its bottom, so they would not move it. */
+  margin: 0 calc(16px + var(--device-inset-right)) 0
     calc(16px + var(--device-inset-left));
   width: calc(
     100% - 32px - var(--device-inset-right) - var(--device-inset-left)
   ) !important;
   border-radius: 16px !important;
-  /* the footer only positions the player; its own surface would otherwise show
-     as opaque wedges outside the player's rounded corners */
-  background: transparent !important;
 }
 
 .player-scrim {
@@ -126,5 +124,9 @@ function clearOverlay() {
 
 .v-footer.mediacontrols-player-float {
   z-index: 2001 !important;
+  /* the footer only positions the player; its own surface would otherwise show
+     as opaque wedges outside the player's rounded corners. The paired class
+     outweighs the equally-!important bg-default the colour prop brings. */
+  background: transparent !important;
 }
 </style>

--- a/src/layouts/default/PlayerOSD/Player.vue
+++ b/src/layouts/default/PlayerOSD/Player.vue
@@ -235,7 +235,7 @@ watch(
 .mediacontrols-mobile-container {
   position: relative;
   width: 100%;
-  border-radius: 10px;
+  border-radius: 16px;
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.2);
   overflow: hidden;
   background-color: rgb(var(--v-theme-overlay));
@@ -258,8 +258,8 @@ watch(
     display: flex;
     background-color: transparent;
     min-height: 0;
-    /* the top matches the side inset, so the artwork sits the same distance
-       from both edges; the volume row carries the space below it */
+    /* the artwork ends up as far from the top as from the left once the row
+       centres it; the volume row carries the space below */
     padding: 8px 10px 5px;
     /* beats the global .player-control-button colour, which is tuned for the
        app surface rather than an artwork tint */
@@ -317,7 +317,7 @@ watch(
   );
 
   &[data-floating="true"] {
-    border-radius: 10px;
+    border-radius: 16px;
     width: 100%;
     background: v-bind("backgroundColor");
   }

--- a/src/layouts/default/PlayerOSD/Player.vue
+++ b/src/layouts/default/PlayerOSD/Player.vue
@@ -258,7 +258,9 @@ watch(
     display: flex;
     background-color: transparent;
     min-height: 0;
-    padding: 5px 10px;
+    /* the top matches the side inset, so the artwork sits the same distance
+       from both edges; the volume row carries the space below it */
+    padding: 8px 10px 5px;
     /* beats the global .player-control-button colour, which is tuned for the
        app surface rather than an artwork tint */
     :deep(.player-control-button) {

--- a/src/layouts/default/PlayerOSD/Player.vue
+++ b/src/layouts/default/PlayerOSD/Player.vue
@@ -260,7 +260,7 @@ watch(
     min-height: 0;
     /* the artwork ends up as far from the top as from the left once the row
        centres it; the volume row carries the space below */
-    padding: 8px 10px 5px;
+    padding: 10px 12px 6px;
     /* beats the global .player-control-button colour, which is tuned for the
        app surface rather than an artwork tint */
     :deep(.player-control-button) {

--- a/src/layouts/default/PlayerOSD/PlayerBarPlayerButton.vue
+++ b/src/layouts/default/PlayerOSD/PlayerBarPlayerButton.vue
@@ -4,7 +4,7 @@
     variant="ghost"
     :class="[
       navigation
-        ? 'player-control-button mobile-navigation-item min-w-0 flex-1 rounded-none px-1'
+        ? 'player-control-button mobile-navigation-item min-w-0 flex-1 px-1'
         : 'player-control-button player-bar-action player-bar-player-button h-20 w-24 min-w-0 rounded-none px-1',
     ]"
     :data-active="store.showPlayersMenu"

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -38,9 +38,6 @@
   /* Size of a single bottom navigation button, which the bar sizes itself from,
      so the two can never drift apart. */
   --mobile-navigation-item-height: 72px;
-  /* Gap the floating mobile player bar keeps above the navigation. The bar sets
-     it as its own margin, and anything stacking on top of the bar adds it. */
-  --mobile-player-bar-gap: 0px;
   /* Space the bottom navigation occupies. Anything anchored above it (sheets,
      popovers, the player bar, scroll padding) is positioned from this. */
   --mobile-navigation-height: calc(
@@ -76,8 +73,7 @@
    player bar floats above the navigation, keeping its gap from it. */
 :root[data-player-bar-overlay] {
   --bottom-bars-height: calc(
-    var(--mobile-navigation-height) + var(--mobile-player-bar-gap) +
-      var(--player-bar-overlay-height)
+    var(--mobile-navigation-height) + var(--player-bar-overlay-height)
   );
 }
 

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -32,15 +32,15 @@
      gesture bar sit well inside the inset reserved around them, so the buttons
      take a share of it instead of all of it, never dropping below the floor. */
   --mobile-navigation-inset-bottom: max(
-    6px,
+    12px,
     calc(var(--device-inset-bottom) * 0.65)
   );
   /* Size of a single bottom navigation button, which the bar sizes itself from,
      so the two can never drift apart. */
-  --mobile-navigation-item-height: 64px;
+  --mobile-navigation-item-height: 72px;
   /* Gap the floating mobile player bar keeps above the navigation. The bar sets
      it as its own margin, and anything stacking on top of the bar adds it. */
-  --mobile-player-bar-gap: 4px;
+  --mobile-player-bar-gap: 0px;
   /* Space the bottom navigation occupies. Anything anchored above it (sheets,
      popovers, the player bar, scroll padding) is positioned from this. */
   --mobile-navigation-height: calc(

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -70,7 +70,8 @@
 }
 
 /* The footer sets this marker while the mobile bars are on screen. There the
-   player bar floats above the navigation, keeping its gap from it. */
+   player bar sits on the navigation, so the two together are what has to be
+   cleared. */
 :root[data-player-bar-overlay] {
   --bottom-bars-height: calc(
     var(--mobile-navigation-height) + var(--player-bar-overlay-height)

--- a/tests/components/BottomNavigation.test.ts
+++ b/tests/components/BottomNavigation.test.ts
@@ -1,5 +1,5 @@
 import BottomNavigation from "@/components/navigation/BottomNavigation.vue";
-import { enableAutoUnmount, mount } from "@vue/test-utils";
+import { enableAutoUnmount, mount, type VueWrapper } from "@vue/test-utils";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 const { routeState, mockRouterPush, mockEmit } = vi.hoisted(() => ({
@@ -28,6 +28,13 @@ const { store } = await import("@/plugins/store");
 
 enableAutoUnmount(afterEach);
 
+/** Finds a bar item by its accessible name, so order changes cannot mislead. */
+function itemNamed(wrapper: VueWrapper, name: string) {
+  return wrapper
+    .findAll("button")
+    .find((button) => button.attributes("aria-label") === name)!;
+}
+
 function mountNavigation() {
   return mount(BottomNavigation, {
     global: {
@@ -55,13 +62,13 @@ describe("BottomNavigation", () => {
 
   it("names the icon-only ends without printing a label", () => {
     const wrapper = mountNavigation();
-    const [menu, , search] = wrapper.findAll("button");
-
     // both keep an accessible name; only the middle items show text
-    expect(menu.attributes("aria-label")).toBe("Menu");
-    expect(menu.find(".mobile-navigation-label").exists()).toBe(false);
-    expect(search.attributes("aria-label")).toBe("search");
-    expect(search.find(".mobile-navigation-label").exists()).toBe(false);
+    expect(
+      itemNamed(wrapper, "Menu").find(".mobile-navigation-label").exists(),
+    ).toBe(false);
+    expect(
+      itemNamed(wrapper, "search").find(".mobile-navigation-label").exists(),
+    ).toBe(false);
   });
 
   it("marks the page you are on", () => {
@@ -102,7 +109,7 @@ describe("BottomNavigation", () => {
     store.showPlayersMenu = true;
     const wrapper = mountNavigation();
 
-    await wrapper.findAll("button")[1].trigger("click");
+    await itemNamed(wrapper, "discover").trigger("click");
 
     expect(mockRouterPush).toHaveBeenCalledWith({ name: "discover" });
     expect(store.showPlayersMenu).toBe(false);
@@ -111,7 +118,7 @@ describe("BottomNavigation", () => {
   it("opens the sidebar from the menu button", async () => {
     const wrapper = mountNavigation();
 
-    await wrapper.findAll("button")[0].trigger("click");
+    await itemNamed(wrapper, "Menu").trigger("click");
 
     expect(mockEmit).toHaveBeenCalledWith("mobile-sidebar-open");
   });

--- a/tests/components/BottomNavigation.test.ts
+++ b/tests/components/BottomNavigation.test.ts
@@ -74,6 +74,19 @@ describe("BottomNavigation", () => {
     expect(active).toEqual(["discover"]);
   });
 
+  it("names the current page for assistive tech, not just by tint", () => {
+    routeState.name = "search";
+    const wrapper = mountNavigation();
+    const current = wrapper
+      .findAll("button")
+      .filter((button) => button.attributes("aria-current") === "page")
+      .map((button) => button.attributes("aria-label"));
+
+    // search carries no visible label, so the tint alone would leave its state
+    // invisible to a screen reader
+    expect(current).toEqual(["search"]);
+  });
+
   it("hands the active state to an open player picker", async () => {
     const wrapper = mountNavigation();
     expect(wrapper.get("nav").attributes("data-picker-open")).toBe("false");

--- a/tests/components/BottomNavigation.test.ts
+++ b/tests/components/BottomNavigation.test.ts
@@ -1,0 +1,105 @@
+import BottomNavigation from "@/components/navigation/BottomNavigation.vue";
+import { enableAutoUnmount, mount } from "@vue/test-utils";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const { routeState, mockRouterPush, mockEmit } = vi.hoisted(() => ({
+  routeState: { name: "discover" } as { name: string },
+  mockRouterPush: vi.fn(),
+  mockEmit: vi.fn(),
+}));
+
+vi.mock("vue-router", () => ({
+  useRoute: () => routeState,
+  useRouter: () => ({ push: mockRouterPush }),
+}));
+
+vi.mock("@/plugins/eventbus", () => ({
+  eventbus: { emit: mockEmit },
+}));
+
+vi.mock("@/plugins/i18n", () => ({ $t: (key: string) => key }));
+
+vi.mock("@/plugins/store", async () => {
+  const { reactive } = await vi.importActual<typeof import("vue")>("vue");
+  return { store: reactive({ showPlayersMenu: false }) };
+});
+
+const { store } = await import("@/plugins/store");
+
+enableAutoUnmount(afterEach);
+
+function mountNavigation() {
+  return mount(BottomNavigation, {
+    global: {
+      stubs: { PlayerBarPlayerButton: true },
+      mocks: { $t: (key: string) => key },
+    },
+  });
+}
+
+afterEach(() => {
+  routeState.name = "discover";
+  store.showPlayersMenu = false;
+  vi.clearAllMocks();
+});
+
+describe("BottomNavigation", () => {
+  it("puts search at the end, past the player", () => {
+    const wrapper = mountNavigation();
+    const order = wrapper
+      .findAll("button, player-bar-player-button-stub")
+      .map((element) => element.attributes("aria-label") ?? "player");
+
+    expect(order).toEqual(["Menu", "discover", "player", "search"]);
+  });
+
+  it("names the icon-only ends without printing a label", () => {
+    const wrapper = mountNavigation();
+    const [menu, , search] = wrapper.findAll("button");
+
+    // both keep an accessible name; only the middle items show text
+    expect(menu.attributes("aria-label")).toBe("Menu");
+    expect(menu.find(".mobile-navigation-label").exists()).toBe(false);
+    expect(search.attributes("aria-label")).toBe("search");
+    expect(search.find(".mobile-navigation-label").exists()).toBe(false);
+  });
+
+  it("marks the page you are on", () => {
+    const wrapper = mountNavigation();
+    const active = wrapper
+      .findAll("button")
+      .filter((button) => button.attributes("data-active") === "true")
+      .map((button) => button.attributes("aria-label"));
+
+    expect(active).toEqual(["discover"]);
+  });
+
+  it("hands the active state to an open player picker", async () => {
+    const wrapper = mountNavigation();
+    expect(wrapper.get("nav").attributes("data-picker-open")).toBe("false");
+
+    store.showPlayersMenu = true;
+    await wrapper.vm.$nextTick();
+
+    // the styling keys off this, so the page underneath stops looking active
+    expect(wrapper.get("nav").attributes("data-picker-open")).toBe("true");
+  });
+
+  it("closes the player picker when navigating away", async () => {
+    store.showPlayersMenu = true;
+    const wrapper = mountNavigation();
+
+    await wrapper.findAll("button")[1].trigger("click");
+
+    expect(mockRouterPush).toHaveBeenCalledWith({ name: "discover" });
+    expect(store.showPlayersMenu).toBe(false);
+  });
+
+  it("opens the sidebar from the menu button", async () => {
+    const wrapper = mountNavigation();
+
+    await wrapper.findAll("button")[0].trigger("click");
+
+    expect(mockEmit).toHaveBeenCalledWith("mobile-sidebar-open");
+  });
+});

--- a/tests/styles/bottomBarsHeight.test.ts
+++ b/tests/styles/bottomBarsHeight.test.ts
@@ -9,8 +9,8 @@ const OVERLAY_MARKER = "data-player-bar-overlay";
 const BAR_HEIGHT = "120px";
 const PLAYER_BAR_HEIGHT = "calc( 104px + env(safe-area-inset-bottom, 0px) )";
 const NAVIGATION_INSET =
-  "max( 6px, calc(env(safe-area-inset-bottom, 0px) * 0.65) )";
-const NAVIGATION_HEIGHT = `calc( 64px + ${NAVIGATION_INSET} )`;
+  "max( 12px, calc(env(safe-area-inset-bottom, 0px) * 0.65) )";
+const NAVIGATION_HEIGHT = `calc( 72px + ${NAVIGATION_INSET} )`;
 
 let appStyles: HTMLStyleElement;
 
@@ -69,7 +69,7 @@ describe("bottom bars height", () => {
     document.documentElement.style.setProperty(OVERLAY_HEIGHT, BAR_HEIGHT);
 
     expect(bottomBarsHeight()).toBe(
-      `calc( ${NAVIGATION_HEIGHT} + 4px + ${BAR_HEIGHT} )`,
+      `calc( ${NAVIGATION_HEIGHT} + 0px + ${BAR_HEIGHT} )`,
     );
   });
 
@@ -86,7 +86,7 @@ describe("bottom bars height", () => {
     // the blur behind the bars softens what scrolls under it without hiding
     // it, so nothing has to clear more than the bars themselves
     expect(bottomObscuredHeight()).toBe(
-      `calc( ${NAVIGATION_HEIGHT} + 4px + ${BAR_HEIGHT} )`,
+      `calc( ${NAVIGATION_HEIGHT} + 0px + ${BAR_HEIGHT} )`,
     );
   });
 });

--- a/tests/styles/bottomBarsHeight.test.ts
+++ b/tests/styles/bottomBarsHeight.test.ts
@@ -69,7 +69,7 @@ describe("bottom bars height", () => {
     document.documentElement.style.setProperty(OVERLAY_HEIGHT, BAR_HEIGHT);
 
     expect(bottomBarsHeight()).toBe(
-      `calc( ${NAVIGATION_HEIGHT} + 0px + ${BAR_HEIGHT} )`,
+      `calc( ${NAVIGATION_HEIGHT} + ${BAR_HEIGHT} )`,
     );
   });
 
@@ -86,7 +86,7 @@ describe("bottom bars height", () => {
     // the blur behind the bars softens what scrolls under it without hiding
     // it, so nothing has to clear more than the bars themselves
     expect(bottomObscuredHeight()).toBe(
-      `calc( ${NAVIGATION_HEIGHT} + 0px + ${BAR_HEIGHT} )`,
+      `calc( ${NAVIGATION_HEIGHT} + ${BAR_HEIGHT} )`,
     );
   });
 });

--- a/tests/styles/safeArea.test.ts
+++ b/tests/styles/safeArea.test.ts
@@ -37,7 +37,7 @@ describe("bottom navigation", () => {
         .getPropertyValue("--mobile-navigation-inset-bottom")
         .replace(/\s+/g, " ")
         .trim(),
-    ).toBe("max( 6px, calc(env(safe-area-inset-bottom, 0px) * 0.65) )");
+    ).toBe("max( 12px, calc(env(safe-area-inset-bottom, 0px) * 0.65) )");
   });
 });
 


### PR DESCRIPTION
# What does this implement/fix?

The bottom menu was a solid bar pinned to the edge of the screen, separate from
the floating player above it, so the blur behind the player stopped dead against
it.

The player and the menu are now one see-through dock: a single rounded surface
that the player sits on as its own card, floating clear of the screen edges with
the content behind it gently blurred.

**Related issue (if applicable):**

- n/a

**Related backend PR (if applicable):**

- n/a

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

Changes:

- The player and the bottom menu form one rounded, see-through dock, inset from
  the screen edges and rounded more at the bottom to suit rounded screens.
- The blur behind them fades in gradually and shows through the dock itself.
- Menu and search are icon only, so the middle items have room for their labels.
- The page you are on keeps the accent colour and a heavier label; an open player
  picker takes that state instead, so only one item is ever marked.
- The menu is a little taller and sits further off the bottom of the screen.
- Added tests for the bottom menu, which had none.

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm lint:check` passes.
- [x] `pnpm test:run` passes, and tests have been added/updated where applicable.
- [x] `pnpm build` passes.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
