### PR TITLE
Derive the mobile dock's rim from a single value

### DIFF
--- a/src/components/navigation/BottomNavigation.vue
+++ b/src/components/navigation/BottomNavigation.vue
@@ -101,9 +101,11 @@ function closePlayersMenu() {
 <style>
 /* :root lifts this above the equally-!important inset utilities the bar carries */
 :root .mobile-bottom-navigation {
-  right: calc(var(--mobile-dock-inset) + var(--device-inset-right)) !important;
+  right: calc(
+    var(--mobile-dock-inset-x) + var(--device-inset-right)
+  ) !important;
   bottom: var(--mobile-navigation-inset-bottom) !important;
-  left: calc(var(--mobile-dock-inset) + var(--device-inset-left)) !important;
+  left: calc(var(--mobile-dock-inset-x) + var(--device-inset-left)) !important;
   height: var(--mobile-navigation-item-height);
   /* the device insets are already covered by left/right, so this only keeps the
      two icon-only ends off the rounded corners */

--- a/src/components/navigation/BottomNavigation.vue
+++ b/src/components/navigation/BottomNavigation.vue
@@ -101,9 +101,9 @@ function closePlayersMenu() {
 <style>
 /* :root lifts this above the equally-!important inset utilities the bar carries */
 :root .mobile-bottom-navigation {
-  right: calc(12px + var(--device-inset-right)) !important;
+  right: calc(var(--mobile-dock-inset) + var(--device-inset-right)) !important;
   bottom: var(--mobile-navigation-inset-bottom) !important;
-  left: calc(12px + var(--device-inset-left)) !important;
+  left: calc(var(--mobile-dock-inset) + var(--device-inset-left)) !important;
   height: var(--mobile-navigation-item-height);
   /* the device insets are already covered by left/right, so this only keeps the
      two icon-only ends off the rounded corners */

--- a/src/layouts/default/Footer.vue
+++ b/src/layouts/default/Footer.vue
@@ -74,13 +74,13 @@ function clearOverlay() {
 .mediacontrols-player-float {
   display: flex;
   flex-direction: column;
-  /* the card's inset carries the dock's rim, so the surface shows evenly around
-     it on every side. The vertical margins are omitted: the bar is fixed and
-     anchored by its bottom, so they would not move it. */
-  margin: 0 calc(var(--mobile-player-inset) + var(--device-inset-right)) 0
-    calc(var(--mobile-player-inset) + var(--device-inset-left));
+  /* the card's inset carries the dock's rim, so the surface shows the same
+     sliver down both sides as it does above. The vertical margins are omitted:
+     the bar is fixed and anchored by its bottom, so they would not move it. */
+  margin: 0 calc(var(--mobile-player-inset-x) + var(--device-inset-right)) 0
+    calc(var(--mobile-player-inset-x) + var(--device-inset-left));
   width: calc(
-    100% - 2 * var(--mobile-player-inset) - var(--device-inset-right) -
+    100% - 2 * var(--mobile-player-inset-x) - var(--device-inset-right) -
       var(--device-inset-left)
   ) !important;
   border-radius: 16px !important;

--- a/src/layouts/default/Footer.vue
+++ b/src/layouts/default/Footer.vue
@@ -74,13 +74,14 @@ function clearOverlay() {
 .mediacontrols-player-float {
   display: flex;
   flex-direction: column;
-  /* 4px inside the dock's own inset, so the surface shows evenly around the
-     card on every side. The vertical margins are omitted: the bar is fixed and
+  /* the card's inset carries the dock's rim, so the surface shows evenly around
+     it on every side. The vertical margins are omitted: the bar is fixed and
      anchored by its bottom, so they would not move it. */
-  margin: 0 calc(16px + var(--device-inset-right)) 0
-    calc(16px + var(--device-inset-left));
+  margin: 0 calc(var(--mobile-player-inset) + var(--device-inset-right)) 0
+    calc(var(--mobile-player-inset) + var(--device-inset-left));
   width: calc(
-    100% - 32px - var(--device-inset-right) - var(--device-inset-left)
+    100% - 2 * var(--mobile-player-inset) - var(--device-inset-right) -
+      var(--device-inset-left)
   ) !important;
   border-radius: 16px !important;
 }

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -39,14 +39,14 @@
      so the two can never drift apart. */
   --mobile-navigation-item-height: 72px;
   /* How far the dock sits in from the sides of the screen. */
-  --mobile-dock-inset: 12px;
-  /* How far the dock's surface shows around the player card sitting on it, on
-     every side. The top edge of the dock is this far above the card, so anything
-     hovering above the dock has to clear it too. */
+  --mobile-dock-inset-x: 12px;
+  /* How far the dock's surface shows around the sides and top of the player card
+     sitting on it. The top edge of the dock is this far above the card, so
+     anything hovering above the dock has to clear it too. */
   --mobile-dock-rim: 4px;
   /* Where the floating player card sits, one rim inside the dock it rides on. */
-  --mobile-player-inset: calc(
-    var(--mobile-dock-inset) + var(--mobile-dock-rim)
+  --mobile-player-inset-x: calc(
+    var(--mobile-dock-inset-x) + var(--mobile-dock-rim)
   );
   /* Space the bottom navigation occupies. Anything anchored above it (sheets,
      popovers, the player bar, scroll padding) is positioned from this. */

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -38,10 +38,16 @@
   /* Size of a single bottom navigation button, which the bar sizes itself from,
      so the two can never drift apart. */
   --mobile-navigation-item-height: 72px;
-  /* How far the dock's surface shows around the player card sitting on it. The
-     top edge of the dock is this far above the card, so anything hovering above
-     the dock has to clear it too. */
+  /* How far the dock sits in from the sides of the screen. */
+  --mobile-dock-inset: 12px;
+  /* How far the dock's surface shows around the player card sitting on it, on
+     every side. The top edge of the dock is this far above the card, so anything
+     hovering above the dock has to clear it too. */
   --mobile-dock-rim: 4px;
+  /* Where the floating player card sits, one rim inside the dock it rides on. */
+  --mobile-player-inset: calc(
+    var(--mobile-dock-inset) + var(--mobile-dock-rim)
+  );
   /* Space the bottom navigation occupies. Anything anchored above it (sheets,
      popovers, the player bar, scroll padding) is positioned from this. */
   --mobile-navigation-height: calc(

--- a/tests/styles/mobileDockRim.test.ts
+++ b/tests/styles/mobileDockRim.test.ts
@@ -1,0 +1,101 @@
+// jsdom leaves var() unresolved in computed styles, so this composition is only
+// observable under happy-dom
+// @vitest-environment happy-dom
+import navSource from "@/components/navigation/BottomNavigation.vue?raw";
+import footerSource from "@/layouts/default/Footer.vue?raw";
+import globalCss from "@/styles/global.css?inline";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+const DOCK_INSET = "111px";
+const RIM = "7px";
+// happy-dom drops a declaration whose substituted custom property expands to a
+// nested calc(), so the card is measured with its inset flattened to a literal
+const PLAYER_INSET = "99px";
+
+let styles: HTMLStyleElement[];
+
+// Use raw selectors so the test does not depend on Vue's generated scope id.
+function extractStyle(source: string) {
+  return source.match(/<style>([\s\S]*?)<\/style>/)?.[1] ?? "";
+}
+
+// happy-dom caches an element's computed style from its first read, so each
+// probe is built after the custom properties it measures are in place
+function probe(className: string) {
+  const element = document.createElement("div");
+  element.className = className;
+  document.body.appendChild(element);
+  return getComputedStyle(element);
+}
+
+// the declarations wrap at different points once the token names are in them,
+// so compare them free of the source formatting
+function normalize(value: string) {
+  return value.replace(/\s+/g, "");
+}
+
+describe("mobile dock rim", () => {
+  beforeEach(() => {
+    styles = [
+      globalCss,
+      extractStyle(footerSource),
+      extractStyle(navSource),
+    ].map((css) => {
+      const element = document.createElement("style");
+      element.textContent = css;
+      document.head.appendChild(element);
+      return element;
+    });
+    // the device insets are env() values happy-dom cannot substitute, which
+    // would drop every declaration that adds one; the embedded layout zeroes
+    // them through the same cascade the app uses inside Home Assistant
+    document.documentElement.setAttribute("data-embedded-layout", "");
+  });
+
+  afterEach(() => {
+    styles.forEach((element) => element.remove());
+    document.documentElement.removeAttribute("data-embedded-layout");
+    document.documentElement.removeAttribute("style");
+    document.body.innerHTML = "";
+  });
+
+  it("insets the player card by the dock's inset plus the rim", () => {
+    document.documentElement.style.setProperty(
+      "--mobile-dock-inset-x",
+      DOCK_INSET,
+    );
+    document.documentElement.style.setProperty("--mobile-dock-rim", RIM);
+
+    expect(
+      normalize(
+        getComputedStyle(document.documentElement).getPropertyValue(
+          "--mobile-player-inset-x",
+        ),
+      ),
+    ).toBe(`calc(${DOCK_INSET}+${RIM})`);
+  });
+
+  it("sits the dock at its own inset", () => {
+    document.documentElement.style.setProperty(
+      "--mobile-dock-inset-x",
+      DOCK_INSET,
+    );
+    const dock = probe("mobile-bottom-navigation");
+
+    expect(normalize(dock.left)).toBe(`calc(${DOCK_INSET}+0px)`);
+    expect(normalize(dock.right)).toBe(`calc(${DOCK_INSET}+0px)`);
+  });
+
+  it("sits the player card at the card's inset, on both sides", () => {
+    document.documentElement.style.setProperty(
+      "--mobile-player-inset-x",
+      PLAYER_INSET,
+    );
+    const card = probe("mediacontrols-player-float");
+
+    expect(normalize(card.marginLeft)).toBe(`calc(${PLAYER_INSET}+0px)`);
+    expect(normalize(card.marginRight)).toBe(`calc(${PLAYER_INSET}+0px)`);
+    // the width gives back both margins, so the card stays centred on the dock
+    expect(normalize(card.width)).toBe(`calc(100%-2*${PLAYER_INSET}-0px-0px)`);
+  });
+});


### PR DESCRIPTION
# What does this implement/fix?

The mobile dock shows a thin sliver of its own surface around the floating player card sitting on it. That sliver is named by `--mobile-dock-rim`, but only the top edge used it — on the left and right it was the difference between two hardcoded numbers, the dock inset 12px from the screen and the card 16px. Nothing tied those together, so changing one would have quietly made the rim uneven. Bumping the rim was already lopsided: it thickened the top edge only, leaving the sides at 4px.

The dock's own screen inset now has a name, and the card's inset derives from it plus the rim, so every exposed edge comes from one value. No visual change — the rim measures 4px on the left, right and top, exactly as before.

**Related issue (if applicable):**

- n/a

**Related backend PR (if applicable):**

- n/a

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Changes

- add `--mobile-dock-inset-x` for how far the dock sits in from the sides of the screen
- add `--mobile-player-inset-x`, the dock inset plus the rim, and use it for the floating player card's margin and width
- point the bottom navigation's left/right at the new dock inset token
- add a test pinning each link of the chain, so hardcoding either number back in fails

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm lint:check` passes.
- [x] `pnpm test:run` passes, and tests have been added/updated where applicable.
- [x] `pnpm build` passes.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
