### PR TITLE
Keep floating buttons and popups clear of the screen cutout

### DIFF
--- a/src/layouts/default/PlayerOSD/PlayerControlBtn/PlayerTrackMenu.vue
+++ b/src/layouts/default/PlayerOSD/PlayerControlBtn/PlayerTrackMenu.vue
@@ -328,7 +328,11 @@ onBeforeUnmount(flushPendingSpeed);
    opened it. */
 .playback-speed-dialog {
   width: 360px;
-  max-width: calc(100vw - 2rem) !important;
+  /* Both insets, so a dialog wide enough to be clamped still stops at the far
+     safe edge rather than running past it. */
+  max-width: calc(
+    100vw - 2rem - var(--device-inset-left) - var(--device-inset-right)
+  ) !important;
   top: auto !important;
   left: auto !important;
   right: calc(1rem + var(--device-inset-right)) !important;

--- a/src/layouts/default/PlayerOSD/PlayerControlBtn/PlayerTrackMenu.vue
+++ b/src/layouts/default/PlayerOSD/PlayerControlBtn/PlayerTrackMenu.vue
@@ -331,7 +331,7 @@ onBeforeUnmount(flushPendingSpeed);
   max-width: calc(100vw - 2rem) !important;
   top: auto !important;
   left: auto !important;
-  right: 1rem !important;
+  right: calc(1rem + var(--device-inset-right)) !important;
   bottom: calc(var(--bottom-bars-height) + 8px) !important;
   transform: none !important;
 }

--- a/src/layouts/default/ReloadPrompt.vue
+++ b/src/layouts/default/ReloadPrompt.vue
@@ -25,7 +25,8 @@ const close = async () => {
 <style>
 .pwa-toast {
   position: fixed;
-  right: 0;
+  /* The margin below sets the gap, so this only has to clear a side cutout. */
+  right: var(--device-inset-right);
   bottom: 0;
   margin: 16px;
   padding: 12px;

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -142,8 +142,8 @@ onMounted(async () => {
 
 .ed-edit-done {
   position: fixed;
-  right: 24px;
-  top: 24px;
+  right: calc(24px + var(--device-inset-right));
+  top: calc(24px + var(--device-inset-top));
   /* Only has to clear the drag ghost in HomeWidgetRows, so it stays out of the
      global stacking scale and below the player bar and its backdrops. */
   z-index: 60;

--- a/src/views/settings/EditConfig.vue
+++ b/src/views/settings/EditConfig.vue
@@ -603,7 +603,9 @@ const getCategoryIcon = function (category: string): Component {
 
 .floating-save {
   position: fixed;
-  right: 24px;
+  /* A landscape phone is wide enough to count as the desktop layout, so this
+     rule is what keeps the button clear of a side cutout. */
+  right: calc(24px + var(--device-inset-right));
   bottom: calc(var(--v-layout-bottom, var(--player-bar-height)) + 16px);
   z-index: 20;
 }

--- a/tests/styles/fixedElementSafeArea.test.ts
+++ b/tests/styles/fixedElementSafeArea.test.ts
@@ -1,0 +1,100 @@
+// jsdom leaves var() unresolved in computed styles, so this cascade is only
+// observable under happy-dom
+// @vitest-environment happy-dom
+import reloadPromptSource from "@/layouts/default/ReloadPrompt.vue?raw";
+import playerTrackMenuSource from "@/layouts/default/PlayerOSD/PlayerControlBtn/PlayerTrackMenu.vue?raw";
+import homeViewSource from "@/views/HomeView.vue?raw";
+import editConfigSource from "@/views/settings/EditConfig.vue?raw";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+// Every inset carries a distinct value, so an element reaching for the wrong
+// side reads as the wrong number instead of quietly passing.
+const INSET_RIGHT = "33px";
+const INSET_LEFT = "77px";
+const INSET_TOP = "55px";
+const INSET_BOTTOM = "11px";
+
+// Use raw selectors so the tests do not depend on Vue's generated scope id.
+function extractStyle(source: string) {
+  return source.match(/<style(?: scoped)?>([\s\S]*?)<\/style>/)?.[1] ?? "";
+}
+
+// happy-dom substitutes var() but never evaluates calc(), so a sum is only
+// observable as the expression composing it
+function normalize(value: string) {
+  return value.replace(/\s+/g, "");
+}
+
+let appStyles: HTMLStyleElement;
+
+function render(source: string, className: string) {
+  appStyles = document.createElement("style");
+  appStyles.textContent = extractStyle(source);
+  document.head.appendChild(appStyles);
+
+  const element = document.createElement("div");
+  element.className = className;
+  document.body.appendChild(element);
+  return element;
+}
+
+beforeEach(() => {
+  document.documentElement.style.setProperty("--device-inset-top", INSET_TOP);
+  document.documentElement.style.setProperty(
+    "--device-inset-right",
+    INSET_RIGHT,
+  );
+  document.documentElement.style.setProperty(
+    "--device-inset-bottom",
+    INSET_BOTTOM,
+  );
+  document.documentElement.style.setProperty("--device-inset-left", INSET_LEFT);
+});
+
+afterEach(() => {
+  appStyles?.remove();
+  document.documentElement.removeAttribute("style");
+  document.body.innerHTML = "";
+});
+
+describe.each([
+  // The desktop rule is what a landscape phone gets, so it carries the inset
+  // even though the mobile variant has its own.
+  ["settings save button", editConfigSource, "floating-save", "24px"],
+  ["home screen edit button", homeViewSource, "ed-edit-done", "24px"],
+  // The dialog writes its gap as 1rem, which resolves to the root font size.
+  [
+    "playback speed dialog",
+    playerTrackMenuSource,
+    "playback-speed-dialog",
+    "16px",
+  ],
+])("%s", (_name, source, className, gap) => {
+  it("keeps its gap clear of a side cutout", () => {
+    const element = render(source, className);
+
+    expect(normalize(getComputedStyle(element).right)).toBe(
+      `calc(${gap}+${INSET_RIGHT})`,
+    );
+  });
+});
+
+describe("update toast", () => {
+  it("sits its margin clear of a side cutout", () => {
+    const element = render(reloadPromptSource, "pwa-toast");
+
+    // The margin sets the gap, so the offset is the inset on its own.
+    expect(normalize(getComputedStyle(element).right)).toBe(INSET_RIGHT);
+    expect(normalize(getComputedStyle(element).marginRight)).toBe("16px");
+  });
+});
+
+describe("home screen edit button", () => {
+  it("clears the notch it sits under in portrait", () => {
+    const element = render(homeViewSource, "ed-edit-done");
+
+    expect(normalize(getComputedStyle(element).top)).toBe(
+      `calc(24px+${INSET_TOP})`,
+    );
+  });
+});

--- a/tests/styles/fixedElementSafeArea.test.ts
+++ b/tests/styles/fixedElementSafeArea.test.ts
@@ -79,6 +79,19 @@ describe.each([
   });
 });
 
+describe("playback speed dialog", () => {
+  // Offsetting only the near edge would push the far one off screen once the
+  // dialog is wide enough to be clamped.
+  it("clamps its width to both safe edges", () => {
+    const element = render(playerTrackMenuSource, "playback-speed-dialog");
+
+    // happy-dom resolves 100vw and 2rem before handing the expression back.
+    expect(normalize(getComputedStyle(element).maxWidth)).toBe(
+      `calc(${window.innerWidth}px-32px-${INSET_LEFT}-${INSET_RIGHT})`,
+    );
+  });
+});
+
 describe("update toast", () => {
   it("sits its margin clear of a side cutout", () => {
     const element = render(reloadPromptSource, "pwa-toast");

--- a/tests/styles/fixedElementSafeArea.test.ts
+++ b/tests/styles/fixedElementSafeArea.test.ts
@@ -25,12 +25,13 @@ function normalize(value: string) {
   return value.replace(/\s+/g, "");
 }
 
-let appStyles: HTMLStyleElement;
+const appStyles: HTMLStyleElement[] = [];
 
 function render(source: string, className: string) {
-  appStyles = document.createElement("style");
-  appStyles.textContent = extractStyle(source);
-  document.head.appendChild(appStyles);
+  const styles = document.createElement("style");
+  styles.textContent = extractStyle(source);
+  document.head.appendChild(styles);
+  appStyles.push(styles);
 
   const element = document.createElement("div");
   element.className = className;
@@ -52,7 +53,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
-  appStyles?.remove();
+  appStyles.splice(0).forEach((styles) => styles.remove());
   document.documentElement.removeAttribute("style");
   document.body.innerHTML = "";
 });
@@ -79,6 +80,16 @@ describe.each([
   });
 });
 
+describe("home screen edit button", () => {
+  it("clears the notch it sits under in portrait", () => {
+    const element = render(homeViewSource, "ed-edit-done");
+
+    expect(normalize(getComputedStyle(element).top)).toBe(
+      `calc(24px+${INSET_TOP})`,
+    );
+  });
+});
+
 describe("playback speed dialog", () => {
   // Offsetting only the near edge would push the far one off screen once the
   // dialog is wide enough to be clamped.
@@ -99,15 +110,5 @@ describe("update toast", () => {
     // The margin sets the gap, so the offset is the inset on its own.
     expect(normalize(getComputedStyle(element).right)).toBe(INSET_RIGHT);
     expect(normalize(getComputedStyle(element).marginRight)).toBe("16px");
-  });
-});
-
-describe("home screen edit button", () => {
-  it("clears the notch it sits under in portrait", () => {
-    const element = render(homeViewSource, "ed-edit-done");
-
-    expect(normalize(getComputedStyle(element).top)).toBe(
-      `calc(24px+${INSET_TOP})`,
-    );
   });
 });


### PR DESCRIPTION
# What does this implement/fix?

On phones with a rounded corner or camera cutout, a few floating buttons and
popups could sit underneath it and become hard to tap. The app started drawing
into that area in #2427, and #2448 fixed the settings save button for the mobile
layout — these are the remaining spots.

Each one now keeps its existing gap measured from the safe edge instead of the
screen edge, so nothing moves on a device without a cutout.

- Settings save button: the desktop rule now carries the inset too, which is
  what a landscape phone actually gets.
- Home screen "done editing" button: clears a side cutout, and the notch above
  it in portrait.
- Playback speed dialog: clears a side cutout in both the desktop and mobile
  player bars.
- App update toast: clears a side cutout.

**Related issue (if applicable):**

- n/a

**Related backend PR (if applicable):**

- n/a

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm lint:check` passes.
- [x] `pnpm test:run` passes, and tests have been added/updated where applicable.
- [x] `pnpm build` passes.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
