### PR TITLE
Catch modules that get imported twice in the same file

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -1,11 +1,12 @@
 {
   "$schema": "./node_modules/oxlint/configuration_schema.json",
   "ignorePatterns": ["dist", "dev-dist", "coverage", "src/translations"],
-  "plugins": ["vue", "typescript", "oxc", "unicorn"],
+  "plugins": ["vue", "typescript", "oxc", "unicorn", "import"],
   "categories": {
     "correctness": "error"
   },
   "rules": {
-    "no-unused-vars": "off"
+    "no-unused-vars": "off",
+    "import/no-duplicates": "error"
   }
 }

--- a/src/components/MediaItemImages.vue
+++ b/src/components/MediaItemImages.vue
@@ -90,9 +90,8 @@
 
 <script setup lang="ts">
 import Container from "@/components/Container.vue";
-import { getMediaItemImageUrl } from "@/helpers/utils";
+import { getMediaItemImageUrl, panelViewItemResponsive } from "@/helpers/utils";
 import Toolbar from "@/components/Toolbar.vue";
-import { panelViewItemResponsive } from "@/helpers/utils";
 import { api } from "@/plugins/api";
 import { ImageType, type MediaItemImage } from "@/plugins/api/interfaces";
 import { eventbus } from "@/plugins/eventbus";

--- a/src/composables/guest/useGuestQueue.ts
+++ b/src/composables/guest/useGuestQueue.ts
@@ -5,8 +5,12 @@
 
 import { ref, computed, watch, nextTick } from "vue";
 import api from "@/plugins/api";
-import type { PlayerQueue, QueueItem } from "@/plugins/api/interfaces";
-import { EventType, type EventMessage } from "@/plugins/api/interfaces";
+import {
+  type EventMessage,
+  EventType,
+  type PlayerQueue,
+  type QueueItem,
+} from "@/plugins/api/interfaces";
 import { currentQueueIndex as resolveCurrentQueueIndex } from "@/helpers/queue_position";
 
 export function useGuestQueue(options?: { onItemsChanged?: () => void }) {

--- a/src/helpers/utils.ts
+++ b/src/helpers/utils.ts
@@ -1,12 +1,15 @@
 import { api } from "@/plugins/api";
 import {
   Artist,
+  type Audiobook,
   BrowseFolder,
   type ConfigEntry,
   ConfigEntryType,
   ImageType,
   ItemMapping,
+  type MediaCollection,
   MediaItemImage,
+  type MediaItemPalette,
   MediaItemType,
   MediaType,
   Player,
@@ -19,11 +22,6 @@ import { getBreakpointValue } from "@/plugins/breakpoint";
 import DOMPurify from "dompurify";
 import { marked } from "marked";
 
-import type {
-  Audiobook,
-  MediaCollection,
-  MediaItemPalette,
-} from "@/plugins/api/interfaces";
 import { Volume, Volume1, Volume2, VolumeX } from "@lucide/vue";
 
 export const isWebUrl = (url?: string | null): url is string => {

--- a/src/views/TrackDetails.vue
+++ b/src/views/TrackDetails.vue
@@ -59,7 +59,7 @@
 <script setup lang="ts">
 import ItemsListing, { LoadDataParams } from "@/components/ItemsListing.vue";
 import InfoHeader from "@/components/InfoHeader.vue";
-import { computed, onBeforeUnmount, onMounted, ref } from "vue";
+import { computed, onBeforeUnmount, onMounted, ref, watch } from "vue";
 import {
   EventMessage,
   EventType,
@@ -68,7 +68,6 @@ import {
   type Track,
 } from "@/plugins/api/interfaces";
 import { api } from "@/plugins/api";
-import { watch } from "vue";
 import ProviderDetails from "@/components/ProviderDetails.vue";
 
 export interface Props {

--- a/src/views/settings/PlayerOptionField.vue
+++ b/src/views/settings/PlayerOptionField.vue
@@ -95,8 +95,11 @@
 
 <script setup lang="ts">
 import api from "@/plugins/api";
-import { PlayerOption, PlayerOptionValueType } from "@/plugins/api/interfaces";
-import { PlayerOptionType } from "@/plugins/api/interfaces";
+import {
+  PlayerOption,
+  PlayerOptionType,
+  PlayerOptionValueType,
+} from "@/plugins/api/interfaces";
 import { computed } from "vue";
 import { toast } from "vue-sonner";
 


### PR DESCRIPTION
# What does this implement/fix?

Nothing stopped the same module being imported twice in one file. That is how the
stray second `import { watch } from "vue"` in #2421 got through review. Oxlint already
ships a rule for exactly this, so it costs no new dependency to turn on.

Turning it on found five more files with the same problem, all merged here.

- Enable oxlint's `import/no-duplicates` rule
- Merge the duplicate imports it flagged in `TrackDetails.vue`, `MediaItemImages.vue`,
  `PlayerOptionField.vue`, `helpers/utils.ts` and `useGuestQueue.ts`

No behaviour change — the merged statements import exactly the same names as before.

Two things worth knowing:

- Adding the `import` plugin also activates `import/default` and `import/namespace`,
  since they sit in the `correctness` category we already run at error level. The tree
  passes both today. Cost is ~0.3s on a full `oxlint` run, from the module resolution
  they need.
- The rule does not flag a plain `import type { ... }` sitting alongside a plain value
  import from the same module — that is the normal shadcn-vue split and there are ~188
  of them. Only genuinely mergeable statements are reported, which is why the count is
  five and not two hundred.

Import *ordering* is deliberately left alone; see the comment below for the numbers.

**Related issue (if applicable):**

- follow-up to #2421

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm lint:check` passes.
- [x] `pnpm test:run` passes, and tests have been added/updated where applicable.
- [x] `pnpm build` passes.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
