### PR TITLE
Lay a phone out as a phone when it is turned on its side

### DIFF
--- a/src/components/ui/sidebar/SidebarProvider.vue
+++ b/src/components/ui/sidebar/SidebarProvider.vue
@@ -1,12 +1,8 @@
 <script setup lang="ts">
 import { cn } from "@/lib/utils";
+import { isPhoneSizedScreen } from "@/plugins/breakpoint";
 import { store } from "@/plugins/store";
-import {
-  defaultDocument,
-  useEventListener,
-  useMediaQuery,
-  useVModel,
-} from "@vueuse/core";
+import { defaultDocument, useEventListener, useVModel } from "@vueuse/core";
 import { TooltipProvider } from "reka-ui";
 import type { HTMLAttributes, Ref } from "vue";
 import { computed, ref } from "vue";
@@ -38,9 +34,11 @@ const emits = defineEmits<{
   "update:open": [open: boolean];
 }>();
 
-const isMobileScreen = useMediaQuery("(max-width: 768px)");
+// a phone on its side has the width for a sidebar and none of the height, so
+// the screen has to be phone-sized in neither direction for one to stay open.
+// A tablet keeps its sidebar, which is why this is not store.mobileLayout
 const isMobile = computed(
-  () => isMobileScreen.value || !!store.forceMobileLayout,
+  () => isPhoneSizedScreen() || !!store.forceMobileLayout,
 );
 const openMobile = ref(false);
 

--- a/src/components/ui/sidebar/SidebarProvider.vue
+++ b/src/components/ui/sidebar/SidebarProvider.vue
@@ -35,8 +35,10 @@ const emits = defineEmits<{
 }>();
 
 // a phone on its side has the width for a sidebar and none of the height, so
-// the sidebar goes wherever the screen is phone-sized rather than merely
-// narrow. A tablet keeps its sidebar, which is why this is not store.mobileLayout
+// the sidebar goes wherever the screen is phone-sized rather than merely narrow.
+// A tablet is measured here rather than taken at its word, which is why this is
+// not store.mobileLayout: one with the room for a sidebar keeps it, and a narrow
+// one in portrait folds it away
 const isMobile = computed(
   () => isPhoneSizedScreen() || !!store.forceMobileLayout,
 );

--- a/src/components/ui/sidebar/SidebarProvider.vue
+++ b/src/components/ui/sidebar/SidebarProvider.vue
@@ -35,8 +35,8 @@ const emits = defineEmits<{
 }>();
 
 // a phone on its side has the width for a sidebar and none of the height, so
-// the screen has to be phone-sized in neither direction for one to stay open.
-// A tablet keeps its sidebar, which is why this is not store.mobileLayout
+// the sidebar goes wherever the screen is phone-sized rather than merely
+// narrow. A tablet keeps its sidebar, which is why this is not store.mobileLayout
 const isMobile = computed(
   () => isPhoneSizedScreen() || !!store.forceMobileLayout,
 );

--- a/src/plugins/breakpoint.ts
+++ b/src/plugins/breakpoint.ts
@@ -35,11 +35,36 @@ const breakpoints: { [key in Breakpoints]: number } = {
   bp12: 415,
 };
 
-const state = reactive({ width: window.innerWidth });
+const state = reactive({
+  width: window.innerWidth,
+  height: window.innerHeight,
+});
 
 window.addEventListener("resize", () => {
   state.width = window.innerWidth;
+  state.height = window.innerHeight;
 });
+
+/** Width up to which the screen is laid out for a phone. */
+const PHONE_LAYOUT_WIDTH = 769;
+
+/**
+ * Height below which there is no room to lay out for a desktop whatever the
+ * width. A phone on its side is what this catches: wide enough to pass for a
+ * desktop, nowhere near tall enough to be one.
+ */
+const PHONE_LAYOUT_HEIGHT = 500;
+
+/**
+ * Whether the screen is phone-sized, by its own account or by either dimension.
+ *
+ * Reactive: reading this inside a computed re-runs it as the screen resizes or
+ * turns.
+ */
+export const isPhoneSizedScreen = () =>
+  IS_PHONE_UA ||
+  state.width < PHONE_LAYOUT_WIDTH ||
+  state.height < PHONE_LAYOUT_HEIGHT;
 
 type Condition = "lt" | "gt";
 type Key =

--- a/src/plugins/breakpoint.ts
+++ b/src/plugins/breakpoint.ts
@@ -1,5 +1,10 @@
 import { App, reactive, toRefs, watch, Directive } from "vue";
-import { IS_MOBILE_UA, IS_PHONE_UA, IS_TABLET_UA } from "@/helpers/device";
+import {
+  DEVICE_TYPE,
+  IS_MOBILE_UA,
+  IS_PHONE_UA,
+  IS_TABLET_UA,
+} from "@/helpers/device";
 
 type MobileDeviceType = "mobile" | "phone" | "tablet";
 
@@ -49,22 +54,29 @@ window.addEventListener("resize", () => {
 const PHONE_LAYOUT_WIDTH = 769;
 
 /**
- * Height below which there is no room to lay out for a desktop whatever the
- * width. A phone on its side is what this catches: wide enough to pass for a
- * desktop, nowhere near tall enough to be one.
+ * The screen a phone on its side presents: too short to lay out for a desktop,
+ * and no wider than a phone ever gets (the largest reach about 960).
+ *
+ * The width is what keeps a short but wide window out of it. The mobile layout
+ * reserves more than twice the room at the bottom of the screen that the
+ * desktop one does, so applying it there would cost more height than the
+ * sidebar it saves.
  */
-const PHONE_LAYOUT_HEIGHT = 500;
+const PHONE_LANDSCAPE_HEIGHT = 500;
+const PHONE_LANDSCAPE_WIDTH = 1100;
 
 /**
- * Whether the screen is phone-sized, by its own account or by either dimension.
+ * Whether the screen is phone-sized: a phone by its own account, too narrow to
+ * lay out for a desktop, or the short wide screen a phone on its side presents.
  *
  * Reactive: reading this inside a computed re-runs it as the screen resizes or
  * turns.
  */
 export const isPhoneSizedScreen = () =>
-  IS_PHONE_UA ||
+  DEVICE_TYPE === "phone" ||
   state.width < PHONE_LAYOUT_WIDTH ||
-  state.height < PHONE_LAYOUT_HEIGHT;
+  (state.height < PHONE_LANDSCAPE_HEIGHT &&
+    state.width < PHONE_LANDSCAPE_WIDTH);
 
 type Condition = "lt" | "gt";
 type Key =

--- a/src/plugins/store.ts
+++ b/src/plugins/store.ts
@@ -11,6 +11,7 @@ import {
 import type { StoredState } from "@/components/ItemsListing.vue";
 import {
   DEVICE_TYPE,
+  IS_TABLET_UA,
   isTouchscreenDevice,
   type DeviceType,
 } from "@/helpers/device";
@@ -19,7 +20,7 @@ import { parseBool } from "@/helpers/parse";
 import api from "./api";
 import { resolvePlayerQueue } from "./api/helpers";
 
-import { getBreakpointValue, isPhoneSizedScreen } from "./breakpoint";
+import { isPhoneSizedScreen } from "./breakpoint";
 
 interface Store {
   activePlayerId?: string;
@@ -92,13 +93,14 @@ export const store: Store = reactive({
   isTouchscreen: isTouchscreenDevice(),
   playMenuShown: false,
   deviceType: DEVICE_TYPE,
-  mobileLayout: computed(() => {
-    const isTablet = getBreakpointValue({ breakpoint: "tablet" });
-
-    return (
-      isPhoneSizedScreen() || isTablet || parseBool(store.forceMobileLayout)
-    );
-  }),
+  // a tablet has the screen for a desktop layout and is laid out for touch all
+  // the same, so it is taken at its word rather than measured
+  mobileLayout: computed(
+    () =>
+      isPhoneSizedScreen() ||
+      IS_TABLET_UA ||
+      parseBool(store.forceMobileLayout),
+  ),
   currentUser: undefined,
   serverInfo: undefined,
   isIngressSession: computed(() =>

--- a/src/plugins/store.ts
+++ b/src/plugins/store.ts
@@ -19,7 +19,7 @@ import { parseBool } from "@/helpers/parse";
 import api from "./api";
 import { resolvePlayerQueue } from "./api/helpers";
 
-import { getBreakpointValue } from "./breakpoint";
+import { getBreakpointValue, isPhoneSizedScreen } from "./breakpoint";
 
 interface Store {
   activePlayerId?: string;
@@ -93,15 +93,10 @@ export const store: Store = reactive({
   playMenuShown: false,
   deviceType: DEVICE_TYPE,
   mobileLayout: computed(() => {
-    const isMobileDevice = getBreakpointValue({ breakpoint: "tablet" });
-    const isNarrowScreen = getBreakpointValue({
-      breakpoint: "bp5",
-      condition: "lt",
-      offset: -31, // bp5 (800px) - 31 ≈ 769px
-    });
+    const isTablet = getBreakpointValue({ breakpoint: "tablet" });
 
     return (
-      isMobileDevice || isNarrowScreen || parseBool(store.forceMobileLayout)
+      isPhoneSizedScreen() || isTablet || parseBool(store.forceMobileLayout)
     );
   }),
   currentUser: undefined,

--- a/tests/plugins/breakpoint.test.ts
+++ b/tests/plugins/breakpoint.test.ts
@@ -185,12 +185,21 @@ describe("isPhoneSizedScreen", () => {
     },
   );
 
-  // a tablet has the room for a desktop layout, so it is decided elsewhere
-  it("leaves a tablet to be judged on its screen", async () => {
-    expect(
-      await isPhoneSized(DESKTOP, { IS_TABLET_UA: true, IS_MOBILE_UA: true }),
-    ).toBe(false);
-  });
+  // A tablet is only taken at its word where the layout is decided; here it is
+  // measured like anything else, so a narrow one in portrait reads as
+  // phone-sized and folds its sidebar away, as it did before this predicate.
+  it.each([
+    ["a screen with the room for a desktop", DESKTOP, false],
+    ["a large tablet in portrait", { width: 834, height: 1194 }, false],
+    ["a narrow tablet in portrait", { width: 768, height: 1024 }, true],
+  ])(
+    "measures %s rather than taking the tablet at its word",
+    async (_, screen, expected) => {
+      expect(
+        await isPhoneSized(screen, { IS_TABLET_UA: true, IS_MOBILE_UA: true }),
+      ).toBe(expected);
+    },
+  );
 
   // The mobile layout gives up more room at the bottom of the screen than the
   // desktop one, so a short window only gains by it while it is phone-narrow.

--- a/tests/plugins/breakpoint.test.ts
+++ b/tests/plugins/breakpoint.test.ts
@@ -37,7 +37,19 @@ async function loadModule(
     configurable: true,
   });
   vi.resetModules();
-  vi.doMock("@/helpers/device", () => ({ ...NO_FLAGS, ...flags }));
+  vi.doMock("@/helpers/device", () => {
+    const ua = { ...NO_FLAGS, ...flags };
+    // mirrors how the real module ranks the flags, so a user agent that only
+    // says "mobile" still stands for a phone here
+    return {
+      ...ua,
+      DEVICE_TYPE: ua.IS_TABLET_UA
+        ? "tablet"
+        : ua.IS_PHONE_UA || ua.IS_MOBILE_UA
+          ? "phone"
+          : "desktop",
+    };
+  });
   return await import("@/plugins/breakpoint");
 }
 
@@ -164,20 +176,54 @@ describe("isPhoneSizedScreen", () => {
     expect(await isPhoneSized(PHONE_LANDSCAPE)).toBe(true);
   });
 
-  it("takes the device at its word whatever the screen measures", async () => {
-    expect(await isPhoneSized(DESKTOP, { IS_PHONE_UA: true })).toBe(true);
-  });
+  // Android reports only "mobile" — no browser there still names the model the
+  // phone check wants — so taking the device at its word has to mean that too
+  it.each([{ IS_PHONE_UA: true }, { IS_MOBILE_UA: true }])(
+    "takes the device at its word whatever the screen measures (%o)",
+    async (flags) => {
+      expect(await isPhoneSized(DESKTOP, flags)).toBe(true);
+    },
+  );
 
   // a tablet has the room for a desktop layout, so it is decided elsewhere
   it("leaves a tablet to be judged on its screen", async () => {
-    expect(await isPhoneSized(DESKTOP, { IS_TABLET_UA: true })).toBe(false);
+    expect(
+      await isPhoneSized(DESKTOP, { IS_TABLET_UA: true, IS_MOBILE_UA: true }),
+    ).toBe(false);
+  });
+
+  // The mobile layout gives up more room at the bottom of the screen than the
+  // desktop one, so a short window only gains by it while it is phone-narrow.
+  it("leaves a window that is short but far wider than a phone alone", async () => {
+    expect(await isPhoneSized({ width: 1600, height: 430 })).toBe(false);
   });
 
   it.each([
     ["width", { width: 769, height: 900 }, { width: 768, height: 900 }],
-    ["height", { width: 1280, height: 500 }, { width: 1280, height: 499 }],
+    ["height", { width: 1000, height: 500 }, { width: 1000, height: 499 }],
+    [
+      "width a short screen may reach",
+      { width: 1100, height: 430 },
+      { width: 1099, height: 430 },
+    ],
   ])("takes the %s up to its limit but not past it", async (_, over, under) => {
     expect(await isPhoneSized(over)).toBe(false);
     expect(await isPhoneSized(under)).toBe(true);
+  });
+
+  // the resize handler is the only thing keeping the height current, and every
+  // other case here loads the module with the screen already at its size
+  it("follows the screen as it turns", async () => {
+    const { isPhoneSizedScreen } = await loadModule(1000, {}, 900);
+    expect(isPhoneSizedScreen()).toBe(false);
+
+    Object.defineProperty(window, "innerHeight", {
+      value: 430,
+      writable: true,
+      configurable: true,
+    });
+    window.dispatchEvent(new Event("resize"));
+
+    expect(isPhoneSizedScreen()).toBe(true);
   });
 });

--- a/tests/plugins/breakpoint.test.ts
+++ b/tests/plugins/breakpoint.test.ts
@@ -15,31 +15,54 @@ const NO_FLAGS: UserAgentFlags = {
   IS_TABLET_UA: false,
 };
 
+// tall enough that the height never decides anything on its own
+const DESKTOP_HEIGHT = 900;
+
 /**
- * Load a fresh breakpoint plugin for the given viewport width and user agent flags.
+ * Load a fresh breakpoint plugin for the given viewport and user agent flags.
  */
-async function loadBreakpoint(
+async function loadModule(
   width: number,
   flags: Partial<UserAgentFlags> = {},
+  height: number = DESKTOP_HEIGHT,
 ) {
   Object.defineProperty(window, "innerWidth", {
     value: width,
     writable: true,
     configurable: true,
   });
+  Object.defineProperty(window, "innerHeight", {
+    value: height,
+    writable: true,
+    configurable: true,
+  });
   vi.resetModules();
   vi.doMock("@/helpers/device", () => ({ ...NO_FLAGS, ...flags }));
-  return (await import("@/plugins/breakpoint")).getBreakpointValue;
+  return await import("@/plugins/breakpoint");
+}
+
+async function loadBreakpoint(
+  width: number,
+  flags: Partial<UserAgentFlags> = {},
+) {
+  return (await loadModule(width, flags)).getBreakpointValue;
 }
 
 const originalInnerWidth = Object.getOwnPropertyDescriptor(
   window,
   "innerWidth",
 );
+const originalInnerHeight = Object.getOwnPropertyDescriptor(
+  window,
+  "innerHeight",
+);
 
 afterEach(() => {
   if (originalInnerWidth) {
     Object.defineProperty(window, "innerWidth", originalInnerWidth);
+  }
+  if (originalInnerHeight) {
+    Object.defineProperty(window, "innerHeight", originalInnerHeight);
   }
   vi.doUnmock("@/helpers/device");
   vi.resetModules();
@@ -110,5 +133,51 @@ describe("getBreakpointValue", () => {
 
       expect(getBreakpointValue({ breakpoint: "tablet" })).toBe(true);
     });
+  });
+});
+
+describe("isPhoneSizedScreen", () => {
+  // the two dimensions carry values that are nowhere near each other, so a
+  // screen measured on the wrong one reads as the wrong answer
+  const DESKTOP = { width: 1280, height: 900 };
+  // a phone on its side: wide enough to pass for a desktop, far too short
+  const PHONE_LANDSCAPE = { width: 932, height: 430 };
+  const PHONE_PORTRAIT = { width: 430, height: 932 };
+
+  async function isPhoneSized(
+    { width, height }: { width: number; height: number },
+    flags: Partial<UserAgentFlags> = {},
+  ) {
+    return (await loadModule(width, flags, height)).isPhoneSizedScreen();
+  }
+
+  it("leaves a desktop alone", async () => {
+    expect(await isPhoneSized(DESKTOP)).toBe(false);
+  });
+
+  it("catches a narrow screen", async () => {
+    expect(await isPhoneSized(PHONE_PORTRAIT)).toBe(true);
+  });
+
+  // the case a width-only rule misses, and the reason the height is read at all
+  it("catches a screen too short to lay out for a desktop", async () => {
+    expect(await isPhoneSized(PHONE_LANDSCAPE)).toBe(true);
+  });
+
+  it("takes the device at its word whatever the screen measures", async () => {
+    expect(await isPhoneSized(DESKTOP, { IS_PHONE_UA: true })).toBe(true);
+  });
+
+  // a tablet has the room for a desktop layout, so it is decided elsewhere
+  it("leaves a tablet to be judged on its screen", async () => {
+    expect(await isPhoneSized(DESKTOP, { IS_TABLET_UA: true })).toBe(false);
+  });
+
+  it.each([
+    ["width", { width: 769, height: 900 }, { width: 768, height: 900 }],
+    ["height", { width: 1280, height: 500 }, { width: 1280, height: 499 }],
+  ])("takes the %s up to its limit but not past it", async (_, over, under) => {
+    expect(await isPhoneSized(over)).toBe(false);
+    expect(await isPhoneSized(under)).toBe(true);
   });
 });


### PR DESCRIPTION
# What does this implement/fix?

A phone turned on its side is wide enough to be taken for a desktop, so it got the full desktop layout: a permanent sidebar eating a third of the screen and the desktop player bar, in a window with nowhere near the height for either. The result was unusable.

The layout already does the right thing for a tablet — it follows the device, in any orientation — but never consulted the phone flag, so only the width decided. This adds the device and the screen height to that decision, and points the sidebar at the same answer so the two cannot disagree.

A tablet keeps its sidebar, as before.

**Related issue (if applicable):**

- n/a

**Related backend PR (if applicable):**

- n/a

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

### Changes

- Treat a screen as phone-sized when the device reports a phone, or when either dimension is too small for a desktop layout
- Collapse the sidebar into its slide-out panel on those screens, from the same answer the rest of the layout uses

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm lint:check` passes.
- [x] `pnpm test:run` passes, and tests have been added/updated where applicable.
- [x] `pnpm build` passes.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
