### PR TITLE
Keep the party dashboard filling the screen

### DIFF
--- a/src/layouts/default/Default.vue
+++ b/src/layouts/default/Default.vue
@@ -1,10 +1,9 @@
 <template>
   <v-app>
-    <MainView v-if="store.frameless" />
-    <template v-else>
-      <MainView />
-      <Footer />
-    </template>
+    <!-- a single view across both modes, so toggling fullscreen swaps the
+         chrome without tearing down the view behind it -->
+    <MainView />
+    <Footer v-if="!store.frameless" />
   </v-app>
   <reload-prompt />
 </template>

--- a/src/layouts/default/View.vue
+++ b/src/layouts/default/View.vue
@@ -11,6 +11,7 @@
             'content-section',
             { 'content-section--mobile': store.mobileLayout },
             { 'content-section--frameless': store.frameless },
+            { 'party-view-active': route.meta.partyView === true },
           ]"
         >
           <router-view v-slot="{ Component }">
@@ -58,6 +59,7 @@ import {
 import { eventbus } from "@/plugins/eventbus";
 import { store } from "@/plugins/store";
 import { onBeforeUnmount, onMounted, ref } from "vue";
+import { useRoute } from "vue-router";
 import AddToPlaylistDialog from "./AddToPlaylistDialog.vue";
 import AudioOverlayDialog from "./AudioOverlayDialog.vue";
 import CreatePlaylistDialog from "./CreatePlaylistDialog.vue";
@@ -66,6 +68,8 @@ import ImportPlaylistDialog from "./ImportPlaylistDialog.vue";
 import ItemContextMenu from "./ItemContextMenu.vue";
 import PlayAnnouncementDialog from "./PlayAnnouncementDialog.vue";
 import PlayerSelect from "./PlayerSelect.vue";
+
+const route = useRoute();
 
 const showEditItemDialog = ref(false);
 const editItem = ref<Radio | Track | Playlist | undefined>(undefined);

--- a/src/plugins/router.ts
+++ b/src/plugins/router.ts
@@ -57,6 +57,9 @@ export const routes: RouteRecordRaw[] = [
       {
         path: "",
         name: "party",
+        // the dashboard fills its container and scrolls internally, so the
+        // layout drops the content section's padding and outer scrolling
+        meta: { partyView: true },
         component: () =>
           import(
             /* webpackChunkName: "party" */ "@/views/PartyDashboardView.vue"

--- a/src/views/PartyDashboardView.vue
+++ b/src/views/PartyDashboardView.vue
@@ -767,25 +767,6 @@ const handleVisibilityChange = () => {
 };
 
 // Lifecycle and event subscriptions
-// Apply layout overrides to the parent .content-section so the party view
-// fills its container. Scoped to mount/unmount to avoid leaking global styles.
-const parentSection = ref<HTMLElement | null>(null);
-
-const applyParentStyles = () => {
-  const el = document.querySelector(".content-section");
-  if (el instanceof HTMLElement) {
-    parentSection.value = el;
-    el.classList.add("party-view-active");
-  }
-};
-
-const cleanupParentStyles = () => {
-  if (parentSection.value) {
-    parentSection.value.classList.remove("party-view-active");
-    parentSection.value = null;
-  }
-};
-
 const BURN_IN_SWAP_MS = 10 * 60 * 1000; // 10 minutes
 
 watch(antiBurnIn, (enabled) => {
@@ -804,9 +785,6 @@ watch(antiBurnIn, (enabled) => {
 });
 
 onMounted(async () => {
-  // Apply parent container overrides
-  applyParentStyles();
-
   // Request wake lock to keep screen on
   await requestWakeLock();
   document.addEventListener("visibilitychange", handleVisibilityChange);
@@ -889,7 +867,6 @@ onBeforeUnmount(() => {
     clearInterval(burnInInterval);
     burnInInterval = null;
   }
-  cleanupParentStyles();
   document.removeEventListener("visibilitychange", handleVisibilityChange);
 });
 
@@ -1373,7 +1350,7 @@ watch(
 </style>
 
 <style>
-/* Classes toggled programmatically on .content-section by mount/unmount */
+/* .party-view-active is set by the Default layout for the party route */
 .content-section.party-view-active {
   overflow: hidden !important;
   display: flex;

--- a/src/views/PartyDashboardView.vue
+++ b/src/views/PartyDashboardView.vue
@@ -1350,7 +1350,7 @@ watch(
 </style>
 
 <style>
-/* .party-view-active is set by the Default layout for the party route */
+/* .party-view-active is set by layouts/default/View.vue for the party route */
 .content-section.party-view-active {
   overflow: hidden !important;
   display: flex;

--- a/tests/layouts/Default.test.ts
+++ b/tests/layouts/Default.test.ts
@@ -1,0 +1,78 @@
+import Default from "@/layouts/default/Default.vue";
+import View from "@/layouts/default/View.vue";
+import Footer from "@/layouts/default/Footer.vue";
+import { store } from "@/plugins/store";
+import { type VueWrapper, mount } from "@vue/test-utils";
+import { nextTick } from "vue";
+import { createMemoryHistory, createRouter } from "vue-router";
+import { createVuetify } from "vuetify";
+import * as components from "vuetify/components";
+import * as directives from "vuetify/directives";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/plugins/store", async () => {
+  const { reactive } = await vi.importActual<typeof import("vue")>("vue");
+  return {
+    store: reactive({
+      frameless: false,
+      activePlayerId: undefined,
+      showFullscreenPlayer: false,
+    }),
+  };
+});
+
+const vuetify = createVuetify({ components, directives });
+
+const router = createRouter({
+  history: createMemoryHistory(),
+  routes: [{ path: "/", component: { template: "<div />" } }],
+});
+
+let wrapper: VueWrapper | undefined;
+
+async function mountLayout() {
+  await router.push("/");
+  await router.isReady();
+  wrapper = mount(Default, {
+    shallow: true,
+    global: {
+      plugins: [vuetify, router],
+      // v-app hosts the whole tree, so it has to render its slot
+      stubs: { VApp: { template: "<div><slot /></div>" } },
+    },
+  });
+  return wrapper;
+}
+
+describe("Default layout", () => {
+  beforeEach(() => {
+    store.frameless = false;
+  });
+
+  afterEach(() => {
+    wrapper?.unmount();
+    wrapper = undefined;
+  });
+
+  it("drops the player chrome in frameless mode", async () => {
+    const layout = await mountLayout();
+    expect(layout.findComponent(Footer).exists()).toBe(true);
+
+    store.frameless = true;
+    await nextTick();
+
+    expect(layout.findComponent(Footer).exists()).toBe(false);
+  });
+
+  it("keeps the view mounted across a frameless toggle", async () => {
+    const layout = await mountLayout();
+    // the party dashboard lives in here and holds a wake lock, a burn-in timer
+    // and fetched config, so going fullscreen must not restart it
+    const view = layout.findComponent(View).element;
+
+    store.frameless = true;
+    await nextTick();
+
+    expect(layout.findComponent(View).element).toBe(view);
+  });
+});

--- a/tests/layouts/View.test.ts
+++ b/tests/layouts/View.test.ts
@@ -1,0 +1,100 @@
+import View from "@/layouts/default/View.vue";
+import { routes } from "@/plugins/router";
+import { store } from "@/plugins/store";
+import { type VueWrapper, mount } from "@vue/test-utils";
+import { nextTick } from "vue";
+import { createMemoryHistory, createRouter, type Router } from "vue-router";
+import { createVuetify } from "vuetify";
+import * as components from "vuetify/components";
+import * as directives from "vuetify/directives";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/plugins/store", async () => {
+  const { reactive } = await vi.importActual<typeof import("vue")>("vue");
+  return { store: reactive({ mobileLayout: false, frameless: false }) };
+});
+
+vi.mock("@/plugins/eventbus", () => ({
+  eventbus: { on: vi.fn(), off: vi.fn(), emit: vi.fn() },
+}));
+
+const vuetify = createVuetify({ components, directives });
+
+// the content section is nested in wrappers that carry no state of their own,
+// so they stand in as plain hosts while every other child is shallow-stubbed
+const host = { template: "<div><slot /></div>" };
+const blank = { template: "<div />" };
+
+// the app's own party route is guarded on a live server connection, so the
+// layout is exercised against the route shape it has to read: meta on a child
+// of the record the layout itself is mounted by
+const testRoutes = [
+  { path: "/", component: blank },
+  {
+    path: "/party",
+    component: blank,
+    children: [{ path: "", component: blank, meta: { partyView: true } }],
+  },
+];
+
+let router: Router;
+let wrapper: VueWrapper | undefined;
+
+async function mountAt(path: string) {
+  router = createRouter({ history: createMemoryHistory(), routes: testRoutes });
+  await router.push(path);
+  await router.isReady();
+  wrapper = mount(View, {
+    shallow: true,
+    global: {
+      plugins: [vuetify, router],
+      stubs: { VMain: host, SidebarProvider: host, SidebarInset: host },
+    },
+  });
+  return wrapper.get(".content-section");
+}
+
+describe("View", () => {
+  beforeEach(() => {
+    store.mobileLayout = false;
+    store.frameless = false;
+  });
+
+  afterEach(() => {
+    // the store is shared, so an instance left mounted would react to the
+    // next test's state
+    wrapper?.unmount();
+    wrapper = undefined;
+  });
+
+  it("marks the content section for a view that fills it", async () => {
+    expect((await mountAt("/party")).classes()).toContain("party-view-active");
+  });
+
+  it("leaves the content section unmarked for a regular view", async () => {
+    expect((await mountAt("/")).classes()).not.toContain("party-view-active");
+  });
+
+  it.each([
+    ["mobileLayout", "content-section--mobile"],
+    ["frameless", "content-section--frameless"],
+  ] as const)("keeps the mark when %s changes under it", async (flag, mod) => {
+    const section = await mountAt("/party");
+
+    // vue patches this class by assigning className, so the mark only survives
+    // a change to its siblings by being part of the same binding
+    store[flag] = true;
+    await nextTick();
+
+    expect(section.classes()).toContain(mod);
+    expect(section.classes()).toContain("party-view-active");
+  });
+
+  it("is the flag the party route hands the layout", () => {
+    const party = routes
+      .find((route) => route.path === "/party")
+      ?.children?.find((child) => child.name === "party");
+
+    expect(party?.meta?.partyView).toBe(true);
+  });
+});

--- a/tests/layouts/View.test.ts
+++ b/tests/layouts/View.test.ts
@@ -2,7 +2,7 @@ import View from "@/layouts/default/View.vue";
 import { store } from "@/plugins/store";
 import { type VueWrapper, mount } from "@vue/test-utils";
 import { nextTick } from "vue";
-import { createMemoryHistory, createRouter, type Router } from "vue-router";
+import { createMemoryHistory, createRouter } from "vue-router";
 import { createVuetify } from "vuetify";
 import * as components from "vuetify/components";
 import * as directives from "vuetify/directives";
@@ -36,11 +36,13 @@ const testRoutes = [
   },
 ];
 
-let router: Router;
 let wrapper: VueWrapper | undefined;
 
 async function mountAt(path: string) {
-  router = createRouter({ history: createMemoryHistory(), routes: testRoutes });
+  const router = createRouter({
+    history: createMemoryHistory(),
+    routes: testRoutes,
+  });
   await router.push(path);
   await router.isReady();
   wrapper = mount(View, {
@@ -50,7 +52,7 @@ async function mountAt(path: string) {
       stubs: { VMain: host, SidebarProvider: host, SidebarInset: host },
     },
   });
-  return wrapper.get(".content-section");
+  return { section: wrapper.get(".content-section"), router };
 }
 
 describe("View", () => {
@@ -67,18 +69,36 @@ describe("View", () => {
   });
 
   it("marks the content section for a view that fills it", async () => {
-    expect((await mountAt("/party")).classes()).toContain("party-view-active");
+    const { section } = await mountAt("/party");
+
+    expect(section.classes()).toContain("party-view-active");
   });
 
   it("leaves the content section unmarked for a regular view", async () => {
-    expect((await mountAt("/")).classes()).not.toContain("party-view-active");
+    const { section } = await mountAt("/");
+
+    expect(section.classes()).not.toContain("party-view-active");
+  });
+
+  it("follows the route without being remounted", async () => {
+    // navigating between the app's routes patches this instance in place, so
+    // the mark has to track the route rather than settle at first render
+    const { section, router } = await mountAt("/");
+
+    await router.push("/party");
+    await nextTick();
+    expect(section.classes()).toContain("party-view-active");
+
+    await router.push("/");
+    await nextTick();
+    expect(section.classes()).not.toContain("party-view-active");
   });
 
   it.each([
     ["mobileLayout", "content-section--mobile"],
     ["frameless", "content-section--frameless"],
   ] as const)("keeps the mark when %s changes under it", async (flag, mod) => {
-    const section = await mountAt("/party");
+    const { section } = await mountAt("/party");
 
     // vue patches this class by assigning className, so the mark only survives
     // a change to its siblings by being part of the same binding

--- a/tests/layouts/View.test.ts
+++ b/tests/layouts/View.test.ts
@@ -1,5 +1,4 @@
 import View from "@/layouts/default/View.vue";
-import { routes } from "@/plugins/router";
 import { store } from "@/plugins/store";
 import { type VueWrapper, mount } from "@vue/test-utils";
 import { nextTick } from "vue";
@@ -88,13 +87,5 @@ describe("View", () => {
 
     expect(section.classes()).toContain(mod);
     expect(section.classes()).toContain("party-view-active");
-  });
-
-  it("is the flag the party route hands the layout", () => {
-    const party = routes
-      .find((route) => route.path === "/party")
-      ?.children?.find((child) => child.name === "party");
-
-    expect(party?.meta?.partyView).toBe(true);
   });
 });

--- a/tests/plugins/router.test.ts
+++ b/tests/plugins/router.test.ts
@@ -153,6 +153,18 @@ describe("music quiz dashboard route", () => {
   });
 });
 
+describe("party dashboard route", () => {
+  // the layout reads this to hand the dashboard its container whole, so the
+  // flag has to reach it through the route the layout is mounted by
+  it("asks the layout for a container it can fill", () => {
+    const dashboardRoute = routes
+      .find((route) => route.path === "/party")
+      ?.children?.find((route) => route.name === "party");
+
+    expect(dashboardRoute?.meta?.partyView).toBe(true);
+  });
+});
+
 describe("party dashboard guard", () => {
   it("redirects to Discover when the party plugin is disabled", async () => {
     await expect(


### PR DESCRIPTION
# What does this implement/fix?

The party dashboard asks the page layout for the whole screen: no page padding, no outer scrolling. It did that by setting a class on the layout's container from script, but the layout owns that class and overwrote it on its next update. Crossing the mobile/desktop breakpoint or toggling fullscreen dropped the class again, and the dashboard fell back to a normal padded, scrolling page with the "Powered by" line floating in the middle of it.

The layout now sets that class itself, based on the route, so it can't be lost. Toggling fullscreen also no longer rebuilds the whole view underneath — which used to restart the dashboard, refetching its config, re-requesting the screen wake lock and resetting the anti burn-in timer.

- the layout marks the party route's container itself instead of the view reaching out to it
- fullscreen keeps a single view instance, so it swaps the chrome rather than restarting the dashboard
- tests covering the mark surviving a layout change, and the view surviving a fullscreen toggle

**Related issue (if applicable):**

n/a

**Related backend PR (if applicable):**

n/a

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm lint:check` passes.
- [x] `pnpm test:run` passes, and tests have been added/updated where applicable.
- [x] `pnpm build` passes.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
