### PR TITLE
Player bar buttons stay highlighted while your mouse is still on them

### DIFF
--- a/src/composables/usePopoutTriggerHover.ts
+++ b/src/composables/usePopoutTriggerHover.ts
@@ -15,16 +15,18 @@ export function usePopoutTriggerHover(isOpen: () => boolean) {
   // genuinely on the button after clicking the popout shut, and a click brings
   // no fresh pointerenter that could say so.
   const suppressHover = ref(false);
-  let hoveredByMouse = false;
+  // a finger landing on the button announces itself with its own pointerenter,
+  // so this needs no clearing when the mouse leaves
+  let lastPointerWasMouse = false;
 
   watch(isOpen, (open) => {
-    if (!open) suppressHover.value = !hoveredByMouse;
+    if (!open) suppressHover.value = !lastPointerWasMouse;
   });
 
   return {
     suppressHover: readonly(suppressHover),
     onPointerEnter: (event: PointerEvent) => {
-      hoveredByMouse = event.pointerType === "mouse";
+      lastPointerWasMouse = event.pointerType === "mouse";
       suppressHover.value = false;
     },
   };

--- a/src/composables/usePopoutTriggerHover.ts
+++ b/src/composables/usePopoutTriggerHover.ts
@@ -3,25 +3,28 @@ import { readonly, ref, watch } from "vue";
 /**
  * Hover state for the button that opens a player bar popout.
  *
- * Bind `suppressHover` to the button's `data-suppress-hover` and `releaseHover`
- * to its `pointerenter`.
+ * Bind `suppressHover` to the button's `data-suppress-hover` and
+ * `onPointerEnter` to its `pointerenter`.
  *
  * @param isOpen - whether the popout the button owns is showing
  */
 export function usePopoutTriggerHover(isOpen: () => boolean) {
   // touch browsers keep hovering whatever was tapped last, so the tap that
   // opened the popout leaves the button reading as active once the popout is
-  // gone, however it was dismissed. Only the pointer arriving on the button
-  // again says anything about where it really is.
+  // gone, however it was dismissed. A mouse is the exception: it is still
+  // genuinely on the button after clicking the popout shut, and a click brings
+  // no fresh pointerenter that could say so.
   const suppressHover = ref(false);
+  let hoveredByMouse = false;
 
   watch(isOpen, (open) => {
-    if (!open) suppressHover.value = true;
+    if (!open) suppressHover.value = !hoveredByMouse;
   });
 
   return {
     suppressHover: readonly(suppressHover),
-    releaseHover: () => {
+    onPointerEnter: (event: PointerEvent) => {
+      hoveredByMouse = event.pointerType === "mouse";
       suppressHover.value = false;
     },
   };

--- a/src/layouts/default/PlayerOSD/PlayerBarGroupControl.vue
+++ b/src/layouts/default/PlayerOSD/PlayerBarGroupControl.vue
@@ -38,7 +38,7 @@
           :data-active="open"
           :data-suppress-hover="suppressHover"
           :aria-label="groupMembersLabel"
-          @pointerenter="releaseHover"
+          @pointerenter="onPointerEnter"
         >
           <span v-if="floating" class="inline-flex">
             <!-- matches the track menu beside it in the floating bar -->
@@ -130,7 +130,9 @@ withDefaults(
 );
 
 const open = ref(false);
-const { suppressHover, releaseHover } = usePopoutTriggerHover(() => open.value);
+const { suppressHover, onPointerEnter } = usePopoutTriggerHover(
+  () => open.value,
+);
 const filter = ref<PlayerGroupFilter>("all");
 const player = computed(() => store.activePlayer);
 const canEditGroup = computed(

--- a/src/layouts/default/PlayerOSD/PlayerBarPlayerButton.vue
+++ b/src/layouts/default/PlayerOSD/PlayerBarPlayerButton.vue
@@ -13,7 +13,7 @@
     :aria-expanded="store.showPlayersMenu"
     aria-haspopup="dialog"
     @click="togglePlayersMenu"
-    @pointerenter="releaseHover"
+    @pointerenter="onPointerEnter"
   >
     <span
       :class="navigation ? 'mobile-navigation-icon' : 'player-bar-action-icon'"
@@ -43,7 +43,7 @@ import { $t } from "@/plugins/i18n";
 import { store } from "@/plugins/store";
 import { computed } from "vue";
 
-const { suppressHover, releaseHover } = usePopoutTriggerHover(
+const { suppressHover, onPointerEnter } = usePopoutTriggerHover(
   () => store.showPlayersMenu,
 );
 const playerName = computed(() => store.activePlayer?.name || $t("no_player"));

--- a/src/layouts/default/PlayerOSD/PlayerBarVolumeControl.vue
+++ b/src/layouts/default/PlayerOSD/PlayerBarVolumeControl.vue
@@ -28,7 +28,7 @@
         :data-suppress-hover="suppressHover"
         :disabled="disabled"
         :aria-label="`${$t('audio_overlay_volume')}: ${displayVolume}%`"
-        @pointerenter="releaseHover"
+        @pointerenter="onPointerEnter"
         @wheel="adjustVolume"
       >
         <span class="player-bar-action-icon">
@@ -89,7 +89,9 @@ const props = defineProps<{
 }>();
 
 const open = ref(false);
-const { suppressHover, releaseHover } = usePopoutTriggerHover(() => open.value);
+const { suppressHover, onPointerEnter } = usePopoutTriggerHover(
+  () => open.value,
+);
 
 const grouped = computed(() => isPlayerGrouped(props.player));
 const displayVolume = computed(() =>

--- a/src/layouts/default/PlayerOSD/PlayerControlBtn/PlayerTrackMenu.vue
+++ b/src/layouts/default/PlayerOSD/PlayerControlBtn/PlayerTrackMenu.vue
@@ -16,7 +16,7 @@
         :data-suppress-hover="suppressHover"
         :title="$t('more_options')"
         :aria-label="$t('tooltip.more_options')"
-        @pointerenter="releaseHover"
+        @pointerenter="onPointerEnter"
       >
         <template v-if="compact">
           <EllipsisVertical :stroke-width="1.5" class="size-6" />
@@ -171,7 +171,7 @@ withDefaults(
 );
 
 const menuOpen = ref(false);
-const { suppressHover, releaseHover } = usePopoutTriggerHover(
+const { suppressHover, onPointerEnter } = usePopoutTriggerHover(
   () => menuOpen.value,
 );
 const playbackSpeedDialogOpen = ref(false);

--- a/tests/composables/usePopoutTriggerHover.test.ts
+++ b/tests/composables/usePopoutTriggerHover.test.ts
@@ -2,6 +2,9 @@ import { usePopoutTriggerHover } from "@/composables/usePopoutTriggerHover";
 import { describe, expect, it } from "vitest";
 import { nextTick, ref } from "vue";
 
+const arrives = (pointerType: string) =>
+  new PointerEvent("pointerenter", { pointerType });
+
 describe("usePopoutTriggerHover", () => {
   it("leaves the button alone while its popout opens", async () => {
     const open = ref(false);
@@ -17,8 +20,11 @@ describe("usePopoutTriggerHover", () => {
   // button would stay highlighted after a swipe or a tap outside dismissed it
   it("stops trusting the hover once the popout closes", async () => {
     const open = ref(true);
-    const { suppressHover } = usePopoutTriggerHover(() => open.value);
+    const { suppressHover, onPointerEnter } = usePopoutTriggerHover(
+      () => open.value,
+    );
 
+    onPointerEnter(arrives("touch"));
     open.value = false;
     await nextTick();
 
@@ -27,14 +33,49 @@ describe("usePopoutTriggerHover", () => {
 
   it("trusts it again once the pointer arrives on the button", async () => {
     const open = ref(true);
-    const { suppressHover, releaseHover } = usePopoutTriggerHover(
+    const { suppressHover, onPointerEnter } = usePopoutTriggerHover(
       () => open.value,
     );
 
     open.value = false;
     await nextTick();
-    releaseHover();
+    onPointerEnter(arrives("touch"));
 
     expect(suppressHover.value).toBe(false);
+  });
+
+  // clicking the popout shut fires no pointerenter of its own, so nothing later
+  // would tell the button the mouse never went anywhere
+  it("keeps trusting a mouse that is still on the button", async () => {
+    const open = ref(false);
+    const { suppressHover, onPointerEnter } = usePopoutTriggerHover(
+      () => open.value,
+    );
+
+    onPointerEnter(arrives("mouse"));
+    open.value = true;
+    await nextTick();
+    open.value = false;
+    await nextTick();
+
+    expect(suppressHover.value).toBe(false);
+  });
+
+  // on a touchscreen laptop both pointers reach the same button, and the finger
+  // that tapped it last is the one that left the hover behind
+  it("stops trusting a mouse hover a finger has landed on top of", async () => {
+    const open = ref(false);
+    const { suppressHover, onPointerEnter } = usePopoutTriggerHover(
+      () => open.value,
+    );
+
+    onPointerEnter(arrives("mouse"));
+    onPointerEnter(arrives("touch"));
+    open.value = true;
+    await nextTick();
+    open.value = false;
+    await nextTick();
+
+    expect(suppressHover.value).toBe(true);
   });
 });

--- a/tests/layouts/PlayerBarGroupControl.test.ts
+++ b/tests/layouts/PlayerBarGroupControl.test.ts
@@ -1,5 +1,5 @@
 import PlayerBarGroupControl from "@/layouts/default/PlayerOSD/PlayerBarGroupControl.vue";
-import { mount, type VueWrapper } from "@vue/test-utils";
+import { flushPromises, mount, type VueWrapper } from "@vue/test-utils";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const { groupSize } = vi.hoisted(() => ({ groupSize: { value: 3 } }));
@@ -56,6 +56,21 @@ describe("PlayerBarGroupControl", () => {
     expect(trigger.attributes("aria-expanded")).toBe("false");
     expect(trigger.attributes("aria-haspopup")).toBe("dialog");
     expect(trigger.attributes("aria-pressed")).toBeUndefined();
+  });
+
+  // the mouse that clicked the panel shut is still on the button, and no second
+  // pointerenter is coming to say so
+  it("keeps the hover color when a mouse clicks the panel closed", async () => {
+    const trigger = mountGroupButton();
+
+    await trigger.trigger("pointerenter", { pointerType: "mouse" });
+    await trigger.trigger("click", { button: 0, ctrlKey: false });
+    await flushPromises();
+    await trigger.trigger("click", { button: 0, ctrlKey: false });
+    await flushPromises();
+
+    expect(trigger.attributes("data-state")).toBe("closed");
+    expect(trigger.attributes("data-suppress-hover")).toBe("false");
   });
 
   it("keeps the visible member count in the accessible name", () => {

--- a/tests/layouts/PlayerBarPlayerButton.test.ts
+++ b/tests/layouts/PlayerBarPlayerButton.test.ts
@@ -63,6 +63,19 @@ describe("PlayerBarPlayerButton", () => {
     expect(button.attributes("aria-expanded")).toBe("true");
   });
 
+  // the mouse that clicked the panel shut is still on the button, and no second
+  // pointerenter is coming to say so
+  it("keeps the hover color when a mouse clicks the panel closed", async () => {
+    const button = mountPlayerButton();
+
+    await button.trigger("pointerenter", { pointerType: "mouse" });
+    await button.trigger("click");
+    await button.trigger("click");
+
+    expect(testStore.showPlayersMenu).toBe(false);
+    expect(button.attributes("data-suppress-hover")).toBe("false");
+  });
+
   it("names the empty selection when no player is active", () => {
     const button = mountPlayerButton();
 

--- a/tests/layouts/PlayerBarVolumeControl.test.ts
+++ b/tests/layouts/PlayerBarVolumeControl.test.ts
@@ -243,19 +243,36 @@ describe("PlayerBarVolumeControl", () => {
     expect(wrapper.get(".popover").attributes("data-open")).toBe("false");
   });
 
-  it("suppresses hover color after clicking the popover closed", async () => {
+  it("suppresses hover color after tapping the popover closed", async () => {
     const player = createPlayer();
     api.players = { [player.player_id]: player };
     const wrapper = mountControl(player);
     const trigger = wrapper.get("[data-player-volume-trigger]");
 
+    await trigger.trigger("pointerenter", { pointerType: "touch" });
     await trigger.trigger("click");
     await trigger.trigger("click");
 
     expect(trigger.attributes("data-active")).toBe("false");
     expect(trigger.attributes("data-suppress-hover")).toBe("true");
 
-    await trigger.trigger("pointerenter");
+    await trigger.trigger("pointerenter", { pointerType: "touch" });
+    expect(trigger.attributes("data-suppress-hover")).toBe("false");
+  });
+
+  // the mouse that clicked the popover shut is still on the button, and no
+  // second pointerenter is coming to say so
+  it("keeps the hover color when a mouse clicks the popover closed", async () => {
+    const player = createPlayer();
+    api.players = { [player.player_id]: player };
+    const wrapper = mountControl(player);
+    const trigger = wrapper.get("[data-player-volume-trigger]");
+
+    await trigger.trigger("pointerenter", { pointerType: "mouse" });
+    await trigger.trigger("click");
+    await trigger.trigger("click");
+
+    expect(trigger.attributes("data-active")).toBe("false");
     expect(trigger.attributes("data-suppress-hover")).toBe("false");
   });
 
@@ -267,6 +284,7 @@ describe("PlayerBarVolumeControl", () => {
     const wrapper = mountControl(player);
     const trigger = wrapper.get("[data-player-volume-trigger]");
 
+    await trigger.trigger("pointerenter", { pointerType: "touch" });
     await trigger.trigger("click");
     await wrapper.get(".player-volume-backdrop").trigger("click");
 

--- a/tests/layouts/PlayerTrackMenu.test.ts
+++ b/tests/layouts/PlayerTrackMenu.test.ts
@@ -99,6 +99,7 @@ describe("PlayerTrackMenu", () => {
 
     expect(trigger.attributes("data-suppress-hover")).toBe("false");
 
+    await trigger.trigger("pointerenter", { pointerType: "touch" });
     await wrapper.get("button.player-control-button").trigger("click");
     expect(wrapper.get(".dropdown").attributes("data-open")).toBe("true");
     expect(trigger.attributes("data-suppress-hover")).toBe("false");
@@ -107,7 +108,21 @@ describe("PlayerTrackMenu", () => {
     expect(wrapper.get(".dropdown").attributes("data-open")).toBe("false");
     expect(trigger.attributes("data-suppress-hover")).toBe("true");
 
-    await trigger.trigger("pointerenter");
+    await trigger.trigger("pointerenter", { pointerType: "touch" });
+    expect(trigger.attributes("data-suppress-hover")).toBe("false");
+  });
+
+  // the mouse that clicked the menu shut is still on the button, and no second
+  // pointerenter is coming to say so
+  it("keeps the hover color when a mouse clicks the menu closed", async () => {
+    const wrapper = mountMenu();
+    const trigger = wrapper.get("button.player-control-button");
+
+    await trigger.trigger("pointerenter", { pointerType: "mouse" });
+    await trigger.trigger("click");
+    await trigger.trigger("click");
+
+    expect(wrapper.get(".dropdown").attributes("data-open")).toBe("false");
     expect(trigger.attributes("data-suppress-hover")).toBe("false");
   });
 
@@ -117,6 +132,7 @@ describe("PlayerTrackMenu", () => {
     const wrapper = mountMenu();
     const trigger = wrapper.get("button.player-control-button");
 
+    await trigger.trigger("pointerenter", { pointerType: "touch" });
     await trigger.trigger("click");
     await wrapper.get(".dropdown-dismiss").trigger("click");
 
@@ -145,6 +161,7 @@ describe("PlayerTrackMenu", () => {
 
     expect(trigger.attributes("data-suppress-hover")).toBe("false");
 
+    await trigger.trigger("pointerenter", { pointerType: "touch" });
     await trigger.trigger("click", { button: 0, ctrlKey: false });
     await flushPromises();
     await trigger.trigger("click", { button: 0, ctrlKey: false });


### PR DESCRIPTION
# What does this implement/fix?

Clicking a player bar button a second time to close its popout (volume, group, player select, the ⋯ menu) left that button looking un-hovered — muted grey, no highlight — while the mouse was still sitting right on it. It only lit up again after moving the pointer away and back.

The dimming is deliberate: touchscreens keep a button "hovered" after a tap, so a tapped button would otherwise stay lit once its popout is gone. That is right for a finger, but a mouse really is still on the button, and a click brings no pointer event that would undo the dimming. The button now looks at which kind of pointer is on it, and only dims when that pointer was not a mouse.

**Related issue (if applicable):**

- follow-up to #2482 and #2487

## Changes

- A player bar popout button keeps its highlight when the mouse closes the popout and never leaves the button.
- Touch is unchanged: a tapped button still settles back to its resting look once the popout is dismissed, however it was dismissed.
- On a device with both a mouse and a touchscreen, whichever pointer last landed on the button decides.
- This also shifts the desktop side of #2482: the button no longer drops to its muted colour while the mouse is on it.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm lint:check` passes.
- [x] `pnpm test:run` passes, and tests have been added/updated where applicable.
- [x] `pnpm build` passes.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
