### PR TITLE
Use real pointer events in the panel swipe tests

### DIFF
--- a/tests/components/PanelDragHandle.test.ts
+++ b/tests/components/PanelDragHandle.test.ts
@@ -205,6 +205,54 @@ describe("PanelDragHandle", () => {
       expect(wrapper.emitted("dismiss")).toBeUndefined();
     });
 
+    it("leaves mouse drags alone", () => {
+      const { panel, wrapper, content } = mountWithContent();
+
+      // the drag handle itself still works with a mouse; only swiping from
+      // panel content is touch-only, so a mouse never drags the panel away
+      firePointer(content, "pointerdown", {
+        pointerId: 1,
+        pointerType: "mouse",
+        clientY: 100,
+      });
+      firePointer(content, "pointermove", {
+        pointerId: 1,
+        pointerType: "mouse",
+        clientY: 200,
+      });
+      firePointer(content, "pointerup", {
+        pointerId: 1,
+        pointerType: "mouse",
+        clientY: 200,
+      });
+
+      expect(panel.style.transform).toBe("");
+      expect(wrapper.emitted("dismiss")).toBeUndefined();
+    });
+
+    it("leaves the second finger of a multi-touch gesture alone", () => {
+      const { panel, wrapper, content } = mountWithContent();
+
+      firePointer(content, "pointerdown", {
+        pointerId: 2,
+        isPrimary: false,
+        clientY: 100,
+      });
+      firePointer(content, "pointermove", {
+        pointerId: 2,
+        isPrimary: false,
+        clientY: 200,
+      });
+      firePointer(content, "pointerup", {
+        pointerId: 2,
+        isPrimary: false,
+        clientY: 200,
+      });
+
+      expect(panel.style.transform).toBe("");
+      expect(wrapper.emitted("dismiss")).toBeUndefined();
+    });
+
     it("swallows the click that follows an engaged swipe", async () => {
       vi.useFakeTimers();
       const { content } = mountWithContent();

--- a/tests/components/PanelDragHandle.test.ts
+++ b/tests/components/PanelDragHandle.test.ts
@@ -29,14 +29,11 @@ function mountWithContent(swipeAnywhere = true) {
   return { panel, wrapper, content };
 }
 
-/** jsdom has no PointerEvent constructor; synthesize like wrapper.trigger. */
-function firePointer(
-  el: Element,
-  type: string,
-  props: Record<string, unknown>,
-) {
-  const event = new Event(type, { bubbles: true, cancelable: true });
-  Object.assign(event, {
+/** Dispatches a bubbling pointer event defaulting to a primary touch pointer. */
+function firePointer(el: Element, type: string, props: PointerEventInit) {
+  const event = new PointerEvent(type, {
+    bubbles: true,
+    cancelable: true,
     button: 0,
     isPrimary: true,
     pointerType: "touch",


### PR DESCRIPTION
# What does this implement/fix?

The panel drag tests built their pointer events by hand — creating a plain
`Event` and bolting the pointer fields on afterwards — because of a comment
claiming jsdom has no `PointerEvent` constructor.

That comment is wrong on both counts: the file has no `@vitest-environment`
docblock, so it runs under happy-dom like the rest of the suite, and happy-dom
does provide a working `PointerEvent` constructor. Several other test files
already use it directly.

It's worth fixing rather than just tidy, because the comment gets read as fact:
during the review of #2494 it was cited as evidence that pointer events can't be
constructed in this repo's tests, and used to flag correct new tests.

**Related issue (if applicable):**

- n/a

**Related backend PR (if applicable):**

- n/a

## Changes

- Build the test pointer events with the real `PointerEvent` constructor instead
  of assembling them by hand.
- Type the helper's overrides as `PointerEventInit`, so a typo like `clienty`
  is now a compile error instead of a silently-wrong assertion.
- Drop the stale comment about jsdom.
- Add two tests for a gap this uncovered: swiping a panel away from its content
  is touch-only, but nothing checked that a mouse drag or a second finger leaves
  the panel alone. (Dragging the handle itself with a mouse still works.)

No app code changed.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm lint:check` passes.
- [x] `pnpm test:run` passes, and tests have been added/updated where applicable.
- [x] `pnpm build` passes.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
