### PR TITLE
Keep the volume button's screen reader state in one place

### DIFF
--- a/src/layouts/default/PlayerOSD/PlayerBarVolumeControl.vue
+++ b/src/layouts/default/PlayerOSD/PlayerBarVolumeControl.vue
@@ -28,8 +28,6 @@
         :data-suppress-hover="suppressHover"
         :disabled="disabled"
         :aria-label="`${$t('audio_overlay_volume')}: ${displayVolume}%`"
-        :aria-expanded="open"
-        aria-haspopup="dialog"
         @click.capture="handleTriggerClick"
         @pointerleave="suppressHover = false"
         @wheel="adjustVolume"

--- a/tests/layouts/PlayerBarVolumeControl.test.ts
+++ b/tests/layouts/PlayerBarVolumeControl.test.ts
@@ -7,9 +7,9 @@ import {
   PlayerFeature,
   PlayerType,
 } from "@/plugins/api/interfaces";
-import { mount } from "@vue/test-utils";
+import { enableAutoUnmount, mount } from "@vue/test-utils";
 import { h, inject, provide, type InjectionKey, type SetupContext } from "vue";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@/plugins/api", async () => {
   const { reactive } = await vi.importActual<typeof import("vue")>("vue");
@@ -164,11 +164,56 @@ function mountControl(player: Player) {
   });
 }
 
+// the popover stubs above keep the interaction tests independent of reka-ui;
+// the trigger's own attributes only show up with the real component
+function mountWithPopover(player: Player) {
+  return mount(PlayerBarVolumeControl, {
+    props: { player },
+    global: {
+      mocks: {
+        $t: (key: string) => key,
+      },
+      stubs: { PlayerVolumePanel: true, Teleport: true },
+    },
+  });
+}
+
+enableAutoUnmount(afterEach);
+
 describe("PlayerBarVolumeControl", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.useRealTimers();
     api.players = {};
+  });
+
+  it("leaves the panel state to the popover trigger", async () => {
+    const player = createPlayer();
+    api.players = { [player.player_id]: player };
+    const wrapper = mountWithPopover(player);
+    const trigger = wrapper.get("[data-player-volume-trigger]");
+
+    // reka-ui's PopoverTrigger supplies the disclosure state; a second,
+    // hand-written copy must not ride along and drift from it
+    expect(trigger.attributes("aria-haspopup")).toBe("dialog");
+    expect(trigger.attributes("aria-expanded")).toBe("false");
+
+    await trigger.trigger("click");
+    expect(trigger.attributes("aria-expanded")).toBe("true");
+
+    // the volume in the accessible name is ours; reka-ui has no notion of it
+    expect(trigger.attributes("aria-label")).toBe("audio_overlay_volume: 25%");
+  });
+
+  it("does not announce the panel state itself", () => {
+    const player = createPlayer();
+    api.players = { [player.player_id]: player };
+    // the stubbed trigger announces nothing, so whatever is left on the button
+    // is the component's own copy of what reka-ui already supplies
+    const trigger = mountControl(player).get("[data-player-volume-trigger]");
+
+    expect(trigger.attributes("aria-haspopup")).toBeUndefined();
+    expect(trigger.attributes("aria-expanded")).toBeUndefined();
   });
 
   it("does not open on hover", async () => {


### PR DESCRIPTION
# What does this implement/fix?

The volume button in the player bar told screen readers itself whether its panel was open (`aria-expanded`) and what kind of panel it opens (`aria-haspopup`). The popover it lives in already announces both, so the same information was being written twice. Both copies happen to agree today, so nothing is wrong on screen or in a screen reader — but the hand-written pair can silently drift away from the real panel state, which is exactly the kind of bug that only shows up for the people relying on it.

**Related issue (if applicable):**

- n/a

**Related backend PR (if applicable):**

- n/a

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Changes

- Removed the duplicated `aria-expanded` and `aria-haspopup` from the volume button; the popover trigger supplies both
- Kept the button's own `aria-label`, which spells out the current volume — the popover has no notion of that
- Added a test that mounts the real popover and pins the attributes to it, including the flip to open

Same fix as #2415 did for the group button, and verified the same way.

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm lint:check` passes.
- [x] `pnpm test:run` passes, and tests have been added/updated where applicable.
- [x] `pnpm build` passes.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
