### PR TITLE
Back buttons no longer leave you stuck on a directly opened page

### DIFF
--- a/src/components/InfoHeader.vue
+++ b/src/components/InfoHeader.vue
@@ -509,6 +509,7 @@ import {
 import { useUserPreferences } from "@/composables/userPreferences";
 import type { ContextMenuItem } from "@/helpers/context_menu_item";
 import { MarqueeTextSync } from "@/helpers/marquee_text_sync";
+import { backFromMediaDetails } from "@/helpers/navigation";
 import {
   handleMediaItemClick,
   handlePlayBtnClick,
@@ -683,24 +684,7 @@ const artistClick = function (item: Artist | ItemMapping) {
 };
 
 const backButtonClick = function () {
-  // if we have stored routes, we can safely use history back
-  if (store.prevRoute) {
-    router.back();
-    return;
-  }
-  // back to main listing for itemtype
-  const curRoute = router.currentRoute.value.name?.toString() || "";
-  for (const itemType of ["artist", "album", "track", "playlist", "radio"]) {
-    if (curRoute.includes(itemType)) {
-      router.push({
-        name: `${itemType}s`,
-      });
-      return;
-    }
-  }
-  router.push({
-    name: "discover",
-  });
+  backFromMediaDetails(router);
 };
 
 // Resolve the queue playMedia targets directly, since activePlayerQueue is

--- a/src/components/genre/DeleteGenreDialog.vue
+++ b/src/components/genre/DeleteGenreDialog.vue
@@ -39,6 +39,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
+import { backFromMediaDetails } from "@/helpers/navigation";
 import { api } from "@/plugins/api";
 import { eventbus, type DeleteGenreDialogEvent } from "@/plugins/eventbus";
 import { store } from "@/plugins/store";
@@ -81,7 +82,7 @@ const handleConfirm = () => {
     );
     open.value = false;
     if (navigateBack.value) {
-      router.back();
+      backFromMediaDetails(router);
     }
     eventbus.emit("clearSelection");
   }

--- a/src/composables/useEdgeSwipeNavigation.ts
+++ b/src/composables/useEdgeSwipeNavigation.ts
@@ -3,6 +3,7 @@ import {
   useMobileSidebarSide,
   type MobileSidebarSide,
 } from "@/composables/useMobileSidebarSide";
+import { canGoBack } from "@/helpers/navigation";
 import { ref } from "vue";
 import { useRoute, useRouter } from "vue-router";
 
@@ -78,7 +79,7 @@ export function useEdgeSwipeNavigation() {
 
     if (opensMenu) {
       setOpenMobile(true);
-    } else if (router.options.history.state.back != null) {
+    } else if (canGoBack(router)) {
       router.back();
     }
   }

--- a/src/helpers/navigation.ts
+++ b/src/helpers/navigation.ts
@@ -1,0 +1,38 @@
+import type { Router } from "vue-router";
+
+/**
+ * Whether there is an earlier in-app view to return to.
+ *
+ * False when the current view was opened directly - a deep link, a reload or
+ * a fresh tab - where going back would leave the app.
+ */
+export function canGoBack(router: Router): boolean {
+  return router.options.history.state.back != null;
+}
+
+/**
+ * Leaves a media details view, back to where the user came from or, when the
+ * details view was opened directly, up to the library listing it belongs to.
+ */
+export function backFromMediaDetails(router: Router): void {
+  if (canGoBack(router)) {
+    router.back();
+    return;
+  }
+  const routeName = router.currentRoute.value.name?.toString() ?? "";
+  router.push({ name: LISTING_ROUTES[routeName] ?? "discover" });
+}
+
+// Details route name -> the library listing it sits under. Collections are
+// browsed from the audiobooks listing, which is where their route nests too.
+const LISTING_ROUTES: Record<string, string | undefined> = {
+  album: "albums",
+  artist: "artists",
+  audiobook: "audiobooks",
+  collection: "audiobooks",
+  genre: "genres",
+  playlist: "playlists",
+  podcast: "podcasts",
+  radio: "radios",
+  track: "tracks",
+};

--- a/src/helpers/navigation.ts
+++ b/src/helpers/navigation.ts
@@ -1,4 +1,4 @@
-import type { Router } from "vue-router";
+import type { RouteLocationRaw, Router } from "vue-router";
 
 /**
  * Whether there is an earlier in-app view to return to.
@@ -12,16 +12,24 @@ export function canGoBack(router: Router): boolean {
 }
 
 /**
- * Leaves a media details view, back to where the user came from or, when the
- * details view was opened directly, up to the library listing it belongs to.
+ * Returns to the previous view, or goes to `fallback` when the current view
+ * was opened directly and a plain back would strand the user where they are.
  */
-export function backFromMediaDetails(router: Router): void {
+export function goBack(router: Router, fallback: RouteLocationRaw): void {
   if (canGoBack(router)) {
     router.back();
     return;
   }
+  router.push(fallback);
+}
+
+/**
+ * Leaves a media details view, back to where the user came from or, when the
+ * details view was opened directly, up to the library listing it belongs to.
+ */
+export function backFromMediaDetails(router: Router): void {
   const routeName = router.currentRoute.value.name?.toString() ?? "";
-  router.push({ name: LISTING_ROUTES[routeName] ?? "discover" });
+  goBack(router, { name: LISTING_ROUTES[routeName] ?? "discover" });
 }
 
 // Details route name -> the library listing it sits under. Collections are

--- a/src/helpers/navigation.ts
+++ b/src/helpers/navigation.ts
@@ -3,8 +3,9 @@ import type { Router } from "vue-router";
 /**
  * Whether there is an earlier in-app view to return to.
  *
- * False when the current view was opened directly - a deep link, a reload or
- * a fresh tab - where going back would leave the app.
+ * False only on the view a session started at, reached by a deep link or in a
+ * fresh tab. History state outlives a reload, so anything navigated to inside
+ * the app keeps its way back.
  */
 export function canGoBack(router: Router): boolean {
   return router.options.history.state.back != null;

--- a/src/layouts/default/ItemContextMenu.vue
+++ b/src/layouts/default/ItemContextMenu.vue
@@ -677,7 +677,11 @@ export const getContextMenuItems = async function (
               if ("provider_mappings" in item)
                 item.provider_mappings.forEach((pm) => (pm.in_library = false));
             }
-            if (resolvedItem.item_id == parentItem?.item_id)
+            // library ids restart per media type, so the type has to match too
+            if (
+              resolvedItem.item_id == parentItem?.item_id &&
+              resolvedItem.media_type == parentItem.media_type
+            )
               backFromMediaDetails(router);
             // Clear the multi-select after action
             eventbus.emit("clearSelection");

--- a/src/layouts/default/ItemContextMenu.vue
+++ b/src/layouts/default/ItemContextMenu.vue
@@ -247,6 +247,7 @@ import {
   radioSupported,
 } from "@/helpers/radio";
 import { runWithConcurrency } from "@/helpers/concurrency";
+import { backFromMediaDetails } from "@/helpers/navigation";
 import {
   isItemInLibrary,
   itemIsAvailable,
@@ -676,7 +677,8 @@ export const getContextMenuItems = async function (
               if ("provider_mappings" in item)
                 item.provider_mappings.forEach((pm) => (pm.in_library = false));
             }
-            if (resolvedItem.item_id == parentItem?.item_id) router.go(-1);
+            if (resolvedItem.item_id == parentItem?.item_id)
+              backFromMediaDetails(router);
             // Clear the multi-select after action
             eventbus.emit("clearSelection");
           },

--- a/src/plugins/router.ts
+++ b/src/plugins/router.ts
@@ -755,7 +755,6 @@ router.beforeEach(async (to) => {
 
 router.afterEach((to, from) => {
   if (!from?.path) return;
-  store.prevRoute = from.path;
 
   if (store.isIngressSession) {
     notifyHARouteChange(to.fullPath);

--- a/src/plugins/router.ts
+++ b/src/plugins/router.ts
@@ -754,8 +754,6 @@ router.beforeEach(async (to) => {
 });
 
 router.afterEach((to, from) => {
-  if (!from?.path) return;
-
   if (store.isIngressSession) {
     notifyHARouteChange(to.fullPath);
   }

--- a/src/plugins/store.ts
+++ b/src/plugins/store.ts
@@ -37,7 +37,6 @@ interface Store {
   // media type filter for the global search; empty means all media types
   globalSearchMediaTypes: MediaType[];
   prevState?: StoredState;
-  prevRoute?: string;
   libraryArtistsCount?: number;
   libraryAlbumsCount?: number;
   libraryTracksCount?: number;
@@ -84,7 +83,6 @@ export const store: Store = reactive({
   globalSearchTerm: undefined,
   globalSearchMediaTypes: [],
   prevState: undefined,
-  prevRoute: undefined,
   libraryArtistsCount: undefined,
   libraryAlbumsCount: undefined,
   libraryTracksCount: undefined,

--- a/src/views/NotFound.vue
+++ b/src/views/NotFound.vue
@@ -43,7 +43,7 @@
 
           <!-- Buttons -->
           <div class="actions">
-            <Button variant="default" @click="router.back()">
+            <Button variant="default" @click="goBack(router, '/discover')">
               <ArrowLeft class="size-4" />
               {{ $t("back") }}
             </Button>
@@ -60,6 +60,7 @@
 
 <script setup lang="ts">
 import { Button } from "@/components/ui/button";
+import { goBack } from "@/helpers/navigation";
 import { ArrowLeft, Compass } from "@lucide/vue";
 import { useRouter } from "vue-router";
 

--- a/src/views/NotFound.vue
+++ b/src/views/NotFound.vue
@@ -43,7 +43,10 @@
 
           <!-- Buttons -->
           <div class="actions">
-            <Button variant="default" @click="goBack(router, '/discover')">
+            <Button
+              variant="default"
+              @click="goBack(router, { name: 'discover' })"
+            >
               <ArrowLeft class="size-4" />
               {{ $t("back") }}
             </Button>

--- a/src/views/settings/AddPlayerGroup.vue
+++ b/src/views/settings/AddPlayerGroup.vue
@@ -79,7 +79,7 @@
           </v-btn>
         </v-form>
         <br />
-        <v-btn block @click="router.back()">
+        <v-btn block @click="goBack(router, { name: 'playersettings' })">
           {{ $t("close") }}
         </v-btn>
       </div>
@@ -91,6 +91,7 @@
 import { computed, ref } from "vue";
 import { useRouter } from "vue-router";
 import { api } from "@/plugins/api";
+import { goBack } from "@/helpers/navigation";
 import { groupMemberPickerVisible } from "@/helpers/players";
 import { markdownToHtml } from "@/helpers/utils";
 import { PlayerFeature, PlayerType } from "@/plugins/api/interfaces";

--- a/src/views/settings/EditConfig.vue
+++ b/src/views/settings/EditConfig.vue
@@ -174,6 +174,7 @@ import {
   OutputProtocol,
   SECURE_STRING_SUBSTITUTE,
 } from "@/plugins/api/interfaces";
+import { goBack } from "@/helpers/navigation";
 import { $t } from "@/plugins/i18n";
 import { store } from "@/plugins/store";
 import {
@@ -422,7 +423,7 @@ const confirmDiscard = function () {
   showUnsavedDialog.value = false;
   allowNavigation.value = true;
   // Navigate back after setting the flag
-  router.back();
+  goBack(router, { name: "settings" });
 };
 
 const cancelDiscard = function () {

--- a/src/views/settings/EditPlayer.vue
+++ b/src/views/settings/EditPlayer.vue
@@ -344,6 +344,7 @@ import {
   mergeConfigEntries,
 } from "@/helpers/config_entry_ui";
 import { getHassProviderInstance } from "@/helpers/hass_controls";
+import { goBack } from "@/helpers/navigation";
 import { getPlayerSetupLabel } from "@/helpers/player_config";
 import { useConfigAction } from "@/composables/useConfigAction";
 import { openLinkInNewTab } from "@/helpers/utils";
@@ -622,7 +623,7 @@ const onSubmit = async function (values: Record<string, ConfigValueType>) {
   loading.value = true;
   try {
     await api.savePlayerConfig(props.playerId!, values);
-    router.back();
+    goBack(router, { name: "playersettings" });
   } catch {
     // Error toast is already shown by the API layer (handleResultMessage).
     // We just prevent navigation so the user can correct values.

--- a/src/views/settings/EditPlayerQueue.vue
+++ b/src/views/settings/EditPlayerQueue.vue
@@ -51,6 +51,7 @@ import { ConfigValueType, PlayerQueueConfig } from "@/plugins/api/interfaces";
 import { Button } from "@/components/ui/button";
 import { Spinner } from "@/components/ui/spinner";
 import { hasAdvancedEntries } from "@/helpers/config_entry_ui";
+import { goBack } from "@/helpers/navigation";
 import { Info, SlidersHorizontal } from "@lucide/vue";
 import { computed, ref, watch } from "vue";
 import { RouterLink, useRouter } from "vue-router";
@@ -101,7 +102,7 @@ const onSubmit = async function (values: Record<string, ConfigValueType>) {
   api
     .savePlayerQueueConfig(props.queueId!, values)
     .then(() => {
-      router.back();
+      goBack(router, { name: "playersettings" });
     })
     .catch((err) => {
       toast.error(err.message || err);

--- a/tests/helpers/navigation.test.ts
+++ b/tests/helpers/navigation.test.ts
@@ -1,4 +1,4 @@
-import { backFromMediaDetails, canGoBack } from "@/helpers/navigation";
+import { backFromMediaDetails, canGoBack, goBack } from "@/helpers/navigation";
 import type { Router } from "vue-router";
 import { describe, expect, it, vi } from "vitest";
 
@@ -22,6 +22,29 @@ describe("canGoBack", () => {
 
   it("is false on a view opened directly", () => {
     expect(canGoBack(fakeRouter("album").router)).toBe(false);
+  });
+});
+
+describe("goBack", () => {
+  it("returns to the previous view when there is one", () => {
+    const { router, back, push } = fakeRouter(
+      "editplayer",
+      "/settings/players",
+    );
+
+    goBack(router, { name: "playersettings" });
+
+    expect(back).toHaveBeenCalledOnce();
+    expect(push).not.toHaveBeenCalled();
+  });
+
+  it("takes the fallback on a view opened directly", () => {
+    const { router, back, push } = fakeRouter("editplayer");
+
+    goBack(router, { name: "playersettings" });
+
+    expect(push).toHaveBeenCalledWith({ name: "playersettings" });
+    expect(back).not.toHaveBeenCalled();
   });
 });
 

--- a/tests/helpers/navigation.test.ts
+++ b/tests/helpers/navigation.test.ts
@@ -1,0 +1,72 @@
+import { backFromMediaDetails, canGoBack } from "@/helpers/navigation";
+import type { Router } from "vue-router";
+import { describe, expect, it, vi } from "vitest";
+
+/** A router on `routeName`, reached from `backEntry` when one is given. */
+function fakeRouter(routeName?: string, backEntry: string | null = null) {
+  const back = vi.fn();
+  const push = vi.fn();
+  const router = {
+    back,
+    push,
+    currentRoute: { value: { name: routeName } },
+    options: { history: { state: { back: backEntry } } },
+  } as unknown as Router;
+  return { router, back, push };
+}
+
+describe("canGoBack", () => {
+  it("is true while history holds an earlier entry", () => {
+    expect(canGoBack(fakeRouter("album", "/albums").router)).toBe(true);
+  });
+
+  it("is false on a view opened directly", () => {
+    expect(canGoBack(fakeRouter("album").router)).toBe(false);
+  });
+});
+
+describe("backFromMediaDetails", () => {
+  it("returns to the previous view when there is one", () => {
+    const { router, back, push } = fakeRouter("album", "/albums");
+
+    backFromMediaDetails(router);
+
+    expect(back).toHaveBeenCalledOnce();
+    expect(push).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["album", "albums"],
+    ["artist", "artists"],
+    ["audiobook", "audiobooks"],
+    ["collection", "audiobooks"],
+    ["genre", "genres"],
+    ["playlist", "playlists"],
+    ["podcast", "podcasts"],
+    ["radio", "radios"],
+    ["track", "tracks"],
+  ])("goes up from %s opened directly to %s", (details, listing) => {
+    const { router, back, push } = fakeRouter(details);
+
+    backFromMediaDetails(router);
+
+    expect(push).toHaveBeenCalledWith({ name: listing });
+    expect(back).not.toHaveBeenCalled();
+  });
+
+  it("falls back to discover for a route without a listing", () => {
+    const { router, push } = fakeRouter("search");
+
+    backFromMediaDetails(router);
+
+    expect(push).toHaveBeenCalledWith({ name: "discover" });
+  });
+
+  it("falls back to discover for an unnamed route", () => {
+    const { router, push } = fakeRouter(undefined);
+
+    backFromMediaDetails(router);
+
+    expect(push).toHaveBeenCalledWith({ name: "discover" });
+  });
+});

--- a/tests/plugins/router.test.ts
+++ b/tests/plugins/router.test.ts
@@ -426,6 +426,15 @@ describe("media details back button", () => {
     expect(detailRoutes.length).toBeGreaterThanOrEqual(9);
   });
 
+  // the views that fall back somewhere fixed name it inline, so a rename in
+  // the route table would otherwise strand them silently
+  it.each(["discover", "settings", "playersettings"])(
+    "keeps %s reachable for the views that fall back to it",
+    (name) => {
+      expect(findRouteRecord(name, routes)?.name).toBe(name);
+    },
+  );
+
   it.each(detailRoutes)(
     "goes up from $name to $listing",
     ({ name, listing }) => {

--- a/tests/plugins/router.test.ts
+++ b/tests/plugins/router.test.ts
@@ -1,4 +1,5 @@
 import { DASHBOARD_VIEWER_PATH_STORAGE_KEY } from "@/helpers/guest_session";
+import { backFromMediaDetails } from "@/helpers/navigation";
 import { ConnectionState } from "@/plugins/api";
 import { routes } from "@/plugins/router";
 import type {
@@ -410,6 +411,35 @@ describe("global navigation guard", () => {
 
     expect(pending.isSettled()).toBe(true);
     await expect(pending.result).resolves.toBeUndefined();
+  });
+});
+
+describe("media details back button", () => {
+  // A details view opened directly has no history to return to, so the back
+  // button goes up to a listing instead. Both ends of that step are route
+  // names, which this pins to the route table so a rename cannot break it.
+  it.each([
+    "album",
+    "artist",
+    "audiobook",
+    "collection",
+    "genre",
+    "playlist",
+    "podcast",
+    "radio",
+    "track",
+  ])("goes up from %s to a route that exists", (details) => {
+    const push = vi.fn<(to: { name: string }) => void>();
+    backFromMediaDetails({
+      back: vi.fn(),
+      push,
+      currentRoute: { value: { name: details } },
+      options: { history: { state: { back: null } } },
+    } as unknown as Router);
+
+    const [target] = push.mock.calls[0];
+    expect(findRouteRecord(details, routes)?.name).toBe(details);
+    expect(findRouteRecord(target.name, routes)?.name).toBe(target.name);
   });
 });
 

--- a/tests/plugins/router.test.ts
+++ b/tests/plugins/router.test.ts
@@ -416,31 +416,31 @@ describe("global navigation guard", () => {
 
 describe("media details back button", () => {
   // A details view opened directly has no history to return to, so the back
-  // button goes up to a listing instead. Both ends of that step are route
-  // names, which this pins to the route table so a rename cannot break it.
-  it.each([
-    "album",
-    "artist",
-    "audiobook",
-    "collection",
-    "genre",
-    "playlist",
-    "podcast",
-    "radio",
-    "track",
-  ])("goes up from %s to a route that exists", (details) => {
-    const push = vi.fn<(to: { name: string }) => void>();
-    backFromMediaDetails({
-      back: vi.fn(),
-      push,
-      currentRoute: { value: { name: details } },
-      options: { history: { state: { back: null } } },
-    } as unknown as Router);
+  // button goes up to the listing above it instead. Both ends come out of the
+  // route table here, so a details route added without a target fails rather
+  // than quietly landing on discover.
+  const detailRoutes = mediaDetailRoutes(routes);
 
-    const [target] = push.mock.calls[0];
-    expect(findRouteRecord(details, routes)?.name).toBe(details);
-    expect(findRouteRecord(target.name, routes)?.name).toBe(target.name);
+  it("finds the media details routes to check", () => {
+    // guards the discovery below against silently matching nothing
+    expect(detailRoutes.length).toBeGreaterThanOrEqual(9);
   });
+
+  it.each(detailRoutes)(
+    "goes up from $name to $listing",
+    ({ name, listing }) => {
+      const push = vi.fn<(to: { name: string }) => void>();
+
+      backFromMediaDetails({
+        back: vi.fn(),
+        push,
+        currentRoute: { value: { name } },
+        options: { history: { state: { back: null } } },
+      } as unknown as Router);
+
+      expect(push).toHaveBeenCalledWith({ name: listing });
+    },
+  );
 });
 
 /**
@@ -488,6 +488,35 @@ function beforeEnterGuard(name: string): NavigationGuardWithThis<undefined> {
     throw new Error(`Route "${name}" has no single beforeEnter guard`);
   }
   return guard;
+}
+
+/**
+ * Every media details route paired with the listing it sits under.
+ *
+ * A details route is a provider-scoped child of a library section, and that
+ * section's index route is the listing above it.
+ */
+function mediaDetailRoutes(
+  records: RouteRecordRaw[],
+): { name: string; listing: string }[] {
+  const found: { name: string; listing: string }[] = [];
+  for (const record of records) {
+    const children = "children" in record ? record.children : undefined;
+    if (!children) continue;
+
+    const listing = children.find((child) => child.path === "")?.name;
+    if (typeof listing === "string") {
+      for (const child of children) {
+        if (
+          child.path.startsWith(":provider/") &&
+          typeof child.name === "string"
+        )
+          found.push({ name: child.name, listing });
+      }
+    }
+    found.push(...mediaDetailRoutes(children));
+  }
+  return found;
 }
 
 function findRouteRecord(


### PR DESCRIPTION
# What does this implement/fix?

Opening a page straight from a link (or just reloading) and then pressing back
took you out of the app, or did nothing at all.

Back buttons decide whether they can go back. The media details one checked a
stored "previous route" value that is set on the very first navigation and
never cleared, so it was effectively always set and its fallback never ran. The
others didn't check at all. Either way, on a page you opened directly there was
nothing to go back to.

They now check the browser history for a real previous page, the same signal
the edge-swipe back gesture already uses, and each falls back somewhere sensible.

- Details pages go up to their library listing (album → albums, artist →
  artists, and so on) instead of leaving the app
- Podcast, audiobook, genre and collection pages land on a listing too; they
  weren't covered before
- The 404 page's Back button works instead of doing nothing
- Removing or deleting the item a details page is showing goes up to its listing
- Settings pages fall back to their settings section
- Dropped the unused stored previous route
- Tests for both paths, with the listing targets derived from the app's own
  route table so a details page added without one fails

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm lint:check` passes.
- [x] `pnpm test:run` passes, and tests have been added/updated where applicable.
- [x] `pnpm build` passes.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
