### PR TITLE
Stop the fullscreen player button changing colour on hover

### DIFF
--- a/src/layouts/default/PlayerOSD/PlayerFullscreen.vue
+++ b/src/layouts/default/PlayerOSD/PlayerFullscreen.vue
@@ -452,11 +452,15 @@
             padding-top: 4px;
           "
         >
+          <!-- Without a competing hover:text- here, the outline variant's own
+               hover:text-accent-foreground survives the class merge and recolours
+               the label against the artwork, so the hover colour is pinned to
+               the --text-color the rest of the panel follows. -->
           <Button
             id="fullscreen-player-select-button"
             variant="outline"
             size="xs"
-            class="border-transparent bg-background/40 shadow-none backdrop-blur-md hover:bg-background/60 dark:border-transparent dark:bg-background/40 dark:hover:bg-background/60"
+            class="border-transparent bg-background/40 shadow-none backdrop-blur-md hover:bg-background/60 hover:text-[var(--text-color)] dark:border-transparent dark:bg-background/40 dark:hover:bg-background/60"
             :aria-label="playerSelectLabel"
             :aria-expanded="store.showPlayersMenu"
             aria-haspopup="dialog"

--- a/tests/layouts/PlayerFullscreen.test.ts
+++ b/tests/layouts/PlayerFullscreen.test.ts
@@ -232,7 +232,9 @@ describe("PlayerFullscreen lyrics clock", () => {
 });
 
 describe("PlayerFullscreen player select button", () => {
-  async function mountFullscreenDialog(): Promise<VueWrapper> {
+  async function mountFullscreenDialog(
+    extraStubs: Record<string, unknown> = {},
+  ): Promise<VueWrapper> {
     const { store } = await import("@/plugins/store");
     (store as unknown as TestStore).showFullscreenPlayer = true;
 
@@ -244,6 +246,7 @@ describe("PlayerFullscreen player select button", () => {
         stubs: {
           "v-dialog": { template: "<div><slot /></div>" },
           "v-card": { template: "<div><slot /></div>" },
+          ...extraStubs,
         },
       },
     });
@@ -294,5 +297,23 @@ describe("PlayerFullscreen player select button", () => {
         .get("#fullscreen-player-select-button")
         .attributes("aria-label"),
     ).toBe("tooltip.select_player: Kitchen");
+  });
+
+  // Rendered through the real Button so the variant classes actually go through
+  // class-variance-authority and tailwind-merge; a stub would only echo back the
+  // class prop and never show which of the two hover colours survives.
+  it("keeps the label colour on hover", async () => {
+    const fullscreen = await mountFullscreenDialog({ Button: false });
+    const classes = fullscreen
+      .get("#fullscreen-player-select-button")
+      .classes();
+
+    // the bare border width comes from the outline variant alone, so it pins
+    // both halves of the merge this test reads: cva ran, and it contributed
+    expect(classes).toContain("border");
+    expect(classes).toContain("hover:text-[var(--text-color)]");
+    // the outline variant also offers this one, and it resolves to the theme
+    // foreground rather than the white forced over a dominant visualizer
+    expect(classes).not.toContain("hover:text-accent-foreground");
   });
 });


### PR DESCRIPTION
# What does this implement/fix?

In the fullscreen player, hovering the player select button (the pill with the
speaker name at the bottom) recoloured its label and icon from white to black,
against the artwork backdrop. The colour jumped on hover and jumped back off it.

The button uses the `outline` button variant, which brings its own
`hover:text-accent-foreground`. The button overrides the variant's hover
background but nothing in its class list competes with the hover *text* colour,
so that one survives the class merge and wins over the white text the fullscreen
player forces while a dominant visualizer is running. It only shows up on a light
app theme, where `--accent-foreground` is black.

**Related issue (if applicable):**

- n/a

**Related backend PR (if applicable):**

- n/a

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

Changes:

- Pin the button's hover text colour to `--text-color`, so it keeps the same
  colour as at rest.
- Add a regression test that renders the real button and checks which of the two
  hover colours survives the class merge.

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm lint:check` passes.
- [x] `pnpm test:run` passes, and tests have been added/updated where applicable.
- [x] `pnpm build` passes.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
