### PR TITLE
Stop ItemsListing tests from leaking state into each other

### DIFF
--- a/tests/components/ItemsListing.test.ts
+++ b/tests/components/ItemsListing.test.ts
@@ -2,6 +2,7 @@ import ItemsListing from "@/components/ItemsListing.vue";
 import type { MusicAssistantApi } from "@/plugins/api";
 import type { Track } from "@/plugins/api/interfaces";
 import { eventbus } from "@/plugins/eventbus";
+import { store } from "@/plugins/store";
 import { enableAutoUnmount, flushPromises, mount } from "@vue/test-utils";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { genre } from "../fixtures/genre";
@@ -157,6 +158,7 @@ describe("ItemsListing unmount cleanup", () => {
     mockGetLibraryGenres.mockResolvedValue([]);
     mockSubscribeMulti.mockReset();
     mockSubscribeMulti.mockImplementation(events.subscribeMulti);
+    store.prevState = undefined;
   });
 
   it("undoes everything it set up when the listing is closed", async () => {


### PR DESCRIPTION
# What does this implement/fix?

The `ItemsListing` tests share one mocked `store` singleton, and `store.prevState` is a single global slot. The `beforeEach` resets the eventbus and both api mocks, but not that slot.

It is harmless today because `restoreState` defaults to `false`, so nothing ever writes the slot. But the mount helper now takes props overrides, so `restoreState: true` is one keyword away — the first test that passes it would leave state behind on unmount, and a later mount in the same file would silently restore it and skip its initial load. That failure would look unrelated to its cause.

**Related issue (if applicable):**

- n/a

**Related backend PR (if applicable):**

- n/a

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Changes

- Clear `store.prevState` in the `ItemsListing` test `beforeEach` so the shared slot cannot leak between tests.

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm lint:check` passes.
- [x] `pnpm test:run` passes, and tests have been added/updated where applicable.
- [x] `pnpm build` passes.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
