### PR TITLE
Let the mobile menu fill the screen behind the phone's controls

### DIFF
--- a/src/components/ui/sidebar/Sidebar.vue
+++ b/src/components/ui/sidebar/Sidebar.vue
@@ -116,30 +116,26 @@ const mobileSheetSide = useMobileSidebarSide();
 </template>
 
 <style>
-/* :root lifts these above the equally-!important inset, size, padding and radius
+/* :root lifts these above the equally-!important size, padding and radius
    utilities the sheet carries */
 :root .sidebar-mobile-sheet {
-  top: 0 !important;
-  bottom: 0 !important;
-  height: auto !important;
+  /* The panel keeps the edge-to-edge span its own utilities give it, so its
+     surface fills the strips the phone reserves for the status bar and the home
+     indicator, and pads its contents back out of them. */
   border-radius: 0 !important;
-  /* The panel reaches the edges of the screen so its surface fills the strips
-     the phone keeps for the status bar and the home indicator, and pads its
-     contents back out of them. The widths below count that padding in. */
-  box-sizing: border-box !important;
+  /* The widths below count that padding in. */
+  box-sizing: border-box;
   padding-top: var(--device-inset-top) !important;
   padding-bottom: var(--device-inset-bottom) !important;
 }
 
 /* Widened by the inset they pad away, so the menu keeps its full width. */
 :root .sidebar-mobile-sheet--left {
-  left: 0 !important;
   width: calc(var(--sidebar-width) + var(--device-inset-left)) !important;
   padding-left: var(--device-inset-left) !important;
 }
 
 :root .sidebar-mobile-sheet--right {
-  right: 0 !important;
   width: calc(var(--sidebar-width) + var(--device-inset-right)) !important;
   padding-right: var(--device-inset-right) !important;
 }

--- a/src/components/ui/sidebar/Sidebar.vue
+++ b/src/components/ui/sidebar/Sidebar.vue
@@ -116,20 +116,31 @@ const mobileSheetSide = useMobileSidebarSide();
 </template>
 
 <style>
-/* :root lifts these above the equally-!important inset and radius utilities the
-   sheet carries */
+/* :root lifts these above the equally-!important inset, size, padding and radius
+   utilities the sheet carries */
 :root .sidebar-mobile-sheet {
-  top: var(--device-inset-top) !important;
-  bottom: var(--device-inset-bottom) !important;
+  top: 0 !important;
+  bottom: 0 !important;
   height: auto !important;
   border-radius: 0 !important;
+  /* The panel reaches the edges of the screen so its surface fills the strips
+     the phone keeps for the status bar and the home indicator, and pads its
+     contents back out of them. The widths below count that padding in. */
+  box-sizing: border-box !important;
+  padding-top: var(--device-inset-top) !important;
+  padding-bottom: var(--device-inset-bottom) !important;
 }
 
+/* Widened by the inset they pad away, so the menu keeps its full width. */
 :root .sidebar-mobile-sheet--left {
-  left: var(--device-inset-left) !important;
+  left: 0 !important;
+  width: calc(var(--sidebar-width) + var(--device-inset-left)) !important;
+  padding-left: var(--device-inset-left) !important;
 }
 
 :root .sidebar-mobile-sheet--right {
-  right: var(--device-inset-right) !important;
+  right: 0 !important;
+  width: calc(var(--sidebar-width) + var(--device-inset-right)) !important;
+  padding-right: var(--device-inset-right) !important;
 }
 </style>

--- a/tests/styles/mobileSidebarSafeArea.test.ts
+++ b/tests/styles/mobileSidebarSafeArea.test.ts
@@ -1,0 +1,150 @@
+// jsdom leaves var() unresolved in computed styles, so this cascade is only
+// observable under happy-dom, which in turn ignores @layer: the comparison
+// holds because both rules are unlayered in the compiled stylesheet
+// @vitest-environment happy-dom
+import sidebarSource from "@/components/ui/sidebar/Sidebar.vue?raw";
+import tokens from "@/styles/global.css?inline";
+import css from "@/styles/style.css?inline";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+const INSET_TOP = "44px";
+const INSET_BOTTOM = "34px";
+const INSET_SIDE = "59px";
+// stands in for SIDEBAR_WIDTH_MOBILE, in px so the expected width stays legible
+const MENU_WIDTH = "288px";
+
+let appStyles: HTMLStyleElement;
+let tokenStyles: HTMLStyleElement;
+let sheetStyles: HTMLStyleElement;
+
+// Use raw selectors so the test does not depend on Vue's generated scope id.
+function extractStyle(source: string) {
+  return source.match(/<style>([\s\S]*?)<\/style>/)?.[1] ?? "";
+}
+
+// happy-dom caches an element's computed style from its first read, so every
+// case builds its panel after the insets it measures are in place
+function panel(side: "left" | "right") {
+  const sheet = document.createElement("div");
+  // the classes Sidebar.vue and SheetContent.vue put on the mobile sheet
+  sheet.className = [
+    "sidebar-mobile-sheet",
+    `sidebar-mobile-sheet--${side}`,
+    "w-(--sidebar-width)",
+    "p-0",
+    "top-0",
+    "bottom-0",
+    side === "left" ? "left-0" : "right-0",
+    side === "left" ? "rounded-r-md" : "rounded-l-md",
+  ].join(" ");
+  sheet.style.setProperty("--sidebar-width", MENU_WIDTH);
+  document.body.appendChild(sheet);
+  return getComputedStyle(sheet);
+}
+
+function utilityPriority(selector: string, property: string) {
+  return [...(appStyles.sheet?.cssRules ?? [])]
+    .filter((rule) => rule instanceof CSSStyleRule)
+    .find((rule) => rule.selectorText === selector)
+    ?.style.getPropertyPriority(property);
+}
+
+describe("mobile sidebar safe area", () => {
+  beforeEach(() => {
+    tokenStyles = document.createElement("style");
+    tokenStyles.textContent = tokens;
+    document.head.appendChild(tokenStyles);
+    appStyles = document.createElement("style");
+    appStyles.textContent = css;
+    document.head.appendChild(appStyles);
+    sheetStyles = document.createElement("style");
+    sheetStyles.textContent = extractStyle(sidebarSource);
+    document.head.appendChild(sheetStyles);
+
+    for (const [side, inset] of [
+      ["top", INSET_TOP],
+      ["bottom", INSET_BOTTOM],
+      ["left", INSET_SIDE],
+      ["right", INSET_SIDE],
+    ]) {
+      document.documentElement.style.setProperty(
+        `--device-inset-${side}`,
+        inset,
+      );
+    }
+  });
+
+  afterEach(() => {
+    sheetStyles.remove();
+    appStyles.remove();
+    tokenStyles.remove();
+    document.body.innerHTML = "";
+    for (const side of ["top", "right", "bottom", "left"]) {
+      document.documentElement.style.removeProperty(`--device-inset-${side}`);
+    }
+  });
+
+  it("reaches the edges of the screen", () => {
+    const sheet = panel("left");
+
+    // the surface has to fill the strips the phone keeps for the status bar and
+    // the home indicator, or the menu reads as cut off against the page
+    expect(sheet.top).toBe("0px");
+    expect(sheet.bottom).toBe("0px");
+    expect(sheet.left).toBe("0px");
+    expect(sheet.borderRadius).toBe("0px");
+  });
+
+  it("holds the menu clear of the phone's controls", () => {
+    // the padding only proves anything while the utility it has to out-rank is
+    // itself !important
+    expect(
+      utilityPriority(".p-0", "padding"),
+      "the Tailwind utilities import must stay `important` and unlayered",
+    ).toBe("important");
+
+    const sheet = panel("left");
+
+    expect(sheet.paddingTop).toBe(INSET_TOP);
+    expect(sheet.paddingBottom).toBe(INSET_BOTTOM);
+    expect(sheet.paddingLeft).toBe(INSET_SIDE);
+    // the inner edge is nowhere near a device inset
+    expect(sheet.paddingRight).toBe("0px");
+  });
+
+  it("keeps the menu its full width beside a horizontal inset", () => {
+    expect(
+      utilityPriority(".w-\\(--sidebar-width\\)", "width"),
+      "the Tailwind utilities import must stay `important` and unlayered",
+    ).toBe("important");
+
+    // happy-dom does not evaluate calc(), so the width is only observable as
+    // the expression it composes: the panel carries the padding on top of the
+    // width the menu itself needs
+    expect(panel("left").width).toBe(`calc(${MENU_WIDTH} + ${INSET_SIDE})`);
+  });
+
+  it("mirrors the inset it pads when the menu opens from the right", () => {
+    const sheet = panel("right");
+
+    expect(sheet.right).toBe("0px");
+    expect(sheet.paddingRight).toBe(INSET_SIDE);
+    expect(sheet.paddingLeft).toBe("0px");
+    expect(sheet.width).toBe(`calc(${MENU_WIDTH} + ${INSET_SIDE})`);
+  });
+
+  it("leaves the menu untouched where the host owns the insets", () => {
+    // the embedded layout zeroes every inset, so the panel has to come out
+    // exactly as it was before any of this padding existed
+    document.documentElement.setAttribute("data-embedded-layout", "");
+    for (const side of ["top", "right", "bottom", "left"]) {
+      document.documentElement.style.removeProperty(`--device-inset-${side}`);
+    }
+
+    const sheet = panel("left");
+
+    expect(sheet.padding).toBe("0px");
+    expect(sheet.width).toBe(`calc(${MENU_WIDTH} + 0px)`);
+    document.documentElement.removeAttribute("data-embedded-layout");
+  });
+});


### PR DESCRIPTION
# What does this implement/fix?

On phones the navigation menu stopped short of the screen edges, leaving a strip
of the page showing above and below it, so the menu looked cut off at the status
bar and the home indicator.

The panel now reaches the edges of the screen and keeps its contents clear of the
phone's controls with padding instead, so the menu itself sits exactly where it
did before.

**Related issue (if applicable):**

- n/a

**Related backend PR (if applicable):**

- n/a

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm lint:check` passes.
- [x] `pnpm test:run` passes, and tests have been added/updated where applicable.
- [x] `pnpm build` passes.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
