### PR TITLE
Show the app update prompt instead of hiding it behind the player bar

### DIFF
--- a/src/layouts/default/ReloadPrompt.vue
+++ b/src/layouts/default/ReloadPrompt.vue
@@ -38,9 +38,9 @@ const close = async () => {
   padding: 12px;
   border: 1px solid #8885;
   border-radius: 4px;
-  /* Renders outside v-app, so this competes with the player bar directly.
-     Above the bars, below the dialogs and menus that should cover it. */
-  z-index: 2100;
+  /* Renders outside v-app, so this competes with the player bar directly. Just
+     enough to clear the bars, leaving everything above them covering it. */
+  z-index: 2002;
   text-align: left;
   box-shadow: 3px 4px 5px 0 #8885;
   background-color: white;

--- a/src/layouts/default/ReloadPrompt.vue
+++ b/src/layouts/default/ReloadPrompt.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { store } from "@/plugins/store";
 import { useRegisterSW } from "virtual:pwa-register/vue";
 
 const { offlineReady, needRefresh, updateServiceWorker } = useRegisterSW();
@@ -10,7 +11,11 @@ const close = async () => {
 </script>
 
 <template>
-  <div v-if="offlineReady || needRefresh" class="pwa-toast" role="alert">
+  <div
+    v-if="offlineReady || needRefresh"
+    :class="['pwa-toast', { 'pwa-toast--frameless': store.frameless }]"
+    role="alert"
+  >
     <div class="message">
       <span v-if="offlineReady"> App ready to work offline </span>
       <span v-else>
@@ -25,18 +30,28 @@ const close = async () => {
 <style>
 .pwa-toast {
   position: fixed;
-  /* The margin below sets the gap, so this only has to clear a side cutout. */
+  /* The margin below sets the gap, so these only have to clear the bars pinned
+     to the bottom of the screen and a side cutout. */
   right: var(--device-inset-right);
-  bottom: 0;
+  bottom: var(--bottom-bars-height);
   margin: 16px;
   padding: 12px;
   border: 1px solid #8885;
   border-radius: 4px;
-  z-index: 1;
+  /* Renders outside v-app, so this competes with the player bar directly.
+     Above the bars, below the dialogs and menus that should cover it. */
+  z-index: 2100;
   text-align: left;
   box-shadow: 3px 4px 5px 0 #8885;
   background-color: white;
 }
+
+/* Without the app frame there are no bars to clear, only the screen's own
+   bottom edge. */
+.pwa-toast--frameless {
+  bottom: var(--device-inset-bottom);
+}
+
 .pwa-toast .message {
   margin-bottom: 8px;
 }

--- a/src/layouts/default/ReloadPrompt.vue
+++ b/src/layouts/default/ReloadPrompt.vue
@@ -43,7 +43,10 @@ const close = async () => {
   z-index: 2002;
   text-align: left;
   box-shadow: 3px 4px 5px 0 #8885;
-  background-color: white;
+  /* The same tokens the app's other toasts take, so it follows the theme. The
+     buttons below inherit the text colour from here. */
+  background-color: var(--popover);
+  color: var(--popover-foreground);
 }
 
 /* Without the app frame there are no bars to clear, only the screen's own

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -124,7 +124,8 @@ html {
        1000  desktop player bar
        2000  mobile bottom navigation, and Vuetify's default overlay z-index
        2001  floating mobile player bar
-       2100  settings loading overlays, and the app update prompt
+       2002  app update prompt
+       2100  settings loading overlays
        9000  fullscreen player
        9001  player select backdrop, opened from the fullscreen player
        9002  player select popout, opened from the fullscreen player

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -124,7 +124,7 @@ html {
        1000  desktop player bar
        2000  mobile bottom navigation, and Vuetify's default overlay z-index
        2001  floating mobile player bar
-       2100  settings loading overlays
+       2100  settings loading overlays, and the app update prompt
        9000  fullscreen player
        9001  player select backdrop, opened from the fullscreen player
        9002  player select popout, opened from the fullscreen player

--- a/tests/styles/fixedElementSafeArea.test.ts
+++ b/tests/styles/fixedElementSafeArea.test.ts
@@ -1,6 +1,7 @@
 // jsdom leaves var() unresolved in computed styles, so this cascade is only
 // observable under happy-dom
 // @vitest-environment happy-dom
+import footerSource from "@/layouts/default/Footer.vue?raw";
 import reloadPromptSource from "@/layouts/default/ReloadPrompt.vue?raw";
 import playerTrackMenuSource from "@/layouts/default/PlayerOSD/PlayerControlBtn/PlayerTrackMenu.vue?raw";
 import homeViewSource from "@/views/HomeView.vue?raw";
@@ -13,6 +14,9 @@ const INSET_RIGHT = "33px";
 const INSET_LEFT = "77px";
 const INSET_TOP = "55px";
 const INSET_BOTTOM = "11px";
+// Taller than the bottom inset it already folds in, so an element measuring
+// from the wrong one cannot read as the right number.
+const BARS_HEIGHT = "158px";
 
 // Use raw selectors so the tests do not depend on Vue's generated scope id.
 function extractStyle(source: string) {
@@ -50,6 +54,10 @@ beforeEach(() => {
     INSET_BOTTOM,
   );
   document.documentElement.style.setProperty("--device-inset-left", INSET_LEFT);
+  document.documentElement.style.setProperty(
+    "--bottom-bars-height",
+    BARS_HEIGHT,
+  );
 });
 
 afterEach(() => {
@@ -110,5 +118,36 @@ describe("update toast", () => {
     // The margin sets the gap, so the offset is the inset on its own.
     expect(normalize(getComputedStyle(element).right)).toBe(INSET_RIGHT);
     expect(normalize(getComputedStyle(element).marginRight)).toBe("16px");
+  });
+
+  it("sits its margin clear of the bars pinned to the bottom", () => {
+    const element = render(reloadPromptSource, "pwa-toast");
+
+    // Those already reserve the bottom inset, so this clears it as well.
+    expect(normalize(getComputedStyle(element).bottom)).toBe(BARS_HEIGHT);
+    expect(normalize(getComputedStyle(element).marginBottom)).toBe("16px");
+  });
+
+  it("clears only the bottom edge without the app frame", () => {
+    const element = render(
+      reloadPromptSource,
+      "pwa-toast pwa-toast--frameless",
+    );
+
+    expect(normalize(getComputedStyle(element).bottom)).toBe(INSET_BOTTOM);
+  });
+
+  it("paints above the player bar it floats over", () => {
+    const element = render(reloadPromptSource, "pwa-toast");
+    // It renders outside v-app, which is no stacking context, so the two
+    // compete directly.
+    const playerBar = render(
+      footerSource,
+      "v-footer mediacontrols-player-float",
+    );
+
+    expect(Number(getComputedStyle(element).zIndex)).toBeGreaterThan(
+      Number(getComputedStyle(playerBar).zIndex),
+    );
   });
 });

--- a/tests/styles/fixedElementSafeArea.test.ts
+++ b/tests/styles/fixedElementSafeArea.test.ts
@@ -123,7 +123,7 @@ describe("update toast", () => {
   it("sits its margin clear of the bars pinned to the bottom", () => {
     const element = render(reloadPromptSource, "pwa-toast");
 
-    // Those already reserve the bottom inset, so this clears it as well.
+    // Those rest on the bottom edge, so clearing them clears its inset too.
     expect(normalize(getComputedStyle(element).bottom)).toBe(BARS_HEIGHT);
     expect(normalize(getComputedStyle(element).marginBottom)).toBe("16px");
   });
@@ -149,5 +149,8 @@ describe("update toast", () => {
     expect(Number(getComputedStyle(element).zIndex)).toBeGreaterThan(
       Number(getComputedStyle(playerBar).zIndex),
     );
+    // Anything that blocks the screen on purpose still covers it, starting
+    // with the settings loading overlays.
+    expect(Number(getComputedStyle(element).zIndex)).toBeLessThan(2100);
   });
 });


### PR DESCRIPTION
# What does this implement/fix?

The "new content available, click to reload" prompt that appears after an app
update was placed at the very bottom of the screen with almost no stacking
order, so in practice you could not see or click it:

- The player bar painted straight over it. The prompt renders outside `v-app`,
  which is not a stacking context, so its `z-index: 1` competed directly with
  the player bar's `1000`/`2001` and lost.
- It also sat inside the home indicator area at the bottom of the screen on
  phones, so part of it fell under the system gesture bar.
- Once it was visible it turned out to be unreadable: it hardcoded a white
  background while its text colour came from the theme, so under the dark theme
  the message and both buttons were white on white.

It now sits above the bars pinned to the bottom of the screen, keeping the same
16px gap every other floating element uses, and stacks just high enough to clear
them so everything above them still covers it. Without the app frame
(fullscreen/embedded views) there is no player bar to clear, so it only keeps
clear of the screen edge. It now takes the same theme colours as the app's
other toasts.

**Related issue (if applicable):**

- related issue `n/a`

**Related backend PR (if applicable):**

- related backend PR `n/a`

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm lint:check` passes.
- [x] `pnpm test:run` passes, and tests have been added/updated where applicable.
- [x] `pnpm build` passes.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.


