### PR TITLE
Bring the app back when leaving the party dashboard fullscreen

### DIFF
--- a/src/views/PartyDashboardView.vue
+++ b/src/views/PartyDashboardView.vue
@@ -463,7 +463,13 @@ const goToSettings = () => {
   }
 };
 
+// A frameless session can also be started elsewhere (a dashboard viewer login,
+// a ?frameless deep link), and those are meant to stay frameless, so only the
+// fullscreen this view switched on is its to switch back off again.
+let enteredFullscreen = false;
+
 const goFullscreen = (frameless: boolean) => {
+  enteredFullscreen = frameless;
   store.frameless = frameless;
   if (frameless) {
     document.documentElement.requestFullscreen?.();
@@ -476,6 +482,7 @@ const goFullscreen = (frameless: boolean) => {
 const onFullscreenChange = () => {
   if (!document.fullscreenElement && store.frameless) {
     store.frameless = false;
+    enteredFullscreen = false;
   }
 };
 onMounted(() => {
@@ -487,6 +494,10 @@ onBeforeUnmount(() => {
   if (typeof document !== "undefined") {
     document.removeEventListener("fullscreenchange", onFullscreenChange);
   }
+  // Leaving without the minimize button — browser back, a redirect — takes the
+  // listener above with it, so the rest of the app would be left with no
+  // navigation and no player bar.
+  if (enteredFullscreen) goFullscreen(false);
 });
 
 // Compact mode: hide previous tracks on small screens to reclaim space

--- a/src/views/PartyDashboardView.vue
+++ b/src/views/PartyDashboardView.vue
@@ -464,8 +464,8 @@ const goToSettings = () => {
 };
 
 // A frameless session can also be started elsewhere (a dashboard viewer login,
-// a ?frameless deep link), and those are meant to stay frameless, so only the
-// fullscreen this view switched on is its to switch back off again.
+// a ?frameless deep link) and is meant to last, so this view only switches back
+// off the fullscreen it switched on itself.
 let enteredFullscreen = false;
 
 const goFullscreen = (frameless: boolean) => {

--- a/tests/views/PartyDashboardView.test.ts
+++ b/tests/views/PartyDashboardView.test.ts
@@ -1,18 +1,21 @@
+import { store } from "@/plugins/store";
 import PartyDashboardView from "@/views/PartyDashboardView.vue";
 import { type VueWrapper, flushPromises, mount } from "@vue/test-utils";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-const { storeMock } = vi.hoisted(() => ({
-  storeMock: {
-    frameless: false,
-    activePlayerId: undefined as string | undefined,
-    activePlayer: undefined,
-    activePlayerQueue: undefined,
-    curQueueItem: undefined,
-  },
-}));
-
-vi.mock("@/plugins/store", () => ({ store: storeMock }));
+// Reactive, so the view's own chrome follows the flag the way it does in the app.
+vi.mock("@/plugins/store", async () => {
+  const { reactive } = await vi.importActual<typeof import("vue")>("vue");
+  return {
+    store: reactive({
+      frameless: false,
+      activePlayerId: undefined,
+      activePlayer: undefined,
+      activePlayerQueue: undefined,
+      curQueueItem: undefined,
+    }),
+  };
+});
 
 vi.mock("@/plugins/api", () => ({
   default: {
@@ -101,12 +104,15 @@ async function mountView() {
   return wrapper;
 }
 
+const ENTER_FULLSCREEN = '[aria-label="tooltip.enter_fullscreen"]';
+const EXIT_FULLSCREEN = '[aria-label="tooltip.exit_fullscreen"]';
+
 const enterFullscreen = (view: VueWrapper) =>
-  view.get('[aria-label="tooltip.enter_fullscreen"]').trigger("click");
+  view.get(ENTER_FULLSCREEN).trigger("click");
 
 describe("PartyDashboardView fullscreen", () => {
   beforeEach(() => {
-    storeMock.frameless = false;
+    store.frameless = false;
     fullscreenElement = null;
     requestFullscreen.mockClear();
     exitFullscreen.mockClear();
@@ -128,8 +134,9 @@ describe("PartyDashboardView fullscreen", () => {
 
     await enterFullscreen(view);
 
-    expect(storeMock.frameless).toBe(true);
+    expect(store.frameless).toBe(true);
     expect(requestFullscreen).toHaveBeenCalled();
+    expect(view.find(EXIT_FULLSCREEN).exists()).toBe(true);
   });
 
   it("hands the chrome back when the dashboard is left while fullscreen", async () => {
@@ -141,21 +148,38 @@ describe("PartyDashboardView fullscreen", () => {
     view.unmount();
     wrapper = undefined;
 
-    expect(storeMock.frameless).toBe(false);
+    expect(store.frameless).toBe(false);
     expect(exitFullscreen).toHaveBeenCalled();
   });
 
   it("leaves a frameless session it did not start alone", async () => {
     // a dashboard viewer login and a ?frameless deep link are both meant to
     // stay frameless for the whole session
-    storeMock.frameless = true;
+    store.frameless = true;
     const view = await mountView();
+
+    // what makes the flag enough to tell the two apart: the control that would
+    // claim ownership is not on screen while the session is already frameless
+    expect(view.find(ENTER_FULLSCREEN).exists()).toBe(false);
 
     view.unmount();
     wrapper = undefined;
 
-    expect(storeMock.frameless).toBe(true);
+    expect(store.frameless).toBe(true);
     expect(exitFullscreen).not.toHaveBeenCalled();
+  });
+
+  it("leaves fullscreen once for the minimize button", async () => {
+    const view = await mountView();
+    await enterFullscreen(view);
+
+    await view.get(EXIT_FULLSCREEN).trigger("click");
+    expect(store.frameless).toBe(false);
+
+    view.unmount();
+    wrapper = undefined;
+
+    expect(exitFullscreen).toHaveBeenCalledTimes(1);
   });
 
   it("stays out of the way once the browser has left fullscreen", async () => {
@@ -165,12 +189,27 @@ describe("PartyDashboardView fullscreen", () => {
     // Escape, which the browser reports as a fullscreen change
     fullscreenElement = null;
     document.dispatchEvent(new Event("fullscreenchange"));
-    expect(storeMock.frameless).toBe(false);
+    expect(store.frameless).toBe(false);
 
     view.unmount();
     wrapper = undefined;
 
-    expect(storeMock.frameless).toBe(false);
+    expect(store.frameless).toBe(false);
     expect(exitFullscreen).not.toHaveBeenCalled();
+  });
+
+  it("keeps a frameless session started after the browser left fullscreen", async () => {
+    const view = await mountView();
+    await enterFullscreen(view);
+
+    fullscreenElement = null;
+    document.dispatchEvent(new Event("fullscreenchange"));
+    // the router guard re-frames a dashboard viewer on its next navigation
+    store.frameless = true;
+
+    view.unmount();
+    wrapper = undefined;
+
+    expect(store.frameless).toBe(true);
   });
 });

--- a/tests/views/PartyDashboardView.test.ts
+++ b/tests/views/PartyDashboardView.test.ts
@@ -1,0 +1,176 @@
+import PartyDashboardView from "@/views/PartyDashboardView.vue";
+import { type VueWrapper, flushPromises, mount } from "@vue/test-utils";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { storeMock } = vi.hoisted(() => ({
+  storeMock: {
+    frameless: false,
+    activePlayerId: undefined as string | undefined,
+    activePlayer: undefined,
+    activePlayerQueue: undefined,
+    curQueueItem: undefined,
+  },
+}));
+
+vi.mock("@/plugins/store", () => ({ store: storeMock }));
+
+vi.mock("@/plugins/api", () => ({
+  default: {
+    baseUrl: "",
+    players: {},
+    providers: {},
+    queues: {},
+    sendCommand: vi.fn().mockResolvedValue(null),
+    subscribe: vi.fn(() => () => undefined),
+    getPlayerQueueItems: vi.fn().mockResolvedValue([]),
+    getTrackLyrics: vi.fn().mockResolvedValue([null, null]),
+  },
+}));
+
+// Pulled in transitively via @/helpers/utils; mocked so their module-load side effects (AuthManager reading localStorage) don't leak into this test.
+vi.mock("@/plugins/router", () => ({ default: {} }));
+vi.mock("@/plugins/auth", () => ({ authManager: {}, default: {} }));
+
+vi.mock("vue-router", () => ({ useRouter: () => ({ push: vi.fn() }) }));
+
+// Only the theme read is stood in for; the dialog primitives further down the
+// tree use the rest of the module for real.
+vi.mock("@vueuse/core", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@vueuse/core")>()),
+  useColorMode: () => ({ value: "light" }),
+}));
+
+vi.mock("@/composables/usePartyConfig", () => ({
+  usePartyConfig: () => ({
+    config: { value: null },
+    fetchConfig: vi.fn().mockResolvedValue(null),
+  }),
+}));
+
+vi.mock("@/composables/visualizer/useVisualizer", () => ({
+  useVisualizer: () => ({
+    visualizerEnabledPref: { value: false },
+    visualizerPresetPref: { value: "" },
+    visualizerBlurPref: { value: 0 },
+    visualizerOpacityPref: { value: 1 },
+    visualizerAvailable: { value: false },
+    visualizerActive: { value: false },
+    toggleVisualizer: vi.fn(),
+  }),
+}));
+
+vi.mock("@/composables/lyrics/useLyricsElapsedTime", () => ({
+  useLyricsElapsedTime: () => ({ elapsedTime: { value: 0 } }),
+}));
+
+// The view drives the real Fullscreen API, which happy-dom does not implement,
+// so it is stood up here as a small state machine that fires the same event the
+// browser does.
+let fullscreenElement: Element | null = null;
+const requestFullscreen = vi.fn(() => {
+  fullscreenElement = document.documentElement;
+  document.dispatchEvent(new Event("fullscreenchange"));
+  return Promise.resolve();
+});
+const exitFullscreen = vi.fn(() => {
+  fullscreenElement = null;
+  document.dispatchEvent(new Event("fullscreenchange"));
+  return Promise.resolve();
+});
+
+const ButtonStub = { template: "<button><slot /></button>" };
+
+let wrapper: VueWrapper | undefined;
+
+async function mountView() {
+  wrapper = mount(PartyDashboardView, {
+    global: {
+      mocks: { $t: (key: string) => key },
+      stubs: {
+        Badge: { template: "<span><slot /></span>" },
+        Button: ButtonStub,
+        LyricsViewer: true,
+        PartyQR: true,
+        PartyTrackCard: true,
+        ShowDashboardButton: true,
+        VisualizerCanvas: true,
+      },
+    },
+  });
+  await flushPromises();
+  return wrapper;
+}
+
+const enterFullscreen = (view: VueWrapper) =>
+  view.get('[aria-label="tooltip.enter_fullscreen"]').trigger("click");
+
+describe("PartyDashboardView fullscreen", () => {
+  beforeEach(() => {
+    storeMock.frameless = false;
+    fullscreenElement = null;
+    requestFullscreen.mockClear();
+    exitFullscreen.mockClear();
+    Object.defineProperty(document, "fullscreenElement", {
+      configurable: true,
+      get: () => fullscreenElement,
+    });
+    document.documentElement.requestFullscreen = requestFullscreen;
+    document.exitFullscreen = exitFullscreen;
+  });
+
+  afterEach(() => {
+    wrapper?.unmount();
+    wrapper = undefined;
+  });
+
+  it("drops the app chrome when the dashboard goes fullscreen", async () => {
+    const view = await mountView();
+
+    await enterFullscreen(view);
+
+    expect(storeMock.frameless).toBe(true);
+    expect(requestFullscreen).toHaveBeenCalled();
+  });
+
+  it("hands the chrome back when the dashboard is left while fullscreen", async () => {
+    // browser back skips the minimize button, so the view has to undo its own
+    // fullscreen on the way out or the next route has no navigation at all
+    const view = await mountView();
+    await enterFullscreen(view);
+
+    view.unmount();
+    wrapper = undefined;
+
+    expect(storeMock.frameless).toBe(false);
+    expect(exitFullscreen).toHaveBeenCalled();
+  });
+
+  it("leaves a frameless session it did not start alone", async () => {
+    // a dashboard viewer login and a ?frameless deep link are both meant to
+    // stay frameless for the whole session
+    storeMock.frameless = true;
+    const view = await mountView();
+
+    view.unmount();
+    wrapper = undefined;
+
+    expect(storeMock.frameless).toBe(true);
+    expect(exitFullscreen).not.toHaveBeenCalled();
+  });
+
+  it("stays out of the way once the browser has left fullscreen", async () => {
+    const view = await mountView();
+    await enterFullscreen(view);
+
+    // Escape, which the browser reports as a fullscreen change
+    fullscreenElement = null;
+    document.dispatchEvent(new Event("fullscreenchange"));
+    expect(storeMock.frameless).toBe(false);
+
+    view.unmount();
+    wrapper = undefined;
+
+    expect(storeMock.frameless).toBe(false);
+    expect(exitFullscreen).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
# What does this implement/fix?

Going fullscreen on the party dashboard hides the navigation and the player bar. Leaving the dashboard any way other than the minimize button — the browser's back button, a back gesture, a redirect — left the whole app that way: no navigation, no player bar, on every page, until you reloaded. The dashboard only put the chrome back from a listener that goes away with the view, and the browser stays in fullscreen across a page change, so nothing was left to notice.

The dashboard now switches its own fullscreen back off when you leave it. A screen that was already frameless for another reason — a dashboard viewer login, a `?frameless` link — is left alone.

- Track whether the dashboard is the one that went fullscreen, and undo it on the way out
- Also leave the browser's fullscreen, since the dashboard is what asked for it
- Cover both the fix and the sessions it must not touch with tests

**Related issue (if applicable):**

- related issue `<link to issue>`

**Related backend PR (if applicable):**

- related backend PR `<link to PR>`

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm lint:check` passes.
- [x] `pnpm test:run` passes, and tests have been added/updated where applicable.
- [x] `pnpm build` passes.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
