### PR TITLE
Reload the app when a page fails to load after an update

### DIFF
--- a/src/plugins/router.ts
+++ b/src/plugins/router.ts
@@ -655,6 +655,8 @@ const router = createRouter({
 // When a dynamic import fails with a 404, it means the chunk no longer exists
 // on the server (likely due to a new deployment with different hashes).
 // In this case, we reload the page to get the fresh assets.
+const CHUNK_RELOAD_STORAGE_KEY = "chunkReloadAttempted";
+
 router.onError((error, to) => {
   // Check if this is a chunk loading error
   const isChunkLoadError =
@@ -664,27 +666,33 @@ router.onError((error, to) => {
     (error.name === "TypeError" && error.message.includes("fetch"));
 
   if (isChunkLoadError) {
-    const reloadKey = "chunkReloadAttempted";
-    if (sessionStorage.getItem(reloadKey)) {
-      // Already tried reloading once this session — avoid an infinite loop.
-      // Clear the flag so a future manual navigation can try again.
-      sessionStorage.removeItem(reloadKey);
+    if (sessionStorage.getItem(CHUNK_RELOAD_STORAGE_KEY)) {
+      // A reload is already in flight or did not help, so stop here to avoid
+      // an endless reload loop while the server keeps failing.
       console.error(
         "Chunk loading failed again after reload. Server may be unavailable.",
         error,
       );
       return;
     }
-    sessionStorage.setItem(reloadKey, "1");
+    sessionStorage.setItem(CHUNK_RELOAD_STORAGE_KEY, "1");
     console.warn(
       "Chunk loading failed, likely due to app update. Reloading page...",
       error,
     );
-    // Use location.href to do a full reload to the intended route
-    // This ensures we get fresh HTML and assets from the server
-    window.location.href =
-      window.location.origin + window.location.pathname + "#" + to.fullPath;
+    // With hash history the intended route only differs from the current URL
+    // in its fragment, so assigning it would stay on the same document. Move
+    // the hash and reload explicitly to fetch fresh HTML and assets, keeping
+    // the rest of the URL (e.g. Home Assistant ingress query params) intact.
+    window.location.hash = to.fullPath;
+    window.location.reload();
   }
+});
+
+// A completed navigation proves chunks load again, so a later update can
+// recover the same way.
+router.afterEach((_to, _from, failure) => {
+  if (!failure) sessionStorage.removeItem(CHUNK_RELOAD_STORAGE_KEY);
 });
 
 // Navigation guard for admin-only routes and guest mode restrictions

--- a/src/plugins/router.ts
+++ b/src/plugins/router.ts
@@ -651,12 +651,12 @@ const router = createRouter({
   routes,
 });
 
+const CHUNK_RELOAD_STORAGE_KEY = "chunkReloadAttempted";
+
 // Handle chunk loading errors (e.g., after frontend update with stale cache)
 // When a dynamic import fails with a 404, it means the chunk no longer exists
 // on the server (likely due to a new deployment with different hashes).
 // In this case, we reload the page to get the fresh assets.
-const CHUNK_RELOAD_STORAGE_KEY = "chunkReloadAttempted";
-
 router.onError((error, to) => {
   // Check if this is a chunk loading error
   const isChunkLoadError =
@@ -680,16 +680,17 @@ router.onError((error, to) => {
       "Chunk loading failed, likely due to app update. Reloading page...",
       error,
     );
-    // With hash history the intended route only differs from the current URL
-    // in its fragment, so assigning it would stay on the same document. Move
-    // the hash and reload explicitly to fetch fresh HTML and assets, keeping
-    // the rest of the URL (e.g. Home Assistant ingress query params) intact.
+    // The intended route differs from the current URL only in its fragment, so
+    // moving the hash stays on the same document and the reload is what fetches
+    // fresh HTML and assets. Moving only the hash also keeps the rest of the
+    // URL (e.g. Home Assistant ingress query params) intact.
     window.location.hash = to.fullPath;
     window.location.reload();
   }
 });
 
-// A completed navigation proves chunks load again, so a later update can
+// The reload above lands on the route that just failed, so a navigation
+// completing afterwards means the app loads again and a later update can
 // recover the same way.
 router.afterEach((_to, _from, failure) => {
   if (!failure) sessionStorage.removeItem(CHUNK_RELOAD_STORAGE_KEY);

--- a/tests/plugins/router.test.ts
+++ b/tests/plugins/router.test.ts
@@ -462,12 +462,10 @@ describe("media details back button", () => {
 });
 
 describe("chunk loading recovery", () => {
-  // A real Location normalises the assignment to "#/artists"; this stub keeps
-  // whatever the recovery hands it.
-  const location = { hash: "#/discover", reload: vi.fn() };
+  let location = locationStub();
 
   beforeEach(() => {
-    location.hash = "#/discover";
+    location = locationStub();
     vi.stubGlobal("location", location);
     // both branches of the recovery log
     vi.spyOn(console, "warn").mockImplementation(() => {});
@@ -480,38 +478,51 @@ describe("chunk loading recovery", () => {
     vi.mocked(console.error).mockRestore();
   });
 
-  // Moving the hash alone is a same-document navigation, so without the reload
-  // the app never refetches and the route stays broken.
+  // Moving the hash is a same-document navigation, so the reload is what
+  // refetches the app, and it has to come second to keep the intended route.
   it("reloads onto the intended route when its chunk is gone", async () => {
     await failNavigationWithChunkError("/artists");
 
-    expect(location.hash).toBe("/artists");
-    expect(location.reload).toHaveBeenCalledOnce();
+    expect(location.hash).toBe("#/artists");
+    expect(location.steps).toEqual(["hash", "reload"]);
+  });
+
+  // how a cached index.html hits this: the app opens straight onto the route
+  // whose chunk the update replaced
+  it("reloads when the app opened on the failing route", async () => {
+    location.hash = "#/artists";
+    location.steps.length = 0;
+
+    await failNavigationWithChunkError("/artists");
+
+    expect(location.hash).toBe("#/artists");
+    expect(location.steps).toEqual(["hash", "reload"]);
   });
 
   it("stops reloading while the chunk keeps failing", async () => {
     await failNavigationWithChunkError("/artists");
-    location.reload.mockClear();
+    location.steps.length = 0;
 
     await failNavigationWithChunkError("/albums");
+    await failNavigationWithChunkError("/tracks");
 
-    expect(location.reload).not.toHaveBeenCalled();
+    expect(location.steps).toEqual([]);
   });
 
   it("recovers again after a later update", async () => {
     await failNavigationWithChunkError("/artists");
-    location.reload.mockClear();
+    location.steps.length = 0;
     runAfterEachHooks();
 
     await failNavigationWithChunkError("/albums");
 
-    expect(location.hash).toBe("/albums");
-    expect(location.reload).toHaveBeenCalledOnce();
+    expect(location.hash).toBe("#/albums");
+    expect(location.steps).toEqual(["hash", "reload"]);
   });
 
   it("keeps blocking reloads while no navigation completed", async () => {
     await failNavigationWithChunkError("/artists");
-    location.reload.mockClear();
+    location.steps.length = 0;
     // only the presence of a failure matters to the hook
     runAfterEachHooks({
       type: NavigationFailureType.aborted,
@@ -519,7 +530,7 @@ describe("chunk loading recovery", () => {
 
     await failNavigationWithChunkError("/albums");
 
-    expect(location.reload).not.toHaveBeenCalled();
+    expect(location.steps).toEqual([]);
   });
 });
 
@@ -549,6 +560,28 @@ function invokeGuard(
 }
 
 /**
+ * Stand in for window.location, recording the order of what is done to it.
+ */
+function locationStub() {
+  const steps: string[] = [];
+  let hash = "#/discover";
+  return {
+    steps,
+    get hash() {
+      return hash;
+    },
+    set hash(value: string) {
+      // a real Location normalises the assignment the same way
+      hash = value.startsWith("#") ? value : `#${value}`;
+      steps.push("hash");
+    },
+    reload: () => {
+      steps.push("reload");
+    },
+  };
+}
+
+/**
  * Navigate to a route whose chunk is no longer on the server.
  */
 async function failNavigationWithChunkError(fullPath: string) {
@@ -562,6 +595,8 @@ async function failNavigationWithChunkError(fullPath: string) {
   });
   await mocks.router.push(fullPath).catch(() => {});
   removeGuard();
+  // the mock records every guard, so drop this one from that list as well
+  mocks.globalGuards.pop();
 }
 
 /**

--- a/tests/plugins/router.test.ts
+++ b/tests/plugins/router.test.ts
@@ -2,17 +2,21 @@ import { DASHBOARD_VIEWER_PATH_STORAGE_KEY } from "@/helpers/guest_session";
 import { backFromMediaDetails } from "@/helpers/navigation";
 import { ConnectionState } from "@/plugins/api";
 import { routes } from "@/plugins/router";
-import type {
-  NavigationGuardNext,
-  NavigationGuardWithThis,
-  RouteLocationNormalizedLoaded,
-  RouteRecordRaw,
-  Router,
-  RouterOptions,
+import {
+  NavigationFailureType,
+  type NavigationFailure,
+  type NavigationGuardNext,
+  type NavigationGuardWithThis,
+  type NavigationHookAfter,
+  type RouteLocationNormalizedLoaded,
+  type RouteRecordRaw,
+  type Router,
+  type RouterOptions,
 } from "vue-router";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
+  afterEachHooks: [] as NavigationHookAfter[],
   apiState: { value: "initialized" },
   globalGuards: [] as NavigationGuardWithThis<undefined>[],
   isDashboardViewer: vi.fn(() => false),
@@ -76,6 +80,11 @@ vi.mock("vue-router", async () => {
       router.beforeEach = (guard) => {
         mocks.globalGuards.push(guard);
         return addGuard(guard);
+      };
+      const addAfterEachHook = router.afterEach.bind(router);
+      router.afterEach = (hook) => {
+        mocks.afterEachHooks.push(hook);
+        return addAfterEachHook(hook);
       };
       mocks.router = router;
       return router;
@@ -452,6 +461,68 @@ describe("media details back button", () => {
   );
 });
 
+describe("chunk loading recovery", () => {
+  // A real Location normalises the assignment to "#/artists"; this stub keeps
+  // whatever the recovery hands it.
+  const location = { hash: "#/discover", reload: vi.fn() };
+
+  beforeEach(() => {
+    location.hash = "#/discover";
+    vi.stubGlobal("location", location);
+    // both branches of the recovery log
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.mocked(console.warn).mockRestore();
+    vi.mocked(console.error).mockRestore();
+  });
+
+  // Moving the hash alone is a same-document navigation, so without the reload
+  // the app never refetches and the route stays broken.
+  it("reloads onto the intended route when its chunk is gone", async () => {
+    await failNavigationWithChunkError("/artists");
+
+    expect(location.hash).toBe("/artists");
+    expect(location.reload).toHaveBeenCalledOnce();
+  });
+
+  it("stops reloading while the chunk keeps failing", async () => {
+    await failNavigationWithChunkError("/artists");
+    location.reload.mockClear();
+
+    await failNavigationWithChunkError("/albums");
+
+    expect(location.reload).not.toHaveBeenCalled();
+  });
+
+  it("recovers again after a later update", async () => {
+    await failNavigationWithChunkError("/artists");
+    location.reload.mockClear();
+    runAfterEachHooks();
+
+    await failNavigationWithChunkError("/albums");
+
+    expect(location.hash).toBe("/albums");
+    expect(location.reload).toHaveBeenCalledOnce();
+  });
+
+  it("keeps blocking reloads while no navigation completed", async () => {
+    await failNavigationWithChunkError("/artists");
+    location.reload.mockClear();
+    // only the presence of a failure matters to the hook
+    runAfterEachHooks({
+      type: NavigationFailureType.aborted,
+    } as unknown as NavigationFailure);
+
+    await failNavigationWithChunkError("/albums");
+
+    expect(location.reload).not.toHaveBeenCalled();
+  });
+});
+
 /**
  * Build a navigation target for a guard.
  *
@@ -475,6 +546,33 @@ function invokeGuard(
 ) {
   const next = (() => {}) as NavigationGuardNext;
   return Promise.resolve(guard.call(undefined, to, from, next));
+}
+
+/**
+ * Navigate to a route whose chunk is no longer on the server.
+ */
+async function failNavigationWithChunkError(fullPath: string) {
+  if (!mocks.router) {
+    throw new Error("The router module did not create a router");
+  }
+  const removeGuard = mocks.router.beforeEach(() => {
+    throw new Error(
+      "Failed to fetch dynamically imported module: /assets/index-Bq1xY2z3.js",
+    );
+  });
+  await mocks.router.push(fullPath).catch(() => {});
+  removeGuard();
+}
+
+/**
+ * Run the router's afterEach hooks the way a finished navigation does.
+ */
+function runAfterEachHooks(failure?: NavigationFailure) {
+  const to = resolveRoute("/artists");
+  const from = resolveRoute("/discover");
+  for (const hook of mocks.afterEachHooks) {
+    hook.call(undefined, to, from, failure);
+  }
 }
 
 /**

--- a/tests/plugins/router.test.ts
+++ b/tests/plugins/router.test.ts
@@ -575,6 +575,11 @@ function locationStub() {
       hash = value.startsWith("#") ? value : `#${value}`;
       steps.push("hash");
     },
+    // navigating by URL only moves the fragment, so a recovery doing that names
+    // itself here instead of failing on an empty step list
+    set href(value: string) {
+      steps.push("href");
+    },
     reload: () => {
       steps.push("reload");
     },


### PR DESCRIPTION
# What does this implement/fix?

After an update, opening a page whose code hadn't been loaded yet could leave you
stuck. The app is supposed to notice this, reload itself and continue to the page
you clicked, but that reload never happened: because the app uses `#` based
addresses, the address it sent the browser to only differed after the `#`, so the
browser just moved to that spot on the same outdated page. You had to refresh by
hand to get going again.

- Reload the page explicitly after pointing it at the page you clicked
- Keep the rest of the address intact, so Home Assistant ingress sessions no longer lose their parameters on such a reload
- Let the recovery run again after a later update instead of only once per browser session
- Cover the recovery with tests

**Related issue (if applicable):**

- n/a — spotted while reviewing #2483

**Related backend PR (if applicable):**

- n/a

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm lint:check` passes.
- [x] `pnpm test:run` passes, and tests have been added/updated where applicable.
- [x] `pnpm build` passes.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
