### PR TITLE
Tests fail fast when they try to reach the network

### DIFF
--- a/tests/setup/blockNetworkAccess.test.ts
+++ b/tests/setup/blockNetworkAccess.test.ts
@@ -1,0 +1,50 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+describe("network guard", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("blocks fetch and names the URL", () => {
+    expect(() => fetch("https://ma.example/imageproxy/album.jpg")).toThrow(
+      'fetch("https://ma.example/imageproxy/album.jpg")',
+    );
+  });
+
+  it("names the URL of a URL object", () => {
+    expect(() => fetch(new URL("https://ma.example/info"))).toThrow(
+      'fetch("https://ma.example/info")',
+    );
+  });
+
+  it("names the URL of a Request object", () => {
+    expect(() =>
+      fetch(new Request("https://ma.example/preview?path=track")),
+    ).toThrow('fetch("https://ma.example/preview?path=track")');
+  });
+
+  it("blocks a WebSocket and names the URL", () => {
+    expect(() => new WebSocket("wss://ma.example/ws")).toThrow(
+      'new WebSocket("wss://ma.example/ws")',
+    );
+  });
+
+  it("keeps the WebSocket readyState constants", () => {
+    expect(WebSocket.CONNECTING).toBe(0);
+    expect(WebSocket.OPEN).toBe(1);
+    expect(WebSocket.CLOSING).toBe(2);
+    expect(WebSocket.CLOSED).toBe(3);
+  });
+
+  it("lets a test stub the globals and restores the guard afterwards", () => {
+    const stub = vi.fn();
+    vi.stubGlobal("fetch", stub);
+    fetch("https://ma.example/info");
+    expect(stub).toHaveBeenCalledOnce();
+
+    vi.unstubAllGlobals();
+    expect(() => fetch("https://ma.example/info")).toThrow(
+      "Blocked a real network request",
+    );
+  });
+});

--- a/tests/setup/blockNetworkAccess.ts
+++ b/tests/setup/blockNetworkAccess.ts
@@ -1,0 +1,36 @@
+/**
+ * Fails a test that reaches the network instead of stubbing it.
+ *
+ * happy-dom resolves real hostnames, so an unstubbed request surfaces as a DNS
+ * error or a timeout raised wherever the response happened to be awaited -
+ * often nowhere near the call that was left unstubbed. Replacing the globals
+ * with a throw names the offending URL instead, and does it before any packet
+ * leaves the machine.
+ *
+ * Tests that need a response stub these globals as usual; `vi.stubGlobal` puts
+ * the guard back when the test unstubs. Code under test that catches its own
+ * network errors swallows this throw too, so the guard fails a test only where
+ * the error is left to propagate.
+ */
+
+const requestUrl = (input: RequestInfo | URL) =>
+  typeof input === "string" || input instanceof URL ? String(input) : input.url;
+
+const blockRequest = (call: string): never => {
+  throw new Error(
+    `Blocked a real network request from a test: ${call}. Stub it instead of reaching the network.`,
+  );
+};
+
+globalThis.fetch = (input: RequestInfo | URL) =>
+  blockRequest(`fetch("${requestUrl(input)}")`);
+
+globalThis.WebSocket = Object.assign(
+  function (url: string | URL) {
+    blockRequest(`new WebSocket("${url}")`);
+  },
+  // App code compares readyState against these constants on the global
+  // constructor, so they have to survive the swap. The values are fixed by the
+  // WebSocket spec, which keeps this independent of the test environment.
+  { CONNECTING: 0, OPEN: 1, CLOSING: 2, CLOSED: 3 },
+) as unknown as typeof WebSocket;

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -15,9 +15,13 @@ export default mergeConfig(
       // stylesheet has to be compiled instead of stubbed out. Component styles
       // stay unprocessed, so the rest of the suite is unaffected.
       css: { include: [/src\/styles\/(style|global)\.css/] },
-      setupFiles: ["./tests/setup/failOnUnhandledErrors.ts"],
-      // Errors that escape a test must never be silently dropped; the setup
-      // file above additionally surfaces them in the pass/fail tally.
+      setupFiles: [
+        "./tests/setup/blockNetworkAccess.ts",
+        "./tests/setup/failOnUnhandledErrors.ts",
+      ],
+      // Errors that escape a test must never be silently dropped; the
+      // failOnUnhandledErrors setup file additionally surfaces them in the
+      // pass/fail tally.
       dangerouslyIgnoreUnhandledErrors: false,
       server: {
         deps: {


### PR DESCRIPTION
# What does this implement/fix?

Tests run against happy-dom, which resolves real hostnames. So when a test forgets to stub a request, the test process actually goes out to the network: it fails with `getaddrinfo ENOTFOUND ma.example` (or just hangs until it times out), raised wherever the response happened to be awaited rather than at the call that was left unstubbed.

That happened for real while working on #2514: the service worker's fetch handler falls back to a plain `fetch()` when it cannot read the remote-mode state, and a bug in the test's fake cache sent it down that path. The failure pointed at DNS instead of at the bug.

This adds a suite-wide guard, so a test that reaches the network now fails immediately with the URL it tried to call:

```
Blocked a real network request from a test: fetch("https://ma.example/imageproxy/album.jpg"). Stub it instead of reaching the network.
```

No behaviour change for the app itself — test tooling only.

**Related issue (if applicable):**

- follow-up from #2514

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Changes

- New `tests/setup/blockNetworkAccess.ts` setup file that replaces `fetch` and `WebSocket` with a throw naming the target URL.
- Registered it in `vitest.config.ts`.
- Tests for the guard, including that a test stubbing `fetch` itself still works and that the guard comes back afterwards.
- Kept the four `WebSocket` readyState constants on the replacement, since app code compares `readyState` against them on the global constructor.

Checked with a logging probe over the whole suite first: no test was relying on real network access, and no new dependency is needed.

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm lint:check` passes.
- [x] `pnpm test:run` passes, and tests have been added/updated where applicable.
- [x] `pnpm build` passes.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
