### PR TITLE
Player bar buttons no longer keep a grey background after their popout closes

### DIFF
--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -131,6 +131,17 @@
   color: var(--muted-foreground) !important;
 }
 
+/* the ghost variant paints a background on hover too, and its dark counterpart
+   carries the extra .dark, so clearing the pill needs the :hover here to outweigh
+   both. A showing popout keeps its pill: the button is not guessing about the
+   pointer while its own menu is up. */
+.player-control-button[data-suppress-hover="true"]:hover:not(
+    [data-active="true"],
+    [data-state="open"]
+  ) {
+  background-color: transparent !important;
+}
+
 .player-control-button:hover:not([data-suppress-hover="true"]),
 .player-control-button[data-active="true"],
 .player-control-button[data-state="open"] {

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -131,10 +131,11 @@
   color: var(--muted-foreground) !important;
 }
 
-/* the ghost variant paints a background on hover too, and its dark counterpart
-   carries the extra .dark, so clearing the pill needs the :hover here to outweigh
-   both. A showing popout keeps its pill: the button is not guessing about the
-   pointer while its own menu is up. */
+/* the ghost variant paints a hover background as well as a colour. Tailwind gates
+   its hover: utilities behind @media (hover: hover), so unlike the colour above
+   this only reaches devices carrying a pointer, where a tap can still leave the
+   button hovered. The dark utility carries the extra .dark, so clearing the pill
+   needs the :hover here to outweigh both. A showing popout keeps its pill. */
 .player-control-button[data-suppress-hover="true"]:hover:not(
     [data-active="true"],
     [data-state="open"]

--- a/tests/styles/playerControlHoverSuppression.test.ts
+++ b/tests/styles/playerControlHoverSuppression.test.ts
@@ -1,0 +1,55 @@
+// happy-dom has no hover state to simulate, so the rule is asserted with its
+// :hover dropped; which of the competing backgrounds actually wins is only
+// observable in a real browser
+// @vitest-environment happy-dom
+import css from "@/styles/style.css?inline";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+let styles: HTMLStyleElement;
+
+beforeEach(() => {
+  styles = document.createElement("style");
+  styles.textContent = css;
+  document.head.append(styles);
+});
+
+afterEach(() => {
+  styles.remove();
+});
+
+// the one rule clearing a background off a button whose pointer state is stale
+function suppressionSelector() {
+  return [...(styles.sheet?.cssRules ?? [])]
+    .filter((rule): rule is CSSStyleRule => rule instanceof CSSStyleRule)
+    .filter((rule) => rule.style.getPropertyValue("background-color") !== "")
+    .map((rule) => rule.selectorText)
+    .find((selector) => selector.includes("data-suppress-hover"));
+}
+
+function trigger(attributes: Record<string, string>) {
+  const button = document.createElement("button");
+  button.className = "player-control-button";
+  button.setAttribute("data-suppress-hover", "true");
+  for (const [name, value] of Object.entries(attributes)) {
+    button.setAttribute(name, value);
+  }
+  return button;
+}
+
+describe("player control hover suppression", () => {
+  it("clears the hover background only while the popout is closed", () => {
+    const selector = suppressionSelector();
+    expect(selector).toBeDefined();
+    const closed = selector!.replace(":hover", "");
+
+    // reka writes data-state="closed" and Vue renders a false data-active as
+    // "false", so both are present and only the value tells them apart: an
+    // exclusion on the bare attribute would switch the rule off for every
+    // trigger it is meant to cover
+    expect(trigger({ "data-state": "closed" }).matches(closed)).toBe(true);
+    expect(trigger({ "data-active": "false" }).matches(closed)).toBe(true);
+
+    expect(trigger({ "data-state": "open" }).matches(closed)).toBe(false);
+    expect(trigger({ "data-active": "true" }).matches(closed)).toBe(false);
+  });
+});


### PR DESCRIPTION
# What does this implement/fix?

Follow-up to #2482. A player bar button that opens a popout can be left looking
hovered after the popout is dismissed, because a tap leaves the hover behind.
#2482 settled the button's colour back but stopped there, so the button was still
wearing a grey background pill it should not have.

This clears the pill too. A popout that is actually showing keeps its background,
so nothing changes while a menu is up.

Worth knowing for the scope: the background comes from a Tailwind `hover:` utility,
and those are gated behind `@media (hover: hover)`. Phones report no hover, so the
pill only ever shows up on devices that have a pointer as well as a touchscreen —
touchscreen laptops, iPad with a trackpad, Android with a mouse. (The colour half in
#2482 was unconditional, which is why that one was visible on phones.)

**Related issue (if applicable):**

- related issue `n/a`

**Related backend PR (if applicable):**

- related backend PR `n/a`

## Changes

- Clear the leftover hover background on the volume, grouping, player select and
  track menu buttons once their popout closes.
- Works in both light and dark themes — the dark hover background is a heavier
  rule, so the new one is weighted to beat it.
- Add a test pinning which states the rule skips, so the exclusions cannot be
  loosened by accident.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm lint:check` passes.
- [x] `pnpm test:run` passes, and tests have been added/updated where applicable.
- [x] `pnpm build` passes.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
