### PR TITLE
Say what the fullscreen player card's overflow actually does

### DIFF
--- a/src/layouts/default/PlayerOSD/PlayerFullscreen.vue
+++ b/src/layouts/default/PlayerOSD/PlayerFullscreen.vue
@@ -1402,7 +1402,12 @@ onBeforeUnmount(() => {
 <style scoped>
 .fullscreen-player-card {
   box-sizing: border-box;
-  overflow: hidden;
+  /* y is left to Vuetify, which holds it at auto from a more specific
+     .v-dialog > .v-overlay__content > .v-card. That keeps the card scrollable
+     when the viewport is too short for .player-bottom (flex-shrink: 0) to
+     fit; clipping instead would put the play button out of reach of the wheel
+     and of any pan global.css has not refused. */
+  overflow-x: hidden;
   height: 100%;
   display: flex;
   flex-direction: column;

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -167,8 +167,9 @@ html {
    - gives the rule above no chain to cut, and embedded it reaches the host
    instead, whose pull-to-refresh reloads us. Refusing the pan stops it. The
    value resets at every scroll container, which is what leaves the lists
-   scrolling and why the panels have to repeat it: Vuetify makes the fullscreen
-   player's card a scroll container, so the root's value never reaches inside. */
+   scrolling and why the panels have to repeat it: Vuetify makes both the
+   fullscreen player's card and the `.v-overlay__content` wrapper above it
+   scroll containers, so the root's value never reaches inside. */
 :root[data-embedded-layout],
 :root[data-embedded-layout] [data-player-panel] {
   touch-action: pinch-zoom;


### PR DESCRIPTION
# What does this implement/fix?

The fullscreen player's card declared `overflow: hidden`, but Vuetify overrides
`overflow-y` back to `auto` from a more specific selector, so only the x axis
ever took effect. That reads like a bug and invites a "fix" that would actually
break things — the card staying scrollable is what keeps the play/next buttons
reachable when the viewport is too short to fit them, since they live in a
`flex-shrink: 0` block.

So the declaration now says what it does, and the reasons are written down next
to it. `overflow-x: hidden` computes identically to the old shorthand (verified
against the real cascade in a browser) — no behaviour change.

The same note also records that the overlay wrapper above the card is a scroll
container too, which is why the extra `touch-action` rule for the embedded
Home Assistant app cannot be dropped by tightening the card's overflow.

**Related issue (if applicable):**

- n/a

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm lint:check` passes.
- [x] `pnpm test:run` passes, and tests have been added/updated where applicable.
- [x] `pnpm build` passes.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
