### PR TITLE
Share the CSS cascade helpers between the style tests

### DIFF
--- a/tests/styles/cascade.ts
+++ b/tests/styles/cascade.ts
@@ -1,17 +1,17 @@
 /**
  * Helpers for the tests that assert which of two competing CSS rules wins.
  *
- * happy-dom takes the last of two equally specific declarations rather than the
- * most specific one, so these tests prove an override applies by ranking the
- * selectors against each other instead of reading the winning value back.
+ * Reading the winner back off getComputedStyle does not stand in for the
+ * shipped cascade here: the raw source these tests inject carries no scope
+ * hash, and happy-dom never expands an inset shorthand, so the competing rules
+ * are weighed by ranking their selectors instead.
  */
 
 /**
- * The compound a scoped block's selectors each gain at compile time.
+ * The compound Vue's compiler adds to every selector in a scoped block.
  *
- * Vue appends a [data-v-hash] to them, which the raw source does not carry, so
- * an override lifted out of a scoped block already out-ranks a rival in an
- * unscoped one by this much before either side's own compounds are counted.
+ * The raw source these tests read carries no [data-v-hash], so a selector that
+ * ships scoped has to be credited with it by hand before the ranks compare.
  */
 export const SCOPE_COMPOUND = 1;
 

--- a/tests/styles/cascade.ts
+++ b/tests/styles/cascade.ts
@@ -48,6 +48,24 @@ export function selectorsSetting(
 }
 
 /**
+ * Whether `styles` declares `property` on `selector` as !important, or
+ * undefined when it carries no rule with exactly that selector.
+ *
+ * A rank only settles which rule wins within one importance level, so the tests
+ * that lean on it check the utility they out-rank is !important to begin with.
+ */
+export function utilityPriority(
+  styles: HTMLStyleElement,
+  selector: string,
+  property: string,
+) {
+  return [...(styles.sheet?.cssRules ?? [])]
+    .filter((rule): rule is CSSStyleRule => rule instanceof CSSStyleRule)
+    .find((rule) => rule.selectorText === selector)
+    ?.style.getPropertyPriority(property);
+}
+
+/**
  * How specific `selector` is, counted in class-level compounds.
  *
  * Comparable only between selectors that carry no id and no element name, which

--- a/tests/styles/cascade.ts
+++ b/tests/styles/cascade.ts
@@ -1,10 +1,10 @@
 /**
  * Helpers for the tests that assert which of two competing CSS rules wins.
  *
- * Reading the winner back off getComputedStyle does not stand in for the
- * shipped cascade here: the raw source these tests inject carries no scope
- * hash, and happy-dom never expands an inset shorthand, so the competing rules
- * are weighed by ranking their selectors instead.
+ * Most of them read the winning value back off getComputedStyle. Where that
+ * cannot settle it — the raw source these tests inject carries no scope hash,
+ * and happy-dom never expands an inset shorthand — the rules are weighed by
+ * ranking their selectors instead.
  */
 
 /**

--- a/tests/styles/cascade.ts
+++ b/tests/styles/cascade.ts
@@ -1,0 +1,64 @@
+/**
+ * Helpers for the tests that assert which of two competing CSS rules wins.
+ *
+ * happy-dom takes the last of two equally specific declarations rather than the
+ * most specific one, so these tests prove an override applies by ranking the
+ * selectors against each other instead of reading the winning value back.
+ */
+
+/**
+ * The compound a scoped block's selectors each gain at compile time.
+ *
+ * Vue appends a [data-v-hash] to them, which the raw source does not carry, so
+ * an override lifted out of a scoped block already out-ranks a rival in an
+ * unscoped one by this much before either side's own compounds are counted.
+ */
+export const SCOPE_COMPOUND = 1;
+
+/**
+ * The contents of every `<style>` block in a component's source, in the order
+ * it declares them.
+ *
+ * vitest only compiles the stylesheets under src/styles, so a component's own
+ * rules have to be lifted straight out of its source to be asserted on.
+ */
+export function styleBlocks(source: string) {
+  return [...source.matchAll(/<style[^>]*>([\s\S]*?)<\/style>/g)].map(
+    (match) => match[1],
+  );
+}
+
+/**
+ * The selectors in `styles` that set `property` and land on `element`.
+ *
+ * A rule may carry a selector list, of which only some parts reach the element,
+ * so the parts are returned one by one rather than as the whole selector text.
+ */
+export function selectorsSetting(
+  styles: HTMLStyleElement,
+  element: Element,
+  property: string,
+) {
+  return [...(styles.sheet?.cssRules ?? [])]
+    .filter((rule): rule is CSSStyleRule => rule instanceof CSSStyleRule)
+    .filter((rule) => rule.style.getPropertyValue(property) !== "")
+    .flatMap((rule) => rule.selectorText.split(","))
+    .map((selector) => selector.trim())
+    .filter((selector) => element.matches(selector));
+}
+
+/**
+ * How specific `selector` is, counted in class-level compounds.
+ *
+ * Comparable only between selectors that carry no id and no element name, which
+ * is what every caller weighs against each other.
+ */
+export function rank(selector: string) {
+  // :where() is what global.css reaches for to contribute no specificity at
+  // all, so it drops out before anything is counted
+  return (
+    selector
+      .replace(/:where\([^)]*\)/g, "")
+      .match(/\.[\w-]+|\[[^\]]+\]|:[\w-]+/g) ?? []
+  ).length;
+}

--- a/tests/styles/groupPopoutTouchAction.test.ts
+++ b/tests/styles/groupPopoutTouchAction.test.ts
@@ -3,18 +3,7 @@
 // @vitest-environment happy-dom
 import volumeSource from "@/layouts/default/PlayerOSD/PlayerVolume.vue?raw";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-
-// vitest only compiles the stylesheets under src/styles, so the component's own
-// rules are lifted straight out of its source, in the order it declares them
-function styleBlocks(source: string) {
-  return [...source.matchAll(/<style[^>]*>([\s\S]*?)<\/style>/g)].map(
-    (match) => match[1],
-  );
-}
-
-// the scoped block's selectors each gain a [data-v-hash] compound at compile
-// time, which the raw source does not carry
-const SCOPE_COMPOUND = 1;
+import { SCOPE_COMPOUND, rank, selectorsSetting, styleBlocks } from "./cascade";
 
 let styles: HTMLStyleElement;
 
@@ -30,22 +19,6 @@ function row() {
     </div>`;
   document.body.appendChild(popout);
   return popout.querySelector(".player-volume-container")!;
-}
-
-// a rule may carry a selector list, of which only some parts land on the row
-function selectorsSettingTouchAction(element: Element) {
-  return [...(styles.sheet?.cssRules ?? [])]
-    .filter((rule): rule is CSSStyleRule => rule instanceof CSSStyleRule)
-    .filter((rule) => rule.style.getPropertyValue("touch-action") !== "")
-    .flatMap((rule) => rule.selectorText.split(","))
-    .map((selector) => selector.trim())
-    .filter((selector) => element.matches(selector));
-}
-
-// neither side carries an id or an element name, so counting their class-level
-// compounds is the whole comparison
-function rank(selector: string) {
-  return (selector.match(/\.[\w-]+|\[[^\]]+\]|:[\w-]+/g) ?? []).length;
 }
 
 describe("group volume popout touch-action", () => {
@@ -67,7 +40,7 @@ describe("group volume popout touch-action", () => {
   });
 
   it("keeps the rows panning independently of the stylesheet load order", () => {
-    const declaring = selectorsSettingTouchAction(row());
+    const declaring = selectorsSetting(styles, row(), "touch-action");
     const winner =
       ".group-popout .player-volume-wrapper .player-volume-container";
 

--- a/tests/styles/mobileGroupVolumeSheet.test.ts
+++ b/tests/styles/mobileGroupVolumeSheet.test.ts
@@ -6,6 +6,7 @@ import sheetSource from "@/layouts/default/PlayerOSD/PlayerBarMobileVolumeSheet.
 import tokens from "@/styles/global.css?inline";
 import css from "@/styles/style.css?inline";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { rank } from "./cascade";
 
 // happy-dom does no calc() arithmetic, and drops a position whose tokens expand
 // to a nested one, so each token the sheet is placed from stands in as a plain
@@ -79,20 +80,6 @@ function overridePriority(element: Element, property: string) {
   return overrideRules(element)
     .find((rule) => rule.style.getPropertyValue(property) !== "")
     ?.style.getPropertyPriority(property);
-}
-
-// happy-dom takes the last of two !important declarations rather than the most
-// specific one, so the rank the component's selectors buy is only observable
-// off the selectors themselves. Neither side carries an id or an element name,
-// so counting their class-level compounds is the whole comparison.
-function rank(selector: string) {
-  // :where() is what global.css reaches for to contribute no specificity at
-  // all, so it drops out before anything is counted
-  return (
-    selector
-      .replace(/:where\([^)]*\)/g, "")
-      .match(/\.[\w-]+|\[[^\]]+\]|:[\w-]+/g) ?? []
-  ).length;
 }
 
 // which of two equally-!important declarations applies comes down to whichever

--- a/tests/styles/mobileGroupVolumeSheet.test.ts
+++ b/tests/styles/mobileGroupVolumeSheet.test.ts
@@ -6,7 +6,7 @@ import sheetSource from "@/layouts/default/PlayerOSD/PlayerBarMobileVolumeSheet.
 import tokens from "@/styles/global.css?inline";
 import css from "@/styles/style.css?inline";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { rank } from "./cascade";
+import { rank, utilityPriority } from "./cascade";
 
 // happy-dom does no calc() arithmetic, and drops a position whose tokens expand
 // to a nested one, so each token the sheet is placed from stands in as a plain
@@ -60,13 +60,6 @@ function overlay() {
   return probe(
     `modal-backdrop fixed inset-0 ${passedClasses("overlay-class")}`,
   );
-}
-
-function utilityPriority(selector: string, property: string) {
-  return [...(appStyles.sheet?.cssRules ?? [])]
-    .filter((rule) => rule instanceof CSSStyleRule)
-    .find((rule) => rule.selectorText === selector)
-    ?.style.getPropertyPriority(property);
 }
 
 // the component's own rules that land on this element
@@ -167,7 +160,7 @@ describe("mobile grouped volume sheet", () => {
     // ranking below proves nothing unless both sides are !important
     for (const [utility, property] of UTILITIES) {
       expect(
-        utilityPriority(utility, property),
+        utilityPriority(appStyles, utility, property),
         "the Tailwind utilities import must stay `important` and unlayered",
       ).toBe("important");
     }

--- a/tests/styles/mobileNavigationHeight.test.ts
+++ b/tests/styles/mobileNavigationHeight.test.ts
@@ -8,6 +8,7 @@ import { cn } from "@/lib/utils";
 import tokens from "@/styles/global.css?inline";
 import utilities from "@/styles/style.css?inline";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { utilityPriority } from "./cascade";
 
 // Read off the template rather than copied, so a class the rules key on going
 // missing fails here instead of leaving the probe measuring rules the bar no
@@ -63,13 +64,6 @@ function probe(className: string) {
   return getComputedStyle(element);
 }
 
-function utilityBottomPriority() {
-  return [...(utilityStyles.sheet?.cssRules ?? [])]
-    .filter((rule) => rule instanceof CSSStyleRule)
-    .find((rule) => rule.selectorText === ".bottom-0")
-    ?.style.getPropertyPriority("bottom");
-}
-
 describe("mobile navigation height", () => {
   beforeEach(() => {
     styles = [tokens, extractStyle(navigationSource)].map((text) => {
@@ -120,7 +114,7 @@ describe("mobile navigation height", () => {
     // the offset only proves anything while the utility it has to out-rank is
     // itself !important
     expect(
-      utilityBottomPriority(),
+      utilityPriority(utilityStyles, ".bottom-0", "bottom"),
       "the Tailwind utilities import must stay `important` and unlayered",
     ).toBe("important");
 

--- a/tests/styles/mobileSidebarSafeArea.test.ts
+++ b/tests/styles/mobileSidebarSafeArea.test.ts
@@ -6,6 +6,7 @@ import sidebarSource from "@/components/ui/sidebar/Sidebar.vue?raw";
 import tokens from "@/styles/global.css?inline";
 import css from "@/styles/style.css?inline";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { utilityPriority } from "./cascade";
 
 const INSET_TOP = "44px";
 const INSET_BOTTOM = "34px";
@@ -40,13 +41,6 @@ function panel(side: "left" | "right") {
   sheet.style.setProperty("--sidebar-width", MENU_WIDTH);
   document.body.appendChild(sheet);
   return getComputedStyle(sheet);
-}
-
-function utilityPriority(selector: string, property: string) {
-  return [...(appStyles.sheet?.cssRules ?? [])]
-    .filter((rule) => rule instanceof CSSStyleRule)
-    .find((rule) => rule.selectorText === selector)
-    ?.style.getPropertyPriority(property);
 }
 
 describe("mobile sidebar safe area", () => {
@@ -99,7 +93,7 @@ describe("mobile sidebar safe area", () => {
     // the padding only proves anything while the utility it has to out-rank is
     // itself !important
     expect(
-      utilityPriority(".p-0", "padding"),
+      utilityPriority(appStyles, ".p-0", "padding"),
       "the Tailwind utilities import must stay `important` and unlayered",
     ).toBe("important");
 
@@ -114,7 +108,7 @@ describe("mobile sidebar safe area", () => {
 
   it("keeps the menu its full width beside a horizontal inset", () => {
     expect(
-      utilityPriority(".w-\\(--sidebar-width\\)", "width"),
+      utilityPriority(appStyles, ".w-\\(--sidebar-width\\)", "width"),
       "the Tailwind utilities import must stay `important` and unlayered",
     ).toBe("important");
 

--- a/tests/styles/playerBarPopout.test.ts
+++ b/tests/styles/playerBarPopout.test.ts
@@ -13,6 +13,7 @@ import {
 import tokens from "@/styles/global.css?inline";
 import css from "@/styles/style.css?inline";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { utilityPriority } from "./cascade";
 
 const OVERLAY_HEIGHT = "--player-bar-overlay-height";
 const OVERLAY_MARKER = "data-player-bar-overlay";
@@ -36,13 +37,6 @@ function customProperty(name: string) {
   return getComputedStyle(document.documentElement)
     .getPropertyValue(name)
     .trim();
-}
-
-function utilityPaddingPriority() {
-  return [...(appStyles.sheet?.cssRules ?? [])]
-    .filter((rule) => rule instanceof CSSStyleRule)
-    .find((rule) => rule.selectorText === ".p-0")
-    ?.style.getPropertyPriority("padding");
 }
 
 describe("player bar popout inset", () => {
@@ -69,7 +63,7 @@ describe("player bar popout inset", () => {
     // the inset only proves anything while the utility it has to out-rank is
     // itself !important
     expect(
-      utilityPaddingPriority(),
+      utilityPriority(appStyles, ".p-0", "padding"),
       "the Tailwind utilities import must stay `important` and unlayered",
     ).toBe("important");
 

--- a/tests/styles/volumeScrollerTouchAction.test.ts
+++ b/tests/styles/volumeScrollerTouchAction.test.ts
@@ -5,6 +5,7 @@ import volumeSource from "@/layouts/default/PlayerOSD/PlayerVolume.vue?raw";
 import panelSource from "@/layouts/default/PlayerOSD/PlayerVolumePanel.vue?raw";
 import selectSource from "@/layouts/default/PlayerSelect.vue?raw";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { SCOPE_COMPOUND, rank, selectorsSetting, styleBlocks } from "./cascade";
 
 // the lists outside PlayerVolume that opt their rows into the vertical pan
 const SCROLLERS = [
@@ -15,19 +16,7 @@ const SCROLLERS = [
 const OVERRIDE =
   ".player-volume-scroller .player-volume-wrapper .player-volume-container";
 
-// the scoped block's selectors each gain a [data-v-hash] compound at compile
-// time, which the raw source does not carry
-const SCOPE_COMPOUND = 1;
-
 let styles: HTMLStyleElement;
-
-// vitest only compiles the stylesheets under src/styles, so PlayerVolume's own
-// rules are lifted straight out of its source, in the order it declares them
-function styleBlocks(source: string) {
-  return [...source.matchAll(/<style[^>]*>([\s\S]*?)<\/style>/g)].map(
-    (match) => match[1],
-  );
-}
 
 // the classes the list is rendered with, read off the template so the probe
 // cannot drift from the markup it stands in for
@@ -47,22 +36,6 @@ function row(classes: string) {
     </div>`;
   document.body.appendChild(list);
   return list.querySelector(".player-volume-container")!;
-}
-
-// a rule may carry a selector list, of which only some parts land on the row
-function selectorsSettingTouchAction(element: Element) {
-  return [...(styles.sheet?.cssRules ?? [])]
-    .filter((rule): rule is CSSStyleRule => rule instanceof CSSStyleRule)
-    .filter((rule) => rule.style.getPropertyValue("touch-action") !== "")
-    .flatMap((rule) => rule.selectorText.split(","))
-    .map((selector) => selector.trim())
-    .filter((selector) => element.matches(selector));
-}
-
-// neither side carries an id or an element name, so counting their class-level
-// compounds is the whole comparison
-function rank(selector: string) {
-  return (selector.match(/\.[\w-]+|\[[^\]]+\]|:[\w-]+/g) ?? []).length;
 }
 
 // the list has to still be the element that scrolls, or the rows would be
@@ -98,7 +71,11 @@ describe("volume rows in a scrolling list", () => {
   it.each(SCROLLERS)(
     "keeps %s panning independently of the stylesheet load order",
     (_name, source) => {
-      const declaring = selectorsSettingTouchAction(row(scroller(source)));
+      const declaring = selectorsSetting(
+        styles,
+        row(scroller(source)),
+        "touch-action",
+      );
 
       expect(declaring).toContain(OVERRIDE);
       for (const selector of declaring) {


### PR DESCRIPTION
# What does this implement/fix?

Several of the style tests prove that a CSS rule beats the one it competes with by ranking the two selectors against each other. Each of them carried its own copy of the helpers doing that, so a fix to one copy would silently miss the others — and the copies had already started to drift apart.

They now share one module. No test changed what it asserts.

- add `tests/styles/cascade.ts` holding `styleBlocks`, `selectorsSetting`, `rank`, `utilityPriority` and `SCOPE_COMPOUND`
- point the six tests that were carrying their own copies at it
- `rank` now handles `:where()` everywhere rather than in one copy only

Left alone on purpose: `extractStyle` looks duplicated but each test picks a different `<style>` block on purpose (scoped, unscoped, or either), and `probe` differs in what it hands back. Unifying either would need a per-caller options bag for no gain.

**Related issue (if applicable):**

- related issue `n/a`

**Related backend PR (if applicable):**

- related backend PR `n/a`

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm lint:check` passes.
- [x] `pnpm test:run` passes, and tests have been added/updated where applicable.
- [x] `pnpm build` passes.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
