### PR TITLE
Translate the menu button on the mobile bottom bar

### DIFF
--- a/src/components/navigation/BottomNavigation.vue
+++ b/src/components/navigation/BottomNavigation.vue
@@ -2,12 +2,12 @@
   <nav
     class="mobile-bottom-navigation fixed inset-x-0 bottom-0 z-[2000] flex"
     :data-picker-open="store.showPlayersMenu"
-    aria-label="Main navigation"
+    :aria-label="$t('main_navigation')"
   >
     <Button
       variant="ghost"
       class="player-control-button mobile-navigation-item mobile-navigation-item--bare px-1"
-      aria-label="Menu"
+      :aria-label="$t('menu')"
       @click="handleMenuClick"
     >
       <span class="mobile-navigation-icon">

--- a/src/components/navigation/BottomNavigation.vue
+++ b/src/components/navigation/BottomNavigation.vue
@@ -1,4 +1,6 @@
 <template>
+  <!-- the label deliberately omits "navigation": screen readers append the
+       landmark role, so anything else reads as "... navigation navigation" -->
   <nav
     class="mobile-bottom-navigation fixed inset-x-0 bottom-0 z-[2000] flex"
     :data-picker-open="store.showPlayersMenu"

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -2240,5 +2240,5 @@
     },
     "searching": "Searching...",
     "menu": "Menu",
-    "main_navigation": "Main navigation"
+    "main_navigation": "Main"
 }

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -2238,5 +2238,7 @@
         "nothing_active_title": "Nothing is currently active",
         "nothing_active_description": "Ask the host to start a guest experience."
     },
-    "searching": "Searching..."
+    "searching": "Searching...",
+    "menu": "Menu",
+    "main_navigation": "Main navigation"
 }

--- a/tests/components/BottomNavigation.test.ts
+++ b/tests/components/BottomNavigation.test.ts
@@ -57,18 +57,25 @@ describe("BottomNavigation", () => {
       .findAll("button, player-bar-player-button-stub")
       .map((element) => element.attributes("aria-label") ?? "player");
 
-    expect(order).toEqual(["Menu", "discover", "player", "search"]);
+    expect(order).toEqual(["menu", "discover", "player", "search"]);
   });
 
   it("names the icon-only ends without printing a label", () => {
     const wrapper = mountNavigation();
     // both keep an accessible name; only the middle items show text
     expect(
-      itemNamed(wrapper, "Menu").find(".mobile-navigation-label").exists(),
+      itemNamed(wrapper, "menu").find(".mobile-navigation-label").exists(),
     ).toBe(false);
     expect(
       itemNamed(wrapper, "search").find(".mobile-navigation-label").exists(),
     ).toBe(false);
+  });
+
+  it("names the bar itself for landmark navigation", () => {
+    const wrapper = mountNavigation();
+
+    // $t is mocked to its key here, so a literal would mean an untranslated name
+    expect(wrapper.get("nav").attributes("aria-label")).toBe("main_navigation");
   });
 
   it("marks the page you are on", () => {
@@ -118,7 +125,7 @@ describe("BottomNavigation", () => {
   it("opens the sidebar from the menu button", async () => {
     const wrapper = mountNavigation();
 
-    await itemNamed(wrapper, "Menu").trigger("click");
+    await itemNamed(wrapper, "menu").trigger("click");
 
     expect(mockEmit).toHaveBeenCalledWith("mobile-sidebar-open");
   });


### PR DESCRIPTION
# What does this implement/fix?

The hamburger button on the mobile bottom bar was labelled "Menu" in hardcoded English, so screen readers announced it in English no matter which language the app was set to.

It used to also show a visible "Menu" label, but since the floating dock (#2441) the button is icon-only — which makes that hardcoded string its *only* name for assistive tech. The bottom bar itself was labelled "Main navigation" the same way.

Both now go through the translation system, next to the `Discover` and `Search` buttons that already did.

- New `menu` and `main_navigation` translation keys, matching how the neighbouring buttons are named
- Bottom bar's menu button and navigation landmark now use those keys instead of English text
- The bar's landmark is now labelled "Main" rather than "Main navigation" — screen readers add the role themselves, so the old wording was announced as "Main navigation navigation"
- Test covering the bar's own landmark name

**Related issue (if applicable):**

- n/a

**Related backend PR (if applicable):**

- n/a

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm lint:check` passes.
- [x] `pnpm test:run` passes, and tests have been added/updated where applicable.
- [x] `pnpm build` passes.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
