### PR TITLE
Keep the party dashboard's badge clear of the player bar

### DIFF
--- a/src/views/PartyDashboardView.vue
+++ b/src/views/PartyDashboardView.vue
@@ -1378,15 +1378,18 @@ watch(
   display: flex;
   flex-direction: column;
   padding-bottom: 0 !important;
-  /* total bottom offset for overlays (here, "Powered by"): player bar + tailwind spacing-1 gap */
-  --party-player-bottom: 94px; /* 90px player bar (View.vue .content-section) + 4px (spacing-1) */
+  /* total bottom offset for overlays (here, "Powered by"): the bars pinned to
+     the bottom of the screen + tailwind spacing-1 gap */
+  --party-player-bottom: calc(var(--bottom-bars-height) + 4px);
 }
 
 .content-section--mobile.party-view-active {
   padding-bottom: 0 !important;
-  /* 185px above Footer.vue gradient overlay + 4px (spacing-1), following the
-     navigation inset the gradient and player bar move with */
-  --party-player-bottom: calc(189px + var(--mobile-navigation-inset-bottom));
+  /* the player card sits on the dock, whose surface shows a rim further above
+     it, so the same gap is measured from there */
+  --party-player-bottom: calc(
+    var(--bottom-bars-height) + var(--mobile-dock-rim) + 4px
+  );
 }
 
 .content-section--frameless.party-view-active {

--- a/tests/styles/partyPlayerBottom.test.ts
+++ b/tests/styles/partyPlayerBottom.test.ts
@@ -1,0 +1,83 @@
+// jsdom leaves var() unresolved in computed styles, so this cascade is only
+// observable under happy-dom
+// @vitest-environment happy-dom
+import css from "@/styles/global.css?inline";
+import partySource from "@/views/PartyDashboardView.vue?raw";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+const OVERLAY_HEIGHT = "--player-bar-overlay-height";
+const OVERLAY_MARKER = "data-player-bar-overlay";
+const BAR_HEIGHT = "120px";
+const PLAYER_BAR_HEIGHT = "calc( 104px + env(safe-area-inset-bottom, 0px) )";
+const NAVIGATION_INSET =
+  "max( 12px, calc(env(safe-area-inset-bottom, 0px) * 0.65) )";
+const NAVIGATION_HEIGHT = `calc( 72px + ${NAVIGATION_INSET} )`;
+const DOCK_RIM = "4px";
+const GAP = "4px";
+
+// the view's own rules live in its unscoped block, the only one it can reach
+// the container it is mounted in from
+const partyStyles = partySource.match(/<style>([\s\S]*?)<\/style>/)?.[1] ?? "";
+
+let appStyles: HTMLStyleElement;
+let viewStyles: HTMLStyleElement;
+
+// happy-dom substitutes every var() but does not evaluate calc(), so the offset
+// is only observable as the expression it composes
+function playerBottom(...classes: string[]) {
+  const section = document.createElement("div");
+  section.className = ["content-section", ...classes, "party-view-active"].join(
+    " ",
+  );
+  document.body.appendChild(section);
+  return getComputedStyle(section)
+    .getPropertyValue("--party-player-bottom")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+describe("party dashboard bottom offset", () => {
+  beforeEach(() => {
+    appStyles = document.createElement("style");
+    appStyles.textContent = css;
+    document.head.appendChild(appStyles);
+    viewStyles = document.createElement("style");
+    viewStyles.textContent = partyStyles;
+    document.head.appendChild(viewStyles);
+  });
+
+  afterEach(() => {
+    appStyles.remove();
+    viewStyles.remove();
+    document.body.innerHTML = "";
+    document.documentElement.removeAttribute(OVERLAY_MARKER);
+    document.documentElement.style.removeProperty(OVERLAY_HEIGHT);
+  });
+
+  it("clears the player bar in the desktop layout", () => {
+    expect(playerBottom()).toBe(`calc(${PLAYER_BAR_HEIGHT} + ${GAP})`);
+  });
+
+  it("clears the dock the player card sits on, on mobile", () => {
+    document.documentElement.setAttribute(OVERLAY_MARKER, "");
+    document.documentElement.style.setProperty(OVERLAY_HEIGHT, BAR_HEIGHT);
+
+    // the card is measured at runtime and the dock rises with it. Offset by a
+    // height of its own instead, this ends up either adrift above the dock or
+    // behind it, depending on how tall the card has grown.
+    expect(playerBottom("content-section--mobile")).toBe(
+      `calc( calc( ${NAVIGATION_HEIGHT} + ${BAR_HEIGHT} ) + ${DOCK_RIM} + ${GAP} )`,
+    );
+  });
+
+  it("sits at the screen edge in frameless mode, which has no bars at all", () => {
+    document.documentElement.setAttribute(OVERLAY_MARKER, "");
+    document.documentElement.style.setProperty(OVERLAY_HEIGHT, BAR_HEIGHT);
+
+    // frameless is mobile as well, and the two rules weigh the same, so only
+    // the order between them keeps the bars out of a layout without any
+    expect(
+      playerBottom("content-section--mobile", "content-section--frameless"),
+    ).toBe(GAP);
+  });
+});

--- a/tests/styles/partyPlayerBottom.test.ts
+++ b/tests/styles/partyPlayerBottom.test.ts
@@ -12,7 +12,9 @@ const PLAYER_BAR_HEIGHT = "calc( 104px + env(safe-area-inset-bottom, 0px) )";
 const NAVIGATION_INSET =
   "max( 12px, calc(env(safe-area-inset-bottom, 0px) * 0.65) )";
 const NAVIGATION_HEIGHT = `calc( 72px + ${NAVIGATION_INSET} )`;
-const DOCK_RIM = "4px";
+// distinct from the rim's own 4px, so the assertion cannot pass on a rule that
+// hardcodes the number instead of reading the property
+const DOCK_RIM = "7px";
 const GAP = "4px";
 
 // the view's own rules live in its unscoped block, the only one it can reach
@@ -61,10 +63,11 @@ describe("party dashboard bottom offset", () => {
   it("clears the dock the player card sits on, on mobile", () => {
     document.documentElement.setAttribute(OVERLAY_MARKER, "");
     document.documentElement.style.setProperty(OVERLAY_HEIGHT, BAR_HEIGHT);
+    document.documentElement.style.setProperty("--mobile-dock-rim", DOCK_RIM);
 
-    // the card is measured at runtime and the dock rises with it. Offset by a
-    // height of its own instead, this ends up either adrift above the dock or
-    // behind it, depending on how tall the card has grown.
+    // the card is measured at runtime and the dock rises with it, so the offset
+    // has to carry that measured height and the rim above it rather than a
+    // height of its own
     expect(playerBottom("content-section--mobile")).toBe(
       `calc( calc( ${NAVIGATION_HEIGHT} + ${BAR_HEIGHT} ) + ${DOCK_RIM} + ${GAP} )`,
     );
@@ -74,7 +77,7 @@ describe("party dashboard bottom offset", () => {
     document.documentElement.setAttribute(OVERLAY_MARKER, "");
     document.documentElement.style.setProperty(OVERLAY_HEIGHT, BAR_HEIGHT);
 
-    // frameless is mobile as well, and the two rules weigh the same, so only
+    // frameless can be mobile too, and the two rules weigh the same, so only
     // the order between them keeps the bars out of a layout without any
     expect(
       playerBottom("content-section--mobile", "content-section--frameless"),


### PR DESCRIPTION
# What does this implement/fix?

The "Powered by Music Assistant" badge on the party dashboard offset itself
by a fixed number of pixels that no longer matches either layout. On desktop
the player bar clips its bottom edge. On mobile the player card is measured
at runtime, so the badge floats well above the dock with a player active, and
slips behind it once the card grows at larger text sizes.

It now offsets from the bars themselves, plus the dock's rim on mobile, so it
keeps the same small gap however tall the card gets.

**Related issue (if applicable):**

- n/a

**Related backend PR (if applicable):**

- n/a

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm lint:check` passes.
- [x] `pnpm test:run` passes, and tests have been added/updated where applicable.
- [x] `pnpm build` passes.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
