### PR TITLE
Stop loading the genre filter list after you leave a listing

### DIFF
--- a/src/components/ItemsListing.vue
+++ b/src/components/ItemsListing.vue
@@ -1811,7 +1811,7 @@ const loadGenreOptions = async () => {
     const mediaType = itemtypeToMediaType[props.itemtype];
 
     do {
-      // the paging outlives the listing, so stop fetching once it is gone
+      // the paging can outlast the listing, so stop fetching once it is gone
       if (unmounted) return;
 
       page = await api.getLibraryGenres({

--- a/src/components/ItemsListing.vue
+++ b/src/components/ItemsListing.vue
@@ -1811,6 +1811,9 @@ const loadGenreOptions = async () => {
     const mediaType = itemtypeToMediaType[props.itemtype];
 
     do {
+      // the paging outlives the listing, so stop fetching once it is gone
+      if (unmounted) return;
+
       page = await api.getLibraryGenres({
         limit: pageSize,
         offset,
@@ -1840,8 +1843,8 @@ const clearSelection = () => {
   showCheckboxes.value = false;
 };
 
-// Set by the unmount hook, so the startup below can tell that the listing it is
-// setting things up for is already gone.
+// Set by the unmount hook, so the async startup can tell that the listing it is
+// working for is already gone.
 let unmounted = false;
 
 onBeforeUnmount(() => {

--- a/tests/components/ItemsListing.test.ts
+++ b/tests/components/ItemsListing.test.ts
@@ -188,20 +188,27 @@ describe("ItemsListing startup cleanup", () => {
   });
 
   it("stops paging through the genres when the listing is closed mid-load", async () => {
-    // a full page is what makes the loop ask for another one; a short page
-    // would end the paging on its own and prove nothing
-    const fullPage = Array.from({ length: 100 }, (_, index) =>
-      genre({ item_id: String(index), name: `Genre ${index}` }),
-    );
+    // a full page is what makes the loop ask for another one; taking the size
+    // from the request keeps that true whatever page size the listing asks for
+    let requestedPageSize = 0;
     let resolveFirstPage: () => void = () => {};
-    mockGetLibraryGenres.mockReturnValueOnce(
-      new Promise((resolve) => {
-        resolveFirstPage = () => resolve(fullPage);
-      }),
-    );
+    mockGetLibraryGenres.mockImplementationOnce(({ limit } = {}) => {
+      requestedPageSize = limit ?? 0;
+      return new Promise((resolve) => {
+        resolveFirstPage = () =>
+          resolve(
+            Array.from({ length: requestedPageSize }, (_, index) =>
+              genre({ item_id: String(index), name: `Genre ${index}` }),
+            ),
+          );
+      });
+    });
 
     const listing = mountListingRaw();
     expect(mockGetLibraryGenres).toHaveBeenCalledTimes(1);
+    // a page the listing never asked to fill would end the paging on its own,
+    // leaving the assertion below true no matter what
+    expect(requestedPageSize).toBeGreaterThan(0);
 
     listing.unmount();
     resolveFirstPage();

--- a/tests/components/ItemsListing.test.ts
+++ b/tests/components/ItemsListing.test.ts
@@ -3,6 +3,7 @@ import type { MusicAssistantApi } from "@/plugins/api";
 import { eventbus } from "@/plugins/eventbus";
 import { enableAutoUnmount, flushPromises, mount } from "@vue/test-utils";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { genre } from "../fixtures/genre";
 
 // Tracks live subscriptions the way the api does, so one that outlives the
 // listing stays listed here.
@@ -184,6 +185,29 @@ describe("ItemsListing startup cleanup", () => {
 
     expect(clearSelectionHandlers()).toBe(0);
     expect(events.listeners).toHaveLength(0);
+  });
+
+  it("stops paging through the genres when the listing is closed mid-load", async () => {
+    // a full page is what makes the loop ask for another one; a short page
+    // would end the paging on its own and prove nothing
+    const fullPage = Array.from({ length: 100 }, (_, index) =>
+      genre({ item_id: String(index), name: `Genre ${index}` }),
+    );
+    let resolveFirstPage: () => void = () => {};
+    mockGetLibraryGenres.mockReturnValueOnce(
+      new Promise((resolve) => {
+        resolveFirstPage = () => resolve(fullPage);
+      }),
+    );
+
+    const listing = mountListingRaw();
+    expect(mockGetLibraryGenres).toHaveBeenCalledTimes(1);
+
+    listing.unmount();
+    resolveFirstPage();
+    await flushPromises();
+
+    expect(mockGetLibraryGenres).toHaveBeenCalledTimes(1);
   });
 
   it("leaves a second listing on the page still clearing its own selection", async () => {


### PR DESCRIPTION
# What does this implement/fix?

Music listings build their genre filter by paging through the whole genre library, 100 at a time. Leaving the listing while that was running let it page all the way to the end anyway, firing every remaining request for a listing nobody is looking at.

It stops by itself, so nothing leaks, but listings mount on nearly every navigation and a large genre library turns each quick navigation away into a burst of pointless requests.

Follow-up to #2492, which listed this as a known leftover.

**Related issue (if applicable):**

- related issue `n/a`

**Related backend PR (if applicable):**

- related backend PR `n/a`

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Changes

- The genre paging loop now checks whether the listing is still open before each page, so it stops as soon as you navigate away instead of finishing the whole library first.
- Added a test that closes a listing while the first page is in flight and pins that no further page is requested.

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm lint:check` passes.
- [x] `pnpm test:run` passes, and tests have been added/updated where applicable.
- [x] `pnpm build` passes.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
