### PR TITLE
Swiping the fullscreen player closed no longer reloads the Home Assistant app

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -163,16 +163,14 @@ html {
   background-color: rgb(var(--v-theme-background));
 }
 
-/* The above only reaches a drag that starts on something scrollable. One that
-   starts where nothing scrolls - a panel header, the fullscreen player - has no
-   scroll to chain from, and embedded it reaches the host instead: out of the
-   Home Assistant ingress iframe and into its app, which takes it for a
-   pull-to-refresh and reloads. Refusing the pan stops that gesture ever
-   starting. Scrollers inside still pan, since touch-action is intersected only
-   up to the scroll container that would move; none is the fallback for engines
-   that do not know pinch-zoom, which trades zoom away to keep the refusal. */
-:root[data-embedded-layout] {
-  touch-action: none;
+/* A drag starting where nothing scrolls - a panel header, the fullscreen player
+   - gives the rule above no chain to cut, and embedded it reaches the host
+   instead, whose pull-to-refresh reloads us. Refusing the pan stops it. The
+   value resets at every scroll container, which is what leaves the lists
+   scrolling and why the panels have to repeat it: Vuetify makes the fullscreen
+   player's card a scroll container, so the root's value never reaches inside. */
+:root[data-embedded-layout],
+:root[data-embedded-layout] [data-player-panel] {
   touch-action: pinch-zoom;
 }
 

--- a/tests/styles/embeddedTouchAction.test.ts
+++ b/tests/styles/embeddedTouchAction.test.ts
@@ -8,7 +8,7 @@ const PANEL = ":root[data-embedded-layout] [data-player-panel]";
 
 let styles: HTMLStyleElement;
 
-// an element as one of the panels renders it
+// a panel root, carrying the attribute all five of them mark themselves with
 function panel() {
   const el = document.createElement("div");
   el.setAttribute("data-player-panel", "");
@@ -47,14 +47,16 @@ describe("embedded touch-action", () => {
 
   it("keeps pinch-zoom, which is the whole reason it is not none", () => {
     // none would take zoom away with it, and manipulation still permits the pan
-    const declaring = [...(styles.sheet?.cssRules ?? [])]
-      .filter((rule): rule is CSSStyleRule => rule instanceof CSSStyleRule)
-      .filter((rule) => rule.style.getPropertyValue("touch-action") !== "");
+    // found by selector rather than by being the only one, so an unrelated
+    // touch-action landing in global.css later does not read as a failure
+    const rule = [...(styles.sheet?.cssRules ?? [])]
+      .filter((each): each is CSSStyleRule => each instanceof CSSStyleRule)
+      .filter((each) => each.style.getPropertyValue("touch-action") !== "")
+      .find((each) =>
+        each.selectorText.split(",").some((part) => part.trim() === ROOT),
+      );
 
-    expect(declaring).toHaveLength(1);
-    expect(declaring[0].style.getPropertyValue("touch-action")).toBe(
-      "pinch-zoom",
-    );
+    expect(rule?.style.getPropertyValue("touch-action")).toBe("pinch-zoom");
   });
 
   it("leaves a standalone session alone", () => {

--- a/tests/styles/embeddedTouchAction.test.ts
+++ b/tests/styles/embeddedTouchAction.test.ts
@@ -3,10 +3,18 @@ import css from "@/styles/global.css?inline";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { selectorsSetting } from "./cascade";
 
+const ROOT = ":root[data-embedded-layout]";
+const PANEL = ":root[data-embedded-layout] [data-player-panel]";
+
 let styles: HTMLStyleElement;
 
-// Drop the comments so the prose explaining the rule cannot stand in for it.
-const declarations = css.replace(/\/\*[\s\S]*?\*\//g, "");
+// an element as one of the panels renders it
+function panel() {
+  const el = document.createElement("div");
+  el.setAttribute("data-player-panel", "");
+  document.body.appendChild(el);
+  return el;
+}
 
 beforeEach(() => {
   styles = document.createElement("style");
@@ -16,6 +24,7 @@ beforeEach(() => {
 
 afterEach(() => {
   styles.remove();
+  document.body.innerHTML = "";
   document.documentElement.removeAttribute("data-embedded-layout");
 });
 
@@ -25,23 +34,44 @@ describe("embedded touch-action", () => {
 
     expect(
       selectorsSetting(styles, document.documentElement, "touch-action"),
-    ).toEqual([":root[data-embedded-layout]"]);
+    ).toEqual([ROOT]);
+  });
+
+  it("reaches the panels the root value cannot", () => {
+    // Vuetify gives the fullscreen player's card overflow-y: auto, and the
+    // value resets at a scroll container, so the root alone never lands inside
+    document.documentElement.setAttribute("data-embedded-layout", "");
+
+    expect(selectorsSetting(styles, panel(), "touch-action")).toEqual([PANEL]);
+  });
+
+  it("keeps pinch-zoom, which is the whole reason it is not none", () => {
+    // none would take zoom away with it, and manipulation still permits the pan
+    const declaring = [...(styles.sheet?.cssRules ?? [])]
+      .filter((rule): rule is CSSStyleRule => rule instanceof CSSStyleRule)
+      .filter((rule) => rule.style.getPropertyValue("touch-action") !== "");
+
+    expect(declaring).toHaveLength(1);
+    expect(declaring[0].style.getPropertyValue("touch-action")).toBe(
+      "pinch-zoom",
+    );
   });
 
   it("leaves a standalone session alone", () => {
-    // there is no host to hand a drag to, and the rule is the one part of this
-    // whose effect on in-page scrollers is engine-dependent
+    // there is no host to hand a drag to
     expect(
       selectorsSetting(styles, document.documentElement, "touch-action"),
     ).toEqual([]);
+    expect(selectorsSetting(styles, panel(), "touch-action")).toEqual([]);
   });
 
-  it("keeps pinch-zoom where the engine knows it", () => {
-    // declaration order is the fallback: an engine that does not parse
-    // pinch-zoom keeps the none above it and still refuses the pan, so
-    // reversing these would drop the refusal rather than the zoom
-    expect(declarations).toMatch(
-      /:root\[data-embedded-layout\]\s*\{[^}]*touch-action:\s*none;\s*touch-action:\s*pinch-zoom/,
-    );
+  it("refuses nothing outside a panel", () => {
+    // a rule broad enough to cover a plain element would reach the scrollers
+    // too, which is the one thing this must not do
+    document.documentElement.setAttribute("data-embedded-layout", "");
+    const plain = document.createElement("div");
+    document.body.appendChild(plain);
+
+    expect(selectorsSetting(styles, plain, "touch-action")).toEqual([]);
   });
 });


### PR DESCRIPTION
# What does this implement/fix?

Follow-up to #2490. That fixed the popouts, but swiping down on the fullscreen player in the Home Assistant app still reloaded everything.

The rule from #2490 is set once at the top of the page, and the browser drops it again at every element that can scroll — which is what leaves the lists inside the panels scrolling normally. Vuetify marks the fullscreen player's card as one of those, even though it has nothing to scroll, so the rule was being dropped before it ever reached the contents. Setting it on the panels as well puts it back past that point.

Confirmed on device, before and after.

**Related issue (if applicable):**

- follow-up to #2490

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Changes

- Also set `touch-action` on `[data-player-panel]`, so it survives the reset Vuetify's scroll container causes and reaches inside the fullscreen player.
- Drop the `touch-action: none` fallback. `pinch-zoom` has been supported since Safari 13, so no engine we run on ever took it.
- Tests for the panel selector, the value, and that nothing broader than a panel is covered — a rule that reached plain elements would stop the lists scrolling.

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm lint:check` passes.
- [x] `pnpm test:run` passes, and tests have been added/updated where applicable.
- [x] `pnpm build` passes.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
