### PR TITLE
Let the screen sleep again after visiting the party dashboard

### DIFF
--- a/src/composables/useShortcuts.ts
+++ b/src/composables/useShortcuts.ts
@@ -435,9 +435,13 @@ export function useShortcuts() {
   });
 
   let _unsubscribeUpdated: (() => void) | undefined;
+  let _unmounted = false;
 
   onMounted(async () => {
     await loadShortcuts();
+    // The load can outlast the component, and the cleanup hook has already run
+    // by then with nothing to unsubscribe.
+    if (_unmounted) return;
 
     _unsubscribeUpdated = api.subscribe(
       EventType.MEDIA_ITEM_UPDATED,
@@ -460,6 +464,7 @@ export function useShortcuts() {
   });
 
   onUnmounted(() => {
+    _unmounted = true;
     _unsubscribeUpdated?.();
   });
 

--- a/src/views/PartyDashboardView.vue
+++ b/src/views/PartyDashboardView.vue
@@ -376,8 +376,8 @@ const logoSrc = new URL("@/assets/logo/logo.svg", import.meta.url).href;
 const logoDarkSrc = new URL("@/assets/logo/logo-dark.svg", import.meta.url)
   .href;
 
-// Set by the unmount hook, so the async work started here can tell that the
-// view it belongs to is gone before it acts on a result.
+// Set by the unmount hook, so the async work below can tell that the view it
+// belongs to is gone before it acts on a result.
 let unmounted = false;
 
 const refreshPartyPlayer = async () => {

--- a/src/views/PartyDashboardView.vue
+++ b/src/views/PartyDashboardView.vue
@@ -376,8 +376,15 @@ const logoSrc = new URL("@/assets/logo/logo.svg", import.meta.url).href;
 const logoDarkSrc = new URL("@/assets/logo/logo-dark.svg", import.meta.url)
   .href;
 
+// Set by the unmount hook, so the async work started here can tell that the
+// view it belongs to is gone before it acts on a result.
+let unmounted = false;
+
 const refreshPartyPlayer = async () => {
   const partyPlayerId = await api.sendCommand<string | null>("party/player");
+  // Leaving the view mid-request would otherwise hand the whole app the party
+  // player, over whatever the next route picked.
+  if (unmounted) return;
   accessError.value = "";
   if (partyPlayerId) {
     store.activePlayerId = partyPlayerId;
@@ -753,13 +760,20 @@ let wakeLock: WakeLockSentinel | null = null;
 const requestWakeLock = async () => {
   if ("wakeLock" in navigator) {
     try {
-      wakeLock = await navigator.wakeLock.request("screen");
-      wakeLock.addEventListener("release", () => {
+      const sentinel = await navigator.wakeLock.request("screen");
+      // The request can outlive the view, and the unmount hook has no way to
+      // reach a sentinel that did not exist while it ran.
+      if (unmounted) {
+        sentinel.release();
+        return;
+      }
+      wakeLock = sentinel;
+      sentinel.addEventListener("release", () => {
         console.debug("Wake lock released");
         wakeLock = null;
         // Re-acquire wake lock if document is still visible
         // This handles cases where the system releases it unexpectedly
-        if (document.visibilityState === "visible") {
+        if (!unmounted && document.visibilityState === "visible") {
           requestWakeLock();
         }
       });
@@ -784,7 +798,6 @@ const BURN_IN_SWAP_MS = 10 * 60 * 1000; // 10 minutes
 // active instance and onBeforeUnmount would be a no-op, so the subscriptions
 // are collected here for the unmount hook registered at setup level.
 const unsubscribers: Array<() => void> = [];
-let unmounted = false;
 
 watch(antiBurnIn, (enabled) => {
   if (burnInInterval) {

--- a/src/views/PartyGuestView.vue
+++ b/src/views/PartyGuestView.vue
@@ -466,13 +466,14 @@ watch(partyConfig, (newConfig) => {
 });
 
 // --- Lifecycle ---
-// Set by the unmount hook, so the startup below can tell that the view it is
-// setting things up for is already gone.
-let unmounted = false;
 let cleanupCountdown: (() => void) | null = null;
 let cleanupQueueEvents: (() => void) | null = null;
 let cleanupProvidersSub: (() => void) | null = null;
 let cleanupQueueUpdatedSub: (() => void) | null = null;
+
+// Set by the unmount hook, so the startup below can tell that the view it is
+// setting things up for is already gone.
+let unmounted = false;
 
 const refreshPartyPlayer = async () => {
   try {

--- a/src/views/PartyGuestView.vue
+++ b/src/views/PartyGuestView.vue
@@ -466,6 +466,9 @@ watch(partyConfig, (newConfig) => {
 });
 
 // --- Lifecycle ---
+// Set by the unmount hook, so the startup below can tell that the view it is
+// setting things up for is already gone.
+let unmounted = false;
 let cleanupCountdown: (() => void) | null = null;
 let cleanupQueueEvents: (() => void) | null = null;
 let cleanupProvidersSub: (() => void) | null = null;
@@ -489,6 +492,9 @@ const fetchAndApplyConfig = async () => {
 
 onMounted(async () => {
   await fetchAndApplyConfig();
+  // Each await can outlast the view, and the unmount hook only reaches what
+  // was already set up by the time it ran.
+  if (unmounted) return;
 
   history.pushState(null, "", location.href);
   window.addEventListener("popstate", handleBack);
@@ -496,6 +502,7 @@ onMounted(async () => {
   cleanupCountdown = rateLimit.startCountdown();
 
   await refreshPartyPlayer();
+  if (unmounted) return;
 
   fetchQueueItems();
   cleanupQueueEvents = queue.subscribeToEvents();
@@ -527,6 +534,7 @@ onMounted(async () => {
 });
 
 onBeforeUnmount(() => {
+  unmounted = true;
   window.removeEventListener("popstate", handleBack);
   cleanupQueueEvents?.();
   cleanupCountdown?.();

--- a/tests/composables/useShortcuts.test.ts
+++ b/tests/composables/useShortcuts.test.ts
@@ -247,7 +247,7 @@ describe("useShortcuts media item subscription", () => {
     expect(unsubscribe).toHaveBeenCalled();
   });
 
-  it("never starts listening when its component goes away while loading", async () => {
+  it("never starts listening when its component goes away during startup", async () => {
     const consumer = mount(Consumer);
 
     consumer.unmount();

--- a/tests/composables/useShortcuts.test.ts
+++ b/tests/composables/useShortcuts.test.ts
@@ -1,9 +1,12 @@
+import { flushPromises, mount } from "@vue/test-utils";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { defineComponent, h } from "vue";
 import type { MusicAssistantApi } from "@/plugins/api";
 
-const { mockUpdateUser, storeMock } = vi.hoisted(() => {
+const { mockUpdateUser, mockSubscribe, storeMock } = vi.hoisted(() => {
   return {
     mockUpdateUser: vi.fn<MusicAssistantApi["updateUser"]>(),
+    mockSubscribe: vi.fn(() => vi.fn()),
     storeMock: {
       currentUser: {
         user_id: "user-1",
@@ -16,6 +19,7 @@ const { mockUpdateUser, storeMock } = vi.hoisted(() => {
 vi.mock("@/plugins/api", () => ({
   api: {
     updateUser: mockUpdateUser,
+    subscribe: mockSubscribe,
   },
 }));
 
@@ -25,6 +29,7 @@ vi.mock("@/plugins/store", () => ({
 
 import {
   getShortcutMoveAvailability,
+  useShortcuts,
   isShortcutPinned,
   isShortcutPinnedItem,
   moveShortcutStandaloneItem,
@@ -214,5 +219,40 @@ describe("useShortcuts standalone helpers", () => {
       ENCODED_PODCAST_URI,
       "builtin://radio/http%3A%2F%2Fexample.com%2Fstream",
     ]);
+  });
+});
+
+describe("useShortcuts media item subscription", () => {
+  // the composable's hooks bind to whichever component calls it
+  const Consumer = defineComponent({
+    setup() {
+      useShortcuts();
+      return () => h("div");
+    },
+  });
+
+  beforeEach(() => {
+    mockSubscribe.mockClear();
+    storeMock.currentUser = { user_id: "user-1", preferences: {} };
+  });
+
+  it("stops listening when its component goes away", async () => {
+    const consumer = mount(Consumer);
+    await flushPromises();
+    const [unsubscribe] = mockSubscribe.mock.results.map((r) => r.value);
+    expect(unsubscribe).toBeDefined();
+
+    consumer.unmount();
+
+    expect(unsubscribe).toHaveBeenCalled();
+  });
+
+  it("never starts listening when its component goes away while loading", async () => {
+    const consumer = mount(Consumer);
+
+    consumer.unmount();
+    await flushPromises();
+
+    expect(mockSubscribe).not.toHaveBeenCalled();
   });
 });

--- a/tests/views/PartyDashboardView.test.ts
+++ b/tests/views/PartyDashboardView.test.ts
@@ -141,6 +141,52 @@ const enterFullscreen = (view: VueWrapper) =>
   view.get(ENTER_FULLSCREEN).trigger("click");
 
 /**
+ * Stands in for the Wake Lock API, which happy-dom does not implement.
+ *
+ * `settle()` resolves a pending request, so a test can leave the view while
+ * one is still in flight. Sentinels fire `release` on release, the way the
+ * browser does.
+ */
+function fakeWakeLock() {
+  const sentinels: { released: boolean }[] = [];
+  let pending: ((sentinel: unknown) => void) | undefined;
+  const request = vi.fn(
+    () =>
+      new Promise((resolve) => {
+        pending = resolve;
+      }),
+  );
+  Object.defineProperty(navigator, "wakeLock", {
+    configurable: true,
+    value: { request },
+  });
+  return {
+    request,
+    sentinels,
+    settle: () => {
+      const listeners: (() => void)[] = [];
+      const sentinel = {
+        released: false,
+        release: vi.fn(() => {
+          sentinel.released = true;
+          listeners.forEach((listener) => listener());
+          return Promise.resolve();
+        }),
+        addEventListener: (_type: string, listener: () => void) =>
+          listeners.push(listener),
+      };
+      sentinels.push(sentinel);
+      pending?.(sentinel);
+      pending = undefined;
+      return sentinel;
+    },
+    restore: () => {
+      delete (navigator as { wakeLock?: unknown }).wakeLock;
+    },
+  };
+}
+
+/**
  * Records document listeners while a view runs.
  *
  * `stop()` restores the originals and returns the event types still attached,
@@ -340,5 +386,93 @@ describe("PartyDashboardView event subscriptions", () => {
     const remaining = live.stop();
 
     expect(remaining).not.toContain("visibilitychange");
+  });
+});
+
+describe("PartyDashboardView screen wake lock", () => {
+  let wakeLock: ReturnType<typeof fakeWakeLock>;
+
+  beforeEach(() => {
+    store.frameless = false;
+    wakeLock = fakeWakeLock();
+  });
+
+  afterEach(() => {
+    wrapper?.unmount();
+    wrapper = undefined;
+    wakeLock.restore();
+  });
+
+  it("lets the screen sleep again once the dashboard is closed", async () => {
+    const view = mountViewRaw();
+    const sentinel = wakeLock.settle();
+    await flushPromises();
+    expect(wakeLock.request).toHaveBeenCalledTimes(1);
+
+    view.unmount();
+    wrapper = undefined;
+    await flushPromises();
+
+    expect(sentinel.released).toBe(true);
+    // releasing fires the sentinel's own release event, whose handler would
+    // otherwise take the still-visible page as a cue to acquire a new one
+    expect(wakeLock.request).toHaveBeenCalledTimes(1);
+  });
+
+  it("releases a wake lock that only arrives after it closed", async () => {
+    const view = mountViewRaw();
+
+    view.unmount();
+    wrapper = undefined;
+    const sentinel = wakeLock.settle();
+    await flushPromises();
+
+    expect(sentinel.released).toBe(true);
+  });
+
+  it("re-acquires when the screen is released while still open", async () => {
+    // the handler exists because the system can drop the lock on its own, so
+    // pin that the guard above did not cost the view that behaviour
+    const view = mountViewRaw();
+    const sentinel = wakeLock.settle();
+    await flushPromises();
+
+    sentinel.release();
+    await flushPromises();
+
+    expect(wakeLock.request).toHaveBeenCalledTimes(2);
+    view.unmount();
+    wrapper = undefined;
+  });
+});
+
+describe("PartyDashboardView active player", () => {
+  beforeEach(() => {
+    store.frameless = false;
+    store.activePlayerId = "the_users_own_pick";
+    vi.mocked(api.sendCommand).mockResolvedValue("party_player_1" as never);
+  });
+
+  afterEach(() => {
+    wrapper?.unmount();
+    wrapper = undefined;
+    store.activePlayerId = undefined;
+    vi.mocked(api.sendCommand).mockResolvedValue(null as never);
+  });
+
+  it("takes over the active player while open", async () => {
+    await mountView();
+
+    expect(store.activePlayerId).toBe("party_player_1");
+  });
+
+  it("leaves the active player alone when closed mid-request", async () => {
+    const view = mountViewRaw();
+
+    view.unmount();
+    wrapper = undefined;
+    await flushPromises();
+
+    expect(store.activePlayerId).toBe("the_users_own_pick");
   });
 });

--- a/tests/views/PartyDashboardView.test.ts
+++ b/tests/views/PartyDashboardView.test.ts
@@ -148,7 +148,6 @@ const enterFullscreen = (view: VueWrapper) =>
  * browser does.
  */
 function fakeWakeLock() {
-  const sentinels: { released: boolean }[] = [];
   let pending: ((sentinel: unknown) => void) | undefined;
   const request = vi.fn(
     () =>
@@ -162,7 +161,6 @@ function fakeWakeLock() {
   });
   return {
     request,
-    sentinels,
     settle: () => {
       const listeners: (() => void)[] = [];
       const sentinel = {
@@ -175,7 +173,6 @@ function fakeWakeLock() {
         addEventListener: (_type: string, listener: () => void) =>
           listeners.push(listener),
       };
-      sentinels.push(sentinel);
       pending?.(sentinel);
       pending = undefined;
       return sentinel;

--- a/tests/views/PartyGuestView.test.ts
+++ b/tests/views/PartyGuestView.test.ts
@@ -179,6 +179,34 @@ describe("PartyGuestView startup cleanup", () => {
     expect(stopQueueEvents).toHaveBeenCalled();
   });
 
+  it("stops partway through when closed while resolving the party player", async () => {
+    // the startup pauses twice, and by this one the countdown and the back
+    // handler are already up, so only the second half must be skipped
+    let resolvePlayer: (playerId: string | null) => void = () => {};
+    vi.mocked(api.sendCommand).mockReturnValue(
+      new Promise<string | null>((resolve) => {
+        resolvePlayer = resolve;
+      }) as never,
+    );
+    const live = trackWindowListeners();
+    const view = mountViewRaw();
+    await flushPromises();
+    const [stopCountdown] = guest.startCountdown.mock.results.map(
+      (result) => result.value,
+    );
+
+    view.unmount();
+    resolvePlayer(null);
+    await flushPromises();
+    const remaining = live.stop();
+
+    // what the first half set up is torn down, and the second half never runs
+    expect(stopCountdown).toHaveBeenCalled();
+    expect(remaining).not.toContain("popstate");
+    expect(guest.subscribeToEvents).not.toHaveBeenCalled();
+    expect(events.listeners).toHaveLength(0);
+  });
+
   it("sets nothing up when the guest page is closed while still loading", async () => {
     const live = trackWindowListeners();
     const view = mountViewRaw();

--- a/tests/views/PartyGuestView.test.ts
+++ b/tests/views/PartyGuestView.test.ts
@@ -1,0 +1,195 @@
+import api from "@/plugins/api";
+import PartyGuestView from "@/views/PartyGuestView.vue";
+import { flushPromises, mount } from "@vue/test-utils";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ref } from "vue";
+
+// Tracks live subscriptions the way the api does, so one that outlives the
+// view stays listed here.
+const events = vi.hoisted(() => {
+  const listeners: unknown[] = [];
+  return {
+    listeners,
+    subscribe: (_type: unknown, handler: unknown) => {
+      listeners.push(handler);
+      return () => {
+        const index = listeners.indexOf(handler);
+        if (index !== -1) listeners.splice(index, 1);
+      };
+    },
+  };
+});
+
+const guest = vi.hoisted(() => ({
+  startCountdown: vi.fn(() => vi.fn()),
+  subscribeToEvents: vi.fn(() => vi.fn()),
+}));
+
+vi.mock("@/plugins/api", () => ({
+  default: {
+    baseUrl: "",
+    players: {},
+    providers: {},
+    queues: {},
+    sendCommand: vi.fn().mockResolvedValue(null),
+    subscribe: vi.fn(events.subscribe),
+    getPlayerQueueItems: vi.fn().mockResolvedValue([]),
+  },
+}));
+
+vi.mock("@/plugins/router", () => ({ default: {} }));
+vi.mock("@/plugins/auth", () => ({ authManager: {}, default: {} }));
+vi.mock("@/plugins/i18n", () => ({ $t: (key: string) => key }));
+vi.mock("vue-sonner", () => ({
+  toast: { error: vi.fn(), success: vi.fn() },
+}));
+
+vi.mock("@/composables/usePartyConfig", () => ({
+  usePartyConfig: () => ({
+    config: ref(null),
+    fetchConfig: vi.fn().mockResolvedValue(null),
+  }),
+}));
+
+vi.mock("@/composables/useRateLimiting", () => ({
+  useRateLimiting: () => ({
+    rateLimitingEnabled: ref(false),
+    boostEnabled: ref(false),
+    addQueueEnabled: ref(false),
+    skipSongEnabled: ref(false),
+    requestBadgeColor: ref("#2196F3"),
+    boostBadgeColor: ref("#FF5722"),
+    boostTokens: ref(0),
+    addQueueTokens: ref(0),
+    skipSongTokens: ref(0),
+    BOOST_MAX_TOKENS: 3,
+    ADD_QUEUE_MAX_TOKENS: 3,
+    nextTokenCountdown: ref(""),
+    addQueueTokenCountdown: ref(""),
+    skipTokenCountdown: ref(""),
+    consumeBoostToken: vi.fn(),
+    consumeAddQueueToken: vi.fn(),
+    consumeSkipSongToken: vi.fn(),
+    getTimeUntilNextToken: vi.fn(),
+    getTimeUntilNextAddQueueToken: vi.fn(),
+    getTimeUntilNextSkipToken: vi.fn(),
+    configure: vi.fn(),
+    startCountdown: guest.startCountdown,
+  }),
+}));
+
+vi.mock("@/composables/guest/useGuestQueue", () => ({
+  useGuestQueue: () => ({
+    queueItems: ref([]),
+    queueFetchOffset: ref(0),
+    loadingMoreQueueItems: ref(false),
+    partyQueueId: ref(null),
+    currentQueue: ref(null),
+    currentQueueIndex: ref(0),
+    fetchQueueItems: vi.fn(),
+    handleQueueScroll: vi.fn(),
+    subscribeToEvents: guest.subscribeToEvents,
+  }),
+}));
+
+vi.mock("@/composables/guest/useGuestArtistTracks", () => ({
+  useGuestArtistTracks: () => ({
+    selectedArtist: ref(null),
+    artistTracks: ref([]),
+    loadingArtistTracks: ref(false),
+    selectArtist: vi.fn(),
+    clearArtistSelection: vi.fn(),
+  }),
+}));
+
+/**
+ * Records window listeners while a view runs.
+ *
+ * `stop()` restores the originals and returns the event types still attached,
+ * which is what tells a removed listener apart from one added back afterwards.
+ */
+function trackWindowListeners() {
+  const attached = new Map<unknown, string>();
+  const { addEventListener, removeEventListener } = window;
+  window.addEventListener = ((type: string, handler: never) => {
+    attached.set(handler, type);
+    return addEventListener.call(window, type, handler);
+  }) as never;
+  window.removeEventListener = ((type: string, handler: never) => {
+    attached.delete(handler);
+    return removeEventListener.call(window, type, handler);
+  }) as never;
+  return {
+    stop: () => {
+      Object.assign(window, { addEventListener, removeEventListener });
+      return [...attached.values()];
+    },
+  };
+}
+
+function mountViewRaw() {
+  return mount(PartyGuestView, {
+    global: {
+      mocks: { $t: (key: string) => key },
+      stubs: {
+        MediaSearch: true,
+        PartyListenIn: true,
+        PartyQueueSection: true,
+        PartyResultItem: true,
+        PartyTokensBadge: true,
+        Spinner: true,
+        Button: { template: "<button><slot /></button>" },
+      },
+    },
+  });
+}
+
+describe("PartyGuestView startup cleanup", () => {
+  beforeEach(() => {
+    events.listeners.length = 0;
+    guest.startCountdown.mockClear();
+    guest.subscribeToEvents.mockClear();
+    vi.mocked(api.subscribe).mockClear();
+  });
+
+  afterEach(() => {
+    vi.mocked(api.sendCommand).mockResolvedValue(null as never);
+  });
+
+  it("undoes everything it set up when the guest page is closed", async () => {
+    const live = trackWindowListeners();
+    const view = mountViewRaw();
+    await flushPromises();
+    // pin that the startup really ran, so the teardown assertions below mean
+    // something
+    expect(events.listeners.length).toBeGreaterThan(0);
+    const [stopCountdown] = guest.startCountdown.mock.results.map(
+      (result) => result.value,
+    );
+    const [stopQueueEvents] = guest.subscribeToEvents.mock.results.map(
+      (result) => result.value,
+    );
+
+    view.unmount();
+    const remaining = live.stop();
+
+    expect(events.listeners).toHaveLength(0);
+    expect(remaining).not.toContain("popstate");
+    expect(stopCountdown).toHaveBeenCalled();
+    expect(stopQueueEvents).toHaveBeenCalled();
+  });
+
+  it("sets nothing up when the guest page is closed while still loading", async () => {
+    const live = trackWindowListeners();
+    const view = mountViewRaw();
+
+    view.unmount();
+    await flushPromises();
+    const remaining = live.stop();
+
+    expect(events.listeners).toHaveLength(0);
+    expect(remaining).not.toContain("popstate");
+    expect(guest.startCountdown).not.toHaveBeenCalled();
+    expect(guest.subscribeToEvents).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
# What does this implement/fix?

Visiting the party dashboard kept the screen awake for the rest of the browser
session, even after leaving it. On the way out the view releases its screen wake
lock, but releasing one fires a "released" notification that the view answers by
taking out a fresh lock — and by then nothing is left to hand that one back.

Closing either party page while it is still starting up left more behind, since
the cleanup runs before the startup has finished setting anything up:

- The screen wake lock is now handed back on the way out and stays handed back,
  so the display can sleep again. It is still re-taken if the system drops it
  while the dashboard is open.
- Leaving the dashboard while it is still loading no longer switches the whole
  app over to the party player, and no longer keeps a wake lock nothing can
  release.
- The guest page no longer leaves behind a back-button handler, a running token
  countdown or queue listeners when it is closed while loading.
- The sidebar shortcuts no longer keep listening for track updates when the
  sidebar is closed before they finish loading.

**Related issue (if applicable):**

- related issue `<link to issue>`

**Related backend PR (if applicable):**

- related backend PR `<link to PR>`

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm lint:check` passes.
- [x] `pnpm test:run` passes, and tests have been added/updated where applicable.
- [x] `pnpm build` passes.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
