### PR TITLE
Stop paging through the library after you leave a listing

### DIFF
--- a/src/components/ItemsListing.vue
+++ b/src/components/ItemsListing.vue
@@ -939,6 +939,9 @@ const loadNextPage = async function ({
 
 const loadAllItems = async function () {
   while (!allItemsReceived.value) {
+    // the paging can outlast the listing, so stop fetching once it is gone
+    if (unmounted) return;
+
     await loadNextPage({ done: function () {} });
   }
 };

--- a/tests/components/ItemsListing.test.ts
+++ b/tests/components/ItemsListing.test.ts
@@ -1,9 +1,11 @@
 import ItemsListing from "@/components/ItemsListing.vue";
 import type { MusicAssistantApi } from "@/plugins/api";
+import type { Track } from "@/plugins/api/interfaces";
 import { eventbus } from "@/plugins/eventbus";
 import { enableAutoUnmount, flushPromises, mount } from "@vue/test-utils";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { genre } from "../fixtures/genre";
+import { track } from "../fixtures/track";
 
 // Tracks live subscriptions the way the api does, so one that outlives the
 // listing stays listed here.
@@ -112,13 +114,16 @@ function clearSelectionHandlers() {
   return eventbus.all.get("clearSelection")?.length ?? 0;
 }
 
-function mountListingRaw() {
+function mountListingRaw(
+  props: Partial<InstanceType<typeof ItemsListing>["$props"]> = {},
+) {
   return mount(ItemsListing, {
     props: {
       itemtype: "tracks",
       path: "librarytracks",
       showGenreFilter: true,
       loadPagedData: vi.fn().mockResolvedValue([]),
+      ...props,
     },
     global: {
       mocks: {
@@ -144,7 +149,7 @@ function mountListingRaw() {
 
 enableAutoUnmount(afterEach);
 
-describe("ItemsListing startup cleanup", () => {
+describe("ItemsListing unmount cleanup", () => {
   beforeEach(() => {
     eventbus.all.clear();
     events.listeners.length = 0;
@@ -215,6 +220,52 @@ describe("ItemsListing startup cleanup", () => {
     await flushPromises();
 
     expect(mockGetLibraryGenres).toHaveBeenCalledTimes(1);
+  });
+
+  it("stops paging through the library when the listing is closed mid-selection", async () => {
+    // a full page is what keeps the paging loop going; taking the size from the
+    // request keeps that true whatever page size the listing asks for
+    const fullPage = (limit: number) =>
+      Array.from({ length: limit }, (_, index) =>
+        track({ item_id: String(index), name: `Track ${index}` }),
+      );
+    let requestedPageSize = 0;
+    let resolveHeldPage: () => void = () => {};
+    const loadPagedData =
+      vi.fn<(params: { limit: number }) => Promise<Track[]>>();
+    loadPagedData
+      // the load on mount, leaving more pages for the selection to page through
+      .mockImplementationOnce(async ({ limit }) => fullPage(limit))
+      // the first page the selection asks for, held open across the unmount
+      .mockImplementationOnce(({ limit }) => {
+        requestedPageSize = limit;
+        return new Promise<Track[]>((resolve) => {
+          resolveHeldPage = () => resolve(fullPage(limit));
+        });
+      })
+      // a short page, so paging that carries on regardless still comes to an end
+      .mockResolvedValue([]);
+
+    const listing = mountListingRaw({ allowKeyHooks: true, loadPagedData });
+    await flushPromises();
+    expect(loadPagedData).toHaveBeenCalledTimes(1);
+
+    document.dispatchEvent(
+      new KeyboardEvent("keydown", { key: "a", ctrlKey: true }),
+    );
+    await flushPromises();
+    // pin that selecting everything really is paused on a page request, so the
+    // closing assertion is about the resumed loop and not one that never started
+    expect(loadPagedData).toHaveBeenCalledTimes(2);
+    // a page the listing never asked to fill would end the paging on its own,
+    // leaving the closing assertion true no matter what
+    expect(requestedPageSize).toBeGreaterThan(0);
+
+    listing.unmount();
+    resolveHeldPage();
+    await flushPromises();
+
+    expect(loadPagedData).toHaveBeenCalledTimes(2);
   });
 
   it("leaves a second listing on the page still clearing its own selection", async () => {


### PR DESCRIPTION
# What does this implement/fix?

Selecting everything in a library listing pages through the whole library one page at a time. That loop had no idea the listing could disappear underneath it, so leaving the page mid-selection left it fetching every remaining page for nothing — on a large library that is hundreds of requests after you are already somewhere else.

It now checks the same unmount flag the genre filter loop uses (#2500) and stops as soon as the listing is gone.

- Stop the select-all paging loop once the listing is closed
- Added a test covering a listing closed while it is still paging

**Related issue (if applicable):**

- related issue `n/a`

**Related backend PR (if applicable):**

<!--
Link the music-assistant/server PR when this change relies on new server
behaviour, so the two can be reviewed and released together.
-->

- related backend PR `n/a`

## Types of changes

<!--
Tick exactly one box below. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm lint:check` passes.
- [x] `pnpm test:run` passes, and tests have been added/updated where applicable.
- [x] `pnpm build` passes.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
