### PR TITLE
Keep the player menu open when scrolling a nested select on touch

### DIFF
--- a/src/layouts/default/ItemContextMenu.vue
+++ b/src/layouts/default/ItemContextMenu.vue
@@ -191,10 +191,13 @@ const onOpenChange = function (value: boolean) {
 function closeOnOutsidePointer(event: PointerEvent) {
   if (!show.value) return;
   const target = event.target;
+  // Select dropdowns hosted by menu rows (e.g. the visualizer preset picker)
+  // teleport their list to <body>, outside [data-item-context-menu]; touching
+  // one to scroll it must not read as an outside press and close the menu.
   if (
     target instanceof Element &&
     target.closest(
-      "[data-item-context-menu], [data-slot='dropdown-menu-sub-content']",
+      "[data-item-context-menu], [data-slot='dropdown-menu-sub-content'], [data-slot='select-content']",
     )
   ) {
     return;

--- a/tests/layouts/ItemContextMenu.test.ts
+++ b/tests/layouts/ItemContextMenu.test.ts
@@ -102,4 +102,33 @@ describe("ItemContextMenu", () => {
     expect(storeMock.dialogActive).toBe(false);
     wrapper.unmount();
   });
+
+  it("stays open for pointers inside a select dropdown teleported to body", async () => {
+    const wrapper = mountContextMenu();
+    eventHandlers.get("contextmenu")?.({
+      items: [{ label: "visualizer_options" }],
+      posX: 10,
+      posY: 20,
+    });
+    await nextTick();
+    await nextTick();
+    expect(storeMock.dialogActive).toBe(true);
+
+    // A menu row's Select (e.g. the visualizer preset picker) teleports its
+    // list to <body>; touching it to scroll starts with a pointerdown there.
+    const selectContent = document.createElement("div");
+    selectContent.setAttribute("data-slot", "select-content");
+    const selectItem = document.createElement("div");
+    selectContent.appendChild(selectItem);
+    document.body.appendChild(selectContent);
+
+    selectItem.dispatchEvent(
+      new PointerEvent("pointerdown", { bubbles: true }),
+    );
+    await Promise.resolve();
+    expect(storeMock.dialogActive).toBe(true);
+
+    selectContent.remove();
+    wrapper.unmount();
+  });
 });


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes. -->
Visualiser preset picker would immediately close the player menu when attempting to scroll presets. This fixes that behaviour.

**Related issue (if applicable):**

- related issue `<link to issue>`

**Related backend PR (if applicable):**

<!--
Link the music-assistant/server PR when this change relies on new server
behaviour, so the two can be reviewed and released together.
-->

- related backend PR `<link to PR>`

## Types of changes

<!--
Tick exactly one box below. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm lint:check` passes.
- [x] `pnpm test:run` passes, and tests have been added/updated where applicable.
- [x] `pnpm build` passes.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
