### PR TITLE
Settings page no longer reloads when nothing changed

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -47,6 +47,11 @@ import { initGlobalShortcutsSync } from "@/composables/useShortcuts";
 import { useThemePreference } from "@/composables/useThemePreference";
 import { sanitizeDashboardViewerPath } from "@/helpers/dashboard_viewer_access";
 import {
+  FORCE_MOBILE_LAYOUT,
+  readDeviceSetting,
+  subscribeToDeviceSetting,
+} from "@/helpers/device_settings";
+import {
   createLocalConnectionIdentity,
   createRemoteConnectionIdentity,
 } from "@/helpers/connection_identity";
@@ -428,8 +433,8 @@ onMounted(async () => {
       Array.from(i18n.global.availableLocales),
     );
   }
-  store.forceMobileLayout =
-    localStorage.getItem("frontend.settings.force_mobile_layout") == "true";
+  applyForceMobileLayout();
+  subscribeToDeviceSetting(FORCE_MOBILE_LAYOUT, applyForceMobileLayout);
 
   setTheme();
 
@@ -566,6 +571,10 @@ onMounted(async () => {
 onUnmounted(() => {
   unsubscribeFromHAProperties();
 });
+
+function applyForceMobileLayout() {
+  store.forceMobileLayout = readDeviceSetting(FORCE_MOBILE_LAYOUT) === "true";
+}
 
 function getCurrentAuthConnectionIdentity() {
   return api.isRemoteConnection.value

--- a/src/helpers/device_settings.ts
+++ b/src/helpers/device_settings.ts
@@ -6,6 +6,7 @@ const STORAGE_KEY_PREFIX = "frontend.settings.";
 
 export const MOBILE_SIDEBAR_SIDE = "mobile_sidebar_side";
 export const HA_KIOSK_MODE = "ha_kiosk_mode";
+export const FORCE_MOBILE_LAYOUT = "force_mobile_layout";
 
 /**
  * Read a per-device setting, or null when it is unset.

--- a/src/views/settings/FrontendConfig.vue
+++ b/src/views/settings/FrontendConfig.vue
@@ -70,6 +70,15 @@ const loading = ref(false);
 // makes an advanced entry reachable the moment one is added
 const showAdvancedSettings = ref(false);
 
+// The form hands back every entry on save, not just the edited ones, so the
+// values it submits are compared against these to tell a real change from a
+// re-save of what was already there.
+const initialValues = ref<Record<string, ConfigValueType | undefined>>({});
+
+const valueChanged = (key: string, value: ConfigValueType): boolean =>
+  JSON.stringify(value ?? null) !==
+  JSON.stringify(initialValues.value[key] ?? null);
+
 onMounted(() => {
   // TODO: Remove localStorage fallbacks below once migration period is over
   // (theme and language moved from localStorage to user preferences)
@@ -236,6 +245,10 @@ onMounted(() => {
     }));
   }
   config.value = configEntries;
+  // snapshot before the form can edit entry.value in place
+  initialValues.value = Object.fromEntries(
+    configEntries.map((entry) => [entry.key, entry.value]),
+  );
 });
 
 // methods
@@ -263,7 +276,7 @@ const saveValues = async function (values: Record<string, ConfigValueType>) {
       } else {
         // Save to backend via user preferences
         await setPreference(key, values[key]);
-        hasPerUserChanges = true;
+        if (valueChanged(key, values[key])) hasPerUserChanges = true;
       }
     }
 

--- a/src/views/settings/FrontendConfig.vue
+++ b/src/views/settings/FrontendConfig.vue
@@ -72,12 +72,15 @@ const showAdvancedSettings = ref(false);
 
 // The form hands back every entry on save, not just the edited ones, so the
 // values it submits are compared against these to tell a real change from a
-// re-save of what was already there.
-const initialValues = ref<Record<string, ConfigValueType | undefined>>({});
+// re-save of what was already there. Held serialized: the form edits entry.value
+// in place, which an array or object snapshot would follow.
+let initialValues: Record<string, string> = {};
+
+const serializeValue = (value: ConfigValueType | undefined): string =>
+  JSON.stringify(value ?? null);
 
 const valueChanged = (key: string, value: ConfigValueType): boolean =>
-  JSON.stringify(value ?? null) !==
-  JSON.stringify(initialValues.value[key] ?? null);
+  serializeValue(value) !== initialValues[key];
 
 onMounted(() => {
   // TODO: Remove localStorage fallbacks below once migration period is over
@@ -245,9 +248,8 @@ onMounted(() => {
     }));
   }
   config.value = configEntries;
-  // snapshot before the form can edit entry.value in place
-  initialValues.value = Object.fromEntries(
-    configEntries.map((entry) => [entry.key, entry.value]),
+  initialValues = Object.fromEntries(
+    configEntries.map((entry) => [entry.key, serializeValue(entry.value)]),
   );
 });
 

--- a/tests/App.test.ts
+++ b/tests/App.test.ts
@@ -5,6 +5,7 @@ import {
   UserRole,
   type ProviderConfig,
 } from "@/plugins/api/interfaces";
+import { saveDeviceSetting } from "@/helpers/device_settings";
 import type { MusicAssistantApi } from "@/plugins/api";
 import { flushPromises, shallowMount, type VueWrapper } from "@vue/test-utils";
 import { nextTick } from "vue";
@@ -405,6 +406,17 @@ describe("App initialization", () => {
       expect(mockPruneStaleProviderFilters).not.toHaveBeenCalled();
     },
   );
+
+  it("follows the force mobile layout setting without a reload", async () => {
+    wrapper = await mountApp();
+    expect(storeMock.forceMobileLayout).toBe(false);
+
+    saveDeviceSetting("force_mobile_layout", "true");
+    expect(storeMock.forceMobileLayout).toBe(true);
+
+    saveDeviceSetting("force_mobile_layout", null);
+    expect(storeMock.forceMobileLayout).toBe(false);
+  });
 
   it("keeps full initialization and plugin discovery for regular users", async () => {
     wrapper = await mountApp();

--- a/tests/views/FrontendConfig.test.ts
+++ b/tests/views/FrontendConfig.test.ts
@@ -1,0 +1,120 @@
+import { enableAutoUnmount, flushPromises, mount } from "@vue/test-utils";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import FrontendConfig from "@/views/settings/FrontendConfig.vue";
+
+const { apiMock, routerMock, storeMock, setPreference } = vi.hoisted(() => ({
+  apiMock: { players: {}, providers: {} },
+  routerMock: { push: vi.fn(() => Promise.resolve()) },
+  storeMock: {
+    isIngressSession: false,
+    currentUser: {
+      user_id: "user",
+      preferences: {} as Record<string, unknown>,
+    },
+  },
+  setPreference: vi.fn(() => Promise.resolve()),
+}));
+
+vi.mock("@/plugins/api", () => ({ api: apiMock, default: apiMock }));
+vi.mock("@/plugins/store", () => ({ store: storeMock }));
+vi.mock("@/plugins/i18n", () => ({
+  $t: (key: string) => key,
+  i18n: { global: { availableLocales: ["en", "nl"] } },
+}));
+vi.mock("vue-router", () => ({ useRouter: () => routerMock }));
+vi.mock("@/composables/userPreferences", () => ({
+  useUserPreferences: () => ({ setPreference }),
+}));
+
+const createLocalStorageMock = (): Storage => {
+  const store = new Map<string, string>();
+  return {
+    get length() {
+      return store.size;
+    },
+    clear() {
+      store.clear();
+    },
+    getItem(key: string) {
+      return store.get(key) ?? null;
+    },
+    key(index: number) {
+      return Array.from(store.keys())[index] ?? null;
+    },
+    removeItem(key: string) {
+      store.delete(key);
+    },
+    setItem(key: string, value: string) {
+      store.set(key, value);
+    },
+  } as Storage;
+};
+
+// the page builds its entries on mount, so a leaked instance would answer the
+// next test's submit alongside the fresh one
+enableAutoUnmount(afterEach);
+
+type ConfiguredPage = Awaited<ReturnType<typeof mountPage>>;
+
+// the entries are built in onMounted, and the form is behind a v-if on them
+async function mountPage() {
+  const wrapper = mount(FrontendConfig, {
+    global: {
+      stubs: {
+        SettingsHeaderCard: true,
+        Spinner: true,
+        EditConfig: { name: "EditConfig", template: "<div />" },
+      },
+    },
+  });
+  await flushPromises();
+  return wrapper;
+}
+
+/** Submits every entry, the way EditConfig's getCurrentValues does. */
+async function submitAll(
+  wrapper: ConfiguredPage,
+  overrides: Record<string, unknown> = {},
+) {
+  const entries = (
+    wrapper.vm as unknown as { config: { key: string; value: unknown }[] }
+  ).config;
+  const values = Object.fromEntries(entries.map((e) => [e.key, e.value]));
+  wrapper
+    .findComponent({ name: "EditConfig" })
+    .vm.$emit("submit", { ...values, ...overrides });
+  await flushPromises();
+}
+
+describe("FrontendConfig save", () => {
+  let reload: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    storeMock.currentUser.preferences = {};
+    vi.stubGlobal("localStorage", createLocalStorageMock());
+    reload = vi.spyOn(window.location, "reload").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    reload.mockRestore();
+  });
+
+  it("does not reload the page when a save changes nothing", async () => {
+    const wrapper = await mountPage();
+    await submitAll(wrapper);
+
+    // every preference is still written; only the reload is conditional
+    expect(setPreference).toHaveBeenCalled();
+    expect(reload).not.toHaveBeenCalled();
+  });
+
+  it("reloads the page when a per-user preference actually changes", async () => {
+    const wrapper = await mountPage();
+    await submitAll(wrapper, { theme: "dark" });
+
+    expect(setPreference).toHaveBeenCalledWith("theme", "dark");
+    expect(reload).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
# What does this implement/fix?

Saving anything on Settings → Frontend reloads the whole app, even when nothing
was edited. Opening the page and pressing Save is enough to do it.

The settings form hands back every entry on save, not just the ones you touched,
so the "did a per-user preference change" check saw theme, language and the rest
being written every time and was always true. The reload then fired regardless of
what you actually changed.

Saving now compares each value against what the form was built from, so the reload
only happens when a setting that needs it really changed.

**Related issue (if applicable):**

- n/a

**Related backend PR (if applicable):**

- n/a

## Changes

- Snapshot the values the settings form was built from, before it can edit them in
  place.
- Only flag a reload when a submitted value differs from that snapshot.
- Add tests covering both directions: an unchanged save does not reload, changing
  the theme still does.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm lint:check` passes.
- [x] `pnpm test:run` passes, and tests have been added/updated where applicable.
- [x] `pnpm build` passes.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
