### PR TITLE
Make the mobile volume slider easier to hit

### DIFF
--- a/src/layouts/default/PlayerOSD/Player.vue
+++ b/src/layouts/default/PlayerOSD/Player.vue
@@ -143,6 +143,7 @@
         :prefer-group-volume="true"
         :enable-popout="false"
         :request-expand-on-group-tap="true"
+        :expand-on-touch="true"
         @toggle-group-expansion="showMobileVolumeControls = true"
       />
     </div>

--- a/src/layouts/default/PlayerOSD/PlayerBarMobileVolumeSheet.vue
+++ b/src/layouts/default/PlayerOSD/PlayerBarMobileVolumeSheet.vue
@@ -66,12 +66,4 @@ function preventAutoFocus(event: Event) {
 :root .mobile-group-volume-overlay {
   bottom: var(--mobile-navigation-height) !important;
 }
-
-.mobile-group-volume-sheet [data-slot="slider-thumb"]::before {
-  transition: transform 120ms ease;
-}
-
-.mobile-group-volume-sheet [data-slot="slider-thumb"]:active::before {
-  transform: scale(1.8);
-}
 </style>

--- a/src/layouts/default/PlayerOSD/PlayerVolume.vue
+++ b/src/layouts/default/PlayerOSD/PlayerVolume.vue
@@ -104,6 +104,7 @@
         @touchstart.stop
         @touchmove.stop
         @touchend.stop
+        @touchcancel.stop
       >
         <button
           class="volume-icon-btn volume-slot-item"
@@ -145,6 +146,7 @@
         @touchstart.stop
         @touchmove.stop
         @touchend.stop
+        @touchcancel.stop
       >
         <span
           v-if="showVolumeLevel"

--- a/src/layouts/default/PlayerOSD/PlayerVolume.vue
+++ b/src/layouts/default/PlayerOSD/PlayerVolume.vue
@@ -95,11 +95,20 @@
       @touchend="onTouchEnd"
       @touchcancel="onTouchCancel"
     >
-      <!-- Mute button with dynamic volume icon -->
-      <div class="volume-prepend" @touchstart.stop @touchend.stop>
+      <!-- Mute button with dynamic volume icon. The slot swallows the whole
+           touch sequence, moves included: a touch that starts on a button is
+           never the slider being dragged, and letting the moves through would
+           measure them against whatever the last touch on the track started at. -->
+      <div
+        class="volume-prepend"
+        @touchstart.stop
+        @touchmove.stop
+        @touchend.stop
+      >
         <button
           class="volume-icon-btn volume-slot-item"
           :class="{ 'is-hidden': showStepButtons }"
+          :inert="showStepButtons"
           :disabled="muteDisabled"
           @click.stop="onMuteToggle"
         >
@@ -110,10 +119,9 @@
           type="button"
           class="volume-step-btn volume-slot-item"
           :class="{ 'is-hidden': !showStepButtons }"
+          :inert="!showStepButtons"
           :aria-label="$t('tooltip.volume_down')"
-          @click.stop
-          @mousedown.stop="onStepDown"
-          @touchstart.stop.prevent="onStepDown"
+          @click.stop="onStepDown"
         >
           <Minus :size="iconSize" />
         </button>
@@ -135,12 +143,14 @@
         v-if="showVolumeLevel || expandOnTouch"
         class="volume-append"
         @touchstart.stop
+        @touchmove.stop
         @touchend.stop
       >
         <span
           v-if="showVolumeLevel"
           class="volume-level-text volume-slot-item"
           :class="{ 'is-hidden': showStepButtons }"
+          :inert="showStepButtons"
         >
           {{ Math.round(displayValue) }}
         </span>
@@ -149,10 +159,9 @@
           type="button"
           class="volume-step-btn volume-slot-item"
           :class="{ 'is-hidden': !showStepButtons }"
+          :inert="!showStepButtons"
           :aria-label="$t('tooltip.volume_up')"
-          @click.stop
-          @mousedown.stop="onStepUp"
-          @touchstart.stop.prevent="onStepUp"
+          @click.stop="onStepUp"
         >
           <Plus :size="iconSize" />
         </button>
@@ -467,6 +476,7 @@ const displayValue = ref(currentVolume.value);
 const touchStartX = ref(0);
 const touchStartY = ref(0);
 const touchStartValue = ref(0);
+const touchStartThumbCenter = ref<number | null>(null);
 const isScrolling = ref(false);
 const isDrag = ref(false);
 const touchMoveCount = ref(0);
@@ -649,6 +659,13 @@ const vibrate = (duration: number = 10) => {
   }
 };
 
+const getThumbCenter = (): number | null => {
+  const thumb = sliderContainerRef.value?.querySelector("[role=slider]");
+  if (!thumb) return null;
+  const rect = thumb.getBoundingClientRect();
+  return rect.left + rect.width / 2;
+};
+
 const getPercentageFromX = (clientX: number): number => {
   if (!sliderContainerRef.value) return displayValue.value;
 
@@ -673,6 +690,9 @@ const onTouchStart = (event: TouchEvent) => {
   isDrag.value = false;
   touchMoveCount.value = 0;
   maxMovement.value = 0;
+  // read before expanding: the rail's ends draw in as it grows, so measuring at
+  // touchend would compare the tap against a thumb that has since moved
+  touchStartThumbCenter.value = getThumbCenter();
 
   // a group slider answers a tap by opening its own volume controls, so it waits
   // for a drag rather than swapping its buttons out from under the tap
@@ -740,16 +760,18 @@ const onTouchMove = (event: TouchEvent) => {
 };
 
 const onTouchEnd = (event: TouchEvent) => {
+  // ahead of the guard: a player that goes unavailable mid-touch would
+  // otherwise leave the slider latched open, to expand again on its own the
+  // moment it comes back
+  collapseControlsSoon();
   if (isSliderDisabled.value && !handlesGroupTap.value) return;
 
   if (isScrolling.value) {
     isScrolling.value = false;
     isTouching.value = false;
-    collapseControlsSoon();
     return;
   }
 
-  collapseControlsSoon();
   const isTap = !isDrag.value;
 
   if (isTap) {
@@ -764,10 +786,8 @@ const onTouchEnd = (event: TouchEvent) => {
     } else if (!isSliderDisabled.value) {
       // Single player: tap before/after handle for volume up/down
       const touch = event.changedTouches[0];
-      const thumb = sliderContainerRef.value?.querySelector("[role=slider]");
-      if (thumb) {
-        const thumbRect = thumb.getBoundingClientRect();
-        const thumbCenter = thumbRect.left + thumbRect.width / 2;
+      const thumbCenter = touchStartThumbCenter.value ?? getThumbCenter();
+      if (thumbCenter !== null) {
         if (touch.clientX > thumbCenter) {
           volumeUp();
         } else {

--- a/src/layouts/default/PlayerOSD/PlayerVolume.vue
+++ b/src/layouts/default/PlayerOSD/PlayerVolume.vue
@@ -2,6 +2,18 @@
   <div ref="wrapperRef" class="player-volume-wrapper">
     <!-- Sonos-style group volume popout (teleported to body to escape overflow clipping) -->
     <Teleport to="body">
+      <!-- Volume readout, teleported for the same reason: the bars this slider
+           sits in clip their own overflow -->
+      <Transition name="volume-bubble">
+        <div
+          v-if="showStepButtons"
+          class="volume-bubble"
+          :style="bubbleStyle"
+          aria-hidden="true"
+        >
+          {{ Math.round(displayValue) }}
+        </div>
+      </Transition>
       <!-- Invisible backdrop: catches all clicks/taps outside the popout and stops propagation -->
       <Transition name="popout-backdrop">
         <div
@@ -68,6 +80,8 @@
         disabled: isDisabled,
         muted: isMuted,
         'not-powered': player.powered == false,
+        expandable: expandOnTouch,
+        expanded: showStepButtons,
       }"
       :style="{ width: width }"
       @click="onSliderClick"
@@ -84,11 +98,24 @@
       <!-- Mute button with dynamic volume icon -->
       <div class="volume-prepend" @touchstart.stop @touchend.stop>
         <button
-          class="volume-icon-btn"
+          class="volume-icon-btn volume-slot-item"
+          :class="{ 'is-hidden': showStepButtons }"
           :disabled="muteDisabled"
           @click.stop="onMuteToggle"
         >
           <component :is="volumeIconComponent" :size="iconSize" />
+        </button>
+        <button
+          v-if="expandOnTouch"
+          type="button"
+          class="volume-step-btn volume-slot-item"
+          :class="{ 'is-hidden': !showStepButtons }"
+          :aria-label="$t('tooltip.volume_down')"
+          @click.stop
+          @mousedown.stop="onStepDown"
+          @touchstart.stop.prevent="onStepDown"
+        >
+          <Minus :size="iconSize" />
         </button>
       </div>
 
@@ -105,14 +132,30 @@
 
       <!-- Volume level display -->
       <div
-        v-if="showVolumeLevel"
+        v-if="showVolumeLevel || expandOnTouch"
         class="volume-append"
         @touchstart.stop
         @touchend.stop
       >
-        <span class="volume-level-text">
+        <span
+          v-if="showVolumeLevel"
+          class="volume-level-text volume-slot-item"
+          :class="{ 'is-hidden': showStepButtons }"
+        >
           {{ Math.round(displayValue) }}
         </span>
+        <button
+          v-if="expandOnTouch"
+          type="button"
+          class="volume-step-btn volume-slot-item"
+          :class="{ 'is-hidden': !showStepButtons }"
+          :aria-label="$t('tooltip.volume_up')"
+          @click.stop
+          @mousedown.stop="onStepUp"
+          @touchstart.stop.prevent="onStepUp"
+        >
+          <Plus :size="iconSize" />
+        </button>
       </div>
     </div>
   </div>
@@ -131,6 +174,7 @@ import {
   PlayerType,
 } from "@/plugins/api/interfaces";
 import { store } from "@/plugins/store";
+import { Minus, Plus } from "@lucide/vue";
 import { computed, nextTick, onUnmounted, ref, watch } from "vue";
 
 export interface Props {
@@ -147,6 +191,8 @@ export interface Props {
   enablePopout?: boolean;
   /** Ask the parent to expand inline group controls when the slider is tapped */
   requestExpandOnGroupTap?: boolean;
+  /** Fatten the rail and swap the mute and level slots for step buttons while in use */
+  expandOnTouch?: boolean;
   width?: string;
   step?: number;
   allowWheel?: boolean;
@@ -161,6 +207,7 @@ const props = withDefaults(defineProps<Props>(), {
   preferGroupVolume: false,
   enablePopout: true,
   requestExpandOnGroupTap: false,
+  expandOnTouch: false,
   width: "100%",
   step: 2,
   allowWheel: false,
@@ -342,6 +389,9 @@ const toggleGroupPopout = () => {
 };
 
 const handleGroupTap = () => {
+  // the group controls carry their own volume rows, so the bar's own step
+  // buttons must not linger behind them
+  collapseControls();
   if (hasGroupPopout.value) {
     toggleGroupPopout();
   } else {
@@ -437,6 +487,8 @@ const POINTER_DRAG_THRESHOLD = 4;
 onUnmounted(() => {
   if (dragEndTimeout) clearTimeout(dragEndTimeout);
   if (sliderUpdateDebounceTimeout) clearTimeout(sliderUpdateDebounceTimeout);
+  stopTrackingBubble();
+  cancelCollapse();
 });
 
 const clamp = (value: number, min: number, max: number) =>
@@ -501,6 +553,94 @@ const onMuteToggle = () => {
   }
 };
 
+// --- Touch expansion ---
+
+const isExpanded = ref(false);
+const bubbleStyle = ref<Record<string, string>>({});
+let collapseTimeout: ReturnType<typeof setTimeout> | null = null;
+let bubbleFrame: number | null = null;
+const COLLAPSE_DELAY_MS = 2000;
+const BUBBLE_GAP = 10;
+
+// The step buttons take over the mute and level slots, so a slider that cannot
+// be dragged keeps the mute button the user needs to get out of that state
+const showStepButtons = computed(
+  () => props.expandOnTouch && !isSliderDisabled.value && isExpanded.value,
+);
+
+const expandControls = () => {
+  if (!props.expandOnTouch || isSliderDisabled.value) return;
+  // placed before the readout renders, so it never shows up at the last
+  // position it was dismissed from
+  updateBubblePosition();
+  isExpanded.value = true;
+  cancelCollapse();
+};
+
+const collapseControlsSoon = () => {
+  if (!isExpanded.value) return;
+  cancelCollapse();
+  collapseTimeout = setTimeout(() => {
+    isExpanded.value = false;
+    collapseTimeout = null;
+  }, COLLAPSE_DELAY_MS);
+};
+
+const collapseControls = () => {
+  cancelCollapse();
+  isExpanded.value = false;
+};
+
+const onStepDown = () => {
+  expandControls();
+  volumeDown();
+  collapseControlsSoon();
+};
+
+const onStepUp = () => {
+  expandControls();
+  volumeUp();
+  collapseControlsSoon();
+};
+
+const cancelCollapse = () => {
+  if (collapseTimeout) {
+    clearTimeout(collapseTimeout);
+    collapseTimeout = null;
+  }
+};
+
+// The readout rides the thumb, which sits at the value's fraction of the track
+// because the slider aligns its thumb by overflow rather than inset. It is
+// fixed to the viewport to clear the bars' own clipping, so it is re-measured
+// rather than assumed: the rail thickens under it, and the panel it sits in can
+// still be sliding open or scrolling.
+const updateBubblePosition = () => {
+  const track = sliderContainerRef.value?.querySelector(
+    '[data-slot="slider-track"]',
+  );
+  if (!track) return;
+  const rect = track.getBoundingClientRect();
+  const left = `${rect.left + (clamp(displayValue.value, 0, 100) / 100) * rect.width}px`;
+  const bottom = `${window.innerHeight - rect.top + BUBBLE_GAP}px`;
+  // settling on a position ends the re-renders until something moves again
+  if (bubbleStyle.value.left === left && bubbleStyle.value.bottom === bottom) {
+    return;
+  }
+  bubbleStyle.value = { left, bottom };
+};
+
+const trackBubble = () => {
+  updateBubblePosition();
+  bubbleFrame = requestAnimationFrame(trackBubble);
+};
+
+const stopTrackingBubble = () => {
+  if (bubbleFrame === null) return;
+  cancelAnimationFrame(bubbleFrame);
+  bubbleFrame = null;
+};
+
 // --- Helpers ---
 
 const vibrate = (duration: number = 10) => {
@@ -534,6 +674,9 @@ const onTouchStart = (event: TouchEvent) => {
   touchMoveCount.value = 0;
   maxMovement.value = 0;
 
+  // a group slider answers a tap by opening its own volume controls, so it waits
+  // for a drag rather than swapping its buttons out from under the tap
+  if (!handlesGroupTap.value) expandControls();
   vibrate();
 };
 
@@ -565,6 +708,9 @@ const onTouchMove = (event: TouchEvent) => {
     // the group popout), so a drag from here would fight a scroll it cannot stop
     if (!event.cancelable || (absDeltaY > 10 && absDeltaY > absDeltaX * 2)) {
       isScrolling.value = true;
+      // the panels these sliders sit in scroll, so a list of them must not be
+      // left fattened in the wake of a swipe
+      collapseControls();
       displayValue.value = touchStartValue.value;
       emit("update:local-value", touchStartValue.value);
       return;
@@ -572,6 +718,7 @@ const onTouchMove = (event: TouchEvent) => {
 
     if (absDeltaX > 8) {
       isDrag.value = true;
+      expandControls();
       startDragging();
       event.preventDefault();
     }
@@ -598,9 +745,11 @@ const onTouchEnd = (event: TouchEvent) => {
   if (isScrolling.value) {
     isScrolling.value = false;
     isTouching.value = false;
+    collapseControlsSoon();
     return;
   }
 
+  collapseControlsSoon();
   const isTap = !isDrag.value;
 
   if (isTap) {
@@ -655,6 +804,7 @@ const onPointerDown = (event: PointerEvent) => {
     return;
   }
   if (!handlesGroupTap.value || !targetsSlider) {
+    if (targetsSlider) expandControls();
     return;
   }
   pointerStartX = event.clientX;
@@ -666,10 +816,12 @@ const onPointerMove = (event: PointerEvent) => {
   if (pointerStartX === null) return;
   if (Math.abs(event.clientX - pointerStartX) > POINTER_DRAG_THRESHOLD) {
     pointerMoved = true;
+    expandControls();
   }
 };
 
 const onPointerUp = () => {
+  collapseControlsSoon();
   if (pointerStartX === null) return;
   const shouldExpand = !pointerMoved;
   resetPointerInteraction();
@@ -703,6 +855,7 @@ const onPointerUp = () => {
 };
 
 const onPointerCancel = () => {
+  collapseControlsSoon();
   if (pointerStartX === null) return;
   resetPointerInteraction();
   if (sliderUpdateDebounceTimeout) {
@@ -724,6 +877,7 @@ const resetPointerInteraction = () => {
 };
 
 const onTouchCancel = () => {
+  collapseControlsSoon();
   isDrag.value = false;
   isScrolling.value = false;
   touchMoveCount.value = 0;
@@ -784,6 +938,18 @@ const onSliderClick = () => {
   if (Date.now() - lastPopoutToggleTime < 500) return;
   handleGroupTap();
 };
+
+// a swapped-in player starts from the resting slider rather than inheriting
+// the step buttons the previous one was left with
+watch(() => props.player.player_id, collapseControls);
+
+watch(showStepButtons, (shown) => {
+  if (shown) {
+    if (bubbleFrame === null) trackBubble();
+  } else {
+    stopTrackingBubble();
+  }
+});
 
 // Sync server volume to display when not actively dragging
 watch(
@@ -881,6 +1047,81 @@ watch(
   margin-left: 8px;
 }
 
+/* --- Touch expansion --- */
+
+/* The step buttons are absolute so they cross-fade over the mute button and the
+   level readout without ever taking width from the track: the slider keeps the
+   same geometry expanded or not, so the thumb never jumps under the finger. */
+.player-volume-container.expandable .volume-prepend,
+.player-volume-container.expandable .volume-append {
+  position: relative;
+  align-self: stretch;
+  transition: width 0.15s ease;
+}
+
+/* both slots widen by the same amount, so the track loses length evenly at each
+   end and its midpoint - and with it the thumb - barely moves */
+.player-volume-container.expanded .volume-prepend,
+.player-volume-container.expanded .volume-append {
+  width: 38px;
+}
+
+.volume-slot-item {
+  transition: opacity 0.15s ease;
+}
+
+.volume-slot-item.is-hidden {
+  opacity: 0;
+  pointer-events: none;
+}
+
+.volume-step-btn {
+  position: absolute;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: none;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+  color: inherit;
+  -webkit-tap-highlight-color: transparent;
+}
+
+/* they also reach outwards, into the margin the row already keeps clear, which
+   buys the tap target width the track does not have to give up */
+.volume-prepend .volume-step-btn {
+  inset: 0 0 0 -8px;
+}
+
+.volume-append .volume-step-btn {
+  inset: 0 -8px 0 0;
+}
+
+.volume-step-btn:active {
+  opacity: 0.5;
+}
+
+/* the rail fattens in place: it stays well inside the row's height, so the bar
+   around it keeps the height it rests at */
+.player-volume-container.expandable :deep([data-slot="slider-track"]),
+.player-volume-container.expandable :deep([data-slot="slider-track"])::before,
+.player-volume-container.expandable :deep([data-slot="slider-thumb"])::before {
+  transition:
+    height 0.15s ease,
+    width 0.15s ease;
+}
+
+.player-volume-container.expanded :deep([data-slot="slider-track"]),
+.player-volume-container.expanded :deep([data-slot="slider-track"])::before {
+  height: 12px !important;
+}
+
+.player-volume-container.expanded :deep([data-slot="slider-thumb"])::before {
+  width: 18px !important;
+  height: 18px !important;
+}
+
 /* --- Group volume popout styles are in the unscoped style block below --- */
 
 @media (pointer: coarse) {
@@ -891,8 +1132,36 @@ watch(
 }
 </style>
 
-<!-- Unscoped styles for the teleported popout -->
+<!-- Unscoped styles for the teleported popout and volume readout -->
 <style>
+/* left is the thumb's centre, so the readout is shifted back over it */
+.volume-bubble {
+  position: fixed;
+  transform: translateX(-50%);
+  z-index: 10001;
+  padding: 2px 8px;
+  border-radius: 8px;
+  font-size: 0.75rem;
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+  line-height: 1.4;
+  background: rgb(var(--v-theme-surface));
+  border: 1px solid rgba(var(--v-border-color), 0.12);
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.18);
+  /* it tracks the thumb the finger is already on, so it must never take a touch */
+  pointer-events: none;
+}
+
+.volume-bubble-enter-active,
+.volume-bubble-leave-active {
+  transition: opacity 0.15s ease;
+}
+
+.volume-bubble-enter-from,
+.volume-bubble-leave-to {
+  opacity: 0;
+}
+
 .group-popout-backdrop {
   position: fixed;
   top: 0;

--- a/src/layouts/default/PlayerOSD/PlayerVolume.vue
+++ b/src/layouts/default/PlayerOSD/PlayerVolume.vue
@@ -200,7 +200,7 @@ export interface Props {
   enablePopout?: boolean;
   /** Ask the parent to expand inline group controls when the slider is tapped */
   requestExpandOnGroupTap?: boolean;
-  /** Fatten the rail and swap the mute and level slots for step buttons while in use */
+  /** Fatten the rail and swap the mute and level slots for step buttons while a finger is on it */
   expandOnTouch?: boolean;
   width?: string;
   step?: number;
@@ -578,6 +578,8 @@ const showStepButtons = computed(
   () => props.expandOnTouch && !isSliderDisabled.value && isExpanded.value,
 );
 
+// Only the touch handlers reach this: a pointer hits the resting rail
+// accurately enough, so growing it under a mouse would be noise
 const expandControls = () => {
   if (!props.expandOnTouch || isSliderDisabled.value) return;
   // placed before the readout renders, so it never shows up at the last
@@ -824,7 +826,6 @@ const onPointerDown = (event: PointerEvent) => {
     return;
   }
   if (!handlesGroupTap.value || !targetsSlider) {
-    if (targetsSlider) expandControls();
     return;
   }
   pointerStartX = event.clientX;
@@ -836,7 +837,6 @@ const onPointerMove = (event: PointerEvent) => {
   if (pointerStartX === null) return;
   if (Math.abs(event.clientX - pointerStartX) > POINTER_DRAG_THRESHOLD) {
     pointerMoved = true;
-    expandControls();
   }
 };
 

--- a/src/layouts/default/PlayerOSD/PlayerVolumePanel.vue
+++ b/src/layouts/default/PlayerOSD/PlayerVolumePanel.vue
@@ -31,6 +31,7 @@
           <PlayerVolume
             :player="volumePlayer"
             :allow-wheel="allowWheel"
+            :expand-on-touch="expandOnTouch"
             width="100%"
           />
         </div>
@@ -49,6 +50,7 @@
           :allow-wheel="allowWheel"
           :prefer-group-volume="true"
           :enable-popout="false"
+          :expand-on-touch="expandOnTouch"
           width="100%"
         />
       </div>
@@ -67,6 +69,7 @@ import {
   PLAYER_CONTROL_NONE,
   PlayerType,
 } from "@/plugins/api/interfaces";
+import { store } from "@/plugins/store";
 import { computed } from "vue";
 import PlayerVolume from "./PlayerVolume.vue";
 
@@ -82,6 +85,10 @@ const props = withDefaults(
 
 const grouped = computed(() => isPlayerGrouped(props.player));
 const playerDisplayName = computed(() => getPlayerName(props.player, 36));
+
+// the same panel backs the desktop volume popout, where a pointer has no
+// trouble with the resting rail
+const expandOnTouch = computed(() => store.mobileLayout);
 
 const volumePlayers = computed(() => {
   if (!grouped.value) return [];

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -873,6 +873,8 @@
         "exit_fullscreen": "Exit fullscreen",
         "decrease_offset": "Decrease offset",
         "increase_offset": "Increase offset",
+        "volume_down": "Volume down",
+        "volume_up": "Volume up",
         "toggle_queue": "Toggle queue",
         "select_player": "Select player",
         "show_dashboard": "Cast dashboard to a device",

--- a/tests/layouts/PlayerVolume.test.ts
+++ b/tests/layouts/PlayerVolume.test.ts
@@ -922,6 +922,30 @@ describe("PlayerVolume touch expansion", () => {
     expect(wrapper.find(".volume-level-text").text()).toBe("55");
   });
 
+  it("keeps a cancelled step touch from rewinding the readout", async () => {
+    const player = createPlayer({ volume_level: 20 });
+    api.players = { [player.player_id]: player };
+    wrapper = mountExpandable(player);
+
+    // a touch on the track puts its starting value on record, then the volume
+    // moves on from there
+    await touchStart(wrapper);
+    await touchEnd(wrapper);
+    await wrapper.setProps({ player: { ...player, volume_level: 70 } });
+    await nextTick();
+    expect(wrapper.find(".volume-level-text").text()).toBe("70");
+
+    // the system cancelling a touch that began on a step button must not rewind
+    // the readout to that recorded value
+    await wrapper
+      .find(".volume-append .volume-step-btn")
+      .trigger("touchcancel", {
+        changedTouches: [{ clientX: 300, clientY: 10 }],
+      });
+
+    expect(wrapper.find(".volume-level-text").text()).toBe("70");
+  });
+
   it("steps the volume from a click, so a keyboard can reach the buttons", async () => {
     const player = createPlayer();
     api.players = { [player.player_id]: player };

--- a/tests/layouts/PlayerVolume.test.ts
+++ b/tests/layouts/PlayerVolume.test.ts
@@ -822,6 +822,25 @@ describe("PlayerVolume touch expansion", () => {
     );
   });
 
+  it("leaves the slider at its resting size for a mouse", async () => {
+    const player = createPlayer();
+    api.players = { [player.player_id]: player };
+    wrapper = mountExpandable(player);
+    const container = wrapper.find(".player-volume-container");
+    const slider = wrapper.find('[data-slot="slider"]');
+
+    // a pointer hits the resting rail accurately enough, so neither a click nor
+    // a drag with one has any reason to grow it
+    await slider.trigger("pointerdown", { clientX: 50, pointerType: "mouse" });
+    expect(container.classes()).not.toContain("expanded");
+
+    await slider.trigger("pointermove", { clientX: 90, pointerType: "mouse" });
+    await slider.trigger("pointerup", { clientX: 90, pointerType: "mouse" });
+
+    expect(container.classes()).not.toContain("expanded");
+    expect(document.querySelector(".volume-bubble")).toBeNull();
+  });
+
   it("leaves a group slider alone until the touch becomes a drag", async () => {
     wrapper = mountExpandableGroup();
     const container = wrapper.find(".player-volume-container");

--- a/tests/layouts/PlayerVolume.test.ts
+++ b/tests/layouts/PlayerVolume.test.ts
@@ -115,7 +115,7 @@ const sliderStub = {
         data-slot="slider"
         role="slider"
         @pointerdown="$emit('update:modelValue', [80])"
-      />
+      ><div data-slot="slider-track" /></div>
     `,
   },
 };
@@ -638,5 +638,263 @@ describe("PlayerVolume group popout", () => {
 
     expect(event.defaultPrevented).toBe(true);
     expect(api.playerCommandVolumeUp).toHaveBeenCalledWith(player.player_id);
+  });
+});
+
+describe("PlayerVolume touch expansion", () => {
+  let wrapper: ReturnType<typeof mountExpandable> | undefined;
+
+  function mountExpandable(
+    player: Player,
+    props: Record<string, unknown> = {},
+  ) {
+    return mount(PlayerVolume, {
+      props: { player, expandOnTouch: true, ...props },
+      global: {
+        stubs: sliderStub,
+        mocks: { $t: (key: string) => key },
+      },
+    });
+  }
+
+  function mountExpandableGroup() {
+    const child = createPlayer({ player_id: "child", name: "Office" });
+    const parent = createPlayer({ group_members: ["parent", "child"] });
+    api.players = { parent, child };
+    return mountExpandable(parent, {
+      preferGroupVolume: true,
+      enablePopout: false,
+      requestExpandOnGroupTap: true,
+    });
+  }
+
+  function touchStart(target: ReturnType<typeof mountExpandable>) {
+    return target
+      .find(".player-volume-container")
+      .trigger("touchstart", { touches: [{ clientX: 50, clientY: 10 }] });
+  }
+
+  function touchEnd(target: ReturnType<typeof mountExpandable>) {
+    return target
+      .find(".player-volume-container")
+      .trigger("touchend", { changedTouches: [{ clientX: 50, clientY: 10 }] });
+  }
+
+  // past the 8px the slider needs to call a touch a drag rather than a tap
+  function touchDrag(target: ReturnType<typeof mountExpandable>) {
+    return target
+      .find(".player-volume-container")
+      .trigger("touchmove", { touches: [{ clientX: 90, clientY: 10 }] });
+  }
+
+  function touchScroll(target: ReturnType<typeof mountExpandable>) {
+    return target
+      .find(".player-volume-container")
+      .trigger("touchmove", { touches: [{ clientX: 51, clientY: 60 }] });
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useRealTimers();
+    api.players = {};
+  });
+
+  afterEach(() => {
+    wrapper?.unmount();
+    wrapper = undefined;
+  });
+
+  it("leaves the other volume sliders without step buttons", () => {
+    const player = createPlayer();
+    api.players = { [player.player_id]: player };
+    wrapper = mount(PlayerVolume, {
+      props: { player },
+      global: { stubs: sliderStub },
+    });
+
+    expect(wrapper.findAll(".volume-step-btn")).toHaveLength(0);
+    expect(wrapper.find(".volume-icon-btn").classes()).not.toContain(
+      "is-hidden",
+    );
+  });
+
+  it("swaps the mute button and level readout for step buttons on touch", async () => {
+    const player = createPlayer();
+    api.players = { [player.player_id]: player };
+    wrapper = mountExpandable(player);
+    const container = wrapper.find(".player-volume-container");
+
+    expect(container.classes()).toContain("expandable");
+    expect(container.classes()).not.toContain("expanded");
+    expect(wrapper.find(".volume-icon-btn").classes()).not.toContain(
+      "is-hidden",
+    );
+    expect(
+      wrapper.find(".volume-prepend .volume-step-btn").classes(),
+    ).toContain("is-hidden");
+
+    await touchStart(wrapper);
+
+    expect(container.classes()).toContain("expanded");
+    expect(wrapper.find(".volume-icon-btn").classes()).toContain("is-hidden");
+    expect(wrapper.find(".volume-level-text").classes()).toContain("is-hidden");
+    expect(
+      wrapper.find(".volume-prepend .volume-step-btn").classes(),
+    ).not.toContain("is-hidden");
+    expect(
+      wrapper.find(".volume-append .volume-step-btn").classes(),
+    ).not.toContain("is-hidden");
+  });
+
+  it("fills both slots in either state, so the track keeps its width", async () => {
+    const player = createPlayer();
+    api.players = { [player.player_id]: player };
+    wrapper = mountExpandable(player);
+
+    // the step buttons cross-fade over the slots the mute button and the level
+    // readout already occupy: nothing enters or leaves the row, so the thumb
+    // cannot jump sideways under a finger that is mid-drag
+    const slotContents = () => [
+      wrapper!.findAll(".volume-prepend > *").length,
+      wrapper!.findAll(".volume-append > *").length,
+    ];
+    const atRest = slotContents();
+
+    await touchStart(wrapper);
+
+    expect(atRest).toEqual([2, 2]);
+    expect(slotContents()).toEqual(atRest);
+  });
+
+  it("steps the volume from the buttons without reading them as track taps", async () => {
+    const player = createPlayer();
+    api.players = { [player.player_id]: player };
+    wrapper = mountExpandable(player);
+    await touchStart(wrapper);
+
+    await wrapper
+      .find(".volume-prepend .volume-step-btn")
+      .trigger("touchstart", { touches: [{ clientX: 5, clientY: 10 }] });
+    expect(api.playerCommandVolumeDown).toHaveBeenCalledWith(player.player_id);
+
+    await wrapper
+      .find(".volume-append .volume-step-btn")
+      .trigger("touchstart", { touches: [{ clientX: 300, clientY: 10 }] });
+    expect(api.playerCommandVolumeUp).toHaveBeenCalledWith(player.player_id);
+
+    expect(api.playerCommandVolumeSet).not.toHaveBeenCalled();
+  });
+
+  it("returns to the resting slider two seconds after the last interaction", async () => {
+    vi.useFakeTimers();
+    const player = createPlayer();
+    api.players = { [player.player_id]: player };
+    wrapper = mountExpandable(player);
+    const container = wrapper.find(".player-volume-container");
+
+    await touchStart(wrapper);
+    await touchEnd(wrapper);
+    expect(container.classes()).toContain("expanded");
+
+    await vi.advanceTimersByTimeAsync(1999);
+    await nextTick();
+    expect(container.classes()).toContain("expanded");
+
+    // a step tap buys another full window, so a second press never lands on a
+    // slider that is already collapsing
+    await wrapper
+      .find(".volume-append .volume-step-btn")
+      .trigger("touchstart", { touches: [{ clientX: 300, clientY: 10 }] });
+    await vi.advanceTimersByTimeAsync(1999);
+    await nextTick();
+    expect(container.classes()).toContain("expanded");
+
+    await vi.advanceTimersByTimeAsync(1);
+    await nextTick();
+    expect(container.classes()).not.toContain("expanded");
+  });
+
+  it("keeps the mute button reachable while the slider is muted", async () => {
+    const player = createPlayer({ volume_muted: true });
+    api.players = { [player.player_id]: player };
+    wrapper = mountExpandable(player);
+    const container = wrapper.find(".player-volume-container");
+
+    await touchStart(wrapper);
+
+    expect(container.classes()).not.toContain("expanded");
+    expect(wrapper.find(".volume-icon-btn").classes()).not.toContain(
+      "is-hidden",
+    );
+  });
+
+  it("leaves a group slider alone until the touch becomes a drag", async () => {
+    wrapper = mountExpandableGroup();
+    const container = wrapper.find(".player-volume-container");
+
+    // a tap on a group slider opens its own volume controls, so the buttons
+    // must not swap in under the finger that is about to lift
+    await touchStart(wrapper);
+    expect(container.classes()).not.toContain("expanded");
+
+    await touchDrag(wrapper);
+    expect(container.classes()).toContain("expanded");
+  });
+
+  it("still opens the group controls from a tap that never drags", async () => {
+    wrapper = mountExpandableGroup();
+    const container = wrapper.find(".player-volume-container");
+
+    await touchStart(wrapper);
+    await touchEnd(wrapper);
+
+    expect(wrapper.emitted("toggle-group-expansion")).toHaveLength(1);
+    expect(container.classes()).not.toContain("expanded");
+  });
+
+  it("steps the group volume when the bar is showing a group", async () => {
+    wrapper = mountExpandableGroup();
+    await touchStart(wrapper);
+    await touchDrag(wrapper);
+
+    await wrapper
+      .find(".volume-prepend .volume-step-btn")
+      .trigger("touchstart", { touches: [{ clientX: 5, clientY: 10 }] });
+
+    expect(api.playerCommandGroupVolumeDown).toHaveBeenCalledWith("parent");
+    expect(api.playerCommandVolumeDown).not.toHaveBeenCalled();
+  });
+
+  it("drops the step buttons as soon as the touch turns into a scroll", async () => {
+    const player = createPlayer();
+    api.players = { [player.player_id]: player };
+    wrapper = mountExpandable(player);
+    const container = wrapper.find(".player-volume-container");
+
+    await touchStart(wrapper);
+    expect(container.classes()).toContain("expanded");
+
+    // the panels these rows sit in scroll, so a swipe must not leave a list of
+    // them fattened in its wake
+    await touchScroll(wrapper);
+
+    expect(container.classes()).not.toContain("expanded");
+  });
+
+  it("shows the volume readout over the thumb while expanded", async () => {
+    const player = createPlayer({ volume_level: 40 });
+    api.players = { [player.player_id]: player };
+    wrapper = mountExpandable(player);
+
+    expect(document.querySelector(".volume-bubble")).toBeNull();
+
+    await touchStart(wrapper);
+    await nextTick();
+
+    const bubble = document.querySelector<HTMLElement>(".volume-bubble");
+    expect(bubble?.textContent?.trim()).toBe("40");
+    // anchored to the thumb's position along the track rather than to the row
+    expect(bubble?.style.left).not.toBe("");
+    expect(bubble?.style.bottom).not.toBe("");
   });
 });

--- a/tests/layouts/PlayerVolume.test.ts
+++ b/tests/layouts/PlayerVolume.test.ts
@@ -772,14 +772,10 @@ describe("PlayerVolume touch expansion", () => {
     wrapper = mountExpandable(player);
     await touchStart(wrapper);
 
-    await wrapper
-      .find(".volume-prepend .volume-step-btn")
-      .trigger("touchstart", { touches: [{ clientX: 5, clientY: 10 }] });
+    await wrapper.find(".volume-prepend .volume-step-btn").trigger("click");
     expect(api.playerCommandVolumeDown).toHaveBeenCalledWith(player.player_id);
 
-    await wrapper
-      .find(".volume-append .volume-step-btn")
-      .trigger("touchstart", { touches: [{ clientX: 300, clientY: 10 }] });
+    await wrapper.find(".volume-append .volume-step-btn").trigger("click");
     expect(api.playerCommandVolumeUp).toHaveBeenCalledWith(player.player_id);
 
     expect(api.playerCommandVolumeSet).not.toHaveBeenCalled();
@@ -802,9 +798,7 @@ describe("PlayerVolume touch expansion", () => {
 
     // a step tap buys another full window, so a second press never lands on a
     // slider that is already collapsing
-    await wrapper
-      .find(".volume-append .volume-step-btn")
-      .trigger("touchstart", { touches: [{ clientX: 300, clientY: 10 }] });
+    await wrapper.find(".volume-append .volume-step-btn").trigger("click");
     await vi.advanceTimersByTimeAsync(1999);
     await nextTick();
     expect(container.classes()).toContain("expanded");
@@ -857,9 +851,7 @@ describe("PlayerVolume touch expansion", () => {
     await touchStart(wrapper);
     await touchDrag(wrapper);
 
-    await wrapper
-      .find(".volume-prepend .volume-step-btn")
-      .trigger("touchstart", { touches: [{ clientX: 5, clientY: 10 }] });
+    await wrapper.find(".volume-prepend .volume-step-btn").trigger("click");
 
     expect(api.playerCommandGroupVolumeDown).toHaveBeenCalledWith("parent");
     expect(api.playerCommandVolumeDown).not.toHaveBeenCalled();
@@ -877,6 +869,91 @@ describe("PlayerVolume touch expansion", () => {
     // the panels these rows sit in scroll, so a swipe must not leave a list of
     // them fattened in its wake
     await touchScroll(wrapper);
+
+    expect(container.classes()).not.toContain("expanded");
+  });
+
+  it("keeps a step tap from being read as a drag on the track", async () => {
+    const player = createPlayer({ volume_level: 20 });
+    api.players = { [player.player_id]: player };
+    wrapper = mountExpandable(player);
+
+    // a tap on the track, so the slider has a start position on record
+    await touchStart(wrapper);
+    await touchEnd(wrapper);
+
+    // tapping a step button far from that position must not be measured
+    // against it: the slot swallows the whole sequence, moves included
+    const plus = wrapper.find(".volume-append .volume-step-btn");
+    await plus.trigger("touchstart", {
+      touches: [{ clientX: 300, clientY: 10 }],
+    });
+    await plus.trigger("touchmove", {
+      touches: [{ clientX: 302, clientY: 11 }],
+    });
+    await plus.trigger("touchend", {
+      changedTouches: [{ clientX: 302, clientY: 11 }],
+    });
+
+    // a latched drag would block the server sync for good, because the touch
+    // that started it never reaches the handler that ends it
+    await wrapper.setProps({ player: { ...player, volume_level: 55 } });
+    await nextTick();
+
+    expect(wrapper.find(".volume-level-text").text()).toBe("55");
+  });
+
+  it("steps the volume from a click, so a keyboard can reach the buttons", async () => {
+    const player = createPlayer();
+    api.players = { [player.player_id]: player };
+    wrapper = mountExpandable(player);
+    await touchStart(wrapper);
+
+    await wrapper.find(".volume-append .volume-step-btn").trigger("click");
+    await wrapper.find(".volume-prepend .volume-step-btn").trigger("click");
+
+    expect(api.playerCommandVolumeUp).toHaveBeenCalledWith(player.player_id);
+    expect(api.playerCommandVolumeDown).toHaveBeenCalledWith(player.player_id);
+  });
+
+  it("takes the hidden half of each slot out of the tab order", async () => {
+    const player = createPlayer();
+    api.players = { [player.player_id]: player };
+    wrapper = mountExpandable(player);
+
+    const inert = (selector: string) =>
+      wrapper!.find(selector).attributes("inert") !== undefined;
+
+    expect(inert(".volume-prepend .volume-step-btn")).toBe(true);
+    expect(inert(".volume-icon-btn")).toBe(false);
+
+    await touchStart(wrapper);
+
+    // both halves stay mounted to hold the slot's width, so the one that is
+    // faded out has to leave the a11y tree rather than just the screen
+    expect(inert(".volume-prepend .volume-step-btn")).toBe(false);
+    expect(inert(".volume-icon-btn")).toBe(true);
+    expect(inert(".volume-level-text")).toBe(true);
+  });
+
+  it("collapses on a touch that ends after the player goes unavailable", async () => {
+    vi.useFakeTimers();
+    const player = createPlayer();
+    api.players = { [player.player_id]: player };
+    wrapper = mountExpandable(player);
+    const container = wrapper.find(".player-volume-container");
+
+    await touchStart(wrapper);
+    expect(container.classes()).toContain("expanded");
+
+    // it would otherwise stay latched and re-expand on its own once the player
+    // came back, with no touch behind it
+    api.players[player.player_id]!.available = false;
+    await wrapper.setProps({ player: { ...player, available: false } });
+    await touchEnd(wrapper);
+    await vi.advanceTimersByTimeAsync(2000);
+    await wrapper.setProps({ player: { ...player, available: true } });
+    await nextTick();
 
     expect(container.classes()).not.toContain("expanded");
   });

--- a/tests/layouts/PlayerVolumePanel.test.ts
+++ b/tests/layouts/PlayerVolumePanel.test.ts
@@ -1,0 +1,97 @@
+import PlayerVolume from "@/layouts/default/PlayerOSD/PlayerVolume.vue";
+import PlayerVolumePanel from "@/layouts/default/PlayerOSD/PlayerVolumePanel.vue";
+import type { Player } from "@/plugins/api/interfaces";
+import { store } from "@/plugins/store";
+import { shallowMount, type VueWrapper } from "@vue/test-utils";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { isPlayerGrouped } = vi.hoisted(() => ({
+  isPlayerGrouped: vi.fn(() => true),
+}));
+
+vi.mock("@/plugins/api", async () => {
+  const { reactive } = await vi.importActual<typeof import("vue")>("vue");
+  const api = reactive({ players: {} as Record<string, Player> });
+  return { api, default: api };
+});
+
+vi.mock("@/plugins/store", async () => {
+  const { reactive } = await vi.importActual<typeof import("vue")>("vue");
+  return { store: reactive({ mobileLayout: false }) };
+});
+
+vi.mock("@/helpers/players", () => ({ isPlayerGrouped }));
+
+vi.mock("@/helpers/utils", () => ({
+  getPlayerName: (player: Player) => player.name,
+}));
+
+const mockStore = store as unknown as { mobileLayout: boolean };
+
+function createPlayer(overrides: Partial<Player> = {}): Player {
+  return {
+    player_id: "parent",
+    name: "Kitchen",
+    available: true,
+    volume_control: "volume",
+    group_members: ["parent", "child"],
+    ...overrides,
+  } as Player;
+}
+
+let wrapper: VueWrapper | undefined;
+
+async function mountPanel(mobileLayout: boolean) {
+  const { api } = await import("@/plugins/api");
+  const parent = createPlayer();
+  api.players = {
+    parent,
+    child: createPlayer({ player_id: "child", name: "Office" }),
+  };
+  mockStore.mobileLayout = mobileLayout;
+  wrapper = shallowMount(PlayerVolumePanel, {
+    props: { player: parent },
+    global: { mocks: { $t: (key: string) => key } },
+  });
+  return wrapper;
+}
+
+describe("PlayerVolumePanel", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    isPlayerGrouped.mockReturnValue(true);
+  });
+
+  afterEach(() => {
+    wrapper?.unmount();
+    wrapper = undefined;
+  });
+
+  it.each([
+    { mobileLayout: true, expandOnTouch: true },
+    { mobileLayout: false, expandOnTouch: false },
+  ])(
+    "grows its rows on touch when mobileLayout is $mobileLayout",
+    async ({ mobileLayout, expandOnTouch }) => {
+      // the same panel backs the desktop volume popout, where a pointer has no
+      // trouble with the resting rail
+      const panel = await mountPanel(mobileLayout);
+      const sliders = panel.findAllComponents(PlayerVolume);
+
+      expect(sliders.length).toBeGreaterThan(1);
+      for (const slider of sliders) {
+        expect(slider.props("expandOnTouch")).toBe(expandOnTouch);
+      }
+    },
+  );
+
+  it("covers the child rows as well as the grouped row", async () => {
+    const panel = await mountPanel(true);
+    const sliders = panel.findAllComponents(PlayerVolume);
+
+    // the last slider is the grouped one; everything before it is a child
+    expect(sliders).toHaveLength(3);
+    expect(sliders.at(-1)!.props("preferGroupVolume")).toBe(true);
+    expect(sliders.at(0)!.props("preferGroupVolume")).toBe(false);
+  });
+});


### PR DESCRIPTION
# What does this implement/fix?

The volume rail in the mobile floating player is only a few pixels tall, so it is
easy to miss and hard to nudge by a small amount. Touching it now grows it into a
chunky bar with dedicated minus and plus buttons, the way the Sonos app does.

- Touching the slider thickens the rail and enlarges the thumb, and swaps the mute
  icon and the level readout for minus and plus buttons in the same slots
- The volume shows as a small readout that floats above the thumb and follows it
- The bar keeps the height it rests at, so nothing around it moves
- Returns to the slim resting slider two seconds after the last touch
- The group volume sheet's rows get the same treatment
- On a group, tapping the slider still opens the volume controls as before; the
  slider only grows once you start dragging

**Related issue (if applicable):**

- related issue `<link to issue>`

**Related backend PR (if applicable):**

- related backend PR `<link to PR>`

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm lint:check` passes.
- [x] `pnpm test:run` passes, and tests have been added/updated where applicable.
- [x] `pnpm build` passes.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
