### PR TITLE
Translate the app update prompt

### DIFF
--- a/src/layouts/default/ReloadPrompt.vue
+++ b/src/layouts/default/ReloadPrompt.vue
@@ -17,13 +17,13 @@ const close = async () => {
     role="alert"
   >
     <div class="message">
-      <span v-if="offlineReady"> App ready to work offline </span>
-      <span v-else>
-        New content available, click on reload button to update.
-      </span>
+      <span v-if="offlineReady">{{ $t("offline_ready") }}</span>
+      <span v-else>{{ $t("update_available") }}</span>
     </div>
-    <button v-if="needRefresh" @click="updateServiceWorker()">Reload</button>
-    <button @click="close">Close</button>
+    <button v-if="needRefresh" @click="updateServiceWorker()">
+      {{ $t("reload") }}
+    </button>
+    <button @click="close">{{ $t("close") }}</button>
   </div>
 </template>
 

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -2286,5 +2286,8 @@
     "searching": "Searching...",
     "menu": "Menu",
     "home_assistant_menu": "Home Assistant",
-    "main_navigation": "Main"
+    "main_navigation": "Main",
+    "offline_ready": "App ready to work offline",
+    "update_available": "A new version is available. Reload to update.",
+    "reload": "Reload"
 }


### PR DESCRIPTION
# What does this implement/fix?

The little toast that asks you to reload after an app update was still hardcoded in English, so it showed up untranslated no matter which language you use. It went unnoticed because until #2515 the prompt almost never appeared — that change makes it show up on every update, so the English text would now be visible to everyone.

- Moved the update prompt's texts and its Reload/Close buttons into the translation files
- Reworded the update message so it reads naturally on touch devices too ("A new version is available. Reload to update.")

**Related issue (if applicable):**

- related issue `n/a`

**Related backend PR (if applicable):**

- related backend PR `n/a`

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm lint:check` passes.
- [x] `pnpm test:run` passes, and tests have been added/updated where applicable.
- [x] `pnpm build` passes.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
