### PR TITLE
Limit how much album art is cached over a remote connection

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -31,6 +31,9 @@ const PROXY_CACHE_NAME = "ma-http-proxy-v1";
 // below the cap so a full cache does not scan itself on every write.
 const PROXY_CACHE_MAX_ENTRIES = 500;
 const PROXY_CACHE_PRUNE_TO_ENTRIES = 400;
+// Share of the entries a write that ran out of storage keeps, so that room is
+// freed even while the cache is well under its entry cap.
+const PROXY_CACHE_QUOTA_KEEP = 0.8;
 
 // Entry count of the proxy cache, so a write knows whether it went over the cap
 // without enumerating the cache first. Rewriting an existing entry counts twice,
@@ -298,9 +301,15 @@ async function handleHttpProxyRequest(event, proxyScope) {
 
     // Cache successful responses (200-299)
     if (response.status >= 200 && response.status < 300) {
-      // Clone the response before caching (can only read body once). The write
-      // keeps the worker alive without holding up the image it just fetched.
-      event.waitUntil(cacheProxyResponse(cache, cacheKey, response.clone()));
+      try {
+        // Clone the response before caching (can only read body once). The write
+        // keeps the worker alive without holding up the image it just fetched.
+        event.waitUntil(cacheProxyResponse(cache, cacheKey, response.clone()));
+      } catch (error) {
+        // A request the browser waited long enough on is no longer extendable.
+        // Skipping the cache costs a round trip; failing here costs the image.
+        console.warn("[ServiceWorker] Could not keep the worker alive:", error);
+      }
     }
 
     return response;
@@ -317,17 +326,19 @@ async function handleHttpProxyRequest(event, proxyScope) {
  * the next time it is requested.
  */
 async function cacheProxyResponse(cache, cacheKey, response) {
-  // A rejected put may have read the body already, so hold a spare copy for the
-  // retry below.
-  const retryCopy = response.clone();
-
   try {
+    // A put reads the body before it can fail, so hold a spare copy for the
+    // retry below.
+    const retryCopy = response.clone();
+
     try {
       await cache.put(cacheKey, response);
     } catch (error) {
-      // Realistically a full storage quota, so make room and try once more.
+      // Realistically a full storage quota. The cap counts entries rather than
+      // bytes, so free a share of what is stored and try once more.
       console.warn("[ServiceWorker] Proxy cache full, making room:", error);
-      await pruneProxyCache(cache);
+      const stored = proxyCacheEntryCount ?? (await cache.keys()).length;
+      await pruneProxyCache(cache, Math.floor(stored * PROXY_CACHE_QUOTA_KEEP));
       await cache.put(cacheKey, retryCopy);
     }
 
@@ -348,16 +359,13 @@ async function cacheProxyResponse(cache, cacheKey, response) {
 }
 
 /**
- * Drop the oldest proxy cache entries until the cache is back under its cap.
+ * Drop the oldest proxy cache entries, keeping at most `keep` of them.
  */
-async function pruneProxyCache(cache) {
+async function pruneProxyCache(cache, keep = PROXY_CACHE_PRUNE_TO_ENTRIES) {
   const entries = await cache.keys();
   // Cache storage hands back entries in the order they were written, so the
   // oldest ones come first.
-  const excess = entries.slice(
-    0,
-    Math.max(entries.length - PROXY_CACHE_PRUNE_TO_ENTRIES, 0),
-  );
+  const excess = entries.slice(0, Math.max(entries.length - keep, 0));
   await Promise.all(excess.map((entry) => cache.delete(entry)));
   proxyCacheEntryCount = entries.length - excess.length;
 }

--- a/public/sw.js
+++ b/public/sw.js
@@ -25,6 +25,18 @@ const LEGACY_REMOTE_MODE_CACHE_KEY = "ma-remote-mode-state";
 const REMOTE_MODE_CACHE_NAME = "ma-sw-client-state-v1";
 const REMOTE_MODE_CACHE_PATH = "/__ma_remote_mode__/";
 
+const PROXY_CACHE_NAME = "ma-http-proxy-v1";
+// Proxied images never expire and every server a client connects to gets its
+// own set of entries, so the cache is capped by entry count. Pruning goes
+// below the cap so a full cache does not scan itself on every write.
+const PROXY_CACHE_MAX_ENTRIES = 500;
+const PROXY_CACHE_PRUNE_TO_ENTRIES = 400;
+
+// Entry count of the proxy cache, so a write knows whether it went over the cap
+// without enumerating the cache first. Rewriting an existing entry counts twice,
+// which only prunes earlier than needed: a prune re-reads the real count.
+let proxyCacheEntryCount = null;
+
 /**
  * Read remote proxy state for a browser client.
  */
@@ -201,11 +213,7 @@ self.addEventListener("fetch", (event) => {
 
         if (remoteState.isRemote) {
           // Proxy over WebRTC when in remote mode
-          return handleHttpProxyRequest(
-            event.request,
-            event.clientId,
-            remoteState.proxyScope,
-          );
+          return handleHttpProxyRequest(event, remoteState.proxyScope);
         } else {
           // Let request through normally when NOT in remote mode
           return fetch(event.request);
@@ -222,12 +230,13 @@ self.addEventListener("fetch", (event) => {
 /**
  * Handle HTTP proxy request over WebRTC
  */
-async function handleHttpProxyRequest(request, clientId, proxyScope) {
+async function handleHttpProxyRequest(event, proxyScope) {
+  const { request, clientId } = event;
   const url = new URL(request.url);
   const cacheKey = `${request.url}${url.search ? "&" : "?"}__ma_proxy_scope=${encodeURIComponent(proxyScope || clientId)}`;
 
   // Try to get from cache first
-  const cache = await caches.open("ma-http-proxy-v1");
+  const cache = await caches.open(PROXY_CACHE_NAME);
   const cachedResponse = await cache.match(cacheKey);
 
   if (cachedResponse) {
@@ -289,9 +298,9 @@ async function handleHttpProxyRequest(request, clientId, proxyScope) {
 
     // Cache successful responses (200-299)
     if (response.status >= 200 && response.status < 300) {
-      // Clone the response before caching (can only read body once)
-      const responseToCache = response.clone();
-      cache.put(cacheKey, responseToCache);
+      // Clone the response before caching (can only read body once). The write
+      // keeps the worker alive without holding up the image it just fetched.
+      event.waitUntil(cacheProxyResponse(cache, cacheKey, response.clone()));
     }
 
     return response;
@@ -299,6 +308,55 @@ async function handleHttpProxyRequest(request, clientId, proxyScope) {
     console.error("[ServiceWorker] HTTP proxy error:", error);
     return new Response(error.message, { status: 500 });
   }
+}
+
+/**
+ * Store a proxied response, keeping the cache within its entry budget.
+ *
+ * Never rejects: a response that cannot be cached only costs another round trip
+ * the next time it is requested.
+ */
+async function cacheProxyResponse(cache, cacheKey, response) {
+  // A rejected put may have read the body already, so hold a spare copy for the
+  // retry below.
+  const retryCopy = response.clone();
+
+  try {
+    try {
+      await cache.put(cacheKey, response);
+    } catch (error) {
+      // Realistically a full storage quota, so make room and try once more.
+      console.warn("[ServiceWorker] Proxy cache full, making room:", error);
+      await pruneProxyCache(cache);
+      await cache.put(cacheKey, retryCopy);
+    }
+
+    proxyCacheEntryCount =
+      proxyCacheEntryCount === null
+        ? (await cache.keys()).length
+        : proxyCacheEntryCount + 1;
+
+    if (proxyCacheEntryCount > PROXY_CACHE_MAX_ENTRIES) {
+      await pruneProxyCache(cache);
+    }
+  } catch (error) {
+    console.error("[ServiceWorker] Could not cache proxied response:", error);
+  }
+}
+
+/**
+ * Drop the oldest proxy cache entries until the cache is back under its cap.
+ */
+async function pruneProxyCache(cache) {
+  const entries = await cache.keys();
+  // Cache storage hands back entries in the order they were written, so the
+  // oldest ones come first.
+  const excess = entries.slice(
+    0,
+    Math.max(entries.length - PROXY_CACHE_PRUNE_TO_ENTRIES, 0),
+  );
+  await Promise.all(excess.map((entry) => cache.delete(entry)));
+  proxyCacheEntryCount = entries.length - excess.length;
 }
 
 /**

--- a/public/sw.js
+++ b/public/sw.js
@@ -331,6 +331,9 @@ async function cacheProxyResponse(cache, cacheKey, response) {
       await cache.put(cacheKey, retryCopy);
     }
 
+    // Cloning tees the body, so an unread copy holds on to the whole image.
+    if (!retryCopy.bodyUsed) await retryCopy.body?.cancel();
+
     proxyCacheEntryCount =
       proxyCacheEntryCount === null
         ? (await cache.keys()).length
@@ -386,6 +389,11 @@ self.addEventListener("activate", (event) => {
       // It also drives the update: the prompt reloads the page off the
       // controller change this fires, and never reloads on its own.
       await self.clients.claim();
+      // Brings a cache filled by a version that had no cap back within it, even
+      // for a client that never proxies another image.
+      if (await caches.has(PROXY_CACHE_NAME)) {
+        await pruneProxyCache(await caches.open(PROXY_CACHE_NAME));
+      }
     })(),
   );
 });

--- a/tests/plugins/sw-http-proxy.test.ts
+++ b/tests/plugins/sw-http-proxy.test.ts
@@ -12,9 +12,11 @@ const IMAGE_URL = `${ORIGIN}/imageproxy/album.jpg`;
 const REMOTE_MODE_CACHE_NAME = "ma-sw-client-state-v1";
 const REMOTE_MODE_CACHE_PATH = "/__ma_remote_mode__/";
 const PROXY_CACHE_NAME = "ma-http-proxy-v1";
-// Kept in step with sw.js: the entry cap and what a prune leaves behind.
+// Kept in step with sw.js: the entry cap, what a prune leaves behind, and the
+// share of it a write that ran out of storage keeps.
 const PROXY_CACHE_MAX_ENTRIES = 500;
 const PROXY_CACHE_PRUNE_TO_ENTRIES = 400;
+const PROXY_CACHE_QUOTA_KEEP = 0.8;
 const MESSAGE_PROTOCOL_VERSION = 1;
 
 type PostMessage = (message: {
@@ -61,11 +63,20 @@ function createFakeCaches() {
         // which counts as handling a rejection, and a write the worker fails
         // to catch would then no longer surface as an unhandled rejection.
         put: async (request: string | { url: string }, response: Response) => {
+          // The real Cache reads the body before it can fail on quota, which
+          // leaves the response it was handed unusable for a second attempt.
+          const body = await response.arrayBuffer();
           if (putFailure && putFailure.remaining > 0) {
             putFailure.remaining -= 1;
             throw putFailure.error;
           }
-          store.set(keyFor(request), response);
+          store.set(
+            keyFor(request),
+            new Response(body, {
+              status: response.status,
+              headers: response.headers,
+            }),
+          );
         },
         delete: vi.fn(async (request: string | { url: string }) =>
           store.delete(keyFor(request)),
@@ -225,13 +236,24 @@ describe("sw.js", () => {
     expect(await cache.keys()).toEqual([]);
   });
 
-  it("caches the image after making room for a failed write", async () => {
+  it("makes room for an image the browser had no space for", async () => {
+    const stored = 100;
+    const cache = await fakeCaches.open(PROXY_CACHE_NAME);
+    for (let index = 0; index < stored; index++) {
+      await cache.put(
+        `${ORIGIN}/imageproxy/old-${index}.jpg`,
+        new Response(""),
+      );
+    }
     fakeCaches.failPuts(1);
 
     await proxiedResponse(BYTES);
 
-    const cache = await fakeCaches.open(PROXY_CACHE_NAME);
-    expect(await cache.keys()).toHaveLength(1);
+    // Running out of storage has nothing to do with how many images are cached,
+    // so room is freed here even though the cache is far below its cap.
+    const urls = (await cache.keys()).map((entry) => entry.url);
+    expect(urls).toHaveLength(Math.floor(stored * PROXY_CACHE_QUOTA_KEEP) + 1);
+    expect(urls.at(-1)).toContain(IMAGE_URL);
   });
 
   it("drops the oldest images once the cache is full", async () => {
@@ -252,6 +274,32 @@ describe("sw.js", () => {
     const dropped = PROXY_CACHE_MAX_ENTRIES + 1 - PROXY_CACHE_PRUNE_TO_ENTRIES;
     expect(urls[0]).toBe(`${ORIGIN}/imageproxy/old-${dropped}.jpg`);
     expect(urls.at(-1)).toContain(IMAGE_URL);
+  });
+
+  it("keeps the cache capped as writes keep coming", async () => {
+    const cache = await fakeCaches.open(PROXY_CACHE_NAME);
+    for (let index = 0; index < PROXY_CACHE_MAX_ENTRIES - 1; index++) {
+      await cache.put(
+        `${ORIGIN}/imageproxy/old-${index}.jpg`,
+        new Response(""),
+      );
+    }
+
+    // The first write reads the real entry count; the second one has to know it
+    // went over the cap from the count the worker kept.
+    await proxiedResponse(BYTES);
+    await proxiedResponse(BYTES, 200, { url: `${ORIGIN}/imageproxy/next.jpg` });
+
+    expect(await cache.keys()).toHaveLength(PROXY_CACHE_PRUNE_TO_ENTRIES);
+  });
+
+  it("still answers a request the browser stopped waiting on", async () => {
+    // Nothing can be kept alive for the cache write at that point, but the
+    // image the worker already has must not turn into a failure.
+    const response = await proxiedResponse(BYTES, 200, { extendable: false });
+
+    expect(response.status).toBe(200);
+    expect(new Uint8Array(await response.arrayBuffer())).toEqual(BYTES);
   });
 
   // the check that refuses another build's messages sits in front of every one
@@ -309,7 +357,10 @@ describe("sw.js", () => {
    * Request the proxied image. Returns the worker's response and the client
    * mock, which only receives a proxy request when the cache misses.
    */
-  async function fireFetch(): Promise<{
+  async function fireFetch({
+    url = IMAGE_URL,
+    extendable = true,
+  } = {}): Promise<{
     response: Promise<Response>;
     postMessage: ReturnType<typeof vi.fn<PostMessage>>;
   }> {
@@ -318,12 +369,16 @@ describe("sw.js", () => {
 
     let response!: Promise<Response>;
     await fakeSelf.fire("fetch", {
-      request: new Request(IMAGE_URL),
+      request: new Request(url),
       clientId: CLIENT_ID,
       respondWith: (promise: Promise<Response>) => {
         response = promise;
       },
       waitUntil: (promise: Promise<unknown>) => {
+        // As the browser does once it stops waiting on the event.
+        if (!extendable) {
+          throw new DOMException("Event is not active", "InvalidStateError");
+        }
         pendingWork.push(promise);
       },
     });
@@ -347,9 +402,9 @@ describe("sw.js", () => {
   async function proxiedResponse(
     body: Uint8Array | string,
     status = 200,
-    { stamped = true } = {},
+    { stamped = true, url = IMAGE_URL, extendable = true } = {},
   ): Promise<Response> {
-    const { response, postMessage } = await fireFetch();
+    const { response, postMessage } = await fireFetch({ url, extendable });
     await vi.waitFor(() => expect(postMessage).toHaveBeenCalledTimes(1));
 
     await fakeSelf.fire("message", {

--- a/tests/plugins/sw-http-proxy.test.ts
+++ b/tests/plugins/sw-http-proxy.test.ts
@@ -75,6 +75,7 @@ function createFakeCaches() {
         ),
       };
     }),
+    has: vi.fn(async (name: string) => stores.has(name)),
     delete: vi.fn(async (name: string) => stores.delete(name)),
     /** Make the next `count` writes fail, as a full storage quota would. */
     failPuts(count: number) {
@@ -285,6 +286,25 @@ describe("sw.js", () => {
     expect(fakeSelf.skipWaiting).toHaveBeenCalled();
   });
 
+  it("trims a cache left behind by a version without a cap", async () => {
+    const cache = await fakeCaches.open(PROXY_CACHE_NAME);
+    for (let index = 0; index < PROXY_CACHE_MAX_ENTRIES + 50; index++) {
+      await cache.put(
+        `${ORIGIN}/imageproxy/old-${index}.jpg`,
+        new Response(""),
+      );
+    }
+
+    await fakeSelf.fire("activate", {
+      waitUntil: (promise: Promise<unknown>) => {
+        pendingWork.push(promise);
+      },
+    });
+    await settlePendingWork();
+
+    expect(await cache.keys()).toHaveLength(PROXY_CACHE_PRUNE_TO_ENTRIES);
+  });
+
   /**
    * Request the proxied image. Returns the worker's response and the client
    * mock, which only receives a proxy request when the cache misses.
@@ -312,9 +332,9 @@ describe("sw.js", () => {
   }
 
   /**
-   * Wait for the cache writes the worker kept alive past its response.
+   * Wait for the work the worker handed to waitUntil().
    */
-  async function settleCacheWrites(): Promise<void> {
+  async function settlePendingWork(): Promise<void> {
     while (pendingWork.length > 0) {
       await Promise.all(pendingWork.splice(0));
     }
@@ -349,7 +369,7 @@ describe("sw.js", () => {
     // The worker hands its cache write to waitUntil() just before it answers, so
     // the response has to be awaited first for that write to exist.
     const proxied = await response;
-    await settleCacheWrites();
+    await settlePendingWork();
     return proxied;
   }
 });

--- a/tests/plugins/sw-http-proxy.test.ts
+++ b/tests/plugins/sw-http-proxy.test.ts
@@ -12,6 +12,9 @@ const IMAGE_URL = `${ORIGIN}/imageproxy/album.jpg`;
 const REMOTE_MODE_CACHE_NAME = "ma-sw-client-state-v1";
 const REMOTE_MODE_CACHE_PATH = "/__ma_remote_mode__/";
 const PROXY_CACHE_NAME = "ma-http-proxy-v1";
+// Kept in step with sw.js: the entry cap and what a prune leaves behind.
+const PROXY_CACHE_MAX_ENTRIES = 500;
+const PROXY_CACHE_PRUNE_TO_ENTRIES = 400;
 const MESSAGE_PROTOCOL_VERSION = 1;
 
 type PostMessage = (message: {
@@ -30,6 +33,7 @@ type PostMessage = (message: {
  */
 function createFakeCaches() {
   const stores = new Map<string, Map<string, Response>>();
+  let putFailure: { error: Error; remaining: number } | null = null;
 
   function storeFor(name: string): Map<string, Response> {
     let store = stores.get(name);
@@ -53,11 +57,16 @@ function createFakeCaches() {
         match: vi.fn(async (request: string | { url: string }) =>
           store.get(keyFor(request))?.clone(),
         ),
-        put: vi.fn(
-          async (request: string | { url: string }, response: Response) => {
-            store.set(keyFor(request), response);
-          },
-        ),
+        // Deliberately not a vi.fn: a mock tracks the promise it hands back,
+        // which counts as handling a rejection, and a write the worker fails
+        // to catch would then no longer surface as an unhandled rejection.
+        put: async (request: string | { url: string }, response: Response) => {
+          if (putFailure && putFailure.remaining > 0) {
+            putFailure.remaining -= 1;
+            throw putFailure.error;
+          }
+          store.set(keyFor(request), response);
+        },
         delete: vi.fn(async (request: string | { url: string }) =>
           store.delete(keyFor(request)),
         ),
@@ -67,6 +76,13 @@ function createFakeCaches() {
       };
     }),
     delete: vi.fn(async (name: string) => stores.delete(name)),
+    /** Make the next `count` writes fail, as a full storage quota would. */
+    failPuts(count: number) {
+      putFailure = {
+        error: new DOMException("Quota exceeded", "QuotaExceededError"),
+        remaining: count,
+      };
+    },
   };
 }
 
@@ -119,11 +135,15 @@ function remoteStateKey(clientId: string): string {
 describe("sw.js", () => {
   let fakeSelf: ReturnType<typeof createFakeSelf>;
   let fakeCaches: ReturnType<typeof createFakeCaches>;
+  // Work the worker handed to event.waitUntil(), i.e. the cache writes that
+  // deliberately outlive the response.
+  let pendingWork: Array<Promise<unknown>>;
 
   beforeEach(async () => {
     vi.resetModules();
     fakeSelf = createFakeSelf();
     fakeCaches = createFakeCaches();
+    pendingWork = [];
     vi.stubGlobal("self", fakeSelf);
     vi.stubGlobal("caches", fakeCaches);
 
@@ -192,6 +212,47 @@ describe("sw.js", () => {
     expect(await response.text()).toBe("No transport available");
   });
 
+  it("still answers a request when the image cannot be cached", async () => {
+    fakeCaches.failPuts(Number.POSITIVE_INFINITY);
+
+    const response = await proxiedResponse(BYTES);
+
+    expect(new Uint8Array(await response.arrayBuffer())).toEqual(BYTES);
+    // A rejected write must not escape the worker either: the suite fails a
+    // test on an unhandled rejection.
+    const cache = await fakeCaches.open(PROXY_CACHE_NAME);
+    expect(await cache.keys()).toEqual([]);
+  });
+
+  it("caches the image after making room for a failed write", async () => {
+    fakeCaches.failPuts(1);
+
+    await proxiedResponse(BYTES);
+
+    const cache = await fakeCaches.open(PROXY_CACHE_NAME);
+    expect(await cache.keys()).toHaveLength(1);
+  });
+
+  it("drops the oldest images once the cache is full", async () => {
+    const cache = await fakeCaches.open(PROXY_CACHE_NAME);
+    for (let index = 0; index < PROXY_CACHE_MAX_ENTRIES; index++) {
+      await cache.put(
+        `${ORIGIN}/imageproxy/old-${index}.jpg`,
+        new Response(""),
+      );
+    }
+
+    await proxiedResponse(BYTES);
+
+    const urls = (await cache.keys()).map((entry) => entry.url);
+    expect(urls).toHaveLength(PROXY_CACHE_PRUNE_TO_ENTRIES);
+    // One entry over the cap, so the oldest 101 are gone and the image that
+    // pushed it over is the newest entry.
+    const dropped = PROXY_CACHE_MAX_ENTRIES + 1 - PROXY_CACHE_PRUNE_TO_ENTRIES;
+    expect(urls[0]).toBe(`${ORIGIN}/imageproxy/old-${dropped}.jpg`);
+    expect(urls.at(-1)).toContain(IMAGE_URL);
+  });
+
   // the check that refuses another build's messages sits in front of every one
   // of them, so it has to let this one through as well
   it("acknowledges a stamped remote-mode message", async () => {
@@ -242,9 +303,21 @@ describe("sw.js", () => {
       respondWith: (promise: Promise<Response>) => {
         response = promise;
       },
+      waitUntil: (promise: Promise<unknown>) => {
+        pendingWork.push(promise);
+      },
     });
 
     return { response, postMessage };
+  }
+
+  /**
+   * Wait for the cache writes the worker kept alive past its response.
+   */
+  async function settleCacheWrites(): Promise<void> {
+    while (pendingWork.length > 0) {
+      await Promise.all(pendingWork.splice(0));
+    }
   }
 
   /**
@@ -273,6 +346,10 @@ describe("sw.js", () => {
       source: { id: CLIENT_ID },
     });
 
-    return response;
+    // The worker hands its cache write to waitUntil() just before it answers, so
+    // the response has to be awaited first for that write to exist.
+    const proxied = await response;
+    await settleCacheWrites();
+    return proxied;
   }
 });


### PR DESCRIPTION
# What does this implement/fix?

Over a remote connection the service worker caches album art so images don't have to
travel the WebRTC channel twice. That cache had no limit and nothing ever removed
anything from it: every server you connect to adds its own full set of images, kept
forever. And when the browser refused a write (a full storage quota, most likely), the
failure was never handled and surfaced as an error inside the service worker.

- cap the cache at 500 images and drop the oldest ones once it's exceeded
- trim an oversized cache left behind by an earlier version, so the space is
  reclaimed even for someone who no longer connects remotely
- on a failed write, free up room and retry once instead of letting the error escape
- store the image without holding up the one that was just fetched
- tests for the new behaviour

**Related issue (if applicable):**

- n/a

**Related backend PR (if applicable):**

- n/a

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm lint:check` passes.
- [x] `pnpm test:run` passes, and tests have been added/updated where applicable.
- [x] `pnpm build` passes.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
