### PR TITLE
Show dynamic radio stations with a sample tracklist

### DIFF
--- a/src/components/DynamicItemSample.vue
+++ b/src/components/DynamicItemSample.vue
@@ -6,7 +6,13 @@
       </div>
       <div>
         <div class="text-h6">
-          {{ $t("smart_playlist.dynamic_sample_heading") }}
+          {{
+            $t(
+              isPlaylist
+                ? "smart_playlist.dynamic_sample_heading"
+                : "dynamic_radio_heading",
+            )
+          }}
         </div>
         <div class="text-body-2 text-medium-emphasis">
           {{ $t("smart_playlist.dynamic_sample_note") }}
@@ -45,10 +51,16 @@
         <EmptyHeader>
           <EmptyTitle>{{ $t("smart_playlist.empty_title") }}</EmptyTitle>
           <EmptyDescription>
-            {{ $t("smart_playlist.empty_desc") }}
+            {{
+              $t(
+                isPlaylist
+                  ? "smart_playlist.empty_desc"
+                  : "dynamic_radio_empty_desc",
+              )
+            }}
           </EmptyDescription>
         </EmptyHeader>
-        <EmptyContent>
+        <EmptyContent v-if="isPlaylist">
           <Button variant="outline" size="sm" @click="emit('edit-rules')">
             <SlidersHorizontal class="h-3.5 w-3.5 mr-1.5" />
             {{ $t("smart_playlist.edit_rules") }}
@@ -75,6 +87,7 @@ import { Separator } from "@/components/ui/separator";
 import { api } from "@/plugins/api";
 import { itemIsAvailable } from "@/plugins/api/helpers";
 import {
+  MediaType,
   PlaybackState,
   type Audiobook,
   type MediaItemType,
@@ -85,14 +98,18 @@ import {
 } from "@/plugins/api/interfaces";
 import { store } from "@/plugins/store";
 import { Music2, SlidersHorizontal } from "@lucide/vue";
-import { ref, watch } from "vue";
+import { computed, ref, watch } from "vue";
 
 export interface Props {
-  itemDetails: Playlist;
+  itemDetails: Playlist | Radio;
   provider: string;
 }
 const props = defineProps<Props>();
 const emit = defineEmits<{ (e: "edit-rules"): void }>();
+
+const isPlaylist = computed(
+  () => props.itemDetails.media_type === MediaType.PLAYLIST,
+);
 
 const loading = ref(true);
 const tracks = ref<(Track | Radio | PodcastEpisode | Audiobook)[]>([]);
@@ -102,12 +119,14 @@ const loadSample = async function () {
   try {
     // request a fresh evaluation: the overview should show a current sample rather than
     // a (possibly stale/empty) cached browse result.
-    const result = await api.getPlaylistTracks(
-      props.itemDetails.item_id,
-      props.provider,
-      false,
-    );
-    // the provider returns a bounded sample for dynamic playlists; cap defensively
+    const result = isPlaylist.value
+      ? await api.getPlaylistTracks(
+          props.itemDetails.item_id,
+          props.provider,
+          false,
+        )
+      : await api.getRadioTracks(props.itemDetails.item_id, props.provider);
+    // the provider returns a bounded sample for dynamic sources; cap defensively
     tracks.value = result.slice(0, 25);
   } catch {
     tracks.value = [];

--- a/src/plugins/api/index.ts
+++ b/src/plugins/api/index.ts
@@ -991,6 +991,16 @@ export class MusicAssistantApi {
     });
   }
 
+  public getRadioTracks(
+    item_id: string,
+    provider_instance_id_or_domain: string,
+  ): Promise<Track[]> {
+    return this.sendCommand("music/radios/radio_tracks", {
+      item_id,
+      provider_instance_id_or_domain,
+    });
+  }
+
   // Audiobook related endpoints
   /**
    * Get Audiobooks listing from the server.

--- a/src/plugins/api/interfaces.ts
+++ b/src/plugins/api/interfaces.ts
@@ -979,7 +979,9 @@ export interface Playlist extends MediaItem {
   is_dynamic: boolean;
 }
 
-export interface Radio extends MediaItem {}
+export interface Radio extends MediaItem {
+  is_dynamic: boolean;
+}
 
 export interface SoundEffect extends MediaItem {
   duration: number;

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -915,6 +915,8 @@
     "recently_played": "Recently played",
     "load_more_items": "Load more items...",
     "radio": "Radio",
+    "dynamic_radio_heading": "Dynamic station",
+    "dynamic_radio_empty_desc": "This station didn't return any tracks. Try again in a moment.",
     "muted": "muted",
     "enter_name": "Enter a new (custom) name",
     "image_url": "Input the URL to an image or icon (optional)",

--- a/src/views/PlaylistDetails.vue
+++ b/src/views/PlaylistDetails.vue
@@ -32,7 +32,7 @@
     @saved="loadItemDetails"
   />
   <!-- dynamic playlist: content is generated on the fly, so show a sample instead of a fixed tracklist -->
-  <DynamicPlaylistSample
+  <DynamicItemSample
     v-if="itemDetails && itemDetails.is_dynamic"
     :item-details="itemDetails"
     :provider="props.provider"
@@ -72,7 +72,7 @@
 </template>
 
 <script setup lang="ts">
-import DynamicPlaylistSample from "@/components/DynamicPlaylistSample.vue";
+import DynamicItemSample from "@/components/DynamicItemSample.vue";
 import InfoHeader from "@/components/InfoHeader.vue";
 import ItemsListing, { LoadDataParams } from "@/components/ItemsListing.vue";
 import ProviderDetails from "@/components/ProviderDetails.vue";

--- a/src/views/RadioDetails.vue
+++ b/src/views/RadioDetails.vue
@@ -1,8 +1,14 @@
 <template>
   <section>
     <InfoHeader :item="itemDetails" />
+    <!-- dynamic station: content is generated on the fly, so show a sample instead of "other versions" -->
+    <DynamicItemSample
+      v-if="itemDetails && itemDetails.is_dynamic"
+      :item-details="itemDetails"
+      :provider="props.provider"
+    />
     <ItemsListing
-      v-if="itemDetails"
+      v-else-if="itemDetails"
       itemtype="radioversions"
       :parent-item="itemDetails"
       :show-provider="true"
@@ -24,6 +30,7 @@
 <script setup lang="ts">
 import ItemsListing, { LoadDataParams } from "@/components/ItemsListing.vue";
 import InfoHeader from "@/components/InfoHeader.vue";
+import DynamicItemSample from "@/components/DynamicItemSample.vue";
 import { ref, watch, onMounted, onBeforeUnmount } from "vue";
 import {
   EventType,

--- a/tests/components/DynamicItemSample.test.ts
+++ b/tests/components/DynamicItemSample.test.ts
@@ -1,0 +1,119 @@
+import DynamicItemSample from "@/components/DynamicItemSample.vue";
+import type { MusicAssistantApi } from "@/plugins/api";
+import type { Playlist, Radio } from "@/plugins/api/interfaces";
+import { flushPromises, mount } from "@vue/test-utils";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { playlist } from "../fixtures/playlist";
+import { radio } from "../fixtures/radio";
+import { track } from "../fixtures/track";
+
+const { mockGetPlaylistTracks, mockGetRadioTracks, apiMock } = vi.hoisted(
+  () => {
+    const mockGetPlaylistTracks =
+      vi.fn<MusicAssistantApi["getPlaylistTracks"]>();
+    const mockGetRadioTracks = vi.fn<MusicAssistantApi["getRadioTracks"]>();
+    return {
+      mockGetPlaylistTracks,
+      mockGetRadioTracks,
+      apiMock: {
+        providers: {},
+        getPlaylistTracks: mockGetPlaylistTracks,
+        getRadioTracks: mockGetRadioTracks,
+      },
+    };
+  },
+);
+
+vi.mock("@/plugins/api", () => ({
+  api: apiMock,
+  default: apiMock,
+}));
+
+vi.mock("@/plugins/store", () => ({
+  store: { activePlayer: undefined, curQueueItem: undefined },
+}));
+
+// the real component pulls in router/toast/breakpoint machinery this suite
+// doesn't need; a minimal stand-in keeps the sample's own tracks assertable
+vi.mock("@/components/ListviewItem.vue", () => ({
+  default: {
+    name: "ListviewItem",
+    props: ["item"],
+    template: '<div class="listview-item-stub">{{ item.name }}</div>',
+  },
+}));
+
+function mountSample(itemDetails: Playlist | Radio) {
+  return mount(DynamicItemSample, {
+    props: { itemDetails, provider: "spotify" },
+    global: {
+      mocks: { $t: (key: string) => key },
+      // the decorative badge icon needs a real Vuetify instance to render;
+      // it's irrelevant to this component's branching logic
+      stubs: { VIcon: true },
+    },
+  });
+}
+
+describe("DynamicItemSample", () => {
+  beforeEach(() => {
+    mockGetPlaylistTracks.mockReset();
+    mockGetRadioTracks.mockReset();
+  });
+
+  it("loads and renders tracks from a dynamic playlist", async () => {
+    mockGetPlaylistTracks.mockResolvedValue([
+      track({ item_id: "1", name: "Track one" }),
+      track({ item_id: "2", name: "Track two" }),
+    ]);
+    const wrapper = mountSample(
+      playlist({ item_id: "p1", provider: "library", is_dynamic: true }),
+    );
+    await flushPromises();
+
+    expect(mockGetPlaylistTracks).toHaveBeenCalledWith("p1", "spotify", false);
+    expect(mockGetRadioTracks).not.toHaveBeenCalled();
+    expect(
+      wrapper.findAll(".listview-item-stub").map((item) => item.text()),
+    ).toEqual(["Track one", "Track two"]);
+    expect(wrapper.text()).toContain("smart_playlist.dynamic_sample_heading");
+  });
+
+  it("loads and renders tracks from a dynamic radio", async () => {
+    mockGetRadioTracks.mockResolvedValue([
+      track({ item_id: "1", name: "Sample one" }),
+    ]);
+    const wrapper = mountSample(
+      radio({ item_id: "r1", provider: "library", is_dynamic: true }),
+    );
+    await flushPromises();
+
+    expect(mockGetRadioTracks).toHaveBeenCalledWith("r1", "spotify");
+    expect(mockGetPlaylistTracks).not.toHaveBeenCalled();
+    expect(
+      wrapper.findAll(".listview-item-stub").map((item) => item.text()),
+    ).toEqual(["Sample one"]);
+    expect(wrapper.text()).toContain("dynamic_radio_heading");
+  });
+
+  it("offers to edit the rules of an empty dynamic playlist", async () => {
+    mockGetPlaylistTracks.mockResolvedValue([]);
+    const wrapper = mountSample(playlist({ is_dynamic: true }));
+    await flushPromises();
+
+    expect(wrapper.text()).toContain("smart_playlist.empty_desc");
+    expect(wrapper.find('[data-slot="button"]').exists()).toBe(true);
+
+    await wrapper.find('[data-slot="button"]').trigger("click");
+    expect(wrapper.emitted("edit-rules")).toHaveLength(1);
+  });
+
+  it("has no rules to edit for an empty dynamic radio", async () => {
+    mockGetRadioTracks.mockResolvedValue([]);
+    const wrapper = mountSample(radio({ is_dynamic: true }));
+    await flushPromises();
+
+    expect(wrapper.text()).toContain("dynamic_radio_empty_desc");
+    expect(wrapper.find('[data-slot="button"]').exists()).toBe(false);
+  });
+});

--- a/tests/fixtures/radio.ts
+++ b/tests/fixtures/radio.ts
@@ -17,6 +17,7 @@ export function radio(overrides: Partial<Radio> = {}): Radio {
     provider_mappings: [],
     metadata: {},
     favorite: false,
+    is_dynamic: false,
     ...overrides,
   });
 }

--- a/tests/views/RadioDetails.test.ts
+++ b/tests/views/RadioDetails.test.ts
@@ -1,0 +1,67 @@
+import RadioDetails from "@/views/RadioDetails.vue";
+import type { MusicAssistantApi } from "@/plugins/api";
+import type { Radio } from "@/plugins/api/interfaces";
+import { flushPromises, mount } from "@vue/test-utils";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { radio } from "../fixtures/radio";
+
+const { mockGetRadio, mockSubscribe } = vi.hoisted(() => ({
+  mockGetRadio: vi.fn<MusicAssistantApi["getRadio"]>(),
+  mockSubscribe: vi.fn(() => () => {}),
+}));
+
+vi.mock("@/plugins/api", () => ({
+  api: { getRadio: mockGetRadio, subscribe: mockSubscribe },
+}));
+
+vi.mock("@/components/InfoHeader.vue", () => ({
+  default: { name: "InfoHeader", template: "<div />" },
+}));
+// stubs identify which branch RadioDetails picked; their own machinery
+// (router, auth, i18n composables) is irrelevant to that choice
+vi.mock("@/components/ItemsListing.vue", () => ({
+  default: {
+    name: "ItemsListing",
+    template: '<div class="items-listing-stub" />',
+  },
+}));
+vi.mock("@/components/ProviderDetails.vue", () => ({
+  default: { name: "ProviderDetails", template: "<div />" },
+}));
+vi.mock("@/components/DynamicItemSample.vue", () => ({
+  default: {
+    name: "DynamicItemSample",
+    template: '<div class="dynamic-item-sample-stub" />',
+  },
+}));
+
+async function mountDetails(item: Radio) {
+  mockGetRadio.mockResolvedValue(item);
+  const wrapper = mount(RadioDetails, {
+    props: { itemId: item.item_id, provider: item.provider },
+    global: { mocks: { $t: (key: string) => key } },
+  });
+  await flushPromises();
+  return wrapper;
+}
+
+describe("RadioDetails", () => {
+  beforeEach(() => {
+    mockGetRadio.mockReset();
+    mockSubscribe.mockReset().mockReturnValue(() => {});
+  });
+
+  it("shows the dynamic sample for a dynamic station", async () => {
+    const wrapper = await mountDetails(radio({ is_dynamic: true }));
+
+    expect(wrapper.find(".dynamic-item-sample-stub").exists()).toBe(true);
+    expect(wrapper.find(".items-listing-stub").exists()).toBe(false);
+  });
+
+  it("shows other versions for a non-dynamic station", async () => {
+    const wrapper = await mountDetails(radio({ is_dynamic: false }));
+
+    expect(wrapper.find(".items-listing-stub").exists()).toBe(true);
+    expect(wrapper.find(".dynamic-item-sample-stub").exists()).toBe(false);
+  });
+});


### PR DESCRIPTION
# What does this implement/fix?

Radio stations can now be "dynamic": the provider hands out a fresh batch of tracks on demand
instead of a single live stream, the same way a dynamic playlist already works. Pandora is the
first service that will use this, so its stations can live under Radio where users look for them.

A dynamic station has no fixed tracklist and no other versions, so its details view shows a
refreshable sample of what would play, reusing the component the playlist view already uses.

**Related issue (if applicable):**

- related issue `<link to issue>`

**Related backend PR (if applicable):**

<!--
Link the music-assistant/server PR when this change relies on new server
behaviour, so the two can be reviewed and released together.
-->

- related backend PR https://github.com/music-assistant/server/pull/5628

## Types of changes

<!--
Tick exactly one box below. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm lint:check` passes.
- [x] `pnpm test:run` passes, and tests have been added/updated where applicable.
- [x] `pnpm build` passes.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.

## Changes

- `Radio` gains an `is_dynamic` flag and a `getRadioTracks` API call.
- `RadioDetails` shows the track sample for a dynamic station instead of the versions listing.
- `DynamicPlaylistSample` becomes `DynamicItemSample` and serves both playlists and stations.
