### PR TITLE
Milkdrop settings and preset picker mobile fixes

### DIFF
--- a/src/layouts/default/PlayerOSD/VisualizerMenuControl.vue
+++ b/src/layouts/default/PlayerOSD/VisualizerMenuControl.vue
@@ -11,7 +11,13 @@
         <SelectTrigger class="visualizer-menu__select" size="sm">
           <span class="visualizer-menu__trigger-label">{{ triggerLabel }}</span>
         </SelectTrigger>
-        <SelectContent class="visualizer-menu__dropdown">
+        <!-- the hosting context menu renders at z-[999999] (above the
+             fullscreen player overlay), so this list must stack above that.
+             cap the width so long preset names wrap instead of growing the
+             panel past the viewport on small screens -->
+        <SelectContent
+          class="visualizer-menu__dropdown !z-[1000000] w-[min(92vw,26rem)]"
+        >
           <SelectItem :value="RANDOM_VALUE">
             {{ $t("visualizer.preset_random") }}
           </SelectItem>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -138,6 +138,7 @@ html {
      100000  sheets
      100001  menus opened from a sheet or a player bar popout
      999999  item context menu
+    1000000  popovers opened from inside the item context menu
 
    Values below this range mostly order elements inside a component's own
    stacking context.

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -768,15 +768,15 @@
         },
         "visualizer_enabled": {
             "label": "MilkDrop visualizer",
-            "description": "Render a MilkDrop (Butterchurn) music visualizer behind the fullscreen player, replacing the gradient background. Reacts live to the audio playing on the active player. This is the default for all players; the toggle in a player's fullscreen menu or party screen overrides it for that player only."
+            "description": "Show a MilkDrop visualizer behind the fullscreen player, reacting live to the music. Each player can override this from its fullscreen menu."
         },
         "visualizer_blur": {
             "label": "Visualizer blur",
-            "description": "Blur radius (in pixels) applied to the visualizer for a softer, ambient background. 0 disables blur."
+            "description": "Softens the visualizer for a calmer background. 0 disables blur."
         },
         "visualizer_opacity": {
             "label": "Visualizer opacity",
-            "description": "Opacity of the visualizer layer; lower values blend the album-color gradient background through. Note: at 55% and above the view switches to an immersive dark look with light text; at 50% and below it keeps the normal theme background and text colors."
+            "description": "Lower values blend the album colors through. Above 50% the view switches to a dark look with light text."
         },
         "download_diagnostics": "Download diagnostics",
         "diagnostics": "Diagnostics",
@@ -2041,11 +2041,11 @@
         },
         "fixed_preset": "Preset",
         "beat_switch": "Switch preset on downbeat",
-        "beat_switch_description": "Automatically switch to another preset on a downbeat, using Music Assistant's beat analysis. Takes precedence over a fixed preset selection.",
+        "beat_switch_description": "Switch to another preset on a downbeat. Overrides a fixed preset.",
         "beat_dwell": "Minimum time between switches",
         "beat_dwell_description": "How long a preset stays on screen before a downbeat may switch it.",
         "favorites": "Favorite presets",
-        "no_favorites": "No favorites yet. Use the star next to the preset picker in the fullscreen player to favorite the preset currently showing.",
+        "no_favorites": "No favorites yet. Star the current preset in the fullscreen player.",
         "remove_favorite": "Remove favorite",
         "credits": "Credits",
         "credits_butterchurn": "Rendering powered by Butterchurn by Jordan Berg (MIT license), the WebGL implementation of MilkDrop 2.",

--- a/src/views/settings/VisualizerConfig.vue
+++ b/src/views/settings/VisualizerConfig.vue
@@ -56,7 +56,9 @@
           />
         </div>
 
-        <div class="flex items-center justify-between gap-6">
+        <div
+          class="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between sm:gap-6"
+        >
           <div class="min-w-0">
             <div class="font-medium">{{ $t("visualizer.quality") }}</div>
             <div class="text-sm text-muted-foreground">
@@ -69,7 +71,7 @@
               (v: unknown) => setPref('visualizer_quality', String(v))
             "
           >
-            <SelectTrigger class="w-56 shrink-0">
+            <SelectTrigger class="w-full shrink-0 sm:w-56">
               <SelectValue />
             </SelectTrigger>
             <SelectContent>
@@ -84,7 +86,9 @@
           </Select>
         </div>
 
-        <div class="flex items-center justify-between gap-6">
+        <div
+          class="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between sm:gap-6"
+        >
           <div class="min-w-0">
             <div class="font-medium">
               {{ $t("settings.visualizer_opacity.label") }}
@@ -93,7 +97,7 @@
               {{ $t("settings.visualizer_opacity.description") }}
             </div>
           </div>
-          <div class="flex w-64 shrink-0 items-center gap-3">
+          <div class="flex w-full shrink-0 items-center gap-3 sm:w-64">
             <Slider
               :model-value="[opacityDraft]"
               :min="10"
@@ -112,7 +116,9 @@
           </div>
         </div>
 
-        <div class="flex items-center justify-between gap-6">
+        <div
+          class="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between sm:gap-6"
+        >
           <div class="min-w-0">
             <div class="font-medium">
               {{ $t("settings.visualizer_blur.label") }}
@@ -121,7 +127,7 @@
               {{ $t("settings.visualizer_blur.description") }}
             </div>
           </div>
-          <div class="flex w-64 shrink-0 items-center gap-3">
+          <div class="flex w-full shrink-0 items-center gap-3 sm:w-64">
             <Slider
               :model-value="[blurDraft]"
               :min="0"
@@ -150,7 +156,9 @@
         </div>
       </CardHeader>
       <CardContent class="space-y-5">
-        <div class="flex items-center justify-between gap-6">
+        <div
+          class="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between sm:gap-6"
+        >
           <div class="min-w-0">
             <div class="font-medium">{{ $t("visualizer.preset_mode") }}</div>
             <div class="text-sm text-muted-foreground">
@@ -163,7 +171,7 @@
               (v: unknown) => setPref('visualizer_preset_mode', String(v))
             "
           >
-            <SelectTrigger class="w-56 shrink-0">
+            <SelectTrigger class="w-full shrink-0 sm:w-56">
               <SelectValue />
             </SelectTrigger>
             <SelectContent>
@@ -180,7 +188,7 @@
 
         <div
           v-if="presetModePref === 'fixed'"
-          class="flex items-center justify-between gap-6"
+          class="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between sm:gap-6"
         >
           <div class="min-w-0 font-medium">
             {{ $t("visualizer.fixed_preset") }}
@@ -191,7 +199,7 @@
               (v: unknown) => setPref('visualizer_preset', String(v))
             "
           >
-            <SelectTrigger class="w-72 shrink-0">
+            <SelectTrigger class="w-full shrink-0 sm:w-72">
               <SelectValue :placeholder="$t('visualizer.preset_random')" />
             </SelectTrigger>
             <SelectContent>
@@ -219,7 +227,7 @@
 
         <div
           v-if="beatSwitchPref"
-          class="flex items-center justify-between gap-6"
+          class="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between sm:gap-6"
         >
           <div class="min-w-0">
             <div class="font-medium">{{ $t("visualizer.beat_dwell") }}</div>
@@ -227,7 +235,7 @@
               {{ $t("visualizer.beat_dwell_description") }}
             </div>
           </div>
-          <div class="flex w-64 shrink-0 items-center gap-3">
+          <div class="flex w-full shrink-0 items-center gap-3 sm:w-64">
             <Slider
               :model-value="[beatDwellDraft]"
               :min="5"


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes. -->
Fix the settings view for milkdrop plugin on mobile.

Also fix preset picker

<img width="1056" height="1850" alt="image" src="https://github.com/user-attachments/assets/a0911dd0-8f8d-4849-831e-c4925c7cd236" />

<img width="1018" height="1772" alt="image" src="https://github.com/user-attachments/assets/2526a256-8cbb-4794-866b-0fc67a718540" />


**Related issue (if applicable):**

- related issue `<link to issue>`

**Related backend PR (if applicable):**

<!--
Link the music-assistant/server PR when this change relies on new server
behaviour, so the two can be reviewed and released together.
-->

- related backend PR `<link to PR>`

## Types of changes

<!--
Tick exactly one box below. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm lint:check` passes.
- [x] `pnpm test:run` passes, and tests have been added/updated where applicable.
- [x] `pnpm build` passes.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
