### PR TITLE
Keep the player popouts clear of the screen cutout

### DIFF
--- a/src/helpers/device.ts
+++ b/src/helpers/device.ts
@@ -17,6 +17,22 @@ export const DEVICE_TYPE: DeviceType = IS_TABLET_UA
     ? "phone"
     : "desktop";
 
+/**
+ * How far in from a side of the screen it is safe to draw, in pixels.
+ *
+ * The layout viewport spans the cutout and the rounded corners, so anything
+ * measured from `window.innerWidth` has to take this off to clear them.
+ */
+export function deviceInset(side: "left" | "right") {
+  return (
+    parseFloat(
+      getComputedStyle(document.documentElement).getPropertyValue(
+        `--device-inset-${side}`,
+      ),
+    ) || 0
+  );
+}
+
 export function isTouchscreenDevice() {
   // detect if device/browser is touch enabled
   let result = false;

--- a/src/helpers/device.ts
+++ b/src/helpers/device.ts
@@ -24,13 +24,15 @@ export const DEVICE_TYPE: DeviceType = IS_TABLET_UA
  * measured from `window.innerWidth` has to take this off to clear them.
  */
 export function deviceInset(side: "left" | "right") {
-  return (
-    parseFloat(
-      getComputedStyle(document.documentElement).getPropertyValue(
-        `--device-inset-${side}`,
-      ),
-    ) || 0
-  );
+  // read off a padding rather than the custom property itself: WebKit reports 0
+  // for a custom property holding env(), while a length it lays a box out with
+  // carries the inset the page is actually drawn against
+  const probe = document.createElement("div");
+  probe.style.cssText = `position:fixed;top:0;left:0;width:0;height:0;visibility:hidden;padding-left:var(--device-inset-${side})`;
+  document.body.appendChild(probe);
+  const inset = parseFloat(getComputedStyle(probe).paddingLeft) || 0;
+  probe.remove();
+  return inset;
 }
 
 export function isTouchscreenDevice() {

--- a/src/helpers/player_bar.ts
+++ b/src/helpers/player_bar.ts
@@ -17,8 +17,9 @@ const PLAYER_BAR_POPOUT_TOP_GAP = 24;
 export const PLAYER_BAR_POPOUT_COLLISION_PADDING = {
   top: PLAYER_BAR_POPOUT_TOP_GAP,
   // the boundary this is measured against spans the cutout, so the side gaps
-  // only stay clear of it by carrying the inset of the moment; reading them
-  // through a getter keeps this one object stable for floating-ui
+  // only stay clear of it by carrying the inset. Reading them through getters
+  // hands each popout the inset it opens under without handing floating-ui a
+  // new object to rebuild its middleware around
   get right() {
     return PLAYER_BAR_POPOUT_GAP + deviceInset("right");
   },

--- a/src/helpers/player_bar.ts
+++ b/src/helpers/player_bar.ts
@@ -1,3 +1,5 @@
+import { deviceInset } from "@/helpers/device";
+
 /**
  * Gap the popouts keep from the bar below them and from the sides of the
  * screen. Mirrors --player-bar-popout-gap.
@@ -14,9 +16,16 @@ const PLAYER_BAR_POPOUT_TOP_GAP = 24;
 /** Room the popouts leave around themselves as they grow with their contents. */
 export const PLAYER_BAR_POPOUT_COLLISION_PADDING = {
   top: PLAYER_BAR_POPOUT_TOP_GAP,
-  right: PLAYER_BAR_POPOUT_GAP,
+  // the boundary this is measured against spans the cutout, so the side gaps
+  // only stay clear of it by carrying the inset of the moment; reading them
+  // through a getter keeps this one object stable for floating-ui
+  get right() {
+    return PLAYER_BAR_POPOUT_GAP + deviceInset("right");
+  },
   bottom: PLAYER_BAR_POPOUT_GAP,
-  left: PLAYER_BAR_POPOUT_GAP,
+  get left() {
+    return PLAYER_BAR_POPOUT_GAP + deviceInset("left");
+  },
 };
 
 export const playerBarEndAnchor = {
@@ -28,8 +37,10 @@ export const playerBarEndAnchor = {
       document.getElementById("player-bar") ??
       document.getElementById("player-select-button")
     )?.getBoundingClientRect();
+    // the window reaches past the cutout, so the gap is kept from the last
+    // column of pixels that is actually safe to draw in
     return new DOMRect(
-      window.innerWidth - PLAYER_BAR_POPOUT_GAP,
+      window.innerWidth - PLAYER_BAR_POPOUT_GAP - deviceInset("right"),
       anchorRect?.top ?? window.innerHeight,
       0,
       anchorRect?.height ?? 0,

--- a/src/layouts/default/PlayerOSD/PlayerBarGroupControl.vue
+++ b/src/layouts/default/PlayerOSD/PlayerBarGroupControl.vue
@@ -73,8 +73,8 @@
         :class="[
           'player-bar-popout player-group-popover flex flex-col gap-0 overflow-hidden p-0',
           store.mobileLayout
-            ? 'w-[calc(100vw-2*var(--player-bar-popout-gap))]'
-            : 'w-[400px] max-w-[calc(100vw-2*var(--player-bar-popout-gap))]',
+            ? 'w-[calc(100vw-2*var(--player-bar-popout-gap)-var(--device-inset-left)-var(--device-inset-right))]'
+            : 'w-[400px] max-w-[calc(100vw-2*var(--player-bar-popout-gap)-var(--device-inset-left)-var(--device-inset-right))]',
         ]"
         @open-auto-focus="preventAutoFocus"
         @interact-outside="handleInteractOutside"

--- a/src/layouts/default/PlayerOSD/PlayerBarVolumeControl.vue
+++ b/src/layouts/default/PlayerOSD/PlayerBarVolumeControl.vue
@@ -53,7 +53,7 @@
       align="end"
       :side-offset="PLAYER_BAR_POPOUT_GAP"
       :collision-padding="PLAYER_BAR_POPOUT_COLLISION_PADDING"
-      class="player-bar-popout player-volume-popover flex w-[340px] max-w-[calc(100vw-2*var(--player-bar-popout-gap))] flex-col overflow-hidden p-0"
+      class="player-bar-popout player-volume-popover flex w-[340px] max-w-[calc(100vw-2*var(--player-bar-popout-gap)-var(--device-inset-left)-var(--device-inset-right))] flex-col overflow-hidden p-0"
       @open-auto-focus="preventAutoFocus"
       @interact-outside="handleInteractOutside"
     >

--- a/src/layouts/default/PlayerOSD/PlayerVolume.vue
+++ b/src/layouts/default/PlayerOSD/PlayerVolume.vue
@@ -288,8 +288,9 @@ const updatePopoutPosition = () => {
   const bottom = `${window.innerHeight - rect.bottom}px`;
   // It grows upwards from there, so a large group is capped at the room above
   const maxHeight = `${rect.bottom - POPOUT_MARGIN}px`;
-  // The popout is fixed, so it escapes the padding its container keeps clear of
-  // the cutout and has to hold the margin off the safe edges itself
+  // The popout is teleported out to the body, so the padding its container
+  // keeps clear of the cutout never reaches it and it holds the margin off the
+  // safe edges itself
   const insetLeft = deviceInset("left");
   const insetRight = deviceInset("right");
 

--- a/src/layouts/default/PlayerOSD/PlayerVolume.vue
+++ b/src/layouts/default/PlayerOSD/PlayerVolume.vue
@@ -120,6 +120,7 @@
 
 <script setup lang="ts">
 import { Slider } from "@/components/ui/slider";
+import { deviceInset } from "@/helpers/device";
 import { getVolumeIconComponent, truncateString } from "@/helpers/utils";
 import { cn } from "@/lib/utils";
 import { api } from "@/plugins/api";
@@ -287,6 +288,10 @@ const updatePopoutPosition = () => {
   const bottom = `${window.innerHeight - rect.bottom}px`;
   // It grows upwards from there, so a large group is capped at the room above
   const maxHeight = `${rect.bottom - POPOUT_MARGIN}px`;
+  // The popout is fixed, so it escapes the padding its container keeps clear of
+  // the cutout and has to hold the margin off the safe edges itself
+  const insetLeft = deviceInset("left");
+  const insetRight = deviceInset("right");
 
   if (store.mobileLayout) {
     // Full width with padding on mobile
@@ -294,20 +299,20 @@ const updatePopoutPosition = () => {
       position: "fixed",
       bottom,
       maxHeight,
-      left: `${POPOUT_MARGIN}px`,
-      right: `${POPOUT_MARGIN}px`,
+      left: `${POPOUT_MARGIN + insetLeft}px`,
+      right: `${POPOUT_MARGIN + insetRight}px`,
     };
   } else {
     // Desktop: use wrapper width but at least POPOUT_MIN_WIDTH, centered
-    // on the wrapper, clamped to viewport edges
+    // on the wrapper, clamped to the safe edges
     const popoutWidth = Math.max(rect.width, POPOUT_MIN_WIDTH);
     const wrapperCenter = rect.left + rect.width / 2;
     let left = wrapperCenter - popoutWidth / 2;
 
-    // Clamp to viewport edges
-    if (left < POPOUT_MARGIN) left = POPOUT_MARGIN;
-    if (left + popoutWidth > window.innerWidth - POPOUT_MARGIN) {
-      left = window.innerWidth - POPOUT_MARGIN - popoutWidth;
+    // Clamp to the safe edges
+    if (left < POPOUT_MARGIN + insetLeft) left = POPOUT_MARGIN + insetLeft;
+    if (left + popoutWidth > window.innerWidth - POPOUT_MARGIN - insetRight) {
+      left = window.innerWidth - POPOUT_MARGIN - insetRight - popoutWidth;
     }
 
     popoutStyle.value = {

--- a/src/layouts/default/PlayerSelect.vue
+++ b/src/layouts/default/PlayerSelect.vue
@@ -42,8 +42,8 @@
         'player-bar-popout player-select-popover flex flex-col gap-0 overflow-hidden p-0',
         popoutFromFullscreen && 'player-select-popover-fullscreen',
         store.mobileLayout
-          ? 'w-[calc(100vw-2*var(--player-bar-popout-gap))]'
-          : 'w-[400px] max-w-[calc(100vw-2*var(--player-bar-popout-gap))]',
+          ? 'w-[calc(100vw-2*var(--player-bar-popout-gap)-var(--device-inset-left)-var(--device-inset-right))]'
+          : 'w-[400px] max-w-[calc(100vw-2*var(--player-bar-popout-gap)-var(--device-inset-left)-var(--device-inset-right))]',
       ]"
       @keydown="handleSheetKeydown"
       @close-auto-focus="preventAutoFocus"

--- a/tests/helpers/device.test.ts
+++ b/tests/helpers/device.test.ts
@@ -1,0 +1,42 @@
+import { deviceInset } from "@/helpers/device";
+import { afterEach, describe, expect, it } from "vitest";
+
+// Each side carries its own value, so reaching for the wrong one reads as the
+// wrong number instead of quietly passing.
+const INSET_LEFT = "77px";
+const INSET_RIGHT = "44px";
+
+describe("deviceInset", () => {
+  afterEach(() => {
+    document.documentElement.removeAttribute("style");
+    document.body.innerHTML = "";
+  });
+
+  it("reports the room each side of the screen reserves", () => {
+    document.documentElement.style.setProperty(
+      "--device-inset-left",
+      INSET_LEFT,
+    );
+    document.documentElement.style.setProperty(
+      "--device-inset-right",
+      INSET_RIGHT,
+    );
+
+    expect(deviceInset("left")).toBe(parseFloat(INSET_LEFT));
+    expect(deviceInset("right")).toBe(parseFloat(INSET_RIGHT));
+  });
+
+  it("reports no room where the screen reserves none", () => {
+    expect(deviceInset("left")).toBe(0);
+    expect(deviceInset("right")).toBe(0);
+  });
+
+  // It is read once per popout that opens, so anything it leaves behind piles
+  // up for as long as the app is on screen.
+  it("leaves nothing behind to measure against", () => {
+    deviceInset("left");
+    deviceInset("right");
+
+    expect(document.body.children).toHaveLength(0);
+  });
+});

--- a/tests/helpers/player_bar.test.ts
+++ b/tests/helpers/player_bar.test.ts
@@ -135,9 +135,9 @@ describe("PLAYER_BAR_POPOUT_COLLISION_PADDING", () => {
     );
   });
 
-  // The insets are read every time the padding is, so a rotation cannot leave
-  // the popouts holding the gaps of the orientation they opened in.
-  it("reads the insets of the moment", () => {
+  // The padding is read afresh for every popout that opens, so a rotation
+  // cannot leave the next one holding the gaps of the orientation before it.
+  it("reads the insets each time it is asked", () => {
     expect(PLAYER_BAR_POPOUT_COLLISION_PADDING.right).toBe(
       PLAYER_BAR_POPOUT_GAP,
     );

--- a/tests/helpers/player_bar.test.ts
+++ b/tests/helpers/player_bar.test.ts
@@ -1,4 +1,5 @@
 import {
+  PLAYER_BAR_POPOUT_COLLISION_PADDING,
   PLAYER_BAR_POPOUT_GAP,
   fullscreenPlayerSelectAnchor,
   playerBarEndAnchor,
@@ -8,6 +9,22 @@ import { afterEach, describe, expect, it } from "vitest";
 const BUTTON_ID = "fullscreen-player-select-button";
 const PLAYER_BAR_ID = "player-bar";
 const PLAYER_SELECT_BUTTON_ID = "player-select-button";
+
+// Each side carries its own value, so a popout reaching for the wrong one reads
+// as the wrong number instead of quietly passing.
+const INSET_RIGHT = 44;
+const INSET_LEFT = 77;
+
+function setDeviceInsets() {
+  document.documentElement.style.setProperty(
+    "--device-inset-right",
+    `${INSET_RIGHT}px`,
+  );
+  document.documentElement.style.setProperty(
+    "--device-inset-left",
+    `${INSET_LEFT}px`,
+  );
+}
 
 function addTrigger(rect: Partial<DOMRect>) {
   const trigger = document.createElement("button");
@@ -54,6 +71,7 @@ describe("playerBarEndAnchor", () => {
   afterEach(() => {
     document.getElementById(PLAYER_BAR_ID)?.remove();
     document.getElementById(PLAYER_SELECT_BUTTON_ID)?.remove();
+    document.documentElement.removeAttribute("style");
   });
 
   it("hangs the popouts above the player bar rather than above its buttons", () => {
@@ -85,6 +103,49 @@ describe("playerBarEndAnchor", () => {
   it("keeps the popout gap from the end of the screen", () => {
     expect(playerBarEndAnchor.getBoundingClientRect().x).toBe(
       window.innerWidth - PLAYER_BAR_POPOUT_GAP,
+    );
+  });
+
+  // The window reaches past the cutout, so hanging the popouts off it would
+  // leave them tucked underneath one.
+  it("keeps that gap from the last safe column rather than the screen edge", () => {
+    setDeviceInsets();
+
+    expect(playerBarEndAnchor.getBoundingClientRect().x).toBe(
+      window.innerWidth - PLAYER_BAR_POPOUT_GAP - INSET_RIGHT,
+    );
+  });
+});
+
+describe("PLAYER_BAR_POPOUT_COLLISION_PADDING", () => {
+  afterEach(() => {
+    document.documentElement.removeAttribute("style");
+  });
+
+  // The boundary a popout is held inside spans the cutout, so the side gaps
+  // have to carry the inset to stop short of one.
+  it("grows the side gaps by the room the cutout takes", () => {
+    setDeviceInsets();
+
+    expect(PLAYER_BAR_POPOUT_COLLISION_PADDING.left).toBe(
+      PLAYER_BAR_POPOUT_GAP + INSET_LEFT,
+    );
+    expect(PLAYER_BAR_POPOUT_COLLISION_PADDING.right).toBe(
+      PLAYER_BAR_POPOUT_GAP + INSET_RIGHT,
+    );
+  });
+
+  // The insets are read every time the padding is, so a rotation cannot leave
+  // the popouts holding the gaps of the orientation they opened in.
+  it("reads the insets of the moment", () => {
+    expect(PLAYER_BAR_POPOUT_COLLISION_PADDING.right).toBe(
+      PLAYER_BAR_POPOUT_GAP,
+    );
+
+    setDeviceInsets();
+
+    expect(PLAYER_BAR_POPOUT_COLLISION_PADDING.right).toBe(
+      PLAYER_BAR_POPOUT_GAP + INSET_RIGHT,
     );
   });
 });

--- a/tests/layouts/PlayerVolume.test.ts
+++ b/tests/layouts/PlayerVolume.test.ts
@@ -475,9 +475,10 @@ describe("PlayerVolume group popout", () => {
     expect(popout.style.width).toBe("");
   });
 
-  // The popout is fixed, so the padding the fullscreen player keeps clear of the
-  // cutout never reaches it and it has to hold the margin off the safe edges
-  // itself. Each side carries its own inset, so a mix-up cannot pass.
+  // The popout is teleported out to the body, so the padding the fullscreen
+  // player keeps clear of the cutout never reaches it and it has to hold the
+  // margin off the safe edges itself. Each side carries its own inset, so a
+  // mix-up cannot pass.
   describe("with a cutout on both sides", () => {
     const INSET_LEFT = 77;
     const INSET_RIGHT = 44;

--- a/tests/layouts/PlayerVolume.test.ts
+++ b/tests/layouts/PlayerVolume.test.ts
@@ -475,6 +475,88 @@ describe("PlayerVolume group popout", () => {
     expect(popout.style.width).toBe("");
   });
 
+  // The popout is fixed, so the padding the fullscreen player keeps clear of the
+  // cutout never reaches it and it has to hold the margin off the safe edges
+  // itself. Each side carries its own inset, so a mix-up cannot pass.
+  describe("with a cutout on both sides", () => {
+    const INSET_LEFT = 77;
+    const INSET_RIGHT = 44;
+    const VIEWPORT_WIDTH = 1000;
+    const POPOUT_WIDTH = 300;
+    const MARGIN = 8;
+
+    const originalInnerWidth = Object.getOwnPropertyDescriptor(
+      window,
+      "innerWidth",
+    );
+
+    function placeSlider(left: number, width: number) {
+      vi.spyOn(Element.prototype, "getBoundingClientRect").mockReturnValue({
+        top: SLIDER_BOTTOM - 40,
+        bottom: SLIDER_BOTTOM,
+        left,
+        right: left + width,
+        width,
+        height: 40,
+      } as DOMRect);
+    }
+
+    beforeEach(() => {
+      Object.defineProperty(window, "innerWidth", {
+        value: VIEWPORT_WIDTH,
+        writable: true,
+        configurable: true,
+      });
+      document.documentElement.style.setProperty(
+        "--device-inset-left",
+        `${INSET_LEFT}px`,
+      );
+      document.documentElement.style.setProperty(
+        "--device-inset-right",
+        `${INSET_RIGHT}px`,
+      );
+    });
+
+    afterEach(() => {
+      document.documentElement.removeAttribute("style");
+      if (originalInnerWidth) {
+        Object.defineProperty(window, "innerWidth", originalInnerWidth);
+      }
+    });
+
+    it("stops the popout short of the cutout at the end of the screen", async () => {
+      // far enough over that centring it on the slider would run past the end
+      placeSlider(850, 140);
+      const { wrapper } = mountLargeGroup();
+
+      const popout = await openPopout(wrapper);
+
+      expect(popout.style.left).toBe(
+        `${VIEWPORT_WIDTH - MARGIN - INSET_RIGHT - POPOUT_WIDTH}px`,
+      );
+    });
+
+    it("stops it short of the one at the start of the screen", async () => {
+      placeSlider(20, 140);
+      const { wrapper } = mountLargeGroup();
+
+      const popout = await openPopout(wrapper);
+
+      expect(popout.style.left).toBe(`${MARGIN + INSET_LEFT}px`);
+    });
+
+    it("holds the margin off both safe edges on mobile", async () => {
+      store.mobileLayout = true;
+      placeSlider(100, 200);
+      const { wrapper } = mountLargeGroup();
+
+      const popout = await openPopout(wrapper);
+
+      expect(popout.style.left).toBe(`${MARGIN + INSET_LEFT}px`);
+      expect(popout.style.right).toBe(`${MARGIN + INSET_RIGHT}px`);
+    });
+  });
+
   it("opens at the group slider so it still overlaps the tapped one", async () => {
     vi.spyOn(HTMLElement.prototype, "scrollHeight", "get").mockReturnValue(900);
     const { wrapper } = mountLargeGroup();

--- a/tests/styles/playerBarPopout.test.ts
+++ b/tests/styles/playerBarPopout.test.ts
@@ -2,6 +2,9 @@
 // observable under happy-dom, which in turn ignores @layer: the comparison
 // holds because both rules are unlayered in the compiled stylesheet
 // @vitest-environment happy-dom
+import groupControlSource from "@/layouts/default/PlayerOSD/PlayerBarGroupControl.vue?raw";
+import volumeControlSource from "@/layouts/default/PlayerOSD/PlayerBarVolumeControl.vue?raw";
+import playerSelectSource from "@/layouts/default/PlayerSelect.vue?raw";
 import {
   PLAYER_BAR_POPOUT_COLLISION_PADDING,
   PLAYER_BAR_POPOUT_GAP,
@@ -92,5 +95,71 @@ describe("player bar popout inset", () => {
     expect(customProperty("--player-bar-popout-top-gap")).toBe(
       `${PLAYER_BAR_POPOUT_COLLISION_PADDING.top}px`,
     );
+  });
+});
+
+// Every term carries its own value, so one going missing or landing on the
+// wrong side reads as the wrong number instead of quietly passing.
+const GAP = "5px";
+const INSET_LEFT = "77px";
+const INSET_RIGHT = "44px";
+
+// Tailwind writes its arbitrary values without spaces around the operators and
+// resolves them at build time, which vitest does not run, so the widths are
+// lifted out of the templates and resolved here instead.
+function popoutWidths(source: string) {
+  return [
+    ...source.matchAll(
+      /(?:max-)?w-\[(calc\([^\]]*--player-bar-popout-gap[^\]]*)\]/g,
+    ),
+  ].map((match) => match[1]);
+}
+
+function resolveWidth(value: string) {
+  const styles = document.createElement("style");
+  styles.textContent = `.popout-width { width: ${value}; }`;
+  document.head.appendChild(styles);
+  const element = document.createElement("div");
+  element.className = "popout-width";
+  document.body.appendChild(element);
+  const width = getComputedStyle(element).width;
+  styles.remove();
+  element.remove();
+  return width.replace(/\s+/g, "");
+}
+
+describe.each([
+  ["player select", playerSelectSource],
+  ["group control", groupControlSource],
+  ["volume control", volumeControlSource],
+])("%s popout width", (_name, source) => {
+  beforeEach(() => {
+    document.documentElement.style.setProperty("--player-bar-popout-gap", GAP);
+    document.documentElement.style.setProperty(
+      "--device-inset-left",
+      INSET_LEFT,
+    );
+    document.documentElement.style.setProperty(
+      "--device-inset-right",
+      INSET_RIGHT,
+    );
+  });
+
+  afterEach(() => {
+    document.documentElement.removeAttribute("style");
+    document.body.innerHTML = "";
+  });
+
+  // The popouts hang off the safe end of the bar, so a width measured from the
+  // whole screen would push their far edge back under the opposite cutout.
+  it("spans the screen less both cutouts", () => {
+    const widths = popoutWidths(source);
+
+    expect(widths.length).toBeGreaterThan(0);
+    for (const width of widths) {
+      expect(resolveWidth(width)).toBe(
+        `calc(${window.innerWidth}px-2*${GAP}-${INSET_LEFT}-${INSET_RIGHT})`,
+      );
+    }
   });
 });

--- a/tests/styles/playerBarPopout.test.ts
+++ b/tests/styles/playerBarPopout.test.ts
@@ -104,27 +104,24 @@ const GAP = "5px";
 const INSET_LEFT = "77px";
 const INSET_RIGHT = "44px";
 
-// Tailwind writes its arbitrary values without spaces around the operators and
-// resolves them at build time, which vitest does not run, so the widths are
-// lifted out of the templates and resolved here instead.
-function popoutWidths(source: string) {
+// the widths are Tailwind utilities, so the templates name them and the
+// compiled sheet is what they mean; taking the class from one and reading it
+// against the other covers both a term going missing and the utility itself
+// stopping being emitted
+function popoutWidthClasses(source: string) {
   return [
     ...source.matchAll(
-      /(?:max-)?w-\[(calc\([^\]]*--player-bar-popout-gap[^\]]*)\]/g,
+      /(?:max-)?w-\[calc\([^\]]*--player-bar-popout-gap[^\]]*\]/g,
     ),
-  ].map((match) => match[1]);
+  ].map((match) => match[0]);
 }
 
-function resolveWidth(value: string) {
-  const styles = document.createElement("style");
-  styles.textContent = `.popout-width { width: ${value}; }`;
-  document.head.appendChild(styles);
+function resolveWidth(className: string) {
   const element = document.createElement("div");
-  element.className = "popout-width";
+  element.className = className;
   document.body.appendChild(element);
-  const width = getComputedStyle(element).width;
-  styles.remove();
-  element.remove();
+  const styles = getComputedStyle(element);
+  const width = className.startsWith("max-") ? styles.maxWidth : styles.width;
   return width.replace(/\s+/g, "");
 }
 
@@ -133,7 +130,12 @@ describe.each([
   ["group control", groupControlSource],
   ["volume control", volumeControlSource],
 ])("%s popout width", (_name, source) => {
+  let widthStyles: HTMLStyleElement;
+
   beforeEach(() => {
+    widthStyles = document.createElement("style");
+    widthStyles.textContent = css;
+    document.head.appendChild(widthStyles);
     document.documentElement.style.setProperty("--player-bar-popout-gap", GAP);
     document.documentElement.style.setProperty(
       "--device-inset-left",
@@ -146,6 +148,7 @@ describe.each([
   });
 
   afterEach(() => {
+    widthStyles.remove();
     document.documentElement.removeAttribute("style");
     document.body.innerHTML = "";
   });
@@ -153,11 +156,11 @@ describe.each([
   // The popouts hang off the safe end of the bar, so a width measured from the
   // whole screen would push their far edge back under the opposite cutout.
   it("spans the screen less both cutouts", () => {
-    const widths = popoutWidths(source);
+    const classNames = popoutWidthClasses(source);
 
-    expect(widths.length).toBeGreaterThan(0);
-    for (const width of widths) {
-      expect(resolveWidth(width)).toBe(
+    expect(classNames.length).toBeGreaterThan(0);
+    for (const className of classNames) {
+      expect(resolveWidth(className)).toBe(
         `calc(${window.innerWidth}px-2*${GAP}-${INSET_LEFT}-${INSET_RIGHT})`,
       );
     }


### PR DESCRIPTION
# What does this implement/fix?

The player bar popouts (players, volume, group members) and the group volume popout work out where to sit from JavaScript, measuring from the window. Since the app started drawing edge to edge, the window reaches past the camera cutout and the rounded corners, so those popouts ended up tucked partly underneath one on a phone held sideways. The playback speed dialog next to them was already fixed in #2459, which only covered the ones positioned from CSS.

**Related issue (if applicable):**

- follow-up to #2459

**Related backend PR (if applicable):**

- n/a

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

### Changes

- Hang the player bar popouts off the last safe column of the screen rather than the window edge, and hold their collision gaps off it too
- Size those popouts to the screen less both cutouts, so the far edge cannot land back underneath one
- Clamp the group volume popout in the fullscreen player to the safe edges as well
- Add a shared `deviceInset()` reader so the JavaScript and the stylesheets agree on where the safe edges are

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm lint:check` passes.
- [x] `pnpm test:run` passes, and tests have been added/updated where applicable.
- [x] `pnpm build` passes.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
