### PR TITLE
Album art no longer holds up the app over a remote connection

### DIFF
--- a/src/plugins/remote/webrtc-transport.ts
+++ b/src/plugins/remote/webrtc-transport.ts
@@ -49,11 +49,21 @@ const FALLBACK_ICE_SERVERS: IceServerConfig[] = [
 // otherwise a flapping loop (which briefly connects) keeps backoff flat.
 const STABLE_CONNECTION_THRESHOLD_MS = 5000;
 
+// Proxied HTTP requests (album art, previews) get their own channel so their large
+// payloads don't hold up API messages. Older servers take a label they don't know for
+// the API channel itself, so the channel is only opened once the server reports it
+// knows this one.
+const HTTP_PROXY_CHANNEL_LABEL = "http_proxy";
+const HTTP_PROXY_CHANNEL_SCHEMA_VERSION = 49;
+
 export class WebRTCTransport extends BaseTransport {
   private options: Required<WebRTCTransportOptions>;
   private signaling: SignalingClient;
   private peerConnection: RTCPeerConnection | null = null;
   private dataChannel: RTCDataChannel | null = null;
+  private httpProxyChannel: RTCDataChannel | null = null;
+  // The proxy channel is negotiated at most once per connection.
+  private httpProxyChannelRequested = false;
   private iceCandidateBuffer: RTCIceCandidateInit[] = [];
   private remoteDescriptionSet = false;
   private reconnectAttempts = 0;
@@ -74,9 +84,16 @@ export class WebRTCTransport extends BaseTransport {
     }
   >();
   // Reassembly buffers for oversized messages the server splits into chunks, keyed by group id.
+  // Group ids are unique across channels, so the dispatch of the channel a group started on
+  // is kept with it.
   private chunkGroups = new Map<
     number,
-    { count: number; parts: string[]; received: number }
+    {
+      count: number;
+      parts: string[];
+      received: number;
+      dispatch: (data: string) => void;
+    }
   >();
   // ICE servers received from the signaling server (provided by MA server)
   private iceServers: IceServerConfig[] = [];
@@ -255,21 +272,36 @@ export class WebRTCTransport extends BaseTransport {
       this.emit("error", new Error("Data channel error"));
     };
 
-    this.dataChannel.onmessage = (event) => {
-      // The server splits oversized messages into "__chunk__" frames (see gateway
-      // _send_ma_api); reassemble them before dispatching. Everything else is a whole message.
+    this.attachMessageHandler(this.dataChannel, (data) =>
+      this.dispatchMessage(data),
+    );
+  }
+
+  /**
+   * Deliver a channel's incoming messages to a dispatch function.
+   *
+   * @param channel - Channel to read from.
+   * @param dispatch - Receives every whole message from that channel.
+   */
+  private attachMessageHandler(
+    channel: RTCDataChannel,
+    dispatch: (data: string) => void,
+  ): void {
+    channel.onmessage = (event) => {
+      // The server splits oversized messages into "__chunk__" frames; reassemble them
+      // before dispatching. Everything else is a whole message.
       if (typeof event.data === "string") {
         try {
           const frame = JSON.parse(event.data);
           if (frame.type === "__chunk__") {
-            this.handleChunk(frame);
+            this.handleChunk(frame, dispatch);
             return;
           }
         } catch {
           // not a JSON chunk frame; fall through to normal dispatch
         }
       }
-      this.dispatchMessage(event.data);
+      dispatch(event.data);
     };
   }
 
@@ -281,24 +313,84 @@ export class WebRTCTransport extends BaseTransport {
         this.handleHttpProxyResponse(parsed);
         return;
       }
+      // server_info is the first message on this channel and carries the schema version.
+      if (typeof parsed.schema_version === "number") {
+        this.maybeOpenHttpProxyChannel(parsed.schema_version);
+      }
     } catch {
       // not JSON or not an HTTP proxy response
     }
     this.emit("message", data);
   }
 
-  private handleChunk(frame: {
-    id: number;
-    seq: number;
-    count: number;
-    b64: string;
-  }): void {
+  /**
+   * Handle a message from the http_proxy channel, which only ever carries proxy responses.
+   */
+  private dispatchHttpProxyMessage(data: string): void {
+    try {
+      const parsed = JSON.parse(data);
+      if (parsed.type === "http-proxy-response") {
+        this.handleHttpProxyResponse(parsed);
+      }
+    } catch {
+      // not JSON; nothing on this channel to dispatch
+    }
+  }
+
+  private maybeOpenHttpProxyChannel(schemaVersion: number): void {
+    if (
+      this.httpProxyChannelRequested ||
+      schemaVersion < HTTP_PROXY_CHANNEL_SCHEMA_VERSION
+    ) {
+      return;
+    }
+    this.httpProxyChannelRequested = true;
+    void this.openHttpProxyChannel();
+  }
+
+  private async openHttpProxyChannel(): Promise<void> {
+    try {
+      const channel = await this.openDataChannel(HTTP_PROXY_CHANNEL_LABEL);
+      if (!channel) return;
+      if (!this.httpProxyChannelRequested) {
+        // the connection this channel was opened for is already torn down
+        channel.close();
+        return;
+      }
+      this.attachMessageHandler(channel, (data) =>
+        this.dispatchHttpProxyMessage(data),
+      );
+      channel.onclose = () => {
+        if (this.httpProxyChannel === channel) {
+          this.httpProxyChannel = null;
+        }
+      };
+      this.httpProxyChannel = channel;
+    } catch (error) {
+      // proxying over the API channel remains a working fallback
+      console.warn(
+        "[WebRTCTransport] http_proxy DataChannel unavailable:",
+        error,
+      );
+    }
+  }
+
+  private handleChunk(
+    frame: {
+      id: number;
+      seq: number;
+      count: number;
+      b64: string;
+    },
+    dispatch: (data: string) => void,
+  ): void {
     let pending = this.chunkGroups.get(frame.id);
     if (!pending) {
       pending = {
         count: frame.count,
         parts: Array.from<string>({ length: frame.count }),
         received: 0,
+        dispatch,
       };
       this.chunkGroups.set(frame.id, pending);
     }
@@ -310,7 +402,7 @@ export class WebRTCTransport extends BaseTransport {
 
     this.chunkGroups.delete(frame.id);
     const bytes = this.base64PartsToBytes(pending.parts);
-    this.dispatchMessage(new TextDecoder().decode(bytes));
+    pending.dispatch(new TextDecoder().decode(bytes));
   }
 
   private base64PartsToBytes(parts: string[]): Uint8Array {
@@ -460,7 +552,12 @@ export class WebRTCTransport extends BaseTransport {
     headers: Record<string, string>;
     body: Uint8Array;
   }> {
-    if (!this.dataChannel || this.dataChannel.readyState !== "open") {
+    // Falls back to the API channel when the server has no dedicated proxy channel.
+    const channel =
+      this.httpProxyChannel?.readyState === "open"
+        ? this.httpProxyChannel
+        : this.dataChannel;
+    if (!channel || channel.readyState !== "open") {
       throw new Error("DataChannel is not open");
     }
 
@@ -494,7 +591,7 @@ export class WebRTCTransport extends BaseTransport {
       headers,
     };
 
-    this.dataChannel.send(JSON.stringify(request));
+    channel.send(JSON.stringify(request));
 
     return responsePromise;
   }
@@ -629,6 +726,16 @@ export class WebRTCTransport extends BaseTransport {
       this.dataChannel.close();
       this.dataChannel = null;
     }
+
+    if (this.httpProxyChannel) {
+      this.httpProxyChannel.onopen = null;
+      this.httpProxyChannel.onclose = null;
+      this.httpProxyChannel.onerror = null;
+      this.httpProxyChannel.onmessage = null;
+      this.httpProxyChannel.close();
+      this.httpProxyChannel = null;
+    }
+    this.httpProxyChannelRequested = false;
 
     if (this.peerConnection) {
       // Detach first so close doesn't re-enter handleConnectionFailure().

--- a/src/plugins/remote/webrtc-transport.ts
+++ b/src/plugins/remote/webrtc-transport.ts
@@ -357,10 +357,13 @@ export class WebRTCTransport extends BaseTransport {
         channel.close();
         return;
       }
-      this.attachMessageHandler(channel, (data) =>
-        this.dispatchHttpProxyMessage(data),
-      );
+      const dispatch = (data: string) => this.dispatchHttpProxyMessage(data);
+      this.attachMessageHandler(channel, dispatch);
       channel.onclose = () => {
+        // a response cut off mid-chunk can never be reassembled, so drop what it left
+        for (const [id, group] of this.chunkGroups) {
+          if (group.dispatch === dispatch) this.chunkGroups.delete(id);
+        }
         if (this.httpProxyChannel === channel) {
           this.httpProxyChannel = null;
         }

--- a/tests/plugins/webrtc-transport-chunking.test.ts
+++ b/tests/plugins/webrtc-transport-chunking.test.ts
@@ -16,12 +16,15 @@ type TransportInternals = {
     { resolve: (value: ProxyResult) => void; reject: (error: Error) => void }
   >;
   dispatchMessage: (data: string) => void;
-  handleChunk: (frame: {
-    id: number;
-    seq: number;
-    count: number;
-    b64: string;
-  }) => void;
+  handleChunk: (
+    frame: {
+      id: number;
+      seq: number;
+      count: number;
+      b64: string;
+    },
+    dispatch: (data: string) => void,
+  ) => void;
   on: (event: string, cb: (...args: unknown[]) => void) => void;
 };
 
@@ -40,6 +43,15 @@ function pending(
   return new Promise<ProxyResult>((resolve, reject) => {
     transport.httpProxyCallbacks.set(id, { resolve, reject });
   });
+}
+
+// A chunk group is delivered to the dispatch of the channel it arrived on; these tests
+// drive the API channel.
+function feedChunk(
+  transport: TransportInternals,
+  frame: { id: number; seq: number; count: number; b64: string },
+): void {
+  transport.handleChunk(frame, (data) => transport.dispatchMessage(data));
 }
 
 function toHex(bytes: number[]): string {
@@ -98,7 +110,7 @@ describe("WebRTCTransport chunk reassembly", () => {
       body: toHex([9, 8, 7, 6, 5, 4, 3, 2, 1, 0]),
     });
 
-    for (const frame of makeChunks(msg, 42)) transport.handleChunk(frame);
+    for (const frame of makeChunks(msg, 42)) feedChunk(transport, frame);
 
     const { body } = await result;
     expect(Array.from(body)).toEqual([9, 8, 7, 6, 5, 4, 3, 2, 1, 0]);
@@ -116,7 +128,7 @@ describe("WebRTCTransport chunk reassembly", () => {
     });
 
     for (const frame of [...makeChunks(msg, 7)].reverse())
-      transport.handleChunk(frame);
+      feedChunk(transport, frame);
 
     const { body } = await result;
     expect(Array.from(body)).toEqual([1, 2, 3, 4, 5, 6, 7, 8]);
@@ -128,7 +140,7 @@ describe("WebRTCTransport chunk reassembly", () => {
     transport.on("message", (m) => received.push(m));
 
     const msg = JSON.stringify({ command: "players/all", message_id: 1 });
-    for (const frame of makeChunks(msg, 99)) transport.handleChunk(frame);
+    for (const frame of makeChunks(msg, 99)) feedChunk(transport, frame);
 
     expect(received).toEqual([msg]);
   });
@@ -140,7 +152,7 @@ describe("WebRTCTransport chunk reassembly", () => {
 
     const msg = JSON.stringify({ name: "音楽ライブラリ".repeat(5) });
     // pieceBytes = 5 forces slices to fall inside 3-byte characters
-    for (const frame of makeChunks(msg, 5, 5)) transport.handleChunk(frame);
+    for (const frame of makeChunks(msg, 5, 5)) feedChunk(transport, frame);
 
     expect(received).toEqual([msg]);
   });
@@ -148,7 +160,7 @@ describe("WebRTCTransport chunk reassembly", () => {
   it("does not throw on an unknown/duplicate chunk", () => {
     const transport = makeTransport();
     expect(() =>
-      transport.handleChunk({ id: 123, seq: 0, count: 2, b64: btoa("x") }),
+      feedChunk(transport, { id: 123, seq: 0, count: 2, b64: btoa("x") }),
     ).not.toThrow();
   });
 });

--- a/tests/plugins/webrtc-transport-http-proxy-channel.test.ts
+++ b/tests/plugins/webrtc-transport-http-proxy-channel.test.ts
@@ -1,0 +1,239 @@
+import { describe, expect, it } from "vitest";
+
+import { WebRTCTransport } from "../../src/plugins/remote/webrtc-transport";
+
+// Stands in for an RTCDataChannel: records what the transport sends and lets a test push
+// messages back in.
+class FakeDataChannel {
+  readyState: RTCDataChannelState = "connecting";
+  sent: string[] = [];
+  onopen: (() => void) | null = null;
+  onclose: (() => void) | null = null;
+  onerror: (() => void) | null = null;
+  onmessage: ((event: { data: string }) => void) | null = null;
+
+  constructor(readonly label: string) {}
+
+  send(data: string): void {
+    this.sent.push(data);
+  }
+
+  open(): void {
+    this.readyState = "open";
+    this.onopen?.();
+  }
+
+  close(): void {
+    this.readyState = "closed";
+    this.onclose?.();
+  }
+
+  receive(data: string): void {
+    this.onmessage?.({ data });
+  }
+}
+
+// The channel wiring lives on private members; a thin cast keeps the tests focused on
+// behaviour without widening the public API.
+type TransportInternals = {
+  peerConnection: unknown;
+  dataChannel: FakeDataChannel | null;
+  httpProxyChannel: FakeDataChannel | null;
+  setupDataChannelHandlers: () => void;
+};
+
+function makeTransport() {
+  const transport = new WebRTCTransport({
+    signalingServerUrl: "wss://example.invalid/ws",
+    remoteId: "TEST-REMOTE-ID",
+  });
+  const internals = transport as unknown as TransportInternals;
+  const channels: FakeDataChannel[] = [];
+
+  const apiChannel = new FakeDataChannel("ma-api");
+  apiChannel.readyState = "open";
+  internals.peerConnection = {
+    connectionState: "connected",
+    close: () => {},
+    createDataChannel: (label: string) => {
+      const channel = new FakeDataChannel(label);
+      channels.push(channel);
+      // a real channel opens a moment after it is created
+      queueMicrotask(() => channel.open());
+      return channel;
+    },
+  };
+  internals.dataChannel = apiChannel;
+  internals.setupDataChannelHandlers();
+
+  return { transport, internals, apiChannel, channels };
+}
+
+// Yields a macrotask so the channel negotiation triggered by server_info can settle.
+function flush(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+function serverInfo(schemaVersion: number): string {
+  return JSON.stringify({
+    server_id: "test-server",
+    server_version: "2.9.0",
+    schema_version: schemaVersion,
+    min_supported_schema_version: 28,
+    base_url: "http://localhost:8095",
+    homeassistant_addon: false,
+    onboard_done: true,
+    name: "Test server",
+    status: "running",
+  });
+}
+
+function proxyResponse(id: string, body: number[]): string {
+  return JSON.stringify({
+    type: "http-proxy-response",
+    id,
+    status: 200,
+    headers: { "content-type": "image/png" },
+    body: body.map((b) => b.toString(16).padStart(2, "0")).join(""),
+  });
+}
+
+function sentRequestId(channel: FakeDataChannel): string {
+  return JSON.parse(channel.sent[0]).id;
+}
+
+// Split a message into "__chunk__" frames the way the server does.
+function makeChunks(text: string, id: number, pieceBytes = 8): string[] {
+  const bytes = new TextEncoder().encode(text);
+  const count = Math.max(1, Math.ceil(bytes.length / pieceBytes));
+  const frames: string[] = [];
+  for (let seq = 0; seq < count; seq++) {
+    const slice = bytes.slice(seq * pieceBytes, (seq + 1) * pieceBytes);
+    let binary = "";
+    slice.forEach((b) => (binary += String.fromCharCode(b)));
+    frames.push(
+      JSON.stringify({ type: "__chunk__", id, seq, count, b64: btoa(binary) }),
+    );
+  }
+  return frames;
+}
+
+describe("WebRTCTransport http_proxy channel", () => {
+  it("keeps proxied requests on the API channel for a server that predates it", async () => {
+    const { transport, apiChannel, channels } = makeTransport();
+
+    apiChannel.receive(serverInfo(48));
+    await flush();
+
+    expect(channels).toEqual([]);
+
+    const response = transport.sendHttpProxyRequest("GET", "/imageproxy?p=1");
+    expect(JSON.parse(apiChannel.sent[0])).toMatchObject({
+      type: "http-proxy-request",
+      method: "GET",
+      path: "/imageproxy?p=1",
+    });
+
+    apiChannel.receive(proxyResponse(sentRequestId(apiChannel), [1, 2, 3]));
+    await expect(response).resolves.toMatchObject({ status: 200 });
+  });
+
+  it("sends proxied requests on the dedicated channel and resolves its responses", async () => {
+    const { transport, internals, apiChannel, channels } = makeTransport();
+
+    apiChannel.receive(serverInfo(49));
+    await flush();
+
+    expect(channels.map((channel) => channel.label)).toEqual(["http_proxy"]);
+    const proxyChannel = channels[0];
+    expect(internals.httpProxyChannel).toBe(proxyChannel);
+
+    const response = transport.sendHttpProxyRequest("GET", "/imageproxy?p=1");
+    expect(apiChannel.sent).toEqual([]);
+    expect(JSON.parse(proxyChannel.sent[0])).toMatchObject({
+      type: "http-proxy-request",
+      path: "/imageproxy?p=1",
+    });
+
+    proxyChannel.receive(
+      proxyResponse(sentRequestId(proxyChannel), [1, 2, 3, 4]),
+    );
+    const { status, body } = await response;
+    expect(status).toBe(200);
+    expect(Array.from(body)).toEqual([1, 2, 3, 4]);
+  });
+
+  it("negotiates the dedicated channel only once per connection", async () => {
+    const { apiChannel, channels } = makeTransport();
+
+    apiChannel.receive(serverInfo(49));
+    apiChannel.receive(serverInfo(49));
+    await flush();
+
+    expect(channels).toHaveLength(1);
+  });
+
+  it("reassembles a chunked response that arrives on the dedicated channel", async () => {
+    const { transport, apiChannel, channels } = makeTransport();
+
+    apiChannel.receive(serverInfo(49));
+    await flush();
+    const proxyChannel = channels[0];
+
+    const response = transport.sendHttpProxyRequest("GET", "/imageproxy?p=1");
+    const message = proxyResponse(
+      sentRequestId(proxyChannel),
+      [9, 8, 7, 6, 5, 4, 3, 2, 1, 0],
+    );
+    for (const frame of makeChunks(message, 42)) proxyChannel.receive(frame);
+
+    const { body } = await response;
+    expect(Array.from(body)).toEqual([9, 8, 7, 6, 5, 4, 3, 2, 1, 0]);
+  });
+
+  it("falls back to the API channel once the dedicated channel closes", async () => {
+    const { transport, internals, apiChannel, channels } = makeTransport();
+
+    apiChannel.receive(serverInfo(49));
+    await flush();
+
+    channels[0].close();
+    expect(internals.httpProxyChannel).toBeNull();
+
+    const response = transport.sendHttpProxyRequest("GET", "/imageproxy?p=1");
+    expect(JSON.parse(apiChannel.sent[0])).toMatchObject({
+      type: "http-proxy-request",
+    });
+
+    apiChannel.receive(proxyResponse(sentRequestId(apiChannel), [5]));
+    await expect(response).resolves.toMatchObject({ status: 200 });
+  });
+
+  it("never emits a message that arrives on the dedicated channel", async () => {
+    const { transport, apiChannel, channels } = makeTransport();
+    const received: string[] = [];
+    transport.on("message", (data) => received.push(data));
+
+    apiChannel.receive(serverInfo(49));
+    await flush();
+    expect(received).toEqual([serverInfo(49)]);
+
+    channels[0].receive(
+      JSON.stringify({ command: "players/all", message_id: 1 }),
+    );
+    expect(received).toEqual([serverInfo(49)]);
+  });
+
+  it("closes the dedicated channel when the transport is torn down", async () => {
+    const { transport, internals, apiChannel, channels } = makeTransport();
+
+    apiChannel.receive(serverInfo(49));
+    await flush();
+    const proxyChannel = channels[0];
+
+    transport.disconnect();
+
+    expect(proxyChannel.readyState).toBe("closed");
+    expect(internals.httpProxyChannel).toBeNull();
+  });
+});

--- a/tests/plugins/webrtc-transport-http-proxy-channel.test.ts
+++ b/tests/plugins/webrtc-transport-http-proxy-channel.test.ts
@@ -39,6 +39,7 @@ type TransportInternals = {
   peerConnection: unknown;
   dataChannel: FakeDataChannel | null;
   httpProxyChannel: FakeDataChannel | null;
+  chunkGroups: Map<number, unknown>;
   setupDataChannelHandlers: () => void;
 };
 
@@ -207,6 +208,27 @@ describe("WebRTCTransport http_proxy channel", () => {
 
     apiChannel.receive(proxyResponse(sentRequestId(apiChannel), [5]));
     await expect(response).resolves.toMatchObject({ status: 200 });
+  });
+
+  it("drops half-received chunks when the dedicated channel closes", async () => {
+    const { transport, internals, apiChannel, channels } = makeTransport();
+
+    apiChannel.receive(serverInfo(49));
+    await flush();
+    const proxyChannel = channels[0];
+
+    void transport.sendHttpProxyRequest("GET", "/imageproxy?p=1");
+    const frames = makeChunks(
+      proxyResponse(sentRequestId(proxyChannel), [1, 2, 3, 4, 5, 6, 7, 8]),
+      42,
+    );
+    // the channel drops with the response only partly delivered
+    proxyChannel.receive(frames[0]);
+    expect(internals.chunkGroups.size).toBe(1);
+
+    proxyChannel.close();
+
+    expect(internals.chunkGroups.size).toBe(0);
   });
 
   it("never emits a message that arrives on the dedicated channel", async () => {


### PR DESCRIPTION
# What does this implement/fix?

Over a remote connection, album art and previews are fetched through the WebRTC
connection. They shared the same channel as the API messages, so a screen full of
album art queued up in front of API traffic and the app felt sluggish while a big
list was loading.

The server now offers a dedicated channel for these image requests, and this uses it.

- Send proxied image/preview requests on the server's `http_proxy` channel
- Keep using the API channel when the server does not offer one, so nothing breaks
  against an older server
- Fall back to the API channel if the dedicated channel goes away mid-session

**Related issue (if applicable):**

- related issue `<link to issue>`

**Related backend PR (if applicable):**

- related backend PR https://github.com/music-assistant/server/pull/5635

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm lint:check` passes.
- [x] `pnpm test:run` passes, and tests have been added/updated where applicable.
- [x] `pnpm build` passes.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
