### PR TITLE
Keep the blur behind the mobile player bar sized to the dock

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -47,10 +47,14 @@
   --mobile-navigation-height: calc(
     var(--mobile-navigation-item-height) + var(--mobile-navigation-inset-bottom)
   );
-  /* Height of the blur behind the floating player bar. It softens what scrolls
-     under it without hiding it, and fades out towards the top. */
+  /* Height of the blur behind the dock. It softens what scrolls under it without
+     hiding it, and fades out towards the top, so it clears the dock's own top by
+     a further 16px for the fade to finish above it rather than across it. The
+     card is measured at runtime, so this follows it rather than assuming a height
+     the card is free to outgrow. */
   --mobile-player-scrim-height: calc(
-    180px + var(--mobile-navigation-inset-bottom)
+    var(--mobile-navigation-height) + var(--player-bar-overlay-height, 0px) +
+      var(--mobile-dock-rim) + 16px
   );
   /* Space the player bar occupies in the desktop layout, where it sits flush
      against the bottom of the screen. The mobile player bar floats and varies

--- a/tests/styles/playerScrim.test.ts
+++ b/tests/styles/playerScrim.test.ts
@@ -1,0 +1,86 @@
+// jsdom leaves var() unresolved in computed styles, so this cascade is only
+// observable under happy-dom
+// @vitest-environment happy-dom
+import navigationSource from "@/components/navigation/BottomNavigation.vue?raw";
+import css from "@/styles/global.css?inline";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+const OVERLAY_HEIGHT = "--player-bar-overlay-height";
+const BAR_HEIGHT = "120px";
+const NAVIGATION_INSET =
+  "max( 12px, calc(env(safe-area-inset-bottom, 0px) * 0.65) )";
+const NAVIGATION_HEIGHT = `calc( 72px + ${NAVIGATION_INSET} )`;
+const DOCK_RIM = "4px";
+const SCRIM_FADE = "16px";
+
+let appStyles: HTMLStyleElement;
+
+// happy-dom substitutes every var() but does not evaluate calc(), so the height
+// is only observable as the expression it composes
+function customProperty(name: string) {
+  return getComputedStyle(document.documentElement)
+    .getPropertyValue(name)
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function scrimHeight() {
+  return customProperty("--mobile-player-scrim-height");
+}
+
+// happy-dom drops a calc() holding a var() from anything but a custom property,
+// so the navigation's own offset is only observable in its source
+function dockSurfaceTop() {
+  const rule = navigationSource.match(
+    /\.mobile-bottom-navigation::before\s*\{([^}]*)\}/,
+  )?.[1];
+  return rule
+    ?.match(/top:([^;]*);/)?.[1]
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+describe("player scrim height", () => {
+  beforeEach(() => {
+    appStyles = document.createElement("style");
+    appStyles.textContent = css;
+    document.head.appendChild(appStyles);
+  });
+
+  afterEach(() => {
+    appStyles.remove();
+    document.documentElement.style.removeProperty(OVERLAY_HEIGHT);
+  });
+
+  it("reaches past the dock so the fade finishes clear of it", () => {
+    document.documentElement.style.setProperty(OVERLAY_HEIGHT, BAR_HEIGHT);
+
+    // the blur fades out towards its own top. Sized from anything other than the
+    // dock it stops short of it once the card grows, leaving the see-through
+    // dock on unblurred content with the fade ending across it.
+    expect(scrimHeight()).toBe(
+      `calc( ${NAVIGATION_HEIGHT} + ${BAR_HEIGHT} + ${DOCK_RIM} + ${SCRIM_FADE} )`,
+    );
+  });
+
+  it("keeps that clearance before the card has been measured", () => {
+    // the footer publishes the card's height once it is on screen. Until it
+    // does, the blur takes the same unmeasured card the dock does, so the two
+    // still line up.
+    expect(scrimHeight()).toBe(
+      `calc( ${NAVIGATION_HEIGHT} + 0px + ${DOCK_RIM} + ${SCRIM_FADE} )`,
+    );
+  });
+
+  it("clears the same dock top the navigation lifts its surface to", () => {
+    // the blur clears the dock only while both measure it the same way. The rim
+    // is shared, but the composition is not, so this is what catches the two
+    // drifting apart again.
+    expect(
+      dockSurfaceTop(),
+      "the navigation's ::before must lift its surface by the card plus the rim",
+    ).toBe(
+      `calc( -1 * (var(${OVERLAY_HEIGHT}, 0px) + var(--mobile-dock-rim)) )`,
+    );
+  });
+});


### PR DESCRIPTION
# What does this implement/fix?

The blur behind the mobile dock was a fixed height, but since #2441 the dock's
top is not: it follows the player card, which is measured at runtime. The two had
drifted apart, leaving only 16px of slack — a card taller than ~104px pushes the
see-through dock onto unblurred content, with the blur's edge cutting across it.
That is already reachable today at larger text sizes (a 1.5× text scale puts the
card at ~108px), and any extra row in the card would do the same.

The blur now measures the dock the same way the dock does, and clears it by a
fixed 16px. With a player active that works out to the same height as before, so
nothing looks different there. With no player selected the card drops its volume
row, and the blur now shrinks with it rather than staying full height — the halo
above the dock goes from 44px to the same 16px as everywhere else.

Builds on the `--mobile-dock-rim` token from #2443.

**Related issue (if applicable):**

- n/a

**Related backend PR (if applicable):**

- n/a

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Changes

- Sized `--mobile-player-scrim-height` from the navigation, the measured player
  card and the dock rim, plus a fixed fade margin, replacing the hardcoded
  `180px`.
- Added `tests/styles/playerScrim.test.ts` covering the blur's clearance over the
  dock, the frame before the card has been measured, and that the navigation
  still lifts its surface to the same dock top.

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm lint:check` passes.
- [x] `pnpm test:run` passes, and tests have been added/updated where applicable.
- [x] `pnpm build` passes.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
