### PR TITLE
Same page heading on Browse as on Settings

### DIFF
--- a/src/components/ToolbarHeading.vue
+++ b/src/components/ToolbarHeading.vue
@@ -1,0 +1,92 @@
+<template>
+  <div class="toolbar-heading">
+    <component
+      :is="to ? RouterLink : 'span'"
+      :to="to"
+      class="toolbar-heading-title"
+    >
+      {{ title }}
+    </component>
+    <v-breadcrumbs
+      v-if="items.length"
+      :items="items"
+      class="pa-0 toolbar-heading-trail"
+    />
+  </div>
+</template>
+
+<script setup lang="ts">
+import { RouterLink, type RouteLocationRaw } from "vue-router";
+
+// properties
+interface Props {
+  title: string;
+  // leave unset on the section root, where the heading has nowhere to link to
+  to?: RouteLocationRaw;
+  items?: ToolbarHeadingItem[];
+}
+withDefaults(defineProps<Props>(), {
+  to: undefined,
+  items: () => [],
+});
+</script>
+
+<script lang="ts">
+export interface ToolbarHeadingItem {
+  title: string;
+  // set on the page you are on, which is the crumb without a destination
+  disabled: boolean;
+  to?: RouteLocationRaw;
+}
+</script>
+
+<style scoped>
+.toolbar-heading {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  justify-content: center;
+  min-width: 0;
+  line-height: 1.2;
+}
+
+/* the trail carries the detail, so the heading only has to name the section */
+.toolbar-heading-title {
+  color: inherit;
+  text-decoration: none;
+  font-size: 1rem;
+  font-weight: 500;
+}
+
+/* the trail can outgrow the toolbar, so it scrolls rather than pushing the
+   actions off the end */
+.toolbar-heading-trail {
+  max-width: 100%;
+  overflow-x: auto;
+  font-size: 0.7rem;
+  scrollbar-width: none;
+}
+
+.toolbar-heading-trail::-webkit-scrollbar {
+  display: none;
+}
+
+.toolbar-heading-trail :deep(.v-breadcrumbs-item) {
+  padding: 0;
+  font-size: inherit;
+  white-space: nowrap;
+  opacity: 0.6;
+}
+
+/* vuetify dims the last crumb as "disabled"; it is the page you are on, so it
+   is the one that stands out and the trail above it recedes */
+.toolbar-heading-trail :deep(.v-breadcrumbs-item--disabled) {
+  opacity: 1;
+}
+
+.toolbar-heading-trail :deep(.v-breadcrumbs-divider) {
+  padding: 0 4px;
+  font-size: inherit;
+  opacity: 0.6;
+}
+</style>

--- a/src/components/ToolbarHeading.vue
+++ b/src/components/ToolbarHeading.vue
@@ -15,7 +15,9 @@
       <template #item="{ item, index }">
         <button
           v-if="index === trail.collapsedIndex"
+          type="button"
           class="toolbar-heading-more"
+          :aria-label="t('tooltip.show_full_path')"
           :title="t('tooltip.show_full_path')"
           @click="expanded = true"
         >

--- a/src/components/ToolbarHeading.vue
+++ b/src/components/ToolbarHeading.vue
@@ -34,7 +34,7 @@ withDefaults(defineProps<Props>(), {
 <script lang="ts">
 export interface ToolbarHeadingItem {
   title: string;
-  // set on the page you are on, which is the crumb without a destination
+  // marks the page you are on: highlighted and not clickable, even with a route
   disabled: boolean;
   to?: RouteLocationRaw;
 }

--- a/src/components/ToolbarHeading.vue
+++ b/src/components/ToolbarHeading.vue
@@ -9,13 +9,14 @@
     </component>
     <v-breadcrumbs
       v-if="items.length"
-      :items="items"
+      :items="crumbs"
       class="pa-0 toolbar-heading-trail"
     />
   </div>
 </template>
 
 <script setup lang="ts">
+import { computed } from "vue";
 import { RouterLink, type RouteLocationRaw } from "vue-router";
 
 // properties
@@ -25,10 +26,16 @@ interface Props {
   to?: RouteLocationRaw;
   items?: ToolbarHeadingItem[];
 }
-withDefaults(defineProps<Props>(), {
+const props = withDefaults(defineProps<Props>(), {
   to: undefined,
   items: () => [],
 });
+
+// crumbs in a trail can share a route and differ only by query, so only an
+// exact match may announce itself as the current page
+const crumbs = computed(() =>
+  props.items.map((item) => ({ ...item, exact: true })),
+);
 </script>
 
 <script lang="ts">

--- a/src/components/ToolbarHeading.vue
+++ b/src/components/ToolbarHeading.vue
@@ -9,15 +9,33 @@
     </component>
     <v-breadcrumbs
       v-if="items.length"
-      :items="crumbs"
+      :items="trail.crumbs"
       class="pa-0 toolbar-heading-trail"
-    />
+    >
+      <template #item="{ item, index }">
+        <button
+          v-if="index === trail.collapsedIndex"
+          class="toolbar-heading-more"
+          :title="t('tooltip.show_full_path')"
+          @click="expanded = true"
+        >
+          {{ ELLIPSIS }}
+        </button>
+        <v-breadcrumbs-item v-else v-bind="item" />
+      </template>
+    </v-breadcrumbs>
   </div>
 </template>
 
 <script setup lang="ts">
-import { computed } from "vue";
+import { isPhoneSizedScreen } from "@/plugins/breakpoint";
+import { computed, ref, watch } from "vue";
+import { useI18n } from "vue-i18n";
 import { RouterLink, type RouteLocationRaw } from "vue-router";
+
+// beyond this a phone shows only where the trail starts and where you are now
+const PHONE_MAX_CRUMBS = 3;
+const ELLIPSIS = "…";
 
 // properties
 interface Props {
@@ -31,11 +49,31 @@ const props = withDefaults(defineProps<Props>(), {
   items: () => [],
 });
 
-// crumbs in a trail can share a route and differ only by query, so only an
-// exact match may announce itself as the current page
-const crumbs = computed(() =>
-  props.items.map((item) => ({ ...item, exact: true })),
+const { t } = useI18n();
+const expanded = ref(false);
+
+// moving to another page gives a trail that was never collapsed by hand
+watch(
+  () => props.items,
+  () => (expanded.value = false),
 );
+
+const trail = computed(() => {
+  // crumbs in a trail can share a route and differ only by query, so only an
+  // exact match may announce itself as the current page
+  const crumbs = props.items.map((item) => ({ ...item, exact: true }));
+  if (
+    expanded.value ||
+    !isPhoneSizedScreen() ||
+    crumbs.length <= PHONE_MAX_CRUMBS
+  ) {
+    return { crumbs, collapsedIndex: -1 };
+  }
+  return {
+    crumbs: [crumbs[0], { title: ELLIPSIS }, crumbs[crumbs.length - 1]],
+    collapsedIndex: 1,
+  };
+});
 </script>
 
 <script lang="ts">
@@ -95,5 +133,22 @@ export interface ToolbarHeadingItem {
   padding: 0 4px;
   font-size: inherit;
   opacity: 0.6;
+}
+
+/* stands in for the crumbs a phone has no room for, and reveals them on tap */
+.toolbar-heading-more {
+  background: none;
+  border: none;
+  color: inherit;
+  cursor: pointer;
+  font: inherit;
+  padding: 0 2px;
+  opacity: 0.6;
+}
+
+@media (max-width: 600px) {
+  .toolbar-heading-trail {
+    font-size: 0.65rem;
+  }
 }
 </style>

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -849,6 +849,7 @@
         "collapse_expand": "Collapse\/expand this listing",
         "back": "Back",
         "show_menu": "Show\/hide menu",
+        "show_full_path": "Show the full path",
         "search_filter_active": "Search is currently filtering results",
         "play_sample": "Play sample",
         "album_type": "Album type",

--- a/src/views/BrowseView.vue
+++ b/src/views/BrowseView.vue
@@ -6,41 +6,19 @@
       :show-library="false"
       :show-favorites-only-filter="false"
       :show-track-number="false"
-      :show-select-button="
-        path && path != 'root' && !hasOnlyFolders ? true : false
-      "
+      :show-select-button="!isRoot && !hasOnlyFolders"
       :load-items="loadItems"
       :sort-keys="['original', 'name', 'name_desc']"
       :path="path"
       :allow-key-hooks="true"
       :icon="Folder"
-      :title="title"
     >
       <template #title>
-        <div class="breadcrumb-container">
-          <span
-            v-for="(segment, index) in breadcrumbSegments"
-            :key="index"
-            class="breadcrumb-segment"
-          >
-            <button
-              v-if="segment.clickable"
-              class="breadcrumb-link"
-              @click="navigateToSegment(segment.path)"
-            >
-              {{ segment.text }}
-            </button>
-            <span v-else class="breadcrumb-text">
-              {{ segment.text }}
-            </span>
-            <v-icon
-              v-if="index < breadcrumbSegments.length - 1"
-              icon="mdi-chevron-right"
-              size="small"
-              class="breadcrumb-separator"
-            />
-          </span>
-        </div>
+        <ToolbarHeading
+          :title="t('browse')"
+          :to="isRoot ? undefined : { name: 'browse' }"
+          :items="breadcrumbItems"
+        />
       </template>
     </ItemsListing>
   </section>
@@ -48,9 +26,11 @@
 
 <script setup lang="ts">
 import ItemsListing, { LoadDataParams } from "@/components/ItemsListing.vue";
+import ToolbarHeading, {
+  type ToolbarHeadingItem,
+} from "@/components/ToolbarHeading.vue";
 import api from "@/plugins/api";
 import { MediaItemType, MediaType } from "@/plugins/api/interfaces";
-import router from "@/plugins/router";
 import { Folder } from "@lucide/vue";
 import { computed, ref } from "vue";
 import { useI18n } from "vue-i18n";
@@ -59,73 +39,40 @@ export interface Props {
   path?: string;
 }
 
-interface BreadcrumbSegment {
-  text: string;
-  path: string | null;
-  clickable: boolean;
-}
-
 const props = defineProps<Props>();
 const { t } = useI18n();
 const hasOnlyFolders = ref(false);
 
-const title = computed(() => "");
+const isRoot = computed(() => !props.path || props.path === "root");
 
-const breadcrumbSegments = computed((): BreadcrumbSegment[] => {
-  const segments: BreadcrumbSegment[] = [];
+const breadcrumbItems = computed((): ToolbarHeadingItem[] => {
+  const path = props.path;
+  if (isRoot.value || !path) return [];
 
-  segments.push({
-    text: t("browse"),
-    path: null,
-    clickable: (props.path && props.path !== "root") || false,
-  });
+  // a browse path reads as "<provider>://<folder>/<folder>", where the provider
+  // prefix is a level of its own that lists that provider's top-level folders
+  const [providerPart, folderPart] = path.includes("://")
+    ? path.split("://")
+    : ["", path];
+  const prefix = providerPart ? `${providerPart}://` : "";
+  const folders = folderPart.split("/").filter((folder) => folder.length > 0);
 
-  if (props.path && props.path !== "root") {
-    if (props.path.includes("://")) {
-      const [providerPart, pathPart] = props.path.split("://");
-      const provider = providerPart + "://";
-      const providerName = api.getProviderName(providerPart);
-
-      segments.push({
-        text: providerName,
-        path: provider,
-        clickable: (pathPart && pathPart.length > 0) || false,
-      });
-
-      if (pathPart && pathPart.length > 0) {
-        const pathSegments = pathPart
-          .split("/")
-          .filter((segment) => segment.length > 0);
-
-        pathSegments.forEach((segment, index) => {
-          const fullPath =
-            provider + pathSegments.slice(0, index + 1).join("/");
-
-          segments.push({
-            text: segment,
-            path: fullPath,
-            clickable: index < pathSegments.length - 1,
-          });
-        });
-      }
-    } else {
-      const pathSegments = props.path
-        .split("/")
-        .filter((segment) => segment.length > 0);
-
-      pathSegments.forEach((segment, index) => {
-        const fullPath = pathSegments.slice(0, index + 1).join("/");
-
-        segments.push({
-          text: segment,
-          path: fullPath,
-          clickable: index < pathSegments.length - 1,
-        });
-      });
-    }
+  const items: ToolbarHeadingItem[] = [];
+  if (providerPart) {
+    items.push({
+      title: api.getProviderName(providerPart),
+      disabled: folders.length === 0,
+      to: browseRoute(prefix),
+    });
   }
-
-  return segments;
+  folders.forEach((folder, index) => {
+    items.push({
+      title: folder,
+      disabled: index === folders.length - 1,
+      to: browseRoute(prefix + folders.slice(0, index + 1).join("/")),
+    });
+  });
+  return items;
 });
 
 const loadItems = async function (params: LoadDataParams) {
@@ -136,84 +83,8 @@ const loadItems = async function (params: LoadDataParams) {
   return items;
 };
 
-const navigateToSegment = (path: string | null) => {
-  if (path === null) {
-    router.push({ name: "browse" });
-  } else {
-    router.push({
-      name: "browse",
-      query: { path },
-    });
-  }
-};
+const browseRoute = (path: string) => ({
+  name: "browse",
+  query: { path },
+});
 </script>
-
-<style scoped>
-.breadcrumb-container {
-  display: flex;
-  align-items: center;
-  flex-wrap: wrap;
-  gap: 4px;
-  min-width: 0;
-  max-width: 100%;
-}
-
-.breadcrumb-segment {
-  display: flex;
-  align-items: center;
-  gap: 4px;
-  min-width: 0;
-}
-
-.breadcrumb-link {
-  background: none;
-  border: none;
-  color: inherit;
-  cursor: pointer;
-  text-decoration: underline;
-  font-family: inherit;
-  font-size: inherit;
-  padding: 0;
-  margin: 0;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  max-width: 200px;
-}
-
-.breadcrumb-link:hover {
-  opacity: 0.7;
-}
-
-.breadcrumb-text {
-  color: inherit;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  max-width: 200px;
-}
-
-.breadcrumb-separator {
-  opacity: 0.5;
-  margin: 0 2px;
-  flex-shrink: 0;
-}
-
-/* Scale down font size when there are many segments */
-.breadcrumb-container:has(.breadcrumb-segment:nth-child(4)) .breadcrumb-link,
-.breadcrumb-container:has(.breadcrumb-segment:nth-child(4)) .breadcrumb-text {
-  font-size: 0.9em;
-}
-
-.breadcrumb-container:has(.breadcrumb-segment:nth-child(5)) .breadcrumb-link,
-.breadcrumb-container:has(.breadcrumb-segment:nth-child(5)) .breadcrumb-text {
-  font-size: 0.85em;
-  max-width: 150px;
-}
-
-.breadcrumb-container:has(.breadcrumb-segment:nth-child(6)) .breadcrumb-link,
-.breadcrumb-container:has(.breadcrumb-segment:nth-child(6)) .breadcrumb-text {
-  font-size: 0.8em;
-  max-width: 120px;
-}
-</style>

--- a/src/views/settings/Settings.vue
+++ b/src/views/settings/Settings.vue
@@ -2,20 +2,11 @@
   <div>
     <Toolbar :icon="Settings">
       <template #title>
-        <div class="settings-heading">
-          <component
-            :is="isOverview ? 'span' : RouterLink"
-            :to="isOverview ? undefined : { name: 'settings' }"
-            class="settings-heading-title"
-          >
-            {{ t("settings.settings") }}
-          </component>
-          <v-breadcrumbs
-            v-if="breadcrumbItems.length"
-            :items="breadcrumbItems"
-            class="pa-0 settings-heading-trail"
-          />
-        </div>
+        <ToolbarHeading
+          :title="t('settings.settings')"
+          :to="isOverview ? undefined : { name: 'settings' }"
+          :items="breadcrumbItems"
+        />
       </template>
       <template #append>
         <v-btn
@@ -298,6 +289,9 @@ import Container from "@/components/Container.vue";
 import Icon from "@/components/Icon.vue";
 import ListItem from "@/components/ListItem.vue";
 import Toolbar from "@/components/Toolbar.vue";
+import ToolbarHeading, {
+  type ToolbarHeadingItem,
+} from "@/components/ToolbarHeading.vue";
 import {
   Card,
   CardDescription,
@@ -315,7 +309,7 @@ import { Settings } from "@lucide/vue";
 import { match } from "ts-pattern";
 import { computed, provide, ref, watch } from "vue";
 import { useI18n } from "vue-i18n";
-import { RouterLink, useRouter, type RouteLocationRaw } from "vue-router";
+import { useRouter } from "vue-router";
 import { useDisplay } from "vuetify";
 
 // global refs
@@ -731,12 +725,7 @@ const breadcrumbItems = computed(() => {
   const name = route.name?.toString() || "";
 
   // "Settings" heads the toolbar on its own line, so the trail starts below it
-  const items: Array<{
-    title: string;
-    disabled: boolean;
-    href?: string;
-    to?: RouteLocationRaw;
-  }> = [];
+  const items: ToolbarHeadingItem[] = [];
 
   if (!isOverview.value) {
     const currentTab = activeTab.value;
@@ -918,55 +907,6 @@ const documentationUrl = computed(() => {
 </script>
 
 <style scoped>
-.settings-heading {
-  display: flex;
-  flex-direction: column;
-  align-items: flex-start;
-  justify-content: center;
-  min-width: 0;
-  line-height: 1.2;
-}
-
-/* the trail carries the detail, so the heading only has to name the section */
-.settings-heading-title {
-  color: inherit;
-  text-decoration: none;
-  font-size: 1rem;
-  font-weight: 500;
-}
-
-/* the trail can outgrow the toolbar, so it scrolls rather than pushing the
-   actions off the end */
-.settings-heading-trail {
-  max-width: 100%;
-  overflow-x: auto;
-  font-size: 0.7rem;
-  scrollbar-width: none;
-}
-
-.settings-heading-trail::-webkit-scrollbar {
-  display: none;
-}
-
-.settings-heading-trail :deep(.v-breadcrumbs-item) {
-  padding: 0;
-  font-size: inherit;
-  white-space: nowrap;
-  opacity: 0.6;
-}
-
-/* vuetify dims the last crumb as "disabled"; it is the page you are on, so it
-   is the one that stands out and the trail above it recedes */
-.settings-heading-trail :deep(.v-breadcrumbs-item--disabled) {
-  opacity: 1;
-}
-
-.settings-heading-trail :deep(.v-breadcrumbs-divider) {
-  padding: 0 4px;
-  font-size: inherit;
-  opacity: 0.6;
-}
-
 .settings-overview {
   max-width: 1200px !important;
   margin: 0 auto;

--- a/tests/components/ToolbarHeading.test.ts
+++ b/tests/components/ToolbarHeading.test.ts
@@ -1,0 +1,76 @@
+import ToolbarHeading from "@/components/ToolbarHeading.vue";
+import { mount } from "@vue/test-utils";
+import { describe, expect, it } from "vitest";
+import { createMemoryHistory, createRouter } from "vue-router";
+import { createVuetify } from "vuetify";
+import * as components from "vuetify/components";
+import * as directives from "vuetify/directives";
+
+const vuetify = createVuetify({ components, directives });
+
+const blank = { template: "<div />" };
+const testRoutes = [
+  { path: "/", name: "root", component: blank },
+  { path: "/section", name: "section", component: blank },
+  { path: "/section/child", name: "child", component: blank },
+];
+
+describe("ToolbarHeading", () => {
+  it("links the heading back to the section root", async () => {
+    const wrapper = await mountHeading({
+      title: "Settings",
+      to: { name: "section" },
+      items: [{ title: "Players", disabled: true }],
+    });
+
+    expect(wrapper.get(".toolbar-heading-title").attributes("href")).toBe(
+      "/section",
+    );
+  });
+
+  it("renders the heading as plain text on the section root", async () => {
+    const wrapper = await mountHeading({ title: "Settings" });
+
+    const heading = wrapper.get(".toolbar-heading-title");
+    expect(heading.element.tagName).toBe("SPAN");
+    expect(heading.text()).toBe("Settings");
+  });
+
+  it("leaves out the trail when there is nothing below the section", async () => {
+    const wrapper = await mountHeading({ title: "Settings" });
+
+    expect(wrapper.find(".toolbar-heading-trail").exists()).toBe(false);
+  });
+
+  it("keeps ancestor crumbs clickable and marks the current page", async () => {
+    const wrapper = await mountHeading({
+      title: "Settings",
+      to: { name: "section" },
+      items: [
+        { title: "Players", disabled: false, to: { name: "section" } },
+        { title: "Kitchen", disabled: true, to: { name: "child" } },
+      ],
+    });
+
+    const crumbs = wrapper.findAll(".v-breadcrumbs-item");
+    expect(crumbs.map((crumb) => crumb.text())).toEqual(["Players", "Kitchen"]);
+    expect(crumbs[0].classes()).not.toContain("v-breadcrumbs-item--disabled");
+    expect(crumbs[1].classes()).toContain("v-breadcrumbs-item--disabled");
+  });
+});
+
+async function mountHeading(
+  props: InstanceType<typeof ToolbarHeading>["$props"],
+) {
+  const router = createRouter({
+    history: createMemoryHistory(),
+    routes: testRoutes,
+  });
+  await router.push("/");
+  await router.isReady();
+
+  return mount(ToolbarHeading, {
+    props,
+    global: { plugins: [router, vuetify] },
+  });
+}

--- a/tests/components/ToolbarHeading.test.ts
+++ b/tests/components/ToolbarHeading.test.ts
@@ -54,8 +54,44 @@ describe("ToolbarHeading", () => {
 
     const crumbs = wrapper.findAll(".v-breadcrumbs-item");
     expect(crumbs.map((crumb) => crumb.text())).toEqual(["Players", "Kitchen"]);
+    expect(crumbs[0].get("a").attributes("href")).toBe("/section");
     expect(crumbs[0].classes()).not.toContain("v-breadcrumbs-item--disabled");
     expect(crumbs[1].classes()).toContain("v-breadcrumbs-item--disabled");
+  });
+
+  it("lets only the crumb you are on announce itself as the current page", async () => {
+    // browse-style trail: every crumb shares one route and differs only by query
+    const router = createRouter({
+      history: createMemoryHistory(),
+      routes: [{ path: "/browse", name: "browse", component: blank }],
+    });
+    await router.push({ name: "browse", query: { path: "fs://Music" } });
+    await router.isReady();
+
+    const wrapper = mount(ToolbarHeading, {
+      props: {
+        title: "Browse",
+        to: { name: "browse" },
+        items: [
+          {
+            title: "fs",
+            disabled: false,
+            to: { name: "browse", query: { path: "fs://" } },
+          },
+          {
+            title: "Music",
+            disabled: true,
+            to: { name: "browse", query: { path: "fs://Music" } },
+          },
+        ],
+      },
+      global: { plugins: [router, vuetify] },
+    });
+
+    const announced = wrapper
+      .findAll(".v-breadcrumbs-item a")
+      .filter((crumb) => crumb.attributes("aria-current") === "page");
+    expect(announced.map((crumb) => crumb.text())).toEqual(["Music"]);
   });
 });
 

--- a/tests/components/ToolbarHeading.test.ts
+++ b/tests/components/ToolbarHeading.test.ts
@@ -1,10 +1,17 @@
 import ToolbarHeading from "@/components/ToolbarHeading.vue";
 import { mount } from "@vue/test-utils";
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { createMemoryHistory, createRouter } from "vue-router";
 import { createVuetify } from "vuetify";
 import * as components from "vuetify/components";
 import * as directives from "vuetify/directives";
+
+vi.mock("vue-i18n", () => ({ useI18n: () => ({ t: (key: string) => key }) }));
+
+const screen = vi.hoisted(() => ({ isPhone: false }));
+vi.mock("@/plugins/breakpoint", () => ({
+  isPhoneSizedScreen: () => screen.isPhone,
+}));
 
 const vuetify = createVuetify({ components, directives });
 
@@ -16,6 +23,10 @@ const testRoutes = [
 ];
 
 describe("ToolbarHeading", () => {
+  beforeEach(() => {
+    screen.isPhone = false;
+  });
+
   it("links the heading back to the section root", async () => {
     const wrapper = await mountHeading({
       title: "Settings",
@@ -59,6 +70,41 @@ describe("ToolbarHeading", () => {
     expect(crumbs[1].classes()).toContain("v-breadcrumbs-item--disabled");
   });
 
+  it("drops the middle of a long trail on a phone", async () => {
+    screen.isPhone = true;
+    const wrapper = await mountHeading({
+      title: "Browse",
+      to: { name: "section" },
+      items: deepTrail(),
+    });
+
+    expect(crumbText(wrapper)).toEqual(["one", "\u2026", "five"]);
+  });
+
+  it("reveals the whole trail once the ellipsis is tapped", async () => {
+    screen.isPhone = true;
+    const wrapper = await mountHeading({
+      title: "Browse",
+      to: { name: "section" },
+      items: deepTrail(),
+    });
+
+    await wrapper.get(".toolbar-heading-more").trigger("click");
+
+    expect(crumbText(wrapper)).toEqual(["one", "two", "three", "four", "five"]);
+  });
+
+  it("keeps the whole trail where there is room for it", async () => {
+    const wrapper = await mountHeading({
+      title: "Browse",
+      to: { name: "section" },
+      items: deepTrail(),
+    });
+
+    expect(wrapper.find(".toolbar-heading-more").exists()).toBe(false);
+    expect(crumbText(wrapper)).toEqual(["one", "two", "three", "four", "five"]);
+  });
+
   it("lets only the crumb you are on announce itself as the current page", async () => {
     // browse-style trail: every crumb shares one route and differs only by query
     const router = createRouter({
@@ -94,6 +140,21 @@ describe("ToolbarHeading", () => {
     expect(announced.map((crumb) => crumb.text())).toEqual(["Music"]);
   });
 });
+
+function deepTrail() {
+  const names = ["one", "two", "three", "four", "five"];
+  return names.map((title, index) => ({
+    title,
+    disabled: index === names.length - 1,
+    to: { name: "section" },
+  }));
+}
+
+function crumbText(wrapper: ReturnType<typeof mount>) {
+  return wrapper
+    .findAll(".v-breadcrumbs-item, .toolbar-heading-more")
+    .map((crumb) => crumb.text());
+}
 
 async function mountHeading(
   props: InstanceType<typeof ToolbarHeading>["$props"],

--- a/tests/components/ToolbarHeading.test.ts
+++ b/tests/components/ToolbarHeading.test.ts
@@ -79,6 +79,9 @@ describe("ToolbarHeading", () => {
     });
 
     expect(crumbText(wrapper)).toEqual(["one", "\u2026", "five"]);
+    const more = wrapper.get(".toolbar-heading-more");
+    expect(more.attributes("aria-label")).toBe("tooltip.show_full_path");
+    expect(more.attributes("type")).toBe("button");
   });
 
   it("reveals the whole trail once the ellipsis is tapped", async () => {

--- a/tests/views/BrowseView.test.ts
+++ b/tests/views/BrowseView.test.ts
@@ -15,7 +15,11 @@ vi.mock("@/plugins/api", () => ({
 // only the toolbar heading is under test, so the listing stands in as a host
 // for the title slot it normally forwards to the toolbar
 vi.mock("@/components/ItemsListing.vue", () => ({
-  default: { template: '<div><slot name="title" /></div>' },
+  default: {
+    name: "ItemsListing",
+    props: ["showSelectButton"],
+    template: '<div><slot name="title" /></div>',
+  },
 }));
 
 describe("BrowseView", () => {
@@ -68,7 +72,62 @@ describe("BrowseView", () => {
       },
     ]);
   });
+
+  it("treats the 'root' path as the browse root", () => {
+    const heading = mountBrowse("root").getComponent(ToolbarHeading);
+
+    expect(heading.props("items")).toEqual([]);
+    expect(heading.props("to")).toBeUndefined();
+  });
+
+  it("builds a trail for a path that names no provider", () => {
+    const heading = mountBrowse("foo/bar").getComponent(ToolbarHeading);
+
+    expect(heading.props("items")).toEqual([
+      {
+        title: "foo",
+        disabled: false,
+        to: { name: "browse", query: { path: "foo" } },
+      },
+      {
+        title: "bar",
+        disabled: true,
+        to: { name: "browse", query: { path: "foo/bar" } },
+      },
+    ]);
+  });
+
+  it("skips empty steps so a trailing slash adds no blank crumb", () => {
+    const heading = mountBrowse("filesystem://Music/").getComponent(
+      ToolbarHeading,
+    );
+
+    expect(heading.props("items")).toEqual([
+      {
+        title: "filesystem provider",
+        disabled: false,
+        to: { name: "browse", query: { path: "filesystem://" } },
+      },
+      {
+        title: "Music",
+        disabled: true,
+        to: { name: "browse", query: { path: "filesystem://Music" } },
+      },
+    ]);
+  });
+
+  it("offers the select button only inside a folder holding more than folders", () => {
+    expect(selectButtonShown(mountBrowse())).toBe(false);
+    expect(selectButtonShown(mountBrowse("root"))).toBe(false);
+    expect(selectButtonShown(mountBrowse("filesystem://Music"))).toBe(true);
+  });
 });
+
+function selectButtonShown(wrapper: ReturnType<typeof mountBrowse>) {
+  return wrapper
+    .findComponent({ name: "ItemsListing" })
+    .props("showSelectButton");
+}
 
 function mountBrowse(path?: string) {
   return mount(BrowseView, {

--- a/tests/views/BrowseView.test.ts
+++ b/tests/views/BrowseView.test.ts
@@ -1,14 +1,17 @@
 import ToolbarHeading from "@/components/ToolbarHeading.vue";
 import BrowseView from "@/views/BrowseView.vue";
 import { mount } from "@vue/test-utils";
+import { MediaType } from "@/plugins/api/interfaces";
 import { describe, expect, it, vi } from "vitest";
+import { nextTick } from "vue";
 
 vi.mock("vue-i18n", () => ({ useI18n: () => ({ t: (key: string) => key }) }));
 
+const browsed = vi.hoisted(() => ({ items: [] as { media_type: string }[] }));
 vi.mock("@/plugins/api", () => ({
   default: {
     getProviderName: (domain: string) => `${domain} provider`,
-    browse: vi.fn(),
+    browse: async () => browsed.items,
   },
 }));
 
@@ -17,7 +20,7 @@ vi.mock("@/plugins/api", () => ({
 vi.mock("@/components/ItemsListing.vue", () => ({
   default: {
     name: "ItemsListing",
-    props: ["showSelectButton"],
+    props: ["showSelectButton", "loadItems"],
     template: '<div><slot name="title" /></div>',
   },
 }));
@@ -116,10 +119,22 @@ describe("BrowseView", () => {
     ]);
   });
 
-  it("offers the select button only inside a folder holding more than folders", () => {
+  it("offers the select button only below the browse root", () => {
     expect(selectButtonShown(mountBrowse())).toBe(false);
     expect(selectButtonShown(mountBrowse("root"))).toBe(false);
     expect(selectButtonShown(mountBrowse("filesystem://Music"))).toBe(true);
+  });
+
+  it("withdraws the select button where there are only folders to open", async () => {
+    const wrapper = mountBrowse("filesystem://Music");
+    browsed.items = [{ media_type: MediaType.FOLDER }];
+
+    await wrapper.findComponent({ name: "ItemsListing" }).props("loadItems")(
+      {},
+    );
+    await nextTick();
+
+    expect(selectButtonShown(wrapper)).toBe(false);
   });
 });
 

--- a/tests/views/BrowseView.test.ts
+++ b/tests/views/BrowseView.test.ts
@@ -1,0 +1,78 @@
+import ToolbarHeading from "@/components/ToolbarHeading.vue";
+import BrowseView from "@/views/BrowseView.vue";
+import { mount } from "@vue/test-utils";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("vue-i18n", () => ({ useI18n: () => ({ t: (key: string) => key }) }));
+
+vi.mock("@/plugins/api", () => ({
+  default: {
+    getProviderName: (domain: string) => `${domain} provider`,
+    browse: vi.fn(),
+  },
+}));
+
+// only the toolbar heading is under test, so the listing stands in as a host
+// for the title slot it normally forwards to the toolbar
+vi.mock("@/components/ItemsListing.vue", () => ({
+  default: { template: '<div><slot name="title" /></div>' },
+}));
+
+describe("BrowseView", () => {
+  it("shows no trail at the browse root", () => {
+    const heading = mountBrowse().getComponent(ToolbarHeading);
+
+    expect(heading.props("items")).toEqual([]);
+    expect(heading.props("to")).toBeUndefined();
+  });
+
+  it("links the heading back to the browse root once inside a folder", () => {
+    const heading =
+      mountBrowse("filesystem://Music").getComponent(ToolbarHeading);
+
+    expect(heading.props("to")).toEqual({ name: "browse" });
+  });
+
+  it("gives the provider its own crumb above the folders", () => {
+    const heading = mountBrowse("filesystem://Music/Live").getComponent(
+      ToolbarHeading,
+    );
+
+    expect(heading.props("items")).toEqual([
+      {
+        title: "filesystem provider",
+        disabled: false,
+        to: { name: "browse", query: { path: "filesystem://" } },
+      },
+      {
+        title: "Music",
+        disabled: false,
+        to: { name: "browse", query: { path: "filesystem://Music" } },
+      },
+      {
+        title: "Live",
+        disabled: true,
+        to: { name: "browse", query: { path: "filesystem://Music/Live" } },
+      },
+    ]);
+  });
+
+  it("marks the provider as the current page at its own root", () => {
+    const heading = mountBrowse("filesystem://").getComponent(ToolbarHeading);
+
+    expect(heading.props("items")).toEqual([
+      {
+        title: "filesystem provider",
+        disabled: true,
+        to: { name: "browse", query: { path: "filesystem://" } },
+      },
+    ]);
+  });
+});
+
+function mountBrowse(path?: string) {
+  return mount(BrowseView, {
+    props: { path },
+    global: { stubs: { RouterLink: true, VBreadcrumbs: true } },
+  });
+}


### PR DESCRIPTION
# What does this implement/fix?

The Settings screen got a two-line toolbar heading in #2518: the section name on
the first line, with the breadcrumb trail beneath it in smaller, dimmed text.
Browse showed its own path in a different style, so the two screens looked
unrelated. This gives Browse the same heading.

The heading is now a small shared `ToolbarHeading` component, so both screens
render the exact same thing instead of keeping two copies of the styling.

**Related issue (if applicable):**

- follow-up to #2518

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Changes

- Added a shared `ToolbarHeading` component holding the section name, the
  optional link back to the section root, and the breadcrumb trail.
- Browse now uses it, so its path matches Settings: dimmed ancestors, the
  current folder highlighted, and the provider as its own step.
- On a phone a long path shortens to the first step, a "…" and the folder you
  are in, so the current folder is always readable. Tapping the "…" shows the
  whole path.
- Only the page you are actually on is announced as the current page to screen
  readers; before, every step of a Browse path claimed to be.
- Settings switched over to the shared component; no visual change there.
- Added tests for the new component and for the Browse trail.

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm lint:check` passes.
- [x] `pnpm test:run` passes, and tests have been added/updated where applicable.
- [x] `pnpm build` passes.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
