### PR TITLE
Round the home screen's edit button again

### DIFF
--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -147,7 +147,8 @@ onMounted(async () => {
   /* Only has to clear the drag ghost in HomeWidgetRows, so it stays out of the
      global stacking scale and below the player bar and its backdrops. */
   z-index: 60;
-  border-radius: 999px;
+  /* Outweighs the equally-!important radius the button's own variants carry. */
+  border-radius: 999px !important;
   box-shadow: 0 6px 20px rgba(0, 0, 0, 0.3);
 }
 </style>

--- a/tests/styles/fixedElementSafeArea.test.ts
+++ b/tests/styles/fixedElementSafeArea.test.ts
@@ -22,9 +22,11 @@ const INSET_BOTTOM = "11px";
 // from the wrong one cannot read as the right number.
 const BARS_HEIGHT = "158px";
 
-// A scoped block arrives here without the [data-v-hash] compound the compiler
-// pairs each of its selectors with, so it is a rank short of what ships. The
-// utilities load first below to stand in for the tie that rank settles.
+// The unscoped blocks ship as written; a scoped one arrives without the
+// [data-v-hash] compound the compiler pairs each of its selectors with, so it
+// is a rank short. The utilities load first below to stand in for that rank,
+// which is why the order here is the opposite of mobileNavigationHeight's -
+// that bar declares its rules unscoped, so it can be held to the harder one.
 function extractStyle(source: string) {
   return source.match(/<style(?: scoped)?>([\s\S]*?)<\/style>/)?.[1] ?? "";
 }
@@ -48,10 +50,12 @@ function dialogContentClasses(className: string) {
   return cn(base, className);
 }
 
+// each pattern stops at the tag's own `>`, so a tag that stops carrying a
+// static class list throws rather than reaching on to the next element's
 const PLAYBACK_SPEED_DIALOG = dialogContentClasses(
   templateClasses(
     playerTrackMenuSource,
-    /<DialogContent[\s\S]*?\sclass="([^"]*)"/,
+    /<DialogContent[^>]*\sclass="([^"]*)"/,
   ),
 );
 // a Button merges the classes it is passed onto its own, and its variants are
@@ -73,8 +77,10 @@ function normalize(value: string) {
 const appStyles: HTMLStyleElement[] = [];
 let utilityStyles: HTMLStyleElement;
 
-// an override proves nothing unless the ui component's own utilities really do
-// set the property, and set it !important
+// an override proves nothing unless a utility on the element really does set
+// the property, and set it !important. Only the top level is read: a utility
+// nested in a media query is a competitor at some widths, and what has to be
+// there is one that competes at every width.
 function expectUtilitiesCompete(element: Element, property: string) {
   const priorities = [...(utilityStyles.sheet?.cssRules ?? [])]
     .filter((rule) => rule instanceof CSSStyleRule)
@@ -87,7 +93,7 @@ function expectUtilitiesCompete(element: Element, property: string) {
 
   expect(
     priorities,
-    `the component the element is built from must keep setting ${property}`,
+    `a utility the element carries has to keep setting ${property}`,
   ).not.toHaveLength(0);
   expect(
     [...new Set(priorities)],
@@ -173,9 +179,9 @@ describe("home screen edit button", () => {
   it("keeps its pill shape against the corners every button gets", () => {
     const element = render(homeViewSource, EDIT_DONE);
 
-    // happy-dom keeps no declaration for the border-radius shorthand the
-    // variants carry, so the competition is only observable in the value: a
-    // pill that loses reads as the radius token every other button takes
+    // the radius the variants carry is a calc() holding a var(), which
+    // happy-dom drops from the CSSOM, so the competition is only observable in
+    // the value: a pill that loses reads as the token every other button takes
     expect(getComputedStyle(element).borderRadius).toBe("999px");
   });
 });

--- a/tests/styles/fixedElementSafeArea.test.ts
+++ b/tests/styles/fixedElementSafeArea.test.ts
@@ -1,9 +1,13 @@
 // jsdom leaves var() unresolved in computed styles, so this cascade is only
 // observable under happy-dom
 // @vitest-environment happy-dom
+import { buttonVariants } from "@/components/ui/button";
+import dialogContentSource from "@/components/ui/dialog/DialogContent.vue?raw";
 import footerSource from "@/layouts/default/Footer.vue?raw";
 import reloadPromptSource from "@/layouts/default/ReloadPrompt.vue?raw";
 import playerTrackMenuSource from "@/layouts/default/PlayerOSD/PlayerControlBtn/PlayerTrackMenu.vue?raw";
+import { cn } from "@/lib/utils";
+import utilities from "@/styles/style.css?inline";
 import homeViewSource from "@/views/HomeView.vue?raw";
 import editConfigSource from "@/views/settings/EditConfig.vue?raw";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
@@ -18,10 +22,47 @@ const INSET_BOTTOM = "11px";
 // from the wrong one cannot read as the right number.
 const BARS_HEIGHT = "158px";
 
-// Use raw selectors so the tests do not depend on Vue's generated scope id.
+// A scoped block arrives here without the [data-v-hash] compound the compiler
+// pairs each of its selectors with, so it is a rank short of what ships. The
+// utilities load first below to stand in for the tie that rank settles.
 function extractStyle(source: string) {
   return source.match(/<style(?: scoped)?>([\s\S]*?)<\/style>/)?.[1] ?? "";
 }
+
+// Read off the template rather than copied, so a class the rules key on going
+// missing fails here instead of leaving the probe measuring rules the element
+// no longer carries.
+function templateClasses(source: string, pattern: RegExp) {
+  const classes = source.match(pattern)?.[1];
+  if (!classes)
+    throw new Error(`the template carries no class list for ${pattern}`);
+  return classes;
+}
+
+// DialogContent composes its own list in the template, so the dialog is probed
+// the way it is rendered: the !important max-width in there is exactly what the
+// dialog's own placement has to beat.
+function dialogContentClasses(className: string) {
+  const base = dialogContentSource.match(/cn\(\s*'([^']*)'/)?.[1];
+  if (!base) throw new Error("DialogContent no longer composes a base list");
+  return cn(base, className);
+}
+
+const PLAYBACK_SPEED_DIALOG = dialogContentClasses(
+  templateClasses(
+    playerTrackMenuSource,
+    /<DialogContent[\s\S]*?\sclass="([^"]*)"/,
+  ),
+);
+// a Button merges the classes it is passed onto its own, and its variants are
+// where the competing radius comes from
+const EDIT_DONE = cn(
+  buttonVariants(),
+  templateClasses(
+    homeViewSource,
+    /<Button[^>]*\sclass="([^"]*\bed-edit-done\b[^"]*)"/,
+  ),
+);
 
 // happy-dom substitutes var() but never evaluates calc(), so a sum is only
 // observable as the expression composing it
@@ -30,6 +71,29 @@ function normalize(value: string) {
 }
 
 const appStyles: HTMLStyleElement[] = [];
+let utilityStyles: HTMLStyleElement;
+
+// an override proves nothing unless the ui component's own utilities really do
+// set the property, and set it !important
+function expectUtilitiesCompete(element: Element, property: string) {
+  const priorities = [...(utilityStyles.sheet?.cssRules ?? [])]
+    .filter((rule) => rule instanceof CSSStyleRule)
+    .filter(
+      (rule) =>
+        element.matches(rule.selectorText) &&
+        rule.style.getPropertyValue(property) !== "",
+    )
+    .map((rule) => rule.style.getPropertyPriority(property));
+
+  expect(
+    priorities,
+    `the component the element is built from must keep setting ${property}`,
+  ).not.toHaveLength(0);
+  expect(
+    [...new Set(priorities)],
+    "the Tailwind utilities import must stay `important` and unlayered",
+  ).toEqual(["important"]);
+}
 
 function render(source: string, className: string) {
   const styles = document.createElement("style");
@@ -44,6 +108,13 @@ function render(source: string, className: string) {
 }
 
 beforeEach(() => {
+  // first, so a rule the components declare still wins the ties their shipped
+  // selectors win on rank alone
+  utilityStyles = document.createElement("style");
+  utilityStyles.textContent = utilities;
+  document.head.appendChild(utilityStyles);
+  appStyles.push(utilityStyles);
+
   document.documentElement.style.setProperty("--device-inset-top", INSET_TOP);
   document.documentElement.style.setProperty(
     "--device-inset-right",
@@ -70,12 +141,12 @@ describe.each([
   // The desktop rule is what a landscape phone gets, so it carries the inset
   // even though the mobile variant has its own.
   ["settings save button", editConfigSource, "floating-save", "24px"],
-  ["home screen edit button", homeViewSource, "ed-edit-done", "24px"],
+  ["home screen edit button", homeViewSource, EDIT_DONE, "24px"],
   // The dialog writes its gap as 1rem, which resolves to the root font size.
   [
     "playback speed dialog",
     playerTrackMenuSource,
-    "playback-speed-dialog",
+    PLAYBACK_SPEED_DIALOG,
     "16px",
   ],
 ])("%s", (_name, source, className, gap) => {
@@ -90,11 +161,22 @@ describe.each([
 
 describe("home screen edit button", () => {
   it("clears the notch it sits under in portrait", () => {
-    const element = render(homeViewSource, "ed-edit-done");
+    const element = render(homeViewSource, EDIT_DONE);
 
     expect(normalize(getComputedStyle(element).top)).toBe(
       `calc(24px+${INSET_TOP})`,
     );
+  });
+
+  // It floats over the widgets rather than sitting in a row of controls, so it
+  // is shaped to read as its own thing instead of as one more button.
+  it("keeps its pill shape against the corners every button gets", () => {
+    const element = render(homeViewSource, EDIT_DONE);
+
+    // happy-dom keeps no declaration for the border-radius shorthand the
+    // variants carry, so the competition is only observable in the value: a
+    // pill that loses reads as the radius token every other button takes
+    expect(getComputedStyle(element).borderRadius).toBe("999px");
   });
 });
 
@@ -102,8 +184,9 @@ describe("playback speed dialog", () => {
   // Offsetting only the near edge would push the far one off screen once the
   // dialog is wide enough to be clamped.
   it("clamps its width to both safe edges", () => {
-    const element = render(playerTrackMenuSource, "playback-speed-dialog");
+    const element = render(playerTrackMenuSource, PLAYBACK_SPEED_DIALOG);
 
+    expectUtilitiesCompete(element, "max-width");
     // happy-dom resolves 100vw and 2rem before handing the expression back.
     expect(normalize(getComputedStyle(element).maxWidth)).toBe(
       `calc(${window.innerWidth}px-32px-${INSET_LEFT}-${INSET_RIGHT})`,

--- a/tests/styles/floatingSaveMobile.test.ts
+++ b/tests/styles/floatingSaveMobile.test.ts
@@ -13,7 +13,9 @@ const DEVICE_INSET_RIGHT = "33px";
 let appStyles: HTMLStyleElement;
 let saveButton: HTMLDivElement;
 
-// Use raw selectors so the test does not depend on Vue's generated scope id.
+// the block is scoped, so it arrives without the [data-v-hash] compound the
+// compiler pairs each of its selectors with; nothing here competes with them,
+// so the raw selectors stand in for the shipped ones
 function extractStyle(source: string) {
   return source.match(/<style scoped>([\s\S]*?)<\/style>/)?.[1] ?? "";
 }

--- a/tests/styles/mobileDockRim.test.ts
+++ b/tests/styles/mobileDockRim.test.ts
@@ -18,7 +18,7 @@ const DEVICE_INSET_RIGHT = "33px";
 
 let styles: HTMLStyleElement[];
 
-// Use raw selectors so the test does not depend on Vue's generated scope id.
+// both blocks are unscoped, so the selectors they declare are the shipped ones
 function extractStyle(source: string) {
   return source.match(/<style>([\s\S]*?)<\/style>/)?.[1] ?? "";
 }

--- a/tests/styles/mobileSidebarSafeArea.test.ts
+++ b/tests/styles/mobileSidebarSafeArea.test.ts
@@ -17,7 +17,7 @@ let appStyles: HTMLStyleElement;
 let tokenStyles: HTMLStyleElement;
 let sheetStyles: HTMLStyleElement;
 
-// Use raw selectors so the test does not depend on Vue's generated scope id.
+// the block is unscoped, so the selectors it declares are the shipped ones
 function extractStyle(source: string) {
   return source.match(/<style>([\s\S]*?)<\/style>/)?.[1] ?? "";
 }


### PR DESCRIPTION
# What does this implement/fix?

The floating "done editing" button on the home screen was drawn with ordinary
square-ish corners instead of the pill it is meant to be — its rounding lost to
the rounding every button gets.

It went unnoticed because the layout tests build their probe element from a
hand-copied class list. The copy leaves out the classes a component brings
along itself, so a probe can keep measuring rules the real element no longer
gets, and the test stays green while the app is wrong.

Both are fixed here, and the rest of `tests/styles/` was audited for the same
blind spot.

**Related issue (if applicable):**

- n/a

**Related backend PR (if applicable):**

- n/a

## Changes

- Round the home screen's floating edit button again.
- Read the class list off the component's own template, and compose it the way
  the button and dialog components do, so the probes measure what really
  renders.
- Cover the button's pill shape and the playback speed dialog's width limit —
  both go red now if the rule stops applying.
- Audited every other test in `tests/styles/`: their probes already match what
  renders, so they are left alone. Corrected a comment in four of them that
  described the wrong reason for reading the styles raw.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm lint:check` passes.
- [x] `pnpm test:run` passes, and tests have been added/updated where applicable.
- [x] `pnpm build` passes.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
