### PR TITLE
Keep the settings save button lined up with the mobile player

### DIFF
--- a/src/views/settings/EditConfig.vue
+++ b/src/views/settings/EditConfig.vue
@@ -609,7 +609,9 @@ const getCategoryIcon = function (category: string): Component {
 }
 
 .floating-save--mobile {
-  right: 16px;
+  /* the button floats directly above the player card, so it takes the card's
+     inset to line up with its right edge */
+  right: calc(var(--mobile-player-inset-x) + var(--device-inset-right));
   bottom: calc(var(--bottom-bars-height) + 16px);
   /* Above the player scrim, below the mobile bars. */
   z-index: 1000;

--- a/src/views/settings/EditConfig.vue
+++ b/src/views/settings/EditConfig.vue
@@ -609,8 +609,7 @@ const getCategoryIcon = function (category: string): Component {
 }
 
 .floating-save--mobile {
-  /* the button floats directly above the player card, so it takes the card's
-     inset to line up with its right edge */
+  /* Takes the floating player card's inset, so the two right edges line up. */
   right: calc(var(--mobile-player-inset-x) + var(--device-inset-right));
   bottom: calc(var(--bottom-bars-height) + 16px);
   /* Above the player scrim, below the mobile bars. */

--- a/tests/styles/floatingSaveMobile.test.ts
+++ b/tests/styles/floatingSaveMobile.test.ts
@@ -1,16 +1,16 @@
 // jsdom leaves var() unresolved in computed styles, so this cascade is only
 // observable under happy-dom
 // @vitest-environment happy-dom
-import globalCss from "@/styles/global.css?inline";
 import editConfigSource from "@/views/settings/EditConfig.vue?raw";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 // happy-dom drops a declaration whose substituted custom property expands to a
-// nested calc(), so the button is measured with the card's inset flattened to a
-// literal
+// nested calc(), so the card's inset is read as a literal. The device inset
+// carries its own value so neither term can stand in for the other.
 const PLAYER_INSET = "99px";
+const DEVICE_INSET_RIGHT = "33px";
 
-let styles: HTMLStyleElement[];
+let appStyles: HTMLStyleElement;
 let saveButton: HTMLDivElement;
 
 // Use raw selectors so the test does not depend on Vue's generated scope id.
@@ -18,18 +18,17 @@ function extractStyle(source: string) {
   return source.match(/<style scoped>([\s\S]*?)<\/style>/)?.[1] ?? "";
 }
 
+// the declarations wrap at different points once the token names are in them,
+// so compare them free of the source formatting
+function normalize(value: string) {
+  return value.replace(/\s+/g, "");
+}
+
 describe("mobile floating save position", () => {
   beforeEach(() => {
-    styles = [globalCss, extractStyle(editConfigSource)].map((css) => {
-      const element = document.createElement("style");
-      element.textContent = css;
-      document.head.appendChild(element);
-      return element;
-    });
-    // the device insets are env() values happy-dom cannot substitute, which
-    // would drop every declaration that adds one; the embedded layout zeroes
-    // them through the same cascade the app uses inside Home Assistant
-    document.documentElement.setAttribute("data-embedded-layout", "");
+    appStyles = document.createElement("style");
+    appStyles.textContent = extractStyle(editConfigSource);
+    document.head.appendChild(appStyles);
 
     document.documentElement.style.setProperty("--bottom-bars-height", "158px");
     // Taller than the bars, so a passing test proves the fix measures the
@@ -42,6 +41,10 @@ describe("mobile floating save position", () => {
       "--mobile-player-inset-x",
       PLAYER_INSET,
     );
+    document.documentElement.style.setProperty(
+      "--device-inset-right",
+      DEVICE_INSET_RIGHT,
+    );
 
     saveButton = document.createElement("div");
     saveButton.className = "floating-save floating-save--mobile";
@@ -49,21 +52,20 @@ describe("mobile floating save position", () => {
   });
 
   afterEach(() => {
-    styles.forEach((element) => element.remove());
-    document.documentElement.removeAttribute("data-embedded-layout");
+    appStyles.remove();
     document.documentElement.removeAttribute("style");
     document.body.innerHTML = "";
   });
 
   it("clears the bottom bars by 16px", () => {
-    expect(getComputedStyle(saveButton).bottom.replace(/\s+/g, "")).toBe(
+    expect(normalize(getComputedStyle(saveButton).bottom)).toBe(
       "calc(158px+16px)",
     );
   });
 
   it("lines up with the right edge of the player card below it", () => {
-    expect(getComputedStyle(saveButton).right.replace(/\s+/g, "")).toBe(
-      `calc(${PLAYER_INSET}+0px)`,
+    expect(normalize(getComputedStyle(saveButton).right)).toBe(
+      `calc(${PLAYER_INSET}+${DEVICE_INSET_RIGHT})`,
     );
   });
 

--- a/tests/styles/floatingSaveMobile.test.ts
+++ b/tests/styles/floatingSaveMobile.test.ts
@@ -1,10 +1,16 @@
 // jsdom leaves var() unresolved in computed styles, so this cascade is only
 // observable under happy-dom
 // @vitest-environment happy-dom
+import globalCss from "@/styles/global.css?inline";
 import editConfigSource from "@/views/settings/EditConfig.vue?raw";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
-let appStyles: HTMLStyleElement;
+// happy-dom drops a declaration whose substituted custom property expands to a
+// nested calc(), so the button is measured with the card's inset flattened to a
+// literal
+const PLAYER_INSET = "99px";
+
+let styles: HTMLStyleElement[];
 let saveButton: HTMLDivElement;
 
 // Use raw selectors so the test does not depend on Vue's generated scope id.
@@ -14,9 +20,16 @@ function extractStyle(source: string) {
 
 describe("mobile floating save position", () => {
   beforeEach(() => {
-    appStyles = document.createElement("style");
-    appStyles.textContent = extractStyle(editConfigSource);
-    document.head.appendChild(appStyles);
+    styles = [globalCss, extractStyle(editConfigSource)].map((css) => {
+      const element = document.createElement("style");
+      element.textContent = css;
+      document.head.appendChild(element);
+      return element;
+    });
+    // the device insets are env() values happy-dom cannot substitute, which
+    // would drop every declaration that adds one; the embedded layout zeroes
+    // them through the same cascade the app uses inside Home Assistant
+    document.documentElement.setAttribute("data-embedded-layout", "");
 
     document.documentElement.style.setProperty("--bottom-bars-height", "158px");
     // Taller than the bars, so a passing test proves the fix measures the
@@ -25,6 +38,10 @@ describe("mobile floating save position", () => {
       "--mobile-player-scrim-height",
       "200px",
     );
+    document.documentElement.style.setProperty(
+      "--mobile-player-inset-x",
+      PLAYER_INSET,
+    );
 
     saveButton = document.createElement("div");
     saveButton.className = "floating-save floating-save--mobile";
@@ -32,17 +49,21 @@ describe("mobile floating save position", () => {
   });
 
   afterEach(() => {
-    appStyles.remove();
+    styles.forEach((element) => element.remove());
+    document.documentElement.removeAttribute("data-embedded-layout");
+    document.documentElement.removeAttribute("style");
     document.body.innerHTML = "";
-    document.documentElement.style.removeProperty("--bottom-bars-height");
-    document.documentElement.style.removeProperty(
-      "--mobile-player-scrim-height",
-    );
   });
 
   it("clears the bottom bars by 16px", () => {
     expect(getComputedStyle(saveButton).bottom.replace(/\s+/g, "")).toBe(
       "calc(158px+16px)",
+    );
+  });
+
+  it("lines up with the right edge of the player card below it", () => {
+    expect(getComputedStyle(saveButton).right.replace(/\s+/g, "")).toBe(
+      `calc(${PLAYER_INSET}+0px)`,
     );
   });
 


### PR DESCRIPTION
# What does this implement/fix?

On a phone, the floating **Save** button in settings sits just above the floating player card and lines up with its right edge. That only worked because both were written as `16px` in two different files — the player card has since moved onto shared spacing values, so any tweak to the dock spacing would have quietly knocked the Save button out of line.

The Save button now reads its right edge from the same value the player card uses, so the two stay together. Nothing moves on screen: with today's values it still resolves to the same `16px`.

**Related issue (if applicable):**

- n/a

**Related backend PR (if applicable):**

- n/a

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Changes

- Save button's right edge now derives from the player card's inset plus the device safe-area inset, instead of a hard-coded `16px`
- Extended the existing style test to pin that alignment

The safe-area term matches how the player card itself is positioned. It only has an effect on a narrow screen that also has a side cutout, which is rare — the wider "keep fixed elements out of the safe area" cleanup is a separate job.

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm lint:check` passes.
- [x] `pnpm test:run` passes, and tests have been added/updated where applicable.
- [x] `pnpm build` passes.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
