### PR TITLE
Swipe left to go back, plus tidier mobile popouts

### DIFF
--- a/src/components/ui/sidebar/SidebarInset.vue
+++ b/src/components/ui/sidebar/SidebarInset.vue
@@ -1,72 +1,13 @@
 <script setup lang="ts">
-import { useMobileSidebarSide } from "@/composables/useMobileSidebarSide";
+import { useEdgeSwipeNavigation } from "@/composables/useEdgeSwipeNavigation";
 import { cn } from "@/lib/utils";
 import type { HTMLAttributes } from "vue";
-import { ref } from "vue";
-import { useSidebar } from "./utils";
 
 const props = defineProps<{
   class?: HTMLAttributes["class"];
 }>();
 
-const { isMobile, openMobile, setOpenMobile } = useSidebar();
-
-const mobileSidebarSide = useMobileSidebarSide();
-
-const touchStartX = ref(0);
-const touchStartY = ref(0);
-const trackingSwipe = ref(false);
-
-const EDGE_ZONE_PX = 32;
-const SWIPE_THRESHOLD_PX = 60;
-const VERTICAL_TOLERANCE_PX = 40;
-
-function onTouchStart(event: TouchEvent) {
-  if (!isMobile.value || openMobile.value) return;
-  const touch = event.touches[0];
-  if (!touch) return;
-
-  touchStartX.value = touch.clientX;
-  touchStartY.value = touch.clientY;
-  if (mobileSidebarSide.value === "left") {
-    trackingSwipe.value = touchStartX.value <= EDGE_ZONE_PX;
-  } else {
-    const width =
-      window.innerWidth ||
-      (typeof document !== "undefined"
-        ? document.documentElement.clientWidth
-        : 0);
-    trackingSwipe.value =
-      width > 0 && touchStartX.value >= width - EDGE_ZONE_PX;
-  }
-}
-
-function onTouchMove(event: TouchEvent) {
-  if (!trackingSwipe.value || !isMobile.value || openMobile.value) return;
-
-  const touch = event.touches[0];
-  if (!touch) return;
-
-  const deltaX = touch.clientX - touchStartX.value;
-  const deltaY = touch.clientY - touchStartY.value;
-
-  if (Math.abs(deltaY) > VERTICAL_TOLERANCE_PX) {
-    trackingSwipe.value = false;
-    return;
-  }
-
-  if (
-    (mobileSidebarSide.value === "left" && deltaX > SWIPE_THRESHOLD_PX) ||
-    (mobileSidebarSide.value === "right" && -deltaX > SWIPE_THRESHOLD_PX)
-  ) {
-    setOpenMobile(true);
-    trackingSwipe.value = false;
-  }
-}
-
-function onTouchEnd() {
-  trackingSwipe.value = false;
-}
+const { onTouchStart, onTouchMove, onTouchEnd } = useEdgeSwipeNavigation();
 </script>
 
 <template>

--- a/src/composables/useEdgeSwipeNavigation.ts
+++ b/src/composables/useEdgeSwipeNavigation.ts
@@ -3,7 +3,6 @@ import {
   useMobileSidebarSide,
   type MobileSidebarSide,
 } from "@/composables/useMobileSidebarSide";
-import { store } from "@/plugins/store";
 import { ref } from "vue";
 import { useRoute, useRouter } from "vue-router";
 
@@ -18,7 +17,7 @@ const VERTICAL_TOLERANCE_PX = 40;
  * the navigation sheet on the `discover` route, and navigates back on any
  * other route. When the menu opens from the right, that edge always opens
  * the sheet instead, and the left edge navigates back on every route.
- * Navigating back does nothing when there is no previous in-app route.
+ * Navigating back does nothing when there is nowhere to go back to.
  *
  * Only active while the mobile sidebar is closed. Bind the returned
  * handlers as passive touchstart/touchmove/touchend listeners.
@@ -40,7 +39,10 @@ export function useEdgeSwipeNavigation() {
 
     touchStartX.value = touch.clientX;
     touchStartY.value = touch.clientY;
-    swipeEdge.value = edgeAt(touch.clientX, mobileSidebarSide.value);
+    const edge = edgeAt(touch.clientX, mobileSidebarSide.value);
+    // a carousel reaches close enough to the edge to be dragged from inside
+    // this zone, and the listeners are passive, so the two would both run
+    swipeEdge.value = edge && !insideHorizontalScroller(event) ? edge : null;
   }
 
   function onTouchMove(event: TouchEvent) {
@@ -76,7 +78,7 @@ export function useEdgeSwipeNavigation() {
 
     if (opensMenu) {
       setOpenMobile(true);
-    } else if (store.prevRoute) {
+    } else if (router.options.history.state.back != null) {
       router.back();
     }
   }
@@ -98,4 +100,24 @@ function edgeAt(x: number, side: MobileSidebarSide): MobileSidebarSide | null {
       ? document.documentElement.clientWidth
       : 0);
   return width > 0 && x >= width - EDGE_ZONE_PX ? "right" : null;
+}
+
+/**
+ * Whether a touch landed on something that scrolls sideways, looking no
+ * further out than the element the handlers are bound to.
+ */
+function insideHorizontalScroller(event: TouchEvent) {
+  let element = event.target instanceof Element ? event.target : null;
+
+  while (element && element !== event.currentTarget) {
+    const { overflowX } = getComputedStyle(element);
+    if (
+      (overflowX === "auto" || overflowX === "scroll") &&
+      element.scrollWidth > element.clientWidth
+    ) {
+      return true;
+    }
+    element = element.parentElement;
+  }
+  return false;
 }

--- a/src/composables/useEdgeSwipeNavigation.ts
+++ b/src/composables/useEdgeSwipeNavigation.ts
@@ -1,0 +1,101 @@
+import { useSidebar } from "@/components/ui/sidebar/utils";
+import {
+  useMobileSidebarSide,
+  type MobileSidebarSide,
+} from "@/composables/useMobileSidebarSide";
+import { store } from "@/plugins/store";
+import { ref } from "vue";
+import { useRoute, useRouter } from "vue-router";
+
+const EDGE_ZONE_PX = 32;
+const SWIPE_THRESHOLD_PX = 60;
+const VERTICAL_TOLERANCE_PX = 40;
+
+/**
+ * Touch handlers for the mobile edge-swipe gesture.
+ *
+ * Swiping from the configured menu side (see `useMobileSidebarSide`) opens
+ * the navigation sheet on the `discover` route, and navigates back on any
+ * other route. When the menu opens from the right, that edge always opens
+ * the sheet instead, and the left edge navigates back on every route.
+ * Navigating back does nothing when there is no previous in-app route.
+ *
+ * Only active while the mobile sidebar is closed. Bind the returned
+ * handlers as passive touchstart/touchmove/touchend listeners.
+ */
+export function useEdgeSwipeNavigation() {
+  const { isMobile, openMobile, setOpenMobile } = useSidebar();
+  const mobileSidebarSide = useMobileSidebarSide();
+  const route = useRoute();
+  const router = useRouter();
+
+  const touchStartX = ref(0);
+  const touchStartY = ref(0);
+  const swipeEdge = ref<MobileSidebarSide | null>(null);
+
+  function onTouchStart(event: TouchEvent) {
+    if (!isMobile.value || openMobile.value) return;
+    const touch = event.touches[0];
+    if (!touch) return;
+
+    touchStartX.value = touch.clientX;
+    touchStartY.value = touch.clientY;
+    swipeEdge.value = edgeAt(touch.clientX, mobileSidebarSide.value);
+  }
+
+  function onTouchMove(event: TouchEvent) {
+    const edge = swipeEdge.value;
+    if (!edge || !isMobile.value || openMobile.value) return;
+
+    const touch = event.touches[0];
+    if (!touch) return;
+
+    const deltaX = touch.clientX - touchStartX.value;
+    const deltaY = touch.clientY - touchStartY.value;
+
+    if (Math.abs(deltaY) > VERTICAL_TOLERANCE_PX) {
+      swipeEdge.value = null;
+      return;
+    }
+
+    const traveled = edge === "left" ? deltaX : -deltaX;
+    if (traveled > SWIPE_THRESHOLD_PX) {
+      triggerSwipeAction(edge);
+      swipeEdge.value = null;
+    }
+  }
+
+  function onTouchEnd() {
+    swipeEdge.value = null;
+  }
+
+  function triggerSwipeAction(edge: MobileSidebarSide) {
+    const side = mobileSidebarSide.value;
+    const opensMenu =
+      edge === side && (side === "right" || route.name === "discover");
+
+    if (opensMenu) {
+      setOpenMobile(true);
+    } else if (store.prevRoute) {
+      router.back();
+    }
+  }
+
+  return { onTouchStart, onTouchMove, onTouchEnd };
+}
+
+/**
+ * The screen edge a touch started at, or null when that edge carries no
+ * swipe gesture for the current menu side.
+ */
+function edgeAt(x: number, side: MobileSidebarSide): MobileSidebarSide | null {
+  if (x <= EDGE_ZONE_PX) return "left";
+  if (side !== "right") return null;
+
+  const width =
+    window.innerWidth ||
+    (typeof document !== "undefined"
+      ? document.documentElement.clientWidth
+      : 0);
+  return width > 0 && x >= width - EDGE_ZONE_PX ? "right" : null;
+}

--- a/src/composables/usePopoutTriggerHover.ts
+++ b/src/composables/usePopoutTriggerHover.ts
@@ -1,0 +1,28 @@
+import { readonly, ref, watch } from "vue";
+
+/**
+ * Hover state for the button that opens a player bar popout.
+ *
+ * Bind `suppressHover` to the button's `data-suppress-hover` and `releaseHover`
+ * to its `pointerenter`.
+ *
+ * @param isOpen - whether the popout the button owns is showing
+ */
+export function usePopoutTriggerHover(isOpen: () => boolean) {
+  // touch browsers keep hovering whatever was tapped last, so the tap that
+  // opened the popout leaves the button reading as active once the popout is
+  // gone, however it was dismissed. Only the pointer arriving on the button
+  // again says anything about where it really is.
+  const suppressHover = ref(false);
+
+  watch(isOpen, (open) => {
+    if (!open) suppressHover.value = true;
+  });
+
+  return {
+    suppressHover: readonly(suppressHover),
+    releaseHover: () => {
+      suppressHover.value = false;
+    },
+  };
+}

--- a/src/helpers/player_bar.ts
+++ b/src/helpers/player_bar.ts
@@ -1,10 +1,16 @@
 import { deviceInset } from "@/helpers/device";
 
 /**
- * Gap the popouts keep from the bar below them and from the sides of the
- * screen. Mirrors --player-bar-popout-gap.
+ * Gap the popouts keep from the bar below them. Mirrors
+ * --player-bar-popout-gap.
  */
 export const PLAYER_BAR_POPOUT_GAP = 8;
+
+/**
+ * How far in from the sides of the screen the popouts sit. Mirrors
+ * --player-bar-popout-inset-x.
+ */
+export const PLAYER_BAR_POPOUT_INSET_X = 12;
 
 /**
  * Room a tall popout leaves at the top of the screen, so it keeps reading as a
@@ -21,11 +27,11 @@ export const PLAYER_BAR_POPOUT_COLLISION_PADDING = {
   // hands each popout the inset it opens under without handing floating-ui a
   // new object to rebuild its middleware around
   get right() {
-    return PLAYER_BAR_POPOUT_GAP + deviceInset("right");
+    return PLAYER_BAR_POPOUT_INSET_X + deviceInset("right");
   },
   bottom: PLAYER_BAR_POPOUT_GAP,
   get left() {
-    return PLAYER_BAR_POPOUT_GAP + deviceInset("left");
+    return PLAYER_BAR_POPOUT_INSET_X + deviceInset("left");
   },
 };
 
@@ -41,7 +47,7 @@ export const playerBarEndAnchor = {
     // the window reaches past the cutout, so the gap is kept from the last
     // column of pixels that is actually safe to draw in
     return new DOMRect(
-      window.innerWidth - PLAYER_BAR_POPOUT_GAP - deviceInset("right"),
+      window.innerWidth - PLAYER_BAR_POPOUT_INSET_X - deviceInset("right"),
       anchorRect?.top ?? window.innerHeight,
       0,
       anchorRect?.height ?? 0,

--- a/src/layouts/default/PlayerOSD/PlayerBarGroupControl.vue
+++ b/src/layouts/default/PlayerOSD/PlayerBarGroupControl.vue
@@ -38,8 +38,7 @@
           :data-active="open"
           :data-suppress-hover="suppressHover"
           :aria-label="groupMembersLabel"
-          @click.capture="handleTriggerClick"
-          @pointerleave="suppressHover = false"
+          @pointerenter="releaseHover"
         >
           <span v-if="floating" class="inline-flex">
             <!-- matches the track menu beside it in the floating bar -->
@@ -73,8 +72,8 @@
         :class="[
           'player-bar-popout player-group-popover flex flex-col gap-0 overflow-hidden p-0',
           store.mobileLayout
-            ? 'w-[calc(100vw-2*var(--player-bar-popout-gap)-var(--device-inset-left)-var(--device-inset-right))]'
-            : 'w-[400px] max-w-[calc(100vw-2*var(--player-bar-popout-gap)-var(--device-inset-left)-var(--device-inset-right))]',
+            ? 'w-[calc(100vw-2*var(--player-bar-popout-inset-x)-var(--device-inset-left)-var(--device-inset-right))]'
+            : 'w-[400px] max-w-[calc(100vw-2*var(--player-bar-popout-inset-x)-var(--device-inset-left)-var(--device-inset-right))]',
         ]"
         @open-auto-focus="preventAutoFocus"
         @interact-outside="handleInteractOutside"
@@ -101,6 +100,7 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from "@/components/ui/popover";
+import { usePopoutTriggerHover } from "@/composables/usePopoutTriggerHover";
 import {
   PLAYER_BAR_POPOUT_COLLISION_PADDING,
   PLAYER_BAR_POPOUT_GAP,
@@ -130,7 +130,7 @@ withDefaults(
 );
 
 const open = ref(false);
-const suppressHover = ref(false);
+const { suppressHover, releaseHover } = usePopoutTriggerHover(() => open.value);
 const filter = ref<PlayerGroupFilter>("all");
 const player = computed(() => store.activePlayer);
 const canEditGroup = computed(
@@ -211,10 +211,6 @@ watch([hasLights, hasVisualizers], () => {
 function handleOpenChange(value: boolean) {
   open.value = value;
   if (!value) filter.value = "all";
-}
-
-function handleTriggerClick() {
-  suppressHover.value = open.value;
 }
 
 function preventAutoFocus(event: Event) {

--- a/src/layouts/default/PlayerOSD/PlayerBarMobileVolumeSheet.vue
+++ b/src/layouts/default/PlayerOSD/PlayerBarMobileVolumeSheet.vue
@@ -48,11 +48,11 @@ function preventAutoFocus(event: Event) {
 /* the paired class outweighs the equally-!important inset utilities the sheet
    carries */
 .player-bar-popout.mobile-group-volume-sheet {
-  right: var(--player-bar-popout-gap) !important;
+  right: var(--player-bar-popout-inset-x) !important;
   bottom: calc(
     var(--mobile-navigation-height) + var(--player-bar-popout-gap)
   ) !important;
-  left: var(--player-bar-popout-gap) !important;
+  left: var(--player-bar-popout-inset-x) !important;
   width: auto !important;
   /* a sheet has no popper measuring the free space for it, so it grows with the
      group it shows up to the room left above the navigation instead */

--- a/src/layouts/default/PlayerOSD/PlayerBarPlayerButton.vue
+++ b/src/layouts/default/PlayerOSD/PlayerBarPlayerButton.vue
@@ -13,7 +13,7 @@
     :aria-expanded="store.showPlayersMenu"
     aria-haspopup="dialog"
     @click="togglePlayersMenu"
-    @pointerleave="suppressHover = false"
+    @pointerenter="releaseHover"
   >
     <span
       :class="navigation ? 'mobile-navigation-icon' : 'player-bar-action-icon'"
@@ -38,11 +38,14 @@
 <script setup lang="ts">
 import PlayerIcon from "@/components/PlayerIcon.vue";
 import { Button } from "@/components/ui/button";
+import { usePopoutTriggerHover } from "@/composables/usePopoutTriggerHover";
 import { $t } from "@/plugins/i18n";
 import { store } from "@/plugins/store";
-import { computed, ref } from "vue";
+import { computed } from "vue";
 
-const suppressHover = ref(false);
+const { suppressHover, releaseHover } = usePopoutTriggerHover(
+  () => store.showPlayersMenu,
+);
 const playerName = computed(() => store.activePlayer?.name || $t("no_player"));
 const playerSelectLabel = computed(
   () => `${$t("tooltip.select_player")}: ${playerName.value}`,
@@ -58,7 +61,6 @@ withDefaults(
 );
 
 function togglePlayersMenu() {
-  suppressHover.value = store.showPlayersMenu;
   store.showPlayersMenu = !store.showPlayersMenu;
 }
 </script>

--- a/src/layouts/default/PlayerOSD/PlayerBarVolumeControl.vue
+++ b/src/layouts/default/PlayerOSD/PlayerBarVolumeControl.vue
@@ -28,8 +28,7 @@
         :data-suppress-hover="suppressHover"
         :disabled="disabled"
         :aria-label="`${$t('audio_overlay_volume')}: ${displayVolume}%`"
-        @click.capture="handleTriggerClick"
-        @pointerleave="suppressHover = false"
+        @pointerenter="releaseHover"
         @wheel="adjustVolume"
       >
         <span class="player-bar-action-icon">
@@ -53,7 +52,7 @@
       align="end"
       :side-offset="PLAYER_BAR_POPOUT_GAP"
       :collision-padding="PLAYER_BAR_POPOUT_COLLISION_PADDING"
-      class="player-bar-popout player-volume-popover flex w-[340px] max-w-[calc(100vw-2*var(--player-bar-popout-gap)-var(--device-inset-left)-var(--device-inset-right))] flex-col overflow-hidden p-0"
+      class="player-bar-popout player-volume-popover flex w-[340px] max-w-[calc(100vw-2*var(--player-bar-popout-inset-x)-var(--device-inset-left)-var(--device-inset-right))] flex-col overflow-hidden p-0"
       @open-auto-focus="preventAutoFocus"
       @interact-outside="handleInteractOutside"
     >
@@ -72,6 +71,7 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from "@/components/ui/popover";
+import { usePopoutTriggerHover } from "@/composables/usePopoutTriggerHover";
 import {
   PLAYER_BAR_POPOUT_COLLISION_PADDING,
   PLAYER_BAR_POPOUT_GAP,
@@ -89,7 +89,7 @@ const props = defineProps<{
 }>();
 
 const open = ref(false);
-const suppressHover = ref(false);
+const { suppressHover, releaseHover } = usePopoutTriggerHover(() => open.value);
 
 const grouped = computed(() => isPlayerGrouped(props.player));
 const displayVolume = computed(() =>
@@ -119,10 +119,6 @@ const disabled = computed(
 );
 function handleOpenChange(value: boolean) {
   open.value = value;
-}
-
-function handleTriggerClick() {
-  suppressHover.value = open.value;
 }
 
 function preventAutoFocus(event: Event) {

--- a/src/layouts/default/PlayerSelect.vue
+++ b/src/layouts/default/PlayerSelect.vue
@@ -42,8 +42,8 @@
         'player-bar-popout player-select-popover flex flex-col gap-0 overflow-hidden p-0',
         popoutFromFullscreen && 'player-select-popover-fullscreen',
         store.mobileLayout
-          ? 'w-[calc(100vw-2*var(--player-bar-popout-gap)-var(--device-inset-left)-var(--device-inset-right))]'
-          : 'w-[400px] max-w-[calc(100vw-2*var(--player-bar-popout-gap)-var(--device-inset-left)-var(--device-inset-right))]',
+          ? 'w-[calc(100vw-2*var(--player-bar-popout-inset-x)-var(--device-inset-left)-var(--device-inset-right))]'
+          : 'w-[400px] max-w-[calc(100vw-2*var(--player-bar-popout-inset-x)-var(--device-inset-left)-var(--device-inset-right))]',
       ]"
       @keydown="handleSheetKeydown"
       @close-auto-focus="preventAutoFocus"

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -87,9 +87,12 @@ html {
   /* How far up the screen the bottom is covered, for anything that stacks below
      what covers it and still has to stay visible. */
   --bottom-obscured-height: var(--bottom-bars-height);
-  /* Gap the player bar popouts keep from the bar below them and from the sides
-     of the screen. */
+  /* Gap the player bar popouts keep from the bar below them. */
   --player-bar-popout-gap: 8px;
+  /* How far in from the sides of the screen the popouts sit. Level with the
+     dock they hang above, so the two share an edge and the player card stays
+     the only thing set in from it. */
+  --player-bar-popout-inset-x: var(--mobile-dock-inset-x);
   /* Room a tall popout leaves at the top of the screen, so it keeps reading as a
      card floating above the player bar instead of a full-height panel. */
   --player-bar-popout-top-gap: 24px;

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -89,9 +89,9 @@ html {
   --bottom-obscured-height: var(--bottom-bars-height);
   /* Gap the player bar popouts keep from the bar below them. */
   --player-bar-popout-gap: 8px;
-  /* How far in from the sides of the screen the popouts sit. Level with the
-     dock they hang above, so the two share an edge and the player card stays
-     the only thing set in from it. */
+  /* How far in from the sides of the screen the popouts sit. Taken from the
+     mobile dock, which is what they hang above there: the two share an edge and
+     the player card stays the only thing set in from it. */
   --player-bar-popout-inset-x: var(--mobile-dock-inset-x);
   /* Room a tall popout leaves at the top of the screen, so it keeps reading as a
      card floating above the player bar instead of a full-height panel. */

--- a/tests/composables/useEdgeSwipeNavigation.test.ts
+++ b/tests/composables/useEdgeSwipeNavigation.test.ts
@@ -1,0 +1,178 @@
+import { useEdgeSwipeNavigation } from "@/composables/useEdgeSwipeNavigation";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const {
+  mobileSidebarSide,
+  mockRouterBack,
+  mockSetOpenMobile,
+  routeState,
+  sidebarState,
+  storeMock,
+} = vi.hoisted(() => ({
+  mobileSidebarSide: { value: "left" as "left" | "right" },
+  mockRouterBack: vi.fn(),
+  mockSetOpenMobile: vi.fn(),
+  routeState: { name: "discover" as string },
+  sidebarState: { isMobile: { value: true }, openMobile: { value: false } },
+  storeMock: { prevRoute: undefined as string | undefined },
+}));
+
+vi.mock("@/components/ui/sidebar/utils", () => ({
+  useSidebar: () => ({
+    isMobile: sidebarState.isMobile,
+    openMobile: sidebarState.openMobile,
+    setOpenMobile: mockSetOpenMobile,
+  }),
+}));
+
+vi.mock("@/composables/useMobileSidebarSide", () => ({
+  useMobileSidebarSide: () => mobileSidebarSide,
+}));
+
+vi.mock("@/plugins/store", () => ({
+  store: storeMock,
+}));
+
+vi.mock("vue-router", () => ({
+  useRoute: () => routeState,
+  useRouter: () => ({ back: mockRouterBack }),
+}));
+
+const originalInnerWidth = Object.getOwnPropertyDescriptor(
+  window,
+  "innerWidth",
+);
+
+/** A minimal TouchEvent-shaped object, matching what the handlers read. */
+function touchEvent(x: number, y: number): TouchEvent {
+  return { touches: [{ clientX: x, clientY: y }] } as unknown as TouchEvent;
+}
+
+function setViewportWidth(width: number) {
+  Object.defineProperty(window, "innerWidth", {
+    value: width,
+    writable: true,
+    configurable: true,
+  });
+}
+
+beforeEach(() => {
+  setViewportWidth(800);
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+  mobileSidebarSide.value = "left";
+  routeState.name = "discover";
+  sidebarState.isMobile.value = true;
+  sidebarState.openMobile.value = false;
+  storeMock.prevRoute = undefined;
+  if (originalInnerWidth) {
+    Object.defineProperty(window, "innerWidth", originalInnerWidth);
+  }
+});
+
+describe("useEdgeSwipeNavigation", () => {
+  it("opens the menu on a left-edge swipe on discover, with the menu on the left", () => {
+    storeMock.prevRoute = "/settings";
+    const { onTouchStart, onTouchMove } = useEdgeSwipeNavigation();
+
+    onTouchStart(touchEvent(10, 100));
+    onTouchMove(touchEvent(80, 100));
+
+    expect(mockSetOpenMobile).toHaveBeenCalledWith(true);
+    expect(mockRouterBack).not.toHaveBeenCalled();
+  });
+
+  it("goes back on a left-edge swipe off discover, with the menu on the left", () => {
+    routeState.name = "album";
+    storeMock.prevRoute = "/discover";
+    const { onTouchStart, onTouchMove } = useEdgeSwipeNavigation();
+
+    onTouchStart(touchEvent(10, 100));
+    onTouchMove(touchEvent(80, 100));
+
+    expect(mockRouterBack).toHaveBeenCalledTimes(1);
+    expect(mockSetOpenMobile).not.toHaveBeenCalled();
+  });
+
+  it("opens the menu on a right-edge swipe on any route, with the menu on the right", () => {
+    mobileSidebarSide.value = "right";
+    routeState.name = "album";
+    storeMock.prevRoute = "/discover";
+    const { onTouchStart, onTouchMove } = useEdgeSwipeNavigation();
+
+    onTouchStart(touchEvent(790, 100));
+    onTouchMove(touchEvent(720, 100));
+
+    expect(mockSetOpenMobile).toHaveBeenCalledWith(true);
+    expect(mockRouterBack).not.toHaveBeenCalled();
+  });
+
+  it("goes back on a left-edge swipe, with the menu on the right", () => {
+    mobileSidebarSide.value = "right";
+    storeMock.prevRoute = "/discover";
+    const { onTouchStart, onTouchMove } = useEdgeSwipeNavigation();
+
+    onTouchStart(touchEvent(10, 100));
+    onTouchMove(touchEvent(80, 100));
+
+    expect(mockRouterBack).toHaveBeenCalledTimes(1);
+    expect(mockSetOpenMobile).not.toHaveBeenCalled();
+  });
+
+  it("does nothing on a back-eligible swipe without a previous route", () => {
+    routeState.name = "album";
+    storeMock.prevRoute = undefined;
+    const { onTouchStart, onTouchMove } = useEdgeSwipeNavigation();
+
+    onTouchStart(touchEvent(10, 100));
+    onTouchMove(touchEvent(80, 100));
+
+    expect(mockRouterBack).not.toHaveBeenCalled();
+    expect(mockSetOpenMobile).not.toHaveBeenCalled();
+  });
+
+  it("does nothing when the swipe starts away from any edge", () => {
+    const { onTouchStart, onTouchMove } = useEdgeSwipeNavigation();
+
+    onTouchStart(touchEvent(400, 100));
+    onTouchMove(touchEvent(470, 100));
+
+    expect(mockRouterBack).not.toHaveBeenCalled();
+    expect(mockSetOpenMobile).not.toHaveBeenCalled();
+  });
+
+  it("does nothing once vertical drift exceeds the tolerance", () => {
+    const { onTouchStart, onTouchMove } = useEdgeSwipeNavigation();
+
+    onTouchStart(touchEvent(10, 100));
+    onTouchMove(touchEvent(20, 160)); // 60px vertical drift cancels tracking
+    onTouchMove(touchEvent(80, 160)); // would otherwise clear the threshold
+
+    expect(mockRouterBack).not.toHaveBeenCalled();
+    expect(mockSetOpenMobile).not.toHaveBeenCalled();
+  });
+
+  it("does nothing while the mobile sidebar is already open", () => {
+    sidebarState.openMobile.value = true;
+    const { onTouchStart, onTouchMove } = useEdgeSwipeNavigation();
+
+    onTouchStart(touchEvent(10, 100));
+    onTouchMove(touchEvent(80, 100));
+
+    expect(mockRouterBack).not.toHaveBeenCalled();
+    expect(mockSetOpenMobile).not.toHaveBeenCalled();
+  });
+
+  it("does nothing outside mobile layout", () => {
+    sidebarState.isMobile.value = false;
+    const { onTouchStart, onTouchMove } = useEdgeSwipeNavigation();
+
+    onTouchStart(touchEvent(10, 100));
+    onTouchMove(touchEvent(80, 100));
+
+    expect(mockRouterBack).not.toHaveBeenCalled();
+    expect(mockSetOpenMobile).not.toHaveBeenCalled();
+  });
+});

--- a/tests/composables/useEdgeSwipeNavigation.test.ts
+++ b/tests/composables/useEdgeSwipeNavigation.test.ts
@@ -2,19 +2,19 @@ import { useEdgeSwipeNavigation } from "@/composables/useEdgeSwipeNavigation";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const {
+  historyState,
   mobileSidebarSide,
   mockRouterBack,
   mockSetOpenMobile,
   routeState,
   sidebarState,
-  storeMock,
 } = vi.hoisted(() => ({
+  historyState: { back: null as string | null },
   mobileSidebarSide: { value: "left" as "left" | "right" },
   mockRouterBack: vi.fn(),
   mockSetOpenMobile: vi.fn(),
   routeState: { name: "discover" as string },
   sidebarState: { isMobile: { value: true }, openMobile: { value: false } },
-  storeMock: { prevRoute: undefined as string | undefined },
 }));
 
 vi.mock("@/components/ui/sidebar/utils", () => ({
@@ -29,13 +29,12 @@ vi.mock("@/composables/useMobileSidebarSide", () => ({
   useMobileSidebarSide: () => mobileSidebarSide,
 }));
 
-vi.mock("@/plugins/store", () => ({
-  store: storeMock,
-}));
-
 vi.mock("vue-router", () => ({
   useRoute: () => routeState,
-  useRouter: () => ({ back: mockRouterBack }),
+  useRouter: () => ({
+    back: mockRouterBack,
+    options: { history: { state: historyState } },
+  }),
 }));
 
 const originalInnerWidth = Object.getOwnPropertyDescriptor(
@@ -44,8 +43,26 @@ const originalInnerWidth = Object.getOwnPropertyDescriptor(
 );
 
 /** A minimal TouchEvent-shaped object, matching what the handlers read. */
-function touchEvent(x: number, y: number): TouchEvent {
-  return { touches: [{ clientX: x, clientY: y }] } as unknown as TouchEvent;
+function touchEvent(x: number, y: number, target?: Element): TouchEvent {
+  return {
+    touches: [{ clientX: x, clientY: y }],
+    target,
+    currentTarget: target?.closest("main"),
+  } as unknown as TouchEvent;
+}
+
+/** A card inside a shelf that does or does not scroll sideways, under `<main>`. */
+function cardInsideShelf(scrolls: boolean) {
+  const main = document.createElement("main");
+  const shelf = document.createElement("div");
+  shelf.style.overflowX = scrolls ? "auto" : "visible";
+  Object.defineProperty(shelf, "scrollWidth", { value: scrolls ? 900 : 375 });
+  Object.defineProperty(shelf, "clientWidth", { value: 375 });
+  const card = document.createElement("button");
+  shelf.appendChild(card);
+  main.appendChild(shelf);
+  document.body.appendChild(main);
+  return card;
 }
 
 function setViewportWidth(width: number) {
@@ -66,7 +83,8 @@ afterEach(() => {
   routeState.name = "discover";
   sidebarState.isMobile.value = true;
   sidebarState.openMobile.value = false;
-  storeMock.prevRoute = undefined;
+  historyState.back = null;
+  document.body.innerHTML = "";
   if (originalInnerWidth) {
     Object.defineProperty(window, "innerWidth", originalInnerWidth);
   }
@@ -74,7 +92,7 @@ afterEach(() => {
 
 describe("useEdgeSwipeNavigation", () => {
   it("opens the menu on a left-edge swipe on discover, with the menu on the left", () => {
-    storeMock.prevRoute = "/settings";
+    historyState.back = "/settings";
     const { onTouchStart, onTouchMove } = useEdgeSwipeNavigation();
 
     onTouchStart(touchEvent(10, 100));
@@ -86,7 +104,7 @@ describe("useEdgeSwipeNavigation", () => {
 
   it("goes back on a left-edge swipe off discover, with the menu on the left", () => {
     routeState.name = "album";
-    storeMock.prevRoute = "/discover";
+    historyState.back = "/discover";
     const { onTouchStart, onTouchMove } = useEdgeSwipeNavigation();
 
     onTouchStart(touchEvent(10, 100));
@@ -99,7 +117,7 @@ describe("useEdgeSwipeNavigation", () => {
   it("opens the menu on a right-edge swipe on any route, with the menu on the right", () => {
     mobileSidebarSide.value = "right";
     routeState.name = "album";
-    storeMock.prevRoute = "/discover";
+    historyState.back = "/discover";
     const { onTouchStart, onTouchMove } = useEdgeSwipeNavigation();
 
     onTouchStart(touchEvent(790, 100));
@@ -111,7 +129,7 @@ describe("useEdgeSwipeNavigation", () => {
 
   it("goes back on a left-edge swipe, with the menu on the right", () => {
     mobileSidebarSide.value = "right";
-    storeMock.prevRoute = "/discover";
+    historyState.back = "/discover";
     const { onTouchStart, onTouchMove } = useEdgeSwipeNavigation();
 
     onTouchStart(touchEvent(10, 100));
@@ -121,9 +139,23 @@ describe("useEdgeSwipeNavigation", () => {
     expect(mockSetOpenMobile).not.toHaveBeenCalled();
   });
 
-  it("does nothing on a back-eligible swipe without a previous route", () => {
+  it("does nothing on a right-edge swipe, with the menu on the left", () => {
     routeState.name = "album";
-    storeMock.prevRoute = undefined;
+    historyState.back = "/discover";
+    const { onTouchStart, onTouchMove } = useEdgeSwipeNavigation();
+
+    onTouchStart(touchEvent(790, 100));
+    onTouchMove(touchEvent(720, 100));
+
+    expect(mockRouterBack).not.toHaveBeenCalled();
+    expect(mockSetOpenMobile).not.toHaveBeenCalled();
+  });
+
+  // the history entry is what says whether there is anywhere to go: the app is
+  // often opened straight onto a deep-linked page with nothing behind it
+  it("does nothing on a back-eligible swipe with nowhere to go back to", () => {
+    routeState.name = "album";
+    historyState.back = null;
     const { onTouchStart, onTouchMove } = useEdgeSwipeNavigation();
 
     onTouchStart(touchEvent(10, 100));
@@ -131,6 +163,35 @@ describe("useEdgeSwipeNavigation", () => {
 
     expect(mockRouterBack).not.toHaveBeenCalled();
     expect(mockSetOpenMobile).not.toHaveBeenCalled();
+  });
+
+  // the shelves reach into the edge zone, and the listeners are passive, so a
+  // flick along one would otherwise scroll it and navigate away at once
+  it("leaves a sideways drag on a carousel to the carousel", () => {
+    routeState.name = "search";
+    historyState.back = "/discover";
+    const card = cardInsideShelf(true);
+    const { onTouchStart, onTouchMove } = useEdgeSwipeNavigation();
+
+    onTouchStart(touchEvent(10, 100, card));
+    onTouchMove(touchEvent(80, 100, card));
+
+    expect(mockRouterBack).not.toHaveBeenCalled();
+    expect(mockSetOpenMobile).not.toHaveBeenCalled();
+  });
+
+  // the same gesture over the same markup, minus the sideways scroll, so the
+  // case above cannot pass on the plumbing alone
+  it("still goes back over a shelf that has nothing to scroll", () => {
+    routeState.name = "search";
+    historyState.back = "/discover";
+    const card = cardInsideShelf(false);
+    const { onTouchStart, onTouchMove } = useEdgeSwipeNavigation();
+
+    onTouchStart(touchEvent(10, 100, card));
+    onTouchMove(touchEvent(80, 100, card));
+
+    expect(mockRouterBack).toHaveBeenCalledTimes(1);
   });
 
   it("does nothing when the swipe starts away from any edge", () => {

--- a/tests/composables/usePopoutTriggerHover.test.ts
+++ b/tests/composables/usePopoutTriggerHover.test.ts
@@ -1,0 +1,40 @@
+import { usePopoutTriggerHover } from "@/composables/usePopoutTriggerHover";
+import { describe, expect, it } from "vitest";
+import { nextTick, ref } from "vue";
+
+describe("usePopoutTriggerHover", () => {
+  it("leaves the button alone while its popout opens", async () => {
+    const open = ref(false);
+    const { suppressHover } = usePopoutTriggerHover(() => open.value);
+
+    open.value = true;
+    await nextTick();
+
+    expect(suppressHover.value).toBe(false);
+  });
+
+  // the tap that opened the popout keeps hovering the button on touch, so the
+  // button would stay highlighted after a swipe or a tap outside dismissed it
+  it("stops trusting the hover once the popout closes", async () => {
+    const open = ref(true);
+    const { suppressHover } = usePopoutTriggerHover(() => open.value);
+
+    open.value = false;
+    await nextTick();
+
+    expect(suppressHover.value).toBe(true);
+  });
+
+  it("trusts it again once the pointer arrives on the button", async () => {
+    const open = ref(true);
+    const { suppressHover, releaseHover } = usePopoutTriggerHover(
+      () => open.value,
+    );
+
+    open.value = false;
+    await nextTick();
+    releaseHover();
+
+    expect(suppressHover.value).toBe(false);
+  });
+});

--- a/tests/helpers/player_bar.test.ts
+++ b/tests/helpers/player_bar.test.ts
@@ -1,6 +1,7 @@
 import {
   PLAYER_BAR_POPOUT_COLLISION_PADDING,
   PLAYER_BAR_POPOUT_GAP,
+  PLAYER_BAR_POPOUT_INSET_X,
   fullscreenPlayerSelectAnchor,
   playerBarEndAnchor,
 } from "@/helpers/player_bar";
@@ -100,19 +101,21 @@ describe("playerBarEndAnchor", () => {
     expect(rect.height).toBe(0);
   });
 
-  it("keeps the popout gap from the end of the screen", () => {
+  // The popouts line up with the dock they hang above, which sits further in
+  // than the gap they keep from the bar itself.
+  it("holds the popouts at their side inset from the end of the screen", () => {
     expect(playerBarEndAnchor.getBoundingClientRect().x).toBe(
-      window.innerWidth - PLAYER_BAR_POPOUT_GAP,
+      window.innerWidth - PLAYER_BAR_POPOUT_INSET_X,
     );
   });
 
   // The window reaches past the cutout, so hanging the popouts off it would
   // leave them tucked underneath one.
-  it("keeps that gap from the last safe column rather than the screen edge", () => {
+  it("holds it off the last safe column rather than the screen edge", () => {
     setDeviceInsets();
 
     expect(playerBarEndAnchor.getBoundingClientRect().x).toBe(
-      window.innerWidth - PLAYER_BAR_POPOUT_GAP - INSET_RIGHT,
+      window.innerWidth - PLAYER_BAR_POPOUT_INSET_X - INSET_RIGHT,
     );
   });
 });
@@ -128,24 +131,34 @@ describe("PLAYER_BAR_POPOUT_COLLISION_PADDING", () => {
     setDeviceInsets();
 
     expect(PLAYER_BAR_POPOUT_COLLISION_PADDING.left).toBe(
-      PLAYER_BAR_POPOUT_GAP + INSET_LEFT,
+      PLAYER_BAR_POPOUT_INSET_X + INSET_LEFT,
     );
     expect(PLAYER_BAR_POPOUT_COLLISION_PADDING.right).toBe(
-      PLAYER_BAR_POPOUT_GAP + INSET_RIGHT,
+      PLAYER_BAR_POPOUT_INSET_X + INSET_RIGHT,
     );
+  });
+
+  // The sides line up with the dock while the bottom only clears the bar, so a
+  // popout reaching for one of them in place of the other reads as the wrong
+  // number.
+  it("keeps the bar's own gap below the popouts", () => {
+    expect(PLAYER_BAR_POPOUT_COLLISION_PADDING.bottom).toBe(
+      PLAYER_BAR_POPOUT_GAP,
+    );
+    expect(PLAYER_BAR_POPOUT_GAP).not.toBe(PLAYER_BAR_POPOUT_INSET_X);
   });
 
   // The padding is read afresh for every popout that opens, so a rotation
   // cannot leave the next one holding the gaps of the orientation before it.
   it("reads the insets each time it is asked", () => {
     expect(PLAYER_BAR_POPOUT_COLLISION_PADDING.right).toBe(
-      PLAYER_BAR_POPOUT_GAP,
+      PLAYER_BAR_POPOUT_INSET_X,
     );
 
     setDeviceInsets();
 
     expect(PLAYER_BAR_POPOUT_COLLISION_PADDING.right).toBe(
-      PLAYER_BAR_POPOUT_GAP + INSET_RIGHT,
+      PLAYER_BAR_POPOUT_INSET_X + INSET_RIGHT,
     );
   });
 });

--- a/tests/layouts/PlayerBarVolumeControl.test.ts
+++ b/tests/layouts/PlayerBarVolumeControl.test.ts
@@ -255,8 +255,22 @@ describe("PlayerBarVolumeControl", () => {
     expect(trigger.attributes("data-active")).toBe("false");
     expect(trigger.attributes("data-suppress-hover")).toBe("true");
 
-    await trigger.trigger("pointerleave");
+    await trigger.trigger("pointerenter");
     expect(trigger.attributes("data-suppress-hover")).toBe("false");
+  });
+
+  // touch leaves the button hovered from the tap that opened the popover, so
+  // dismissing it anywhere but on the button would leave it reading as active
+  it("suppresses it just the same when the popover closes on its own", async () => {
+    const player = createPlayer();
+    api.players = { [player.player_id]: player };
+    const wrapper = mountControl(player);
+    const trigger = wrapper.get("[data-player-volume-trigger]");
+
+    await trigger.trigger("click");
+    await wrapper.get(".player-volume-backdrop").trigger("click");
+
+    expect(trigger.attributes("data-suppress-hover")).toBe("true");
   });
 
   it("shows child controls and the group volume", () => {

--- a/tests/styles/mobileGroupVolumeSheet.test.ts
+++ b/tests/styles/mobileGroupVolumeSheet.test.ts
@@ -152,7 +152,8 @@ describe("mobile grouped volume sheet", () => {
   it("floats the sheet clear of the navigation and the sides", () => {
     const style = getComputedStyle(sheet());
 
-    // the sides line up with the dock, the bottom only clears the navigation
+    // the sides take the popouts' own inset, the bottom only clears the
+    // navigation
     expect(style.right).toBe(INSET_X);
     expect(style.left).toBe(INSET_X);
     expect(normalize(style.bottom)).toBe(`calc(${NAV_HEIGHT}+${GAP})`);

--- a/tests/styles/mobileGroupVolumeSheet.test.ts
+++ b/tests/styles/mobileGroupVolumeSheet.test.ts
@@ -12,6 +12,7 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 // literal. They are distinct, so no assertion can pass on a coincidence.
 const NAV_HEIGHT = "111px";
 const GAP = "7px";
+const INSET_X = "9px";
 const TOP_GAP = "33px";
 
 // the equally-!important utilities the sheet and its backdrop carry, with the
@@ -133,6 +134,7 @@ describe("mobile grouped volume sheet", () => {
     for (const [token, value] of [
       ["--mobile-navigation-height", NAV_HEIGHT],
       ["--player-bar-popout-gap", GAP],
+      ["--player-bar-popout-inset-x", INSET_X],
       ["--player-bar-popout-top-gap", TOP_GAP],
     ]) {
       document.documentElement.style.setProperty(token, value);
@@ -150,8 +152,9 @@ describe("mobile grouped volume sheet", () => {
   it("floats the sheet clear of the navigation and the sides", () => {
     const style = getComputedStyle(sheet());
 
-    expect(style.right).toBe(GAP);
-    expect(style.left).toBe(GAP);
+    // the sides line up with the dock, the bottom only clears the navigation
+    expect(style.right).toBe(INSET_X);
+    expect(style.left).toBe(INSET_X);
     expect(normalize(style.bottom)).toBe(`calc(${NAV_HEIGHT}+${GAP})`);
     // it spans between those edges instead of keeping a width of its own
     expect(style.width).toBe("auto");

--- a/tests/styles/playerBarPopout.test.ts
+++ b/tests/styles/playerBarPopout.test.ts
@@ -8,6 +8,7 @@ import playerSelectSource from "@/layouts/default/PlayerSelect.vue?raw";
 import {
   PLAYER_BAR_POPOUT_COLLISION_PADDING,
   PLAYER_BAR_POPOUT_GAP,
+  PLAYER_BAR_POPOUT_INSET_X,
 } from "@/helpers/player_bar";
 import tokens from "@/styles/global.css?inline";
 import css from "@/styles/style.css?inline";
@@ -92,15 +93,26 @@ describe("player bar popout inset", () => {
     expect(customProperty("--player-bar-popout-gap")).toBe(
       `${PLAYER_BAR_POPOUT_GAP}px`,
     );
+    expect(customProperty("--player-bar-popout-inset-x")).toBe(
+      `${PLAYER_BAR_POPOUT_INSET_X}px`,
+    );
     expect(customProperty("--player-bar-popout-top-gap")).toBe(
       `${PLAYER_BAR_POPOUT_COLLISION_PADDING.top}px`,
+    );
+  });
+
+  // the popouts hang above the dock and reach down behind it, so anything but a
+  // shared edge leaves the two surfaces stepping over one another
+  it("sets the popouts in as far as the dock they hang above", () => {
+    expect(customProperty("--player-bar-popout-inset-x")).toBe(
+      customProperty("--mobile-dock-inset-x"),
     );
   });
 });
 
 // Every term carries its own value, so one going missing or landing on the
 // wrong side reads as the wrong number instead of quietly passing.
-const GAP = "5px";
+const INSET_X = "5px";
 const INSET_LEFT = "77px";
 const INSET_RIGHT = "44px";
 
@@ -111,7 +123,7 @@ const INSET_RIGHT = "44px";
 function popoutWidthClasses(source: string) {
   return [
     ...source.matchAll(
-      /(?:max-)?w-\[calc\([^\]]*--player-bar-popout-gap[^\]]*\]/g,
+      /(?:max-)?w-\[calc\([^\]]*--player-bar-popout-inset-x[^\]]*\]/g,
     ),
   ].map((match) => match[0]);
 }
@@ -136,7 +148,10 @@ describe.each([
     widthStyles = document.createElement("style");
     widthStyles.textContent = css;
     document.head.appendChild(widthStyles);
-    document.documentElement.style.setProperty("--player-bar-popout-gap", GAP);
+    document.documentElement.style.setProperty(
+      "--player-bar-popout-inset-x",
+      INSET_X,
+    );
     document.documentElement.style.setProperty(
       "--device-inset-left",
       INSET_LEFT,
@@ -161,7 +176,7 @@ describe.each([
     expect(classNames.length).toBeGreaterThan(0);
     for (const className of classNames) {
       expect(resolveWidth(className)).toBe(
-        `calc(${window.innerWidth}px-2*${GAP}-${INSET_LEFT}-${INSET_RIGHT})`,
+        `calc(${window.innerWidth}px-2*${INSET_X}-${INSET_LEFT}-${INSET_RIGHT})`,
       );
     }
   });


### PR DESCRIPTION
# What does this implement/fix?

Follow-up tweaks to the new mobile footer.

- The grouping button stayed highlighted when its popout was swiped away instead of tapped closed. Touch keeps the button hovered after the tap that opened the popout, so hover is now ignored until the pointer really arrives on it again. Same for the player and volume buttons.
- Swiping in from the left edge always opened the navigation menu. It now opens the menu only on Discover and goes back to the previous page everywhere else. With the menu set to open from the right, that edge still opens it on every page and the left edge always goes back.
- The player bar popouts hung a few pixels wider than the dock they sit on. They now share its edge, leaving the player card as the only thing set in from it.

**Related issue (if applicable):**

- n/a

**Related backend PR (if applicable):**

- n/a

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm lint:check` passes.
- [x] `pnpm test:run` passes, and tests have been added/updated where applicable.
- [x] `pnpm build` passes.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
