### PR TITLE
Album art uses less memory over a remote connection

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -132,11 +132,9 @@ self.addEventListener("message", async (event) => {
       pendingRequests.delete(id);
 
       try {
-        // Convert hex string back to Uint8Array
-        const bodyBytes = hexToBytes(body);
-
-        // Create Response object
-        const response = new Response(bodyBytes, {
+        // The page posts the body as raw bytes and transfers its buffer to us,
+        // so it can back the response directly
+        const response = new Response(body, {
           status: status,
           headers: new Headers(headers),
         });
@@ -283,17 +281,6 @@ async function handleHttpProxyRequest(request, clientId, proxyScope) {
     }
     return new Response(error.message, { status: 500 });
   }
-}
-
-/**
- * Convert hex string to Uint8Array
- */
-function hexToBytes(hex) {
-  const bytes = new Uint8Array(hex.length / 2);
-  for (let i = 0; i < hex.length; i += 2) {
-    bytes[i / 2] = parseInt(hex.substring(i, i + 2), 16);
-  }
-  return bytes;
 }
 
 /**

--- a/public/sw.js
+++ b/public/sw.js
@@ -132,9 +132,12 @@ self.addEventListener("message", async (event) => {
       pendingRequests.delete(id);
 
       try {
-        // The page posts the body as raw bytes and transfers its buffer to us,
-        // so it can back the response directly
-        const response = new Response(body, {
+        // The page posts the body as raw bytes and transfers its buffer to us.
+        // A page still running the build before that handoff posts a hex string,
+        // which happens whenever this worker claims a tab that has not reloaded yet.
+        const bodyBytes = typeof body === "string" ? hexToBytes(body) : body;
+
+        const response = new Response(bodyBytes, {
           status: status,
           headers: new Headers(headers),
         });
@@ -281,6 +284,17 @@ async function handleHttpProxyRequest(request, clientId, proxyScope) {
     }
     return new Response(error.message, { status: 500 });
   }
+}
+
+/**
+ * Convert hex string to Uint8Array
+ */
+function hexToBytes(hex) {
+  const bytes = new Uint8Array(hex.length / 2);
+  for (let i = 0; i < hex.length; i += 2) {
+    bytes[i / 2] = parseInt(hex.substring(i, i + 2), 16);
+  }
+  return bytes;
 }
 
 /**

--- a/src/plugins/remote/http-proxy.ts
+++ b/src/plugins/remote/http-proxy.ts
@@ -427,8 +427,8 @@ class HttpProxyBridge {
     const controller = navigator.serviceWorker?.controller;
     if (!controller) return;
     // The transport answers with a view over a buffer sized to the frames it received,
-    // which can span more than the response itself. Only a view covering its whole
-    // buffer may be transferred as-is; anything else is copied down to size first.
+    // which can hold more than the response itself. Transferring that buffer would hand
+    // the surplus over too, so only a view covering its whole buffer goes as-is.
     const bytes =
       body.byteOffset === 0 && body.byteLength === body.buffer.byteLength
         ? body

--- a/src/plugins/remote/http-proxy.ts
+++ b/src/plugins/remote/http-proxy.ts
@@ -332,22 +332,7 @@ class HttpProxyBridge {
     if (this.shouldSuppressRequest(data.path)) {
       // Return a 503 Service Unavailable to indicate temporary failure
       // This prevents retry loops while still informing the client
-      if (navigator.serviceWorker?.controller) {
-        navigator.serviceWorker.controller.postMessage({
-          type: "http-proxy-response",
-          data: {
-            id: data.id,
-            status: 503,
-            headers: {
-              "Content-Type": "text/plain",
-              "Retry-After": "5",
-            },
-            body: this.bytesToHex(
-              new TextEncoder().encode("Request temporarily suppressed"),
-            ),
-          },
-        });
-      }
+      this.sendErrorResponse(data.id, 503, "Request temporarily suppressed");
       return;
     }
 
@@ -375,17 +360,12 @@ class HttpProxyBridge {
       }
 
       // Send response back to service worker
-      if (navigator.serviceWorker?.controller) {
-        navigator.serviceWorker.controller.postMessage({
-          type: "http-proxy-response",
-          data: {
-            id: data.id,
-            status: response.status,
-            headers: response.headers,
-            body: this.bytesToHex(response.body),
-          },
-        });
-      }
+      this.sendProxyResponse(
+        data.id,
+        response.status,
+        response.headers,
+        response.body,
+      );
     } catch (error) {
       // Record the failure to prevent immediate retries
       this.recordFailure(data.path);
@@ -421,29 +401,45 @@ class HttpProxyBridge {
    * Send an error response to the service worker
    */
   private sendErrorResponse(id: string, status: number, message: string): void {
-    if (navigator.serviceWorker?.controller) {
-      navigator.serviceWorker.controller.postMessage({
-        type: "http-proxy-response",
-        data: {
-          id,
-          status,
-          headers: {
-            "Content-Type": "text/plain",
-            ...(status === 503 ? { "Retry-After": "5" } : {}),
-          },
-          body: this.bytesToHex(new TextEncoder().encode(message)),
-        },
-      });
-    }
+    this.sendProxyResponse(
+      id,
+      status,
+      {
+        "Content-Type": "text/plain",
+        ...(status === 503 ? { "Retry-After": "5" } : {}),
+      },
+      new TextEncoder().encode(message),
+    );
   }
 
   /**
-   * Convert Uint8Array to hex string
+   * Send a proxied response to the service worker.
+   *
+   * Hands over ownership of the body: its buffer is transferred, so the bytes
+   * must not be read after this call.
    */
-  private bytesToHex(bytes: Uint8Array): string {
-    return Array.from(bytes)
-      .map((b) => b.toString(16).padStart(2, "0"))
-      .join("");
+  private sendProxyResponse(
+    id: string,
+    status: number,
+    headers: Record<string, string>,
+    body: Uint8Array,
+  ): void {
+    const controller = navigator.serviceWorker?.controller;
+    if (!controller) return;
+    // The transport answers with a view over a buffer sized to the frames it received,
+    // which can span more than the response itself. Only a view covering its whole
+    // buffer may be transferred as-is; anything else is copied down to size first.
+    const bytes =
+      body.byteOffset === 0 && body.byteLength === body.buffer.byteLength
+        ? body
+        : body.slice();
+    controller.postMessage(
+      {
+        type: "http-proxy-response",
+        data: { id, status, headers, body: bytes },
+      },
+      [bytes.buffer],
+    );
   }
 
   private async syncRemoteMode(): Promise<void> {

--- a/tests/plugins/http_proxy.test.ts
+++ b/tests/plugins/http_proxy.test.ts
@@ -2,16 +2,18 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const messageListeners = new Set<(event: MessageEvent) => void>();
 const controllerChangeListeners = new Set<() => void>();
-const postMessage = vi.fn((message: { type: string; data: unknown }) => {
-  if (message.type !== "set-remote-mode") return;
-  const event = {
-    data: {
-      type: "remote-mode-ack",
-      data: message.data,
-    },
-  } as MessageEvent;
-  messageListeners.forEach((listener) => listener(event));
-});
+const postMessage = vi.fn(
+  (message: { type: string; data: unknown }, _transfer?: Transferable[]) => {
+    if (message.type !== "set-remote-mode") return;
+    const event = {
+      data: {
+        type: "remote-mode-ack",
+        data: message.data,
+      },
+    } as MessageEvent;
+    messageListeners.forEach((listener) => listener(event));
+  },
+);
 
 const serviceWorker = {
   addEventListener: vi.fn(
@@ -83,6 +85,146 @@ describe("HttpProxyBridge", () => {
       data: { isRemote: true, proxyScope: "guest-remote-id" },
     });
   });
+
+  it("hands proxied bytes to the service worker without re-encoding them", async () => {
+    const { httpProxyBridge } = await import("@/plugins/remote/http-proxy");
+    const body = new Uint8Array([0, 1, 254, 255]);
+
+    await httpProxyBridge.initialize();
+    await setTransport(async () => ({
+      status: 200,
+      headers: { "content-type": "image/png" },
+      body,
+    }));
+    requestFromServiceWorker("/imageproxy?p=1");
+
+    const { message, transfer } = await waitForProxyResponse();
+    expect(message.data).toMatchObject({
+      id: "req-1",
+      status: 200,
+      headers: { "content-type": "image/png" },
+    });
+    expect(message.data.body).toBeInstanceOf(Uint8Array);
+    expect(Array.from(message.data.body)).toEqual([0, 1, 254, 255]);
+    // the buffer moves to the service worker rather than being copied into the message
+    expect(transfer).toEqual([message.data.body.buffer]);
+  });
+
+  it("transfers only the response bytes when the body is a view over a larger buffer", async () => {
+    const { httpProxyBridge } = await import("@/plugins/remote/http-proxy");
+    // what the transport resolves with: a view over the buffer it sized to the frames
+    const frames = new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8]);
+
+    await httpProxyBridge.initialize();
+    await setTransport(async () => ({
+      status: 200,
+      headers: {},
+      body: frames.subarray(0, 4),
+    }));
+    requestFromServiceWorker("/imageproxy?p=1");
+
+    const { message, transfer } = await waitForProxyResponse();
+    expect(Array.from(message.data.body)).toEqual([1, 2, 3, 4]);
+    // a copy sized to the response is what gets transferred; handing over
+    // `frames.buffer` would give the trailing four bytes away with it
+    expect(transfer).toEqual([message.data.body.buffer]);
+    expect(message.data.body.buffer.byteLength).toBe(4);
+  });
+
+  it("sends error responses as bytes too", async () => {
+    const { httpProxyBridge } = await import("@/plugins/remote/http-proxy");
+
+    await httpProxyBridge.initialize();
+    await setTransport(async () => {
+      throw new Error("Transport closed");
+    });
+    requestFromServiceWorker("/imageproxy?p=1");
+
+    const { message } = await waitForProxyResponse();
+    expect(message.data).toMatchObject({
+      id: "req-1",
+      status: 503,
+      headers: { "Content-Type": "text/plain", "Retry-After": "5" },
+    });
+    expect(new TextDecoder().decode(message.data.body)).toBe(
+      "Transport closed",
+    );
+  });
+
+  it("answers a request in its failure cooldown without asking the transport", async () => {
+    const { httpProxyBridge } = await import("@/plugins/remote/http-proxy");
+    const sendHttpProxyRequest = vi.fn(async () => {
+      throw new Error("boom");
+    });
+
+    await httpProxyBridge.initialize();
+    await setTransport(sendHttpProxyRequest);
+    requestFromServiceWorker("/imageproxy?p=1");
+    await waitForProxyResponse();
+
+    requestFromServiceWorker("/imageproxy?p=1", "req-2");
+
+    const { message } = await waitForProxyResponse("req-2");
+    expect(sendHttpProxyRequest).toHaveBeenCalledTimes(1);
+    expect(message.data).toMatchObject({ id: "req-2", status: 503 });
+    expect(new TextDecoder().decode(message.data.body)).toBe(
+      "Request temporarily suppressed",
+    );
+  });
+
+  type ProxyResponseMessage = {
+    type: string;
+    data: {
+      id: string;
+      status: number;
+      headers: Record<string, string>;
+      body: Uint8Array;
+    };
+  };
+
+  async function setTransport(
+    sendHttpProxyRequest: (
+      method: string,
+      path: string,
+      headers: Record<string, string>,
+    ) => Promise<{
+      status: number;
+      headers: Record<string, string>;
+      body: Uint8Array;
+    }>,
+  ): Promise<void> {
+    const { httpProxyBridge } = await import("@/plugins/remote/http-proxy");
+    await httpProxyBridge.setTransport({
+      sendHttpProxyRequest,
+    } as unknown as Parameters<typeof httpProxyBridge.setTransport>[0]);
+  }
+
+  function requestFromServiceWorker(path: string, id = "req-1"): void {
+    const event = {
+      data: {
+        type: "http-proxy-request",
+        data: { id, method: "GET", path, headers: {} },
+      },
+    } as MessageEvent;
+    messageListeners.forEach((listener) => listener(event));
+  }
+
+  async function waitForProxyResponse(id = "req-1"): Promise<{
+    message: ProxyResponseMessage;
+    transfer: Transferable[] | undefined;
+  }> {
+    await vi.waitFor(() => expect(proxyResponse(id)).toBeDefined());
+    const [message, transfer] = proxyResponse(id)!;
+    return { message: message as ProxyResponseMessage, transfer };
+  }
+
+  function proxyResponse(id: string) {
+    return postMessage.mock.calls.find(
+      ([message]) =>
+        message.type === "http-proxy-response" &&
+        (message.data as { id: string }).id === id,
+    );
+  }
 
   function createStorage(): Storage {
     const values = new Map<string, string>();

--- a/tests/plugins/http_proxy.test.ts
+++ b/tests/plugins/http_proxy.test.ts
@@ -106,8 +106,11 @@ describe("HttpProxyBridge", () => {
     });
     expect(message.data.body).toBeInstanceOf(Uint8Array);
     expect(Array.from(message.data.body)).toEqual([0, 1, 254, 255]);
-    // the buffer moves to the service worker rather than being copied into the message
-    expect(transfer).toEqual([message.data.body.buffer]);
+    // a body that already covers its whole buffer goes over untouched
+    expect(message.data.body).toBe(body);
+    // and that buffer moves to the service worker rather than being copied
+    expect(transfer).toHaveLength(1);
+    expect(transfer![0]).toBe(body.buffer);
   });
 
   it("transfers only the response bytes when the body is a view over a larger buffer", async () => {
@@ -127,7 +130,9 @@ describe("HttpProxyBridge", () => {
     expect(Array.from(message.data.body)).toEqual([1, 2, 3, 4]);
     // a copy sized to the response is what gets transferred; handing over
     // `frames.buffer` would give the trailing four bytes away with it
-    expect(transfer).toEqual([message.data.body.buffer]);
+    expect(transfer).toHaveLength(1);
+    expect(transfer![0]).toBe(message.data.body.buffer);
+    expect(transfer![0]).not.toBe(frames.buffer);
     expect(message.data.body.buffer.byteLength).toBe(4);
   });
 

--- a/tests/plugins/sw-http-proxy.test.ts
+++ b/tests/plugins/sw-http-proxy.test.ts
@@ -142,7 +142,34 @@ describe("sw.js http-proxy-response handling", () => {
     vi.unstubAllGlobals();
   });
 
+  // Includes the 0x00/0xFF boundary values a hex round-trip would be most
+  // likely to mangle.
+  const BYTES = new Uint8Array([0, 1, 2, 3, 127, 128, 254, 255]);
+
   it("turns a raw-bytes body into a Response with those exact bytes", async () => {
+    const response = await proxiedResponse(BYTES);
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toBe("image/jpeg");
+    expect(new Uint8Array(await response.arrayBuffer())).toEqual(BYTES);
+  });
+
+  it("still reads a hex body from a page that has not reloaded yet", async () => {
+    const hex = Array.from(BYTES)
+      .map((byte) => byte.toString(16).padStart(2, "0"))
+      .join("");
+
+    const response = await proxiedResponse(hex);
+
+    expect(response.status).toBe(200);
+    expect(new Uint8Array(await response.arrayBuffer())).toEqual(BYTES);
+  });
+
+  /**
+   * Drive a proxied image request end to end and answer it with the given body,
+   * as the page would.
+   */
+  async function proxiedResponse(body: Uint8Array | string): Promise<Response> {
     const postMessage = vi.fn<PostMessage>();
     fakeSelf.registerClient(CLIENT_ID, postMessage);
 
@@ -157,27 +184,19 @@ describe("sw.js http-proxy-response handling", () => {
     await flush();
 
     expect(postMessage).toHaveBeenCalledTimes(1);
-    const requestId = postMessage.mock.calls[0][0].data.id;
-
-    // Includes the 0x00/0xFF boundary values a hex round-trip would be most
-    // likely to mangle.
-    const bytes = new Uint8Array([0, 1, 2, 3, 127, 128, 254, 255]);
     await fakeSelf.fire("message", {
       data: {
         type: "http-proxy-response",
         data: {
-          id: requestId,
+          id: postMessage.mock.calls[0][0].data.id,
           status: 200,
           headers: { "content-type": "image/jpeg" },
-          body: bytes,
+          body,
         },
       },
       source: { id: CLIENT_ID },
     });
 
-    const response = await capturedResponse;
-    expect(response.status).toBe(200);
-    expect(response.headers.get("content-type")).toBe("image/jpeg");
-    expect(new Uint8Array(await response.arrayBuffer())).toEqual(bytes);
-  });
+    return capturedResponse;
+  }
 });

--- a/tests/plugins/sw-http-proxy.test.ts
+++ b/tests/plugins/sw-http-proxy.test.ts
@@ -109,13 +109,6 @@ function remoteStateKey(clientId: string): string {
   ).href;
 }
 
-// Lets the chained awaits inside sw.js settle before the test inspects side
-// effects (like the postMessage call) that happen off of the captured
-// respondWith promise rather than through it directly.
-function flush(): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, 0));
-}
-
 describe("sw.js http-proxy-response handling", () => {
   let fakeSelf: ReturnType<typeof createFakeSelf>;
 
@@ -149,7 +142,6 @@ describe("sw.js http-proxy-response handling", () => {
   it("turns a raw-bytes body into a Response with those exact bytes", async () => {
     const response = await proxiedResponse(BYTES);
 
-    expect(response.status).toBe(200);
     expect(response.headers.get("content-type")).toBe("image/jpeg");
     expect(new Uint8Array(await response.arrayBuffer())).toEqual(BYTES);
   });
@@ -161,15 +153,27 @@ describe("sw.js http-proxy-response handling", () => {
 
     const response = await proxiedResponse(hex);
 
-    expect(response.status).toBe(200);
     expect(new Uint8Array(await response.arrayBuffer())).toEqual(BYTES);
+  });
+
+  it("passes the status through, so the page can report a failure", async () => {
+    const response = await proxiedResponse(
+      new TextEncoder().encode("No transport available"),
+      503,
+    );
+
+    expect(response.status).toBe(503);
+    expect(await response.text()).toBe("No transport available");
   });
 
   /**
    * Drive a proxied image request end to end and answer it with the given body,
    * as the page would.
    */
-  async function proxiedResponse(body: Uint8Array | string): Promise<Response> {
+  async function proxiedResponse(
+    body: Uint8Array | string,
+    status = 200,
+  ): Promise<Response> {
     const postMessage = vi.fn<PostMessage>();
     fakeSelf.registerClient(CLIENT_ID, postMessage);
 
@@ -181,15 +185,14 @@ describe("sw.js http-proxy-response handling", () => {
         capturedResponse = promise;
       },
     });
-    await flush();
+    await vi.waitFor(() => expect(postMessage).toHaveBeenCalledTimes(1));
 
-    expect(postMessage).toHaveBeenCalledTimes(1);
     await fakeSelf.fire("message", {
       data: {
         type: "http-proxy-response",
         data: {
           id: postMessage.mock.calls[0][0].data.id,
-          status: 200,
+          status,
           headers: { "content-type": "image/jpeg" },
           body,
         },

--- a/tests/plugins/sw-http-proxy.test.ts
+++ b/tests/plugins/sw-http-proxy.test.ts
@@ -1,0 +1,183 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("workbox-precaching", () => ({
+  precacheAndRoute: vi.fn(),
+}));
+
+const ORIGIN = "https://ma.example";
+const CLIENT_ID = "test-client-1";
+const REMOTE_MODE_CACHE_NAME = "ma-sw-client-state-v1";
+const REMOTE_MODE_CACHE_PATH = "/__ma_remote_mode__/";
+
+type PostMessage = (message: {
+  type: string;
+  data: {
+    id: string;
+    method: string;
+    path: string;
+    headers: Record<string, string>;
+  };
+}) => void;
+
+/**
+ * Minimal in-memory Cache Storage stand-in covering the open/match/put/delete/keys
+ * calls sw.js makes against the real `caches` global.
+ */
+function createFakeCaches() {
+  const stores = new Map<string, Map<string, Response>>();
+
+  function storeFor(name: string): Map<string, Response> {
+    let store = stores.get(name);
+    if (!store) {
+      store = new Map();
+      stores.set(name, store);
+    }
+    return store;
+  }
+
+  function keyFor(request: string | { url: string }): string {
+    return typeof request === "string" ? request : request.url;
+  }
+
+  return {
+    open: vi.fn(async (name: string) => {
+      const store = storeFor(name);
+      return {
+        match: vi.fn(async (request: string | { url: string }) =>
+          store.get(keyFor(request)),
+        ),
+        put: vi.fn(
+          async (request: string | { url: string }, response: Response) => {
+            store.set(keyFor(request), response);
+          },
+        ),
+        delete: vi.fn(async (request: string | { url: string }) =>
+          store.delete(keyFor(request)),
+        ),
+        keys: vi.fn(async () =>
+          Array.from(store.keys()).map((url) => ({ url })),
+        ),
+      };
+    }),
+    delete: vi.fn(async (name: string) => stores.delete(name)),
+  };
+}
+
+/**
+ * Stand-in for the ServiceWorkerGlobalScope: records listeners registered via
+ * addEventListener so a test can fire them directly, and tracks clients
+ * `self.clients.get()` can resolve.
+ */
+function createFakeSelf() {
+  const listeners = new Map<string, Array<(event: unknown) => unknown>>();
+  const clientsById = new Map<
+    string,
+    { id: string; postMessage: PostMessage }
+  >();
+
+  return {
+    __WB_MANIFEST: [],
+    location: { origin: ORIGIN },
+    addEventListener: vi.fn(
+      (type: string, listener: (event: unknown) => unknown) => {
+        const forType = listeners.get(type) ?? [];
+        forType.push(listener);
+        listeners.set(type, forType);
+      },
+    ),
+    clients: {
+      get: vi.fn(async (id: string) => clientsById.get(id)),
+      matchAll: vi.fn(async () => Array.from(clientsById.values())),
+      claim: vi.fn(async () => undefined),
+    },
+    skipWaiting: vi.fn(async () => undefined),
+    registerClient(id: string, postMessage: PostMessage) {
+      clientsById.set(id, { id, postMessage });
+    },
+    fire(type: string, event: unknown): Promise<unknown[]> {
+      return Promise.all(
+        (listeners.get(type) ?? []).map((listener) => listener(event)),
+      );
+    },
+  };
+}
+
+function remoteStateKey(clientId: string): string {
+  return new URL(
+    `${REMOTE_MODE_CACHE_PATH}${encodeURIComponent(clientId)}`,
+    ORIGIN,
+  ).href;
+}
+
+// Lets the chained awaits inside sw.js settle before the test inspects side
+// effects (like the postMessage call) that happen off of the captured
+// respondWith promise rather than through it directly.
+function flush(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+describe("sw.js http-proxy-response handling", () => {
+  let fakeSelf: ReturnType<typeof createFakeSelf>;
+
+  beforeEach(async () => {
+    vi.resetModules();
+    fakeSelf = createFakeSelf();
+    const fakeCaches = createFakeCaches();
+    vi.stubGlobal("self", fakeSelf);
+    vi.stubGlobal("caches", fakeCaches);
+
+    // Remote mode has to be ON for the client, otherwise the fetch listener
+    // lets the request through to fetch() instead of proxying it.
+    const cache = await fakeCaches.open(REMOTE_MODE_CACHE_NAME);
+    await cache.put(
+      remoteStateKey(CLIENT_ID),
+      new Response(JSON.stringify({ isRemote: true })),
+    );
+
+    // @ts-expect-error - sw.js is plain JS with no type declarations
+    await import("../../public/sw.js");
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("turns a raw-bytes body into a Response with those exact bytes", async () => {
+    const postMessage = vi.fn<PostMessage>();
+    fakeSelf.registerClient(CLIENT_ID, postMessage);
+
+    let capturedResponse!: Promise<Response>;
+    await fakeSelf.fire("fetch", {
+      request: new Request("https://ma.example/imageproxy/album.jpg"),
+      clientId: CLIENT_ID,
+      respondWith: (promise: Promise<Response>) => {
+        capturedResponse = promise;
+      },
+    });
+    await flush();
+
+    expect(postMessage).toHaveBeenCalledTimes(1);
+    const requestId = postMessage.mock.calls[0][0].data.id;
+
+    // Includes the 0x00/0xFF boundary values a hex round-trip would be most
+    // likely to mangle.
+    const bytes = new Uint8Array([0, 1, 2, 3, 127, 128, 254, 255]);
+    await fakeSelf.fire("message", {
+      data: {
+        type: "http-proxy-response",
+        data: {
+          id: requestId,
+          status: 200,
+          headers: { "content-type": "image/jpeg" },
+          body: bytes,
+        },
+      },
+      source: { id: CLIENT_ID },
+    });
+
+    const response = await capturedResponse;
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toBe("image/jpeg");
+    expect(new Uint8Array(await response.arrayBuffer())).toEqual(bytes);
+  });
+});


### PR DESCRIPTION
# What does this implement/fix?

When album art is loaded over a remote connection, the response now arrives as real
binary data (since #2507). The page was still converting those bytes into a hex text
string just to hand them to the service worker, which immediately converted them back.
That doubled the memory used per image for no benefit.

The bytes are now passed straight across, and their buffer is handed over rather than
copied, so nothing is duplicated on the way.

**Related issue (if applicable):**

- related issue `n/a`

**Related backend PR (if applicable):**

- related backend PR `n/a`

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

Changes:

- Send the proxied response body to the service worker as raw bytes instead of a hex string
- Transfer the body's buffer with the message so it isn't copied
- Copy the body down to size first when it's a view over a larger buffer, so only the response itself is handed over
- Keep reading a hex body, so a tab that hasn't reloaded onto the new build yet still shows its album art
- Remove a duplicated block in the bridge
- Add tests for both sides of the message

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm lint:check` passes.
- [x] `pnpm test:run` passes, and tests have been added/updated where applicable.
- [x] `pnpm build` passes.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
