### PR TITLE
Stop relying on Vuetify for the app's box model

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,5 +1,18 @@
 /* Various global styles used throughout the app */
 
+/* The box model the whole app is written against - every width composed with
+   padding counts the padding in. Vuetify's reset declares the same thing; the
+   app owns it here so it survives that stylesheet leaving with the migration. */
+html {
+  box-sizing: border-box;
+}
+
+*,
+::before,
+::after {
+  box-sizing: inherit;
+}
+
 @font-face {
   font-family: "Material Icons Outlined";
   font-style: normal;

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,8 +1,8 @@
 /* Various global styles used throughout the app */
 
 /* The box model the whole app is written against - every width composed with
-   padding counts the padding in. Vuetify's reset declares the same thing; the
-   app owns it here so it survives that stylesheet leaving with the migration. */
+   padding counts the padding in. Declared here rather than left to Vuetify's
+   reset, which states the same thing but goes away with that stylesheet. */
 html {
   box-sizing: border-box;
 }

--- a/tests/styles/boxSizing.test.ts
+++ b/tests/styles/boxSizing.test.ts
@@ -1,0 +1,16 @@
+// happy-dom resolves neither `inherit` nor the specificity of `html` against
+// `*`, so the box model is only observable in the stylesheet itself
+import css from "@/styles/global.css?inline";
+import { describe, expect, it } from "vitest";
+
+// Drop the comments so the prose explaining the rules cannot stand in for them.
+const declarations = css.replace(/\/\*[\s\S]*?\*\//g, "");
+
+describe("box model", () => {
+  it("is declared by the app rather than borrowed from Vuetify", () => {
+    expect(declarations).toMatch(/html\s*\{[^}]*box-sizing:\s*border-box/);
+    expect(declarations).toMatch(
+      /\*,\s*::before,\s*::after\s*\{[^}]*box-sizing:\s*inherit/,
+    );
+  });
+});

--- a/tests/styles/boxSizing.test.ts
+++ b/tests/styles/boxSizing.test.ts
@@ -1,5 +1,5 @@
-// happy-dom resolves neither `inherit` nor the specificity of `html` against
-// `*`, so the box model is only observable in the stylesheet itself
+// happy-dom, the suite default, reports `inherit` verbatim and picks `*` over
+// `html` for the root element, so the rules are asserted in the stylesheet
 import css from "@/styles/global.css?inline";
 import { describe, expect, it } from "vitest";
 
@@ -8,7 +8,10 @@ const declarations = css.replace(/\/\*[\s\S]*?\*\//g, "");
 
 describe("box model", () => {
   it("is declared by the app rather than borrowed from Vuetify", () => {
-    expect(declarations).toMatch(/html\s*\{[^}]*box-sizing:\s*border-box/);
+    // anchored, so a descendant selector ending in `html` cannot satisfy it
+    expect(declarations).toMatch(
+      /(^|[;}])\s*html\s*\{[^}]*box-sizing:\s*border-box/,
+    );
     expect(declarations).toMatch(
       /\*,\s*::before,\s*::after\s*\{[^}]*box-sizing:\s*inherit/,
     );


### PR DESCRIPTION
# What does this implement/fix?

The app has no box-sizing rule of its own. Tailwind's preflight is deliberately not imported, so the only thing making the whole UI border-box is Vuetify's reset, which arrives with `@import "vuetify/styles"`. Everything written since — all of the shadcn side included — assumes border-box without saying so.

That is a quiet dependency to leave in place while Vuetify is on its way out. Nothing would fail loudly if that stylesheet went: every width that composes with padding would just start overflowing, and the safe-area padding on the layouts and the mobile sidebar sheet is exactly that shape. A handful of components already carry a local `box-sizing: border-box` defensively; the other ~500 do not.

The app now declares the box model itself, ahead of every other stylesheet. Vuetify still declares the same thing afterwards, so nothing changes today — the entire emitted CSS grows by the 63 bytes of the new rule and not one computed value moves.

**Related issue (if applicable):**

- n/a

**Related backend PR (if applicable):**

- n/a

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Changes

- declare `html { box-sizing: border-box }` and `*, ::before, ::after { box-sizing: inherit }` at the top of `global.css`, the first stylesheet the app loads
- add a test pinning it, so it cannot be dropped later as a duplicate of Vuetify's

Swiper's deliberate `content-box` on its wrapper is untouched — it wins on specificity, before and after.

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm lint:check` passes.
- [x] `pnpm test:run` passes, and tests have been added/updated where applicable.
- [x] `pnpm build` passes.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
