### PR TITLE
Swiping a panel closed no longer reloads the Home Assistant app

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -153,14 +153,12 @@ html {
 
 html {
   overflow: hidden;
-  /* Propagates to the viewport, same as the overflow above. The viewport never
-     scrolls, so a drag no in-page scroller consumes chains on to whatever
-     embeds us - out of the Home Assistant ingress iframe and into its app,
-     which takes it for a pull-to-refresh and reloads. Cutting it here is what
-     leaves the swipe-to-dismiss on the panels free to pick the drag up: the
-     panels are position: fixed, so the viewport is their scroll parent, and
-     the gesture only engages once past its slop. */
-  overscroll-behavior: none;
+  /* Nothing here scrolls, so a downward drag no in-page scroller consumes
+     chains out of the Home Assistant ingress iframe and its app takes that for
+     a pull-to-refresh, reloading. The root is where the viewport reads this
+     from - on body it is ignored. The horizontal axis stays open, so the
+     browser keeps its back-navigation swipe. */
+  overscroll-behavior-y: none;
   /* iOS Safari tints the status bar from this background. Must stay set. */
   background-color: rgb(var(--v-theme-background));
 }

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -153,6 +153,14 @@ html {
 
 html {
   overflow: hidden;
+  /* Propagates to the viewport, same as the overflow above. The viewport never
+     scrolls, so a drag no in-page scroller consumes chains on to whatever
+     embeds us - out of the Home Assistant ingress iframe and into its app,
+     which takes it for a pull-to-refresh and reloads. Cutting it here is what
+     leaves the swipe-to-dismiss on the panels free to pick the drag up: the
+     panels are position: fixed, so the viewport is their scroll parent, and
+     the gesture only engages once past its slop. */
+  overscroll-behavior: none;
   /* iOS Safari tints the status bar from this background. Must stay set. */
   background-color: rgb(var(--v-theme-background));
 }

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -163,6 +163,19 @@ html {
   background-color: rgb(var(--v-theme-background));
 }
 
+/* The above only reaches a drag that starts on something scrollable. One that
+   starts where nothing scrolls - a panel header, the fullscreen player - has no
+   scroll to chain from, and embedded it reaches the host instead: out of the
+   Home Assistant ingress iframe and into its app, which takes it for a
+   pull-to-refresh and reloads. Refusing the pan stops that gesture ever
+   starting. Scrollers inside still pan, since touch-action is intersected only
+   up to the scroll container that would move; none is the fallback for engines
+   that do not know pinch-zoom, which trades zoom away to keep the refusal. */
+:root[data-embedded-layout] {
+  touch-action: none;
+  touch-action: pinch-zoom;
+}
+
 * {
   -webkit-user-drag: none;
   /* iOS Safari */

--- a/tests/styles/embeddedTouchAction.test.ts
+++ b/tests/styles/embeddedTouchAction.test.ts
@@ -1,0 +1,47 @@
+// @vitest-environment happy-dom
+import css from "@/styles/global.css?inline";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { selectorsSetting } from "./cascade";
+
+let styles: HTMLStyleElement;
+
+// Drop the comments so the prose explaining the rule cannot stand in for it.
+const declarations = css.replace(/\/\*[\s\S]*?\*\//g, "");
+
+beforeEach(() => {
+  styles = document.createElement("style");
+  styles.textContent = css;
+  document.head.appendChild(styles);
+});
+
+afterEach(() => {
+  styles.remove();
+  document.documentElement.removeAttribute("data-embedded-layout");
+});
+
+describe("embedded touch-action", () => {
+  it("refuses a pan the host would otherwise take", () => {
+    document.documentElement.setAttribute("data-embedded-layout", "");
+
+    expect(
+      selectorsSetting(styles, document.documentElement, "touch-action"),
+    ).toEqual([":root[data-embedded-layout]"]);
+  });
+
+  it("leaves a standalone session alone", () => {
+    // there is no host to hand a drag to, and the rule is the one part of this
+    // whose effect on in-page scrollers is engine-dependent
+    expect(
+      selectorsSetting(styles, document.documentElement, "touch-action"),
+    ).toEqual([]);
+  });
+
+  it("keeps pinch-zoom where the engine knows it", () => {
+    // declaration order is the fallback: an engine that does not parse
+    // pinch-zoom keeps the none above it and still refuses the pan, so
+    // reversing these would drop the refusal rather than the zoom
+    expect(declarations).toMatch(
+      /:root\[data-embedded-layout\]\s*\{[^}]*touch-action:\s*none;\s*touch-action:\s*pinch-zoom/,
+    );
+  });
+});

--- a/tests/styles/rootOverscroll.test.ts
+++ b/tests/styles/rootOverscroll.test.ts
@@ -1,0 +1,41 @@
+// @vitest-environment happy-dom
+import css from "@/styles/global.css?inline";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { selectorsSetting } from "./cascade";
+
+let styles: HTMLStyleElement;
+
+beforeEach(() => {
+  styles = document.createElement("style");
+  styles.textContent = css;
+  document.head.appendChild(styles);
+});
+
+afterEach(() => {
+  styles.remove();
+  document.body.innerHTML = "";
+});
+
+describe("overscroll chaining", () => {
+  it("keeps a drag the app does not consume inside the document", () => {
+    expect(getComputedStyle(document.documentElement).overscrollBehavior).toBe(
+      "none",
+    );
+  });
+
+  it("cuts only the last hop, out of the document", () => {
+    // The viewport takes the property from the root and nowhere else, and it
+    // does not inherit - so declaring it there leaves an in-page scroller
+    // chaining to the scroller around it the way it always has.
+    const scroller = document.createElement("div");
+    scroller.className = "scroll-container";
+    document.body.appendChild(scroller);
+
+    expect(
+      selectorsSetting(styles, document.documentElement, "overscroll-behavior"),
+    ).toEqual(["html"]);
+    expect(selectorsSetting(styles, scroller, "overscroll-behavior")).toEqual(
+      [],
+    );
+  });
+});

--- a/tests/styles/rootOverscroll.test.ts
+++ b/tests/styles/rootOverscroll.test.ts
@@ -17,13 +17,27 @@ afterEach(() => {
 });
 
 describe("overscroll chaining", () => {
-  it("keeps a drag the app does not consume inside the document", () => {
+  it("keeps a downward drag the app does not consume inside the document", () => {
     // happy-dom hands back what the stylesheet declared rather than a resolved
-    // value, so the shorthand is what there is to read - and reading it whole
-    // is what holds the horizontal axis too, which a two-value form would drop
-    expect(getComputedStyle(document.documentElement).overscrollBehavior).toBe(
-      "none",
-    );
+    // value, so the axis has to be read under the name it is declared with
+    const root = getComputedStyle(document.documentElement);
+
+    expect(root.overscrollBehaviorY).toBe("none");
+  });
+
+  it("leaves the horizontal axis to the browser", () => {
+    // that is where the back-navigation swipe lives, and no drag out of the
+    // app goes sideways
+    expect(
+      selectorsSetting(
+        styles,
+        document.documentElement,
+        "overscroll-behavior-x",
+      ),
+    ).toEqual([]);
+    expect(
+      selectorsSetting(styles, document.documentElement, "overscroll-behavior"),
+    ).toEqual([]);
   });
 
   it("cuts only the last hop, out of the document", () => {
@@ -35,9 +49,13 @@ describe("overscroll chaining", () => {
     document.body.appendChild(scroller);
 
     expect(
-      selectorsSetting(styles, document.documentElement, "overscroll-behavior"),
+      selectorsSetting(
+        styles,
+        document.documentElement,
+        "overscroll-behavior-y",
+      ),
     ).toEqual(["html"]);
-    expect(selectorsSetting(styles, scroller, "overscroll-behavior")).toEqual(
+    expect(selectorsSetting(styles, scroller, "overscroll-behavior-y")).toEqual(
       [],
     );
   });

--- a/tests/styles/rootOverscroll.test.ts
+++ b/tests/styles/rootOverscroll.test.ts
@@ -18,6 +18,9 @@ afterEach(() => {
 
 describe("overscroll chaining", () => {
   it("keeps a drag the app does not consume inside the document", () => {
+    // happy-dom hands back what the stylesheet declared rather than a resolved
+    // value, so the shorthand is what there is to read - and reading it whole
+    // is what holds the horizontal axis too, which a two-value form would drop
     expect(getComputedStyle(document.documentElement).overscrollBehavior).toBe(
       "none",
     );


### PR DESCRIPTION
# What does this implement/fix?

In the Home Assistant app, swiping down on a panel — the group members list, the volume popout, the fullscreen player — reloaded the whole of Music Assistant instead of closing the panel.

Nothing in our page scrolls at the top level, so a downward drag we don't consume gets handed on to whatever we are embedded in. Out of the Home Assistant ingress panel that lands in the app itself, which reads it as pull-to-refresh.

There are two ways a drag escapes, and they need different answers:

- It starts on a list and that list runs out — the scroll then chains onward. Keeping it in our own page stops that.
- It starts somewhere that never scrolls at all, like a panel header or the fullscreen player. There is no scroll to chain, so the gesture goes straight to the host. Only refusing the drag outright stops that one, which is why the small drag bar at the top of a panel was the one spot that always worked — it already refuses.

Standalone and PWA were never affected, since there is no app around us to hand the drag to. The second rule is limited to the embedded case for that reason.

**Related issue (if applicable):**

- reported on Home Assistant companion for iOS

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Changes

- `overscroll-behavior-y: none` on the root, so a scroll that runs out stops at our page instead of reaching the host. Vertical only — the horizontal axis is where the browser keeps its back-navigation swipe.
- `touch-action` on the root when embedded, so a drag starting where nothing scrolls is refused before it becomes a gesture. Lists inside still scroll: touch-action is intersected only up to the scroll container that would move. `pinch-zoom` keeps zoom available, with `none` as the fallback for engines that don't parse it.
- Limited to embedded sessions, since that is the only place a drag has somewhere to escape to, and it is the half whose effect on in-page scrollers is engine-dependent.
- Tests pinning both rules, the axis, the gating and the fallback order.

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm lint:check` passes.
- [x] `pnpm test:run` passes, and tests have been added/updated where applicable.
- [x] `pnpm build` passes.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
