### PR TITLE
Make the mobile dock position test catch a left/right swap

### DIFF
--- a/tests/styles/floatingSaveMobile.test.ts
+++ b/tests/styles/floatingSaveMobile.test.ts
@@ -31,8 +31,8 @@ describe("mobile floating save position", () => {
     document.head.appendChild(appStyles);
 
     document.documentElement.style.setProperty("--bottom-bars-height", "158px");
-    // Taller than the bars, so a passing test proves the fix measures the
-    // bars instead of falling back to the old max-with-scrim behavior.
+    // Taller than the bars, so the button only clears them by 16px if it is
+    // measured from the bars rather than the scrim.
     document.documentElement.style.setProperty(
       "--mobile-player-scrim-height",
       "200px",

--- a/tests/styles/mobileDockRim.test.ts
+++ b/tests/styles/mobileDockRim.test.ts
@@ -11,6 +11,10 @@ const RIM = "7px";
 // happy-dom drops a declaration whose substituted custom property expands to a
 // nested calc(), so the card is measured with its inset flattened to a literal
 const PLAYER_INSET = "99px";
+// the two sides carry their own values, so an assertion can only pass for the
+// side it names
+const DEVICE_INSET_LEFT = "22px";
+const DEVICE_INSET_RIGHT = "33px";
 
 let styles: HTMLStyleElement[];
 
@@ -47,14 +51,20 @@ describe("mobile dock rim", () => {
       return element;
     });
     // the device insets are env() values happy-dom cannot substitute, which
-    // would drop every declaration that adds one; the embedded layout zeroes
-    // them through the same cascade the app uses inside Home Assistant
-    document.documentElement.setAttribute("data-embedded-layout", "");
+    // would drop every declaration that adds one; inline values beat the :root
+    // definitions and stand in for them
+    document.documentElement.style.setProperty(
+      "--device-inset-left",
+      DEVICE_INSET_LEFT,
+    );
+    document.documentElement.style.setProperty(
+      "--device-inset-right",
+      DEVICE_INSET_RIGHT,
+    );
   });
 
   afterEach(() => {
     styles.forEach((element) => element.remove());
-    document.documentElement.removeAttribute("data-embedded-layout");
     document.documentElement.removeAttribute("style");
     document.body.innerHTML = "";
   });
@@ -82,8 +92,12 @@ describe("mobile dock rim", () => {
     );
     const dock = probe("mobile-bottom-navigation");
 
-    expect(normalize(dock.left)).toBe(`calc(${DOCK_INSET}+0px)`);
-    expect(normalize(dock.right)).toBe(`calc(${DOCK_INSET}+0px)`);
+    expect(normalize(dock.left)).toBe(
+      `calc(${DOCK_INSET}+${DEVICE_INSET_LEFT})`,
+    );
+    expect(normalize(dock.right)).toBe(
+      `calc(${DOCK_INSET}+${DEVICE_INSET_RIGHT})`,
+    );
   });
 
   it("sits the player card at the card's inset, on both sides", () => {
@@ -93,9 +107,15 @@ describe("mobile dock rim", () => {
     );
     const card = probe("mediacontrols-player-float");
 
-    expect(normalize(card.marginLeft)).toBe(`calc(${PLAYER_INSET}+0px)`);
-    expect(normalize(card.marginRight)).toBe(`calc(${PLAYER_INSET}+0px)`);
+    expect(normalize(card.marginLeft)).toBe(
+      `calc(${PLAYER_INSET}+${DEVICE_INSET_LEFT})`,
+    );
+    expect(normalize(card.marginRight)).toBe(
+      `calc(${PLAYER_INSET}+${DEVICE_INSET_RIGHT})`,
+    );
     // the width gives back both margins, so the card stays centred on the dock
-    expect(normalize(card.width)).toBe(`calc(100%-2*${PLAYER_INSET}-0px-0px)`);
+    expect(normalize(card.width)).toBe(
+      `calc(100%-2*${PLAYER_INSET}-${DEVICE_INSET_RIGHT}-${DEVICE_INSET_LEFT})`,
+    );
   });
 });


### PR DESCRIPTION
# What does this implement/fix?

The test covering the mobile dock and player card positions checked the left
and right edges against the same expected value, because both device insets
were zeroed. Swapping left and right in the stylesheet would still have passed,
so the test could not catch that mistake.

Each side now gets its own distinct value, the same approach as #2448.
Verified by temporarily swapping the sides in the source: the test fails, and
passes again once restored.

**Related issue (if applicable):**

- n/a

**Related backend PR (if applicable):**

- n/a

- Give the left and right device insets distinct test values so each edge is
  checked on its own
- Drop the embedded-layout setup that was only there to zero those insets
- Reword a comment in the neighbouring test to describe what it checks today

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm lint:check` passes.
- [x] `pnpm test:run` passes, and tests have been added/updated where applicable.
- [x] `pnpm build` passes.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
