### PR TITLE
Volume now changes while you drag the slider

### DIFF
--- a/src/layouts/default/PlayerOSD/PlayerVolume.vue
+++ b/src/layouts/default/PlayerOSD/PlayerVolume.vue
@@ -496,9 +496,36 @@ let sliderUpdateDebounceTimeout: ReturnType<typeof setTimeout> | null = null;
 const SLIDER_UPDATE_DEBOUNCE_MS = 100;
 const POINTER_DRAG_THRESHOLD = 4;
 
+// Live drag updates: the volume follows the finger instead of waiting for
+// release. Throttled because every send is a separate websocket command, at the
+// same cadence the mouse path already gets from its debounce.
+const LIVE_SEND_THROTTLE_MS = 100;
+const MAX_GROUP_LIVE_SEND_THROTTLE_MS = 500;
+
+// A group volume command is set on every member in parallel, and each member's
+// resulting state change is broadcast to every connected client, so the cost of
+// one command scales with the size of the group. Widening the window in step
+// keeps that traffic near what a single player costs. The cap is a deliberate
+// trade: past five members the traffic grows again, but a window longer than
+// half a second stops feeling like a drag.
+const liveSendThrottleMs = computed(() =>
+  useGroupVolume.value
+    ? Math.min(
+        MAX_GROUP_LIVE_SEND_THROTTLE_MS,
+        LIVE_SEND_THROTTLE_MS * Math.max(1, childPlayers.value.length),
+      )
+    : LIVE_SEND_THROTTLE_MS,
+);
+let liveSendTimeout: ReturnType<typeof setTimeout> | null = null;
+let lastLiveSendTime = 0;
+// Scoped to one gesture (reset in startDragging) so an external volume change
+// between drags can never make a send look redundant.
+let lastSentValue: number | null = null;
+
 onUnmounted(() => {
   if (dragEndTimeout) clearTimeout(dragEndTimeout);
   if (sliderUpdateDebounceTimeout) clearTimeout(sliderUpdateDebounceTimeout);
+  if (liveSendTimeout) clearTimeout(liveSendTimeout);
   stopTrackingBubble();
   cancelCollapse();
 });
@@ -513,6 +540,7 @@ const roundToStep = (value: number) =>
 
 const startDragging = () => {
   isDragging.value = true;
+  lastSentValue = null;
   if (dragEndTimeout) {
     clearTimeout(dragEndTimeout);
     dragEndTimeout = null;
@@ -535,6 +563,48 @@ const setVolume = (value: number) => {
   } else {
     api.playerCommandVolumeSet(props.player.player_id, value);
   }
+};
+
+const cancelLiveSend = () => {
+  if (liveSendTimeout) {
+    clearTimeout(liveSendTimeout);
+    liveSendTimeout = null;
+  }
+};
+
+// Called while a drag is still in progress. Sends straight away when the last
+// send is old enough, otherwise schedules a trailing send that picks up whatever
+// the value has become by the time it fires.
+const sendVolumeLive = (value: number) => {
+  if (value === lastSentValue) return;
+
+  const throttleMs = liveSendThrottleMs.value;
+  const elapsed = Date.now() - lastLiveSendTime;
+  if (elapsed >= throttleMs) {
+    cancelLiveSend();
+    lastLiveSendTime = Date.now();
+    lastSentValue = value;
+    setVolume(value);
+    return;
+  }
+
+  cancelLiveSend();
+  liveSendTimeout = setTimeout(() => {
+    liveSendTimeout = null;
+    lastLiveSendTime = Date.now();
+    lastSentValue = displayValue.value;
+    setVolume(displayValue.value);
+  }, throttleMs - elapsed);
+};
+
+// Called on release. This value is authoritative, so it cancels any pending
+// throttled send rather than racing it.
+const sendVolumeFinal = (value: number) => {
+  cancelLiveSend();
+  if (value === lastSentValue) return;
+  lastLiveSendTime = Date.now();
+  lastSentValue = value;
+  setVolume(value);
 };
 
 const volumeUp = () => {
@@ -759,6 +829,7 @@ const onTouchMove = (event: TouchEvent) => {
 
     if (valueChanged) {
       vibrate(5);
+      sendVolumeLive(newValue);
     }
   }
 };
@@ -784,6 +855,7 @@ const onTouchEnd = (event: TouchEvent) => {
         clearTimeout(sliderUpdateDebounceTimeout);
         sliderUpdateDebounceTimeout = null;
       }
+      cancelLiveSend();
       displayValue.value = touchStartValue.value;
       emit("update:local-value", touchStartValue.value);
       handleGroupTap();
@@ -800,7 +872,8 @@ const onTouchEnd = (event: TouchEvent) => {
       }
     }
   } else if (!isSliderDisabled.value) {
-    // Drag end: send the final absolute value to the server
+    // Drag end: settle on the exact final value. The drag itself has already
+    // been sending, so this is usually a no-op.
     const touch = event.changedTouches[0];
     const finalValue = clamp(
       roundToStep(getPercentageFromX(touch.clientX)),
@@ -809,7 +882,7 @@ const onTouchEnd = (event: TouchEvent) => {
     );
     displayValue.value = finalValue;
     emit("update:local-value", finalValue);
-    setVolume(finalValue);
+    sendVolumeFinal(finalValue);
     stopDragging();
   }
 
@@ -900,17 +973,28 @@ const resetPointerInteraction = () => {
 
 const onTouchCancel = () => {
   collapseControlsSoon();
+  const wasDragging = isDrag.value;
   isDrag.value = false;
   isScrolling.value = false;
   touchMoveCount.value = 0;
   maxMovement.value = 0;
+  isTouching.value = false;
+
+  if (wasDragging) {
+    // The drag already changed the volume audibly, so an interruption settles
+    // where it left off rather than snapping back to the start.
+    sendVolumeFinal(displayValue.value);
+    stopDragging();
+    return;
+  }
+
+  cancelLiveSend();
   displayValue.value = touchStartValue.value;
   isDragging.value = false;
   if (dragEndTimeout) {
     clearTimeout(dragEndTimeout);
     dragEndTimeout = null;
   }
-  isTouching.value = false;
 };
 
 const onWheel = (event: WheelEvent) => {

--- a/src/layouts/default/PlayerOSD/PlayerVolume.vue
+++ b/src/layouts/default/PlayerOSD/PlayerVolume.vue
@@ -514,9 +514,10 @@ const liveSendThrottleMs = computed(() =>
     : LIVE_SEND_THROTTLE_MS,
 );
 let liveSendTimeout: ReturnType<typeof setTimeout> | null = null;
+// Both reset in startDragging: a fresh gesture sends at once rather than waiting
+// out the previous one's window, and an external volume change between drags can
+// never make its first send look redundant.
 let lastLiveSendTime = 0;
-// Scoped to one gesture (reset in startDragging) so an external volume change
-// between drags can never make a send look redundant.
 let lastSentValue: number | null = null;
 
 onUnmounted(() => {
@@ -538,6 +539,7 @@ const roundToStep = (value: number) =>
 const startDragging = () => {
   isDragging.value = true;
   lastSentValue = null;
+  lastLiveSendTime = 0;
   if (dragEndTimeout) {
     clearTimeout(dragEndTimeout);
     dragEndTimeout = null;
@@ -572,7 +574,12 @@ const cancelLiveSend = () => {
 // Sends straight away when the last send is old enough, otherwise schedules a
 // trailing send that picks up whatever the value has become by the time it fires.
 const sendVolumeLive = (value: number) => {
-  if (value === lastSentValue) return;
+  // Wandering back onto the value already sent leaves nothing to schedule, and
+  // any send still pending for the value in between is now moot.
+  if (value === lastSentValue) {
+    cancelLiveSend();
+    return;
+  }
 
   const throttleMs = liveSendThrottleMs.value;
   const elapsed = Date.now() - lastLiveSendTime;

--- a/src/layouts/default/PlayerOSD/PlayerVolume.vue
+++ b/src/layouts/default/PlayerOSD/PlayerVolume.vue
@@ -497,17 +497,14 @@ const SLIDER_UPDATE_DEBOUNCE_MS = 100;
 const POINTER_DRAG_THRESHOLD = 4;
 
 // Live drag updates: the volume follows the finger instead of waiting for
-// release. Throttled because every send is a separate websocket command, at the
-// same cadence the mouse path already gets from its debounce.
+// release. Throttled because every send is a separate websocket command.
 const LIVE_SEND_THROTTLE_MS = 100;
 const MAX_GROUP_LIVE_SEND_THROTTLE_MS = 500;
 
-// A group volume command is set on every member in parallel, and each member's
-// resulting state change is broadcast to every connected client, so the cost of
-// one command scales with the size of the group. Widening the window in step
-// keeps that traffic near what a single player costs. The cap is a deliberate
-// trade: past five members the traffic grows again, but a window longer than
-// half a second stops feeling like a drag.
+// A group command is applied to every member in parallel and each member's state
+// change is broadcast to every connected client, so one command costs about as
+// much as the group has members. Widening the window in step keeps that near
+// what a single player costs, capped so a large group still tracks the finger.
 const liveSendThrottleMs = computed(() =>
   useGroupVolume.value
     ? Math.min(
@@ -572,9 +569,8 @@ const cancelLiveSend = () => {
   }
 };
 
-// Called while a drag is still in progress. Sends straight away when the last
-// send is old enough, otherwise schedules a trailing send that picks up whatever
-// the value has become by the time it fires.
+// Sends straight away when the last send is old enough, otherwise schedules a
+// trailing send that picks up whatever the value has become by the time it fires.
 const sendVolumeLive = (value: number) => {
   if (value === lastSentValue) return;
 
@@ -597,8 +593,8 @@ const sendVolumeLive = (value: number) => {
   }, throttleMs - elapsed);
 };
 
-// Called on release. This value is authoritative, so it cancels any pending
-// throttled send rather than racing it.
+// Settles the gesture on this value, cancelling any pending throttled send
+// rather than racing it.
 const sendVolumeFinal = (value: number) => {
   cancelLiveSend();
   if (value === lastSentValue) return;
@@ -839,6 +835,9 @@ const onTouchEnd = (event: TouchEvent) => {
   // otherwise leave the slider latched open, to expand again on its own the
   // moment it comes back
   collapseControlsSoon();
+  // ahead of the guards too: every branch below settles the volume itself, so a
+  // throttled send must never outlive the gesture that queued it
+  cancelLiveSend();
   if (isSliderDisabled.value && !handlesGroupTap.value) return;
 
   if (isScrolling.value) {
@@ -855,7 +854,6 @@ const onTouchEnd = (event: TouchEvent) => {
         clearTimeout(sliderUpdateDebounceTimeout);
         sliderUpdateDebounceTimeout = null;
       }
-      cancelLiveSend();
       displayValue.value = touchStartValue.value;
       emit("update:local-value", touchStartValue.value);
       handleGroupTap();
@@ -872,8 +870,7 @@ const onTouchEnd = (event: TouchEvent) => {
       }
     }
   } else if (!isSliderDisabled.value) {
-    // Drag end: settle on the exact final value. The drag itself has already
-    // been sending, so this is usually a no-op.
+    // Drag end: settle on the exact value the finger lifted at
     const touch = event.changedTouches[0];
     const finalValue = clamp(
       roundToStep(getPercentageFromX(touch.clientX)),
@@ -980,9 +977,11 @@ const onTouchCancel = () => {
   maxMovement.value = 0;
   isTouching.value = false;
 
-  if (wasDragging) {
-    // The drag already changed the volume audibly, so an interruption settles
-    // where it left off rather than snapping back to the start.
+  // a disabled slider tracks the drag only to tell it apart from a tap, so it
+  // has no value to settle on
+  if (wasDragging && !isSliderDisabled.value) {
+    // The drag has already changed the volume audibly, so an interruption
+    // settles where it left off rather than snapping back to the start.
     sendVolumeFinal(displayValue.value);
     stopDragging();
     return;

--- a/tests/layouts/PlayerVolumeLiveDrag.test.ts
+++ b/tests/layouts/PlayerVolumeLiveDrag.test.ts
@@ -314,6 +314,44 @@ describe("PlayerVolume live volume while dragging", () => {
     );
   });
 
+  it("sends at once on a new drag instead of waiting out the previous window", async () => {
+    vi.useFakeTimers();
+    const { container, player } = mountVolume();
+    const touch = touchAt(container);
+
+    await touch.start(100);
+    await touch.move(140);
+    await touch.end(140);
+    expect(api.playerCommandVolumeSet).toHaveBeenCalledTimes(1);
+
+    // A second drag well inside the first window still responds immediately.
+    await vi.advanceTimersByTimeAsync(20);
+    await touch.start(140);
+    await touch.move(100);
+
+    expect(api.playerCommandVolumeSet).toHaveBeenCalledTimes(2);
+    expect(api.playerCommandVolumeSet).toHaveBeenLastCalledWith(
+      player.player_id,
+      50,
+    );
+  });
+
+  it("drops a pending send when the drag returns to the value already sent", async () => {
+    vi.useFakeTimers();
+    const { container } = mountVolume();
+    const touch = touchAt(container);
+
+    await touch.start(100);
+    await touch.move(140); // leading edge sends 70
+    expect(api.playerCommandVolumeSet).toHaveBeenCalledTimes(1);
+
+    await touch.move(150); // schedules a trailing send for 76
+    await touch.move(140); // back to 70, so that trailing send is moot
+
+    await vi.advanceTimersByTimeAsync(200);
+    expect(api.playerCommandVolumeSet).toHaveBeenCalledTimes(1);
+  });
+
   it("clears a pending send when the component unmounts mid-drag", async () => {
     vi.useFakeTimers();
     const { container, wrapper } = mountVolume();

--- a/tests/layouts/PlayerVolumeLiveDrag.test.ts
+++ b/tests/layouts/PlayerVolumeLiveDrag.test.ts
@@ -1,0 +1,374 @@
+import PlayerVolume from "@/layouts/default/PlayerOSD/PlayerVolume.vue";
+import { api } from "@/plugins/api";
+import {
+  IdentifierType,
+  PlaybackState,
+  type Player,
+  PlayerFeature,
+  PlayerType,
+} from "@/plugins/api/interfaces";
+import { enableAutoUnmount, mount } from "@vue/test-utils";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/plugins/api", async () => {
+  const { reactive } = await vi.importActual<typeof import("vue")>("vue");
+  const api = reactive({
+    players: {} as Record<string, Player>,
+    playerCommandGroupVolume: vi.fn(),
+    playerCommandVolumeSet: vi.fn(),
+    playerCommandVolumeUp: vi.fn(),
+    playerCommandVolumeDown: vi.fn(),
+    playerCommandMuteToggle: vi.fn(),
+  });
+  return { api, default: api };
+});
+
+vi.mock("@/plugins/store", () => ({
+  store: {
+    isTouchscreen: false,
+    mobileLayout: false,
+    currentUser: { user_id: "user", preferences: {} },
+  },
+}));
+
+vi.mock("@/helpers/utils", () => ({
+  getVolumeIconComponent: vi.fn(() => "span"),
+  truncateString: (value: string) => value,
+}));
+
+// The drag tests leave timers pending, so a leaked instance would keep firing
+// them into later tests.
+enableAutoUnmount(afterEach);
+
+const START_VOLUME = 30;
+// A 200px track makes the position arithmetic exact on the 2% step grid:
+// clientX 140 is 70% of the track.
+const SLIDER_WIDTH = 200;
+
+function createPlayer(overrides: Partial<Player> = {}): Player {
+  return {
+    player_id: "parent",
+    provider: "test",
+    type: PlayerType.PLAYER,
+    name: "Kitchen",
+    available: true,
+    device_info: {
+      model: "Test",
+      manufacturer: "Test",
+      software_version: null,
+      model_id: null,
+      manufacturer_id: null,
+      identifiers: {
+        [IdentifierType.MAC_ADDRESS]: "",
+        [IdentifierType.SERIAL_NUMBER]: "",
+        [IdentifierType.UUID]: "",
+        [IdentifierType.IP_ADDRESS]: "",
+        [IdentifierType.UNKNOWN]: "",
+      },
+    },
+    supported_features: [PlayerFeature.VOLUME_SET],
+    can_group_with: [],
+    enabled: true,
+    playback_state: PlaybackState.PLAYING,
+    powered: true,
+    volume_level: START_VOLUME,
+    volume_muted: false,
+    group_members: [],
+    static_group_members: [],
+    source_list: [],
+    sound_mode_list: [],
+    options: [],
+    group_volume: START_VOLUME,
+    group_volume_muted: false,
+    hide_in_ui: false,
+    icon: "speaker",
+    power_control: "power",
+    volume_control: "volume",
+    mute_control: "mute",
+    needs_setup: false,
+    has_setup_flow: false,
+    output_protocols: [],
+    active_output_protocol: null,
+    elapsed_time: null,
+    elapsed_time_last_updated: null,
+    current_media: null,
+    active_source: null,
+    active_sound_mode: null,
+    active_group: null,
+    synced_to: null,
+    sleep_timer_expires_at: null,
+    ...overrides,
+  };
+}
+
+function mountVolume(
+  props: Record<string, unknown> = {},
+  player: Player = createPlayer(),
+) {
+  if (!api.players[player.player_id]) {
+    api.players = { [player.player_id]: player };
+  }
+
+  const wrapper = mount(PlayerVolume, {
+    props: { player, ...props },
+    global: {
+      stubs: {
+        Slider: {
+          emits: ["update:modelValue"],
+          template: `<div data-slot="slider" role="slider" />`,
+        },
+      },
+    },
+  });
+
+  // happy-dom reports a zero-width rect, which would make every position
+  // calculation divide by zero. Give the container a real width instead.
+  const container = wrapper.find(".player-volume-container");
+  (container.element as HTMLElement).getBoundingClientRect = () =>
+    ({
+      left: 0,
+      top: 0,
+      right: SLIDER_WIDTH,
+      bottom: 40,
+      width: SLIDER_WIDTH,
+      height: 40,
+      x: 0,
+      y: 0,
+      toJSON: () => ({}),
+    }) as DOMRect;
+
+  return { wrapper, container, player };
+}
+
+const touchAt = (container: ReturnType<typeof mountVolume>["container"]) => ({
+  start: (clientX: number) =>
+    container.trigger("touchstart", { touches: [{ clientX, clientY: 10 }] }),
+  move: (clientX: number) =>
+    container.trigger("touchmove", { touches: [{ clientX, clientY: 10 }] }),
+  end: (clientX: number) =>
+    container.trigger("touchend", {
+      changedTouches: [{ clientX, clientY: 10 }],
+    }),
+});
+
+const shownVolume = (wrapper: ReturnType<typeof mountVolume>["wrapper"]) =>
+  Number(wrapper.find(".volume-level-text").text());
+
+describe("PlayerVolume live volume while dragging", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    api.players = {};
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("sends during a touch drag rather than only on release", async () => {
+    const { container, player } = mountVolume();
+    const touch = touchAt(container);
+
+    await touch.start(100);
+    await touch.move(140);
+
+    // Already sent, with no touchend yet: 140/200 of the track.
+    expect(api.playerCommandVolumeSet).toHaveBeenCalledWith(
+      player.player_id,
+      70,
+    );
+  });
+
+  it("settles on the exact final value on release", async () => {
+    const { container, wrapper, player } = mountVolume();
+    const touch = touchAt(container);
+
+    await touch.start(100);
+    await touch.move(140);
+    await touch.end(150);
+
+    expect(shownVolume(wrapper)).toBe(76);
+    expect(api.playerCommandVolumeSet).toHaveBeenLastCalledWith(
+      player.player_id,
+      76,
+    );
+  });
+
+  it("does not repeat the value already sent when the drag ends where it was", async () => {
+    const { container } = mountVolume();
+    const touch = touchAt(container);
+
+    await touch.start(100);
+    await touch.move(140);
+    await touch.end(140);
+
+    expect(api.playerCommandVolumeSet).toHaveBeenCalledTimes(1);
+  });
+
+  it("sends nothing for a tap that never becomes a drag", async () => {
+    const child = createPlayer({ player_id: "child", name: "Office" });
+    const parent = createPlayer({ group_members: ["parent", "child"] });
+    api.players = { parent, child };
+
+    const { container, wrapper } = mountVolume(
+      {
+        preferGroupVolume: true,
+        enablePopout: false,
+        requestExpandOnGroupTap: true,
+      },
+      parent,
+    );
+    const touch = touchAt(container);
+
+    await touch.start(100);
+    await touch.end(100);
+
+    expect(wrapper.emitted("toggle-group-expansion")).toHaveLength(1);
+    expect(api.playerCommandGroupVolume).not.toHaveBeenCalled();
+  });
+
+  it("settles at the dragged value when the drag is cancelled", async () => {
+    const { container, wrapper, player } = mountVolume();
+    const touch = touchAt(container);
+
+    await touch.start(100);
+    await touch.move(140);
+    await container.trigger("touchcancel");
+
+    // Previously a cancel reverted to the value the drag started from. The
+    // volume has already changed audibly, so it stays where it left off.
+    expect(shownVolume(wrapper)).toBe(70);
+    expect(api.playerCommandVolumeSet).toHaveBeenLastCalledWith(
+      player.player_id,
+      70,
+    );
+  });
+
+  it("throttles to one send per 100ms while the drag continues", async () => {
+    vi.useFakeTimers();
+    const { container, player } = mountVolume();
+    const touch = touchAt(container);
+
+    await touch.start(100);
+    // Leading edge goes out immediately.
+    await touch.move(140);
+    expect(api.playerCommandVolumeSet).toHaveBeenCalledTimes(1);
+
+    // Inside the window: held, not sent.
+    await touch.move(150);
+    expect(api.playerCommandVolumeSet).toHaveBeenCalledTimes(1);
+
+    // The trailing edge lands at 100ms with the latest position.
+    await vi.advanceTimersByTimeAsync(100);
+    expect(api.playerCommandVolumeSet).toHaveBeenCalledTimes(2);
+    expect(api.playerCommandVolumeSet).toHaveBeenLastCalledWith(
+      player.player_id,
+      76,
+    );
+  });
+
+  it("clears a pending send when the component unmounts mid-drag", async () => {
+    vi.useFakeTimers();
+    const { container, wrapper } = mountVolume();
+    const touch = touchAt(container);
+
+    await touch.start(100);
+    await touch.move(140);
+    await touch.move(150); // schedules a trailing send
+    wrapper.unmount();
+
+    const callsAtUnmount = (
+      api.playerCommandVolumeSet as unknown as { mock: { calls: unknown[] } }
+    ).mock.calls.length;
+    await vi.advanceTimersByTimeAsync(200);
+
+    expect(api.playerCommandVolumeSet).toHaveBeenCalledTimes(callsAtUnmount);
+  });
+});
+
+// One group volume command is set on every member in parallel and each member's
+// state change is broadcast to every client, so the window widens with the group.
+describe("PlayerVolume live send throttle on a group", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    api.players = {};
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  function mountGroup(memberCount: number) {
+    const ids = Array.from({ length: memberCount - 1 }, (_, i) => `child${i}`);
+    const parent = createPlayer({ group_members: ["parent", ...ids] });
+    api.players = { parent };
+    for (const id of ids) {
+      api.players[id] = createPlayer({ player_id: id, name: `Player ${id}` });
+    }
+    // childPlayers includes the leader itself for a sync leader, so a two-member
+    // group is the parent plus one child.
+    return mountVolume(
+      { preferGroupVolume: true, enablePopout: false },
+      parent,
+    );
+  }
+
+  it("widens the window to 200ms for a two-member group", async () => {
+    vi.useFakeTimers();
+    const { container, player } = mountGroup(2);
+    const touch = touchAt(container);
+
+    await touch.start(100);
+    await touch.move(140);
+    expect(api.playerCommandGroupVolume).toHaveBeenCalledTimes(1);
+
+    await touch.move(150);
+    // A single player would have sent again by now; a two-member group must not.
+    await vi.advanceTimersByTimeAsync(100);
+    expect(api.playerCommandGroupVolume).toHaveBeenCalledTimes(1);
+
+    // The trailing edge lands at 200ms instead.
+    await vi.advanceTimersByTimeAsync(100);
+    expect(api.playerCommandGroupVolume).toHaveBeenCalledTimes(2);
+    expect(api.playerCommandGroupVolume).toHaveBeenLastCalledWith(
+      player.player_id,
+      76,
+    );
+  });
+
+  it("caps the window at 500ms however large the group", async () => {
+    vi.useFakeTimers();
+    const { container } = mountGroup(8);
+    const touch = touchAt(container);
+
+    await touch.start(100);
+    await touch.move(140);
+    expect(api.playerCommandGroupVolume).toHaveBeenCalledTimes(1);
+
+    await touch.move(150);
+    // Uncapped this would be 800ms, so nothing at 400ms...
+    await vi.advanceTimersByTimeAsync(400);
+    expect(api.playerCommandGroupVolume).toHaveBeenCalledTimes(1);
+
+    // ...and the trailing send at 500ms rather than waiting out 800ms.
+    await vi.advanceTimersByTimeAsync(100);
+    expect(api.playerCommandGroupVolume).toHaveBeenCalledTimes(2);
+  });
+
+  it("still sends immediately on release despite the wider window", async () => {
+    vi.useFakeTimers();
+    const { container, player } = mountGroup(4);
+    const touch = touchAt(container);
+
+    await touch.start(100);
+    await touch.move(140);
+    await touch.move(150);
+    // Release without advancing timers: sendVolumeFinal bypasses the throttle.
+    await touch.end(150);
+
+    expect(api.playerCommandGroupVolume).toHaveBeenCalledTimes(2);
+    expect(api.playerCommandGroupVolume).toHaveBeenLastCalledWith(
+      player.player_id,
+      76,
+    );
+  });
+});

--- a/tests/layouts/PlayerVolumeLiveDrag.test.ts
+++ b/tests/layouts/PlayerVolumeLiveDrag.test.ts
@@ -1,5 +1,5 @@
 import PlayerVolume from "@/layouts/default/PlayerOSD/PlayerVolume.vue";
-import { api } from "@/plugins/api";
+import { api, type MusicAssistantApi } from "@/plugins/api";
 import {
   IdentifierType,
   PlaybackState,
@@ -14,11 +14,15 @@ vi.mock("@/plugins/api", async () => {
   const { reactive } = await vi.importActual<typeof import("vue")>("vue");
   const api = reactive({
     players: {} as Record<string, Player>,
-    playerCommandGroupVolume: vi.fn(),
-    playerCommandVolumeSet: vi.fn(),
-    playerCommandVolumeUp: vi.fn(),
-    playerCommandVolumeDown: vi.fn(),
-    playerCommandMuteToggle: vi.fn(),
+    playerCommandGroupVolume:
+      vi.fn<MusicAssistantApi["playerCommandGroupVolume"]>(),
+    playerCommandVolumeSet:
+      vi.fn<MusicAssistantApi["playerCommandVolumeSet"]>(),
+    playerCommandVolumeUp: vi.fn<MusicAssistantApi["playerCommandVolumeUp"]>(),
+    playerCommandVolumeDown:
+      vi.fn<MusicAssistantApi["playerCommandVolumeDown"]>(),
+    playerCommandMuteToggle:
+      vi.fn<MusicAssistantApi["playerCommandMuteToggle"]>(),
   });
   return { api, default: api };
 });
@@ -234,13 +238,57 @@ describe("PlayerVolume live volume while dragging", () => {
     await touch.move(140);
     await container.trigger("touchcancel");
 
-    // Previously a cancel reverted to the value the drag started from. The
-    // volume has already changed audibly, so it stays where it left off.
+    // The volume has already changed audibly, so it stays where it left off
+    // rather than snapping back to the start.
     expect(shownVolume(wrapper)).toBe(70);
     expect(api.playerCommandVolumeSet).toHaveBeenLastCalledWith(
       player.player_id,
       70,
     );
+  });
+
+  it("does not let a pending send follow the cancel that settled the drag", async () => {
+    vi.useFakeTimers();
+    const { container } = mountVolume();
+    const touch = touchAt(container);
+
+    await touch.start(100);
+    await touch.move(140);
+    await touch.move(150); // schedules a trailing send
+    await container.trigger("touchcancel");
+
+    const callsAtCancel = vi.mocked(api.playerCommandVolumeSet).mock.calls
+      .length;
+    await vi.advanceTimersByTimeAsync(200);
+
+    expect(api.playerCommandVolumeSet).toHaveBeenCalledTimes(callsAtCancel);
+  });
+
+  it("sends nothing when a swipe on a muted group slider is cancelled", async () => {
+    const child = createPlayer({ player_id: "child", name: "Office" });
+    const parent = createPlayer({
+      group_members: ["parent", "child"],
+      group_volume_muted: true,
+    });
+    api.players = { parent, child };
+
+    const { container } = mountVolume(
+      {
+        preferGroupVolume: true,
+        enablePopout: false,
+        requestExpandOnGroupTap: true,
+      },
+      parent,
+    );
+    const touch = touchAt(container);
+
+    // A muted slider still tracks the swipe so it can tell a drag from a tap,
+    // but there is no value for the cancel to settle on.
+    await touch.start(100);
+    await touch.move(140);
+    await container.trigger("touchcancel");
+
+    expect(api.playerCommandGroupVolume).not.toHaveBeenCalled();
   });
 
   it("throttles to one send per 100ms while the drag continues", async () => {
@@ -276,9 +324,8 @@ describe("PlayerVolume live volume while dragging", () => {
     await touch.move(150); // schedules a trailing send
     wrapper.unmount();
 
-    const callsAtUnmount = (
-      api.playerCommandVolumeSet as unknown as { mock: { calls: unknown[] } }
-    ).mock.calls.length;
+    const callsAtUnmount = vi.mocked(api.playerCommandVolumeSet).mock.calls
+      .length;
     await vi.advanceTimersByTimeAsync(200);
 
     expect(api.playerCommandVolumeSet).toHaveBeenCalledTimes(callsAtUnmount);


### PR DESCRIPTION
# What does this implement/fix?

Dragging the volume slider on a phone moves the thumb, but the volume itself only
changes once you lift your finger. You drag, hear nothing, let go, and the speaker
jumps to wherever you ended up. This makes the volume follow the drag, so you hear
what you are doing while you are doing it — and can correct it before releasing.

Touch drags only. Mouse and keyboard behaviour is unchanged, and a tap either side
of the handle still steps the volume up or down exactly as before.

**Related issue (if applicable):**

- n/a

**Related backend PR (if applicable):**

- n/a

## Changes

- The volume is sent while a touch drag is in progress, at most once every 100ms.
- For a group, the window widens with the number of members (capped at 500ms), so a
  group drag costs about what a single-player drag costs.
- Releasing settles on the exact final value immediately, without waiting for the
  throttle.
- A drag interrupted by the system (an incoming call, the notification shade) keeps
  the volume where it got to instead of snapping back, since it has already changed
  audibly by that point.
- A cancelled swipe on a muted slider stays silent — it tracks the swipe only to
  tell a drag from a tap.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm lint:check` passes.
- [x] `pnpm test:run` passes, and tests have been added/updated where applicable.
- [x] `pnpm build` passes.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.

---

Note for maintainers: `cmd_group_volume` on the server has no `PlayerLockPurpose.VOLUME`
lock, unlike `cmd_volume_set`, so several group commands can be in flight per device
with no ordering guarantee. Not introduced here and bounded in effect, but worth a
separate server-side follow-up now that a drag issues more than one command.
