### PR TITLE
Pages no longer keep working in the background after you leave them

### DIFF
--- a/src/components/ItemsListing.vue
+++ b/src/components/ItemsListing.vue
@@ -1835,13 +1835,18 @@ const loadGenreOptions = async () => {
 
 let _unsubscribeMediaEvents: (() => void) | undefined;
 
+const clearSelection = () => {
+  selectedItems.value = [];
+  showCheckboxes.value = false;
+};
+
 // Set by the unmount hook, so the startup below can tell that the listing it is
 // setting things up for is already gone.
 let unmounted = false;
 
 onBeforeUnmount(() => {
   unmounted = true;
-  eventbus.off("clearSelection");
+  eventbus.off("clearSelection", clearSelection);
   _unsubscribeMediaEvents?.();
 });
 
@@ -1879,10 +1884,7 @@ onMounted(async () => {
   if (unmounted) return;
 
   // Listen for selection clearing events
-  eventbus.on("clearSelection", () => {
-    selectedItems.value = [];
-    showCheckboxes.value = false;
-  });
+  eventbus.on("clearSelection", clearSelection);
 
   // signal if/when items get played/updated/removed
   _unsubscribeMediaEvents = api.subscribe_multi(

--- a/src/components/ItemsListing.vue
+++ b/src/components/ItemsListing.vue
@@ -1834,7 +1834,13 @@ const loadGenreOptions = async () => {
 };
 
 let _unsubscribeMediaEvents: (() => void) | undefined;
+
+// Set by the unmount hook, so the startup below can tell that the listing it is
+// setting things up for is already gone.
+let unmounted = false;
+
 onBeforeUnmount(() => {
+  unmounted = true;
   eventbus.off("clearSelection");
   _unsubscribeMediaEvents?.();
 });
@@ -1868,6 +1874,9 @@ onMounted(async () => {
   }
 
   await loadGenreOptions();
+  // The await can outlast the listing, and the unmount hook only reaches what
+  // was already set up by the time it ran.
+  if (unmounted) return;
 
   // Listen for selection clearing events
   eventbus.on("clearSelection", () => {

--- a/src/views/AIRadioView.vue
+++ b/src/views/AIRadioView.vue
@@ -330,6 +330,10 @@ async function handleRefresh() {
   }
 }
 
+// Set by the unmount hook, so the startup below can tell that the view it is
+// setting things up for is already gone.
+let unmounted = false;
+
 onMounted(async () => {
   try {
     await Promise.all([
@@ -341,6 +345,10 @@ onMounted(async () => {
   } catch (error) {
     toast.error(errorMessage(error));
   }
+  // Leaving the view while the loads are in flight runs the unmount hook first,
+  // so bail out rather than start a poll loop nothing will stop and rewrite the
+  // query of a route this view no longer owns.
+  if (unmounted) return;
   // Best effort: the "Add host" menu still works with just "Blank host" if this fails.
   void loadPresets().catch(() => {});
   startStatusPolling();
@@ -350,6 +358,7 @@ onMounted(async () => {
 watch(() => route.query, applyRouteQuery);
 
 onUnmounted(() => {
+  unmounted = true;
   stopStatusPolling();
 });
 </script>

--- a/src/views/settings/Diagnostics.vue
+++ b/src/views/settings/Diagnostics.vue
@@ -208,7 +208,9 @@ onMounted(async () => {
   // what was already set up by the time it ran.
   if (unmounted) return;
 
-  if (autoRefresh.value) {
+  // The auto-refresh watcher arms this interval too, and only the handle held
+  // here is the one the unmount hook clears.
+  if (autoRefresh.value && !refreshInterval) {
     refreshInterval = setInterval(() => {
       fetchLogs(true);
     }, 5000);

--- a/src/views/settings/Diagnostics.vue
+++ b/src/views/settings/Diagnostics.vue
@@ -91,6 +91,10 @@ const logContainer = ref<HTMLDivElement | null>(null);
 const maxLines = 150;
 let refreshInterval: ReturnType<typeof setInterval> | null = null;
 
+// Set by the unmount hook, so the startup below can tell that the view it is
+// setting things up for is already gone.
+let unmounted = false;
+
 const displayContent = computed(() => {
   const lines = logContent.value.split("\n");
   if (lines.length > maxLines) {
@@ -200,6 +204,10 @@ watch(autoRefresh, (enabled) => {
 
 onMounted(async () => {
   await fetchLogs(false);
+  // The first fetch can outlast the view, and the unmount hook only reaches
+  // what was already set up by the time it ran.
+  if (unmounted) return;
+
   if (autoRefresh.value) {
     refreshInterval = setInterval(() => {
       fetchLogs(true);
@@ -208,6 +216,7 @@ onMounted(async () => {
 });
 
 onUnmounted(() => {
+  unmounted = true;
   if (refreshInterval) {
     clearInterval(refreshInterval);
   }

--- a/src/views/settings/RemoteAccessSettings.vue
+++ b/src/views/settings/RemoteAccessSettings.vue
@@ -362,6 +362,10 @@ const switching = ref(false);
 const remoteAccessInfo = ref<RemoteAccessInfo | null>(null);
 let pollInterval: ReturnType<typeof setInterval> | null = null;
 
+// Set by the unmount hook, so the startup below can tell that the view it is
+// setting things up for is already gone.
+let unmounted = false;
+
 // Split remote ID into 4 parts: 8-5-5-8 characters
 const remoteIdLengths = [8, 5, 5, 8];
 const remoteIdParts = computed(() => {
@@ -377,12 +381,17 @@ const remoteIdParts = computed(() => {
 
 onMounted(async () => {
   await loadRemoteAccessInfo();
+  // The first load can outlast the view, and the unmount hook only reaches
+  // what was already set up by the time it ran.
+  if (unmounted) return;
+
   pollInterval = setInterval(async () => {
     await loadRemoteAccessInfo(true);
   }, 5000);
 });
 
 onUnmounted(() => {
+  unmounted = true;
   if (pollInterval) {
     clearInterval(pollInterval);
     pollInterval = null;

--- a/tests/components/ItemsListing.test.ts
+++ b/tests/components/ItemsListing.test.ts
@@ -185,4 +185,24 @@ describe("ItemsListing startup cleanup", () => {
     expect(clearSelectionHandlers()).toBe(0);
     expect(events.listeners).toHaveLength(0);
   });
+
+  it("leaves a second listing on the page still clearing its own selection", async () => {
+    const first = mountListingRaw();
+    const second = mountListingRaw();
+    await flushPromises();
+    expect(clearSelectionHandlers()).toBe(2);
+
+    // put the listing that stays into selection mode, so its reaction to the
+    // event below is something to see
+    const survivor = second.vm as unknown as { showCheckboxes: boolean };
+    survivor.showCheckboxes = true;
+    // a write that never landed would leave the closing assertion true anyway
+    expect(survivor.showCheckboxes).toBe(true);
+
+    first.unmount();
+    eventbus.emit("clearSelection");
+
+    expect(clearSelectionHandlers()).toBe(1);
+    expect(survivor.showCheckboxes).toBe(false);
+  });
 });

--- a/tests/components/ItemsListing.test.ts
+++ b/tests/components/ItemsListing.test.ts
@@ -1,0 +1,188 @@
+import ItemsListing from "@/components/ItemsListing.vue";
+import type { MusicAssistantApi } from "@/plugins/api";
+import { eventbus } from "@/plugins/eventbus";
+import { enableAutoUnmount, flushPromises, mount } from "@vue/test-utils";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Tracks live subscriptions the way the api does, so one that outlives the
+// listing stays listed here.
+const events = vi.hoisted(() => {
+  const listeners: unknown[] = [];
+  return {
+    listeners,
+    subscribeMulti: (_types: unknown, handler: unknown) => {
+      listeners.push(handler);
+      return () => {
+        const index = listeners.indexOf(handler);
+        if (index !== -1) listeners.splice(index, 1);
+      };
+    },
+  };
+});
+
+const mockGetLibraryGenres = vi.hoisted(() =>
+  vi.fn<MusicAssistantApi["getLibraryGenres"]>(),
+);
+const mockSubscribeMulti = vi.hoisted(() => vi.fn());
+
+vi.mock("@/plugins/api", () => {
+  const api = {
+    providers: {},
+    providerManifests: {},
+    getLibraryGenres: mockGetLibraryGenres,
+    subscribe_multi: mockSubscribeMulti,
+  };
+  return { api, default: api };
+});
+
+vi.mock("@/plugins/store", async () => {
+  const { reactive } = await import("vue");
+  return {
+    store: reactive({
+      dialogActive: false,
+      showPlayersMenu: false,
+      globalSearchTerm: "",
+      globalSearchMediaTypes: [],
+      activePlayer: undefined,
+      activePlayerQueue: undefined,
+      curQueueItem: undefined,
+      currentUser: undefined,
+      prevState: undefined,
+    }),
+  };
+});
+
+vi.mock("@/composables/userPreferences", async () => {
+  const { computed } = await import("vue");
+  return {
+    useUserPreferences: () => ({
+      getItemsListingPreferences: () => computed(() => ({})),
+      setItemsListingPreference: vi.fn(),
+    }),
+  };
+});
+
+// helpers/utils transitively imports router/auth, which need a real browser
+// environment; the listing only needs these two from it
+vi.mock("@/helpers/utils", () => ({
+  panelViewItemResponsive: () => 2,
+  scrollElement: vi.fn(),
+}));
+
+vi.mock("@/helpers/media_item_actions", () => ({
+  handleMenuBtnClick: vi.fn(),
+}));
+
+vi.mock("vue-i18n", () => ({
+  useI18n: () => ({ t: (key: string) => key, te: () => false }),
+}));
+
+vi.mock("vue-router", () => ({
+  useRoute: () => ({ query: {} }),
+  useRouter: () => ({ push: vi.fn() }),
+}));
+
+vi.mock("vue-sonner", () => ({ toast: { error: vi.fn(), success: vi.fn() } }));
+
+const stubComponent = vi.hoisted(() => (name: string) => ({
+  default: { name, template: "<div />" },
+}));
+
+vi.mock("@/components/Toolbar.vue", () => stubComponent("Toolbar"));
+vi.mock("@/components/Container.vue", () => stubComponent("Container"));
+vi.mock("@/components/icons/GenreIcon.vue", () => stubComponent("GenreIcon"));
+vi.mock("@/components/skeletons/ListViewSkeleton.vue", () =>
+  stubComponent("ListViewSkeleton"),
+);
+vi.mock("@/components/skeletons/PanelViewSkeleton.vue", () =>
+  stubComponent("PanelViewSkeleton"),
+);
+vi.mock("@/components/ListviewItem.vue", () => stubComponent("ListviewItem"));
+vi.mock("@/components/PanelviewItem.vue", () => stubComponent("PanelviewItem"));
+vi.mock("@/components/PanelviewItemCompact.vue", () =>
+  stubComponent("PanelviewItemCompact"),
+);
+
+/**
+ * Number of handlers the real eventbus currently holds for the listing's
+ * selection event, so a handler registered after teardown is visible.
+ */
+function clearSelectionHandlers() {
+  return eventbus.all.get("clearSelection")?.length ?? 0;
+}
+
+function mountListingRaw() {
+  return mount(ItemsListing, {
+    props: {
+      itemtype: "tracks",
+      path: "librarytracks",
+      showGenreFilter: true,
+      loadPagedData: vi.fn().mockResolvedValue([]),
+    },
+    global: {
+      mocks: {
+        $t: (key: string) => key,
+        $vuetify: { display: { width: 1280 } },
+      },
+      stubs: {
+        Button: true,
+        Empty: true,
+        EmptyContent: true,
+        EmptyDescription: true,
+        EmptyHeader: true,
+        EmptyTitle: true,
+        Tabs: true,
+        TabsList: true,
+        TabsTrigger: true,
+        "v-divider": true,
+        "v-text-field": true,
+      },
+    },
+  });
+}
+
+enableAutoUnmount(afterEach);
+
+describe("ItemsListing startup cleanup", () => {
+  beforeEach(() => {
+    eventbus.all.clear();
+    events.listeners.length = 0;
+    mockGetLibraryGenres.mockReset();
+    mockGetLibraryGenres.mockResolvedValue([]);
+    mockSubscribeMulti.mockReset();
+    mockSubscribeMulti.mockImplementation(events.subscribeMulti);
+  });
+
+  it("undoes everything it set up when the listing is closed", async () => {
+    const listing = mountListingRaw();
+    await flushPromises();
+
+    expect(clearSelectionHandlers()).toBe(1);
+    expect(events.listeners).toHaveLength(1);
+
+    listing.unmount();
+
+    expect(clearSelectionHandlers()).toBe(0);
+    expect(events.listeners).toHaveLength(0);
+  });
+
+  it("sets nothing up when the listing is closed while the genres are still loading", async () => {
+    let resolveGenres: () => void = () => {};
+    mockGetLibraryGenres.mockReturnValue(
+      new Promise((resolve) => {
+        resolveGenres = () => resolve([]);
+      }),
+    );
+    const listing = mountListingRaw();
+    // pin that the startup really is paused on the genres, so the assertions
+    // below are about the resumed half and not about a startup that never ran
+    expect(mockGetLibraryGenres).toHaveBeenCalled();
+
+    listing.unmount();
+    resolveGenres();
+    await flushPromises();
+
+    expect(clearSelectionHandlers()).toBe(0);
+    expect(events.listeners).toHaveLength(0);
+  });
+});

--- a/tests/views/AIRadioView.test.ts
+++ b/tests/views/AIRadioView.test.ts
@@ -12,11 +12,14 @@ type SendCommand = (
   args?: Record<string, unknown>,
 ) => Promise<unknown>;
 
-const { sendCommand, getLibraryPlaylists, routeMock } = vi.hoisted(() => ({
-  sendCommand: vi.fn<SendCommand>(async () => []),
-  getLibraryPlaylists: vi.fn(async () => []),
-  routeMock: { query: { station_id: "show-1" } as Record<string, string> },
-}));
+const { sendCommand, getLibraryPlaylists, routeMock, routerMock } = vi.hoisted(
+  () => ({
+    sendCommand: vi.fn<SendCommand>(async () => []),
+    getLibraryPlaylists: vi.fn(async () => []),
+    routeMock: { query: { station_id: "show-1" } as Record<string, string> },
+    routerMock: { push: vi.fn(), replace: vi.fn() },
+  }),
+);
 
 vi.mock("@/plugins/api", () => {
   const mockApi = {
@@ -37,7 +40,7 @@ vi.mock("@/plugins/store", () => ({
 vi.mock("vue-router", async (importOriginal) => ({
   ...(await importOriginal<typeof import("vue-router")>()),
   useRoute: () => routeMock,
-  useRouter: () => ({ push: vi.fn(), replace: vi.fn() }),
+  useRouter: () => routerMock,
   onBeforeRouteLeave: vi.fn(),
 }));
 
@@ -101,13 +104,75 @@ const getShowFetchCount = () =>
     ([command]) => command === "ai_radio/stations/get",
   ).length;
 
+const getStatusFetchCount = () =>
+  sendCommand.mock.calls.filter(([command]) => command === "ai_radio/status")
+    .length;
+
 function findButtonByText(wrapper: VueWrapper, text: string) {
   return wrapper.findAll("button").find((button) => button.text() === text);
 }
 
+/**
+ * Records document listeners while a view runs.
+ *
+ * `live()` reports the event types attached right now; `stop()` restores the
+ * originals and reports what is still attached, which is what tells a removed
+ * listener apart from one added back afterwards.
+ */
+function trackDocumentListeners() {
+  const attached = new Map<unknown, string>();
+  const { addEventListener, removeEventListener } = document;
+  document.addEventListener = ((type: string, handler: never) => {
+    attached.set(handler, type);
+    return addEventListener.call(document, type, handler);
+  }) as never;
+  document.removeEventListener = ((type: string, handler: never) => {
+    attached.delete(handler);
+    return removeEventListener.call(document, type, handler);
+  }) as never;
+  return {
+    live: () => [...attached.values()],
+    stop: () => {
+      Object.assign(document, { addEventListener, removeEventListener });
+      return [...attached.values()];
+    },
+  };
+}
+
+/**
+ * Records the status poll timers armed while a view runs.
+ *
+ * `pending()` reports the ones not cleared again, which is what a poll loop
+ * still running boils down to. Poll delays start at 5s, well clear of the
+ * short timeouts the components and the test harness arm themselves.
+ */
+function trackPollTimers() {
+  const POLL_DELAY_FLOOR_MS = 5000;
+  const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout");
+  const clearTimeoutSpy = vi.spyOn(globalThis, "clearTimeout");
+  return {
+    pending: () => {
+      const cleared = new Set(clearTimeoutSpy.mock.calls.map(([id]) => id));
+      return setTimeoutSpy.mock.results
+        .filter(
+          (_result, index) =>
+            Number(setTimeoutSpy.mock.calls[index][1]) >= POLL_DELAY_FLOOR_MS,
+        )
+        .map((result) => result.value)
+        .filter((timer) => !cleared.has(timer));
+    },
+    stop: () => {
+      setTimeoutSpy.mockRestore();
+      clearTimeoutSpy.mockRestore();
+    },
+  };
+}
+
+// Attached so isVisible() can resolve computed style (v-show toggling).
+const mountViewRaw = () => mount(AIRadioView, { attachTo: document.body });
+
 async function mountView() {
-  // Attached so isVisible() can resolve computed style (v-show toggling).
-  const wrapper = mount(AIRadioView, { attachTo: document.body });
+  const wrapper = mountViewRaw();
   await flushPromises();
   return wrapper;
 }
@@ -120,6 +185,9 @@ afterEach(() => {
   useShows().shows.value = [];
   useShows().sessions.value = [];
   useShows().playlists.value = [];
+  // Polling state lives in the composable's module scope, so a run left behind
+  // here would decide what the next test sees.
+  useShows().stopStatusPolling();
   document.body.replaceChildren();
 });
 
@@ -201,5 +269,52 @@ describe("AIRadioView host editor / show editor interplay", () => {
       (secondOpen.find("#customize-host-name").element as HTMLInputElement)
         .value,
     ).toBe("");
+  });
+});
+
+describe("AIRadioView status polling lifecycle", () => {
+  it("polls while the page is open and stops once it is closed", async () => {
+    routeMock.query = {};
+    setupSendCommand([]);
+    const listeners = trackDocumentListeners();
+    const timers = trackPollTimers();
+
+    const view = mountViewRaw();
+    await flushPromises();
+    const listeningWhileOpen = listeners.live();
+    const pendingWhileOpen = timers.pending();
+
+    view.unmount();
+    const listeningAfterClose = listeners.stop();
+    const pendingAfterClose = timers.pending();
+    timers.stop();
+
+    expect(listeningWhileOpen).toContain("visibilitychange");
+    expect(pendingWhileOpen).toHaveLength(1);
+    expect(getStatusFetchCount()).toBeGreaterThan(0);
+    expect(listeningAfterClose).not.toContain("visibilitychange");
+    expect(pendingAfterClose).toHaveLength(0);
+  });
+
+  it("sets nothing up when the page is closed while still loading", async () => {
+    // leaving before the loads resolve runs the unmount hook first, so anything
+    // starting afterwards would poll on for the lifetime of the page
+    routeMock.query = { station_id: STATION_ID };
+    setupSendCommand([]);
+    const listeners = trackDocumentListeners();
+    const timers = trackPollTimers();
+
+    const view = mountViewRaw();
+    view.unmount();
+    await flushPromises();
+    const remaining = listeners.stop();
+    const pending = timers.pending();
+    timers.stop();
+
+    expect(remaining).not.toContain("visibilitychange");
+    expect(pending).toHaveLength(0);
+    expect(getStatusFetchCount()).toBe(0);
+    // by now the query belongs to whatever route replaced this one
+    expect(routerMock.replace).not.toHaveBeenCalled();
   });
 });

--- a/tests/views/Diagnostics.test.ts
+++ b/tests/views/Diagnostics.test.ts
@@ -1,5 +1,6 @@
 import { flushPromises, shallowMount } from "@vue/test-utils";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { Switch } from "@/components/ui/switch";
 import type { MusicAssistantApi } from "@/plugins/api";
 import Diagnostics from "@/views/settings/Diagnostics.vue";
 
@@ -22,6 +23,9 @@ function mountView() {
       mocks: {
         $t: (key: string) => key,
       },
+      // the auto-refresh switch sits in a card's slot, so the stubs have to
+      // render theirs for it to be reachable
+      renderStubDefaultSlot: true,
     },
   });
 }
@@ -77,6 +81,34 @@ describe("Diagnostics log refresh", () => {
     expect(apiMock.sendCommand).toHaveBeenCalledTimes(1);
     // an interval survives being advanced past, so a count of zero is what
     // rules one out
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it("runs a single refresh interval when auto-refresh is toggled off and on during the first log fetch", async () => {
+    let deliverLog: (text: string) => void = () => {};
+    apiMock.sendCommand.mockReturnValueOnce(
+      new Promise<string>((resolve) => {
+        deliverLog = resolve;
+      }) as never,
+    );
+    const wrapper = mountView();
+
+    // switching back on arms an interval from the watcher, which the fetch
+    // finishing then finds already in place
+    const autoRefreshSwitch = wrapper.findComponent(Switch);
+    await autoRefreshSwitch.setValue(false);
+    await autoRefreshSwitch.setValue(true);
+
+    deliverLog(LOG_TEXT);
+    await flushPromises();
+    // only the fetch the page opened with; nothing has been advanced yet
+    expect(apiMock.sendCommand).toHaveBeenCalledTimes(1);
+
+    wrapper.unmount();
+    await vi.advanceTimersByTimeAsync(15_000);
+
+    // a second interval would outlive the page, since only one handle is closed
+    expect(apiMock.sendCommand).toHaveBeenCalledTimes(1);
     expect(vi.getTimerCount()).toBe(0);
   });
 });

--- a/tests/views/Diagnostics.test.ts
+++ b/tests/views/Diagnostics.test.ts
@@ -1,0 +1,82 @@
+import { flushPromises, shallowMount } from "@vue/test-utils";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { MusicAssistantApi } from "@/plugins/api";
+import Diagnostics from "@/views/settings/Diagnostics.vue";
+
+const { apiMock } = vi.hoisted(() => ({
+  apiMock: {
+    sendCommand: vi.fn<MusicAssistantApi["sendCommand"]>(),
+  },
+}));
+
+vi.mock("@/plugins/api", () => ({
+  api: apiMock,
+  default: apiMock,
+}));
+
+const LOG_TEXT = "server started";
+
+function mountView() {
+  return shallowMount(Diagnostics, {
+    global: {
+      mocks: {
+        $t: (key: string) => key,
+      },
+    },
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  apiMock.sendCommand.mockResolvedValue(LOG_TEXT as never);
+  // flushPromises() resolves on setImmediate, so that one has to stay real.
+  // The refresh interval and the log view's scroll timeout are what these
+  // tests drive.
+  vi.useFakeTimers({
+    toFake: ["setTimeout", "clearTimeout", "setInterval", "clearInterval"],
+  });
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("Diagnostics log refresh", () => {
+  it("refreshes the log every five seconds until the page is closed", async () => {
+    const wrapper = mountView();
+    await flushPromises();
+
+    // auto-refresh starts switched on, so mounting takes the branch that arms
+    // the interval; if that default ever changes this is what fails first
+    expect(apiMock.sendCommand).toHaveBeenCalledTimes(1);
+    await vi.advanceTimersByTimeAsync(5000);
+    expect(apiMock.sendCommand).toHaveBeenCalledTimes(2);
+
+    wrapper.unmount();
+    await vi.advanceTimersByTimeAsync(15_000);
+
+    expect(apiMock.sendCommand).toHaveBeenCalledTimes(2);
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it("arms no refresh interval when the page is closed while the first log fetch is in flight", async () => {
+    let deliverLog: (text: string) => void = () => {};
+    apiMock.sendCommand.mockReturnValueOnce(
+      new Promise<string>((resolve) => {
+        deliverLog = resolve;
+      }) as never,
+    );
+    const wrapper = mountView();
+
+    wrapper.unmount();
+    deliverLog(LOG_TEXT);
+    await flushPromises();
+    await vi.advanceTimersByTimeAsync(15_000);
+
+    // a leaked interval keeps pulling the log down for the rest of the session
+    expect(apiMock.sendCommand).toHaveBeenCalledTimes(1);
+    // an interval survives being advanced past, so a count of zero is what
+    // rules one out
+    expect(vi.getTimerCount()).toBe(0);
+  });
+});

--- a/tests/views/RemoteAccessSettings.test.ts
+++ b/tests/views/RemoteAccessSettings.test.ts
@@ -1,0 +1,127 @@
+import { flushPromises, shallowMount } from "@vue/test-utils";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createVuetify } from "vuetify";
+import * as components from "vuetify/components";
+import * as directives from "vuetify/directives";
+import type { MusicAssistantApi } from "@/plugins/api";
+import type { RemoteAccessInfo } from "@/plugins/api/interfaces";
+import RemoteAccessSettings from "@/views/settings/RemoteAccessSettings.vue";
+
+const { apiMock, qrMock, toastMock } = vi.hoisted(() => ({
+  apiMock: {
+    getRemoteAccessInfo: vi.fn<MusicAssistantApi["getRemoteAccessInfo"]>(),
+    configureRemoteAccess: vi.fn<MusicAssistantApi["configureRemoteAccess"]>(),
+  },
+  qrMock: {
+    toDataURL: vi.fn().mockResolvedValue("data:image/png;base64,qr"),
+  },
+  toastMock: {
+    error: vi.fn(),
+    success: vi.fn(),
+  },
+}));
+
+vi.mock("@/plugins/api", () => ({
+  api: apiMock,
+  default: apiMock,
+}));
+
+vi.mock("@/helpers/utils", () => ({
+  copyToClipboard: vi.fn(),
+}));
+
+vi.mock("qrcode", () => ({
+  default: qrMock,
+}));
+
+vi.mock("vue-sonner", () => ({
+  toast: toastMock,
+}));
+
+vi.mock("vue-i18n", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("vue-i18n")>();
+  return {
+    ...actual,
+    useI18n: () => ({
+      t: (key: string) => key,
+    }),
+  };
+});
+
+const vuetify = createVuetify({ components, directives });
+
+function remoteAccessInfo(): RemoteAccessInfo {
+  return {
+    enabled: true,
+    running: true,
+    connected: true,
+    remote_id: "abcdefgh12345678901234ab",
+    using_ha_cloud: true,
+    signaling_url: "https://signaling.example.com",
+  };
+}
+
+function mountView() {
+  return shallowMount(RemoteAccessSettings, {
+    global: {
+      plugins: [vuetify],
+      mocks: {
+        $t: (key: string) => key,
+      },
+    },
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  apiMock.getRemoteAccessInfo.mockResolvedValue(remoteAccessInfo());
+  qrMock.toDataURL.mockResolvedValue("data:image/png;base64,qr");
+  // flushPromises() resolves on setImmediate, so that one has to stay real.
+  // The status poll is what these tests drive.
+  vi.useFakeTimers({
+    toFake: ["setTimeout", "clearTimeout", "setInterval", "clearInterval"],
+  });
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("RemoteAccessSettings status poll", () => {
+  it("polls the remote access status every five seconds until the page is closed", async () => {
+    const wrapper = mountView();
+    await flushPromises();
+
+    expect(apiMock.getRemoteAccessInfo).toHaveBeenCalledTimes(1);
+    await vi.advanceTimersByTimeAsync(5000);
+    expect(apiMock.getRemoteAccessInfo).toHaveBeenCalledTimes(2);
+
+    wrapper.unmount();
+    await vi.advanceTimersByTimeAsync(15_000);
+
+    expect(apiMock.getRemoteAccessInfo).toHaveBeenCalledTimes(2);
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it("arms no poll when the page is closed while the first status load is in flight", async () => {
+    let deliverInfo: (info: RemoteAccessInfo) => void = () => {};
+    apiMock.getRemoteAccessInfo.mockReturnValueOnce(
+      new Promise<RemoteAccessInfo>((resolve) => {
+        deliverInfo = resolve;
+      }),
+    );
+    const wrapper = mountView();
+
+    wrapper.unmount();
+    deliverInfo(remoteAccessInfo());
+    await flushPromises();
+    await vi.advanceTimersByTimeAsync(15_000);
+
+    // a leaked poll keeps asking the server for status for the rest of the
+    // session
+    expect(apiMock.getRemoteAccessInfo).toHaveBeenCalledTimes(1);
+    // an interval survives being advanced past, so a count of zero is what
+    // rules one out
+    expect(vi.getTimerCount()).toBe(0);
+  });
+});


### PR DESCRIPTION
# What does this implement/fix?

Some pages only start their background work (event subscriptions, listeners, refresh timers) after their first data load finishes. If you leave the page before that load completes, the page's cleanup runs first, finds nothing to clean up, and everything then starts up anyway — with nothing left to stop it. That work keeps running until you reload the app.

Most visible on the AI Radio page, which leaves a status poll running forever, and on music listings, which mount on nearly every navigation so the leftovers pile up quickly.

Follows the same fix already applied to the party pages in #2481 and #2485.

**Related issue (if applicable):**

- related issue `n/a`

**Related backend PR (if applicable):**

- related backend PR `n/a`

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Changes

- Music listings no longer leave a selection handler and a media-event subscription behind when you navigate away while the genre list is still loading.
- The AI Radio page no longer leaves a status poll and a tab-visibility listener running forever when you leave it while it is still loading.
- Settings → Diagnostics no longer leaves its 5-second log refresh running.
- Settings → Remote Access no longer leaves its 5-second status poll running.
- Diagnostics also keeps to a single refresh timer: toggling auto-refresh off and on again while the first log fetch was still running used to leave a second one behind that nothing closed.
- On pages showing more than one listing, closing one no longer stops the others clearing their selection.
- Added tests covering both sides for each page: normal open/close cleans up, and closing mid-load starts nothing.

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm lint:check` passes.
- [x] `pnpm test:run` passes, and tests have been added/updated where applicable.
- [x] `pnpm build` passes.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.

---

Follow-ups, deliberately not done here:

- The safe call sites spell this flag four different ways — `unmounted` (the party pages), `_unmounted` (useShortcuts), `isUnmounted` (HomeWidgetRows) and `active` (ShowDashboardButton, useGuestEntryResolver). Converging on one name would be a reasonable separate cleanup.
- Leaving a listing while its genre list is still loading lets that fetch page to the end before it stops. Bounded, so not a leak, but still work done for a page you left.
