### PR TITLE
Remove the web player from the server when you switch it off

### DIFF
--- a/src/components/SendspinPlayer.vue
+++ b/src/components/SendspinPlayer.vue
@@ -59,6 +59,9 @@ const isMobileOutput = isAndroid || isIOS;
 
 // Sendspin Player instance
 let player: SendspinPlayer | null = null;
+// Set on teardown, so a session that is still being prepared does not connect a
+// player nothing owns.
+let unmounted = false;
 
 // iOS only lets audio start inside a user gesture, but listen-in audio starts
 // asynchronously (after the server groups this player), so the library would
@@ -309,6 +312,8 @@ onMounted(() => {
     // Prepare session first, then create player with appropriate codecs
     prepareSendspinSession()
       .then(() => {
+        if (unmounted) return;
+
         // Prefer opus for bandwidth efficiency, flac as fallback
         // (opus requires secure context which may not be available)
         const codecs: Codec[] = ["opus", "flac"];
@@ -402,12 +407,13 @@ onMounted(() => {
 
 // Cleanup on unmount
 onBeforeUnmount(() => {
+  unmounted = true;
   clearWebPlayerAudioUnlock(primeAudio);
   if (player) {
     // The server holds a player registered for minutes after a "restart"
-    // goodbye, which is what a reload or a hand-over to another tab needs. Once
-    // this browser wants no player at all, say so instead, or it stays
-    // targetable while nothing is listening.
+    // goodbye, which is what a hand-over to another tab needs. Once this
+    // browser wants no player at all, say so instead, or it stays targetable
+    // while nothing is listening.
     player.disconnect(
       isPlaybackMode(webPlayer.mode) ? "restart" : "user_request",
     );

--- a/src/components/SendspinPlayer.vue
+++ b/src/components/SendspinPlayer.vue
@@ -25,6 +25,7 @@ import { PlaybackState } from "@/plugins/api/interfaces";
 import { store } from "@/plugins/store";
 import {
   webPlayer,
+  isPlaybackMode,
   registerWebPlayerAudioUnlock,
   clearWebPlayerAudioUnlock,
   WebPlayerMode,
@@ -403,7 +404,13 @@ onMounted(() => {
 onBeforeUnmount(() => {
   clearWebPlayerAudioUnlock(primeAudio);
   if (player) {
-    player.disconnect();
+    // The server holds a player registered for minutes after a "restart"
+    // goodbye, which is what a reload or a hand-over to another tab needs. Once
+    // this browser wants no player at all, say so instead, or it stays
+    // targetable while nothing is listening.
+    player.disconnect(
+      isPlaybackMode(webPlayer.mode) ? "restart" : "user_request",
+    );
     player = null;
   }
   if (unsubMetadata) unsubMetadata();

--- a/src/plugins/web_player.ts
+++ b/src/plugins/web_player.ts
@@ -1,5 +1,9 @@
 import { loadSendspinClientIdentity } from "@sendspin/sendspin-js";
 import { reactive, ref, watch } from "vue";
+import {
+  readDeviceSetting,
+  subscribeToDeviceSetting,
+} from "@/helpers/device_settings";
 import { resetMediaSession } from "@/helpers/mediaSession";
 import authManager from "./auth";
 import api from "./api";
@@ -161,6 +165,10 @@ async function isAnotherTabActive(): Promise<boolean> {
   });
 }
 
+// Per-device settings that feed resolvePreferredMode().
+const WEB_PLAYER_ENABLED = "web_player_enabled";
+const BROWSER_CONTROLS_ENABLED = "enable_browser_controls";
+
 let highestPriority: string | undefined;
 let modeSyncInitialized = false;
 let modeSyncInitializationPromise: Promise<void> | null = null;
@@ -194,12 +202,9 @@ function resolvePreferredMode(): WebPlayerMode {
     return WebPlayerMode.SENDSPIN_ONLY;
   }
 
-  const webPlayerEnabledPref =
-    window.localStorage.getItem("frontend.settings.web_player_enabled") ||
-    "true";
+  const webPlayerEnabledPref = readDeviceSetting(WEB_PLAYER_ENABLED) || "true";
   const browserControlsEnabledPref =
-    window.localStorage.getItem("frontend.settings.enable_browser_controls") ||
-    "true";
+    readDeviceSetting(BROWSER_CONTROLS_ENABLED) || "true";
 
   if (
     webPlayerEnabledPref !== "false" &&
@@ -261,6 +266,15 @@ export async function initializeWebPlayerModeSync(): Promise<void> {
     watch(partyListenInEnabled, () => {
       void queueModeApplication();
     });
+
+    // The settings page writes these straight to localStorage. Follow them here
+    // so switching the web player off tears it down right away, in every tab of
+    // this browser, instead of at the next navigation.
+    for (const setting of [WEB_PLAYER_ENABLED, BROWSER_CONTROLS_ENABLED]) {
+      subscribeToDeviceSetting(setting, () => {
+        void queueModeApplication();
+      });
+    }
 
     modeSyncInitialized = true;
     modeSyncInitializationPromise = null;

--- a/tests/components/SendspinPlayer.test.ts
+++ b/tests/components/SendspinPlayer.test.ts
@@ -63,6 +63,7 @@ const {
   mockRegisterWebPlayerAudioUnlock,
   mockSendCommand,
   mockSendspinConnect,
+  mockSendspinDisconnect,
   mockSendspinUnlock,
   mockUseMediaBrowserMetaData,
   routeState,
@@ -108,6 +109,7 @@ const {
     mockRegisterWebPlayerAudioUnlock: vi.fn<(handler: () => boolean) => void>(),
     mockSendCommand,
     mockSendspinConnect: vi.fn<() => Promise<void>>(),
+    mockSendspinDisconnect: vi.fn<(reason?: string) => void>(),
     mockSendspinUnlock: vi.fn<() => Promise<void>>(),
     sendspinState: {
       pairingToken: null as string | null,
@@ -161,9 +163,12 @@ vi.mock("@/plugins/web_player", async () => {
       SENDSPIN_WITH_CONTROLS: "sendspin_with_controls",
     },
     clearWebPlayerAudioUnlock: vi.fn(),
+    isPlaybackMode: (mode: string) =>
+      mode === "sendspin_only" || mode === "sendspin_with_controls",
     registerWebPlayerAudioUnlock: mockRegisterWebPlayerAudioUnlock,
     webPlayer: reactive({
       interacted: false,
+      mode: "sendspin_only",
       tabMode: "sendspin_only",
     }),
   };
@@ -188,7 +193,7 @@ vi.mock("@sendspin/sendspin-js", () => ({
     get pairingToken() {
       return sendspinState.pairingToken;
     }
-    disconnect = vi.fn();
+    disconnect = mockSendspinDisconnect;
     setCorrectionMode = vi.fn();
     setMuted = vi.fn();
     setVolume = vi.fn();
@@ -247,11 +252,13 @@ describe("SendspinPlayer MediaSession", () => {
     mockSendCommand.mockResolvedValue(undefined);
     mockSendspinConnect.mockReset();
     mockSendspinConnect.mockResolvedValue(undefined);
+    mockSendspinDisconnect.mockReset();
     sendspinState.pairingToken = "SP:0TESTTOKEN";
     sendspinState.lastOptions = null;
     mockSendspinUnlock.mockReset();
     mockSendspinUnlock.mockResolvedValue(undefined);
     webPlayer.interacted = false;
+    webPlayer.mode = WebPlayerMode.SENDSPIN_ONLY;
     webPlayer.tabMode = WebPlayerMode.SENDSPIN_ONLY;
     if (routeState.current) routeState.current.meta = {};
     Object.defineProperty(navigator, "mediaSession", {
@@ -375,6 +382,34 @@ describe("SendspinPlayer MediaSession", () => {
       { suppressGlobalError: true },
     );
     wrapper.unmount();
+  });
+
+  it("keeps the player registered while another tab takes over playback", async () => {
+    mockPrepareSendspinSession.mockResolvedValue(undefined);
+    const wrapper = mount(SendspinPlayer, {
+      props: { playerId: "web-player" },
+    });
+    await flushPromises();
+
+    // Only this tab steps back; the browser still wants a player.
+    webPlayer.tabMode = WebPlayerMode.CONTROLS_ONLY;
+    wrapper.unmount();
+
+    expect(mockSendspinDisconnect).toHaveBeenCalledWith("restart");
+  });
+
+  it("unregisters the player once this browser wants none", async () => {
+    mockPrepareSendspinSession.mockResolvedValue(undefined);
+    const wrapper = mount(SendspinPlayer, {
+      props: { playerId: "web-player" },
+    });
+    await flushPromises();
+
+    webPlayer.mode = WebPlayerMode.CONTROLS_ONLY;
+    webPlayer.tabMode = WebPlayerMode.CONTROLS_ONLY;
+    wrapper.unmount();
+
+    expect(mockSendspinDisconnect).toHaveBeenCalledWith("user_request");
   });
 
   it("skips pairing when the client has no pairing token", async () => {

--- a/tests/components/SendspinPlayer.test.ts
+++ b/tests/components/SendspinPlayer.test.ts
@@ -412,6 +412,25 @@ describe("SendspinPlayer MediaSession", () => {
     expect(mockSendspinDisconnect).toHaveBeenCalledWith("user_request");
   });
 
+  it("does not connect a player when unmounted while the session is prepared", async () => {
+    let resolvePrepare!: () => void;
+    mockPrepareSendspinSession.mockReturnValue(
+      new Promise<void>((resolve) => {
+        resolvePrepare = resolve;
+      }),
+    );
+    const wrapper = mount(SendspinPlayer, {
+      props: { playerId: "web-player" },
+    });
+
+    wrapper.unmount();
+    resolvePrepare();
+    await flushPromises();
+
+    // A player connected here would never be disconnected again.
+    expect(mockSendspinConnect).not.toHaveBeenCalled();
+  });
+
   it("skips pairing when the client has no pairing token", async () => {
     sendspinState.pairingToken = null;
     mockPrepareSendspinSession.mockResolvedValue(undefined);

--- a/tests/plugins/web_player.test.ts
+++ b/tests/plugins/web_player.test.ts
@@ -105,6 +105,15 @@ function setRegularPreferences(
   );
 }
 
+// Mirrors saveDeviceSetting: the settings page writes the value and announces it.
+function saveWebPlayerEnabled(enabled: boolean): void {
+  const key = "frontend.settings.web_player_enabled";
+  window.localStorage.setItem(key, String(enabled));
+  window.dispatchEvent(
+    new StorageEvent("storage", { key, newValue: String(enabled) }),
+  );
+}
+
 describe("web player preferred mode", () => {
   beforeAll(() => {
     vi.spyOn(webPlayer, "setMode").mockImplementation(async (mode) => {
@@ -170,4 +179,16 @@ describe("web player preferred mode", () => {
       expect(await applyPreferredMode()).toBe(expectedMode);
     },
   );
+
+  it("drops the web player as soon as the setting is switched off", async () => {
+    setRegularPreferences(true, true);
+    expect(await applyPreferredMode()).toBe(
+      WebPlayerMode.SENDSPIN_WITH_CONTROLS,
+    );
+
+    // The settings page reloads right after saving, so waiting for the next
+    // navigation would leave the server holding a player nobody listens to.
+    saveWebPlayerEnabled(false);
+    await vi.waitUntil(() => webPlayer.mode === WebPlayerMode.CONTROLS_ONLY);
+  });
 });


### PR DESCRIPTION
# What does this implement/fix?

Turning off the built-in web player in the interface settings stopped this browser from playing, but the player stayed in the list on the server for another three minutes — still visible and still selectable, so you could start playback on it and hear nothing.

When the web player shuts down it tells the server why. It always said "restarting", which is the server's cue to hold the player for a while so a page reload or a hand-over to another browser tab doesn't make it disappear. Switching the player off is not that, so the server now hears the difference and removes the player right away.

**Related issue (if applicable):**

- n/a

**Related backend PR (if applicable):**

- n/a — no server changes needed

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Changes

- Disconnect the web player as a user request when this browser no longer wants a player at all, so the server drops it immediately instead of holding it for three minutes.
- Keep the existing "restarting" goodbye for a hand-over to another tab, where the player is meant to stay registered.
- Act on the setting the moment it is saved, rather than at the next page navigation — otherwise the shutdown raced the reload that follows saving, and other open tabs never picked the change up at all.
- Don't connect a player when the browser stopped wanting one while its connection was still being set up.
- Also cleans up leftover players faster for party guests leaving listen-in and for companion mode.

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm lint:check` passes.
- [x] `pnpm test:run` passes, and tests have been added/updated where applicable.
- [x] `pnpm build` passes.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
