### PR TITLE
More room for the player bar buttons on a wide screen

### DIFF
--- a/src/layouts/default/PlayerOSD/Player.vue
+++ b/src/layouts/default/PlayerOSD/Player.vue
@@ -403,19 +403,31 @@ watch(
 }
 
 /* a wide screen leaves room to spare in this column, so the actions take a gap
-   between them and the two carrying a label grow with their text - the player
-   name is the first to run out. Growing only starts where the label needs it,
-   so a short name leaves no hole beside the button next to it. */
+   between them and the two whose label varies in length grow with their text -
+   the player name is the first to run out. Growing only starts where the label
+   needs it, so a short name leaves no hole beside the button next to it. */
 @media screen and (min-width: 1100px) {
+  /* the room is only borrowed: these let the row hand it straight back when
+     another control joins it, such as the sleep timer, and send whatever still
+     does not fit towards the middle of the bar rather than off its end */
+  .mediacontrols-bottom-right > div {
+    min-width: 0;
+  }
+
+  .mediacontrols :deep(.player-bar-action-row) {
+    justify-content: flex-end;
+  }
+
   /* spacing the controls rather than the row keeps the popovers' own anchor
      elements, which sit between them and take no space, out of the count */
   .mediacontrols :deep(.player-bar-action-row > button ~ button) {
-    margin-inline-start: clamp(0px, 2vw - 22px, 16px);
+    margin-inline-start: clamp(0px, 2vw - 24px, 16px);
   }
 
   .mediacontrols :deep(.player-bar-group-button),
   .mediacontrols :deep(.player-bar-player-button) {
     width: auto !important;
+    flex-shrink: 1 !important;
   }
 
   .mediacontrols :deep(.player-bar-group-button) {

--- a/src/layouts/default/PlayerOSD/Player.vue
+++ b/src/layouts/default/PlayerOSD/Player.vue
@@ -421,7 +421,7 @@ watch(
   /* spacing the controls rather than the row keeps the popovers' own anchor
      elements, which sit between them and take no space, out of the count */
   .mediacontrols :deep(.player-bar-action-row > button ~ button) {
-    margin-inline-start: clamp(0px, 2vw - 24px, 16px);
+    margin-inline-start: clamp(0px, 2vw - 25px, 16px);
   }
 
   .mediacontrols :deep(.player-bar-group-button),

--- a/src/layouts/default/PlayerOSD/Player.vue
+++ b/src/layouts/default/PlayerOSD/Player.vue
@@ -402,6 +402,33 @@ watch(
   white-space: nowrap;
 }
 
+/* a wide screen leaves room to spare in this column, so the actions take a gap
+   between them and the two carrying a label grow with their text - the player
+   name is the first to run out. Growing only starts where the label needs it,
+   so a short name leaves no hole beside the button next to it. */
+@media screen and (min-width: 1100px) {
+  /* spacing the controls rather than the row keeps the popovers' own anchor
+     elements, which sit between them and take no space, out of the count */
+  .mediacontrols :deep(.player-bar-action-row > button ~ button) {
+    margin-inline-start: clamp(0px, 2vw - 22px, 16px);
+  }
+
+  .mediacontrols :deep(.player-bar-group-button),
+  .mediacontrols :deep(.player-bar-player-button) {
+    width: auto !important;
+  }
+
+  .mediacontrols :deep(.player-bar-group-button) {
+    min-width: 72px !important;
+    max-width: clamp(72px, 5vw + 17px, 112px);
+  }
+
+  .mediacontrols :deep(.player-bar-player-button) {
+    min-width: 96px !important;
+    max-width: clamp(96px, 10vw - 14px, 176px);
+  }
+}
+
 @media screen and (min-width: 769px) and (max-width: 1099px) {
   .mediacontrols .mediacontrols-bottom-center {
     width: auto;

--- a/src/layouts/default/PlayerOSD/PlayerExtendedControls.vue
+++ b/src/layouts/default/PlayerOSD/PlayerExtendedControls.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="flex min-w-0 items-center">
+  <div class="player-bar-action-row flex min-w-0 items-center">
     <Button
       v-if="favorite?.isVisible && favoriteItem"
       variant="ghost"


### PR DESCRIPTION
# What does this implement/fix?

The four buttons on the right of the player bar sit flush against each other at
a fixed width, whatever the screen size. On a wide monitor that leaves a large
empty stretch beside them, and the player name is still cut off at the same
short length as on a laptop - "Apple TV Slaapkamer" became "Apple TV Slaa...".

- from 1100px up the buttons take a gap between them that grows with the screen,
  up to 16px
- the player and grouping buttons now grow with their label, so the player name
  fits about twice as many characters before it is cut off
- they only grow where the label needs it, so a short name still leaves no gap
  beside the button next to it
- narrower screens are untouched, and the sizes match exactly at the crossover

**Related issue (if applicable):**

- related issue `<link to issue>`

**Related backend PR (if applicable):**

- related backend PR `<link to PR>`

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm lint:check` passes.
- [x] `pnpm test:run` passes, and tests have been added/updated where applicable.
- [x] `pnpm build` passes.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
