### PR TITLE
AI Radio: host presets, a per-host language, and a usable segment editor on mobile

### DIFF
--- a/src/components/ai-radio/CustomizeHost.vue
+++ b/src/components/ai-radio/CustomizeHost.vue
@@ -255,16 +255,19 @@ const voiceSelectValue = computed({
   },
 });
 
+// Canonical option values ("el_GR" -> "el-GR") so a stored language matches the
+// option it was picked from, and the server receives a BCP-47 tag.
 const languageOptions = computed(() =>
-  getLocaleOptions(i18n.global.availableLocales, i18n.global.locale.value),
+  getLocaleOptions(i18n.global.availableLocales, i18n.global.locale.value).map(
+    (option) => ({ ...option, value: canonicalizeLocale(option.value) }),
+  ),
 );
 
 const languageSelectValue = computed({
   get: () => draft.value?.language || NONE_SELECT_VALUE,
   set: (value: string) => {
     if (!draft.value) return;
-    draft.value.language =
-      value === NONE_SELECT_VALUE ? "" : canonicalizeLocale(value);
+    draft.value.language = value === NONE_SELECT_VALUE ? "" : value;
   },
 });
 

--- a/src/components/ai-radio/CustomizeHost.vue
+++ b/src/components/ai-radio/CustomizeHost.vue
@@ -88,6 +88,30 @@
               </SelectContent>
             </Select>
           </div>
+
+          <div class="flex flex-col gap-1.5">
+            <FieldLabel
+              html-for="customize-host-language"
+              :label="$t('providers.ai_radio.fields.language')"
+            />
+            <Select v-model="languageSelectValue">
+              <SelectTrigger id="customize-host-language" class="w-full">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem :value="NONE_SELECT_VALUE">
+                  {{ $t("providers.ai_radio.hosts.editor.default_language") }}
+                </SelectItem>
+                <SelectItem
+                  v-for="option in languageOptions"
+                  :key="option.value"
+                  :value="option.value"
+                >
+                  {{ option.label }}
+                </SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
         </CardContent>
       </Card>
 
@@ -183,7 +207,7 @@ import {
   type ShowSegment,
 } from "@/helpers/ai_radio";
 import { eventbus } from "@/plugins/eventbus";
-import { $t } from "@/plugins/i18n";
+import { $t, canonicalizeLocale, getLocaleOptions, i18n } from "@/plugins/i18n";
 import { ArrowLeft, Loader2, Plus } from "@lucide/vue";
 import { computed, onMounted, ref } from "vue";
 import { onBeforeRouteLeave, useRouter } from "vue-router";
@@ -192,6 +216,8 @@ import { toast } from "vue-sonner";
 const props = defineProps<{
   /** Existing host id to edit; omit (or empty) to create a new host. */
   hostId?: string;
+  /** Pre-filled unsaved draft to seed a new host from (e.g. a persona preset); ignored when hostId is set. */
+  presetDraft?: HostDraft;
 }>();
 
 const emit = defineEmits<{
@@ -226,6 +252,19 @@ const voiceSelectValue = computed({
   set: (value: string) => {
     if (!draft.value) return;
     draft.value.ttsEngine = value === NONE_SELECT_VALUE ? "" : value;
+  },
+});
+
+const languageOptions = computed(() =>
+  getLocaleOptions(i18n.global.availableLocales, i18n.global.locale.value),
+);
+
+const languageSelectValue = computed({
+  get: () => draft.value?.language || NONE_SELECT_VALUE,
+  set: (value: string) => {
+    if (!draft.value) return;
+    draft.value.language =
+      value === NONE_SELECT_VALUE ? "" : canonicalizeLocale(value);
   },
 });
 
@@ -286,6 +325,7 @@ function newHostDraft(): HostDraft {
     name: "",
     instructions: GENERIC_HOST_INSTRUCTIONS,
     ttsEngine: "",
+    language: "",
     segments: deepClone(GENERIC_HOST_SEGMENTS),
   };
 }
@@ -390,7 +430,9 @@ onMounted(async () => {
       const host = await getHost(props.hostId);
       draft.value = decompileHost(host, sections.value);
     } else {
-      draft.value = newHostDraft();
+      draft.value = props.presetDraft
+        ? deepClone(props.presetDraft)
+        : newHostDraft();
     }
     originalSnapshot = JSON.stringify(draft.value);
   } catch (error) {

--- a/src/components/ai-radio/CustomizeHost.vue
+++ b/src/components/ai-radio/CustomizeHost.vue
@@ -255,8 +255,7 @@ const voiceSelectValue = computed({
   },
 });
 
-// Canonical option values ("el_GR" -> "el-GR") so a stored language matches the
-// option it was picked from, and the server receives a BCP-47 tag.
+// Canonicalized so a stored "el-GR" matches the option it was picked from.
 const languageOptions = computed(() =>
   getLocaleOptions(i18n.global.availableLocales, i18n.global.locale.value).map(
     (option) => ({ ...option, value: canonicalizeLocale(option.value) }),

--- a/src/components/ai-radio/CustomizeHost.vue
+++ b/src/components/ai-radio/CustomizeHost.vue
@@ -263,7 +263,11 @@ const languageOptions = computed(() =>
 );
 
 const languageSelectValue = computed({
-  get: () => draft.value?.language || NONE_SELECT_VALUE,
+  // Canonicalize for display only: writing back here would mark an untouched host dirty.
+  get: () =>
+    draft.value?.language
+      ? canonicalizeLocale(draft.value.language)
+      : NONE_SELECT_VALUE,
   set: (value: string) => {
     if (!draft.value) return;
     draft.value.language = value === NONE_SELECT_VALUE ? "" : value;

--- a/src/components/ai-radio/SegmentRow.vue
+++ b/src/components/ai-radio/SegmentRow.vue
@@ -96,12 +96,28 @@
         <Label>{{ $t("providers.ai_radio.fields.prompt") }}</Label>
         <Textarea v-model="prompt" rows="4" class="text-sm" />
         <p class="text-xs text-muted-foreground">
-          {{
-            $t("providers.ai_radio.customize.prompt_placeholders_hint", {
-              placeholders: PROMPT_PLACEHOLDERS.join(", "),
-            })
-          }}
+          {{ $t("providers.ai_radio.customize.prompt_placeholders_label") }}
         </p>
+        <div class="flex flex-wrap gap-1.5">
+          <Badge
+            v-for="token in PROMPT_PLACEHOLDERS"
+            :key="token"
+            as="button"
+            type="button"
+            variant="outline"
+            class="cursor-pointer font-mono hover:bg-accent hover:text-accent-foreground"
+            :aria-label="
+              $t('providers.ai_radio.customize.prompt_placeholder_copy_aria', [
+                token,
+              ])
+            "
+            @click="copyPlaceholder(token)"
+          >
+            {{ token }}
+            <Check v-if="copiedToken === token" />
+            <Copy v-else />
+          </Badge>
+        </div>
       </div>
 
       <div class="grid gap-3 sm:grid-cols-2">
@@ -156,6 +172,7 @@
 </template>
 
 <script setup lang="ts">
+import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -179,10 +196,12 @@ import {
   type PlaysRule,
   type ShowSegment,
 } from "@/helpers/ai_radio";
+import { copyToClipboard } from "@/helpers/utils";
 import type { AIRadioWebSearchMode } from "@/plugins/api/interfaces";
 import { $t } from "@/plugins/i18n";
-import { ChevronDown, ChevronUp, Trash2 } from "@lucide/vue";
-import { computed, ref } from "vue";
+import { Check, ChevronDown, ChevronUp, Copy, Trash2 } from "@lucide/vue";
+import { computed, onUnmounted, ref } from "vue";
+import { toast } from "vue-sonner";
 
 // listed literally so translators never handle raw <placeholder> markup
 const PROMPT_PLACEHOLDERS = [
@@ -206,6 +225,32 @@ const emit = defineEmits<{
 }>();
 
 const expanded = ref(false);
+
+const COPIED_FEEDBACK_MS = 1500;
+const copiedToken = ref<string | null>(null);
+let copiedTimer: ReturnType<typeof setTimeout> | undefined;
+
+async function copyPlaceholder(token: string) {
+  const success = await copyToClipboard(token);
+  if (!success) {
+    toast.error(
+      $t("providers.ai_radio.customize.prompt_placeholder_copy_failed", [
+        token,
+      ]),
+    );
+    return;
+  }
+  toast.success(
+    $t("providers.ai_radio.customize.prompt_placeholder_copied", [token]),
+  );
+  clearTimeout(copiedTimer);
+  copiedToken.value = token;
+  copiedTimer = setTimeout(() => {
+    copiedToken.value = null;
+  }, COPIED_FEEDBACK_MS);
+}
+
+onUnmounted(() => clearTimeout(copiedTimer));
 
 const DEFAULT_EVERY_N_SONGS = 3;
 const DEFAULT_EVERY_N_MIN = 60;

--- a/src/components/ai-radio/SegmentRow.vue
+++ b/src/components/ai-radio/SegmentRow.vue
@@ -98,7 +98,7 @@
         <p class="text-xs text-muted-foreground">
           {{ $t("providers.ai_radio.customize.prompt_placeholders_label") }}
         </p>
-        <div class="flex flex-wrap gap-1.5">
+        <div class="flex flex-wrap gap-1.5 pb-2">
           <Badge
             v-for="token in PROMPT_PLACEHOLDERS"
             :key="token"

--- a/src/components/ai-radio/SegmentRow.vue
+++ b/src/components/ai-radio/SegmentRow.vue
@@ -31,9 +31,11 @@
           :aria-label="$t('providers.ai_radio.customize.segment_name')"
         />
 
-        <div class="flex w-full items-center gap-2 sm:w-[240px] sm:shrink-0">
+        <div
+          class="flex w-full items-center gap-1 sm:w-[240px] sm:shrink-0 sm:gap-2"
+        >
           <Select v-model="playsKind">
-            <SelectTrigger class="h-8 min-w-0 flex-1 text-xs">
+            <SelectTrigger class="h-8 min-w-0 flex-1 px-2 text-xs sm:px-3">
               <SelectValue />
             </SelectTrigger>
             <SelectContent>
@@ -51,7 +53,7 @@
           <NumberField
             v-if="needsN"
             v-model="playsN"
-            class="w-16 shrink-0"
+            class="w-12 shrink-0 sm:w-16"
             :min="1"
             :format-options="{ useGrouping: false, maximumFractionDigits: 0 }"
           >
@@ -62,7 +64,7 @@
           <NumberField
             v-if="needsPercent"
             v-model="playsPercent"
-            class="w-16 shrink-0"
+            class="w-12 shrink-0 sm:w-16"
             :min="0"
             :max="100"
             :format-options="{ useGrouping: false, maximumFractionDigits: 0 }"

--- a/src/components/ai-radio/SegmentRow.vue
+++ b/src/components/ai-radio/SegmentRow.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="rounded-[6px] border bg-card/40 transition-colors hover:bg-card">
-    <div class="flex items-center gap-2 px-3 py-2">
-      <div class="flex flex-col">
+    <div class="flex items-start gap-2 px-3 py-2 sm:items-center">
+      <div class="flex shrink-0 flex-col">
         <Button
           variant="ghost-icon"
           size="icon-xs"
@@ -22,52 +22,56 @@
         </Button>
       </div>
 
-      <Input
-        v-model="name"
-        class="h-8 min-w-0 flex-1"
-        :aria-label="$t('providers.ai_radio.customize.segment_name')"
-      />
+      <div
+        class="flex min-w-0 flex-1 flex-col gap-2 sm:flex-row sm:items-center"
+      >
+        <Input
+          v-model="name"
+          class="h-8 min-w-0 flex-1"
+          :aria-label="$t('providers.ai_radio.customize.segment_name')"
+        />
 
-      <div class="flex w-[240px] shrink-0 items-center gap-2">
-        <Select v-model="playsKind">
-          <SelectTrigger class="h-8 min-w-0 flex-1 text-xs">
-            <SelectValue />
-          </SelectTrigger>
-          <SelectContent>
-            <SelectItem
-              v-for="option in playsKindOptions"
-              :key="option.kind"
-              :value="option.kind"
-              class="text-xs"
-            >
-              {{ option.label }}
-            </SelectItem>
-          </SelectContent>
-        </Select>
+        <div class="flex w-full items-center gap-2 sm:w-[240px] sm:shrink-0">
+          <Select v-model="playsKind">
+            <SelectTrigger class="h-8 min-w-0 flex-1 text-xs">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem
+                v-for="option in playsKindOptions"
+                :key="option.kind"
+                :value="option.kind"
+                class="text-xs"
+              >
+                {{ option.label }}
+              </SelectItem>
+            </SelectContent>
+          </Select>
 
-        <NumberField
-          v-if="needsN"
-          v-model="playsN"
-          class="w-16 shrink-0"
-          :min="1"
-          :format-options="{ useGrouping: false, maximumFractionDigits: 0 }"
-        >
-          <NumberFieldContent>
-            <NumberFieldInput class="h-8 text-xs" />
-          </NumberFieldContent>
-        </NumberField>
-        <NumberField
-          v-if="needsPercent"
-          v-model="playsPercent"
-          class="w-16 shrink-0"
-          :min="0"
-          :max="100"
-          :format-options="{ useGrouping: false, maximumFractionDigits: 0 }"
-        >
-          <NumberFieldContent>
-            <NumberFieldInput class="h-8 text-xs" />
-          </NumberFieldContent>
-        </NumberField>
+          <NumberField
+            v-if="needsN"
+            v-model="playsN"
+            class="w-16 shrink-0"
+            :min="1"
+            :format-options="{ useGrouping: false, maximumFractionDigits: 0 }"
+          >
+            <NumberFieldContent>
+              <NumberFieldInput class="h-8 text-xs" />
+            </NumberFieldContent>
+          </NumberField>
+          <NumberField
+            v-if="needsPercent"
+            v-model="playsPercent"
+            class="w-16 shrink-0"
+            :min="0"
+            :max="100"
+            :format-options="{ useGrouping: false, maximumFractionDigits: 0 }"
+          >
+            <NumberFieldContent>
+              <NumberFieldInput class="h-8 text-xs" />
+            </NumberFieldContent>
+          </NumberField>
+        </div>
       </div>
 
       <Button

--- a/src/composables/ai-radio/useHosts.ts
+++ b/src/composables/ai-radio/useHosts.ts
@@ -10,13 +10,21 @@ export interface AIRadioTtsEngine {
   name: string;
 }
 
+/** A bundled persona: a ready-made host plus the section content it references. */
+export interface AIRadioHostPreset {
+  host: AIRadioHost;
+  sections: AIRadioSection[];
+}
+
 const hosts = ref<AIRadioHost[]>([]);
 const ttsEngines = ref<AIRadioTtsEngine[]>([]);
+const presets = ref<AIRadioHostPreset[]>([]);
 // queue_id -> host_id, for queues that currently have a DJ host assigned.
 const queueDjStatus = ref<Record<string, string>>({});
 
 const loadingHosts = ref(false);
 const loadingTtsEngines = ref(false);
+const loadingPresets = ref(false);
 const loadingQueueDjStatus = ref(false);
 const savingHost = ref(false);
 // Host id currently being deleted, so only that row reflects it.
@@ -115,6 +123,19 @@ async function loadTtsEngines(): Promise<AIRadioTtsEngine[]> {
   }
 }
 
+async function loadPresets(): Promise<AIRadioHostPreset[]> {
+  loadingPresets.value = true;
+  try {
+    const result = await api.sendCommand<AIRadioHostPreset[]>(
+      "ai_radio/hosts/presets/list",
+    );
+    presets.value = result || [];
+    return presets.value;
+  } finally {
+    loadingPresets.value = false;
+  }
+}
+
 /** Assigns (or, with hostId null, clears) the DJ host for a queue; returns the updated queue_id -> host_id map. */
 async function setQueueDj(
   queueId: string,
@@ -158,10 +179,12 @@ export function useHosts() {
   return {
     hosts,
     ttsEngines,
+    presets,
     queueDjStatus,
     aiRadioAvailable,
     loadingHosts,
     loadingTtsEngines,
+    loadingPresets,
     loadingQueueDjStatus,
     savingHost,
     deletingHostId,
@@ -172,6 +195,7 @@ export function useHosts() {
     deleteHost,
     loadHostTemplate,
     loadTtsEngines,
+    loadPresets,
     setQueueDj,
     loadQueueDjStatus,
   };

--- a/src/helpers/ai_radio.test.ts
+++ b/src/helpers/ai_radio.test.ts
@@ -58,8 +58,6 @@ describe("uniqueHostName", () => {
   });
 
   it("treats collisions case-insensitively, matching how host ids are slugified", () => {
-    // compileHost derives a host's id by slugifying (and lowercasing) its
-    // name, so "Morning Show" and "morning show" would collide anyway.
     expect(uniqueHostName("morning show", ["Morning Show"])).toBe(
       "morning show 2",
     );

--- a/src/helpers/ai_radio.test.ts
+++ b/src/helpers/ai_radio.test.ts
@@ -1,0 +1,85 @@
+import { compileHost, decompileHost, uniqueHostName } from "./ai_radio";
+import type { HostDraft } from "./ai_radio";
+import type { AIRadioHost } from "@/plugins/api/interfaces";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@/plugins/i18n", () => ({
+  $t: (key: string) => key,
+  canonicalizeLocale: (locale: string) => locale.replaceAll("_", "-"),
+  i18n: {
+    global: {
+      locale: { value: "en" },
+    },
+  },
+}));
+
+const makeDraft = (overrides: Partial<HostDraft> = {}): HostDraft => ({
+  id: "rick",
+  name: "Rick",
+  instructions: "Persona.",
+  ttsEngine: "",
+  language: "",
+  segments: [],
+  ...overrides,
+});
+
+const makeHost = (overrides: Partial<AIRadioHost> = {}): AIRadioHost => ({
+  id: "rick",
+  name: "Rick",
+  instructions: "Persona.",
+  tts_engine: "",
+  language: "",
+  section_ids: [],
+  section_order: [],
+  merge_section_id: "",
+  ...overrides,
+});
+
+describe("uniqueHostName", () => {
+  it("returns the name unchanged when nothing collides", () => {
+    expect(uniqueHostName("Morning show", [])).toBe("Morning show");
+    expect(uniqueHostName("Morning show", ["Party host"])).toBe("Morning show");
+  });
+
+  it("appends 2 on a single collision", () => {
+    expect(uniqueHostName("Morning show", ["Morning show"])).toBe(
+      "Morning show 2",
+    );
+  });
+
+  it("keeps incrementing past several collisions", () => {
+    expect(
+      uniqueHostName("Morning show", [
+        "Morning show",
+        "Morning show 2",
+        "Morning show 3",
+      ]),
+    ).toBe("Morning show 4");
+  });
+
+  it("treats collisions case-insensitively, matching how host ids are slugified", () => {
+    // compileHost derives a host's id by slugifying (and lowercasing) its
+    // name, so "Morning Show" and "morning show" would collide anyway.
+    expect(uniqueHostName("morning show", ["Morning Show"])).toBe(
+      "morning show 2",
+    );
+  });
+});
+
+describe("language field round-trip", () => {
+  it("carries a draft's language through compileHost unchanged", () => {
+    const { host } = compileHost(makeDraft({ language: "nl_NL" }));
+    expect(host.language).toBe("nl_NL");
+  });
+
+  it("carries a host's language through decompileHost", () => {
+    const draft = decompileHost(makeHost({ language: "fr" }), []);
+    expect(draft.language).toBe("fr");
+  });
+
+  it("defaults to the empty string (follow the server language) when absent", () => {
+    const { language: _omitted, ...hostWithoutLanguage } = makeHost();
+    const draft = decompileHost(hostWithoutLanguage as AIRadioHost, []);
+    expect(draft.language).toBe("");
+  });
+});

--- a/src/helpers/ai_radio.test.ts
+++ b/src/helpers/ai_radio.test.ts
@@ -62,6 +62,21 @@ describe("uniqueHostName", () => {
       "morning show 2",
     );
   });
+
+  it("collides on names that slugify alike, not just on case", () => {
+    expect(uniqueHostName("Morning show", ["Morning-show"])).toBe(
+      "Morning show 2",
+    );
+    expect(uniqueHostName("Morning show", ["morning_show"])).toBe(
+      "Morning show 2",
+    );
+  });
+
+  it("collides on names that differ only in surrounding whitespace", () => {
+    expect(uniqueHostName("Morning show ", ["Morning show"])).not.toBe(
+      "Morning show ",
+    );
+  });
 });
 
 describe("language field round-trip", () => {

--- a/src/helpers/ai_radio.ts
+++ b/src/helpers/ai_radio.ts
@@ -591,17 +591,17 @@ export const getQueryValue = (value: unknown) => {
 
 /**
  * Appends " 2", " 3", ... until `name` doesn't collide with `existingNames`.
- * Matching ignores case: ids are slugified from the name, so case-only variants collide.
+ * Compares on the slug `compileHost` derives the id from, so "A b" and "A-b" collide.
  */
 export const uniqueHostName = (
   name: string,
   existingNames: string[],
 ): string => {
-  const used = new Set(existingNames.map((existing) => existing.toLowerCase()));
-  if (!used.has(name.toLowerCase())) return name;
+  const used = new Set(existingNames.map(slugify));
+  if (!used.has(slugify(name))) return name;
   let suffix = 2;
   let candidate = `${name} ${suffix}`;
-  while (used.has(candidate.toLowerCase())) {
+  while (used.has(slugify(candidate))) {
     suffix += 1;
     candidate = `${name} ${suffix}`;
   }

--- a/src/helpers/ai_radio.ts
+++ b/src/helpers/ai_radio.ts
@@ -591,8 +591,7 @@ export const getQueryValue = (value: unknown) => {
 
 /**
  * Appends " 2", " 3", ... until `name` doesn't collide with `existingNames`.
- * Comparison is case-insensitive: host ids are slugified from the name, so
- * names differing only in case would still collide once compiled.
+ * Matching ignores case: ids are slugified from the name, so case-only variants collide.
  */
 export const uniqueHostName = (
   name: string,

--- a/src/helpers/ai_radio.ts
+++ b/src/helpers/ai_radio.ts
@@ -374,6 +374,8 @@ export interface HostDraft {
   instructions: string;
   // ttsEngine: "" = provider default
   ttsEngine: string;
+  // language: "" = follow the server language
+  language: string;
   segments: ShowSegment[];
 }
 
@@ -401,6 +403,7 @@ export const compileHost = (draft: HostDraft): CompiledHost => {
       name: draft.name.trim(),
       instructions: draft.instructions,
       tts_engine: draft.ttsEngine,
+      language: draft.language,
       section_ids: sections.map((section) => section.id),
       section_order: sectionOrder,
       merge_section_id: mergeSectionId,
@@ -547,6 +550,7 @@ export const decompileHost = (
     name: host.name,
     instructions: host.instructions,
     ttsEngine: host.tts_engine,
+    language: host.language || "",
     segments,
   };
 };
@@ -583,4 +587,24 @@ export const resolveShowPlayerId = (
 export const getQueryValue = (value: unknown) => {
   if (typeof value !== "string") return "";
   return value.trim();
+};
+
+/**
+ * Appends " 2", " 3", ... until `name` doesn't collide with `existingNames`.
+ * Comparison is case-insensitive: host ids are slugified from the name, so
+ * names differing only in case would still collide once compiled.
+ */
+export const uniqueHostName = (
+  name: string,
+  existingNames: string[],
+): string => {
+  const used = new Set(existingNames.map((existing) => existing.toLowerCase()));
+  if (!used.has(name.toLowerCase())) return name;
+  let suffix = 2;
+  let candidate = `${name} ${suffix}`;
+  while (used.has(candidate.toLowerCase())) {
+    suffix += 1;
+    candidate = `${name} ${suffix}`;
+  }
+  return candidate;
 };

--- a/src/plugins/api/interfaces.ts
+++ b/src/plugins/api/interfaces.ts
@@ -1823,6 +1823,8 @@ export interface AIRadioHost {
   instructions: string;
   // tts_engine: "" means use the provider default engine
   tts_engine: string;
+  // language: "" means follow the server language
+  language: string;
   section_ids: string[];
   section_order: AIRadioSectionOrderRule[];
   merge_section_id: string;

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1536,7 +1536,10 @@
                 "host_required": "Choose a host before saving",
                 "no_hosts_hint": "You need a host before you can save this show.",
                 "create_host_cta": "Create a host",
-                "prompt_placeholders_hint": "Available placeholders: {placeholders}"
+                "prompt_placeholders_label": "Placeholders — tap to copy:",
+                "prompt_placeholder_copied": "Copied {0} to clipboard",
+                "prompt_placeholder_copy_failed": "Failed to copy {0} to clipboard",
+                "prompt_placeholder_copy_aria": "Copy {0}"
             },
             "hosts": {
                 "title": "Hosts",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1397,6 +1397,7 @@
                 "prompt": "Prompt",
                 "instructions": "Host and Program Instructions",
                 "voice": "Voice",
+                "language": "Language",
                 "host": "Host"
             },
             "field_descriptions": {
@@ -1540,6 +1541,7 @@
             "hosts": {
                 "title": "Hosts",
                 "add_host": "Add host",
+                "blank_host": "Blank host",
                 "card": {
                     "edit": "Edit"
                 },
@@ -1548,6 +1550,7 @@
                     "save": "Save host",
                     "name_label": "Host name",
                     "default_voice": "Default",
+                    "default_language": "Follow server language",
                     "validation": {
                         "name_required": "Host name is required",
                         "duplicate_name": "A host named «{0}» already exists",

--- a/src/views/AIRadioView.vue
+++ b/src/views/AIRadioView.vue
@@ -222,7 +222,6 @@ const customizeShowId = ref("");
 // null = closed; "" = creating a new host; otherwise the id being edited.
 const customizeHostId = ref<string | null>(null);
 const customizeHostOpen = computed(() => customizeHostId.value !== null);
-// Unsaved draft to seed the editor from when creating a host from a preset.
 const presetDraft = ref<HostDraft | null>(null);
 
 const isRefreshing = computed(
@@ -267,8 +266,7 @@ function openCustomizeHostFromPreset(preset: AIRadioHostPreset) {
     draft.name,
     hosts.value.map((host) => host.name),
   );
-  // compileHost namespaces segment ids with the new host id, so strip the
-  // preset's own prefix to keep them readable instead of doubling it up.
+  // compileHost namespaces ids with the new host id, so strip the preset's own prefix.
   const presetPrefix = `${preset.host.id}_`;
   for (const segment of draft.segments) {
     if (segment.id.startsWith(presetPrefix)) {

--- a/src/views/AIRadioView.vue
+++ b/src/views/AIRadioView.vue
@@ -267,6 +267,14 @@ function openCustomizeHostFromPreset(preset: AIRadioHostPreset) {
     draft.name,
     hosts.value.map((host) => host.name),
   );
+  // compileHost namespaces segment ids with the new host id, so strip the
+  // preset's own prefix to keep them readable instead of doubling it up.
+  const presetPrefix = `${preset.host.id}_`;
+  for (const segment of draft.segments) {
+    if (segment.id.startsWith(presetPrefix)) {
+      segment.id = segment.id.slice(presetPrefix.length);
+    }
+  }
   presetDraft.value = draft;
   customizeHostId.value = "";
 }

--- a/src/views/AIRadioView.vue
+++ b/src/views/AIRadioView.vue
@@ -11,6 +11,7 @@
     <CustomizeHost
       v-if="customizeHostOpen"
       :host-id="customizeHostId || undefined"
+      :preset-draft="presetDraft || undefined"
       @back="closeCustomizeHost"
       @saved="closeCustomizeHost"
     />
@@ -48,10 +49,29 @@
           <h2 class="text-lg font-semibold tracking-tight">
             {{ $t("providers.ai_radio.hosts.title") }}
           </h2>
-          <Button @click="openCustomizeHost()">
-            <Plus class="mr-1 h-4 w-4" />
-            {{ $t("providers.ai_radio.hosts.add_host") }}
-          </Button>
+          <DropdownMenu>
+            <DropdownMenuTrigger as-child>
+              <Button>
+                <Plus class="mr-1 h-4 w-4" />
+                {{ $t("providers.ai_radio.hosts.add_host") }}
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end">
+              <DropdownMenuItem @click="openCustomizeHost()">
+                {{ $t("providers.ai_radio.hosts.blank_host") }}
+              </DropdownMenuItem>
+              <template v-if="presets.length">
+                <DropdownMenuSeparator />
+                <DropdownMenuItem
+                  v-for="preset in presets"
+                  :key="preset.host.id"
+                  @click="openCustomizeHostFromPreset(preset)"
+                >
+                  {{ preset.host.name }}
+                </DropdownMenuItem>
+              </template>
+            </DropdownMenuContent>
+          </DropdownMenu>
         </div>
         <div
           class="grid gap-2 [grid-template-columns:repeat(auto-fill,minmax(170px,1fr))]"
@@ -151,9 +171,25 @@ import HostCard from "@/components/ai-radio/HostCard.vue";
 import ShowCard from "@/components/ai-radio/ShowCard.vue";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
-import { useHosts } from "@/composables/ai-radio/useHosts";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import {
+  useHosts,
+  type AIRadioHostPreset,
+} from "@/composables/ai-radio/useHosts";
 import { useShows } from "@/composables/ai-radio/useShows";
-import { errorMessage, getQueryValue } from "@/helpers/ai_radio";
+import {
+  decompileHost,
+  errorMessage,
+  getQueryValue,
+  uniqueHostName,
+  type HostDraft,
+} from "@/helpers/ai_radio";
 import { $t } from "@/plugins/i18n";
 import { Plus, RefreshCw, Sparkles, TriangleAlert, X } from "@lucide/vue";
 import { computed, onMounted, onUnmounted, ref, watch } from "vue";
@@ -178,7 +214,7 @@ const {
   noAiProviderAlert,
   dismissNoAiProviderAlert,
 } = useShows();
-const { hosts, loadingHosts, loadHosts } = useHosts();
+const { hosts, presets, loadingHosts, loadHosts, loadPresets } = useHosts();
 
 const createDialogOpen = ref(false);
 const createDialogInitialPlaylist = ref<PlaylistSelection | undefined>();
@@ -186,6 +222,8 @@ const customizeShowId = ref("");
 // null = closed; "" = creating a new host; otherwise the id being edited.
 const customizeHostId = ref<string | null>(null);
 const customizeHostOpen = computed(() => customizeHostId.value !== null);
+// Unsaved draft to seed the editor from when creating a host from a preset.
+const presetDraft = ref<HostDraft | null>(null);
 
 const isRefreshing = computed(
   () =>
@@ -217,7 +255,20 @@ function closeCustomize() {
 }
 
 function openCustomizeHost(hostId?: string) {
+  presetDraft.value = null;
   customizeHostId.value = hostId || "";
+}
+
+/** Opens the host editor pre-filled with an unsaved draft cloned from a bundled persona preset. */
+function openCustomizeHostFromPreset(preset: AIRadioHostPreset) {
+  const draft = decompileHost(preset.host, preset.sections);
+  draft.id = "";
+  draft.name = uniqueHostName(
+    draft.name,
+    hosts.value.map((host) => host.name),
+  );
+  presetDraft.value = draft;
+  customizeHostId.value = "";
 }
 
 /** The create dialog has no draft to return to, so opening the host editor from it just closes it. */
@@ -284,6 +335,8 @@ onMounted(async () => {
   } catch (error) {
     toast.error(errorMessage(error));
   }
+  // Best effort: the "Add host" menu still works with just "Blank host" if this fails.
+  void loadPresets().catch(() => {});
   startStatusPolling();
   applyRouteQuery();
 });

--- a/tests/components/ai-radio/CustomizeHost.test.ts
+++ b/tests/components/ai-radio/CustomizeHost.test.ts
@@ -104,6 +104,7 @@ describe("CustomizeHost save", () => {
       name: "Morning Crew",
       instructions: "",
       tts_engine: "",
+      language: "",
       section_ids: [],
       section_order: [],
       merge_section_id: "",
@@ -151,6 +152,7 @@ describe("CustomizeHost save", () => {
       name: "Morning Crew",
       instructions: "",
       tts_engine: "",
+      language: "",
       section_ids: [],
       section_order: [],
       merge_section_id: "",
@@ -178,6 +180,7 @@ describe("CustomizeHost save", () => {
       name: "Rick",
       instructions: "Persona.",
       ttsEngine: "",
+      language: "",
       segments: GENERIC_SEGMENT_TEMPLATES.slice(0, 1).map((s) => ({ ...s })),
     };
     const { host, sections } = compileHost(draft);

--- a/tests/components/ai-radio/HostCard.test.ts
+++ b/tests/components/ai-radio/HostCard.test.ts
@@ -41,6 +41,7 @@ const host: AIRadioHost = {
   name: "Morning Crew",
   instructions: "Be upbeat.",
   tts_engine: "",
+  language: "",
   section_ids: [],
   section_order: [],
   merge_section_id: "morning_crew_smoother",

--- a/tests/components/ai-radio/SegmentRow.test.ts
+++ b/tests/components/ai-radio/SegmentRow.test.ts
@@ -1,0 +1,113 @@
+import SegmentRow from "@/components/ai-radio/SegmentRow.vue";
+import type { ShowSegment } from "@/helpers/ai_radio";
+import { flushPromises, mount, type VueWrapper } from "@vue/test-utils";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const { copyToClipboard } = vi.hoisted(() => ({
+  copyToClipboard: vi.fn<(text: string) => Promise<boolean>>(),
+}));
+
+vi.mock("@/helpers/utils", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/helpers/utils")>()),
+  copyToClipboard,
+}));
+
+vi.mock("vue-sonner", () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+const PLACEHOLDER_TOKENS = [
+  "<next_songinfo>",
+  "<prev_songinfo>",
+  "<timestamp>",
+  "<weather_hourly>",
+];
+
+const segment: ShowSegment = {
+  id: "intro",
+  name: "Intro",
+  prompt: "Say hello, <next_songinfo>.",
+  webSearch: "disabled",
+  maxChars: 500,
+  plays: { kind: "start" },
+};
+
+async function mountExpanded() {
+  const wrapper = mount(SegmentRow, {
+    props: { segment, canMoveUp: false, canMoveDown: false },
+  });
+  await wrapper.get('button[aria-label="Show more"]').trigger("click");
+  return wrapper;
+}
+
+function placeholderChip(wrapper: VueWrapper, token: string) {
+  return wrapper
+    .findAll("button")
+    .find((button) => button.attributes("aria-label") === `Copy ${token}`);
+}
+
+afterEach(() => {
+  vi.clearAllMocks();
+  vi.useRealTimers();
+});
+
+describe("SegmentRow placeholder chips", () => {
+  it("renders one chip per placeholder token", async () => {
+    const wrapper = await mountExpanded();
+
+    for (const token of PLACEHOLDER_TOKENS) {
+      expect(placeholderChip(wrapper, token)?.text()).toBe(token);
+    }
+  });
+
+  it("copies the exact token when a chip is clicked", async () => {
+    copyToClipboard.mockResolvedValue(true);
+    const wrapper = await mountExpanded();
+
+    await placeholderChip(wrapper, "<timestamp>")?.trigger("click");
+    await flushPromises();
+
+    expect(copyToClipboard).toHaveBeenCalledWith("<timestamp>");
+  });
+
+  it("shows a check mark after a successful copy, then reverts it", async () => {
+    vi.useFakeTimers();
+    copyToClipboard.mockResolvedValue(true);
+    const { toast } = await import("vue-sonner");
+    const wrapper = await mountExpanded();
+    const chip = placeholderChip(wrapper, "<next_songinfo>");
+
+    await chip?.trigger("click");
+    await flushPromises();
+
+    expect(chip?.find(".lucide-check").exists()).toBe(true);
+    expect(chip?.find(".lucide-copy").exists()).toBe(false);
+    expect(toast.success).toHaveBeenCalledWith(
+      "Copied <next_songinfo> to clipboard",
+    );
+
+    await vi.advanceTimersByTimeAsync(1500);
+
+    expect(chip?.find(".lucide-check").exists()).toBe(false);
+    expect(chip?.find(".lucide-copy").exists()).toBe(true);
+  });
+
+  it("shows an error toast and no check mark when the copy fails", async () => {
+    copyToClipboard.mockResolvedValue(false);
+    const { toast } = await import("vue-sonner");
+    const wrapper = await mountExpanded();
+    const chip = placeholderChip(wrapper, "<prev_songinfo>");
+
+    await chip?.trigger("click");
+    await flushPromises();
+
+    expect(toast.error).toHaveBeenCalledWith(
+      "Failed to copy <prev_songinfo> to clipboard",
+    );
+    expect(toast.success).not.toHaveBeenCalled();
+    expect(chip?.find(".lucide-check").exists()).toBe(false);
+  });
+});

--- a/tests/composables/ai-radio/useHosts.test.ts
+++ b/tests/composables/ai-radio/useHosts.test.ts
@@ -66,6 +66,7 @@ const host: AIRadioHost = {
   name: "Robo DJ",
   instructions: "",
   tts_engine: "",
+  language: "",
   section_ids: [],
   section_order: [],
   merge_section_id: "",

--- a/tests/helpers/ai_radio.test.ts
+++ b/tests/helpers/ai_radio.test.ts
@@ -131,6 +131,7 @@ describe("compileHost", () => {
       name: "Rick",
       instructions: "Persona.",
       ttsEngine: "",
+      language: "",
       segments: GENERIC_SEGMENT_TEMPLATES.slice(0, 2).map((s) => ({ ...s })),
     };
     const { host, sections } = compileHost(draft);
@@ -152,6 +153,7 @@ describe("compileHost", () => {
       name: hostId,
       instructions: "Persona.",
       ttsEngine: "",
+      language: "",
       segments: GENERIC_SEGMENT_TEMPLATES.slice(0, 2).map((s) => ({ ...s })),
     });
     const a = compileHost(draftFor("host_a"));
@@ -170,6 +172,7 @@ describe("compileHost", () => {
       name: "Rick",
       instructions: "Persona.",
       ttsEngine: "",
+      language: "",
       segments: [{ ...GENERIC_SEGMENT_TEMPLATES[0], id: "rick_intro" }],
     };
     const { sections } = compileHost(draft);
@@ -184,6 +187,7 @@ describe("compileHost", () => {
       name: "Rick",
       instructions: "Persona.",
       ttsEngine: "",
+      language: "",
       segments: [
         {
           ...artistFactTemplate,
@@ -212,6 +216,7 @@ describe("decompileHost", () => {
       name: "Rick",
       instructions: "Persona.",
       ttsEngine: "engine-1",
+      language: "",
       segments: GENERIC_SEGMENT_TEMPLATES.slice(0, 2).map((s) => ({ ...s })),
     };
     const { host, sections } = compileHost(draft);
@@ -231,6 +236,7 @@ describe("decompileHost", () => {
       name: "Rick",
       instructions: "Persona.",
       ttsEngine: "",
+      language: "",
       segments: GENERIC_SEGMENT_TEMPLATES.slice(0, 2).map((s) => ({ ...s })),
     };
     const { host, sections } = compileHost(draft);
@@ -258,6 +264,7 @@ describe("decompileHost", () => {
       name: "Rick",
       instructions: "Persona.",
       ttsEngine: "",
+      language: "",
       segments: [{ ...artistFactTemplate }], // every_n_songs n: 3
     };
     const { host, sections } = compileHost(draft);
@@ -289,6 +296,7 @@ describe("decompileHost", () => {
       name: "Rick",
       instructions: "Persona.",
       tts_engine: "",
+      language: "",
       section_ids: [legacySection.id, mergeSection.id],
       section_order: [
         {
@@ -328,6 +336,7 @@ describe("decompileHost", () => {
       name: "Rick",
       instructions: "Persona.",
       ttsEngine: "",
+      language: "",
       segments: round.segments,
     });
     const rule = recompiled.section_order.find(

--- a/tests/helpers/player_menu_items.test.ts
+++ b/tests/helpers/player_menu_items.test.ts
@@ -148,6 +148,7 @@ function makeHost(overrides: Partial<AIRadioHost> = {}): AIRadioHost {
     name: "Robo DJ",
     instructions: "",
     tts_engine: "",
+    language: "",
     section_ids: [],
     section_order: [],
     merge_section_id: "",


### PR DESCRIPTION
# What does this implement/fix?

Beta feedback on the new AI Radio hosts editor. Adding a host always started from a blank persona, the segment rows became unusable on a phone, and a host had no way to pick a language.

- "Add host" is now a menu: a blank host, or one of the bundled presets the server ships. A preset opens the editor with an unsaved draft, its name uniquified against the existing hosts so saving a copy can't overwrite the original's shared sections.
- Segment rows stack the name above the "every ~3 songs" controls below the `sm` breakpoint. They used to overflow the card, squashing the name field to an unreadable square and pushing the expand chevron outside the panel.
- A host can pick a language, defaulting to the server's. It drives both the written script and the spoken voice.
- The prompt placeholders became tap-to-copy chips, so `<next_songinfo>` and friends no longer have to be typed by hand.

**Related issue (if applicable):**

- n/a

**Related backend PR (if applicable):**

<!--
Link the music-assistant/server PR when this change relies on new server
behaviour, so the two can be reviewed and released together.
-->

- related backend PR https://github.com/music-assistant/server/pull/5627

## Types of changes

<!--
Tick exactly one box below. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm lint:check` passes.
- [x] `pnpm test:run` passes, and tests have been added/updated where applicable.
- [x] `pnpm build` passes.
- [ ] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
