### PR TITLE
Update the app in one piece

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -14,6 +14,12 @@ precacheAndRoute(self.__WB_MANIFEST);
 // Store for pending HTTP requests
 const pendingRequests = new Map();
 
+// Shape of the messages the page posts here (src/plugins/remote/http-proxy.ts).
+// Bump on any change: a page from another build is then refused rather than read
+// as if the shapes still matched. Only this direction is checked, because only a
+// misread response ends up in a cache.
+const MESSAGE_PROTOCOL_VERSION = 1;
+
 const LEGACY_REMOTE_MODE_CACHE_NAME = "ma-sw-state-v1";
 const LEGACY_REMOTE_MODE_CACHE_KEY = "ma-remote-mode-state";
 const REMOTE_MODE_CACHE_NAME = "ma-sw-client-state-v1";
@@ -121,7 +127,28 @@ async function migrateLegacyRemoteState() {
 
 // Listen for messages from the main thread
 self.addEventListener("message", async (event) => {
-  const { type, data } = event.data;
+  const { type, protocol, data } = event.data;
+
+  // Sent by the update prompt when the user accepts a new version, and the only
+  // way this worker takes over: a tab otherwise keeps the worker it booted with,
+  // so a page and its worker are always from the same build. It comes from the
+  // prompt rather than the proxy bridge, so it carries no stamp and has to be
+  // handled ahead of the check below.
+  if (type === "SKIP_WAITING") {
+    self.skipWaiting();
+    return;
+  }
+
+  // Message shapes only hold within a single build. Reading a page from another
+  // one as if they matched can yield a response that looks valid and gets cached,
+  // so its request is failed instead.
+  if (protocol !== MESSAGE_PROTOCOL_VERSION) {
+    rejectPendingRequest(
+      data?.id,
+      "Page and service worker are from different builds",
+    );
+    return;
+  }
 
   if (type === "http-proxy-response") {
     // Handle HTTP proxy response
@@ -133,11 +160,7 @@ self.addEventListener("message", async (event) => {
 
       try {
         // The page posts the body as raw bytes and transfers its buffer to us.
-        // A page still running the build before that handoff posts a hex string,
-        // which happens whenever this worker claims a tab that has not reloaded yet.
-        const bodyBytes = typeof body === "string" ? hexToBytes(body) : body;
-
-        const response = new Response(bodyBytes, {
+        const response = new Response(body, {
           status: status,
           headers: new Headers(headers),
         });
@@ -279,14 +302,14 @@ async function handleHttpProxyRequest(request, clientId, proxyScope) {
 }
 
 /**
- * Convert hex string to Uint8Array
+ * Fail the proxy request waiting on this id, if there still is one.
  */
-function hexToBytes(hex) {
-  const bytes = new Uint8Array(hex.length / 2);
-  for (let i = 0; i < hex.length; i += 2) {
-    bytes[i / 2] = parseInt(hex.substring(i, i + 2), 16);
-  }
-  return bytes;
+function rejectPendingRequest(id, reason) {
+  const pendingRequest = pendingRequests.get(id);
+  if (!pendingRequest) return;
+
+  pendingRequests.delete(id);
+  pendingRequest.reject(new Error(reason));
 }
 
 /**
@@ -296,16 +319,12 @@ function generateRequestId() {
   return `req_${Date.now()}_${Math.random().toString(36).substring(2, 11)}`;
 }
 
-// Skip waiting to activate the new service worker immediately
-self.addEventListener("install", (event) => {
-  console.log("[ServiceWorker] Installing...");
-  event.waitUntil(self.skipWaiting());
-});
-
 self.addEventListener("activate", (event) => {
   event.waitUntil(
     (async () => {
       await migrateLegacyRemoteState();
+      // A first install has no worker to wait behind, so claiming is what lets
+      // the page that registered us proxy its images without reloading first.
       await self.clients.claim();
     })(),
   );

--- a/public/sw.js
+++ b/public/sw.js
@@ -129,9 +129,9 @@ async function migrateLegacyRemoteState() {
 self.addEventListener("message", async (event) => {
   const { type, protocol, data } = event.data;
 
-  // Sent by the update prompt when the user accepts a new version, and the only
-  // way this worker takes over: a tab otherwise keeps the worker it booted with,
-  // so a page and its worker are always from the same build. It comes from the
+  // Sent by the update prompt when the user accepts a new version. Without it a
+  // new worker only takes over once no tab is running the old one, so a tab is
+  // never handed a worker from a build it did not load with. It comes from the
   // prompt rather than the proxy bridge, so it carries no stamp and has to be
   // handled ahead of the check below.
   if (type === "SKIP_WAITING") {
@@ -325,6 +325,8 @@ self.addEventListener("activate", (event) => {
       await migrateLegacyRemoteState();
       // A first install has no worker to wait behind, so claiming is what lets
       // the page that registered us proxy its images without reloading first.
+      // It also drives the update: the prompt reloads the page off the
+      // controller change this fires, and never reloads on its own.
       await self.clients.claim();
     })(),
   );

--- a/src/layouts/GuestLayout.vue
+++ b/src/layouts/GuestLayout.vue
@@ -79,6 +79,10 @@
     <main class="guest-layout-content min-h-0 flex-1 overflow-y-auto">
       <router-view />
     </main>
+    <!-- accepting an update is what hands a tab over to a new service worker, so
+         a guest session needs the prompt as much as the app does. It renders
+         fixed to the viewport, which the layout above it does not box in. -->
+    <ReloadPrompt />
   </div>
 </template>
 
@@ -108,6 +112,7 @@ import {
   THEME_PREFERENCES,
   useThemePreference,
 } from "@/composables/useThemePreference";
+import ReloadPrompt from "@/layouts/default/ReloadPrompt.vue";
 import { authManager } from "@/plugins/auth";
 import { $t } from "@/plugins/i18n";
 import { store } from "@/plugins/store";

--- a/src/plugins/remote/http-proxy.ts
+++ b/src/plugins/remote/http-proxy.ts
@@ -14,6 +14,8 @@ const REMOTE_MODE_STORAGE_KEY = "ma_remote_mode";
 const CURRENT_REMOTE_ID_STORAGE_KEY = "ma_current_remote_id";
 // Storage key to track reload attempts (prevents infinite loops)
 const SW_RELOAD_ATTEMPT_KEY = "ma_sw_reload_attempt";
+// Shape of the messages exchanged with the service worker (must match public/sw.js)
+const MESSAGE_PROTOCOL_VERSION = 1;
 
 class HttpProxyBridge {
   private transport: WebRTCTransport | null = null;
@@ -252,6 +254,7 @@ class HttpProxyBridge {
       // Send the message
       navigator.serviceWorker.controller.postMessage({
         type: "set-remote-mode",
+        protocol: MESSAGE_PROTOCOL_VERSION,
         data: { isRemote, proxyScope },
       });
     });
@@ -436,6 +439,7 @@ class HttpProxyBridge {
     controller.postMessage(
       {
         type: "http-proxy-response",
+        protocol: MESSAGE_PROTOCOL_VERSION,
         data: { id, status, headers, body: bytes },
       },
       [bytes.buffer],

--- a/tests/layouts/GuestLayout.test.ts
+++ b/tests/layouts/GuestLayout.test.ts
@@ -1,4 +1,5 @@
 import GuestLayout from "@/layouts/GuestLayout.vue";
+import ReloadPrompt from "@/layouts/default/ReloadPrompt.vue";
 import { mount } from "@vue/test-utils";
 import { ref } from "vue";
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -149,5 +150,11 @@ describe("GuestLayout", () => {
     await wrapper.get('[data-testid="guest-host-controls"]').trigger("click");
 
     expect(mocks.routerPush).toHaveBeenCalledWith({ name: "music-quiz" });
+  });
+
+  // accepting the prompt is what hands a tab over to a new service worker, so
+  // without it a guest session is stuck on the build it loaded with
+  it("offers the update prompt", () => {
+    expect(mountLayout().findComponent(ReloadPrompt).exists()).toBe(true);
   });
 });

--- a/tests/plugins/http_proxy.test.ts
+++ b/tests/plugins/http_proxy.test.ts
@@ -3,7 +3,10 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 const messageListeners = new Set<(event: MessageEvent) => void>();
 const controllerChangeListeners = new Set<() => void>();
 const postMessage = vi.fn(
-  (message: { type: string; data: unknown }, _transfer?: Transferable[]) => {
+  (
+    message: { type: string; protocol: number; data: unknown },
+    _transfer?: Transferable[],
+  ) => {
     if (message.type !== "set-remote-mode") return;
     const event = {
       data: {
@@ -66,6 +69,7 @@ describe("HttpProxyBridge", () => {
     await httpProxyBridge.initialize();
     expect(postMessage).toHaveBeenNthCalledWith(1, {
       type: "set-remote-mode",
+      protocol: 1,
       data: { isRemote: false, proxyScope: undefined },
     });
 
@@ -75,6 +79,7 @@ describe("HttpProxyBridge", () => {
     );
     expect(postMessage).toHaveBeenNthCalledWith(2, {
       type: "set-remote-mode",
+      protocol: 1,
       data: { isRemote: true, proxyScope: "guest-remote-id" },
     });
 
@@ -82,6 +87,7 @@ describe("HttpProxyBridge", () => {
     await vi.waitFor(() => expect(postMessage).toHaveBeenCalledTimes(3));
     expect(postMessage).toHaveBeenNthCalledWith(3, {
       type: "set-remote-mode",
+      protocol: 1,
       data: { isRemote: true, proxyScope: "guest-remote-id" },
     });
   });

--- a/tests/plugins/sw-http-proxy.test.ts
+++ b/tests/plugins/sw-http-proxy.test.ts
@@ -11,6 +11,8 @@ const CLIENT_ID = "test-client-1";
 const IMAGE_URL = `${ORIGIN}/imageproxy/album.jpg`;
 const REMOTE_MODE_CACHE_NAME = "ma-sw-client-state-v1";
 const REMOTE_MODE_CACHE_PATH = "/__ma_remote_mode__/";
+const PROXY_CACHE_NAME = "ma-http-proxy-v1";
+const MESSAGE_PROTOCOL_VERSION = 1;
 
 type PostMessage = (message: {
   type: string;
@@ -114,13 +116,14 @@ function remoteStateKey(clientId: string): string {
   ).href;
 }
 
-describe("sw.js http-proxy-response handling", () => {
+describe("sw.js", () => {
   let fakeSelf: ReturnType<typeof createFakeSelf>;
+  let fakeCaches: ReturnType<typeof createFakeCaches>;
 
   beforeEach(async () => {
     vi.resetModules();
     fakeSelf = createFakeSelf();
-    const fakeCaches = createFakeCaches();
+    fakeCaches = createFakeCaches();
     vi.stubGlobal("self", fakeSelf);
     vi.stubGlobal("caches", fakeCaches);
 
@@ -151,14 +154,19 @@ describe("sw.js http-proxy-response handling", () => {
     expect(new Uint8Array(await response.arrayBuffer())).toEqual(BYTES);
   });
 
-  it("still reads a hex body from a page that has not reloaded yet", async () => {
+  it("refuses a response from a page that speaks another protocol", async () => {
+    // the hex body the build before the raw-bytes handoff posts
     const hex = Array.from(BYTES)
       .map((byte) => byte.toString(16).padStart(2, "0"))
       .join("");
 
-    const response = await proxiedResponse(hex);
+    const response = await proxiedResponse(hex, 200, { stamped: false });
 
-    expect(new Uint8Array(await response.arrayBuffer())).toEqual(BYTES);
+    expect(response.status).toBe(500);
+    // reading it as if the shapes matched yields a 200 that lands in the proxy
+    // cache, which is read back cache-first and so outlives any reload
+    const cache = await fakeCaches.open(PROXY_CACHE_NAME);
+    expect(await cache.keys()).toEqual([]);
   });
 
   it("answers a repeat request from cache without asking the page again", async () => {
@@ -182,6 +190,18 @@ describe("sw.js http-proxy-response handling", () => {
 
     expect(response.status).toBe(503);
     expect(await response.text()).toBe("No transport available");
+  });
+
+  it("does not take over a tab that is running an earlier build", async () => {
+    await fakeSelf.fire("install", { waitUntil: () => undefined });
+
+    expect(fakeSelf.skipWaiting).not.toHaveBeenCalled();
+  });
+
+  it("takes over once the page accepts the update", async () => {
+    await fakeSelf.fire("message", { data: { type: "SKIP_WAITING" } });
+
+    expect(fakeSelf.skipWaiting).toHaveBeenCalled();
   });
 
   /**
@@ -214,6 +234,7 @@ describe("sw.js http-proxy-response handling", () => {
   async function proxiedResponse(
     body: Uint8Array | string,
     status = 200,
+    { stamped = true } = {},
   ): Promise<Response> {
     const { response, postMessage } = await fireFetch();
     await vi.waitFor(() => expect(postMessage).toHaveBeenCalledTimes(1));
@@ -221,6 +242,7 @@ describe("sw.js http-proxy-response handling", () => {
     await fakeSelf.fire("message", {
       data: {
         type: "http-proxy-response",
+        ...(stamped ? { protocol: MESSAGE_PROTOCOL_VERSION } : {}),
         data: {
           id: postMessage.mock.calls[0][0].data.id,
           status,

--- a/tests/plugins/sw-http-proxy.test.ts
+++ b/tests/plugins/sw-http-proxy.test.ts
@@ -192,6 +192,26 @@ describe("sw.js", () => {
     expect(await response.text()).toBe("No transport available");
   });
 
+  // the check that refuses another build's messages sits in front of every one
+  // of them, so it has to let this one through as well
+  it("acknowledges a stamped remote-mode message", async () => {
+    const postMessage = vi.fn();
+
+    await fakeSelf.fire("message", {
+      data: {
+        type: "set-remote-mode",
+        protocol: MESSAGE_PROTOCOL_VERSION,
+        data: { isRemote: true, proxyScope: "remote-id" },
+      },
+      source: { id: CLIENT_ID, postMessage },
+    });
+
+    expect(postMessage).toHaveBeenCalledWith({
+      type: "remote-mode-ack",
+      data: { isRemote: true },
+    });
+  });
+
   it("does not take over a tab that is running an earlier build", async () => {
     await fakeSelf.fire("install", { waitUntil: () => undefined });
 


### PR DESCRIPTION
# What does this implement/fix?

A new service worker took over browser tabs that were still running the previous
version of the app, and those tabs were never reloaded. The page and the service
worker then came from two different versions, and a message between them could be
misread as a valid image and stored in the cache — where it was served again on
every later load, so broken album art survived reloads.

The service worker now waits until the "new content available" prompt hands over,
so a tab keeps the worker it started with and the app updates in one piece. That
prompt has in fact never appeared until now, because a worker that takes over on
its own never reaches the state the prompt watches for, and its Reload button had
nothing to talk to.

**Related issue (if applicable):**

- follow-up to #2513, which worked around this per message

**Related backend PR (if applicable):**

- related backend PR `n/a`

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

Changes:

- the service worker no longer activates over a tab running an older version, and
  handles the update prompt's request to take over
- messages from the page carry a version, and the worker refuses any that do not
  match instead of reading them as if they still fitted
- dropped the hex fallback added in #2513, which that check replaces
- the update prompt is now shown in guest sessions too, which use the same
  remote connection and previously had no way to accept an update
- tests for both handover paths and for a refused message not reaching the cache

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm lint:check` passes.
- [x] `pnpm test:run` passes, and tests have been added/updated where applicable.
- [x] `pnpm build` passes.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.

