### PR TITLE
Album art loads faster over a remote connection

### DIFF
--- a/src/plugins/remote/webrtc-transport.ts
+++ b/src/plugins/remote/webrtc-transport.ts
@@ -81,6 +81,8 @@ export class WebRTCTransport extends BaseTransport {
         body: Uint8Array;
       }) => void;
       reject: (error: Error) => void;
+      // requests sent on the proxy channel die with it, unlike those on the API channel
+      onProxyChannel: boolean;
     }
   >();
   // Reassembly buffers for oversized messages the server splits into chunks, keyed by group id.
@@ -365,15 +367,16 @@ export class WebRTCTransport extends BaseTransport {
     const pending = this.pendingProxyBody;
     if (!pending) return;
     this.pendingProxyBody = null;
+    // check for a waiting caller before assembling, which for an image copies real bytes
+    const callbacks = this.httpProxyCallbacks.get(pending.id);
+    if (!callbacks) return;
+    this.httpProxyCallbacks.delete(pending.id);
     const body = new Uint8Array(pending.received);
     let offset = 0;
     for (const part of pending.parts) {
       body.set(part, offset);
       offset += part.byteLength;
     }
-    const callbacks = this.httpProxyCallbacks.get(pending.id);
-    if (!callbacks) return;
-    this.httpProxyCallbacks.delete(pending.id);
     callbacks.resolve({
       status: pending.status,
       headers: pending.headers,
@@ -409,6 +412,13 @@ export class WebRTCTransport extends BaseTransport {
         this.pendingProxyBody = null;
         if (this.httpProxyChannel === channel) {
           this.httpProxyChannel = null;
+        }
+        // nothing still in flight here can be answered now, so fail those callers at once
+        // rather than leaving each one waiting out its timeout
+        for (const [id, callbacks] of this.httpProxyCallbacks) {
+          if (!callbacks.onProxyChannel) continue;
+          this.httpProxyCallbacks.delete(id);
+          callbacks.reject(new Error("http_proxy channel closed"));
         }
       };
       this.httpProxyChannel = channel;
@@ -616,7 +626,11 @@ export class WebRTCTransport extends BaseTransport {
       body: Uint8Array;
     }>((resolve, reject) => {
       // Store callbacks
-      this.httpProxyCallbacks.set(requestId, { resolve, reject });
+      this.httpProxyCallbacks.set(requestId, {
+        resolve,
+        reject,
+        onProxyChannel: channel === this.httpProxyChannel,
+      });
 
       // Set timeout
       setTimeout(() => {

--- a/src/plugins/remote/webrtc-transport.ts
+++ b/src/plugins/remote/webrtc-transport.ts
@@ -84,17 +84,23 @@ export class WebRTCTransport extends BaseTransport {
     }
   >();
   // Reassembly buffers for oversized messages the server splits into chunks, keyed by group id.
-  // Group ids are unique across channels, so the dispatch of the channel a group started on
-  // is kept with it.
   private chunkGroups = new Map<
     number,
     {
       count: number;
       parts: string[];
       received: number;
-      dispatch: (data: string) => void;
     }
   >();
+  // Response being reassembled on the proxy channel: its header, then raw body frames.
+  private pendingProxyBody: {
+    id: string;
+    status: number;
+    headers: Record<string, string>;
+    size: number;
+    parts: Uint8Array[];
+    received: number;
+  } | null = null;
   // ICE servers received from the signaling server (provided by MA server)
   private iceServers: IceServerConfig[] = [];
 
@@ -324,17 +330,55 @@ export class WebRTCTransport extends BaseTransport {
   }
 
   /**
-   * Handle a message from the http_proxy channel, which only ever carries proxy responses.
+   * Handle a message from the http_proxy channel, which carries each proxy response as a
+   * JSON header followed by its body as raw binary frames.
    */
-  private dispatchHttpProxyMessage(data: string): void {
-    try {
-      const parsed = JSON.parse(data);
-      if (parsed.type === "http-proxy-response") {
-        this.handleHttpProxyResponse(parsed);
-      }
-    } catch {
-      // not JSON; nothing on this channel to dispatch
+  private handleHttpProxyMessage(data: string | ArrayBuffer): void {
+    if (typeof data !== "string") {
+      const pending = this.pendingProxyBody;
+      if (!pending) return;
+      pending.parts.push(new Uint8Array(data));
+      pending.received += data.byteLength;
+      if (pending.received >= pending.size) this.completeHttpProxyBody();
+      return;
     }
+    let parsed;
+    try {
+      parsed = JSON.parse(data);
+    } catch {
+      return; // not JSON; nothing on this channel to dispatch
+    }
+    if (parsed.type !== "http-proxy-response") return;
+    this.pendingProxyBody = {
+      id: parsed.id,
+      status: parsed.status,
+      headers: parsed.headers,
+      size: parsed.size,
+      parts: [],
+      received: 0,
+    };
+    // an empty body is sent as a header on its own
+    if (parsed.size === 0) this.completeHttpProxyBody();
+  }
+
+  private completeHttpProxyBody(): void {
+    const pending = this.pendingProxyBody;
+    if (!pending) return;
+    this.pendingProxyBody = null;
+    const body = new Uint8Array(pending.received);
+    let offset = 0;
+    for (const part of pending.parts) {
+      body.set(part, offset);
+      offset += part.byteLength;
+    }
+    const callbacks = this.httpProxyCallbacks.get(pending.id);
+    if (!callbacks) return;
+    this.httpProxyCallbacks.delete(pending.id);
+    callbacks.resolve({
+      status: pending.status,
+      headers: pending.headers,
+      body: body.subarray(0, pending.size),
+    });
   }
 
   private maybeOpenHttpProxyChannel(schemaVersion: number): void {
@@ -357,13 +401,12 @@ export class WebRTCTransport extends BaseTransport {
         channel.close();
         return;
       }
-      const dispatch = (data: string) => this.dispatchHttpProxyMessage(data);
-      this.attachMessageHandler(channel, dispatch);
+      // body frames arrive as raw binary, which must not be surfaced as Blobs
+      channel.binaryType = "arraybuffer";
+      channel.onmessage = (event) => this.handleHttpProxyMessage(event.data);
       channel.onclose = () => {
-        // a response cut off mid-chunk can never be reassembled, so drop what it left
-        for (const [id, group] of this.chunkGroups) {
-          if (group.dispatch === dispatch) this.chunkGroups.delete(id);
-        }
+        // a body cut off mid-transfer can never be completed, so drop what it left
+        this.pendingProxyBody = null;
         if (this.httpProxyChannel === channel) {
           this.httpProxyChannel = null;
         }
@@ -393,7 +436,6 @@ export class WebRTCTransport extends BaseTransport {
         count: frame.count,
         parts: Array.from<string>({ length: frame.count }),
         received: 0,
-        dispatch,
       };
       this.chunkGroups.set(frame.id, pending);
     }
@@ -405,7 +447,7 @@ export class WebRTCTransport extends BaseTransport {
 
     this.chunkGroups.delete(frame.id);
     const bytes = this.base64PartsToBytes(pending.parts);
-    pending.dispatch(new TextDecoder().decode(bytes));
+    dispatch(new TextDecoder().decode(bytes));
   }
 
   private base64PartsToBytes(parts: string[]): Uint8Array {
@@ -759,6 +801,7 @@ export class WebRTCTransport extends BaseTransport {
     }
     this.httpProxyCallbacks.clear();
     this.chunkGroups.clear();
+    this.pendingProxyBody = null;
   }
 
   /**

--- a/src/plugins/remote/webrtc-transport.ts
+++ b/src/plugins/remote/webrtc-transport.ts
@@ -351,6 +351,12 @@ export class WebRTCTransport extends BaseTransport {
       return; // not JSON; nothing on this channel to dispatch
     }
     if (parsed.type !== "http-proxy-response") return;
+    // a response without a body length is the hex-in-JSON form, which a server that
+    // predates the binary framing still answers with
+    if (typeof parsed.size !== "number") {
+      this.handleHttpProxyResponse(parsed);
+      return;
+    }
     this.pendingProxyBody = {
       id: parsed.id,
       status: parsed.status,

--- a/src/plugins/remote/webrtc-transport.ts
+++ b/src/plugins/remote/webrtc-transport.ts
@@ -350,6 +350,13 @@ export class WebRTCTransport extends BaseTransport {
     } catch {
       return; // not JSON; nothing on this channel to dispatch
     }
+    // a hex response big enough to be split arrives as chunk frames to reassemble first
+    if (parsed.type === "__chunk__") {
+      this.handleChunk(parsed, (message) =>
+        this.handleHttpProxyMessage(message),
+      );
+      return;
+    }
     if (parsed.type !== "http-proxy-response") return;
     // a response without a body length is the hex-in-JSON form, which a server that
     // predates the binary framing still answers with
@@ -642,6 +649,10 @@ export class WebRTCTransport extends BaseTransport {
       setTimeout(() => {
         if (this.httpProxyCallbacks.has(requestId)) {
           this.httpProxyCallbacks.delete(requestId);
+          // stop buffering frames nothing is waiting for any more
+          if (this.pendingProxyBody?.id === requestId) {
+            this.pendingProxyBody = null;
+          }
           reject(new Error("HTTP proxy request timeout"));
         }
       }, 30000);

--- a/src/plugins/remote/webrtc-transport.ts
+++ b/src/plugins/remote/webrtc-transport.ts
@@ -86,14 +86,20 @@ export class WebRTCTransport extends BaseTransport {
     }
   >();
   // Reassembly buffers for oversized messages the server splits into chunks, keyed by group id.
+  // Group ids are unique across channels, so the dispatch of the channel a group started on
+  // is kept with it.
   private chunkGroups = new Map<
     number,
     {
       count: number;
       parts: string[];
       received: number;
+      dispatch: (data: string) => void;
     }
   >();
+  // Stable identity, so a closing proxy channel can find the groups it started.
+  private readonly dispatchHttpProxy = (data: string): void =>
+    this.handleHttpProxyMessage(data);
   // Response being reassembled on the proxy channel: its header, then raw body frames.
   private pendingProxyBody: {
     id: string;
@@ -352,9 +358,7 @@ export class WebRTCTransport extends BaseTransport {
     }
     // a hex response big enough to be split arrives as chunk frames to reassemble first
     if (parsed.type === "__chunk__") {
-      this.handleChunk(parsed, (message) =>
-        this.handleHttpProxyMessage(message),
-      );
+      this.handleChunk(parsed, this.dispatchHttpProxy);
       return;
     }
     if (parsed.type !== "http-proxy-response") return;
@@ -364,6 +368,8 @@ export class WebRTCTransport extends BaseTransport {
       this.handleHttpProxyResponse(parsed);
       return;
     }
+    // no point buffering frames for a request that already gave up
+    if (!this.httpProxyCallbacks.has(parsed.id)) return;
     this.pendingProxyBody = {
       id: parsed.id,
       status: parsed.status,
@@ -421,8 +427,13 @@ export class WebRTCTransport extends BaseTransport {
       channel.binaryType = "arraybuffer";
       channel.onmessage = (event) => this.handleHttpProxyMessage(event.data);
       channel.onclose = () => {
-        // a body cut off mid-transfer can never be completed, so drop what it left
+        // a response cut off mid-transfer can never be completed, so drop what it left
         this.pendingProxyBody = null;
+        for (const [id, group] of this.chunkGroups) {
+          if (group.dispatch === this.dispatchHttpProxy) {
+            this.chunkGroups.delete(id);
+          }
+        }
         if (this.httpProxyChannel === channel) {
           this.httpProxyChannel = null;
         }
@@ -459,6 +470,7 @@ export class WebRTCTransport extends BaseTransport {
         count: frame.count,
         parts: Array.from<string>({ length: frame.count }),
         received: 0,
+        dispatch,
       };
       this.chunkGroups.set(frame.id, pending);
     }
@@ -470,7 +482,7 @@ export class WebRTCTransport extends BaseTransport {
 
     this.chunkGroups.delete(frame.id);
     const bytes = this.base64PartsToBytes(pending.parts);
-    dispatch(new TextDecoder().decode(bytes));
+    pending.dispatch(new TextDecoder().decode(bytes));
   }
 
   private base64PartsToBytes(parts: string[]): Uint8Array {

--- a/tests/plugins/webrtc-transport-http-proxy-channel.test.ts
+++ b/tests/plugins/webrtc-transport-http-proxy-channel.test.ts
@@ -249,7 +249,7 @@ describe("WebRTCTransport http_proxy channel", () => {
     await flush();
     const proxyChannel = channels[0];
 
-    void transport.sendHttpProxyRequest("GET", "/imageproxy?p=1");
+    const request = transport.sendHttpProxyRequest("GET", "/imageproxy?p=1");
     const [header, firstFrame] = binaryProxyResponse(
       sentRequestId(proxyChannel),
       [1, 2, 3, 4, 5, 6, 7, 8],
@@ -262,7 +262,50 @@ describe("WebRTCTransport http_proxy channel", () => {
 
     proxyChannel.close();
 
+    await expect(request).rejects.toThrow();
     expect(internals.pendingProxyBody).toBeNull();
+  });
+
+  it("fails requests still in flight when the dedicated channel closes", async () => {
+    const { transport, apiChannel, channels } = makeTransport();
+
+    apiChannel.receive(serverInfo(49));
+    await flush();
+    const proxyChannel = channels[0];
+
+    const streaming = transport.sendHttpProxyRequest("GET", "/imageproxy?p=1");
+    const alsoWaiting = transport.sendHttpProxyRequest(
+      "GET",
+      "/imageproxy?p=2",
+    );
+    // the first is mid-body, the second has not been answered at all
+    const [header, firstFrame] = binaryProxyResponse(
+      sentRequestId(proxyChannel),
+      [1, 2, 3, 4, 5, 6, 7, 8],
+      4,
+    );
+    proxyChannel.receive(header);
+    proxyChannel.receive(firstFrame);
+
+    proxyChannel.close();
+
+    // both fail now rather than sitting out the 30s request timeout
+    await expect(streaming).rejects.toThrow("http_proxy channel closed");
+    await expect(alsoWaiting).rejects.toThrow("http_proxy channel closed");
+  });
+
+  it("leaves API-channel requests alone when the dedicated channel closes", async () => {
+    const { transport, apiChannel, channels } = makeTransport();
+
+    // this one goes out before the dedicated channel exists, so it must survive its close
+    const viaApi = transport.sendHttpProxyRequest("GET", "/imageproxy?p=1");
+    apiChannel.receive(serverInfo(49));
+    await flush();
+
+    channels[0].close();
+
+    apiChannel.receive(proxyResponse(sentRequestId(apiChannel), [7, 7]));
+    await expect(viaApi).resolves.toMatchObject({ status: 200 });
   });
 
   it("never emits a message that arrives on the dedicated channel", async () => {

--- a/tests/plugins/webrtc-transport-http-proxy-channel.test.ts
+++ b/tests/plugins/webrtc-transport-http-proxy-channel.test.ts
@@ -317,6 +317,28 @@ describe("WebRTCTransport http_proxy channel", () => {
     expect(internals.pendingProxyBody).toBeNull();
   });
 
+  it("drops half-received chunks when the dedicated channel closes", async () => {
+    const { transport, internals, apiChannel, channels } = makeTransport();
+
+    apiChannel.receive(serverInfo(49));
+    await flush();
+    const proxyChannel = channels[0];
+
+    const request = transport.sendHttpProxyRequest("GET", "/imageproxy?p=1");
+    const frames = makeChunks(
+      proxyResponse(sentRequestId(proxyChannel), [1, 2, 3, 4, 5]),
+      11,
+    );
+    // the channel drops with the hex response only partly reassembled
+    proxyChannel.receive(frames[0]);
+    expect(internals.chunkGroups.size).toBe(1);
+
+    proxyChannel.close();
+
+    await expect(request).rejects.toThrow();
+    expect(internals.chunkGroups.size).toBe(0);
+  });
+
   it("fails requests still in flight when the dedicated channel closes", async () => {
     const { transport, apiChannel, channels } = makeTransport();
 

--- a/tests/plugins/webrtc-transport-http-proxy-channel.test.ts
+++ b/tests/plugins/webrtc-transport-http-proxy-channel.test.ts
@@ -194,6 +194,22 @@ describe("WebRTCTransport http_proxy channel", () => {
     expect(body).toHaveLength(0);
   });
 
+  it("still reads a hex response on the dedicated channel", async () => {
+    const { transport, apiChannel, channels } = makeTransport();
+
+    apiChannel.receive(serverInfo(49));
+    await flush();
+    const proxyChannel = channels[0];
+
+    // a server that reports schema 49 but predates the binary framing answers like this
+    const response = transport.sendHttpProxyRequest("GET", "/imageproxy?p=1");
+    proxyChannel.receive(proxyResponse(sentRequestId(proxyChannel), [4, 5, 6]));
+
+    const { status, body } = await response;
+    expect(status).toBe(200);
+    expect(Array.from(body)).toEqual([4, 5, 6]);
+  });
+
   it("negotiates the dedicated channel only once per connection", async () => {
     const { apiChannel, channels } = makeTransport();
 

--- a/tests/plugins/webrtc-transport-http-proxy-channel.test.ts
+++ b/tests/plugins/webrtc-transport-http-proxy-channel.test.ts
@@ -127,6 +127,22 @@ function sentRequestId(channel: FakeDataChannel): string {
   return JSON.parse(channel.sent[0]).id;
 }
 
+// Split a message into "__chunk__" frames the way the server splits an oversized one.
+function makeChunks(text: string, id: number, pieceBytes = 8): string[] {
+  const bytes = new TextEncoder().encode(text);
+  const count = Math.max(1, Math.ceil(bytes.length / pieceBytes));
+  const frames: string[] = [];
+  for (let seq = 0; seq < count; seq++) {
+    const slice = bytes.slice(seq * pieceBytes, (seq + 1) * pieceBytes);
+    let binary = "";
+    slice.forEach((b) => (binary += String.fromCharCode(b)));
+    frames.push(
+      JSON.stringify({ type: "__chunk__", id, seq, count, b64: btoa(binary) }),
+    );
+  }
+  return frames;
+}
+
 describe("WebRTCTransport http_proxy channel", () => {
   it("keeps proxied requests on the API channel for a server that predates it", async () => {
     const { transport, apiChannel, channels } = makeTransport();
@@ -208,6 +224,25 @@ describe("WebRTCTransport http_proxy channel", () => {
     const { status, body } = await response;
     expect(status).toBe(200);
     expect(Array.from(body)).toEqual([4, 5, 6]);
+  });
+
+  it("still reads a chunked hex response on the dedicated channel", async () => {
+    const { transport, apiChannel, channels } = makeTransport();
+
+    apiChannel.receive(serverInfo(49));
+    await flush();
+    const proxyChannel = channels[0];
+
+    // that server splits any hex response past its chunk size, so most images arrive
+    // as several frames rather than one message
+    const response = transport.sendHttpProxyRequest("GET", "/imageproxy?p=1");
+    const message = proxyResponse(sentRequestId(proxyChannel), [1, 2, 3, 4, 5]);
+    const frames = makeChunks(message, 7);
+    expect(frames.length).toBeGreaterThan(1);
+    for (const frame of frames) proxyChannel.receive(frame);
+
+    const { body } = await response;
+    expect(Array.from(body)).toEqual([1, 2, 3, 4, 5]);
   });
 
   it("negotiates the dedicated channel only once per connection", async () => {

--- a/tests/plugins/webrtc-transport-http-proxy-channel.test.ts
+++ b/tests/plugins/webrtc-transport-http-proxy-channel.test.ts
@@ -6,11 +6,12 @@ import { WebRTCTransport } from "../../src/plugins/remote/webrtc-transport";
 // messages back in.
 class FakeDataChannel {
   readyState: RTCDataChannelState = "connecting";
+  binaryType: BinaryType = "blob";
   sent: string[] = [];
   onopen: (() => void) | null = null;
   onclose: (() => void) | null = null;
   onerror: (() => void) | null = null;
-  onmessage: ((event: { data: string }) => void) | null = null;
+  onmessage: ((event: { data: string | ArrayBuffer }) => void) | null = null;
 
   constructor(readonly label: string) {}
 
@@ -28,7 +29,7 @@ class FakeDataChannel {
     this.onclose?.();
   }
 
-  receive(data: string): void {
+  receive(data: string | ArrayBuffer): void {
     this.onmessage?.({ data });
   }
 }
@@ -40,6 +41,7 @@ type TransportInternals = {
   dataChannel: FakeDataChannel | null;
   httpProxyChannel: FakeDataChannel | null;
   chunkGroups: Map<number, unknown>;
+  pendingProxyBody: unknown;
   setupDataChannelHandlers: () => void;
 };
 
@@ -89,6 +91,7 @@ function serverInfo(schemaVersion: number): string {
   });
 }
 
+// The hex-in-JSON response clients still get when they proxy over the API channel.
 function proxyResponse(id: string, body: number[]): string {
   return JSON.stringify({
     type: "http-proxy-response",
@@ -99,24 +102,29 @@ function proxyResponse(id: string, body: number[]): string {
   });
 }
 
-function sentRequestId(channel: FakeDataChannel): string {
-  return JSON.parse(channel.sent[0]).id;
+// Frame a response the way the dedicated channel carries it: a JSON header, then the
+// body as raw binary messages.
+function binaryProxyResponse(
+  id: string,
+  body: number[],
+  frameBytes = Math.max(1, body.length),
+): [string, ...ArrayBuffer[]] {
+  const header = JSON.stringify({
+    type: "http-proxy-response",
+    id,
+    status: 200,
+    headers: { "content-type": "image/png" },
+    size: body.length,
+  });
+  const frames: ArrayBuffer[] = [];
+  for (let offset = 0; offset < body.length; offset += frameBytes) {
+    frames.push(new Uint8Array(body.slice(offset, offset + frameBytes)).buffer);
+  }
+  return [header, ...frames];
 }
 
-// Split a message into "__chunk__" frames the way the server does.
-function makeChunks(text: string, id: number, pieceBytes = 8): string[] {
-  const bytes = new TextEncoder().encode(text);
-  const count = Math.max(1, Math.ceil(bytes.length / pieceBytes));
-  const frames: string[] = [];
-  for (let seq = 0; seq < count; seq++) {
-    const slice = bytes.slice(seq * pieceBytes, (seq + 1) * pieceBytes);
-    let binary = "";
-    slice.forEach((b) => (binary += String.fromCharCode(b)));
-    frames.push(
-      JSON.stringify({ type: "__chunk__", id, seq, count, b64: btoa(binary) }),
-    );
-  }
-  return frames;
+function sentRequestId(channel: FakeDataChannel): string {
+  return JSON.parse(channel.sent[0]).id;
 }
 
 describe("WebRTCTransport http_proxy channel", () => {
@@ -156,12 +164,34 @@ describe("WebRTCTransport http_proxy channel", () => {
       path: "/imageproxy?p=1",
     });
 
-    proxyChannel.receive(
-      proxyResponse(sentRequestId(proxyChannel), [1, 2, 3, 4]),
-    );
+    // the channel must hand raw frames over as ArrayBuffers, not Blobs
+    expect(proxyChannel.binaryType).toBe("arraybuffer");
+
+    for (const frame of binaryProxyResponse(
+      sentRequestId(proxyChannel),
+      [1, 2, 3, 4],
+    )) {
+      proxyChannel.receive(frame);
+    }
     const { status, body } = await response;
     expect(status).toBe(200);
     expect(Array.from(body)).toEqual([1, 2, 3, 4]);
+  });
+
+  it("resolves an empty body from its header alone", async () => {
+    const { transport, apiChannel, channels } = makeTransport();
+
+    apiChannel.receive(serverInfo(49));
+    await flush();
+    const proxyChannel = channels[0];
+
+    const response = transport.sendHttpProxyRequest("GET", "/imageproxy?p=1");
+    const [header] = binaryProxyResponse(sentRequestId(proxyChannel), []);
+    proxyChannel.receive(header);
+
+    const { status, body } = await response;
+    expect(status).toBe(200);
+    expect(body).toHaveLength(0);
   });
 
   it("negotiates the dedicated channel only once per connection", async () => {
@@ -174,7 +204,7 @@ describe("WebRTCTransport http_proxy channel", () => {
     expect(channels).toHaveLength(1);
   });
 
-  it("reassembles a chunked response that arrives on the dedicated channel", async () => {
+  it("reassembles a body split across several binary frames", async () => {
     const { transport, apiChannel, channels } = makeTransport();
 
     apiChannel.receive(serverInfo(49));
@@ -182,11 +212,13 @@ describe("WebRTCTransport http_proxy channel", () => {
     const proxyChannel = channels[0];
 
     const response = transport.sendHttpProxyRequest("GET", "/imageproxy?p=1");
-    const message = proxyResponse(
+    const frames = binaryProxyResponse(
       sentRequestId(proxyChannel),
       [9, 8, 7, 6, 5, 4, 3, 2, 1, 0],
+      4,
     );
-    for (const frame of makeChunks(message, 42)) proxyChannel.receive(frame);
+    expect(frames).toHaveLength(4); // header plus 4/4/2 bytes
+    for (const frame of frames) proxyChannel.receive(frame);
 
     const { body } = await response;
     expect(Array.from(body)).toEqual([9, 8, 7, 6, 5, 4, 3, 2, 1, 0]);
@@ -210,7 +242,7 @@ describe("WebRTCTransport http_proxy channel", () => {
     await expect(response).resolves.toMatchObject({ status: 200 });
   });
 
-  it("drops half-received chunks when the dedicated channel closes", async () => {
+  it("drops a half-received body when the dedicated channel closes", async () => {
     const { transport, internals, apiChannel, channels } = makeTransport();
 
     apiChannel.receive(serverInfo(49));
@@ -218,17 +250,19 @@ describe("WebRTCTransport http_proxy channel", () => {
     const proxyChannel = channels[0];
 
     void transport.sendHttpProxyRequest("GET", "/imageproxy?p=1");
-    const frames = makeChunks(
-      proxyResponse(sentRequestId(proxyChannel), [1, 2, 3, 4, 5, 6, 7, 8]),
-      42,
+    const [header, firstFrame] = binaryProxyResponse(
+      sentRequestId(proxyChannel),
+      [1, 2, 3, 4, 5, 6, 7, 8],
+      4,
     );
-    // the channel drops with the response only partly delivered
-    proxyChannel.receive(frames[0]);
-    expect(internals.chunkGroups.size).toBe(1);
+    // the channel drops with the body only partly delivered
+    proxyChannel.receive(header);
+    proxyChannel.receive(firstFrame);
+    expect(internals.pendingProxyBody).not.toBeNull();
 
     proxyChannel.close();
 
-    expect(internals.chunkGroups.size).toBe(0);
+    expect(internals.pendingProxyBody).toBeNull();
   });
 
   it("never emits a message that arrives on the dedicated channel", async () => {


### PR DESCRIPTION
# What does this implement/fix?

The server now sends proxied album art on its dedicated image channel as a small JSON
header followed by the body as raw binary frames, instead of hex-encoding the image inside
JSON and base64-chunking it. That cuts roughly 2.7x of wire cost per image down to 1x, so
art loads faster over a remote connection.

- Read responses on the image channel as a header plus raw binary frames
- Ask that channel for `arraybuffer` frames, so bodies never arrive as Blobs
- Drop a half-received body if the channel goes away mid-transfer
- Keep hex-decoding for responses that arrive on the API channel

**Related issue (if applicable):**

- follow-up to #2503

**Related backend PR (if applicable):**

- related backend PR https://github.com/music-assistant/server/pull/5643

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm lint:check` passes.
- [x] `pnpm test:run` passes, and tests have been added/updated where applicable.
