### PR TITLE
Use the whole screen when running inside Home Assistant

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -13,6 +13,14 @@
   <!-- Main app (when authenticated and service worker ready for remote) -->
   <router-view v-else-if="showMainApp" />
 
+  <!-- Kiosk mode leaves Home Assistant no chrome of its own, and this screen
+       carries none of ours: a server that is away or restarting would strand
+       the panel on a spinner with nowhere to go. -->
+  <HomeAssistantMenuButton
+    v-if="showLogin && haState.kioskModeEnabled"
+    class="ha-escape-button"
+  />
+
   <PlayerBrowserMediaControls
     v-if="
       webPlayer.audioSource === WebPlayerMode.CONTROLS_ONLY &&
@@ -33,6 +41,7 @@
 </template>
 
 <script setup lang="ts">
+import HomeAssistantMenuButton from "@/components/HomeAssistantMenuButton.vue";
 import { Toaster } from "@/components/ui/sonner";
 import { initGlobalShortcutsSync } from "@/composables/useShortcuts";
 import { useThemePreference } from "@/composables/useThemePreference";
@@ -566,3 +575,14 @@ function getCurrentAuthConnectionIdentity() {
     : createLocalConnectionIdentity(api.baseUrl);
 }
 </script>
+
+<style scoped>
+/* Sits where Home Assistant's own menu button would be. Pinned to the viewport,
+   so it owns the device insets rather than inheriting a parent's padding. */
+.ha-escape-button {
+  position: fixed;
+  top: calc(var(--device-inset-top, 0px) + 0.75rem);
+  left: calc(var(--device-inset-left, 0px) + 0.75rem);
+  z-index: 1000;
+}
+</style>

--- a/src/App.vue
+++ b/src/App.vue
@@ -61,6 +61,7 @@ import PlayerBrowserMediaControls from "./layouts/default/PlayerOSD/PlayerBrowse
 import { pruneStaleProviderFilters } from "./composables/userPreferences";
 import { initializeCompanionIntegration } from "./plugins/companion";
 import {
+  getKioskModePreference,
   haState,
   subscribeToHAProperties,
   unsubscribeFromHAProperties,
@@ -274,11 +275,15 @@ const completeInitialization = async () => {
 
   // Home Assistant pads its ingress iframe for the device safe area, leaving a
   // strip of its own background we cannot reach from in here. Take that padding
-  // over so the app runs to the edge of the screen like it does anywhere else.
+  // over so the app runs to the edge of the screen like it does anywhere else,
+  // and ask it to drop its own header and menu while we are at it.
   // Ask before anything else is awaited, so the app lays itself out once.
   // Reconnecting runs this again while the subscription is still standing.
   if (store.isIngressSession && !haState.isSubscribed) {
-    subscribeToHAProperties({ handleSafeArea: true });
+    subscribeToHAProperties({
+      handleSafeArea: true,
+      kioskMode: getKioskModePreference(),
+    });
   }
 
   const userInfo = await api.getCurrentUserInfo();

--- a/src/components/HomeAssistantMenuButton.vue
+++ b/src/components/HomeAssistantMenuButton.vue
@@ -1,0 +1,40 @@
+<script setup lang="ts">
+import { Button } from "@/components/ui/button";
+import { toggleHAMenu } from "@/plugins/homeassistant";
+import type { HTMLAttributes } from "vue";
+import { useI18n } from "vue-i18n";
+
+const props = defineProps<{
+  /** Render icon-only, for hosts too narrow to carry the label. */
+  collapsed?: boolean;
+  class?: HTMLAttributes["class"];
+}>();
+
+const emit = defineEmits<{ click: [] }>();
+
+const { t } = useI18n();
+
+const handleClick = () => {
+  emit("click");
+  toggleHAMenu();
+};
+</script>
+
+<template>
+  <Button
+    variant="outline"
+    :size="props.collapsed ? 'icon' : 'default'"
+    :class="props.class"
+    :aria-label="t('home_assistant_menu')"
+    @click="handleClick"
+  >
+    <img
+      src="@/assets/home-assistant-logo.svg"
+      alt=""
+      class="size-4 shrink-0"
+    />
+    <span v-if="!props.collapsed" class="truncate">
+      {{ t("home_assistant_menu") }}
+    </span>
+  </Button>
+</template>

--- a/src/components/navigation/AppSidebar.vue
+++ b/src/components/navigation/AppSidebar.vue
@@ -12,11 +12,13 @@ import {
   useSidebar,
 } from "@/components/ui/sidebar";
 import { eventbus } from "@/plugins/eventbus";
+import { haState } from "@/plugins/homeassistant";
 import { store } from "@/plugins/store";
 import { Check } from "@lucide/vue";
 import { computed, onMounted, onUnmounted, watch } from "vue";
 import { useI18n } from "vue-i18n";
 import { useRouter } from "vue-router";
+import NavHomeAssistant from "./NavHomeAssistant.vue";
 import NavMobile from "./NavMobile.vue";
 import {
   getMenuItems,
@@ -177,6 +179,9 @@ onUnmounted(() => {
         <Check class="size-4" />
         {{ t("menu_edit_disable") }}
       </Button>
+      <!-- Kiosk mode leaves no Home Assistant chrome on screen, so this is the
+           only way back to it. -->
+      <NavHomeAssistant v-if="haState.kioskModeEnabled" />
       <NavMobile v-if="isMobile" />
       <SidebarTrigger v-else />
     </SidebarFooter>
@@ -219,27 +224,6 @@ onUnmounted(() => {
 .menu-edit-done {
   width: 100%;
   border-radius: 999px;
-}
-
-.ha-header-button {
-  border: none;
-  background: transparent;
-  padding: 0;
-  margin-right: 4px;
-  cursor: pointer;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-}
-
-.ha-header-button:hover {
-  opacity: 0.9;
-}
-
-.ha-logo-icon {
-  width: 22px;
-  height: 22px;
-  display: block;
 }
 
 :deep([data-sidebar="group"]) {

--- a/src/components/navigation/NavHomeAssistant.vue
+++ b/src/components/navigation/NavHomeAssistant.vue
@@ -1,12 +1,11 @@
 <script setup lang="ts">
-import { Button } from "@/components/ui/button";
+import HomeAssistantMenuButton from "@/components/HomeAssistantMenuButton.vue";
+import { useSidebar } from "@/components/ui/sidebar";
 import {
   Tooltip,
   TooltipContent,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
-import { useSidebar } from "@/components/ui/sidebar";
-import { toggleHAMenu } from "@/plugins/homeassistant";
 import { computed } from "vue";
 import { useI18n } from "vue-i18n";
 
@@ -18,29 +17,17 @@ const isCollapsed = computed(() => state.value === "collapsed");
 const handleClick = () => {
   // Both menus over the same screen would only cover each other up.
   if (isMobile.value) setOpenMobile(false);
-  toggleHAMenu();
 };
 </script>
 
 <template>
   <Tooltip>
     <TooltipTrigger as-child>
-      <Button
-        variant="outline"
-        :size="isCollapsed ? 'icon' : 'default'"
+      <HomeAssistantMenuButton
+        :collapsed="isCollapsed"
         :class="isCollapsed ? 'mx-auto' : 'w-full justify-start'"
-        :aria-label="t('home_assistant_menu')"
         @click="handleClick"
-      >
-        <img
-          src="@/assets/home-assistant-logo.svg"
-          alt=""
-          class="size-4 shrink-0"
-        />
-        <span v-if="!isCollapsed" class="truncate">
-          {{ t("home_assistant_menu") }}
-        </span>
-      </Button>
+      />
     </TooltipTrigger>
     <TooltipContent side="right" align="center" :hidden="!isCollapsed">
       {{ t("home_assistant_menu") }}

--- a/src/components/navigation/NavHomeAssistant.vue
+++ b/src/components/navigation/NavHomeAssistant.vue
@@ -1,0 +1,49 @@
+<script setup lang="ts">
+import { Button } from "@/components/ui/button";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { useSidebar } from "@/components/ui/sidebar";
+import { toggleHAMenu } from "@/plugins/homeassistant";
+import { computed } from "vue";
+import { useI18n } from "vue-i18n";
+
+const { t } = useI18n();
+const { state, isMobile, setOpenMobile } = useSidebar();
+
+const isCollapsed = computed(() => state.value === "collapsed");
+
+const handleClick = () => {
+  // Both menus over the same screen would only cover each other up.
+  if (isMobile.value) setOpenMobile(false);
+  toggleHAMenu();
+};
+</script>
+
+<template>
+  <Tooltip>
+    <TooltipTrigger as-child>
+      <Button
+        variant="outline"
+        :size="isCollapsed ? 'icon' : 'default'"
+        :class="isCollapsed ? 'mx-auto' : 'w-full justify-start'"
+        :aria-label="t('home_assistant_menu')"
+        @click="handleClick"
+      >
+        <img
+          src="@/assets/home-assistant-logo.svg"
+          alt=""
+          class="size-4 shrink-0"
+        />
+        <span v-if="!isCollapsed" class="truncate">
+          {{ t("home_assistant_menu") }}
+        </span>
+      </Button>
+    </TooltipTrigger>
+    <TooltipContent side="right" align="center" :hidden="!isCollapsed">
+      {{ t("home_assistant_menu") }}
+    </TooltipContent>
+  </Tooltip>
+</template>

--- a/src/components/navigation/NavMobile.vue
+++ b/src/components/navigation/NavMobile.vue
@@ -1,41 +1,7 @@
 <template>
-  <!-- HA BUTTON COMMENTED OUT -->
-  <!-- <Button
-    v-if="store.isIngressSession && isMobile"
-    size="sm"
-    variant="outline"
-    class="w-full justify-between"
-    title="HA Menu"
-    @click.stop="handleHAMenuToggle"
-  >
-    <span class="flex items-center gap-2">
-      <img
-        src="@/assets/home-assistant-logo.svg"
-        alt="Home Assistant"
-        class="h-4 w-4 shrink-0"
-      />
-      <span>HA Menu</span>
-    </span>
-    <ArrowLeftToLine class="ha-menu-arrow size-4 shrink-0" />
-  </Button> -->
   <NavUser />
 </template>
 
 <script setup lang="ts">
-// import { Button } from "@/components/ui/button";
-// import { useSidebar } from "@/components/ui/sidebar";
-// import { toggleHAMenu } from "@/plugins/homeassistant";
-// import { store } from "@/plugins/store";
-// import { ArrowLeftToLine } from "@lucide/vue";
 import NavUser from "./NavUser.vue";
-
-// const { isMobile, setOpenMobile } = useSidebar();
-
-// const handleHAMenuToggle = () => {
-//   // Close MA sidebar on mobile when opening HA sidebar
-//   if (isMobile.value) {
-//     setOpenMobile(false);
-//   }
-//   toggleHAMenu();
-// };
 </script>

--- a/src/components/navigation/NavUser.vue
+++ b/src/components/navigation/NavUser.vue
@@ -128,9 +128,3 @@ const handleLogout = () => {
     </SidebarMenuItem>
   </SidebarMenu>
 </template>
-
-<style scoped>
-.ha-menu-arrow {
-  color: rgb(var(--v-theme-primary, 3, 169, 244)) !important;
-}
-</style>

--- a/src/components/ui/sidebar/SidebarTrigger.vue
+++ b/src/components/ui/sidebar/SidebarTrigger.vue
@@ -6,8 +6,6 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
-// import { toggleHAMenu } from "@/plugins/homeassistant";
-// import { store } from "@/plugins/store";
 import { PanelLeft } from "@lucide/vue";
 import { computed, type HTMLAttributes } from "vue";
 import { useSidebar } from "./utils";
@@ -19,15 +17,6 @@ const props = defineProps<{
 const { toggleSidebar, state } = useSidebar();
 
 const isCollapsed = computed(() => state.value === "collapsed");
-
-// const showHaButton = computed(() => store.isIngressSession);
-
-// const handleHAMenuToggle = () => {
-//   if (isMobile.value) {
-//     setOpenMobile(false);
-//   }
-//   toggleHAMenu();
-// };
 </script>
 
 <template>
@@ -45,43 +34,6 @@ const isCollapsed = computed(() => state.value === "collapsed");
         isCollapsed ? 'flex-col' : 'flex-row',
       ]"
     >
-      <!-- HA BUTTON COMMENTED OUT -->
-      <!-- <Tooltip v-if="showHaButton">
-        <TooltipTrigger as-child>
-          <Button
-            v-if="showHaButton"
-            variant="outline"
-            :size="isCollapsed ? 'icon' : 'default'"
-            :class="[
-              isCollapsed && 'order-first',
-              !isCollapsed && 'min-w-0 flex-1',
-            ]"
-            @click="handleHAMenuToggle"
-          >
-            <template v-if="isCollapsed">
-              <img
-                src="@/assets/home-assistant-logo.svg"
-                alt="Home Assistant"
-                class="h-4 w-4 shrink-0"
-              />
-            </template>
-            <template v-else>
-              <span class="flex min-w-0 items-center gap-2">
-                <img
-                  src="@/assets/home-assistant-logo.svg"
-                  alt="Home Assistant"
-                  class="h-4 w-4 shrink-0"
-                />
-                <span class="min-w-0">HA Menu</span>
-              </span>
-              <ArrowLeftToLine class="ha-menu-arrow ml-auto size-4 shrink-0" />
-            </template>
-          </Button>
-        </TooltipTrigger>
-        <TooltipContent side="right" align="center" :hidden="!isCollapsed">
-          HA Menu
-        </TooltipContent>
-      </Tooltip> -->
       <Tooltip>
         <TooltipTrigger as-child>
           <Button
@@ -145,10 +97,6 @@ const isCollapsed = computed(() => state.value === "collapsed");
   height: 2rem !important;
 }
 
-.ha-menu-arrow {
-  color: rgb(var(--v-theme-primary, 3, 169, 244)) !important;
-}
-
 .trigger-container.flex-col {
   flex-direction: column;
   justify-content: center;
@@ -156,12 +104,5 @@ const isCollapsed = computed(() => state.value === "collapsed");
 
 .trigger-container.flex-row {
   flex-direction: row;
-}
-
-.ha-logo-icon {
-  width: 16px;
-  height: 16px;
-  display: block;
-  margin: auto;
 }
 </style>

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -7,4 +7,5 @@ export const DEVICE_SETTING_KEYS = new Set([
   "enable_browser_controls",
   "force_mobile_layout",
   "mobile_sidebar_side",
+  "ha_kiosk_mode",
 ]);

--- a/src/helpers/device_settings.ts
+++ b/src/helpers/device_settings.ts
@@ -5,6 +5,7 @@
 const STORAGE_KEY_PREFIX = "frontend.settings.";
 
 export const MOBILE_SIDEBAR_SIDE = "mobile_sidebar_side";
+export const HA_KIOSK_MODE = "ha_kiosk_mode";
 
 /**
  * Read a per-device setting, or null when it is unset.

--- a/src/plugins/homeassistant.ts
+++ b/src/plugins/homeassistant.ts
@@ -1,3 +1,8 @@
+import {
+  HA_KIOSK_MODE,
+  readDeviceSetting,
+  subscribeToDeviceSetting,
+} from "@/helpers/device_settings";
 import { reactive, readonly } from "vue";
 import type { Router } from "vue-router";
 
@@ -42,6 +47,7 @@ const SAFE_AREA_EDGES = ["top", "right", "bottom", "left"] as const;
 let messageHandler: ((event: MessageEvent) => void) | null = null;
 let routerInstance: Router | null = null;
 let isNavigatingFromHA = false;
+let reportedInsets: Partial<HASafeAreaInsets> | null = null;
 
 /**
  * The part of the reported safe area Music Assistant is left to cover.
@@ -53,17 +59,22 @@ let isNavigatingFromHA = false;
  */
 function ownedInsets(
   insets: Partial<HASafeAreaInsets>,
-  narrow: boolean,
 ): Partial<HASafeAreaInsets> {
-  return narrow ? { ...insets, top: "" } : insets;
+  const headerShown = state.properties.narrow && !state.kioskModeEnabled;
+
+  return headerShown ? { ...insets, top: "" } : insets;
 }
 
 /**
  * Apply the safe area Home Assistant reports to the device inset tokens.
  *
- * Edges Home Assistant reports nothing for are handed back to the stylesheet.
+ * Edges Home Assistant reports nothing for are handed back to the stylesheet,
+ * as is the whole safe area while Home Assistant is padding the frame itself.
  */
-function applySafeAreaInsets(insets: Partial<HASafeAreaInsets>): void {
+function applySafeAreaInsets(): void {
+  const insets =
+    state.safeAreaEnabled && reportedInsets ? ownedInsets(reportedInsets) : {};
+
   for (const edge of SAFE_AREA_EDGES) {
     const property = `--device-inset-${edge}`;
     // Setting these inline is what lifts them above the zeroed tokens an
@@ -89,12 +100,12 @@ function handleMessage(event: MessageEvent) {
     state.properties.route = event.data.route ?? null;
 
     // Home Assistant reports the insets whether or not we asked for them, and
-    // only stops padding the iframe itself once we did.
-    if (state.safeAreaEnabled && event.data.safeAreaInsets) {
-      applySafeAreaInsets(
-        ownedInsets(event.data.safeAreaInsets, state.properties.narrow),
-      );
+    // only stops padding the iframe itself once we did. Keep the last ones it
+    // sent: a later update may leave them out while still moving the header.
+    if (event.data.safeAreaInsets) {
+      reportedInsets = event.data.safeAreaInsets;
     }
+    applySafeAreaInsets();
 
     if (
       state.routeSyncEnabled &&
@@ -120,9 +131,9 @@ function handleMessage(event: MessageEvent) {
 
 /**
  * Subscribe to Home Assistant properties updates.
- * Optionally enables kiosk mode which hides HA's toolbar.
  *
- * @param options.kioskMode - If true, requests HA to hide its toolbar
+ * @param options.kioskMode - If true, asks Home Assistant to drop the header
+ *   and menu it draws around the frame and leave the app the whole screen
  * @param options.handleSafeArea - If true, takes the safe area padding HA puts
  *   around the ingress iframe over into the device inset tokens
  * @param options.router - Vue router instance for route synchronization
@@ -187,79 +198,56 @@ export function unsubscribeFromHAProperties(): void {
     "*",
   );
 
-  // Home Assistant pads the iframe again the moment we unsubscribe, so hand the
-  // safe area back rather than reserving it twice.
-  applySafeAreaInsets({});
-
   state.isSubscribed = false;
   state.kioskModeEnabled = false;
   state.routeSyncEnabled = false;
   state.safeAreaEnabled = false;
   routerInstance = null;
+  reportedInsets = null;
+
+  // Home Assistant pads the iframe again the moment we unsubscribe, so hand the
+  // safe area back rather than reserving it twice.
+  applySafeAreaInsets();
 
   console.debug("[HA Integration] Unsubscribed from HA properties");
 }
 
-let storedRouter: Router | null = null;
-
-const KIOSK_PREF_KEY = "ha.kioskModeEnabled";
-
+/**
+ * Whether Home Assistant should hand its whole screen estate to Music Assistant.
+ *
+ * On unless it was turned off for this device in the frontend settings.
+ */
 export function getKioskModePreference(): boolean {
-  const stored = localStorage.getItem(KIOSK_PREF_KEY);
-
-  return stored === null ? true : stored === "true";
-}
-
-function saveKioskModePreference(enabled: boolean): void {
-  localStorage.setItem(KIOSK_PREF_KEY, String(enabled));
+  return readDeviceSetting(HA_KIOSK_MODE) !== "false";
 }
 
 /**
- * Show the Home Assistant menu by disabling kiosk mode.
- * This unsubscribes from properties (which disables kiosk mode).
+ * Re-subscribe so a changed kiosk mode preference reaches Home Assistant.
+ *
+ * A subscription can only ever turn kiosk mode on, so leaving it takes an
+ * unsubscribe. Everything else the subscription carries has to come along:
+ * dropping the safe area handover would leave Home Assistant padding the frame
+ * for the rest of the visit.
  */
-export function showHAMenu(): void {
-  if (routerInstance) {
-    storedRouter = routerInstance;
+function applyKioskModePreference(): void {
+  const kioskMode = getKioskModePreference();
+
+  if (!state.isSubscribed || kioskMode === state.kioskModeEnabled) {
+    return;
   }
 
-  saveKioskModePreference(false);
+  const handleSafeArea = state.safeAreaEnabled;
+  const router = routerInstance ?? undefined;
+
   unsubscribeFromHAProperties();
+  subscribeToHAProperties({ kioskMode, handleSafeArea, router });
 }
 
-/**
- * Hide the Home Assistant menu by enabling kiosk mode.
- * This re-subscribes with kioskMode: true.
- */
-export function hideHAMenu(): void {
-  saveKioskModePreference(true);
-
-  if (routerInstance) {
-    storedRouter = routerInstance;
-  }
-
-  if (state.isSubscribed) {
-    unsubscribeFromHAProperties();
-  }
-
-  subscribeToHAProperties({
-    kioskMode: true,
-    router: storedRouter || undefined,
-  });
-}
-
-/**
- * Toggle the Home Assistant menu visibility.
- * When visible (kiosk mode off), hides it.
- * When hidden (kiosk mode on), shows it.
- */
-export function toggleHAMenuVisibility(): void {
-  if (state.kioskModeEnabled) {
-    showHAMenu();
-  } else {
-    hideHAMenu();
-  }
-}
+// Home Assistant keeps kiosk mode up across a reload of this frame, so the
+// preference has to be acted on where it is written rather than on the next
+// startup, which would find Home Assistant already in kiosk mode and leave it
+// there.
+subscribeToDeviceSetting(HA_KIOSK_MODE, applyKioskModePreference);
 
 /**
  * Notify Home Assistant of a route change in Music Assistant.
@@ -286,8 +274,10 @@ export function notifyHARouteChange(path: string): void {
 }
 
 /**
- * Toggle the Home Assistant sidebar menu.
- * Useful when in kiosk mode to let users access HA navigation.
+ * Open or close the Home Assistant sidebar over the app.
+ *
+ * Home Assistant opens it as an overlay while kiosk mode is on, which is what
+ * makes this the way back out of a full screen Music Assistant.
  */
 export function toggleHAMenu(): void {
   window.parent.postMessage(

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -613,6 +613,10 @@
                 "right": "Right"
             }
         },
+        "ha_kiosk_mode": {
+            "label": "Use the full screen in Home Assistant",
+            "description": "Hide the Home Assistant header and sidebar so Music Assistant gets the whole screen. The Home Assistant button in the menu brings them back."
+        },
         "add_group_player_desc": "Create a permanent player group with {0} players. When you play to this Player Group, the member players will be automatically synchronized.",
         "add_group_player_desc_sync": "Create a permanent SyncGroup with players that are sync-compatible. When you play to this Player Group, the member players will be automatically synchronized.",
         "genre_management": "Genre Management",
@@ -2280,5 +2284,6 @@
     },
     "searching": "Searching...",
     "menu": "Menu",
+    "home_assistant_menu": "Home Assistant",
     "main_navigation": "Main"
 }

--- a/src/views/settings/FrontendConfig.vue
+++ b/src/views/settings/FrontendConfig.vue
@@ -55,6 +55,7 @@ import {
 } from "@/plugins/api/interfaces";
 import { companionMode } from "@/plugins/companion";
 import { eventbus } from "@/plugins/eventbus";
+import { getKioskModePreference } from "@/plugins/homeassistant";
 import { $t, i18n } from "@/plugins/i18n";
 import { store } from "@/plugins/store";
 import EditConfig from "./EditConfig.vue";
@@ -176,6 +177,20 @@ onMounted(() => {
       multi_value: false,
       category: "display_settings",
       value: readDeviceSetting(MOBILE_SIDEBAR_SIDE) || "left",
+    },
+    {
+      // Only Home Assistant can give up its own chrome, so this is meaningless
+      // anywhere else.
+      key: "ha_kiosk_mode",
+      type: ConfigEntryType.BOOLEAN,
+      label: "ha_kiosk_mode",
+      default_value: true,
+      required: false,
+      options: [],
+      multi_value: false,
+      category: "display_settings",
+      hidden: !store.isIngressSession,
+      value: getKioskModePreference(),
     },
   ];
 

--- a/tests/App.test.ts
+++ b/tests/App.test.ts
@@ -94,7 +94,7 @@ const {
         t: (key: string) => key,
       },
     },
-    haStateMock: { isSubscribed: false },
+    haStateMock: { isSubscribed: false, kioskModeEnabled: false },
     mockInitializeCompanionIntegration: vi.fn(),
     mockInitializeWebPlayerModeSync: vi.fn(),
     mockSubscribeToHAProperties: vi.fn(),
@@ -330,6 +330,7 @@ describe("App initialization", () => {
     mockProxySetTransport.mockResolvedValue(undefined);
     mockPruneStaleProviderFilters.mockResolvedValue(undefined);
     haStateMock.isSubscribed = false;
+    haStateMock.kioskModeEnabled = false;
     mockGetKioskModePreference.mockReturnValue(true);
     storeMock.currentUser = undefined;
     storeMock.enabledPlugins = new Set<string>();
@@ -697,6 +698,30 @@ describe("App initialization", () => {
       handleSafeArea: true,
       kioskMode: false,
     });
+  });
+
+  it("keeps a way back to Home Assistant while the server is away", async () => {
+    haStateMock.kioskModeEnabled = true;
+    wrapper = await mountApp();
+    expect(wrapper.find(".ha-escape-button").exists()).toBe(false);
+
+    // This screen replaces the whole app, sidebar and all, and kiosk mode has
+    // left Home Assistant nothing on screen either: without this the panel is a
+    // spinner with nowhere to go for as long as the server stays away.
+    apiMock.state.value = "reconnecting";
+    await nextTick();
+
+    expect(wrapper.find(".ha-escape-button").exists()).toBe(true);
+  });
+
+  it("leaves the escape button off while Home Assistant shows its own menu", async () => {
+    haStateMock.kioskModeEnabled = false;
+    wrapper = await mountApp();
+
+    apiMock.state.value = "reconnecting";
+    await nextTick();
+
+    expect(wrapper.find(".ha-escape-button").exists()).toBe(false);
   });
 
   it("leaves the safe area to the host outside an ingress session", async () => {

--- a/tests/App.test.ts
+++ b/tests/App.test.ts
@@ -21,6 +21,7 @@ const {
   mockInitializeCompanionIntegration,
   mockInitializeWebPlayerModeSync,
   mockSubscribeToHAProperties,
+  mockGetKioskModePreference,
   mockProxyEnsureReady,
   mockProxySetTransport,
   mockPruneStaleProviderFilters,
@@ -97,6 +98,7 @@ const {
     mockInitializeCompanionIntegration: vi.fn(),
     mockInitializeWebPlayerModeSync: vi.fn(),
     mockSubscribeToHAProperties: vi.fn(),
+    mockGetKioskModePreference: vi.fn(() => true),
     mockProxyEnsureReady: vi.fn(),
     mockProxySetTransport: vi.fn(),
     mockPruneStaleProviderFilters: vi.fn(),
@@ -194,6 +196,7 @@ vi.mock("@/plugins/homeassistant", () => ({
   haState: haStateMock,
   subscribeToHAProperties: mockSubscribeToHAProperties,
   unsubscribeFromHAProperties: vi.fn(),
+  getKioskModePreference: mockGetKioskModePreference,
 }));
 
 vi.mock("@/plugins/remote", () => ({
@@ -327,6 +330,7 @@ describe("App initialization", () => {
     mockProxySetTransport.mockResolvedValue(undefined);
     mockPruneStaleProviderFilters.mockResolvedValue(undefined);
     haStateMock.isSubscribed = false;
+    mockGetKioskModePreference.mockReturnValue(true);
     storeMock.currentUser = undefined;
     storeMock.enabledPlugins = new Set<string>();
     storeMock.isIngressSession = false;
@@ -679,6 +683,19 @@ describe("App initialization", () => {
 
     expect(mockSubscribeToHAProperties).toHaveBeenCalledWith({
       handleSafeArea: true,
+      kioskMode: true,
+    });
+  });
+
+  it("leaves the Home Assistant chrome up when kiosk mode is turned off", async () => {
+    storeMock.isIngressSession = true;
+    mockGetKioskModePreference.mockReturnValue(false);
+
+    wrapper = await mountApp();
+
+    expect(mockSubscribeToHAProperties).toHaveBeenCalledWith({
+      handleSafeArea: true,
+      kioskMode: false,
     });
   });
 

--- a/tests/components/AppSidebarHomeAssistant.test.ts
+++ b/tests/components/AppSidebarHomeAssistant.test.ts
@@ -1,0 +1,85 @@
+import AppSidebar from "@/components/navigation/AppSidebar.vue";
+import { enableAutoUnmount, shallowMount } from "@vue/test-utils";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const { haStateMock } = vi.hoisted(() => ({
+  haStateMock: { kioskModeEnabled: false },
+}));
+
+vi.mock("@/plugins/homeassistant", () => ({ haState: haStateMock }));
+
+vi.mock("@/plugins/eventbus", () => ({
+  eventbus: { on: vi.fn(), off: vi.fn(), emit: vi.fn() },
+}));
+
+vi.mock("@/plugins/store", async () => {
+  const { reactive } = await vi.importActual<typeof import("vue")>("vue");
+  return { store: reactive({ navMenuEditMode: false, mobileLayout: false }) };
+});
+
+vi.mock("@/components/navigation/utils/getMenuItems", () => ({
+  getMenuItems: () => [],
+  resolveMenuConfig: () => ({ sections: {} }),
+}));
+
+// The sidebar shell drags the api and i18n plugins in behind it; only the slots
+// and the collapsed/mobile state matter here.
+vi.mock("@/components/ui/sidebar", () => {
+  const slotHost = { template: "<div><slot /></div>" };
+  return {
+    Sidebar: slotHost,
+    SidebarContent: slotHost,
+    SidebarFooter: slotHost,
+    SidebarHeader: slotHost,
+    SidebarMenu: slotHost,
+    SidebarTrigger: slotHost,
+    useSidebar: () => ({
+      toggleSidebar: vi.fn(),
+      setOpen: vi.fn(),
+      state: { value: "expanded" },
+      isMobile: { value: false },
+    }),
+  };
+});
+
+// These reach for the api plugin on import, which the vue-i18n mock cannot serve.
+vi.mock("@/components/navigation/NavMain.vue", () => ({
+  default: { template: "<div />" },
+}));
+vi.mock("@/components/navigation/NavShortcuts.vue", () => ({
+  default: { template: "<div />" },
+}));
+vi.mock("@/components/navigation/NavMobile.vue", () => ({
+  default: { template: "<div />" },
+}));
+
+vi.mock("vue-router", () => ({ useRouter: () => ({ push: vi.fn() }) }));
+
+vi.mock("vue-i18n", () => ({ useI18n: () => ({ t: (key: string) => key }) }));
+
+enableAutoUnmount(afterEach);
+
+afterEach(() => {
+  haStateMock.kioskModeEnabled = false;
+});
+
+function hasHomeAssistantButton() {
+  const wrapper = shallowMount(AppSidebar, {
+    global: { renderStubDefaultSlot: true },
+  });
+  return wrapper.find("nav-home-assistant-stub").exists();
+}
+
+describe("AppSidebar Home Assistant button", () => {
+  it("offers the way back while kiosk mode holds the whole screen", () => {
+    haStateMock.kioskModeEnabled = true;
+
+    expect(hasHomeAssistantButton()).toBe(true);
+  });
+
+  it("leaves it out while Home Assistant shows its own menu", () => {
+    // Home Assistant is already reachable, and off kiosk mode this same button
+    // would dock or undock its sidebar rather than open it.
+    expect(hasHomeAssistantButton()).toBe(false);
+  });
+});

--- a/tests/components/NavHomeAssistant.test.ts
+++ b/tests/components/NavHomeAssistant.test.ts
@@ -1,0 +1,89 @@
+import NavHomeAssistant from "@/components/navigation/NavHomeAssistant.vue";
+import { enableAutoUnmount, mount } from "@vue/test-utils";
+import { TooltipProvider } from "reka-ui";
+import { h } from "vue";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const { mockToggleHAMenu, mockSetOpenMobile, sidebar } = vi.hoisted(() => ({
+  mockToggleHAMenu: vi.fn(),
+  mockSetOpenMobile: vi.fn(),
+  sidebar: { state: "expanded", isMobile: false },
+}));
+
+vi.mock("@/plugins/homeassistant", () => ({
+  toggleHAMenu: mockToggleHAMenu,
+}));
+
+vi.mock("@/components/ui/sidebar", async () => {
+  const { computed } = await vi.importActual<typeof import("vue")>("vue");
+  return {
+    useSidebar: () => ({
+      state: computed(() => sidebar.state),
+      isMobile: computed(() => sidebar.isMobile),
+      setOpenMobile: mockSetOpenMobile,
+    }),
+  };
+});
+
+vi.mock("vue-i18n", () => ({
+  useI18n: () => ({ t: (key: string) => key }),
+}));
+
+enableAutoUnmount(afterEach);
+
+afterEach(() => {
+  sidebar.state = "expanded";
+  sidebar.isMobile = false;
+  vi.clearAllMocks();
+});
+
+// The sidebar this lives in provides the tooltip context, same as in the app.
+function mountButton() {
+  return mount(TooltipProvider, {
+    slots: { default: () => h(NavHomeAssistant) },
+  });
+}
+
+describe("NavHomeAssistant", () => {
+  it("asks Home Assistant for its menu", async () => {
+    const wrapper = mountButton();
+
+    await wrapper.get("button").trigger("click");
+
+    expect(mockToggleHAMenu).toHaveBeenCalledOnce();
+  });
+
+  it("names itself for a collapsed rail that shows no label", () => {
+    sidebar.state = "collapsed";
+    const wrapper = mountButton();
+
+    expect(wrapper.get("button").attributes("aria-label")).toBe(
+      "home_assistant_menu",
+    );
+    expect(wrapper.text()).not.toContain("home_assistant_menu");
+  });
+
+  it("labels itself in the open sidebar", () => {
+    const wrapper = mountButton();
+
+    expect(wrapper.text()).toContain("home_assistant_menu");
+  });
+
+  it("gets out of the way of the menu it is opening on mobile", async () => {
+    sidebar.isMobile = true;
+    const wrapper = mountButton();
+
+    await wrapper.get("button").trigger("click");
+
+    // Both menus over the same screen would only cover each other up.
+    expect(mockSetOpenMobile).toHaveBeenCalledWith(false);
+  });
+
+  it("leaves the sidebar alone on a screen with room for both", async () => {
+    const wrapper = mountButton();
+
+    await wrapper.get("button").trigger("click");
+
+    expect(mockSetOpenMobile).not.toHaveBeenCalled();
+  });
+});

--- a/tests/plugins/homeassistant.test.ts
+++ b/tests/plugins/homeassistant.test.ts
@@ -1,3 +1,4 @@
+import { HA_KIOSK_MODE, saveDeviceSetting } from "@/helpers/device_settings";
 import {
   subscribeToHAProperties,
   unsubscribeFromHAProperties,
@@ -22,6 +23,30 @@ function readInsets() {
   return INSET_PROPERTIES.map((property) =>
     document.documentElement.style.getPropertyValue(property),
   );
+}
+
+function createStorage(): Storage {
+  const values = new Map<string, string>();
+  return {
+    get length() {
+      return values.size;
+    },
+    clear() {
+      values.clear();
+    },
+    getItem(key) {
+      return values.get(key) ?? null;
+    },
+    key(index) {
+      return Array.from(values.keys())[index] ?? null;
+    },
+    removeItem(key) {
+      values.delete(key);
+    },
+    setItem(key, value) {
+      values.set(key, value);
+    },
+  };
 }
 
 // Home Assistant posts to the frame it embeds us in, which is what puts itself
@@ -85,6 +110,15 @@ describe("Home Assistant safe area", () => {
     expect(readInsets()).toEqual(["", "0px", "34px", "0px"]);
   });
 
+  it("claims the top inset back from a narrow host in kiosk mode", () => {
+    subscribeToHAProperties({ handleSafeArea: true, kioskMode: true });
+
+    // Kiosk mode drops that header, so nothing else is covering the notch.
+    reportProperties({ narrow: true, safeAreaInsets: PHONE_INSETS });
+
+    expect(readInsets()).toEqual(["59px", "0px", "34px", "0px"]);
+  });
+
   it("drops the top inset again once Home Assistant shows its header", () => {
     subscribeToHAProperties({ handleSafeArea: true });
 
@@ -108,9 +142,20 @@ describe("Home Assistant safe area", () => {
     subscribeToHAProperties({ handleSafeArea: true });
 
     reportProperties({ safeAreaInsets: PHONE_INSETS });
-    reportProperties({ narrow: true });
+    reportProperties({});
 
     expect(readInsets()).toEqual(["59px", "0px", "34px", "0px"]);
+  });
+
+  it("gives the top inset up for a header that appears without new insets", () => {
+    subscribeToHAProperties({ handleSafeArea: true });
+
+    reportProperties({ safeAreaInsets: PHONE_INSETS });
+    // Whether the update repeats the insets says nothing about who owns them:
+    // the header Home Assistant just put up is taking the top one either way.
+    reportProperties({ narrow: true });
+
+    expect(readInsets()).toEqual(["", "0px", "34px", "0px"]);
   });
 
   it("ignores the reported insets when it did not ask to handle them", () => {
@@ -165,5 +210,78 @@ describe("Home Assistant safe area", () => {
     reportProperties({ safeAreaInsets: PHONE_INSETS });
 
     expect(readInsets()).toEqual(["", "", "", ""]);
+  });
+});
+
+describe("Home Assistant kiosk mode", () => {
+  let postMessage: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.stubGlobal("localStorage", createStorage());
+    postMessage = vi
+      .spyOn(window.parent, "postMessage")
+      .mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    unsubscribeFromHAProperties();
+    postMessage.mockRestore();
+    vi.unstubAllGlobals();
+  });
+
+  it("asks Home Assistant to give up its own chrome", () => {
+    subscribeToHAProperties({ handleSafeArea: true, kioskMode: true });
+
+    expect(postMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "home-assistant/subscribe-properties",
+        kioskMode: true,
+      }),
+      "*",
+    );
+  });
+
+  it("keeps handling the safe area when the preference turns kiosk mode off", () => {
+    subscribeToHAProperties({ handleSafeArea: true, kioskMode: true });
+
+    // Home Assistant only ever turns kiosk mode on from a subscription, so
+    // leaving it takes an unsubscribe - which hands the safe area back too
+    // unless the fresh subscription asks for it again.
+    saveDeviceSetting(HA_KIOSK_MODE, "false");
+
+    expect(postMessage).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        type: "home-assistant/subscribe-properties",
+        kioskMode: false,
+        handleSafeArea: true,
+      }),
+      "*",
+    );
+  });
+
+  it("drops the top inset again once the header is back", () => {
+    subscribeToHAProperties({ handleSafeArea: true, kioskMode: true });
+    reportProperties({ narrow: true, safeAreaInsets: PHONE_INSETS });
+    expect(readInsets()).toEqual(["59px", "0px", "34px", "0px"]);
+
+    saveDeviceSetting(HA_KIOSK_MODE, "false");
+    reportProperties({ narrow: true, safeAreaInsets: PHONE_INSETS });
+
+    expect(readInsets()).toEqual(["", "0px", "34px", "0px"]);
+  });
+
+  it("leaves Home Assistant alone while the preference is unchanged", () => {
+    subscribeToHAProperties({ handleSafeArea: true, kioskMode: true });
+    postMessage.mockClear();
+
+    saveDeviceSetting(HA_KIOSK_MODE, "true");
+
+    expect(postMessage).not.toHaveBeenCalled();
+  });
+
+  it("ignores the preference outside an ingress session", () => {
+    saveDeviceSetting(HA_KIOSK_MODE, "false");
+
+    expect(postMessage).not.toHaveBeenCalled();
   });
 });

--- a/tests/plugins/homeassistant.test.ts
+++ b/tests/plugins/homeassistant.test.ts
@@ -1,8 +1,10 @@
 import { HA_KIOSK_MODE, saveDeviceSetting } from "@/helpers/device_settings";
 import {
+  haState,
   subscribeToHAProperties,
   unsubscribeFromHAProperties,
 } from "@/plugins/homeassistant";
+import type { Router } from "vue-router";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const INSET_PROPERTIES = ["top", "right", "bottom", "left"].map(
@@ -257,6 +259,15 @@ describe("Home Assistant kiosk mode", () => {
       }),
       "*",
     );
+  });
+
+  it("keeps following Home Assistant's route across a kiosk mode change", () => {
+    const router = { currentRoute: { value: { fullPath: "/" } } } as Router;
+    subscribeToHAProperties({ kioskMode: true, router });
+
+    saveDeviceSetting(HA_KIOSK_MODE, "false");
+
+    expect(haState.routeSyncEnabled).toBe(true);
   });
 
   it("drops the top inset again once the header is back", () => {


### PR DESCRIPTION
# What does this implement/fix?

When Music Assistant runs as a Home Assistant add-on, Home Assistant draws its own header and menu around the panel and keeps them there for the whole session. Kiosk mode asks it to step aside so Music Assistant gets the full screen, with a Home Assistant button in the menu as the way back. It was switched off in #1450 over safe-area problems; the safe-area handover added in #2484 is what makes it work now.

On by default, with a Display setting to turn it off per device (shown only when running as a Home Assistant add-on).

- Ask Home Assistant for kiosk mode on startup, from a new "Use the full screen in Home Assistant" setting
- Add a Home Assistant button to the sidebar footer that opens the Home Assistant menu over the app (desktop, collapsed rail and mobile sheet)
- Claim the top safe-area inset back in kiosk mode — Home Assistant's header is no longer there to cover the notch
- Keep the safe-area handover across a kiosk mode change, so the dead strip at the bottom of the screen does not come back
- Re-evaluate who owns the top inset whenever the header moves, not only when Home Assistant repeats the inset values
- Keep a Home Assistant button on the reconnect screen too — that screen replaces the whole app, sidebar and all, so an add-on restart would otherwise strand the panel on a spinner with no chrome from either app
- Remove the commented-out remains of the old integration

**Related issue (if applicable):**

- related issue `n/a`

**Related backend PR (if applicable):**

- related backend PR `n/a`

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm lint:check` passes.
- [x] `pnpm test:run` passes, and tests have been added/updated where applicable.
- [x] `pnpm build` passes.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
