### PR TITLE
Land on the page you clicked after discarding unsaved settings

### DIFF
--- a/src/views/settings/EditConfig.vue
+++ b/src/views/settings/EditConfig.vue
@@ -140,7 +140,13 @@
     </v-card>
   </v-dialog>
   <!-- Unsaved changes confirmation dialog -->
-  <v-dialog v-model="showUnsavedDialog" max-width="400" persistent>
+  <!-- any way out of this dialog has to answer the navigation it is holding -->
+  <v-dialog
+    :model-value="showUnsavedDialog"
+    max-width="400"
+    persistent
+    @update:model-value="cancelDiscard"
+  >
     <v-card>
       <v-card-title>{{ $t("settings.unsaved_changes") }}</v-card-title>
       <v-card-text>{{ $t("settings.unsaved_changes_message") }}</v-card-text>
@@ -205,9 +211,9 @@ import ProtocolConfigSection from "./ProtocolConfigSection.vue";
 const router = useRouter();
 const showUnsavedDialog = ref(false);
 const allowNavigation = ref(false);
-// lets the buttons in the unsaved-changes dialog release the navigation its
-// guard is holding
-let answerUnsavedDialog: ((discard: boolean) => void) | undefined;
+// answers the navigation the guard is holding; set only while one waits on the
+// unsaved-changes dialog
+let heldNavigation: ((discard: boolean) => void) | undefined;
 
 export interface Props {
   configEntries: ConfigEntryUI[];
@@ -428,22 +434,28 @@ defineExpose({ resetToDefaults });
 
 const confirmDiscard = function () {
   showUnsavedDialog.value = false;
-  answerUnsavedDialog?.(true);
+  // a redirect has the router run the leave guards of the resumed navigation a
+  // second time, and it must not ask again
+  allowNavigation.value = true;
+  releaseNavigation(true);
 };
 
 const cancelDiscard = function () {
   showUnsavedDialog.value = false;
-  answerUnsavedDialog?.(false);
+  releaseNavigation(false);
 };
 
 // Navigation guard for route changes
 onBeforeRouteLeave(() => {
   if (allowNavigation.value || !hasUnsavedChanges.value) return true;
-  // hold the navigation the user asked for instead of cancelling it, so
-  // discarding resumes that very navigation rather than guessing a destination
+  // one is already waiting for an answer: turn this one away rather than hold
+  // both, or the history ends up out of step with the page on screen
+  if (heldNavigation) return false;
+  // holding it, rather than cancelling it, is what lets discarding carry on to
+  // the very page the user asked for
   showUnsavedDialog.value = true;
   return new Promise<boolean>((resolve) => {
-    answerUnsavedDialog = resolve;
+    heldNavigation = resolve;
   });
 });
 
@@ -461,6 +473,11 @@ onBeforeUnmount(() => {
 
 // Add listener when component mounts
 window.addEventListener("beforeunload", handleBeforeUnload);
+
+const releaseNavigation = function (discard: boolean) {
+  heldNavigation?.(discard);
+  heldNavigation = undefined;
+};
 
 const isDisabled = function (entry: ConfigEntryUI) {
   return isEntryDisabled(entry, entries.value || []);

--- a/src/views/settings/EditConfig.vue
+++ b/src/views/settings/EditConfig.vue
@@ -430,7 +430,15 @@ const resetToDefaults = function () {
   }
 };
 
-defineExpose({ resetToDefaults });
+/**
+ * Reports a save that did not land, so the values stay guarded and leaving the
+ * screen asks about them again.
+ */
+const saveFailed = function () {
+  allowNavigation.value = false;
+};
+
+defineExpose({ resetToDefaults, saveFailed });
 
 const confirmDiscard = function () {
   showUnsavedDialog.value = false;

--- a/src/views/settings/EditConfig.vue
+++ b/src/views/settings/EditConfig.vue
@@ -146,10 +146,15 @@
       <v-card-text>{{ $t("settings.unsaved_changes_message") }}</v-card-text>
       <v-card-actions>
         <v-spacer />
-        <v-btn variant="text" @click="cancelDiscard">
+        <v-btn data-testid="config-stay" variant="text" @click="cancelDiscard">
           {{ $t("settings.stay") }}
         </v-btn>
-        <v-btn color="warning" variant="flat" @click="confirmDiscard">
+        <v-btn
+          data-testid="config-discard"
+          color="warning"
+          variant="flat"
+          @click="confirmDiscard"
+        >
           {{ $t("settings.discard") }}
         </v-btn>
       </v-card-actions>
@@ -174,7 +179,6 @@ import {
   OutputProtocol,
   SECURE_STRING_SUBSTITUTE,
 } from "@/plugins/api/interfaces";
-import { goBack } from "@/helpers/navigation";
 import { $t } from "@/plugins/i18n";
 import { store } from "@/plugins/store";
 import {
@@ -201,6 +205,9 @@ import ProtocolConfigSection from "./ProtocolConfigSection.vue";
 const router = useRouter();
 const showUnsavedDialog = ref(false);
 const allowNavigation = ref(false);
+// lets the buttons in the unsaved-changes dialog release the navigation its
+// guard is holding
+let answerUnsavedDialog: ((discard: boolean) => void) | undefined;
 
 export interface Props {
   configEntries: ConfigEntryUI[];
@@ -421,23 +428,23 @@ defineExpose({ resetToDefaults });
 
 const confirmDiscard = function () {
   showUnsavedDialog.value = false;
-  allowNavigation.value = true;
-  // Navigate back after setting the flag
-  goBack(router, { name: "settings" });
+  answerUnsavedDialog?.(true);
 };
 
 const cancelDiscard = function () {
   showUnsavedDialog.value = false;
+  answerUnsavedDialog?.(false);
 };
 
 // Navigation guard for route changes
-onBeforeRouteLeave((_to, _from, next) => {
-  if (allowNavigation.value || !hasUnsavedChanges.value) {
-    next();
-  } else {
-    showUnsavedDialog.value = true;
-    next(false);
-  }
+onBeforeRouteLeave(() => {
+  if (allowNavigation.value || !hasUnsavedChanges.value) return true;
+  // hold the navigation the user asked for instead of cancelling it, so
+  // discarding resumes that very navigation rather than guessing a destination
+  showUnsavedDialog.value = true;
+  return new Promise<boolean>((resolve) => {
+    answerUnsavedDialog = resolve;
+  });
 });
 
 // Handle browser back/refresh

--- a/src/views/settings/EditCoreConfig.vue
+++ b/src/views/settings/EditCoreConfig.vue
@@ -129,6 +129,7 @@ const onSubmit = async function (values: Record<string, ConfigValueType>) {
     })
     .catch((err) => {
       toast.error(err.message || err);
+      editConfig.value?.saveFailed();
     })
     .finally(() => {
       loading.value = false;

--- a/src/views/settings/EditPlayer.vue
+++ b/src/views/settings/EditPlayer.vue
@@ -627,6 +627,7 @@ const onSubmit = async function (values: Record<string, ConfigValueType>) {
   } catch {
     // Error toast is already shown by the API layer (handleResultMessage).
     // We just prevent navigation so the user can correct values.
+    editConfig.value?.saveFailed();
   } finally {
     loading.value = false;
   }

--- a/src/views/settings/EditPlayerQueue.vue
+++ b/src/views/settings/EditPlayerQueue.vue
@@ -106,6 +106,7 @@ const onSubmit = async function (values: Record<string, ConfigValueType>) {
     })
     .catch((err) => {
       toast.error(err.message || err);
+      editConfig.value?.saveFailed();
     })
     .finally(() => {
       loading.value = false;

--- a/src/views/settings/EditProvider.vue
+++ b/src/views/settings/EditProvider.vue
@@ -537,6 +537,7 @@ const onSubmit = async function (values: Record<string, ConfigValueType>) {
     .catch((err) => {
       saveErrorMessage.value = String(err);
       saveErrorOpen.value = true;
+      editConfig.value?.saveFailed();
     })
     .finally(() => {
       loading.value = false;

--- a/src/views/settings/FrontendConfig.vue
+++ b/src/views/settings/FrontendConfig.vue
@@ -263,6 +263,7 @@ const saveValues = async function (values: Record<string, ConfigValueType>) {
   } catch (error) {
     console.error("Failed to save settings:", error);
     loading.value = false;
+    editConfig.value?.saveFailed();
   }
 };
 

--- a/tests/views/EditConfig.test.ts
+++ b/tests/views/EditConfig.test.ts
@@ -413,6 +413,25 @@ describe("EditConfig unsaved changes", () => {
     expect(router.options.history.location).toBe("/settings/provider");
   });
 
+  // saving lets the screen navigate away without asking, but a save that never
+  // landed must not leave the values unguarded
+  it("asks again when the host reports a failed save", async () => {
+    const { router, wrapper } = await mountInRouter();
+    const form = wrapper.findComponent(EditConfig);
+    dirty(wrapper);
+    await nextTick();
+
+    await form.get('[data-testid="config-save"]').trigger("click");
+    await flushPromises();
+    form.vm.saveFailed();
+
+    router.push({ name: "music-quiz" });
+    await flushPromises();
+
+    expect(router.currentRoute.value.name).toBe("editprovider");
+    expect(wrapper.find('[data-testid="config-discard"]').exists()).toBe(true);
+  });
+
   it("lets an unchanged form go without asking", async () => {
     const { router, wrapper } = await mountInRouter();
 

--- a/tests/views/EditConfig.test.ts
+++ b/tests/views/EditConfig.test.ts
@@ -1,16 +1,16 @@
 import {
+  enableAutoUnmount,
   flushPromises,
   mount,
   shallowMount,
   type VueWrapper,
 } from "@vue/test-utils";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { h, nextTick } from "vue";
 import { createMemoryHistory, createRouter, RouterView } from "vue-router";
 import { createVuetify } from "vuetify";
 import * as components from "vuetify/components";
 import * as directives from "vuetify/directives";
-import { canGoBack } from "@/helpers/navigation";
 import { ConfigEntryType, type ConfigEntry } from "@/plugins/api/interfaces";
 import EditConfig from "@/views/settings/EditConfig.vue";
 
@@ -47,6 +47,9 @@ vi.mock("vue-router", async (importOriginal) => {
     useRouter: () => inject(actual.routerKey, routerMock as never),
   };
 });
+
+// the form listens for beforeunload, so a leaked instance keeps reacting
+enableAutoUnmount(afterEach);
 
 describe("EditConfig", () => {
   beforeEach(() => {
@@ -372,9 +375,42 @@ describe("EditConfig unsaved changes", () => {
     router.back();
     await flushPromises();
     await click(wrapper, "config-discard");
-
     expect(router.currentRoute.value.name).toBe("settings");
-    expect(canGoBack(router)).toBe(false);
+
+    router.back();
+    await flushPromises();
+
+    expect(router.currentRoute.value.name).toBe("players");
+  });
+
+  // the router runs the leave guards again for the route it redirects to
+  it("asks only once when the page picked redirects elsewhere", async () => {
+    const { router, wrapper } = await mountInRouter();
+    dirty(wrapper);
+    await nextTick();
+
+    router.push({ name: "redirects-away" });
+    await flushPromises();
+    await click(wrapper, "config-discard");
+
+    expect(router.currentRoute.value.name).toBe("music-quiz");
+  });
+
+  // a back press is how a phone dismisses a dialog, and the second one must not
+  // leave the history a step away from the page on screen
+  it("survives a back press on top of the dialog", async () => {
+    const { router, wrapper } = await mountInRouter();
+    dirty(wrapper);
+    await nextTick();
+
+    router.back();
+    await flushPromises();
+    router.back();
+    await flushPromises();
+    await click(wrapper, "config-stay");
+
+    expect(router.currentRoute.value.name).toBe("editprovider");
+    expect(router.options.history.location).toBe("/settings/provider");
   });
 
   it("lets an unchanged form go without asking", async () => {
@@ -448,6 +484,7 @@ async function mountInRouter() {
   const router = createRouter({
     history: createMemoryHistory(),
     routes: [
+      { path: "/players", name: "players", component: blank },
       { path: "/settings", name: "settings", component: blank },
       {
         path: "/settings/provider",
@@ -457,10 +494,18 @@ async function mountInRouter() {
         },
       },
       { path: "/music-quiz", name: "music-quiz", component: blank },
+      // shaped like the plugin views, which send you away when disabled
+      {
+        path: "/redirects-away",
+        name: "redirects-away",
+        component: blank,
+        beforeEnter: () => ({ name: "music-quiz" }),
+      },
     ],
   });
-  router.push({ name: "settings" });
+  router.push({ name: "players" });
   await router.isReady();
+  await router.push({ name: "settings" });
   await router.push({ name: "editprovider" });
 
   const wrapper = mount(

--- a/tests/views/EditConfig.test.ts
+++ b/tests/views/EditConfig.test.ts
@@ -1,6 +1,16 @@
-import { shallowMount, type VueWrapper } from "@vue/test-utils";
+import {
+  flushPromises,
+  mount,
+  shallowMount,
+  type VueWrapper,
+} from "@vue/test-utils";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { nextTick } from "vue";
+import { h, nextTick } from "vue";
+import { createMemoryHistory, createRouter, RouterView } from "vue-router";
+import { createVuetify } from "vuetify";
+import * as components from "vuetify/components";
+import * as directives from "vuetify/directives";
+import { canGoBack } from "@/helpers/navigation";
 import { ConfigEntryType, type ConfigEntry } from "@/plugins/api/interfaces";
 import EditConfig from "@/views/settings/EditConfig.vue";
 
@@ -30,9 +40,11 @@ vi.mock("@/plugins/store", () => ({ store: storeMock }));
 
 vi.mock("vue-router", async (importOriginal) => {
   const actual = await importOriginal<typeof import("vue-router")>();
+  const { inject } = await vi.importActual<typeof import("vue")>("vue");
   return {
     ...actual,
-    useRouter: () => routerMock,
+    // the routed tests install a real router; the rest mount the form on its own
+    useRouter: () => inject(actual.routerKey, routerMock as never),
   };
 });
 
@@ -321,6 +333,60 @@ describe("EditConfig", () => {
   );
 });
 
+describe("EditConfig unsaved changes", () => {
+  it("carries on to the page the user picked once they discard", async () => {
+    const { router, wrapper } = await mountInRouter();
+    dirty(wrapper);
+    await nextTick();
+
+    // the user picks another entry in the settings menu
+    router.push({ name: "music-quiz" });
+    await flushPromises();
+    expect(router.currentRoute.value.name).toBe("editprovider");
+
+    await click(wrapper, "config-discard");
+
+    expect(router.currentRoute.value.name).toBe("music-quiz");
+  });
+
+  it("keeps the user on the form when they choose to stay", async () => {
+    const { router, wrapper } = await mountInRouter();
+    dirty(wrapper);
+    await nextTick();
+
+    router.push({ name: "music-quiz" });
+    await flushPromises();
+    await click(wrapper, "config-stay");
+
+    expect(router.currentRoute.value.name).toBe("editprovider");
+    expect(wrapper.findComponent(EditConfig).exists()).toBe(true);
+  });
+
+  // a discarded back has to stay a back, or the form the user just left would
+  // sit in the history waiting for the next back press
+  it("goes back rather than forward when a back press is discarded", async () => {
+    const { router, wrapper } = await mountInRouter();
+    dirty(wrapper);
+    await nextTick();
+
+    router.back();
+    await flushPromises();
+    await click(wrapper, "config-discard");
+
+    expect(router.currentRoute.value.name).toBe("settings");
+    expect(canGoBack(router)).toBe(false);
+  });
+
+  it("lets an unchanged form go without asking", async () => {
+    const { router, wrapper } = await mountInRouter();
+
+    await router.push({ name: "music-quiz" });
+
+    expect(router.currentRoute.value.name).toBe("music-quiz");
+    expect(wrapper.find('[data-testid="config-discard"]').exists()).toBe(false);
+  });
+});
+
 function entry(
   overrides: Partial<ConfigEntry> & { key: string; type: ConfigEntryType },
 ): ConfigEntry {
@@ -370,4 +436,57 @@ function saveDisabled(wrapper: VueWrapper) {
   const button = wrapper.find('[data-testid="config-save"]');
   if (!button.exists()) throw new Error("save button not rendered");
   return button.attributes("disabled") === "true";
+}
+
+// the unsaved-changes guard only runs inside a routed view, so this mounts the
+// form the way the settings screens do: as the component of the current route
+async function mountInRouter() {
+  const configEntries = [
+    entry({ key: "server", type: ConfigEntryType.STRING }),
+  ];
+  const blank = { render: () => h("div") };
+  const router = createRouter({
+    history: createMemoryHistory(),
+    routes: [
+      { path: "/settings", name: "settings", component: blank },
+      {
+        path: "/settings/provider",
+        name: "editprovider",
+        component: {
+          render: () => h(EditConfig, { configEntries, disabled: false }),
+        },
+      },
+      { path: "/music-quiz", name: "music-quiz", component: blank },
+    ],
+  });
+  router.push({ name: "settings" });
+  await router.isReady();
+  await router.push({ name: "editprovider" });
+
+  const wrapper = mount(
+    { render: () => h(RouterView) },
+    {
+      global: {
+        plugins: [router, createVuetify({ components, directives })],
+        stubs: {
+          ConfigEntryRow: true,
+          ProtocolConfigSection: true,
+          // the real dialog teleports into an overlay container this bare app
+          // never mounts, so render it where it is declared instead
+          VDialog: {
+            props: ["modelValue"],
+            template: '<div v-if="modelValue"><slot /></div>',
+          },
+        },
+      },
+    },
+  );
+  await flushPromises();
+  return { router, wrapper };
+}
+
+// answering the dialog releases a navigation, so settle that too
+async function click(wrapper: VueWrapper, testId: string) {
+  await wrapper.get(`[data-testid="${testId}"]`).trigger("click");
+  await flushPromises();
 }


### PR DESCRIPTION
# What does this implement/fix?

Editing a setting and then clicking somewhere else in the menu put up the "unsaved changes" dialog, but confirming the discard sent you back to the previous page instead of the page you clicked — so you had to click it a second time.

The dialog now holds on to the navigation you asked for, and discarding simply lets it continue.

Affects every settings form: providers, players, queues, core and frontend settings.

- Discarding carries on to the page you picked, whether you got there by clicking or by pressing back
- Pages that send you elsewhere (the plugin views) no longer ask twice
- A back press on top of the dialog no longer leaves the history a step away from the page on screen
- A save that fails now keeps the warning armed, instead of letting you walk away from the values it could not store

**Related issue (if applicable):**

- related issue `n/a`

**Related backend PR (if applicable):**

- related backend PR `n/a`

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm lint:check` passes.
- [x] `pnpm test:run` passes, and tests have been added/updated where applicable.
- [x] `pnpm build` passes.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
