### PR TITLE
Add a clear return to the Quiz host panel

### DIFF
--- a/src/views/MusicQuizPlayerView.vue
+++ b/src/views/MusicQuizPlayerView.vue
@@ -1,17 +1,26 @@
 <template>
   <div class="music-quiz-player mx-auto flex w-full max-w-3xl flex-col gap-3">
-    <Card v-if="gameRemoved" role="status">
-      <CardHeader class="justify-items-center text-center">
+    <Card v-if="gameRemoved">
+      <CardHeader class="justify-items-center text-center" role="status">
         <CircleStop class="text-muted-foreground size-10" aria-hidden="true" />
         <CardTitle>{{ $t("providers.music_quiz.game_ended") }}</CardTitle>
         <CardDescription>
           {{ $t("providers.music_quiz.game_ended_detail") }}
         </CardDescription>
       </CardHeader>
-      <CardContent>
+      <CardContent class="flex flex-col items-center gap-4">
         <p class="text-muted-foreground text-center text-sm">
           {{ $t("providers.music_quiz.game_ended_wait") }}
         </p>
+        <Button
+          v-if="canReturnToHostPanel"
+          size="lg"
+          data-testid="return-to-host-panel"
+          @click="returnToHostPanel"
+        >
+          <ArrowLeft class="size-4" aria-hidden="true" />
+          {{ $t("providers.music_quiz.return_to_host_panel") }}
+        </Button>
       </CardContent>
     </Card>
 
@@ -99,12 +108,22 @@
       </CardContent>
     </Card>
 
-    <Card v-else role="status">
-      <CardHeader class="justify-items-center text-center">
+    <Card v-else>
+      <CardHeader class="justify-items-center text-center" role="status">
         <Clock3 class="text-muted-foreground size-10" aria-hidden="true" />
         <CardTitle>{{ $t("guest.no_quiz_title") }}</CardTitle>
         <CardDescription>{{ $t("guest.no_quiz_description") }}</CardDescription>
       </CardHeader>
+      <CardContent v-if="canReturnToHostPanel" class="flex justify-center">
+        <Button
+          size="lg"
+          data-testid="return-to-host-panel"
+          @click="returnToHostPanel"
+        >
+          <ArrowLeft class="size-4" aria-hidden="true" />
+          {{ $t("providers.music_quiz.return_to_host_panel") }}
+        </Button>
+      </CardContent>
     </Card>
   </div>
 </template>
@@ -124,6 +143,7 @@ import MusicQuizPlayerHeader from "@/components/music-quiz/MusicQuizPlayerHeader
 import MusicQuizPlayerStage from "@/components/music-quiz/MusicQuizPlayerStage.vue";
 import MusicQuizSessionHeader from "@/components/music-quiz/MusicQuizSessionHeader.vue";
 import MusicQuizUnsupportedGame from "@/components/music-quiz/MusicQuizUnsupportedGame.vue";
+import { Button } from "@/components/ui/button";
 import {
   Card,
   CardContent,
@@ -146,15 +166,19 @@ import {
 } from "@/helpers/music_quiz";
 import api, { ConnectionState } from "@/plugins/api";
 import { EventType } from "@/plugins/api/interfaces";
+import { authManager } from "@/plugins/auth";
 import { $t } from "@/plugins/i18n";
 import { webPlayer } from "@/plugins/web_player";
-import { CircleStop, Clock3 } from "@lucide/vue";
+import { ArrowLeft, CircleStop, Clock3 } from "@lucide/vue";
 import { computed, ref, watch } from "vue";
+import { useRouter } from "vue-router";
 import { toast } from "vue-sonner";
 
+const router = useRouter();
 const player = useMusicQuizPlayer({
   notifyError: (message) => toast.error(message),
 });
+const canReturnToHostPanel = !authManager.isGuestAccessSession();
 
 const {
   info,
@@ -338,6 +362,10 @@ async function handleSubmitAnswer(submission: MusicQuizAnswerSubmission) {
 
 async function handleReady() {
   await player.ready();
+}
+
+function returnToHostPanel() {
+  void router.push({ name: "music-quiz" });
 }
 </script>
 

--- a/tests/views/MusicQuizPlayerView.test.ts
+++ b/tests/views/MusicQuizPlayerView.test.ts
@@ -954,13 +954,16 @@ describe("MusicQuizPlayerView routing", () => {
     },
   );
 
-  it("keeps the host panel action hidden for guests", () => {
+  it.each([
+    ["waiting", false],
+    ["ended", true],
+  ])("keeps the host panel action hidden for guests when %s", (_, ended) => {
     isGuestSession.value = true;
     mockUseMusicQuizPlayer.mockReturnValue({
       info: ref(null),
       state: ref(null),
       playerId: ref(null),
-      gameRemoved: ref(true),
+      gameRemoved: ref(ended),
       busy: ref(false),
       loading: ref(false),
       currentRound: ref(null),

--- a/tests/views/MusicQuizPlayerView.test.ts
+++ b/tests/views/MusicQuizPlayerView.test.ts
@@ -8,23 +8,27 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const {
   apiMock,
+  isGuestSession,
   mockGameAdapterSetup,
   mockGetMusicQuizRoundScore,
   mockGetTrackLyrics,
   mockListenInSetup,
   mockPrimeAudio,
   mockResolveMusicQuizDefinition,
+  mockRouterPush,
   mockToastError,
   mockToastSuccess,
   mockUseMusicQuizPlayer,
 } = vi.hoisted(() => ({
   apiMock: { state: { value: "connected" as string } },
+  isGuestSession: { value: false },
   mockGameAdapterSetup: vi.fn(),
   mockGetMusicQuizRoundScore: vi.fn(),
   mockGetTrackLyrics: vi.fn<MusicAssistantApi["getTrackLyrics"]>(),
   mockListenInSetup: vi.fn(),
   mockPrimeAudio: vi.fn(),
   mockResolveMusicQuizDefinition: vi.fn(),
+  mockRouterPush: vi.fn(),
   mockToastError: vi.fn(),
   mockToastSuccess: vi.fn(),
   mockUseMusicQuizPlayer: vi.fn(),
@@ -103,9 +107,16 @@ vi.mock("@/plugins/i18n", () => ({
       (
         {
           "providers.music_quiz.game_starts_in": "Game starts in {0}",
+          "providers.music_quiz.return_to_host_panel": "Return to host panel",
         } as Record<string, string>
       )[key] ?? key;
     return message.replace("{0}", String(values[0] ?? ""));
+  },
+}));
+
+vi.mock("@/plugins/auth", () => ({
+  authManager: {
+    isGuestAccessSession: () => isGuestSession.value,
   },
 }));
 
@@ -124,6 +135,10 @@ vi.mock("vue-sonner", () => ({
     error: mockToastError,
     success: mockToastSuccess,
   },
+}));
+
+vi.mock("vue-router", () => ({
+  useRouter: () => ({ push: mockRouterPush }),
 }));
 
 const currentRound = {
@@ -234,7 +249,9 @@ describe("MusicQuizPlayerView routing", () => {
     mockListenInSetup.mockReset();
     mockPrimeAudio.mockReset();
     mockPrimeAudio.mockReturnValue(true);
+    mockRouterPush.mockReset();
     webPlayer.player_generation = 0;
+    isGuestSession.value = false;
     mockResolveMusicQuizDefinition.mockReset();
     mockToastError.mockReset();
     mockToastSuccess.mockReset();
@@ -905,6 +922,59 @@ describe("MusicQuizPlayerView routing", () => {
       endedWrapper.get('svg[aria-hidden="true"]').attributes("aria-hidden"),
     ).toBe("true");
     endedWrapper.unmount();
+  });
+
+  it.each([
+    ["waiting", false],
+    ["ended", true],
+  ])(
+    "lets a regular user return to the host panel when %s",
+    async (_, ended) => {
+      mockUseMusicQuizPlayer.mockReturnValue({
+        info: ref(null),
+        state: ref(null),
+        playerId: ref(null),
+        gameRemoved: ref(ended),
+        busy: ref(false),
+        loading: ref(false),
+        currentRound: ref(null),
+        join: vi.fn(),
+        submitAnswer: vi.fn(),
+        ready: vi.fn(),
+      });
+
+      const wrapper = mountView();
+      const returnButton = wrapper.get('[data-testid="return-to-host-panel"]');
+      expect(returnButton.text()).toContain("Return to host panel");
+
+      await returnButton.trigger("click");
+
+      expect(mockRouterPush).toHaveBeenCalledWith({ name: "music-quiz" });
+      wrapper.unmount();
+    },
+  );
+
+  it("keeps the host panel action hidden for guests", () => {
+    isGuestSession.value = true;
+    mockUseMusicQuizPlayer.mockReturnValue({
+      info: ref(null),
+      state: ref(null),
+      playerId: ref(null),
+      gameRemoved: ref(true),
+      busy: ref(false),
+      loading: ref(false),
+      currentRound: ref(null),
+      join: vi.fn(),
+      submitAnswer: vi.fn(),
+      ready: vi.fn(),
+    });
+
+    const wrapper = mountView();
+
+    expect(wrapper.find('[data-testid="return-to-host-panel"]').exists()).toBe(
+      false,
+    );
+    wrapper.unmount();
   });
 });
 


### PR DESCRIPTION
# What does this implement/fix?

Hosts who play along with a Music Quiz only had the small top menu to return after ending the game.

- Add a prominent return button to the ended and inactive Quiz states
- Keep the host action hidden for guest players
- Cover the return flow and guest visibility with tests

**Related issue (if applicable):**

- N/A

**Related backend PR (if applicable):**

- N/A

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm lint:check` passes.
- [x] `pnpm test:run` passes, and tests have been added/updated where applicable.
- [x] `pnpm build` passes.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
