### PR TITLE
Use 4-space indentation in JSON config files

### DIFF
--- a/.lintstagedrc.json
+++ b/.lintstagedrc.json
@@ -1,3 +1,3 @@
 {
-  "*.{js,cjs,ts,vue}": ["oxlint", "eslint --fix", "prettier --write"]
+    "*.{js,cjs,ts,vue}": ["oxlint", "eslint --fix", "prettier --write"]
 }

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -1,12 +1,12 @@
 {
-  "$schema": "./node_modules/oxlint/configuration_schema.json",
-  "ignorePatterns": ["dist", "dev-dist", "coverage", "src/translations"],
-  "plugins": ["vue", "typescript", "oxc", "unicorn", "import"],
-  "categories": {
-    "correctness": "error"
-  },
-  "rules": {
-    "no-unused-vars": "off",
-    "import/no-duplicates": "error"
-  }
+    "$schema": "./node_modules/oxlint/configuration_schema.json",
+    "ignorePatterns": ["dist", "dev-dist", "coverage", "src/translations"],
+    "plugins": ["vue", "typescript", "oxc", "unicorn", "import"],
+    "categories": {
+        "correctness": "error"
+    },
+    "rules": {
+        "no-unused-vars": "off",
+        "import/no-duplicates": "error"
+    }
 }

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,3 +1,3 @@
 {
-  "endOfLine": "auto"
+    "endOfLine": "auto"
 }

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,6 +1,3 @@
 {
-  "recommendations": [
-    "vue.volar",
-    "Vue.vscode-typescript-vue-plugin"
-  ]
+    "recommendations": ["vue.volar", "Vue.vscode-typescript-vue-plugin"]
 }

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -1,11 +1,11 @@
 {
-  "compilerOptions": {
-    "strict": true,
-    "composite": true,
-    "module": "ESNext",
-    "moduleResolution": "Bundler",
-    "allowSyntheticDefaultImports": true,
-    "forceConsistentCasingInFileNames": true
-  },
-  "include": ["vite.config.ts", "vitest.config.ts"]
+    "compilerOptions": {
+        "strict": true,
+        "composite": true,
+        "module": "ESNext",
+        "moduleResolution": "Bundler",
+        "allowSyntheticDefaultImports": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "include": ["vite.config.ts", "vitest.config.ts"]
 }


### PR DESCRIPTION
# What does this implement/fix?

`.editorconfig` sets `indent_size = 4` for `*.json`, but five config files were still
indented with 2 spaces. Nothing formats JSON automatically — the `format` script only
globs `js`/`cjs`/`ts`/`vue` — so the drift went unnoticed, and an editor that honours
`.editorconfig` reformats these files the moment anyone saves them.

No keys or values change, and the files stay strict JSON (no comments, so editor schema
validation keeps working).

Files reindented to 4 spaces:

- `.oxlintrc.json`
- `.lintstagedrc.json`
- `.prettierrc.json`
- `.vscode/extensions.json`
- `tsconfig.node.json`

All other tracked JSON (`package.json`, `tsconfig.json`, `components.json`, the
translation files) was already on 4 spaces.

Prettier reads `.editorconfig`, so all five files now match what Prettier would produce
for them — the short array in `.vscode/extensions.json` is folded onto one line for that
reason, which is the only change here that isn't purely whitespace.

**Related issue (if applicable):**

- n/a

**Related backend PR (if applicable):**

- n/a

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm lint:check` passes.
- [x] `pnpm test:run` passes, and tests have been added/updated where applicable.
- [x] `pnpm build` passes.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
