### PR TITLE
Cover the mobile dock's height with a test

### DIFF
--- a/tests/styles/mobileNavigationHeight.test.ts
+++ b/tests/styles/mobileNavigationHeight.test.ts
@@ -20,9 +20,13 @@ const INSET_BOTTOM = "17px";
 let styles: HTMLStyleElement[];
 let utilityStyles: HTMLStyleElement;
 
-// the block is unscoped, so the selectors it declares are the shipped ones
+// the block is unscoped, so the selectors it declares are the shipped ones. A
+// block that stops matching is compiled differently and no longer says what the
+// bar ships, so say that rather than measuring an empty stylesheet.
 function extractStyle(source: string) {
-  return source.match(/<style>([\s\S]*?)<\/style>/)?.[1] ?? "";
+  const style = source.match(/<style>([\s\S]*?)<\/style>/)?.[1];
+  if (!style) throw new Error("the navigation's plain <style> block is gone");
+  return style;
 }
 
 // happy-dom substitutes every var() but does not evaluate calc(), so the height

--- a/tests/styles/mobileNavigationHeight.test.ts
+++ b/tests/styles/mobileNavigationHeight.test.ts
@@ -3,15 +3,30 @@
 // because both rules are unlayered in the compiled stylesheet
 // @vitest-environment happy-dom
 import navigationSource from "@/components/navigation/BottomNavigation.vue?raw";
+import { buttonVariants } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
 import tokens from "@/styles/global.css?inline";
 import utilities from "@/styles/style.css?inline";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
-// the class list the bar carries in the template, so the utilities it has to
-// out-rank are in play here the same way they are on screen
-const BAR_CLASSES =
-  "mobile-bottom-navigation fixed inset-x-0 bottom-0 z-[2000] flex";
-const ITEM_CLASSES = "player-control-button mobile-navigation-item";
+// Read off the template rather than copied, so a class the rules key on going
+// missing fails here instead of leaving the probe measuring rules the bar no
+// longer carries.
+function templateClasses(pattern: RegExp) {
+  const classes = navigationSource.match(pattern)?.[1];
+  if (!classes)
+    throw new Error(`the template carries no class list for ${pattern}`);
+  return classes;
+}
+
+const BAR_CLASSES = templateClasses(/<nav[\s\S]*?\sclass="([^"]*)"/);
+// every button in the bar is one of its items, so each is measured in turn: a
+// single one dropping the class the height rules key on leaves that button at
+// the size its own variant gives it. A Button merges the classes it is passed
+// onto its own, and its size is where that competing height comes from.
+const ITEM_CLASS_LISTS = [
+  ...navigationSource.matchAll(/<Button[\s\S]*?\sclass="([^"]*)"/g),
+].map(([, classes]) => cn(buttonVariants({ variant: "ghost" }), classes));
 // deliberately not the real values, so a bar that hardcodes its own geometry
 // instead of reading the tokens fails here
 const ITEM_HEIGHT = "71px";
@@ -64,8 +79,9 @@ describe("mobile navigation height", () => {
       return element;
     });
     // last, so the utilities win every tie the bar's own rules do not break.
-    // That is the order the bar is written to survive, and the only one in which
-    // dropping its :root guard is visible.
+    // The app loads them the other way round - the bar's styles ship in a chunk
+    // pulled in after the entry sheet - so this is the harder order, and the only
+    // one in which the bar out-ranking a utility is visible at all.
     utilityStyles = document.createElement("style");
     utilityStyles.textContent = utilities;
     document.head.appendChild(utilityStyles);
@@ -89,9 +105,15 @@ describe("mobile navigation height", () => {
     // it holds leaves them floating off the surface behind them
     expect(probe(BAR_CLASSES).height).toBe(ITEM_HEIGHT);
     expect(
-      probe(ITEM_CLASSES).height,
-      "the buttons must take the same height the bar does",
-    ).toBe(ITEM_HEIGHT);
+      ITEM_CLASS_LISTS.length,
+      "the bar must hold buttons to measure",
+    ).toBeGreaterThan(0);
+    for (const classes of ITEM_CLASS_LISTS) {
+      expect(
+        probe(classes).height,
+        `the button "${classes}" must take the height the bar does`,
+      ).toBe(ITEM_HEIGHT);
+    }
   });
 
   it("lifts the bar clear of the screen edge by the published inset", () => {
@@ -136,12 +158,13 @@ describe("mobile navigation height", () => {
     );
   });
 
-  it("still occupies the floor of that height when the host owns the insets", () => {
+  it("takes its clearance from the inset the host can zero", () => {
     document.documentElement.setAttribute("data-embedded-layout", "");
 
     // embedded in Home Assistant the device insets are the host's to add, so the
-    // bar zeroes them. What is left is the floor under the inset, which is what
-    // holds the buttons clear of the bottom of the panel.
+    // bar zeroes them and falls back on the floor under the inset. Reaching for
+    // the device inset directly reads the same until it is embedded, and then
+    // reserves the home indicator a second time on top of the host's own room.
     expect(customProperty("--mobile-navigation-height")).toBe(
       "calc(72px+max(12px,calc(0px*0.65)))",
     );

--- a/tests/styles/mobileNavigationHeight.test.ts
+++ b/tests/styles/mobileNavigationHeight.test.ts
@@ -1,0 +1,145 @@
+// jsdom leaves var() unresolved in computed styles, so this composition is only
+// observable under happy-dom, which in turn ignores @layer: the comparison holds
+// because both rules are unlayered in the compiled stylesheet
+// @vitest-environment happy-dom
+import navigationSource from "@/components/navigation/BottomNavigation.vue?raw";
+import tokens from "@/styles/global.css?inline";
+import utilities from "@/styles/style.css?inline";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+// the class list the bar carries in the template, so the utilities it has to
+// out-rank are in play here the same way they are on screen
+const BAR_CLASSES =
+  "mobile-bottom-navigation fixed inset-x-0 bottom-0 z-[2000] flex";
+const ITEM_CLASSES = "player-control-button mobile-navigation-item";
+// deliberately not the real values, so a bar that hardcodes its own geometry
+// instead of reading the tokens fails here
+const ITEM_HEIGHT = "71px";
+const INSET_BOTTOM = "17px";
+
+let styles: HTMLStyleElement[];
+let utilityStyles: HTMLStyleElement;
+
+// the block is unscoped, so the selectors it declares are the shipped ones
+function extractStyle(source: string) {
+  return source.match(/<style>([\s\S]*?)<\/style>/)?.[1] ?? "";
+}
+
+// happy-dom substitutes every var() but does not evaluate calc(), so the height
+// is only observable as the expression it composes. The declarations wrap at
+// different points as the token names change, so compare them free of the
+// source formatting.
+function customProperty(name: string) {
+  return getComputedStyle(document.documentElement)
+    .getPropertyValue(name)
+    .replace(/\s+/g, "");
+}
+
+// happy-dom caches an element's computed style from its first read, so each
+// probe is built after the custom properties it measures are in place
+function probe(className: string) {
+  const element = document.createElement("div");
+  element.className = className;
+  document.body.appendChild(element);
+  return getComputedStyle(element);
+}
+
+function utilityBottomPriority() {
+  return [...(utilityStyles.sheet?.cssRules ?? [])]
+    .filter((rule) => rule instanceof CSSStyleRule)
+    .find((rule) => rule.selectorText === ".bottom-0")
+    ?.style.getPropertyPriority("bottom");
+}
+
+describe("mobile navigation height", () => {
+  beforeEach(() => {
+    styles = [tokens, extractStyle(navigationSource)].map((text) => {
+      const element = document.createElement("style");
+      element.textContent = text;
+      document.head.appendChild(element);
+      return element;
+    });
+    // last, so the utilities win every tie the bar's own rules do not break.
+    // That is the order the bar is written to survive, and the only one in which
+    // dropping its :root guard is visible.
+    utilityStyles = document.createElement("style");
+    utilityStyles.textContent = utilities;
+    document.head.appendChild(utilityStyles);
+    styles.push(utilityStyles);
+  });
+
+  afterEach(() => {
+    styles.forEach((element) => element.remove());
+    document.documentElement.removeAttribute("style");
+    document.documentElement.removeAttribute("data-embedded-layout");
+    document.body.innerHTML = "";
+  });
+
+  it("sizes the bar and its buttons from one height", () => {
+    document.documentElement.style.setProperty(
+      "--mobile-navigation-item-height",
+      ITEM_HEIGHT,
+    );
+
+    // the bar is only a track for the buttons, so a bar taller than the buttons
+    // it holds leaves them floating off the surface behind them
+    expect(probe(BAR_CLASSES).height).toBe(ITEM_HEIGHT);
+    expect(
+      probe(ITEM_CLASSES).height,
+      "the buttons must take the same height the bar does",
+    ).toBe(ITEM_HEIGHT);
+  });
+
+  it("lifts the bar clear of the screen edge by the published inset", () => {
+    // the offset only proves anything while the utility it has to out-rank is
+    // itself !important
+    expect(
+      utilityBottomPriority(),
+      "the Tailwind utilities import must stay `important` and unlayered",
+    ).toBe("important");
+
+    // happy-dom drops a declaration whose substituted custom property expands to
+    // a max(), so the bar is measured with its inset flattened to a literal
+    document.documentElement.style.setProperty(
+      "--mobile-navigation-inset-bottom",
+      INSET_BOTTOM,
+    );
+    const bar = probe(BAR_CLASSES);
+
+    // the inset is what holds the bar off the home indicator, and the bar's own
+    // bottom-0 would otherwise drop it flat against the edge of the screen
+    expect(bar.bottom).toBe(INSET_BOTTOM);
+    // an offset means nothing until something takes the bar out of the flow
+    expect(bar.position).toBe("fixed");
+  });
+
+  it("adds up to the height everything else is positioned from", () => {
+    document.documentElement.style.setProperty(
+      "--mobile-navigation-item-height",
+      ITEM_HEIGHT,
+    );
+    document.documentElement.style.setProperty(
+      "--mobile-navigation-inset-bottom",
+      INSET_BOTTOM,
+    );
+
+    // the bar takes its own two measurements straight from the tokens, and the
+    // sheets, popovers, player bar and scroll padding above it all measure from
+    // this instead. Nothing lines the two up at runtime, so this is what catches
+    // the room the bar occupies drifting from the room everything else leaves it.
+    expect(customProperty("--mobile-navigation-height")).toBe(
+      `calc(${ITEM_HEIGHT}+${INSET_BOTTOM})`,
+    );
+  });
+
+  it("still occupies the floor of that height when the host owns the insets", () => {
+    document.documentElement.setAttribute("data-embedded-layout", "");
+
+    // embedded in Home Assistant the device insets are the host's to add, so the
+    // bar zeroes them. What is left is the floor under the inset, which is what
+    // holds the buttons clear of the bottom of the panel.
+    expect(customProperty("--mobile-navigation-height")).toBe(
+      "calc(72px+max(12px,calc(0px*0.65)))",
+    );
+  });
+});


### PR DESCRIPTION
# What does this implement/fix?

The mobile bottom bar was rebuilt as a floating dock in #2441. That change is almost entirely CSS, and the bar's own two measurements were never pinned: it takes its height and its offset straight from the design tokens, while the player bar, sheets, popovers, scroll padding and the settings save button are all positioned from the total those tokens add up to. Existing tests cover the total; nothing checked that the bar itself still reads the same two tokens, so the two sides only ever agreed because someone checked by hand each time the height changed.

**Related issue (if applicable):**

- n/a

**Related backend PR (if applicable):**

- n/a

Changes:

- Pin that the bar and every one of its buttons take their height from the same token, including the bar overruling the height each button's own style would otherwise use.
- Pin that the bar is lifted off the bottom of the screen by the published inset rather than sitting flat against it.
- Pin that the two add up to the height everything else is positioned from, so inlining either one is caught.
- Pin that the clearance comes from the inset the host can zero, so embedding in Home Assistant does not reserve the home indicator's room a second time.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm lint:check` passes.
- [x] `pnpm test:run` passes, and tests have been added/updated where applicable.
- [x] `pnpm build` passes.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
