### PR TITLE
Stop the overflow menu button staying highlighted after its menu closes

### DIFF
--- a/src/layouts/default/PlayerOSD/PlayerControlBtn/PlayerTrackMenu.vue
+++ b/src/layouts/default/PlayerOSD/PlayerControlBtn/PlayerTrackMenu.vue
@@ -1,6 +1,9 @@
 <template>
+  <!-- reka keeps the open state; mirroring it rather than controlling it means
+       the v-if unmounting the menu while open cannot re-open it on remount -->
   <DropdownMenu
     v-if="forceVisible || (store.activePlayer && (currentItem || showQueue))"
+    @update:open="menuOpen = $event"
   >
     <DropdownMenuTrigger as-child>
       <Button
@@ -10,8 +13,10 @@
             ? 'player-control-button size-12 rounded-full p-0'
             : 'player-control-button player-bar-action player-bar-menu-button h-20 w-12 rounded-none px-1'
         "
+        :data-suppress-hover="suppressHover"
         :title="$t('more_options')"
         :aria-label="$t('tooltip.more_options')"
+        @pointerenter="releaseHover"
       >
         <template v-if="compact">
           <EllipsisVertical :stroke-width="1.5" class="size-6" />
@@ -113,6 +118,7 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { Slider } from "@/components/ui/slider";
+import { usePopoutTriggerHover } from "@/composables/usePopoutTriggerHover";
 import { queueItemPlaybackSpeed } from "@/helpers/elapsed";
 import {
   isPlayerQueueControlDisabled,
@@ -164,6 +170,10 @@ withDefaults(
   },
 );
 
+const menuOpen = ref(false);
+const { suppressHover, releaseHover } = usePopoutTriggerHover(
+  () => menuOpen.value,
+);
 const playbackSpeedDialogOpen = ref(false);
 const currentPlaybackSpeed = ref<number>(1);
 const queueDisabled = computed(isPlayerQueueControlDisabled);

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -123,6 +123,14 @@
   color: var(--muted-foreground) !important;
 }
 
+/* the ghost variant's own hover colour outranks the resting colour above, so a
+   suppressed button needs this to settle back. Weight and order both matter:
+   the open states below match this specificity and must win, and the floating
+   player's overrides are heavier still. */
+.player-control-button[data-suppress-hover="true"] {
+  color: var(--muted-foreground) !important;
+}
+
 .player-control-button:hover:not([data-suppress-hover="true"]),
 .player-control-button[data-active="true"],
 .player-control-button[data-state="open"] {

--- a/tests/layouts/PlayerTrackMenu.test.ts
+++ b/tests/layouts/PlayerTrackMenu.test.ts
@@ -1,0 +1,140 @@
+import PlayerTrackMenu from "@/layouts/default/PlayerOSD/PlayerControlBtn/PlayerTrackMenu.vue";
+import { enableAutoUnmount, flushPromises, mount } from "@vue/test-utils";
+import {
+  h,
+  inject,
+  provide,
+  ref,
+  type InjectionKey,
+  type SetupContext,
+} from "vue";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/plugins/api", () => {
+  const api = { toggleFavorite: vi.fn(), providers: {}, players: {} };
+  return { api, default: api };
+});
+
+vi.mock("@/plugins/router", () => ({ default: { push: vi.fn() } }));
+
+vi.mock("@/plugins/eventbus", () => ({ eventbus: { emit: vi.fn() } }));
+
+vi.mock("@/plugins/store", async () => {
+  const { reactive } = await vi.importActual<typeof import("vue")>("vue");
+  return {
+    store: reactive({
+      activePlayer: undefined,
+      curQueueItem: undefined,
+    }),
+  };
+});
+
+// reka-ui owns the open state, so the stub owns it too and reports every change
+// the way the real menu does. Its dismiss button stands in for everything that
+// closes the menu without touching the trigger: an outside tap, escape, or
+// picking an entry.
+const dropdownToggleKey: InjectionKey<() => void> = Symbol();
+const DropdownMenuStub = {
+  emits: ["update:open"],
+  setup(_: unknown, { emit, slots }: SetupContext<["update:open"]>) {
+    const open = ref(false);
+    const setOpen = (value: boolean) => {
+      open.value = value;
+      emit("update:open", value);
+    };
+    provide(dropdownToggleKey, () => setOpen(!open.value));
+    return () =>
+      h("div", { class: "dropdown", "data-open": String(open.value) }, [
+        h("button", {
+          class: "dropdown-dismiss",
+          onClick: () => setOpen(false),
+        }),
+        slots.default?.(),
+      ]);
+  },
+};
+const DropdownMenuTriggerStub = {
+  setup(_: unknown, { slots }: SetupContext) {
+    const toggle = inject(dropdownToggleKey);
+    if (!toggle)
+      throw new Error("DropdownMenuTrigger must be inside DropdownMenu");
+    return () => h("div", { onClick: toggle }, slots.default?.());
+  },
+};
+
+function mountMenu() {
+  return mount(PlayerTrackMenu, {
+    props: { forceVisible: true, showQueue: true },
+    global: {
+      mocks: { $t: (key: string) => key },
+      stubs: {
+        DropdownMenu: DropdownMenuStub,
+        DropdownMenuTrigger: DropdownMenuTriggerStub,
+        DropdownMenuContent: true,
+        Dialog: true,
+        Teleport: true,
+      },
+    },
+  });
+}
+
+// the stubs above keep the interaction tests independent of reka-ui; the
+// trigger's own attributes only show up with the real component
+function mountWithDropdown() {
+  return mount(PlayerTrackMenu, {
+    props: { forceVisible: true, showQueue: true },
+    global: {
+      mocks: { $t: (key: string) => key },
+      stubs: { Dialog: true, Teleport: true },
+    },
+  });
+}
+
+enableAutoUnmount(afterEach);
+
+describe("PlayerTrackMenu", () => {
+  it("suppresses hover color after tapping the menu closed", async () => {
+    const wrapper = mountMenu();
+    const trigger = wrapper.get("button.player-control-button");
+
+    expect(trigger.attributes("data-suppress-hover")).toBe("false");
+
+    await wrapper.get("button.player-control-button").trigger("click");
+    expect(wrapper.get(".dropdown").attributes("data-open")).toBe("true");
+    expect(trigger.attributes("data-suppress-hover")).toBe("false");
+
+    await wrapper.get("button.player-control-button").trigger("click");
+    expect(wrapper.get(".dropdown").attributes("data-open")).toBe("false");
+    expect(trigger.attributes("data-suppress-hover")).toBe("true");
+
+    await trigger.trigger("pointerenter");
+    expect(trigger.attributes("data-suppress-hover")).toBe("false");
+  });
+
+  // touch leaves the button hovered from the tap that opened the menu, so
+  // dismissing it anywhere but on the button would leave it reading as active
+  it("suppresses it just the same when the menu closes on its own", async () => {
+    const wrapper = mountMenu();
+    const trigger = wrapper.get("button.player-control-button");
+
+    await trigger.trigger("click");
+    await wrapper.get(".dropdown-dismiss").trigger("click");
+
+    expect(wrapper.get(".dropdown").attributes("data-open")).toBe("false");
+    expect(trigger.attributes("data-suppress-hover")).toBe("true");
+  });
+
+  it("leaves the open highlight to the menu's own state", async () => {
+    const trigger = mountWithDropdown().get("button.player-control-button");
+
+    // reka-ui marks the trigger data-state, which is what the player control
+    // colour keys off while the menu is open; a second copy would drift from it
+    expect(trigger.attributes("data-state")).toBe("closed");
+    expect(trigger.attributes("data-active")).toBeUndefined();
+
+    await trigger.trigger("click", { button: 0, ctrlKey: false });
+    await flushPromises();
+
+    expect(trigger.attributes("data-state")).toBe("open");
+  });
+});

--- a/tests/layouts/PlayerTrackMenu.test.ts
+++ b/tests/layouts/PlayerTrackMenu.test.ts
@@ -137,4 +137,20 @@ describe("PlayerTrackMenu", () => {
 
     expect(trigger.attributes("data-state")).toBe("open");
   });
+
+  // the stubs cannot show the attribute surviving reka-ui's as-child merge onto
+  // the same button the player control colour keys off
+  it("suppresses hover color through the real menu too", async () => {
+    const trigger = mountWithDropdown().get("button.player-control-button");
+
+    expect(trigger.attributes("data-suppress-hover")).toBe("false");
+
+    await trigger.trigger("click", { button: 0, ctrlKey: false });
+    await flushPromises();
+    await trigger.trigger("click", { button: 0, ctrlKey: false });
+    await flushPromises();
+
+    expect(trigger.attributes("data-state")).toBe("closed");
+    expect(trigger.attributes("data-suppress-hover")).toBe("true");
+  });
 });


### PR DESCRIPTION
# What does this implement/fix?

Touch browsers keep hovering whatever was tapped last, so the button that opened
a popout stays highlighted once the popout is gone. #2480 fixed that for the
volume, group and player buttons; the overflow (⋯) menu button sitting right
beside them was left out, so it still reads as active after its menu closes.

Chasing that down turned up a second half of the same problem: the button
variant's own hover colour outranks the resting colour, so even a suppressed
button stayed lit on the desktop player bar — it lost the blue "active" look but
went white instead of grey. That affected all four buttons, so it is fixed here
too rather than left half-done.

- The overflow menu button releases its hover highlight when the menu closes,
  matching the buttons next to it.
- A suppressed button settles all the way back to its resting colour instead of
  staying lit. Buttons showing a genuinely open popout still highlight.

Deliberately left alone: the player select button on the fullscreen player. It
is not a `player-control-button`, so the highlight rule never reaches it — its
only hover effect is a background tint one step lighter, and it carries no
active-state styling for a leftover hover to be mistaken for.

**Related issue (if applicable):**

- follow-up to #2480

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm lint:check` passes.
- [x] `pnpm test:run` passes, and tests have been added/updated where applicable.
- [x] `pnpm build` passes.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
