### PR TITLE
Keep the player bar popouts floating as they grow

### DIFF
--- a/src/components/navigation/BottomNavigation.vue
+++ b/src/components/navigation/BottomNavigation.vue
@@ -117,7 +117,9 @@ function closePlayersMenu() {
 .mobile-bottom-navigation::before {
   position: absolute;
   z-index: -1;
-  top: calc(-1 * (var(--player-bar-overlay-height, 0px) + 4px));
+  top: calc(
+    -1 * (var(--player-bar-overlay-height, 0px) + var(--mobile-dock-rim))
+  );
   pointer-events: none;
   right: 0;
   bottom: 0;

--- a/src/helpers/player_bar.ts
+++ b/src/helpers/player_bar.ts
@@ -1,16 +1,38 @@
-export const DESKTOP_PLAYER_BAR_POPOUT_GAP = 16;
-export const MOBILE_PLAYER_BAR_POPOUT_GAP = 8;
+/**
+ * Gap the popouts keep from the bar below them and from the sides of the
+ * screen. Mirrors --player-bar-popout-gap.
+ */
+export const PLAYER_BAR_POPOUT_GAP = 8;
+
+/**
+ * Room a tall popout leaves at the top of the screen, so it keeps reading as a
+ * card floating above the player bar instead of a full-height panel. Mirrors
+ * --player-bar-popout-top-gap.
+ */
+const PLAYER_BAR_POPOUT_TOP_GAP = 24;
+
+/** Room the popouts leave around themselves as they grow with their contents. */
+export const PLAYER_BAR_POPOUT_COLLISION_PADDING = {
+  top: PLAYER_BAR_POPOUT_TOP_GAP,
+  right: PLAYER_BAR_POPOUT_GAP,
+  bottom: PLAYER_BAR_POPOUT_GAP,
+  left: PLAYER_BAR_POPOUT_GAP,
+};
 
 export const playerBarEndAnchor = {
   getBoundingClientRect: () => {
-    const triggerRect = document
-      .getElementById("player-select-button")
-      ?.getBoundingClientRect();
+    // hanging off the bar itself keeps the gap below the popouts independent of
+    // where its buttons sit inside it; the mobile bar floats over them instead,
+    // leaving the navigation the trigger sits in as the edge to hang from
+    const anchorRect = (
+      document.getElementById("player-bar") ??
+      document.getElementById("player-select-button")
+    )?.getBoundingClientRect();
     return new DOMRect(
-      window.innerWidth - 8,
-      triggerRect?.top ?? window.innerHeight,
+      window.innerWidth - PLAYER_BAR_POPOUT_GAP,
+      anchorRect?.top ?? window.innerHeight,
       0,
-      triggerRect?.height ?? 0,
+      anchorRect?.height ?? 0,
     );
   },
 };

--- a/src/layouts/default/PlayerOSD/Player.vue
+++ b/src/layouts/default/PlayerOSD/Player.vue
@@ -2,7 +2,12 @@
   <!-- Non-mobile: background gradient and player bar -->
   <template v-if="!useFloatingPlayer">
     <div class="mediacontrols-bg" :data-floating="useFloatingPlayer"></div>
-    <div class="mediacontrols" :data-compact="!getBreakpointValue('bp6')">
+    <!-- the popouts find their top edge to hang above by this id -->
+    <div
+      id="player-bar"
+      class="mediacontrols"
+      :data-compact="!getBreakpointValue('bp6')"
+    >
       <div class="mediacontrols-left">
         <PlayerTrackDetails
           :show-quality-details-btn="getBreakpointValue('bp9') ? true : false"

--- a/src/layouts/default/PlayerOSD/PlayerBarGroupControl.vue
+++ b/src/layouts/default/PlayerOSD/PlayerBarGroupControl.vue
@@ -73,8 +73,8 @@
         :class="[
           'player-bar-popout player-group-popover flex flex-col gap-0 overflow-hidden p-0',
           store.mobileLayout
-            ? 'w-[calc(100vw-1rem)]'
-            : 'w-[400px] max-w-[calc(100vw-1rem)]',
+            ? 'w-[calc(100vw-2*var(--player-bar-popout-gap))]'
+            : 'w-[400px] max-w-[calc(100vw-2*var(--player-bar-popout-gap))]',
         ]"
         @open-auto-focus="preventAutoFocus"
         @interact-outside="handleInteractOutside"

--- a/src/layouts/default/PlayerOSD/PlayerBarGroupControl.vue
+++ b/src/layouts/default/PlayerOSD/PlayerBarGroupControl.vue
@@ -68,12 +68,8 @@
         data-player-panel
         side="top"
         align="end"
-        :side-offset="
-          store.mobileLayout
-            ? MOBILE_PLAYER_BAR_POPOUT_GAP
-            : DESKTOP_PLAYER_BAR_POPOUT_GAP
-        "
-        :collision-padding="8"
+        :side-offset="PLAYER_BAR_POPOUT_GAP"
+        :collision-padding="PLAYER_BAR_POPOUT_COLLISION_PADDING"
         :class="[
           'player-bar-popout player-group-popover flex flex-col gap-0 overflow-hidden p-0',
           store.mobileLayout
@@ -106,8 +102,8 @@ import {
   PopoverTrigger,
 } from "@/components/ui/popover";
 import {
-  DESKTOP_PLAYER_BAR_POPOUT_GAP,
-  MOBILE_PLAYER_BAR_POPOUT_GAP,
+  PLAYER_BAR_POPOUT_COLLISION_PADDING,
+  PLAYER_BAR_POPOUT_GAP,
   playerBarEndAnchor,
 } from "@/helpers/player_bar";
 import type { PlayerGroupFilter } from "@/helpers/player_group";

--- a/src/layouts/default/PlayerOSD/PlayerBarMobileVolumeSheet.vue
+++ b/src/layouts/default/PlayerOSD/PlayerBarMobileVolumeSheet.vue
@@ -48,13 +48,18 @@ function preventAutoFocus(event: Event) {
 /* the paired class outweighs the equally-!important inset utilities the sheet
    carries */
 .player-bar-popout.mobile-group-volume-sheet {
-  right: 8px !important;
-  bottom: calc(var(--mobile-navigation-height) + 8px) !important;
-  left: 8px !important;
+  right: var(--player-bar-popout-gap) !important;
+  bottom: calc(
+    var(--mobile-navigation-height) + var(--player-bar-popout-gap)
+  ) !important;
+  left: var(--player-bar-popout-gap) !important;
   width: auto !important;
   /* a sheet has no popper measuring the free space for it, so it grows with the
      group it shows up to the room left above the navigation instead */
-  max-height: calc(100dvh - var(--mobile-navigation-height) - 16px);
+  max-height: calc(
+    100dvh - var(--mobile-navigation-height) - var(--player-bar-popout-gap) -
+      var(--player-bar-popout-top-gap)
+  );
 }
 
 /* :root lifts this above the equally-!important inset-0 the backdrop carries */

--- a/src/layouts/default/PlayerOSD/PlayerBarVolumeControl.vue
+++ b/src/layouts/default/PlayerOSD/PlayerBarVolumeControl.vue
@@ -55,7 +55,7 @@
       align="end"
       :side-offset="PLAYER_BAR_POPOUT_GAP"
       :collision-padding="PLAYER_BAR_POPOUT_COLLISION_PADDING"
-      class="player-bar-popout player-volume-popover flex w-[340px] max-w-[calc(100vw-1rem)] flex-col overflow-hidden p-0"
+      class="player-bar-popout player-volume-popover flex w-[340px] max-w-[calc(100vw-2*var(--player-bar-popout-gap))] flex-col overflow-hidden p-0"
       @open-auto-focus="preventAutoFocus"
       @interact-outside="handleInteractOutside"
     >

--- a/src/layouts/default/PlayerOSD/PlayerBarVolumeControl.vue
+++ b/src/layouts/default/PlayerOSD/PlayerBarVolumeControl.vue
@@ -53,8 +53,8 @@
       data-player-panel
       side="top"
       align="end"
-      :side-offset="DESKTOP_PLAYER_BAR_POPOUT_GAP"
-      :collision-padding="8"
+      :side-offset="PLAYER_BAR_POPOUT_GAP"
+      :collision-padding="PLAYER_BAR_POPOUT_COLLISION_PADDING"
       class="player-bar-popout player-volume-popover flex w-[340px] max-w-[calc(100vw-1rem)] flex-col overflow-hidden p-0"
       @open-auto-focus="preventAutoFocus"
       @interact-outside="handleInteractOutside"
@@ -75,7 +75,8 @@ import {
   PopoverTrigger,
 } from "@/components/ui/popover";
 import {
-  DESKTOP_PLAYER_BAR_POPOUT_GAP,
+  PLAYER_BAR_POPOUT_COLLISION_PADDING,
+  PLAYER_BAR_POPOUT_GAP,
   playerBarEndAnchor,
 } from "@/helpers/player_bar";
 import { isPlayerGrouped } from "@/helpers/players";

--- a/src/layouts/default/PlayerSelect.vue
+++ b/src/layouts/default/PlayerSelect.vue
@@ -42,8 +42,8 @@
         'player-bar-popout player-select-popover flex flex-col gap-0 overflow-hidden p-0',
         popoutFromFullscreen && 'player-select-popover-fullscreen',
         store.mobileLayout
-          ? 'w-[calc(100vw-1rem)]'
-          : 'w-[400px] max-w-[calc(100vw-1rem)]',
+          ? 'w-[calc(100vw-2*var(--player-bar-popout-gap))]'
+          : 'w-[400px] max-w-[calc(100vw-2*var(--player-bar-popout-gap))]',
       ]"
       @keydown="handleSheetKeydown"
       @close-auto-focus="preventAutoFocus"

--- a/src/layouts/default/PlayerSelect.vue
+++ b/src/layouts/default/PlayerSelect.vue
@@ -36,12 +36,8 @@
       :aria-label="$t('players')"
       side="top"
       :align="popoutFromFullscreen ? 'center' : 'end'"
-      :side-offset="
-        store.mobileLayout
-          ? MOBILE_PLAYER_BAR_POPOUT_GAP
-          : DESKTOP_PLAYER_BAR_POPOUT_GAP
-      "
-      :collision-padding="8"
+      :side-offset="PLAYER_BAR_POPOUT_GAP"
+      :collision-padding="PLAYER_BAR_POPOUT_COLLISION_PADDING"
       :class="[
         'player-bar-popout player-select-popover flex flex-col gap-0 overflow-hidden p-0',
         popoutFromFullscreen && 'player-select-popover-fullscreen',
@@ -213,8 +209,8 @@ import { useOrderedPlayers } from "@/composables/useOrderedPlayers";
 import { useUserPreferences } from "@/composables/userPreferences";
 import type { ContextMenuItem } from "@/helpers/context_menu_item";
 import {
-  DESKTOP_PLAYER_BAR_POPOUT_GAP,
-  MOBILE_PLAYER_BAR_POPOUT_GAP,
+  PLAYER_BAR_POPOUT_COLLISION_PADDING,
+  PLAYER_BAR_POPOUT_GAP,
   fullscreenPlayerSelectAnchor,
   playerBarEndAnchor,
 } from "@/helpers/player_bar";

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -38,6 +38,10 @@
   /* Size of a single bottom navigation button, which the bar sizes itself from,
      so the two can never drift apart. */
   --mobile-navigation-item-height: 72px;
+  /* How far the dock's surface shows around the player card sitting on it. The
+     top edge of the dock is this far above the card, so anything hovering above
+     the dock has to clear it too. */
+  --mobile-dock-rim: 4px;
   /* Space the bottom navigation occupies. Anything anchored above it (sheets,
      popovers, the player bar, scroll padding) is positioned from this. */
   --mobile-navigation-height: calc(

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -60,6 +60,12 @@
   /* How far up the screen the bottom is covered, for anything that stacks below
      what covers it and still has to stay visible. */
   --bottom-obscured-height: var(--bottom-bars-height);
+  /* Gap the player bar popouts keep from the bar below them and from the sides
+     of the screen. */
+  --player-bar-popout-gap: 8px;
+  /* Room a tall popout leaves at the top of the screen, so it keeps reading as a
+     card floating above the player bar instead of a full-height panel. */
+  --player-bar-popout-top-gap: 24px;
 }
 
 :root[data-embedded-layout] {

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -145,13 +145,15 @@
   );
 }
 
-/* the popouts extend behind the floating mobile player bar, so their content is
-   inset to stay scrollable past it; the bar sits on the navigation the popouts
-   hang above, so insetting by its height alone leaves them the popout gap. The
-   marker keeps desktop popouts untouched and lifts this above the
-   equally-!important p-0 utility they carry */
+/* the popouts extend behind the mobile dock, so their content is inset to stay
+   scrollable past it; the dock rises from the navigation the popouts hang
+   above, so insetting by what it covers leaves them the popout gap. The marker
+   keeps desktop popouts untouched and lifts this above the equally-!important
+   p-0 utility they carry */
 :root[data-player-bar-overlay] .player-bar-popout {
-  padding-bottom: var(--player-bar-overlay-height) !important;
+  padding-bottom: calc(
+    var(--player-bar-overlay-height) + var(--mobile-dock-rim)
+  ) !important;
 }
 
 .player-bar-popout[data-state="open"] {

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -137,12 +137,19 @@
 /* the popouts grow with their content, up to the room the popper measured
    between the player bar and the top of the screen */
 .player-bar-popout {
-  max-height: var(--reka-popover-content-available-height, calc(100dvh - 16px));
+  max-height: var(
+    --reka-popover-content-available-height,
+    calc(
+      100dvh - var(--player-bar-popout-top-gap) - var(--player-bar-popout-gap)
+    )
+  );
 }
 
 /* the popouts extend behind the floating mobile player bar, so their content is
-   inset to stay scrollable past it; the marker keeps desktop popouts untouched
-   and lifts this above the equally-!important p-0 utility they carry */
+   inset to stay scrollable past it; the bar sits on the navigation the popouts
+   hang above, so insetting by its height alone leaves them the popout gap. The
+   marker keeps desktop popouts untouched and lifts this above the
+   equally-!important p-0 utility they carry */
 :root[data-player-bar-overlay] .player-bar-popout {
   padding-bottom: var(--player-bar-overlay-height) !important;
 }

--- a/tests/helpers/player_bar.test.ts
+++ b/tests/helpers/player_bar.test.ts
@@ -1,7 +1,13 @@
-import { fullscreenPlayerSelectAnchor } from "@/helpers/player_bar";
+import {
+  PLAYER_BAR_POPOUT_GAP,
+  fullscreenPlayerSelectAnchor,
+  playerBarEndAnchor,
+} from "@/helpers/player_bar";
 import { afterEach, describe, expect, it } from "vitest";
 
 const BUTTON_ID = "fullscreen-player-select-button";
+const PLAYER_BAR_ID = "player-bar";
+const PLAYER_SELECT_BUTTON_ID = "player-select-button";
 
 function addTrigger(rect: Partial<DOMRect>) {
   const trigger = document.createElement("button");
@@ -9,6 +15,14 @@ function addTrigger(rect: Partial<DOMRect>) {
   trigger.getBoundingClientRect = () => rect as DOMRect;
   document.body.appendChild(trigger);
   return trigger;
+}
+
+function addElement(id: string, rect: Partial<DOMRect>) {
+  const element = document.createElement("div");
+  element.id = id;
+  element.getBoundingClientRect = () => rect as DOMRect;
+  document.body.appendChild(element);
+  return element;
 }
 
 describe("fullscreenPlayerSelectAnchor", () => {
@@ -33,5 +47,44 @@ describe("fullscreenPlayerSelectAnchor", () => {
     expect(rect.x).toBe(window.innerWidth / 2);
     expect(rect.y).toBe(window.innerHeight);
     expect(rect.height).toBe(0);
+  });
+});
+
+describe("playerBarEndAnchor", () => {
+  afterEach(() => {
+    document.getElementById(PLAYER_BAR_ID)?.remove();
+    document.getElementById(PLAYER_SELECT_BUTTON_ID)?.remove();
+  });
+
+  it("hangs the popouts above the player bar rather than above its buttons", () => {
+    addElement(PLAYER_BAR_ID, { top: 616, height: 104 });
+    addElement(PLAYER_SELECT_BUTTON_ID, { top: 628, height: 80 });
+
+    const rect = playerBarEndAnchor.getBoundingClientRect();
+
+    expect(rect.y).toBe(616);
+    expect(rect.height).toBe(104);
+  });
+
+  it("hangs them above the navigation the trigger sits in without a player bar", () => {
+    addElement(PLAYER_SELECT_BUTTON_ID, { top: 827, height: 64 });
+
+    const rect = playerBarEndAnchor.getBoundingClientRect();
+
+    expect(rect.y).toBe(827);
+    expect(rect.height).toBe(64);
+  });
+
+  it("falls back to the bottom of the screen without either", () => {
+    const rect = playerBarEndAnchor.getBoundingClientRect();
+
+    expect(rect.y).toBe(window.innerHeight);
+    expect(rect.height).toBe(0);
+  });
+
+  it("keeps the popout gap from the end of the screen", () => {
+    expect(playerBarEndAnchor.getBoundingClientRect().x).toBe(
+      window.innerWidth - PLAYER_BAR_POPOUT_GAP,
+    );
   });
 });

--- a/tests/styles/playerBarPopout.test.ts
+++ b/tests/styles/playerBarPopout.test.ts
@@ -2,14 +2,21 @@
 // observable under happy-dom, which in turn ignores @layer: the comparison
 // holds because both rules are unlayered in the compiled stylesheet
 // @vitest-environment happy-dom
+import {
+  PLAYER_BAR_POPOUT_COLLISION_PADDING,
+  PLAYER_BAR_POPOUT_GAP,
+} from "@/helpers/player_bar";
+import tokens from "@/styles/global.css?inline";
 import css from "@/styles/style.css?inline";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 const OVERLAY_HEIGHT = "--player-bar-overlay-height";
 const OVERLAY_MARKER = "data-player-bar-overlay";
 const BAR_HEIGHT = "72px";
+const DOCK_RIM = "4px";
 
 let appStyles: HTMLStyleElement;
+let tokenStyles: HTMLStyleElement;
 
 // happy-dom caches an element's computed style from its first read, so every
 // case builds its popout after the document state it measures is in place
@@ -21,6 +28,12 @@ function popoutInset() {
   return getComputedStyle(popout).paddingBottom;
 }
 
+function customProperty(name: string) {
+  return getComputedStyle(document.documentElement)
+    .getPropertyValue(name)
+    .trim();
+}
+
 function utilityPaddingPriority() {
   return [...(appStyles.sheet?.cssRules ?? [])]
     .filter((rule) => rule instanceof CSSStyleRule)
@@ -30,6 +43,11 @@ function utilityPaddingPriority() {
 
 describe("player bar popout inset", () => {
   beforeEach(() => {
+    // the inset composes the dock rim the tokens declare, so both sheets have
+    // to be in place for it to resolve
+    tokenStyles = document.createElement("style");
+    tokenStyles.textContent = tokens;
+    document.head.appendChild(tokenStyles);
     appStyles = document.createElement("style");
     appStyles.textContent = css;
     document.head.appendChild(appStyles);
@@ -37,12 +55,13 @@ describe("player bar popout inset", () => {
 
   afterEach(() => {
     appStyles.remove();
+    tokenStyles.remove();
     document.body.innerHTML = "";
     document.documentElement.removeAttribute(OVERLAY_MARKER);
     document.documentElement.style.removeProperty(OVERLAY_HEIGHT);
   });
 
-  it("clears the player bar while the mobile bar is on screen", () => {
+  it("clears the whole dock while the mobile bars are on screen", () => {
     // the inset only proves anything while the utility it has to out-rank is
     // itself !important
     expect(
@@ -53,10 +72,25 @@ describe("player bar popout inset", () => {
     document.documentElement.setAttribute(OVERLAY_MARKER, "");
     document.documentElement.style.setProperty(OVERLAY_HEIGHT, BAR_HEIGHT);
 
-    expect(popoutInset()).toBe(BAR_HEIGHT);
+    // the dock's surface reaches past the player card it carries, so clearing
+    // the card alone would leave the popouts hovering over its rim
+    expect(popoutInset().replace(/\s+/g, " ")).toBe(
+      `calc( ${BAR_HEIGHT} + ${DOCK_RIM} )`,
+    );
   });
 
   it("leaves popouts untouched without the player bar", () => {
     expect(popoutInset()).toBe("0px");
+  });
+
+  // the popovers size themselves from the props and the sheet from the tokens,
+  // so a drift between the two would only show up on one of them
+  it("offsets the popovers by the same gaps the sheet reads", () => {
+    expect(customProperty("--player-bar-popout-gap")).toBe(
+      `${PLAYER_BAR_POPOUT_GAP}px`,
+    );
+    expect(customProperty("--player-bar-popout-top-gap")).toBe(
+      `${PLAYER_BAR_POPOUT_COLLISION_PADDING.top}px`,
+    );
   });
 });


### PR DESCRIPTION
# What does this implement/fix?

The volume, grouping and player popouts hover just above the player bar, but a
long speaker list grew them until they were 8px from the top of the screen, so
they suddenly read as a full-height panel instead of a floating card. The gap
they kept above the bar was also an accident of where the bar's buttons sit
inside it, rather than a real distance from the bar.

- a tall popout now stops 24px below the top of the screen
- the popouts hang off the player bar itself, clearing it by a real 8px
- the same gap is shared by the popouts, the mobile volume sheet and the screen
  edges, so they all keep the same air around them

**Related issue (if applicable):**

- related issue `<link to issue>`

**Related backend PR (if applicable):**

- related backend PR `<link to PR>`

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm lint:check` passes.
- [x] `pnpm test:run` passes, and tests have been added/updated where applicable.
- [x] `pnpm build` passes.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
