### PR TITLE
Let the party dashboard stop listening for updates when you leave it

### DIFF
--- a/src/views/PartyDashboardView.vue
+++ b/src/views/PartyDashboardView.vue
@@ -783,7 +783,7 @@ const BURN_IN_SWAP_MS = 10 * 60 * 1000; // 10 minutes
 // onMounted subscribes after its awaits, where the component is no longer the
 // active instance and onBeforeUnmount would be a no-op, so the subscriptions
 // are collected here for the unmount hook registered at setup level.
-const unsubscribes: (() => void)[] = [];
+const unsubscribers: Array<() => void> = [];
 let unmounted = false;
 
 watch(antiBurnIn, (enabled) => {
@@ -802,9 +802,13 @@ watch(antiBurnIn, (enabled) => {
 });
 
 onMounted(async () => {
+  // Registered before the first await, so that leaving the view while one is
+  // still pending cannot attach the listener after the unmount hook has
+  // already removed it.
+  document.addEventListener("visibilitychange", handleVisibilityChange);
+
   // Request wake lock to keep screen on
   await requestWakeLock();
-  document.addEventListener("visibilitychange", handleVisibilityChange);
 
   // Set active player from party config (needed when opened in a new tab
   // where the Default layout's player selection logic doesn't run)
@@ -837,7 +841,7 @@ onMounted(async () => {
   fetchQueueItems();
 
   // Subscribe to queue item updates
-  unsubscribes.push(
+  unsubscribers.push(
     api.subscribe(EventType.QUEUE_ITEMS_UPDATED, (evt: EventMessage) => {
       if (evt.object_id !== store.activePlayerQueue?.queue_id) return;
       // Force refetch when items are added/removed (e.g., Play Next)
@@ -847,7 +851,7 @@ onMounted(async () => {
   );
 
   // Subscribe to queue updates (for index changes)
-  unsubscribes.push(
+  unsubscribers.push(
     api.subscribe(EventType.QUEUE_UPDATED, (evt: EventMessage) => {
       if (evt.object_id !== store.activePlayerQueue?.queue_id) return;
       // Don't force refetch for index changes - let buffer optimization work
@@ -856,7 +860,7 @@ onMounted(async () => {
   );
 
   // Subscribe to provider updates to detect party player config changes
-  unsubscribes.push(
+  unsubscribers.push(
     api.subscribe(EventType.PROVIDERS_UPDATED, async () => {
       await refreshPartyPlayer();
       fetchQueueItems(true);
@@ -864,7 +868,7 @@ onMounted(async () => {
   );
 
   // Re-resolve party player when a different queue starts playing (auto mode)
-  unsubscribes.push(
+  unsubscribers.push(
     api.subscribe(EventType.QUEUE_UPDATED, async (evt: EventMessage) => {
       if (evt.object_id !== store.activePlayerQueue?.queue_id) {
         const updatedQueue = api.queues[evt.object_id as string];
@@ -880,7 +884,7 @@ onMounted(async () => {
 // Cleanup when leaving the party view
 onBeforeUnmount(() => {
   unmounted = true;
-  for (const unsubscribe of unsubscribes) unsubscribe();
+  unsubscribers.forEach((unsubscribe) => unsubscribe());
   // Release wake lock
   if (wakeLock) {
     wakeLock.release();

--- a/src/views/PartyDashboardView.vue
+++ b/src/views/PartyDashboardView.vue
@@ -780,6 +780,12 @@ const handleVisibilityChange = () => {
 // Lifecycle and event subscriptions
 const BURN_IN_SWAP_MS = 10 * 60 * 1000; // 10 minutes
 
+// onMounted subscribes after its awaits, where the component is no longer the
+// active instance and onBeforeUnmount would be a no-op, so the subscriptions
+// are collected here for the unmount hook registered at setup level.
+const unsubscribes: (() => void)[] = [];
+let unmounted = false;
+
 watch(antiBurnIn, (enabled) => {
   if (burnInInterval) {
     clearInterval(burnInInterval);
@@ -806,6 +812,12 @@ onMounted(async () => {
 
   // Fetch party configuration via shared composable
   const config = await fetchConfig();
+
+  // Leaving the view while the awaits above are still in flight runs the
+  // unmount hook before anything below has been registered, so bail out
+  // rather than subscribe to events nothing will clean up.
+  if (unmounted) return;
+
   if (config) {
     if (config.karaoke_mode !== undefined) {
       karaokeMode.value = config.karaoke_mode;
@@ -825,36 +837,35 @@ onMounted(async () => {
   fetchQueueItems();
 
   // Subscribe to queue item updates
-  const unsub1 = api.subscribe(
-    EventType.QUEUE_ITEMS_UPDATED,
-    (evt: EventMessage) => {
+  unsubscribes.push(
+    api.subscribe(EventType.QUEUE_ITEMS_UPDATED, (evt: EventMessage) => {
       if (evt.object_id !== store.activePlayerQueue?.queue_id) return;
       // Force refetch when items are added/removed (e.g., Play Next)
       // This ensures the view updates even if we're "within buffer"
       fetchQueueItems(true);
-    },
+    }),
   );
-  onBeforeUnmount(unsub1);
 
   // Subscribe to queue updates (for index changes)
-  const unsub2 = api.subscribe(EventType.QUEUE_UPDATED, (evt: EventMessage) => {
-    if (evt.object_id !== store.activePlayerQueue?.queue_id) return;
-    // Don't force refetch for index changes - let buffer optimization work
-    fetchQueueItems();
-  });
-  onBeforeUnmount(unsub2);
+  unsubscribes.push(
+    api.subscribe(EventType.QUEUE_UPDATED, (evt: EventMessage) => {
+      if (evt.object_id !== store.activePlayerQueue?.queue_id) return;
+      // Don't force refetch for index changes - let buffer optimization work
+      fetchQueueItems();
+    }),
+  );
 
   // Subscribe to provider updates to detect party player config changes
-  const unsub3 = api.subscribe(EventType.PROVIDERS_UPDATED, async () => {
-    await refreshPartyPlayer();
-    fetchQueueItems(true);
-  });
-  onBeforeUnmount(unsub3);
+  unsubscribes.push(
+    api.subscribe(EventType.PROVIDERS_UPDATED, async () => {
+      await refreshPartyPlayer();
+      fetchQueueItems(true);
+    }),
+  );
 
   // Re-resolve party player when a different queue starts playing (auto mode)
-  const unsub4 = api.subscribe(
-    EventType.QUEUE_UPDATED,
-    async (evt: EventMessage) => {
+  unsubscribes.push(
+    api.subscribe(EventType.QUEUE_UPDATED, async (evt: EventMessage) => {
       if (evt.object_id !== store.activePlayerQueue?.queue_id) {
         const updatedQueue = api.queues[evt.object_id as string];
         if (updatedQueue?.state === PlaybackState.PLAYING) {
@@ -862,13 +873,14 @@ onMounted(async () => {
           fetchQueueItems(true);
         }
       }
-    },
+    }),
   );
-  onBeforeUnmount(unsub4);
 });
 
 // Cleanup when leaving the party view
 onBeforeUnmount(() => {
+  unmounted = true;
+  for (const unsubscribe of unsubscribes) unsubscribe();
   // Release wake lock
   if (wakeLock) {
     wakeLock.release();

--- a/tests/views/PartyDashboardView.test.ts
+++ b/tests/views/PartyDashboardView.test.ts
@@ -1,5 +1,5 @@
 import api from "@/plugins/api";
-import { EventType } from "@/plugins/api/interfaces";
+import { EventType, PlaybackState } from "@/plugins/api/interfaces";
 import { store } from "@/plugins/store";
 import PartyDashboardView from "@/views/PartyDashboardView.vue";
 import { type VueWrapper, flushPromises, mount } from "@vue/test-utils";
@@ -19,8 +19,8 @@ vi.mock("@/plugins/store", async () => {
   };
 });
 
-// A real registry rather than a stub, so a subscription that outlives the view
-// is observable the way it is in the app: it stays listed and keeps firing.
+// Tracks live subscriptions the way the api does, so one that outlives the
+// view stays listed here and keeps receiving events.
 const events = vi.hoisted(() => {
   type Listener = { type: unknown; handler: (evt: unknown) => unknown };
   const listeners: Listener[] = [];
@@ -140,6 +140,31 @@ const EXIT_FULLSCREEN = '[aria-label="tooltip.exit_fullscreen"]';
 const enterFullscreen = (view: VueWrapper) =>
   view.get(ENTER_FULLSCREEN).trigger("click");
 
+/**
+ * Records document listeners while a view runs.
+ *
+ * `stop()` restores the originals and returns the event types still attached,
+ * which is what tells a removed listener apart from one added back afterwards.
+ */
+function trackDocumentListeners() {
+  const attached = new Map<unknown, string>();
+  const { addEventListener, removeEventListener } = document;
+  document.addEventListener = ((type: string, handler: never) => {
+    attached.set(handler, type);
+    return addEventListener.call(document, type, handler);
+  }) as never;
+  document.removeEventListener = ((type: string, handler: never) => {
+    attached.delete(handler);
+    return removeEventListener.call(document, type, handler);
+  }) as never;
+  return {
+    stop: () => {
+      Object.assign(document, { addEventListener, removeEventListener });
+      return [...attached.values()];
+    },
+  };
+}
+
 describe("PartyDashboardView fullscreen", () => {
   beforeEach(() => {
     store.frameless = false;
@@ -247,8 +272,9 @@ describe("PartyDashboardView fullscreen", () => {
 describe("PartyDashboardView event subscriptions", () => {
   beforeEach(() => {
     events.listeners.length = 0;
+    // the last fullscreen test deliberately leaves this set
+    store.frameless = false;
     store.activePlayerQueue = { queue_id: "q1" } as never;
-    vi.mocked(api.getPlayerQueueItems).mockClear();
   });
 
   afterEach(() => {
@@ -259,39 +285,60 @@ describe("PartyDashboardView event subscriptions", () => {
 
   it("stops listening once the dashboard is closed", async () => {
     const view = await mountView();
-    wrapper = undefined;
     // the subscriptions are set up after several awaits, so pin that they ran
     // at all before reading anything into them being gone
     expect(events.listeners.length).toBeGreaterThan(0);
 
     view.unmount();
+    wrapper = undefined;
 
     expect(events.listeners).toHaveLength(0);
   });
 
   it("leaves the queue alone for events that arrive after it closed", async () => {
+    api.queues.other = {
+      queue_id: "other",
+      state: PlaybackState.PLAYING,
+    } as never;
     const view = await mountView();
-    wrapper = undefined;
 
     view.unmount();
+    wrapper = undefined;
     vi.mocked(api.getPlayerQueueItems).mockClear();
+    vi.mocked(api.sendCommand).mockClear();
+    // one event per subscription, including the queue that is not the active
+    // one, which is what the fourth subscription watches for
     events.emit(EventType.QUEUE_ITEMS_UPDATED, { object_id: "q1" });
     events.emit(EventType.QUEUE_UPDATED, { object_id: "q1" });
+    events.emit(EventType.QUEUE_UPDATED, { object_id: "other" });
     events.emit(EventType.PROVIDERS_UPDATED, {});
     await flushPromises();
 
     expect(api.getPlayerQueueItems).not.toHaveBeenCalled();
+    expect(api.sendCommand).not.toHaveBeenCalled();
   });
 
   it("never starts listening when closed while still loading", async () => {
     // leaving before the config round-trips resolve runs the unmount hook
     // first, so anything subscribing afterwards would never be cleaned up
     const view = mountViewRaw();
-    wrapper = undefined;
 
     view.unmount();
+    wrapper = undefined;
     await flushPromises();
 
     expect(events.listeners).toHaveLength(0);
+  });
+
+  it("drops its visibility listener when closed while still loading", async () => {
+    const live = trackDocumentListeners();
+    const view = mountViewRaw();
+
+    view.unmount();
+    wrapper = undefined;
+    await flushPromises();
+    const remaining = live.stop();
+
+    expect(remaining).not.toContain("visibilitychange");
   });
 });

--- a/tests/views/PartyDashboardView.test.ts
+++ b/tests/views/PartyDashboardView.test.ts
@@ -1,3 +1,5 @@
+import api from "@/plugins/api";
+import { EventType } from "@/plugins/api/interfaces";
 import { store } from "@/plugins/store";
 import PartyDashboardView from "@/views/PartyDashboardView.vue";
 import { type VueWrapper, flushPromises, mount } from "@vue/test-utils";
@@ -17,6 +19,29 @@ vi.mock("@/plugins/store", async () => {
   };
 });
 
+// A real registry rather than a stub, so a subscription that outlives the view
+// is observable the way it is in the app: it stays listed and keeps firing.
+const events = vi.hoisted(() => {
+  type Listener = { type: unknown; handler: (evt: unknown) => unknown };
+  const listeners: Listener[] = [];
+  return {
+    listeners,
+    subscribe: (type: unknown, handler: (evt: unknown) => unknown) => {
+      const listener = { type, handler };
+      listeners.push(listener);
+      return () => {
+        const index = listeners.indexOf(listener);
+        if (index !== -1) listeners.splice(index, 1);
+      };
+    },
+    emit: (type: unknown, evt: unknown) => {
+      for (const listener of listeners) {
+        if (listener.type === type) listener.handler(evt);
+      }
+    },
+  };
+});
+
 vi.mock("@/plugins/api", () => ({
   default: {
     baseUrl: "",
@@ -24,7 +49,7 @@ vi.mock("@/plugins/api", () => ({
     providers: {},
     queues: {},
     sendCommand: vi.fn().mockResolvedValue(null),
-    subscribe: vi.fn(() => () => undefined),
+    subscribe: vi.fn(events.subscribe),
     getPlayerQueueItems: vi.fn().mockResolvedValue([]),
     getTrackLyrics: vi.fn().mockResolvedValue([null, null]),
   },
@@ -85,7 +110,7 @@ const ButtonStub = { template: "<button><slot /></button>" };
 
 let wrapper: VueWrapper | undefined;
 
-async function mountView() {
+function mountViewRaw() {
   wrapper = mount(PartyDashboardView, {
     global: {
       mocks: { $t: (key: string) => key },
@@ -100,8 +125,13 @@ async function mountView() {
       },
     },
   });
-  await flushPromises();
   return wrapper;
+}
+
+async function mountView() {
+  const view = mountViewRaw();
+  await flushPromises();
+  return view;
 }
 
 const ENTER_FULLSCREEN = '[aria-label="tooltip.enter_fullscreen"]';
@@ -211,5 +241,57 @@ describe("PartyDashboardView fullscreen", () => {
     wrapper = undefined;
 
     expect(store.frameless).toBe(true);
+  });
+});
+
+describe("PartyDashboardView event subscriptions", () => {
+  beforeEach(() => {
+    events.listeners.length = 0;
+    store.activePlayerQueue = { queue_id: "q1" } as never;
+    vi.mocked(api.getPlayerQueueItems).mockClear();
+  });
+
+  afterEach(() => {
+    wrapper?.unmount();
+    wrapper = undefined;
+    store.activePlayerQueue = undefined;
+  });
+
+  it("stops listening once the dashboard is closed", async () => {
+    const view = await mountView();
+    wrapper = undefined;
+    // the subscriptions are set up after several awaits, so pin that they ran
+    // at all before reading anything into them being gone
+    expect(events.listeners.length).toBeGreaterThan(0);
+
+    view.unmount();
+
+    expect(events.listeners).toHaveLength(0);
+  });
+
+  it("leaves the queue alone for events that arrive after it closed", async () => {
+    const view = await mountView();
+    wrapper = undefined;
+
+    view.unmount();
+    vi.mocked(api.getPlayerQueueItems).mockClear();
+    events.emit(EventType.QUEUE_ITEMS_UPDATED, { object_id: "q1" });
+    events.emit(EventType.QUEUE_UPDATED, { object_id: "q1" });
+    events.emit(EventType.PROVIDERS_UPDATED, {});
+    await flushPromises();
+
+    expect(api.getPlayerQueueItems).not.toHaveBeenCalled();
+  });
+
+  it("never starts listening when closed while still loading", async () => {
+    // leaving before the config round-trips resolve runs the unmount hook
+    // first, so anything subscribing afterwards would never be cleaned up
+    const view = mountViewRaw();
+    wrapper = undefined;
+
+    view.unmount();
+    await flushPromises();
+
+    expect(events.listeners).toHaveLength(0);
   });
 });


### PR DESCRIPTION
# What does this implement/fix?

Leaving the party dashboard did not stop it listening for server updates. Every
visit added four listeners that were never removed, and they kept fetching the
queue in the background for a screen that was no longer there.

The cleanup was registered from inside the view's `onMounted`, after several
`await`s. Vue only attaches a lifecycle hook while its component is the active
one, so past the first `await` those registrations quietly did nothing.

- Collect the four unsubscribe callbacks and release them from the cleanup hook
  the view already registers at setup level
- Skip subscribing at all when the dashboard is closed before its startup
  requests finish, which otherwise leaked the same four listeners
- Attach the page visibility listener before those requests start, so closing
  the dashboard early cannot re-attach it after the cleanup already ran
- Cover all three in `tests/views/PartyDashboardView.test.ts`, with the api mock
  now tracking listeners so a leftover one is directly observable

**Related issue (if applicable):**

- related issue `<link to issue>`

**Related backend PR (if applicable):**

- related backend PR `<link to PR>`

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm lint:check` passes.
- [x] `pnpm test:run` passes, and tests have been added/updated where applicable.
- [x] `pnpm build` passes.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
