### PR TITLE
Remove dead code from the remote album art cache

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -208,9 +208,9 @@ async function handleHttpProxyRequest(request, clientId, proxyScope) {
   const cachedResponse = await cache.match(cacheKey);
 
   if (cachedResponse) {
-    // Cache-first, and entries are never revalidated: the server marks these
-    // responses cacheable for a year and offers no ETag to revalidate against,
-    // and every proxied request costs a WebRTC round trip.
+    // Cache-first, and entries are never revalidated: every proxied request
+    // costs a WebRTC round trip, and no conditional request is made anyway
+    // (only the headers below are forwarded).
     return cachedResponse;
   }
 

--- a/public/sw.js
+++ b/public/sw.js
@@ -208,8 +208,9 @@ async function handleHttpProxyRequest(request, clientId, proxyScope) {
   const cachedResponse = await cache.match(cacheKey);
 
   if (cachedResponse) {
-    // Return cached response immediately (cache-first strategy)
-    // We'll still revalidate in the background for next time
+    // Cache-first, and entries are never revalidated: the server marks these
+    // responses cacheable for a year and offers no ETag to revalidate against,
+    // and every proxied request costs a WebRTC round trip.
     return cachedResponse;
   }
 
@@ -263,11 +264,6 @@ async function handleHttpProxyRequest(request, clientId, proxyScope) {
   try {
     const response = await responsePromise;
 
-    // If 304 Not Modified, return cached response
-    if (response.status === 304 && cachedResponse) {
-      return cachedResponse;
-    }
-
     // Cache successful responses (200-299)
     if (response.status >= 200 && response.status < 300) {
       // Clone the response before caching (can only read body once)
@@ -278,10 +274,6 @@ async function handleHttpProxyRequest(request, clientId, proxyScope) {
     return response;
   } catch (error) {
     console.error("[ServiceWorker] HTTP proxy error:", error);
-    // Return cached response on error if available
-    if (cachedResponse) {
-      return cachedResponse;
-    }
     return new Response(error.message, { status: 500 });
   }
 }

--- a/tests/plugins/sw-http-proxy.test.ts
+++ b/tests/plugins/sw-http-proxy.test.ts
@@ -185,8 +185,8 @@ describe("sw.js http-proxy-response handling", () => {
   });
 
   /**
-   * Request the proxied image, returning what the worker answers with and the
-   * mock any proxy request for it would be posted to.
+   * Request the proxied image. Returns the worker's response and the client
+   * mock, which only receives a proxy request when the cache misses.
    */
   async function fireFetch(): Promise<{
     response: Promise<Response>;

--- a/tests/plugins/sw-http-proxy.test.ts
+++ b/tests/plugins/sw-http-proxy.test.ts
@@ -164,22 +164,13 @@ describe("sw.js http-proxy-response handling", () => {
   it("answers a repeat request from cache without asking the page again", async () => {
     await proxiedResponse(BYTES);
 
-    const postMessage = vi.fn<PostMessage>();
-    fakeSelf.registerClient(CLIENT_ID, postMessage);
+    const { response, postMessage } = await fireFetch();
 
-    let capturedResponse!: Promise<Response>;
-    await fakeSelf.fire("fetch", {
-      request: new Request(IMAGE_URL),
-      clientId: CLIENT_ID,
-      respondWith: (promise: Promise<Response>) => {
-        capturedResponse = promise;
-      },
-    });
-
-    const response = await capturedResponse;
-    expect(new Uint8Array(await response.arrayBuffer())).toEqual(BYTES);
-    // Cache-first: nothing goes back over the WebRTC channel, so a cached
-    // entry is never revalidated.
+    const cached = await response;
+    expect(new Uint8Array(await cached.arrayBuffer())).toEqual(BYTES);
+    // Cache-first: a cached entry is never revalidated, so nothing goes back
+    // over the WebRTC channel. Losing the cache hit altogether stalls the await
+    // above instead, as no page is standing by to answer the proxy request.
     expect(postMessage).not.toHaveBeenCalled();
   });
 
@@ -194,6 +185,29 @@ describe("sw.js http-proxy-response handling", () => {
   });
 
   /**
+   * Request the proxied image, returning what the worker answers with and the
+   * mock any proxy request for it would be posted to.
+   */
+  async function fireFetch(): Promise<{
+    response: Promise<Response>;
+    postMessage: ReturnType<typeof vi.fn<PostMessage>>;
+  }> {
+    const postMessage = vi.fn<PostMessage>();
+    fakeSelf.registerClient(CLIENT_ID, postMessage);
+
+    let response!: Promise<Response>;
+    await fakeSelf.fire("fetch", {
+      request: new Request(IMAGE_URL),
+      clientId: CLIENT_ID,
+      respondWith: (promise: Promise<Response>) => {
+        response = promise;
+      },
+    });
+
+    return { response, postMessage };
+  }
+
+  /**
    * Drive a proxied image request end to end and answer it with the given body,
    * as the page would.
    */
@@ -201,17 +215,7 @@ describe("sw.js http-proxy-response handling", () => {
     body: Uint8Array | string,
     status = 200,
   ): Promise<Response> {
-    const postMessage = vi.fn<PostMessage>();
-    fakeSelf.registerClient(CLIENT_ID, postMessage);
-
-    let capturedResponse!: Promise<Response>;
-    await fakeSelf.fire("fetch", {
-      request: new Request(IMAGE_URL),
-      clientId: CLIENT_ID,
-      respondWith: (promise: Promise<Response>) => {
-        capturedResponse = promise;
-      },
-    });
+    const { response, postMessage } = await fireFetch();
     await vi.waitFor(() => expect(postMessage).toHaveBeenCalledTimes(1));
 
     await fakeSelf.fire("message", {
@@ -227,6 +231,6 @@ describe("sw.js http-proxy-response handling", () => {
       source: { id: CLIENT_ID },
     });
 
-    return capturedResponse;
+    return response;
   }
 });

--- a/tests/plugins/sw-http-proxy.test.ts
+++ b/tests/plugins/sw-http-proxy.test.ts
@@ -6,6 +6,9 @@ vi.mock("workbox-precaching", () => ({
 
 const ORIGIN = "https://ma.example";
 const CLIENT_ID = "test-client-1";
+// Shared by every request in these tests, so a repeat request hits the same
+// cache entry as the one before it.
+const IMAGE_URL = `${ORIGIN}/imageproxy/album.jpg`;
 const REMOTE_MODE_CACHE_NAME = "ma-sw-client-state-v1";
 const REMOTE_MODE_CACHE_PATH = "/__ma_remote_mode__/";
 
@@ -43,8 +46,10 @@ function createFakeCaches() {
     open: vi.fn(async (name: string) => {
       const store = storeFor(name);
       return {
+        // Every match hands out a fresh response, as the real Cache does:
+        // callers read the body, and a second match must still be readable.
         match: vi.fn(async (request: string | { url: string }) =>
-          store.get(keyFor(request)),
+          store.get(keyFor(request))?.clone(),
         ),
         put: vi.fn(
           async (request: string | { url: string }, response: Response) => {
@@ -156,6 +161,28 @@ describe("sw.js http-proxy-response handling", () => {
     expect(new Uint8Array(await response.arrayBuffer())).toEqual(BYTES);
   });
 
+  it("answers a repeat request from cache without asking the page again", async () => {
+    await proxiedResponse(BYTES);
+
+    const postMessage = vi.fn<PostMessage>();
+    fakeSelf.registerClient(CLIENT_ID, postMessage);
+
+    let capturedResponse!: Promise<Response>;
+    await fakeSelf.fire("fetch", {
+      request: new Request(IMAGE_URL),
+      clientId: CLIENT_ID,
+      respondWith: (promise: Promise<Response>) => {
+        capturedResponse = promise;
+      },
+    });
+
+    const response = await capturedResponse;
+    expect(new Uint8Array(await response.arrayBuffer())).toEqual(BYTES);
+    // Cache-first: nothing goes back over the WebRTC channel, so a cached
+    // entry is never revalidated.
+    expect(postMessage).not.toHaveBeenCalled();
+  });
+
   it("passes the status through, so the page can report a failure", async () => {
     const response = await proxiedResponse(
       new TextEncoder().encode("No transport available"),
@@ -179,7 +206,7 @@ describe("sw.js http-proxy-response handling", () => {
 
     let capturedResponse!: Promise<Response>;
     await fakeSelf.fire("fetch", {
-      request: new Request("https://ma.example/imageproxy/album.jpg"),
+      request: new Request(IMAGE_URL),
       clientId: CLIENT_ID,
       respondWith: (promise: Promise<Response>) => {
         capturedResponse = promise;


### PR DESCRIPTION
# What does this implement/fix?

The service worker that proxies album art over a remote connection had three
branches that can no longer run: a "304 Not Modified" check, the cached-image
fallback on error, and a comment promising a background revalidation.

These were live once. Originally the cache hit only returned early when the
entry was still fresh, and the worker forwarded `If-None-Match` /
`If-Modified-Since` built from the cached image. "Login and serviceworker
tweaks" (`b39fc4c2`) replaced that with an unconditional early return and
dropped the conditional headers, which orphaned the rest — the cache is now
consulted and returned from before those branches are ever reached.

Checked the server before deciding to drop rather than rebuild them:
`/imageproxy` returns a plain response marked cacheable for a year, never sends
an `ETag` or `Last-Modified`, and never answers with a 304. So there is nothing
to revalidate against, and re-adding revalidation would only cost an extra round
trip per image on the remote link.

No behaviour change.

**Related issue (if applicable):**

- n/a

**Related backend PR (if applicable):**

- n/a

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm lint:check` passes.
- [x] `pnpm test:run` passes, and tests have been added/updated where applicable.
- [x] `pnpm build` passes.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
