### PR TITLE
Fill the dead strip at the bottom in the Home Assistant app

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -61,6 +61,7 @@ import PlayerBrowserMediaControls from "./layouts/default/PlayerOSD/PlayerBrowse
 import { pruneStaleProviderFilters } from "./composables/userPreferences";
 import { initializeCompanionIntegration } from "./plugins/companion";
 import {
+  haState,
   subscribeToHAProperties,
   unsubscribeFromHAProperties,
 } from "./plugins/homeassistant";
@@ -270,6 +271,16 @@ const completeInitialization = async () => {
     console.error("[App] No server info received");
     return;
   }
+
+  // Home Assistant pads its ingress iframe for the device safe area, leaving a
+  // strip of its own background we cannot reach from in here. Take that padding
+  // over so the app runs to the edge of the screen like it does anywhere else.
+  // Ask before anything else is awaited, so the app lays itself out once.
+  // Reconnecting runs this again while the subscription is still standing.
+  if (store.isIngressSession && !haState.isSubscribed) {
+    subscribeToHAProperties({ handleSafeArea: true });
+  }
+
   const userInfo = await api.getCurrentUserInfo();
   if (!userInfo) {
     console.error("[App] No user info received");
@@ -284,13 +295,6 @@ const completeInitialization = async () => {
   const connectionIdentity = getCurrentAuthConnectionIdentity();
   if (!isGuestAccessSession && !isDashboardViewer && connectionIdentity) {
     authManager.bindPersistentToken(connectionIdentity);
-  }
-
-  // Home Assistant pads its ingress iframe for the device safe area, leaving a
-  // strip of its own background we cannot reach from in here. Take that padding
-  // over so the app runs to the edge of the screen like it does anywhere else.
-  if (store.isIngressSession) {
-    subscribeToHAProperties({ handleSafeArea: true });
   }
 
   // TODO: Remove this migration code in v2.9 release

--- a/src/App.vue
+++ b/src/App.vue
@@ -60,11 +60,10 @@ import SendspinPlayer from "./components/SendspinPlayer.vue";
 import PlayerBrowserMediaControls from "./layouts/default/PlayerOSD/PlayerBrowserMediaControls.vue";
 import { pruneStaleProviderFilters } from "./composables/userPreferences";
 import { initializeCompanionIntegration } from "./plugins/companion";
-// import {
-//   subscribeToHAProperties,
-//   unsubscribeFromHAProperties,
-//   getKioskModePreference
-// } from "./plugins/homeassistant";
+import {
+  subscribeToHAProperties,
+  unsubscribeFromHAProperties,
+} from "./plugins/homeassistant";
 import type { User } from "./plugins/api/interfaces";
 import { remoteConnectionManager } from "./plugins/remote";
 import { httpProxyBridge } from "./plugins/remote/http-proxy";
@@ -287,12 +286,12 @@ const completeInitialization = async () => {
     authManager.bindPersistentToken(connectionIdentity);
   }
 
-  // Enable kiosk mode when running in Home Assistant ingress
-  // COMMENTED OUT - HA INTEGRATION DISABLED
-  // if (store.isIngressSession && serverInfo.homeassistant_addon) {
-  // const kioskPref = getKioskModePreference();
-  // subscribeToHAProperties({ kioskMode: kioskPref, router });
-  // }
+  // Home Assistant pads its ingress iframe for the device safe area, leaving a
+  // strip of its own background we cannot reach from in here. Take that padding
+  // over so the app runs to the edge of the screen like it does anywhere else.
+  if (store.isIngressSession && serverInfo.homeassistant_addon) {
+    subscribeToHAProperties({ handleSafeArea: true });
+  }
 
   // TODO: Remove this migration code in v2.9 release
   // Migrate localStorage settings to user preferences (one-time migration)
@@ -547,7 +546,7 @@ onMounted(async () => {
 });
 
 onUnmounted(() => {
-  // unsubscribeFromHAProperties();
+  unsubscribeFromHAProperties();
 });
 
 function getCurrentAuthConnectionIdentity() {

--- a/src/App.vue
+++ b/src/App.vue
@@ -289,7 +289,7 @@ const completeInitialization = async () => {
   // Home Assistant pads its ingress iframe for the device safe area, leaving a
   // strip of its own background we cannot reach from in here. Take that padding
   // over so the app runs to the edge of the screen like it does anywhere else.
-  if (store.isIngressSession && serverInfo.homeassistant_addon) {
+  if (store.isIngressSession) {
     subscribeToHAProperties({ handleSafeArea: true });
   }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -51,7 +51,9 @@ installSendspinInterceptor();
 // Embedded (e.g. the Home Assistant panel): the host sizes our viewport and
 // keeps it clear of the system controls, so don't reserve that space again.
 // Browsers disagree here anyway - Chrome reports no insets inside an iframe,
-// Safari reports the ones belonging to the page around us.
+// Safari reports the ones belonging to the page around us. A host that hands
+// the safe area over instead reports what it stopped covering, and those
+// values land on the same properties inline, above this.
 if (window.self !== window.top) {
   document.documentElement.setAttribute("data-embedded-layout", "");
 }

--- a/src/plugins/homeassistant.ts
+++ b/src/plugins/homeassistant.ts
@@ -44,6 +44,21 @@ let routerInstance: Router | null = null;
 let isNavigatingFromHA = false;
 
 /**
+ * The part of the reported safe area Music Assistant is left to cover.
+ *
+ * While Home Assistant is narrow it puts a header of its own above the frame,
+ * and that header already takes the top inset, so claiming it again would only
+ * push the app further down the screen. Kiosk mode drops that header, and hands
+ * the top inset back to us along with it.
+ */
+function ownedInsets(
+  insets: Partial<HASafeAreaInsets>,
+  narrow: boolean,
+): Partial<HASafeAreaInsets> {
+  return narrow ? { ...insets, top: "" } : insets;
+}
+
+/**
  * Apply the safe area Home Assistant reports to the device inset tokens.
  *
  * Edges Home Assistant reports nothing for are handed back to the stylesheet.
@@ -76,7 +91,9 @@ function handleMessage(event: MessageEvent) {
     // Home Assistant reports the insets whether or not we asked for them, and
     // only stops padding the iframe itself once we did.
     if (state.safeAreaEnabled && event.data.safeAreaInsets) {
-      applySafeAreaInsets(event.data.safeAreaInsets);
+      applySafeAreaInsets(
+        ownedInsets(event.data.safeAreaInsets, state.properties.narrow),
+      );
     }
 
     if (

--- a/src/plugins/homeassistant.ts
+++ b/src/plugins/homeassistant.ts
@@ -62,6 +62,12 @@ function applySafeAreaInsets(insets: Partial<HASafeAreaInsets>): void {
 }
 
 function handleMessage(event: MessageEvent) {
+  // Home Assistant posts to the frame it embeds us in, so anything from another
+  // sender is not it.
+  if (event.source !== window.parent) {
+    return;
+  }
+
   if (event.data?.type === "home-assistant/properties") {
     const oldRoute = state.properties.route?.path;
     state.properties.narrow = event.data.narrow ?? false;

--- a/src/plugins/homeassistant.ts
+++ b/src/plugins/homeassistant.ts
@@ -11,10 +11,18 @@ export interface HAProperties {
   route: HARoute | null;
 }
 
+export interface HASafeAreaInsets {
+  top: string;
+  right: string;
+  bottom: string;
+  left: string;
+}
+
 interface HAState {
   isSubscribed: boolean;
   kioskModeEnabled: boolean;
   routeSyncEnabled: boolean;
+  safeAreaEnabled: boolean;
   properties: HAProperties;
 }
 
@@ -22,21 +30,48 @@ const state = reactive<HAState>({
   isSubscribed: false,
   kioskModeEnabled: false,
   routeSyncEnabled: false,
+  safeAreaEnabled: false,
   properties: {
     narrow: false,
     route: null,
   },
 });
 
+const SAFE_AREA_EDGES = ["top", "right", "bottom", "left"] as const;
+
 let messageHandler: ((event: MessageEvent) => void) | null = null;
 let routerInstance: Router | null = null;
 let isNavigatingFromHA = false;
+
+/**
+ * Apply the safe area Home Assistant reports to the device inset tokens.
+ *
+ * Edges Home Assistant reports nothing for are handed back to the stylesheet.
+ */
+function applySafeAreaInsets(insets: Partial<HASafeAreaInsets>): void {
+  for (const edge of SAFE_AREA_EDGES) {
+    const property = `--device-inset-${edge}`;
+    // Setting these inline is what lifts them above the zeroed tokens an
+    // embedded layout gets, which stay right for every host that reports none.
+    if (insets[edge]) {
+      document.documentElement.style.setProperty(property, insets[edge]);
+    } else {
+      document.documentElement.style.removeProperty(property);
+    }
+  }
+}
 
 function handleMessage(event: MessageEvent) {
   if (event.data?.type === "home-assistant/properties") {
     const oldRoute = state.properties.route?.path;
     state.properties.narrow = event.data.narrow ?? false;
     state.properties.route = event.data.route ?? null;
+
+    // Home Assistant reports the insets whether or not we asked for them, and
+    // only stops padding the iframe itself once we did.
+    if (state.safeAreaEnabled && event.data.safeAreaInsets) {
+      applySafeAreaInsets(event.data.safeAreaInsets);
+    }
 
     if (
       state.routeSyncEnabled &&
@@ -65,10 +100,16 @@ function handleMessage(event: MessageEvent) {
  * Optionally enables kiosk mode which hides HA's toolbar.
  *
  * @param options.kioskMode - If true, requests HA to hide its toolbar
+ * @param options.handleSafeArea - If true, takes the safe area padding HA puts
+ *   around the ingress iframe over into the device inset tokens
  * @param options.router - Vue router instance for route synchronization
  */
 export function subscribeToHAProperties(
-  options: { kioskMode?: boolean; router?: Router } = {},
+  options: {
+    kioskMode?: boolean;
+    handleSafeArea?: boolean;
+    router?: Router;
+  } = {},
 ): void {
   if (state.isSubscribed) {
     console.warn("[HA Integration] Already subscribed to HA properties");
@@ -87,12 +128,14 @@ export function subscribeToHAProperties(
     {
       type: "home-assistant/subscribe-properties",
       kioskMode: options.kioskMode ?? false,
+      handleSafeArea: options.handleSafeArea ?? false,
     },
     "*",
   );
 
   state.isSubscribed = true;
   state.kioskModeEnabled = options.kioskMode ?? false;
+  state.safeAreaEnabled = options.handleSafeArea ?? false;
 
   console.debug(
     "[HA Integration] Subscribed to HA properties",
@@ -121,9 +164,14 @@ export function unsubscribeFromHAProperties(): void {
     "*",
   );
 
+  // Home Assistant pads the iframe again the moment we unsubscribe, so hand the
+  // safe area back rather than reserving it twice.
+  applySafeAreaInsets({});
+
   state.isSubscribed = false;
   state.kioskModeEnabled = false;
   state.routeSyncEnabled = false;
+  state.safeAreaEnabled = false;
   routerInstance = null;
 
   console.debug("[HA Integration] Unsubscribed from HA properties");

--- a/tests/App.test.ts
+++ b/tests/App.test.ts
@@ -17,8 +17,10 @@ const {
   authManagerMock,
   guestType,
   i18nMock,
+  haStateMock,
   mockInitializeCompanionIntegration,
   mockInitializeWebPlayerModeSync,
+  mockSubscribeToHAProperties,
   mockProxyEnsureReady,
   mockProxySetTransport,
   mockPruneStaleProviderFilters,
@@ -91,8 +93,10 @@ const {
         t: (key: string) => key,
       },
     },
+    haStateMock: { isSubscribed: false },
     mockInitializeCompanionIntegration: vi.fn(),
     mockInitializeWebPlayerModeSync: vi.fn(),
+    mockSubscribeToHAProperties: vi.fn(),
     mockProxyEnsureReady: vi.fn(),
     mockProxySetTransport: vi.fn(),
     mockPruneStaleProviderFilters: vi.fn(),
@@ -184,6 +188,12 @@ vi.mock("@/plugins/web_player", () => ({
 
 vi.mock("@/plugins/companion", () => ({
   initializeCompanionIntegration: mockInitializeCompanionIntegration,
+}));
+
+vi.mock("@/plugins/homeassistant", () => ({
+  haState: haStateMock,
+  subscribeToHAProperties: mockSubscribeToHAProperties,
+  unsubscribeFromHAProperties: vi.fn(),
 }));
 
 vi.mock("@/plugins/remote", () => ({
@@ -316,6 +326,7 @@ describe("App initialization", () => {
     mockProxyEnsureReady.mockResolvedValue(undefined);
     mockProxySetTransport.mockResolvedValue(undefined);
     mockPruneStaleProviderFilters.mockResolvedValue(undefined);
+    haStateMock.isSubscribed = false;
     storeMock.currentUser = undefined;
     storeMock.enabledPlugins = new Set<string>();
     storeMock.isIngressSession = false;
@@ -659,6 +670,31 @@ describe("App initialization", () => {
     expect(sessionStorage.getItem("ma_guest_session_ended")).toBeNull();
     expect(authManagerMock.clearGuestSession).not.toHaveBeenCalled();
     expect(apiMock.requireAuthentication).toHaveBeenCalledOnce();
+  });
+
+  it("takes the safe area padding over in an ingress session", async () => {
+    storeMock.isIngressSession = true;
+
+    wrapper = await mountApp();
+
+    expect(mockSubscribeToHAProperties).toHaveBeenCalledWith({
+      handleSafeArea: true,
+    });
+  });
+
+  it("leaves the safe area to the host outside an ingress session", async () => {
+    wrapper = await mountApp();
+
+    expect(mockSubscribeToHAProperties).not.toHaveBeenCalled();
+  });
+
+  it("keeps the safe area subscription it already has across a reconnect", async () => {
+    storeMock.isIngressSession = true;
+    haStateMock.isSubscribed = true;
+
+    wrapper = await mountApp();
+
+    expect(mockSubscribeToHAProperties).not.toHaveBeenCalled();
   });
 
   it("re-authenticates an ingress session through the proxy on reconnect", async () => {

--- a/tests/plugins/homeassistant.test.ts
+++ b/tests/plugins/homeassistant.test.ts
@@ -1,0 +1,127 @@
+import {
+  subscribeToHAProperties,
+  unsubscribeFromHAProperties,
+} from "@/plugins/homeassistant";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const INSET_PROPERTIES = ["top", "right", "bottom", "left"].map(
+  (edge) => `--device-inset-${edge}`,
+);
+
+const PHONE_INSETS = {
+  top: "59px",
+  right: "0px",
+  bottom: "34px",
+  left: "0px",
+};
+
+// The inline values are the whole point of the exchange: they are what outranks
+// the zeroed tokens an embedded layout gets, so read them off the element rather
+// than through getComputedStyle.
+function readInsets() {
+  return INSET_PROPERTIES.map((property) =>
+    document.documentElement.style.getPropertyValue(property),
+  );
+}
+
+function reportProperties(data: Record<string, unknown>) {
+  window.dispatchEvent(
+    new MessageEvent("message", {
+      data: { type: "home-assistant/properties", narrow: false, ...data },
+    }),
+  );
+}
+
+describe("Home Assistant safe area", () => {
+  let postMessage: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    postMessage = vi
+      .spyOn(window.parent, "postMessage")
+      .mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    // Also resets the module singleton and the tokens for the next test.
+    unsubscribeFromHAProperties();
+    postMessage.mockRestore();
+  });
+
+  it("asks Home Assistant to hand its safe area padding over", () => {
+    subscribeToHAProperties({ handleSafeArea: true });
+
+    expect(postMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "home-assistant/subscribe-properties",
+        handleSafeArea: true,
+        kioskMode: false,
+      }),
+      "*",
+    );
+  });
+
+  it("applies the insets Home Assistant reports", () => {
+    subscribeToHAProperties({ handleSafeArea: true });
+
+    reportProperties({ safeAreaInsets: PHONE_INSETS });
+
+    expect(readInsets()).toEqual(["59px", "0px", "34px", "0px"]);
+  });
+
+  it("writes nothing when Home Assistant reports no safe area", () => {
+    subscribeToHAProperties({ handleSafeArea: true });
+
+    // Home Assistant older than the safe-area handover sends the same message
+    // without the field, and is still padding the iframe itself.
+    reportProperties({ narrow: true });
+
+    expect(readInsets()).toEqual(["", "", "", ""]);
+  });
+
+  it("keeps the reported insets when a later update leaves them out", () => {
+    subscribeToHAProperties({ handleSafeArea: true });
+
+    reportProperties({ safeAreaInsets: PHONE_INSETS });
+    reportProperties({ narrow: true });
+
+    expect(readInsets()).toEqual(["59px", "0px", "34px", "0px"]);
+  });
+
+  it("ignores the reported insets when it did not ask to handle them", () => {
+    // Home Assistant reports the insets either way but only drops its own
+    // padding when asked, so acting on them here would reserve the space twice.
+    subscribeToHAProperties();
+
+    reportProperties({ safeAreaInsets: PHONE_INSETS });
+
+    expect(readInsets()).toEqual(["", "", "", ""]);
+  });
+
+  it("hands an edge back to the stylesheet when Home Assistant reports none", () => {
+    subscribeToHAProperties({ handleSafeArea: true });
+
+    reportProperties({
+      safeAreaInsets: { top: "59px", right: "", bottom: "34px", left: "" },
+    });
+
+    expect(readInsets()).toEqual(["59px", "", "34px", ""]);
+  });
+
+  it("hands the safe area back on unsubscribe", () => {
+    subscribeToHAProperties({ handleSafeArea: true });
+    reportProperties({ safeAreaInsets: PHONE_INSETS });
+
+    unsubscribeFromHAProperties();
+
+    expect(readInsets()).toEqual(["", "", "", ""]);
+  });
+
+  it("stops following Home Assistant after unsubscribing", () => {
+    subscribeToHAProperties({ handleSafeArea: true });
+    unsubscribeFromHAProperties();
+
+    reportProperties({ safeAreaInsets: PHONE_INSETS });
+
+    expect(readInsets()).toEqual(["", "", "", ""]);
+  });
+});

--- a/tests/plugins/homeassistant.test.ts
+++ b/tests/plugins/homeassistant.test.ts
@@ -75,6 +75,25 @@ describe("Home Assistant safe area", () => {
     expect(readInsets()).toEqual(["59px", "0px", "34px", "0px"]);
   });
 
+  it("leaves the top inset to the header Home Assistant shows when narrow", () => {
+    subscribeToHAProperties({ handleSafeArea: true });
+
+    // That header is as tall as the top inset and sits above the frame, so
+    // taking the inset as well would push the app down a second time.
+    reportProperties({ narrow: true, safeAreaInsets: PHONE_INSETS });
+
+    expect(readInsets()).toEqual(["", "0px", "34px", "0px"]);
+  });
+
+  it("drops the top inset again once Home Assistant shows its header", () => {
+    subscribeToHAProperties({ handleSafeArea: true });
+
+    reportProperties({ safeAreaInsets: PHONE_INSETS });
+    reportProperties({ narrow: true, safeAreaInsets: PHONE_INSETS });
+
+    expect(readInsets()).toEqual(["", "0px", "34px", "0px"]);
+  });
+
   it("writes nothing when Home Assistant reports no safe area", () => {
     subscribeToHAProperties({ handleSafeArea: true });
 

--- a/tests/plugins/homeassistant.test.ts
+++ b/tests/plugins/homeassistant.test.ts
@@ -24,10 +24,16 @@ function readInsets() {
   );
 }
 
-function reportProperties(data: Record<string, unknown>) {
+// Home Assistant posts to the frame it embeds us in, which is what puts itself
+// on the event as the source.
+function reportProperties(
+  data: Record<string, unknown>,
+  source: MessageEventSource | null = window.parent,
+) {
   window.dispatchEvent(
     new MessageEvent("message", {
       data: { type: "home-assistant/properties", narrow: false, ...data },
+      source,
     }),
   );
 }
@@ -45,6 +51,7 @@ describe("Home Assistant safe area", () => {
     // Also resets the module singleton and the tokens for the next test.
     unsubscribeFromHAProperties();
     postMessage.mockRestore();
+    document.querySelector("[data-foreign-frame]")?.remove();
   });
 
   it("asks Home Assistant to hand its safe area padding over", () => {
@@ -93,6 +100,22 @@ describe("Home Assistant safe area", () => {
     subscribeToHAProperties();
 
     reportProperties({ safeAreaInsets: PHONE_INSETS });
+
+    expect(readInsets()).toEqual(["", "", "", ""]);
+  });
+
+  it("ignores properties from anything but the frame it is embedded in", () => {
+    subscribeToHAProperties({ handleSafeArea: true });
+    const foreignFrame = document.createElement("iframe");
+    foreignFrame.dataset.foreignFrame = "";
+    document.body.appendChild(foreignFrame);
+    expect(foreignFrame.contentWindow).toBeTruthy();
+    expect(foreignFrame.contentWindow).not.toBe(window.parent);
+
+    reportProperties(
+      { safeAreaInsets: PHONE_INSETS },
+      foreignFrame.contentWindow,
+    );
 
     expect(readInsets()).toEqual(["", "", "", ""]);
   });

--- a/tests/styles/mobileNavigationHeight.test.ts
+++ b/tests/styles/mobileNavigationHeight.test.ts
@@ -155,10 +155,12 @@ describe("mobile navigation height", () => {
   it("takes its clearance from the inset the host can zero", () => {
     document.documentElement.setAttribute("data-embedded-layout", "");
 
-    // embedded in Home Assistant the device insets are the host's to add, so the
-    // bar zeroes them and falls back on the floor under the inset. Reaching for
-    // the device inset directly reads the same until it is embedded, and then
-    // reserves the home indicator a second time on top of the host's own room.
+    // embedded the device insets are the host's to add, so the bar zeroes them
+    // and falls back on the floor under the inset. Reaching for the device inset
+    // directly reads the same until it is embedded, and then reserves the home
+    // indicator a second time on top of the host's own room. A host that hands
+    // the safe area over writes the same properties inline, and the bar follows
+    // them there without reading anything else.
     expect(customProperty("--mobile-navigation-height")).toBe(
       "calc(72px+max(12px,calc(0px*0.65)))",
     );

--- a/tests/styles/safeArea.test.ts
+++ b/tests/styles/safeArea.test.ts
@@ -15,6 +15,7 @@ function applyGlobalStyles() {
 afterEach(() => {
   document.head.querySelector("[data-safe-area-test]")?.remove();
   document.documentElement.removeAttribute("data-embedded-layout");
+  document.documentElement.style.removeProperty("--device-inset-bottom");
 });
 
 describe.each([
@@ -54,5 +55,17 @@ describe("embedded safe area", () => {
     for (const property of insetProperties) {
       expect(computed.getPropertyValue(property).trim()).toBe("0px");
     }
+  });
+
+  it("takes the insets an embedding host reports over the zeroed tokens", () => {
+    applyGlobalStyles();
+    document.documentElement.setAttribute("data-embedded-layout", "");
+    document.documentElement.style.setProperty("--device-inset-bottom", "34px");
+
+    expect(
+      getComputedStyle(document.documentElement)
+        .getPropertyValue("--device-inset-bottom")
+        .trim(),
+    ).toBe("34px");
   });
 });


### PR DESCRIPTION
# What does this implement/fix?

Opened from the Home Assistant companion app, Music Assistant left a strip of
dead space along the bottom of the screen. Home Assistant puts the phone's safe
area on the ingress iframe as padding, so those pixels never reach us and
nothing we do with CSS can fill them.

Home Assistant now lets a panel take that over, so we ask for it and apply the
insets it reports ourselves. The spacing works out the same, but the app owns
it: the dock and its background run to the bottom edge like they do in the
standalone app, with the buttons still clear of the home indicator.

Changes:

- Ask Home Assistant to hand over its safe area padding when running as the
  add-on panel, and apply the insets it reports to `--device-inset-*`.
- Leave the top inset alone while Home Assistant is narrow. Its own header is
  there in that case and already takes it, so claiming it too would just push
  the app down and trade one gap for a bigger one.
- Nothing else from the old Home Assistant integration is re-enabled — no kiosk
  mode, no route syncing, no menu button.
- Older Home Assistant versions ignore the request and keep padding the iframe
  themselves, so they look exactly as they do today.
- Tests for the message handling and the wiring, including the case where Home
  Assistant reports no safe area.

Checked on an iPhone with Music Assistant opened from the add-on panel in the
Home Assistant companion app.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm lint:check` passes.
- [x] `pnpm test:run` passes, and tests have been added/updated where applicable.
- [x] `pnpm build` passes.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
