### PR TITLE
Localize faceted filter labels

### DIFF
--- a/src/components/FacetedFilter.vue
+++ b/src/components/FacetedFilter.vue
@@ -10,16 +10,18 @@
             <Separator orientation="vertical" class="mx-2 h-4" />
             <Badge
               class="lg:hidden font-medium rounded-[6px]"
-              :aria-label="`${selectedCount} selected`"
+              :aria-label="
+                $t('faceted_filter.selected', { count: selectedCount })
+              "
             >
-              {{ selectedCount }}
+              {{ $t("faceted_filter.selected", { count: selectedCount }) }}
             </Badge>
             <div class="hidden space-x-1 lg:flex">
               <Badge v-if="selectedCount > 2" class="rounded-[6px] gap-2">
-                {{ selectedCount }} selected
+                {{ $t("faceted_filter.selected", { count: selectedCount }) }}
                 <button
                   type="button"
-                  :aria-label="`Clear all ${title} filters`"
+                  :aria-label="$t('faceted_filter.clear_all_for', { title })"
                   class="flex items-center justify-center cursor-pointer hover:opacity-70"
                   @click.stop="clear"
                 >
@@ -35,7 +37,9 @@
                   {{ opt.label }}
                   <button
                     type="button"
-                    :aria-label="`Remove ${opt.label} filter`"
+                    :aria-label="
+                      $t('faceted_filter.remove_filter', { label: opt.label })
+                    "
                     class="flex items-center justify-center cursor-pointer hover:opacity-70"
                     @click.stop="removeFilter(opt.value)"
                   >
@@ -58,7 +62,7 @@
           v-if="showSearch"
           v-model="search"
           :placeholder="title"
-          :aria-label="`Search ${title}`"
+          :aria-label="$t('faceted_filter.search_for', { title })"
           class="mb-2 h-8"
         />
         <div class="faceted-filter-list">
@@ -88,10 +92,10 @@
           v-if="selectedCount > 0"
           type="button"
           class="faceted-filter-clear"
-          :aria-label="`Clear ${title} filters`"
+          :aria-label="$t('faceted_filter.clear_for', { title })"
           @click="clear"
         >
-          Clear filters
+          {{ $t("faceted_filter.clear") }}
         </button>
       </div>
     </PopoverContent>

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -25,6 +25,14 @@
     "artists": "Artists",
     "browse": "Browse",
     "clear_selection": "Clear selection",
+    "faceted_filter": {
+        "clear": "Clear filters",
+        "clear_all_for": "Clear all {title} filters",
+        "clear_for": "Clear {title} filters",
+        "remove_filter": "Remove {label} filter",
+        "search_for": "Search {title}",
+        "selected": "{count} selected"
+    },
     "close": "Close",
     "create_playlist": "Create new playlist on {0}",
     "dark_mode": "Dark mode",

--- a/tests/components/FacetedFilter.test.ts
+++ b/tests/components/FacetedFilter.test.ts
@@ -23,6 +23,8 @@ const stubs = {
   Checkbox: { template: '<input type="checkbox" />' },
 };
 
+const i18nMock = { $t: (key: string) => key };
+
 const STAGE_OPTIONS = [
   { label: "Stable", value: "stable" },
   { label: "Beta", value: "beta" },
@@ -41,7 +43,7 @@ const manyOptions = (count: number) =>
 const mountFilter = (options: { label: string; value: string }[]) =>
   mount(FacetedFilter, {
     props: { title: "Providers", options, modelValue: [] },
-    global: { stubs },
+    global: { mocks: i18nMock, stubs },
   });
 
 // reka opens the popover on pointerdown + click, and settles focus on a timer
@@ -85,6 +87,7 @@ const mountAndOpen = async (options: { label: string; value: string }[]) => {
   const wrapper = mount(FacetedFilter, {
     props: { title: "Providers", options, modelValue: [] },
     attachTo: document.body,
+    global: { mocks: i18nMock },
   });
   return { wrapper, content: await openPopover(wrapper) };
 };
@@ -106,7 +109,7 @@ describe("FacetedFilter", () => {
         options: [{ label: "Albums", value: "album" }],
         modelValue: [],
       },
-      global: { stubs },
+      global: { mocks: i18nMock, stubs },
     });
 
     await wrapper.get(".faceted-filter-item").trigger("keydown.enter");


### PR DESCRIPTION
# What does this implement/fix?

Route filter counts, search, clear, and remove labels through i18n while preserving dynamic filter and option names. Add the English faceted-filter strings for future locale translations.

<!--
Link the music-assistant/server PR when this change relies on new server
behaviour, so the two can be reviewed and released together.
-->

## Types of changes

<!--
Tick exactly one box below. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [X] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [X] The code change is tested and works locally.
- [X] `pnpm lint:check` passes.
- [X] `pnpm test:run` passes, and tests have been added/updated where applicable.
- [X] `pnpm build` passes.
- [X] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
