### PR TITLE
Use one name for the 'component unmounted' guard flag

### DIFF
--- a/src/components/HomeWidgetRows.vue
+++ b/src/components/HomeWidgetRows.vue
@@ -796,7 +796,7 @@ const loadGenres = async () => {
   genres.value = ranked.slice(0, 8);
 };
 
-let isUnmounted = false;
+let unmounted = false;
 let refreshRecommendationsTimer: ReturnType<typeof setTimeout> | undefined;
 
 const cancelScheduledRecommendationRefresh = () => {
@@ -810,13 +810,13 @@ const scheduleRecommendationRefresh = () => {
   cancelScheduledRecommendationRefresh();
   refreshRecommendationsTimer = setTimeout(async () => {
     refreshRecommendationsTimer = undefined;
-    if (isUnmounted) return;
+    if (unmounted) return;
     // Refetches the catalog and the shown rows' content so play-history rows
     // and rotated picks stay current.
     await loadRecommendationRows();
-    if (isUnmounted) return;
+    if (unmounted) return;
     await refreshShownRowItems();
-    if (isUnmounted) return;
+    if (unmounted) return;
     resolveHeroPicks();
   }, 1500);
 };
@@ -847,19 +847,19 @@ onMounted(async () => {
   window.addEventListener("resize", updateHeroNav);
 
   await loadRecommendationRows();
-  if (isUnmounted) return;
+  if (unmounted) return;
   loading.value = false;
 
   await fetchMissingRowItems();
-  if (isUnmounted) return;
+  if (unmounted) return;
   resolveHeroPicks();
   nextTick(() => {
-    if (!isUnmounted) observeHero();
+    if (!unmounted) observeHero();
   });
 });
 
 onBeforeUnmount(() => {
-  isUnmounted = true;
+  unmounted = true;
   window.removeEventListener("resize", updateHeroNav);
   unsubscribeRecommendations();
   cancelScheduledRecommendationRefresh();

--- a/src/components/ShowDashboardButton.vue
+++ b/src/components/ShowDashboardButton.vue
@@ -129,13 +129,12 @@ const activeSession = computed(() =>
 );
 
 // Wait for API init (mount can race a hard page refresh) before fetching lists/subscribing.
-let active = false;
+let unmounted = false;
 const unsubscribers: Array<() => void> = [];
 
 onMounted(async () => {
-  active = true;
   await waitForApiInitialization();
-  if (!active) return;
+  if (unmounted) return;
 
   fetchSessions();
   loadDashboards();
@@ -149,7 +148,7 @@ onMounted(async () => {
 });
 
 onBeforeUnmount(() => {
-  active = false;
+  unmounted = true;
   unsubscribers.forEach((unsubscribe) => unsubscribe());
 });
 

--- a/src/composables/guest/useGuestEntryResolver.ts
+++ b/src/composables/guest/useGuestEntryResolver.ts
@@ -57,7 +57,7 @@ export function useGuestEntryResolver() {
   const state = ref<GuestEntryState>("loading");
   let participantContext = getParticipantContext();
   let quizAffinity = createGuestQuizAffinity(participantContext);
-  let active = false;
+  let unmounted = false;
   let requestedVersion = 0;
   let preserveEndedState = false;
   let resolutionPromise: Promise<void> | null = null;
@@ -65,9 +65,8 @@ export function useGuestEntryResolver() {
   const unsubscribers: (() => void)[] = [];
 
   onMounted(async () => {
-    active = true;
     await waitForApiInitialization();
-    if (!active) return;
+    if (unmounted) return;
 
     unsubscribers.push(
       api.subscribe(EventType.PROVIDERS_UPDATED, requestResolution),
@@ -82,7 +81,7 @@ export function useGuestEntryResolver() {
   );
 
   onBeforeUnmount(() => {
-    active = false;
+    unmounted = true;
     requestedVersion += 1;
     unsubscribers.forEach((unsubscribe) => unsubscribe());
   });
@@ -110,14 +109,14 @@ export function useGuestEntryResolver() {
   }
 
   async function processResolutions() {
-    while (active) {
+    while (!unmounted) {
       const version = requestedVersion;
       const resolutionAffinity = getQuizAffinity();
       let nextState: GuestEntryState;
       try {
         nextState = await resolveGuestEntryState(resolutionAffinity);
       } catch {
-        if (!active) return;
+        if (unmounted) return;
         if (version !== requestedVersion) continue;
         if (resolutionAffinity !== getQuizAffinity()) {
           requestedVersion += 1;
@@ -129,7 +128,7 @@ export function useGuestEntryResolver() {
         }
         return;
       }
-      if (!active) return;
+      if (unmounted) return;
       if (version !== requestedVersion) continue;
       if (resolutionAffinity !== getQuizAffinity()) {
         requestedVersion += 1;
@@ -154,7 +153,7 @@ export function useGuestEntryResolver() {
     if (!isScopedQuizProviderEvent(event.object_id)) return;
     if (event.data.event === "game_removed") {
       queueMicrotask(() => {
-        if (!active) return;
+        if (unmounted) return;
         if (consumeMusicQuizJoinedGameEnded() && route.path === "/guest/quiz") {
           void requestEndedResolution();
           return;

--- a/src/composables/music-quiz/useMusicQuizDashboard.ts
+++ b/src/composables/music-quiz/useMusicQuizDashboard.ts
@@ -24,7 +24,7 @@ export function useMusicQuizDashboard() {
 
   let unsubscribeProviderEvent: (() => void) | undefined;
   let stateRequestId = 0;
-  let disposed = false;
+  let unmounted = false;
 
   const currentRound = computed<MusicQuizCurrentRound | null>(() => {
     const currentState = state.value;
@@ -40,10 +40,10 @@ export function useMusicQuizDashboard() {
     loading.value = true;
     try {
       const nextState = await getMusicQuizPublicState();
-      if (disposed || requestId !== stateRequestId) return;
+      if (unmounted || requestId !== stateRequestId) return;
       state.value = nextState;
     } catch (err) {
-      if (disposed || requestId !== stateRequestId) return;
+      if (unmounted || requestId !== stateRequestId) return;
       // a kiosk display has nowhere to surface an error: fall back to waiting
       console.warn("Could not load the Music Quiz public state", err);
       state.value = null;
@@ -57,7 +57,7 @@ export function useMusicQuizDashboard() {
       // On a hard refresh this can mount before the provider registry is known,
       // which would resolve to a wrong "no quiz" answer.
       await waitForApiInitialization();
-      if (disposed) return;
+      if (unmounted) return;
       await fetchState();
     })();
     unsubscribeProviderEvent = api.subscribe(
@@ -67,7 +67,7 @@ export function useMusicQuizDashboard() {
   });
 
   onBeforeUnmount(() => {
-    disposed = true;
+    unmounted = true;
     stateRequestId += 1;
     unsubscribeProviderEvent?.();
   });

--- a/src/composables/music-quiz/useMusicQuizPlayer.ts
+++ b/src/composables/music-quiz/useMusicQuizPlayer.ts
@@ -78,7 +78,7 @@ export function useMusicQuizPlayer(options: UseMusicQuizPlayerOptions) {
   let gameGeneration = 0;
   let autoJoinAttemptedGeneration: number | null = null;
   const activeJoinRequests = new Map<number, number>();
-  let disposed = false;
+  let unmounted = false;
 
   const currentRound = computed<MusicQuizCurrentRound | null>(() => {
     const currentState = state.value;
@@ -106,13 +106,13 @@ export function useMusicQuizPlayer(options: UseMusicQuizPlayerOptions) {
     try {
       loading.value = true;
       const nextInfo = await getMusicQuizInfo();
-      if (disposed || loadingRequestId !== requestId) return;
+      if (unmounted || loadingRequestId !== requestId) return;
       info.value = nextInfo;
       if (nextInfo) joinedGame = false;
       gameRemoved.value = !nextInfo && joinedGame;
       if (nextInfo) await attemptAutoJoin();
     } catch (err) {
-      if (disposed || loadingRequestId !== requestId) return;
+      if (unmounted || loadingRequestId !== requestId) return;
       notifyError(
         getMusicQuizErrorMessage(
           err,
@@ -222,7 +222,7 @@ export function useMusicQuizPlayer(options: UseMusicQuizPlayerOptions) {
       // connection finishes initializing, and probing quiz state too early
       // would briefly resolve to a wrong "no quiz" answer.
       await waitForApiInitialization();
-      if (disposed) return;
+      if (unmounted) return;
       await fetchState();
     })();
     unsubscribeProviderEvent = api.subscribe(
@@ -232,7 +232,7 @@ export function useMusicQuizPlayer(options: UseMusicQuizPlayerOptions) {
   });
 
   onBeforeUnmount(() => {
-    disposed = true;
+    unmounted = true;
     gameGeneration += 1;
     loadingRequestId += 1;
     requestedPlayerStateId = null;
@@ -393,7 +393,7 @@ export function useMusicQuizPlayer(options: UseMusicQuizPlayerOptions) {
     currentPlayerId: string,
     active: boolean,
   ) {
-    if (disposed || playerId.value !== currentPlayerId) return;
+    if (unmounted || playerId.value !== currentPlayerId) return;
     if (!active) {
       await resetToJoinInfo();
     } else if (reconnectPlayerId === currentPlayerId) {
@@ -403,7 +403,7 @@ export function useMusicQuizPlayer(options: UseMusicQuizPlayerOptions) {
   }
 
   function handleHeartbeatError(currentPlayerId: string, err: unknown) {
-    if (disposed || playerId.value !== currentPlayerId) return;
+    if (unmounted || playerId.value !== currentPlayerId) return;
     notifyError(
       getMusicQuizErrorMessage(
         err,
@@ -445,7 +445,7 @@ export function useMusicQuizPlayer(options: UseMusicQuizPlayerOptions) {
     busy.value = true;
     try {
       const result = await joinMusicQuiz(name);
-      if (disposed || requestGeneration !== gameGeneration) return false;
+      if (unmounted || requestGeneration !== gameGeneration) return false;
       storeMusicQuizPlayerId(result.player_id, participantStorageContext);
       joinedGame = true;
       applyPlayerState(result.state);
@@ -454,7 +454,7 @@ export function useMusicQuizPlayer(options: UseMusicQuizPlayerOptions) {
       return true;
     } catch (err) {
       if (
-        !disposed &&
+        !unmounted &&
         notifyJoinError &&
         requestGeneration === gameGeneration
       ) {
@@ -497,7 +497,7 @@ export function useMusicQuizPlayer(options: UseMusicQuizPlayerOptions) {
     const requestGeneration = gameGeneration;
     if (
       !name ||
-      disposed ||
+      unmounted ||
       busy.value ||
       playerId.value ||
       autoJoinAttemptedGeneration === requestGeneration

--- a/src/composables/useListenIn.ts
+++ b/src/composables/useListenIn.ts
@@ -64,7 +64,7 @@ export function useListenIn(options: UseListenInOptions) {
   let unsubscribeRecheckEvents: (() => void) | undefined;
   let autoEnableAttemptedForGeneration: number | null = null;
   let availabilityRequestId = 0;
-  let disposed = false;
+  let unmounted = false;
   let foreignPlayerRecheckTimer: ReturnType<typeof setTimeout> | null = null;
 
   const webPlayerId = computed(() => webPlayer.player_id ?? null);
@@ -94,7 +94,7 @@ export function useListenIn(options: UseListenInOptions) {
         { suppressGlobalError: true },
       );
       if (
-        disposed ||
+        unmounted ||
         requestId !== availabilityRequestId ||
         !isCurrentWebPlayer(playerId, playerGeneration)
       ) {
@@ -166,7 +166,7 @@ export function useListenIn(options: UseListenInOptions) {
     } finally {
       busy.value = false;
       if (
-        !disposed &&
+        !unmounted &&
         webPlayerId.value &&
         !isCurrentWebPlayer(playerId, playerGeneration) &&
         isLatestListenInOperation(domain, playerId, operationId)
@@ -206,7 +206,7 @@ export function useListenIn(options: UseListenInOptions) {
     } finally {
       busy.value = false;
       if (
-        !disposed &&
+        !unmounted &&
         webPlayerId.value &&
         !isCurrentWebPlayer(playerId, playerGeneration) &&
         isLatestListenInOperation(domain, playerId, operationId)
@@ -230,7 +230,7 @@ export function useListenIn(options: UseListenInOptions) {
     // server has rebuilt every player's groupable set, a beat after ours turns up. Another
     // player's update is the only signal that this happened, so coalesce a re-check while
     // we still believe we cannot listen in.
-    if (canListenIn.value || disposed) return;
+    if (canListenIn.value || unmounted) return;
     if (foreignPlayerRecheckTimer !== null) {
       clearTimeout(foreignPlayerRecheckTimer);
     }
@@ -252,7 +252,7 @@ export function useListenIn(options: UseListenInOptions) {
 
   function isCurrentWebPlayer(playerId: string, generation: number) {
     return (
-      !disposed &&
+      !unmounted &&
       webPlayerId.value === playerId &&
       webPlayerGeneration.value === generation
     );
@@ -282,7 +282,7 @@ export function useListenIn(options: UseListenInOptions) {
   });
 
   onBeforeUnmount(() => {
-    disposed = true;
+    unmounted = true;
     availabilityRequestId++;
     if (foreignPlayerRecheckTimer !== null) {
       clearTimeout(foreignPlayerRecheckTimer);

--- a/src/composables/useShortcuts.ts
+++ b/src/composables/useShortcuts.ts
@@ -435,13 +435,13 @@ export function useShortcuts() {
   });
 
   let _unsubscribeUpdated: (() => void) | undefined;
-  let _unmounted = false;
+  let unmounted = false;
 
   onMounted(async () => {
     await loadShortcuts();
     // The load can outlast the component, and the cleanup hook has already run
     // by then with nothing to unsubscribe.
-    if (_unmounted) return;
+    if (unmounted) return;
 
     _unsubscribeUpdated = api.subscribe(
       EventType.MEDIA_ITEM_UPDATED,
@@ -464,7 +464,7 @@ export function useShortcuts() {
   });
 
   onUnmounted(() => {
-    _unmounted = true;
+    unmounted = true;
     _unsubscribeUpdated?.();
   });
 


### PR DESCRIPTION
# What does this implement/fix?

Several components guard async `onMounted` continuations with a setup-scope boolean that the unmount hook sets, so work resuming after an `await` can tell the component is gone. That flag had grown five different names across the frontend, which made the pattern hard to grep for and easy to reimplement inconsistently.

Everything now uses `unmounted`, the majority spelling already used in eight other files.

**Related issue (if applicable):**

- related issue `n/a`

**Related backend PR (if applicable):**

- related backend PR `n/a`

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Changes

- `_unmounted` → `unmounted` in `useShortcuts`
- `isUnmounted` → `unmounted` in `HomeWidgetRows`
- `disposed` → `unmounted` in `useListenIn`, `useMusicQuizPlayer`, `useMusicQuizDashboard`
- `active` → `unmounted` in `ShowDashboardButton` and `useGuestEntryResolver` — these two carried the opposite polarity, so the guards are inverted and the now-redundant set-on-mount step drops out

Left alone deliberately: `useVisualizerEngine`'s `destroyed`, which an explicit `destroy()` call sets rather than an unmount hook, and is a genuinely different lifecycle.

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm lint:check` passes.
- [x] `pnpm test:run` passes, and tests have been added/updated where applicable.
- [x] `pnpm build` passes.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
