### PR TITLE
Let a touch drag scroll the volume panel and player list

### DIFF
--- a/src/layouts/default/PlayerOSD/PlayerVolume.vue
+++ b/src/layouts/default/PlayerOSD/PlayerVolume.vue
@@ -913,9 +913,11 @@ watch(
 
 /* touch-action is intersected from the touched row up to the scroll container,
    so the rows have to allow the vertical pan themselves; horizontal drags still
-   reach onTouchMove, which claims them. The wrapper is named as well, to
+   reach onTouchMove, which claims them. A scrolling list outside this component
+   opts in with .player-volume-scroller. The wrapper is named as well, to
    out-rank the scoped rule whichever of the two blocks loads last. */
-.group-popout .player-volume-wrapper .player-volume-container {
+.group-popout .player-volume-wrapper .player-volume-container,
+.player-volume-scroller .player-volume-wrapper .player-volume-container {
   touch-action: pan-y;
 }
 

--- a/src/layouts/default/PlayerOSD/PlayerVolumePanel.vue
+++ b/src/layouts/default/PlayerOSD/PlayerVolumePanel.vue
@@ -9,7 +9,9 @@
       </div>
     </div>
 
-    <div class="min-h-0 space-y-3 overflow-y-auto px-4 pt-3 pb-4">
+    <div
+      class="player-volume-scroller min-h-0 space-y-3 overflow-y-auto px-4 pt-3 pb-4"
+    >
       <template v-if="volumePlayers.length > 0">
         <div
           v-for="volumePlayer in volumePlayers"

--- a/src/layouts/default/PlayerSelect.vue
+++ b/src/layouts/default/PlayerSelect.vue
@@ -126,7 +126,10 @@
         <p class="sr-only">{{ $t("tooltip.select_player") }}</p>
       </div>
 
-      <div ref="playerList" class="min-h-0 flex-1 overflow-y-auto pb-6">
+      <div
+        ref="playerList"
+        class="player-volume-scroller min-h-0 flex-1 overflow-y-auto pb-6"
+      >
         <!-- outranks the selected player badge on the cards scrolling underneath -->
         <div
           v-if="showSearch"

--- a/tests/layouts/PlayerBarVolumeControl.test.ts
+++ b/tests/layouts/PlayerBarVolumeControl.test.ts
@@ -285,6 +285,24 @@ describe("PlayerBarVolumeControl", () => {
     ).toBe("audio_overlay_volume: 70%");
   });
 
+  it("keeps the volume rows inside the list that scrolls", () => {
+    const child = createPlayer({ player_id: "child", name: "Office" });
+    const parent = createPlayer({
+      group_members: ["parent", child.player_id],
+    });
+    api.players = {
+      [parent.player_id]: parent,
+      [child.player_id]: child,
+    };
+
+    const scroller = mountControl(parent).get(".player-volume-scroller");
+
+    // PlayerVolume grants the rows their vertical pan through this class;
+    // rendering them outside it would silently leave the list unscrollable
+    expect(scroller.classes()).toContain("overflow-y-auto");
+    expect(scroller.findAll(".player-volume")).toHaveLength(3);
+  });
+
   it("keeps every volume label centered without clipping", () => {
     const player = createPlayer({ volume_level: 5 });
     api.players = { [player.player_id]: player };

--- a/tests/layouts/PlayerSelect.test.ts
+++ b/tests/layouts/PlayerSelect.test.ts
@@ -722,6 +722,20 @@ describe("PlayerSelect", () => {
     ).toBe("true");
   });
 
+  it("keeps the cards inside the list that scrolls", () => {
+    api.players = {
+      kitchen: createPlayer("kitchen", "Kitchen"),
+      office: createPlayer("office", "Office"),
+    };
+
+    const scroller = mountPlayerSelect().get(".player-volume-scroller");
+
+    // this class is what PlayerVolume reaches the volume rows on these cards
+    // through; a card rendered outside it would silently lose the pan
+    expect(scroller.classes()).toContain("overflow-y-auto");
+    expect(scroller.findAll(".player-card")).toHaveLength(2);
+  });
+
   it("shows volume controls only for playing and paused players by default", () => {
     api.players = {
       idle: createPlayer("idle", "Idle"),

--- a/tests/styles/groupPopoutTouchAction.test.ts
+++ b/tests/styles/groupPopoutTouchAction.test.ts
@@ -32,10 +32,14 @@ function row() {
   return popout.querySelector(".player-volume-container")!;
 }
 
-function rulesFor(element: Element) {
+// a rule may carry a selector list, of which only some parts land on the row
+function selectorsSettingTouchAction(element: Element) {
   return [...(styles.sheet?.cssRules ?? [])]
     .filter((rule): rule is CSSStyleRule => rule instanceof CSSStyleRule)
-    .filter((rule) => element.matches(rule.selectorText));
+    .filter((rule) => rule.style.getPropertyValue("touch-action") !== "")
+    .flatMap((rule) => rule.selectorText.split(","))
+    .map((selector) => selector.trim())
+    .filter((selector) => element.matches(selector));
 }
 
 // neither side carries an id or an element name, so counting their class-level
@@ -63,20 +67,18 @@ describe("group volume popout touch-action", () => {
   });
 
   it("keeps the rows panning independently of the stylesheet load order", () => {
-    const declaring = rulesFor(row()).filter(
-      (rule) => rule.style.getPropertyValue("touch-action") !== "",
-    );
+    const declaring = selectorsSettingTouchAction(row());
     const winner =
       ".group-popout .player-volume-wrapper .player-volume-container";
 
-    expect(declaring.map((rule) => rule.selectorText)).toContain(winner);
-    for (const rule of declaring) {
-      if (rule.selectorText === winner) continue;
+    expect(declaring).toContain(winner);
+    for (const selector of declaring) {
+      if (selector === winner) continue;
 
       expect(
         rank(winner),
-        `${rule.selectorText} also sets touch-action on a row, so the override has to out-rank it once scoped`,
-      ).toBeGreaterThan(rank(rule.selectorText) + SCOPE_COMPOUND);
+        `${selector} also sets touch-action on a row, so the override has to out-rank it once scoped`,
+      ).toBeGreaterThan(rank(selector) + SCOPE_COMPOUND);
     }
   });
 });

--- a/tests/styles/volumeScrollerTouchAction.test.ts
+++ b/tests/styles/volumeScrollerTouchAction.test.ts
@@ -1,0 +1,114 @@
+// happy-dom cannot settle a tie between two equally specific rules, so the
+// ranking is what proves the override applies whichever block loads last
+// @vitest-environment happy-dom
+import volumeSource from "@/layouts/default/PlayerOSD/PlayerVolume.vue?raw";
+import panelSource from "@/layouts/default/PlayerOSD/PlayerVolumePanel.vue?raw";
+import selectSource from "@/layouts/default/PlayerSelect.vue?raw";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+// the lists outside PlayerVolume that opt their rows into the vertical pan
+const SCROLLERS = [
+  ["the grouped volume panel", panelSource],
+  ["the player list", selectSource],
+] as const;
+
+const OVERRIDE =
+  ".player-volume-scroller .player-volume-wrapper .player-volume-container";
+
+// the scoped block's selectors each gain a [data-v-hash] compound at compile
+// time, which the raw source does not carry
+const SCOPE_COMPOUND = 1;
+
+let styles: HTMLStyleElement;
+
+// vitest only compiles the stylesheets under src/styles, so PlayerVolume's own
+// rules are lifted straight out of its source, in the order it declares them
+function styleBlocks(source: string) {
+  return [...source.matchAll(/<style[^>]*>([\s\S]*?)<\/style>/g)].map(
+    (match) => match[1],
+  );
+}
+
+// the classes the list is rendered with, read off the template so the probe
+// cannot drift from the markup it stands in for
+function listClasses(source: string) {
+  return source.match(
+    /<div[^>]*\sclass="([^"]*\bplayer-volume-scroller\b[^"]*)"/,
+  )?.[1];
+}
+
+// a volume row as the lists render it
+function row(classes: string) {
+  const list = document.createElement("div");
+  list.className = classes;
+  list.innerHTML = `
+    <div class="player-volume-wrapper">
+      <div class="player-volume-container"></div>
+    </div>`;
+  document.body.appendChild(list);
+  return list.querySelector(".player-volume-container")!;
+}
+
+// a rule may carry a selector list, of which only some parts land on the row
+function selectorsSettingTouchAction(element: Element) {
+  return [...(styles.sheet?.cssRules ?? [])]
+    .filter((rule): rule is CSSStyleRule => rule instanceof CSSStyleRule)
+    .filter((rule) => rule.style.getPropertyValue("touch-action") !== "")
+    .flatMap((rule) => rule.selectorText.split(","))
+    .map((selector) => selector.trim())
+    .filter((selector) => element.matches(selector));
+}
+
+// neither side carries an id or an element name, so counting their class-level
+// compounds is the whole comparison
+function rank(selector: string) {
+  return (selector.match(/\.[\w-]+|\[[^\]]+\]|:[\w-]+/g) ?? []).length;
+}
+
+// the list has to still be the element that scrolls, or the rows would be
+// giving up their horizontal drag for a pan that never happens
+function scroller(source: string) {
+  const classes = listClasses(source);
+
+  expect(classes, "the list has to keep opting in").toBeDefined();
+  expect(classes, "the override only pays off on a scrolling list").toContain(
+    "overflow-y-auto",
+  );
+  return classes!;
+}
+
+describe("volume rows in a scrolling list", () => {
+  beforeEach(() => {
+    styles = document.createElement("style");
+    styles.textContent = styleBlocks(volumeSource).join("\n");
+    document.head.appendChild(styles);
+  });
+
+  afterEach(() => {
+    styles.remove();
+    document.body.innerHTML = "";
+  });
+
+  it.each(SCROLLERS)("lets a touch drag on a row pan %s", (_name, source) => {
+    // touch-action is intersected from the touched element up to the scroll
+    // container, so a row keeping pan-x would leave the list unscrollable
+    expect(getComputedStyle(row(scroller(source))).touchAction).toBe("pan-y");
+  });
+
+  it.each(SCROLLERS)(
+    "keeps %s panning independently of the stylesheet load order",
+    (_name, source) => {
+      const declaring = selectorsSettingTouchAction(row(scroller(source)));
+
+      expect(declaring).toContain(OVERRIDE);
+      for (const selector of declaring) {
+        if (selector === OVERRIDE) continue;
+
+        expect(
+          rank(OVERRIDE),
+          `${selector} also sets touch-action on a row, so the override has to out-rank it once scoped`,
+        ).toBeGreaterThan(rank(selector) + SCOPE_COMPOUND);
+      }
+    },
+  );
+});


### PR DESCRIPTION
# What does this implement/fix?

#2462 fixed this for the group volume popout, but two other lists show the same
volume rows and were left with the same problem: the grouped volume panel (the
mobile volume sheet and the volume popout on the player bar) and the player
list. Each row only permits sideways panning, and the browser applies the
touched row's restriction to the list behind it, so once such a list is long
enough to scroll, a swipe starting on a slider does nothing.

It bites hardest on the volume sheet, where the rows are about half of what
there is to swipe on: on a phone that list already scrolls at five speakers in
the group.

The rows in both lists now permit the vertical pan while still claiming sideways
drags themselves, so a swipe anywhere scrolls the list and a sideways swipe
still sets that speaker's volume.

**Related issue (if applicable):**

- follow-up to #2462

**Related backend PR (if applicable):**

- n/a

## Types of changes

<!--
Tick exactly one box below. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Changes

- Let the volume rows in the grouped volume panel and in the player list be panned vertically, so a swipe on one scrolls the list it sits in
- A list opts in by naming itself, so this stays off sliders that are not in a scrollable list — those keep sideways-only panning, which makes their drags that bit crisper
- Add tests for both lists, pinning the rule against the load order of the component's two style blocks and against the rows moving out of the list that scrolls

Checked in a browser that the rule reaches both lists' rows in either style block order and leaves the player bar and fullscreen sliders alone; the gestures themselves still want a try on a real touch device.

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm lint:check` passes.
- [x] `pnpm test:run` passes, and tests have been added/updated where applicable.
- [x] `pnpm build` passes.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
