### PR TITLE
Let a touch drag scroll the group volume popout

### DIFF
--- a/src/layouts/default/PlayerOSD/PlayerVolume.vue
+++ b/src/layouts/default/PlayerOSD/PlayerVolume.vue
@@ -555,7 +555,9 @@ const onTouchMove = (event: TouchEvent) => {
   }
 
   if (!isDrag.value && !isScrolling.value) {
-    if (absDeltaY > 10 && absDeltaY > absDeltaX * 2) {
+    // A non-cancelable move means the browser already owns the gesture (panning
+    // the group popout), so a drag from here would fight a scroll it cannot stop
+    if (!event.cancelable || (absDeltaY > 10 && absDeltaY > absDeltaX * 2)) {
       isScrolling.value = true;
       displayValue.value = touchStartValue.value;
       emit("update:local-value", touchStartValue.value);
@@ -907,6 +909,14 @@ watch(
   overflow-y: auto;
   overscroll-behavior: contain;
   z-index: 10001;
+}
+
+/* touch-action is intersected from the touched row up to the scroll container,
+   so the rows have to allow the vertical pan themselves; horizontal drags still
+   reach onTouchMove, which claims them. The wrapper is named as well, to
+   out-rank the scoped rule whichever of the two blocks loads last. */
+.group-popout .player-volume-wrapper .player-volume-container {
+  touch-action: pan-y;
 }
 
 .group-popout-row {

--- a/tests/layouts/PlayerVolume.test.ts
+++ b/tests/layouts/PlayerVolume.test.ts
@@ -417,6 +417,38 @@ describe("PlayerVolume group popout", () => {
     return document.body.querySelector<HTMLElement>(".group-popout")!;
   }
 
+  // a diagonal swipe the browser may claim for the popout's own scrolling: far
+  // enough sideways to read as a slider drag, but not steep enough for the
+  // component's own scroll detection to catch it
+  const DIAGONAL = { from: { x: 150, y: 100 }, to: { x: 190, y: 116 } };
+  // where DIAGONAL.to lands on the mocked slider, rounded to the default step
+  const DRAGGED_VOLUME = 46;
+
+  function touchEvent(type: string, x: number, y: number, cancelable = true) {
+    const event = new Event(type, { bubbles: true, cancelable });
+    const touch = { clientX: x, clientY: y };
+    return Object.assign(event, { touches: [touch], changedTouches: [touch] });
+  }
+
+  // the first row's player, whose id mountLargeGroup derives from its name
+  function firstRow(popout: HTMLElement) {
+    const row = popout.querySelector<HTMLElement>(".group-popout-row")!;
+    const name = row.querySelector(".group-popout-label")!.textContent!.trim();
+    return {
+      container: row.querySelector<HTMLElement>(".player-volume-container")!,
+      level: () => row.querySelector(".volume-level-text")!.textContent!.trim(),
+      playerId: name.toLowerCase(),
+    };
+  }
+
+  async function swipeRow(row: HTMLElement, cancelable: boolean) {
+    const { from, to } = DIAGONAL;
+    row.dispatchEvent(touchEvent("touchstart", from.x, from.y));
+    row.dispatchEvent(touchEvent("touchmove", to.x, to.y, cancelable));
+    row.dispatchEvent(touchEvent("touchend", to.x, to.y));
+    await nextTick();
+  }
+
   it("caps the popout at the room above the slider", async () => {
     const { children, wrapper } = mountLargeGroup();
 
@@ -466,6 +498,44 @@ describe("PlayerVolume group popout", () => {
     row.dispatchEvent(event);
 
     expect(event.defaultPrevented).toBe(false);
+  });
+
+  it("nests the rows the way the touch-action override selects them", async () => {
+    const { wrapper } = mountLargeGroup();
+
+    const popout = await openPopout(wrapper);
+
+    // the override in the component's unscoped block names the wrapper as well,
+    // to out-rank the scoped rule; flattening a row would silently drop it
+    expect(
+      popout.querySelector(
+        ".group-popout .player-volume-wrapper .player-volume-container",
+      ),
+    ).not.toBeNull();
+  });
+
+  it("leaves a pan the browser already owns to scroll the popout", async () => {
+    const { wrapper } = mountLargeGroup();
+    const row = firstRow(await openPopout(wrapper));
+
+    await swipeRow(row.container, false);
+
+    expect(api.playerCommandVolumeSet).not.toHaveBeenCalled();
+    // the slider must not have followed the finger on its way past either
+    expect(row.level()).toBe("25");
+  });
+
+  it("still drags a popout row's volume while it can claim the gesture", async () => {
+    const { wrapper } = mountLargeGroup();
+    const row = firstRow(await openPopout(wrapper));
+
+    await swipeRow(row.container, true);
+
+    expect(api.playerCommandVolumeSet).toHaveBeenCalledWith(
+      row.playerId,
+      DRAGGED_VOLUME,
+    );
+    expect(row.level()).toBe(String(DRAGGED_VOLUME));
   });
 
   it("still claims the wheel where it changes volume", async () => {

--- a/tests/styles/groupPopoutTouchAction.test.ts
+++ b/tests/styles/groupPopoutTouchAction.test.ts
@@ -1,0 +1,82 @@
+// happy-dom cannot settle a tie between two equally specific rules, so the
+// ranking is what proves the override applies whichever block loads last
+// @vitest-environment happy-dom
+import volumeSource from "@/layouts/default/PlayerOSD/PlayerVolume.vue?raw";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+// vitest only compiles the stylesheets under src/styles, so the component's own
+// rules are lifted straight out of its source, in the order it declares them
+function styleBlocks(source: string) {
+  return [...source.matchAll(/<style[^>]*>([\s\S]*?)<\/style>/g)].map(
+    (match) => match[1],
+  );
+}
+
+// the scoped block's selectors each gain a [data-v-hash] compound at compile
+// time, which the raw source does not carry
+const SCOPE_COMPOUND = 1;
+
+let styles: HTMLStyleElement;
+
+// a child row as the popout renders it
+function row() {
+  const popout = document.createElement("div");
+  popout.className = "group-popout";
+  popout.innerHTML = `
+    <div class="group-popout-row">
+      <div class="player-volume-wrapper">
+        <div class="player-volume-container"></div>
+      </div>
+    </div>`;
+  document.body.appendChild(popout);
+  return popout.querySelector(".player-volume-container")!;
+}
+
+function rulesFor(element: Element) {
+  return [...(styles.sheet?.cssRules ?? [])]
+    .filter((rule): rule is CSSStyleRule => rule instanceof CSSStyleRule)
+    .filter((rule) => element.matches(rule.selectorText));
+}
+
+// neither side carries an id or an element name, so counting their class-level
+// compounds is the whole comparison
+function rank(selector: string) {
+  return (selector.match(/\.[\w-]+|\[[^\]]+\]|:[\w-]+/g) ?? []).length;
+}
+
+describe("group volume popout touch-action", () => {
+  beforeEach(() => {
+    styles = document.createElement("style");
+    styles.textContent = styleBlocks(volumeSource).join("\n");
+    document.head.appendChild(styles);
+  });
+
+  afterEach(() => {
+    styles.remove();
+    document.body.innerHTML = "";
+  });
+
+  it("lets a touch drag on a row pan the popout", () => {
+    // touch-action is intersected from the touched element up to the scroll
+    // container, so a row keeping pan-x would leave the popout unscrollable
+    expect(getComputedStyle(row()).touchAction).toBe("pan-y");
+  });
+
+  it("keeps the rows panning independently of the stylesheet load order", () => {
+    const declaring = rulesFor(row()).filter(
+      (rule) => rule.style.getPropertyValue("touch-action") !== "",
+    );
+    const winner =
+      ".group-popout .player-volume-wrapper .player-volume-container";
+
+    expect(declaring.map((rule) => rule.selectorText)).toContain(winner);
+    for (const rule of declaring) {
+      if (rule.selectorText === winner) continue;
+
+      expect(
+        rank(winner),
+        `${rule.selectorText} also sets touch-action on a row, so the override has to out-rank it once scoped`,
+      ).toBeGreaterThan(rank(rule.selectorText) + SCOPE_COMPOUND);
+    }
+  });
+});


### PR DESCRIPTION
# What does this implement/fix?

The group volume popout scrolls once a group has more members than fit on screen (#2418), but on a touch device there was barely anything left to scroll it with. Each volume row only permits sideways panning, and the browser applies the touched row's restriction to the popout behind it, so a swipe starting on any row did nothing at all — only the member names and the popout's thin edges responded.

The rows now permit the vertical pan while still claiming sideways drags themselves, so a swipe anywhere in the popout scrolls it and a sideways swipe still sets that member's volume.

**Related issue (if applicable):**

- follow-up to #2418

**Related backend PR (if applicable):**

- n/a

## Types of changes

<!--
Tick exactly one box below. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Changes

- Let the volume rows inside the popout be panned vertically, so a swipe on one scrolls the member list. Deliberately limited to the popout — a slider that is not sitting in a scrollable list keeps sideways-only panning, which makes its drags that bit crisper
- Stop a row from changing the volume once the browser has taken the gesture over for scrolling, so a diagonal swipe scrolls instead of quietly nudging a speaker
- Add tests for both, and pin the rule against the load order of the component's two style blocks

Checked in a browser that the rule reaches the popout's rows and nothing outside them; the gestures themselves still want a try on a real touch device.

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm lint:check` passes.
- [x] `pnpm test:run` passes, and tests have been added/updated where applicable.
- [x] `pnpm build` passes.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
