### PR TITLE
Keep the sleep timer clear of the player bar timeline

### DIFF
--- a/src/layouts/default/PlayerOSD/Player.vue
+++ b/src/layouts/default/PlayerOSD/Player.vue
@@ -62,9 +62,10 @@
       </div>
       <div class="mediacontrols-bottom-right">
         <div>
-          <!-- player extended control buttons. A narrower bar has no room for
-               the sleep timer beside the four actions, so the countdown is
-               left to the player menu and the full screen player there. -->
+          <!-- player extended control buttons. Below 1100px the bar drops to
+               its compact widths and the sleep timer goes with them, leaving
+               the countdown to the full screen player and the player card's
+               menu; it has no room of its own on the narrowest bars. -->
           <PlayerExtendedControls
             :favorite="{
               isVisible: false,
@@ -449,8 +450,10 @@ watch(
 /* the sleep timer joins the actions as a fifth control, which the widths above
    do not budget for: they need a bar of about 1221px before the five of them
    fit, and until then the timer reaches over the timeline. So while one runs
-   the actions keep the sizes they take below 1100px, up to the width where the
-   row starts spacing them out and has room to spare anyway. */
+   the actions take the widths they use below 1100px, which fit from 1034px up.
+   The full widths take over again at 1250px, where they clear the timeline by
+   about 9px - the tightest the row gets, so a sixth control or a wider button
+   would have to raise this bound with it. */
 @media screen and (min-width: 1100px) and (max-width: 1249px) {
   .mediacontrols :deep(.player-bar-action-row:has(.player-bar-sleep-timer)) {
     .player-bar-menu-button {
@@ -461,8 +464,8 @@ watch(
       width: 56px !important;
     }
 
-    /* these two grow with their label from 1100px, so the floor that lets them
-       has to go as well for the width to take effect */
+    /* the floor these two carry above 1100px would outrank the width, so it
+       has to be reset for the width to take effect */
     .player-bar-group-button {
       width: 60px !important;
       min-width: 0 !important;

--- a/src/layouts/default/PlayerOSD/Player.vue
+++ b/src/layouts/default/PlayerOSD/Player.vue
@@ -62,7 +62,9 @@
       </div>
       <div class="mediacontrols-bottom-right">
         <div>
-          <!-- player extended control buttons -->
+          <!-- player extended control buttons. A narrower bar has no room for
+               the sleep timer beside the four actions, so the countdown is
+               left to the player menu and the full screen player there. -->
           <PlayerExtendedControls
             :favorite="{
               isVisible: false,
@@ -77,6 +79,9 @@
             }"
             :volume="{
               isVisible: store.activePlayer != undefined,
+            }"
+            :sleep-timer="{
+              isVisible: getBreakpointValue('bp7'),
             }"
           />
         </div>
@@ -438,6 +443,35 @@ watch(
   .mediacontrols :deep(.player-bar-player-button) {
     min-width: 96px !important;
     max-width: clamp(96px, 10vw - 14px, 176px);
+  }
+}
+
+/* the sleep timer joins the actions as a fifth control, which the widths above
+   do not budget for: they need a bar of about 1221px before the five of them
+   fit, and until then the timer reaches over the timeline. So while one runs
+   the actions keep the sizes they take below 1100px, up to the width where the
+   row starts spacing them out and has room to spare anyway. */
+@media screen and (min-width: 1100px) and (max-width: 1249px) {
+  .mediacontrols :deep(.player-bar-action-row:has(.player-bar-sleep-timer)) {
+    .player-bar-menu-button {
+      width: 40px !important;
+    }
+
+    .player-bar-volume-button {
+      width: 56px !important;
+    }
+
+    /* these two grow with their label from 1100px, so the floor that lets them
+       has to go as well for the width to take effect */
+    .player-bar-group-button {
+      width: 60px !important;
+      min-width: 0 !important;
+    }
+
+    .player-bar-player-button {
+      width: 68px !important;
+      min-width: 0 !important;
+    }
   }
 }
 

--- a/src/layouts/default/PlayerOSD/PlayerExtendedControls.vue
+++ b/src/layouts/default/PlayerOSD/PlayerExtendedControls.vue
@@ -18,7 +18,10 @@
       <span class="player-bar-action-label" aria-hidden="true">&nbsp;</span>
     </Button>
 
-    <SleepTimerBtn />
+    <SleepTimerBtn
+      v-if="sleepTimer?.isVisible"
+      class="player-bar-sleep-timer"
+    />
 
     <QueueBtn
       v-if="queue?.isVisible"
@@ -74,6 +77,9 @@ export interface Props {
   contextMenu?: {
     isVisible?: boolean;
   };
+  sleepTimer?: {
+    isVisible?: boolean;
+  };
 }
 
 withDefaults(defineProps<Props>(), {
@@ -82,6 +88,7 @@ withDefaults(defineProps<Props>(), {
   player: () => ({ isVisible: true }),
   volume: () => ({ isVisible: true }),
   contextMenu: () => ({ isVisible: true }),
+  sleepTimer: () => ({ isVisible: true }),
 });
 
 const favoriteItem = computed(() => {

--- a/tests/layouts/Player.test.ts
+++ b/tests/layouts/Player.test.ts
@@ -1,6 +1,7 @@
 import Player from "@/layouts/default/PlayerOSD/Player.vue";
 import PlayerBarGroupControl from "@/layouts/default/PlayerOSD/PlayerBarGroupControl.vue";
 import PlayerBarMobileVolumeSheet from "@/layouts/default/PlayerOSD/PlayerBarMobileVolumeSheet.vue";
+import PlayerExtendedControls from "@/layouts/default/PlayerOSD/PlayerExtendedControls.vue";
 import PlayerTrackDetails from "@/layouts/default/PlayerOSD/PlayerTrackDetails.vue";
 import PlayerTrackMenu from "@/layouts/default/PlayerOSD/PlayerControlBtn/PlayerTrackMenu.vue";
 import PlayerVolume from "@/layouts/default/PlayerOSD/PlayerVolume.vue";
@@ -42,6 +43,9 @@ const mockStore = store as unknown as {
 
 // bp12: the width from which the floating row has room for the track menu
 const TRACK_MENU_BREAKPOINT = 415;
+
+// bp7: the width from which the desktop action row has room for the sleep timer
+const SLEEP_TIMER_BREAKPOINT = 1100;
 
 const originalInnerWidth = Object.getOwnPropertyDescriptor(
   window,
@@ -127,6 +131,19 @@ describe("Player floating mobile bar", () => {
     expect(player.find(".mediacontrols-bg").attributes("data-floating")).toBe(
       "false",
     );
+  });
+
+  it.each([
+    { width: SLEEP_TIMER_BREAKPOINT, visible: true },
+    { width: SLEEP_TIMER_BREAKPOINT - 1, visible: false },
+  ])("offers the sleep timer at $width px: $visible", ({ width, visible }) => {
+    mockStore.activePlayer = { player_id: "p1" } as PlayerModel;
+    setViewportWidth(width);
+    const player = mountPlayer(false);
+
+    expect(
+      player.findComponent(PlayerExtendedControls).props("sleepTimer"),
+    ).toEqual({ isVisible: visible });
   });
 
   it("closes an open volume sheet when the active player changes", async () => {

--- a/tests/layouts/Player.test.ts
+++ b/tests/layouts/Player.test.ts
@@ -75,18 +75,18 @@ function mountPlayer(useFloatingPlayer: boolean) {
   return wrapper;
 }
 
-describe("Player floating mobile bar", () => {
-  afterEach(() => {
-    wrapper?.unmount();
-    wrapper = undefined;
-    mockStore.activePlayer = undefined;
-    mockStore.activePlayerId = undefined;
-    if (originalInnerWidth) {
-      Object.defineProperty(window, "innerWidth", originalInnerWidth);
-    }
-    window.dispatchEvent(new Event("resize"));
-  });
+afterEach(() => {
+  wrapper?.unmount();
+  wrapper = undefined;
+  mockStore.activePlayer = undefined;
+  mockStore.activePlayerId = undefined;
+  if (originalInnerWidth) {
+    Object.defineProperty(window, "innerWidth", originalInnerWidth);
+  }
+  window.dispatchEvent(new Event("resize"));
+});
 
+describe("Player floating mobile bar", () => {
   it("carries the grouping control, the volume slider and its sheet", () => {
     mockStore.activePlayer = { player_id: "p1" } as PlayerModel;
     const player = mountPlayer(true);
@@ -124,6 +124,29 @@ describe("Player floating mobile bar", () => {
     expect(player.findComponent(PlayerVolume).exists()).toBe(true);
   });
 
+  it("closes an open volume sheet when the active player changes", async () => {
+    mockStore.activePlayer = { player_id: "p1" } as PlayerModel;
+    mockStore.activePlayerId = "p1";
+    const player = mountPlayer(true);
+
+    await player.findComponent(PlayerVolume).vm.$emit("toggle-group-expansion");
+    await nextTick();
+    expect(player.findComponent(PlayerBarMobileVolumeSheet).props("open")).toBe(
+      true,
+    );
+
+    // the sheet controls the volume of the player it was opened for, so it
+    // must not stay open over a player switch
+    mockStore.activePlayer = { player_id: "p2" } as PlayerModel;
+    mockStore.activePlayerId = "p2";
+    await nextTick();
+    expect(player.findComponent(PlayerBarMobileVolumeSheet).props("open")).toBe(
+      false,
+    );
+  });
+});
+
+describe("Player desktop bar", () => {
   it("leaves the desktop player outside the floating container", () => {
     const player = mountPlayer(false);
 
@@ -144,26 +167,5 @@ describe("Player floating mobile bar", () => {
     expect(
       player.findComponent(PlayerExtendedControls).props("sleepTimer"),
     ).toEqual({ isVisible: visible });
-  });
-
-  it("closes an open volume sheet when the active player changes", async () => {
-    mockStore.activePlayer = { player_id: "p1" } as PlayerModel;
-    mockStore.activePlayerId = "p1";
-    const player = mountPlayer(true);
-
-    await player.findComponent(PlayerVolume).vm.$emit("toggle-group-expansion");
-    await nextTick();
-    expect(player.findComponent(PlayerBarMobileVolumeSheet).props("open")).toBe(
-      true,
-    );
-
-    // the sheet controls the volume of the player it was opened for, so it
-    // must not stay open over a player switch
-    mockStore.activePlayer = { player_id: "p2" } as PlayerModel;
-    mockStore.activePlayerId = "p2";
-    await nextTick();
-    expect(player.findComponent(PlayerBarMobileVolumeSheet).props("open")).toBe(
-      false,
-    );
   });
 });

--- a/tests/layouts/PlayerExtendedControls.test.ts
+++ b/tests/layouts/PlayerExtendedControls.test.ts
@@ -2,13 +2,17 @@ import PlayerExtendedControls from "@/layouts/default/PlayerOSD/PlayerExtendedCo
 import SleepTimerBtn from "@/layouts/default/PlayerOSD/PlayerControlBtn/SleepTimerBtn.vue";
 import type { Player as PlayerModel } from "@/plugins/api/interfaces";
 import { store } from "@/plugins/store";
-import { enableAutoUnmount, shallowMount } from "@vue/test-utils";
+import { enableAutoUnmount, mount, shallowMount } from "@vue/test-utils";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@/plugins/api", () => {
   const api = { toggleFavorite: vi.fn(), providers: {}, players: {} };
   return { api, default: api };
 });
+
+vi.mock("@/plugins/i18n", () => ({
+  $t: (key: string) => key,
+}));
 
 vi.mock("@/plugins/store", async () => {
   const { reactive } = await vi.importActual<typeof import("vue")>("vue");
@@ -21,6 +25,14 @@ vi.mock("@/plugins/store", async () => {
 });
 
 const mockStore = store as unknown as { activePlayer?: PlayerModel };
+
+// the countdown only renders while the timer still has time to run
+function playerWithSleepTimer() {
+  return {
+    player_id: "p1",
+    sleep_timer_expires_at: Date.now() / 1000 + 3600,
+  } as PlayerModel;
+}
 
 enableAutoUnmount(afterEach);
 
@@ -35,7 +47,7 @@ describe("PlayerExtendedControls", () => {
   ])(
     "renders the sleep timer for isVisible $isVisible: $present",
     ({ isVisible, present }) => {
-      mockStore.activePlayer = { player_id: "p1" } as PlayerModel;
+      mockStore.activePlayer = playerWithSleepTimer();
 
       const controls = shallowMount(PlayerExtendedControls, {
         props: { sleepTimer: { isVisible } },
@@ -46,13 +58,23 @@ describe("PlayerExtendedControls", () => {
   );
 
   it("marks the sleep timer so the row can budget for it", () => {
-    mockStore.activePlayer = { player_id: "p1" } as PlayerModel;
+    mockStore.activePlayer = playerWithSleepTimer();
 
-    const controls = shallowMount(PlayerExtendedControls);
+    // the real countdown, so the class is checked where the layout reads it:
+    // on the button itself, past the fallthrough attrs it forwards
+    const controls = mount(PlayerExtendedControls, {
+      global: {
+        stubs: {
+          QueueBtn: true,
+          PlayerTrackMenu: true,
+          PlayerBarVolumeControl: true,
+          PlayerBarGroupControl: true,
+          PlayerBarPlayerButton: true,
+        },
+      },
+    });
 
     // the action widths key off this class to make room for the countdown
-    expect(controls.findComponent(SleepTimerBtn).classes()).toContain(
-      "player-bar-sleep-timer",
-    );
+    expect(controls.find("button.player-bar-sleep-timer").exists()).toBe(true);
   });
 });

--- a/tests/layouts/PlayerExtendedControls.test.ts
+++ b/tests/layouts/PlayerExtendedControls.test.ts
@@ -1,0 +1,58 @@
+import PlayerExtendedControls from "@/layouts/default/PlayerOSD/PlayerExtendedControls.vue";
+import SleepTimerBtn from "@/layouts/default/PlayerOSD/PlayerControlBtn/SleepTimerBtn.vue";
+import type { Player as PlayerModel } from "@/plugins/api/interfaces";
+import { store } from "@/plugins/store";
+import { enableAutoUnmount, shallowMount } from "@vue/test-utils";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/plugins/api", () => {
+  const api = { toggleFavorite: vi.fn(), providers: {}, players: {} };
+  return { api, default: api };
+});
+
+vi.mock("@/plugins/store", async () => {
+  const { reactive } = await vi.importActual<typeof import("vue")>("vue");
+  return {
+    store: reactive({
+      activePlayer: undefined,
+      curQueueItem: undefined,
+    }),
+  };
+});
+
+const mockStore = store as unknown as { activePlayer?: PlayerModel };
+
+enableAutoUnmount(afterEach);
+
+describe("PlayerExtendedControls", () => {
+  afterEach(() => {
+    mockStore.activePlayer = undefined;
+  });
+
+  it.each([
+    { isVisible: true, present: true },
+    { isVisible: false, present: false },
+  ])(
+    "renders the sleep timer for isVisible $isVisible: $present",
+    ({ isVisible, present }) => {
+      mockStore.activePlayer = { player_id: "p1" } as PlayerModel;
+
+      const controls = shallowMount(PlayerExtendedControls, {
+        props: { sleepTimer: { isVisible } },
+      });
+
+      expect(controls.findComponent(SleepTimerBtn).exists()).toBe(present);
+    },
+  );
+
+  it("marks the sleep timer so the row can budget for it", () => {
+    mockStore.activePlayer = { player_id: "p1" } as PlayerModel;
+
+    const controls = shallowMount(PlayerExtendedControls);
+
+    // the action widths key off this class to make room for the countdown
+    expect(controls.findComponent(SleepTimerBtn).classes()).toContain(
+      "player-bar-sleep-timer",
+    );
+  });
+});


### PR DESCRIPTION
# What does this implement/fix?

While a sleep timer runs, its countdown sits in the player bar next to the four
action buttons - but those buttons are sized as if they had the row to
themselves. On a mid-width window the countdown had nowhere to go and reached
back over the progress bar; on a narrow one it landed on top of the repeat
button.

Now the four buttons keep their compact sizes while a countdown shares the row,
and on a bar too narrow for both the countdown steps aside - it stays available
in the player menu and the full screen player.

- Keep the action buttons compact between 1100px and 1250px while a sleep timer
  is running, so the countdown has room
- Leave the countdown out of the player bar below 1100px, where the row has no
  space for it at all
- Cover both with tests

**Related issue (if applicable):**

- found while working on #2449

**Related backend PR (if applicable):**

- n/a

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm lint:check` passes.
- [x] `pnpm test:run` passes, and tests have been added/updated where applicable.
- [x] `pnpm build` passes.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
