### PR TITLE
Choose what happens to grouped playback

### DIFF
--- a/src/components/PlayerGroupMembers.vue
+++ b/src/components/PlayerGroupMembers.vue
@@ -55,6 +55,7 @@ import PlayerIcon from "@/components/PlayerIcon.vue";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Separator } from "@/components/ui/separator";
 import type { PlayerGroupFilter } from "@/helpers/player_group";
+import { requestGroupPlaybackConfirmation } from "@/helpers/player_group_playback";
 import { groupMemberPickerVisible } from "@/helpers/players";
 import { api } from "@/plugins/api";
 import {
@@ -210,6 +211,20 @@ function sortPlayers(players: Player[]) {
 }
 
 function updateGroupMember(playerId: string, selected: boolean) {
+  if (
+    !selected &&
+    playerId === props.player.player_id &&
+    requestGroupPlaybackConfirmation(props.player, "remove", () =>
+      applyGroupMemberUpdate(playerId, false),
+    )
+  ) {
+    flushPendingMemberUpdate();
+    return;
+  }
+  applyGroupMemberUpdate(playerId, selected);
+}
+
+function applyGroupMemberUpdate(playerId: string, selected: boolean) {
   const parentPlayerId = props.player.player_id;
 
   if (selected) {

--- a/src/components/PlayerGroupPlaybackDialog.vue
+++ b/src/components/PlayerGroupPlaybackDialog.vue
@@ -1,0 +1,113 @@
+<template>
+  <Dialog :open="open" @update:open="setOpen">
+    <DialogContent class="sm:max-w-[520px]">
+      <DialogHeader>
+        <DialogTitle>{{ $t("player_group_playback.title") }}</DialogTitle>
+        <DialogDescription>{{ message }}</DialogDescription>
+      </DialogHeader>
+      <DialogFooter>
+        <Button
+          type="button"
+          variant="outline"
+          :disabled="loading"
+          @click="close"
+        >
+          {{ $t("cancel") }}
+        </Button>
+        <Button
+          type="button"
+          variant="destructive"
+          data-testid="stop-and-ungroup"
+          :disabled="loading"
+          @click="runAction(onStopAndUngroup)"
+        >
+          {{ $t("player_group_playback.stop_and_ungroup") }}
+        </Button>
+        <Button
+          type="button"
+          data-testid="keep-playing"
+          :disabled="loading"
+          @click="runAction(onKeepPlaying)"
+        >
+          {{ $t("player_group_playback.keep_playing") }}
+        </Button>
+      </DialogFooter>
+    </DialogContent>
+  </Dialog>
+</template>
+
+<script setup lang="ts">
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import {
+  eventbus,
+  type PlayerGroupPlaybackDialogEvent,
+} from "@/plugins/eventbus";
+import { store } from "@/plugins/store";
+import { computed, onBeforeUnmount, onMounted, ref, watch } from "vue";
+import { useI18n } from "vue-i18n";
+import { toast } from "vue-sonner";
+
+const { t } = useI18n();
+const open = ref(false);
+const loading = ref(false);
+const change = ref<PlayerGroupPlaybackDialogEvent["change"]>("remove");
+const playerName = ref("");
+let onKeepPlaying: (() => void | Promise<void>) | undefined;
+let onStopAndUngroup: (() => void | Promise<void>) | undefined;
+
+const message = computed(() =>
+  t(`player_group_playback.${change.value}_message`, [playerName.value]),
+);
+
+watch(open, (value) => {
+  store.dialogActive = value;
+});
+
+onMounted(() => {
+  eventbus.on("playerGroupPlaybackDialog", onPlaybackChangeRequested);
+});
+
+onBeforeUnmount(() => {
+  eventbus.off("playerGroupPlaybackDialog", onPlaybackChangeRequested);
+  if (open.value) store.dialogActive = false;
+});
+
+async function runAction(action?: () => void | Promise<void>) {
+  if (!action || loading.value) return;
+
+  loading.value = true;
+  try {
+    await action();
+    close();
+  } catch (error) {
+    toast.error(String(error));
+  } finally {
+    loading.value = false;
+  }
+}
+
+function setOpen(value: boolean) {
+  if (!value && !loading.value) close();
+}
+
+function close() {
+  open.value = false;
+}
+
+function onPlaybackChangeRequested(evt: PlayerGroupPlaybackDialogEvent) {
+  change.value = evt.change;
+  playerName.value = evt.playerName;
+  onKeepPlaying = evt.onKeepPlaying;
+  onStopAndUngroup = evt.onStopAndUngroup;
+  loading.value = false;
+  open.value = true;
+}
+</script>

--- a/src/helpers/player_group_playback.ts
+++ b/src/helpers/player_group_playback.ts
@@ -1,0 +1,133 @@
+import api from "@/plugins/api";
+import { resolvePlayerQueue } from "@/plugins/api/helpers";
+import {
+  EventType,
+  type Player,
+  PlaybackState,
+  PlayerType,
+} from "@/plugins/api/interfaces";
+import { eventbus, type PlayerGroupPlaybackChange } from "@/plugins/eventbus";
+import { store } from "@/plugins/store";
+
+const PLAYBACK_TRANSFER_TIMEOUT = 10_000;
+
+type PlayerAction = () => void | Promise<void>;
+
+export function requestGroupPlaybackConfirmation(
+  player: Player,
+  change: PlayerGroupPlaybackChange,
+  onKeepPlaying: PlayerAction,
+): boolean {
+  if (!canTransferGroupPlayback(player)) return false;
+
+  eventbus.emit("playerGroupPlaybackDialog", {
+    change,
+    playerName: player.name,
+    onKeepPlaying: () => keepPlaying(player.player_id, onKeepPlaying),
+    onStopAndUngroup: () =>
+      stopAndUngroup(player.player_id, change === "power_off"),
+  });
+  return true;
+}
+
+export function togglePlayerPower(player: Player): void | Promise<void> {
+  if (player.powered !== true) {
+    return api.playerCommandPower(player.player_id, true);
+  }
+  if (
+    requestGroupPlaybackConfirmation(player, "power_off", () =>
+      api.playerCommandPower(player.player_id, false),
+    )
+  ) {
+    return;
+  }
+  return api.playerCommandPower(player.player_id, false);
+}
+
+function canTransferGroupPlayback(player: Player): boolean {
+  const queue = resolvePlayerQueue(player);
+  return (
+    player.type !== PlayerType.GROUP &&
+    player.synced_to === null &&
+    queue !== undefined &&
+    queue.state !== PlaybackState.IDLE &&
+    getAvailableGroupMembers(player).length > 0
+  );
+}
+
+async function keepPlaying(
+  playerId: string,
+  onKeepPlaying: PlayerAction,
+): Promise<void> {
+  const player = api.players[playerId];
+  const stopFollowing = player
+    ? followPlaybackTransfer(playerId, getAvailableGroupMembers(player))
+    : undefined;
+  try {
+    await onKeepPlaying();
+  } catch (error) {
+    stopFollowing?.();
+    throw error;
+  }
+}
+
+async function stopAndUngroup(
+  playerId: string,
+  powerOff: boolean,
+): Promise<void> {
+  const player = api.players[playerId];
+  const memberIds = new Set([playerId, ...(player?.group_members ?? [])]);
+  await api.playerCommandSetMembers(playerId, undefined, Array.from(memberIds));
+  if (powerOff) await api.playerCommandPower(playerId, false);
+}
+
+function followPlaybackTransfer(
+  previousLeaderId: string,
+  memberIds: string[],
+): () => void {
+  if (store.activePlayerId !== previousLeaderId) return () => undefined;
+
+  let unsubscribe: (() => void) | undefined;
+  let timeoutId: ReturnType<typeof setTimeout> | undefined;
+
+  const stopFollowing = () => {
+    unsubscribe?.();
+    unsubscribe = undefined;
+    if (timeoutId) clearTimeout(timeoutId);
+    timeoutId = undefined;
+  };
+  const scheduleStopFollowing = () => queueMicrotask(stopFollowing);
+  const selectTransferredPlayer = () => {
+    if (store.activePlayerId !== previousLeaderId) {
+      scheduleStopFollowing();
+      return;
+    }
+    const newLeader = memberIds
+      .map((playerId) => api.players[playerId])
+      .find(
+        (player) =>
+          player?.synced_to === null &&
+          resolvePlayerQueue(player)?.state !== PlaybackState.IDLE,
+      );
+    if (!newLeader) return;
+
+    store.activePlayerId = newLeader.player_id;
+    scheduleStopFollowing();
+  };
+
+  unsubscribe = api.subscribe_multi(
+    [EventType.PLAYER_UPDATED, EventType.QUEUE_UPDATED],
+    selectTransferredPlayer,
+  );
+  timeoutId = setTimeout(stopFollowing, PLAYBACK_TRANSFER_TIMEOUT);
+  queueMicrotask(selectTransferredPlayer);
+  return stopFollowing;
+}
+
+function getAvailableGroupMembers(player: Player): string[] {
+  return player.group_members.filter(
+    (playerId) =>
+      playerId !== player.player_id &&
+      api.players[playerId]?.available === true,
+  );
+}

--- a/src/helpers/player_group_playback.ts
+++ b/src/helpers/player_group_playback.ts
@@ -104,11 +104,14 @@ function followPlaybackTransfer(
     }
     const newLeader = memberIds
       .map((playerId) => api.players[playerId])
-      .find(
-        (player) =>
-          player?.synced_to === null &&
-          resolvePlayerQueue(player)?.state !== PlaybackState.IDLE,
-      );
+      .find((player) => {
+        if (!player || player.synced_to !== null) return false;
+        const queue = resolvePlayerQueue(player);
+        return (
+          queue?.queue_id === player.player_id &&
+          queue.state !== PlaybackState.IDLE
+        );
+      });
     if (!newLeader) return;
 
     store.activePlayerId = newLeader.player_id;

--- a/src/helpers/player_menu_items.ts
+++ b/src/helpers/player_menu_items.ts
@@ -27,6 +27,7 @@ import router from "@/plugins/router";
 import { eventbus } from "@/plugins/eventbus";
 import { store } from "@/plugins/store";
 import { getPlayerSetupLabel } from "@/helpers/player_config";
+import { togglePlayerPower } from "@/helpers/player_group_playback";
 import { errorMessage } from "@/helpers/ai_radio";
 import { toast } from "vue-sonner";
 
@@ -76,7 +77,7 @@ export const getPlayerMenuItems = (
       label: player.powered ? "power_off_player" : "power_on_player",
       labelArgs: [],
       action: () => {
-        api.playerCommandPowerToggle(player.player_id);
+        return togglePlayerPower(player);
       },
       icon: "mdi-power",
     });

--- a/src/layouts/default/View.vue
+++ b/src/layouts/default/View.vue
@@ -27,6 +27,7 @@
           <delete-genre-dialog />
           <link-genre-dialog />
           <dialog-delete-confirmation />
+          <player-group-playback-dialog />
           <setup-flow-dialog />
           <player-rename-dialog />
           <item-context-menu />
@@ -50,6 +51,7 @@ import LinkGenreDialog from "@/components/genre/LinkGenreDialog.vue";
 import MergeGenreDialog from "@/components/genre/MergeGenreDialog.vue";
 import AppSidebar from "@/components/navigation/AppSidebar.vue";
 import PlayerRenameDialog from "@/components/PlayerRenameDialog.vue";
+import PlayerGroupPlaybackDialog from "@/components/PlayerGroupPlaybackDialog.vue";
 import SetupFlowDialog from "@/components/SetupFlowDialog.vue";
 import { SidebarInset, SidebarProvider } from "@/components/ui/sidebar";
 import {

--- a/src/plugins/eventbus.ts
+++ b/src/plugins/eventbus.ts
@@ -50,6 +50,15 @@ export type DeleteConfirmationDialogEvent = {
   onConfirm: () => void | Promise<void>;
 };
 
+export type PlayerGroupPlaybackChange = "remove" | "power_off";
+
+export type PlayerGroupPlaybackDialogEvent = {
+  change: PlayerGroupPlaybackChange;
+  playerName: string;
+  onKeepPlaying: () => void | Promise<void>;
+  onStopAndUngroup: () => void | Promise<void>;
+};
+
 export type ImportPlaylistEvent = {
   m3uData: string;
   playlistName: string;
@@ -93,6 +102,7 @@ export type Events = {
   mergeGenreDialog: MergeGenreDialogEvent;
   deleteGenreDialog: DeleteGenreDialogEvent;
   deleteConfirmationDialog: DeleteConfirmationDialogEvent;
+  playerGroupPlaybackDialog: PlayerGroupPlaybackDialogEvent;
   linkGenreDialog: LinkGenreDialogEvent;
   importPlaylistDialog: ImportPlaylistEvent;
   createSmartPlaylist: CreateSmartPlaylistEvent;

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -978,6 +978,13 @@
     "transfer_queue": "Transfer queue",
     "power_on_player": "Power on",
     "power_off_player": "Power off",
+    "player_group_playback": {
+        "title": "Group playback",
+        "remove_message": "Playback is active on {0}. Removing this player from the group will move the playback session to the remaining players.",
+        "power_off_message": "Playback is active on {0}. Powering it off will move the playback session to the remaining players.",
+        "keep_playing": "Keep playing",
+        "stop_and_ungroup": "Stop and ungroup"
+    },
     "powered_off_players": "Unpowered players",
     "sync_player_with": "Synchronize with another player",
     "select_repeat_mode": "Select repeat mode",

--- a/tests/components/PlayerGroupMembers.test.ts
+++ b/tests/components/PlayerGroupMembers.test.ts
@@ -11,6 +11,10 @@ import {
 import { mount } from "@vue/test-utils";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+const { requestGroupPlaybackConfirmation } = vi.hoisted(() => ({
+  requestGroupPlaybackConfirmation: vi.fn(),
+}));
+
 vi.mock("@/plugins/api", async () => {
   const { reactive } = await vi.importActual<typeof import("vue")>("vue");
   const api = reactive({
@@ -25,6 +29,10 @@ vi.mock("@/plugins/api", async () => {
 
 vi.mock("@/helpers/players", () => ({
   groupMemberPickerVisible: () => true,
+}));
+
+vi.mock("@/helpers/player_group_playback", () => ({
+  requestGroupPlaybackConfirmation,
 }));
 
 const CheckboxStub = {
@@ -130,6 +138,7 @@ describe("PlayerGroupMembers", () => {
     vi.clearAllMocks();
     vi.useRealTimers();
     api.players = {};
+    requestGroupPlaybackConfirmation.mockReturnValue(false);
   });
 
   it("uses aligned icon slots and prominent checkboxes", () => {
@@ -336,6 +345,49 @@ describe("PlayerGroupMembers", () => {
       parent.player_id,
       undefined,
       [child.player_id],
+    );
+  });
+
+  it("waits for a choice before removing the playing leader", async () => {
+    vi.useFakeTimers();
+    let keepPlaying: (() => void) | undefined;
+    requestGroupPlaybackConfirmation.mockImplementation(
+      (_player, _change, onKeepPlaying) => {
+        keepPlaying = onKeepPlaying;
+        return true;
+      },
+    );
+    const child = createPlayer({
+      player_id: "child",
+      name: "Office",
+    });
+    const parent = createPlayer({
+      playback_state: PlaybackState.PLAYING,
+      group_members: ["parent", child.player_id],
+    });
+    api.players = {
+      [parent.player_id]: parent,
+      [child.player_id]: child,
+    };
+    const wrapper = mountGroupMembers(parent, [parent, child]);
+
+    await wrapper.get('[aria-label="Kitchen"]').trigger("click");
+
+    expect(requestGroupPlaybackConfirmation).toHaveBeenCalledWith(
+      parent,
+      "remove",
+      expect.any(Function),
+    );
+    expect(parent.group_members).toEqual(["parent", child.player_id]);
+    expect(api.playerCommandSetMembers).not.toHaveBeenCalled();
+
+    keepPlaying?.();
+    expect(parent.group_members).toEqual([child.player_id]);
+    await vi.advanceTimersByTimeAsync(500);
+    expect(api.playerCommandSetMembers).toHaveBeenCalledWith(
+      parent.player_id,
+      undefined,
+      [parent.player_id],
     );
   });
 });

--- a/tests/components/PlayerGroupPlaybackDialog.test.ts
+++ b/tests/components/PlayerGroupPlaybackDialog.test.ts
@@ -1,0 +1,142 @@
+import PlayerGroupPlaybackDialog from "@/components/PlayerGroupPlaybackDialog.vue";
+import {
+  eventbus,
+  type PlayerGroupPlaybackDialogEvent,
+} from "@/plugins/eventbus";
+import { enableAutoUnmount, flushPromises, mount } from "@vue/test-utils";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { storeMock, toastError } = vi.hoisted(() => ({
+  storeMock: {
+    dialogActive: false,
+  },
+  toastError: vi.fn(),
+}));
+
+vi.mock("@/plugins/store", () => ({
+  store: storeMock,
+}));
+
+vi.mock("vue-i18n", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("vue-i18n")>()),
+  useI18n: () => ({
+    t: (key: string, args?: string[]) =>
+      args ? `${key}:${args.join(",")}` : key,
+  }),
+}));
+
+vi.mock("vue-sonner", () => ({
+  toast: {
+    error: toastError,
+  },
+}));
+
+const passthroughStub = { template: "<div><slot /></div>" };
+const DialogStub = {
+  props: ["open"],
+  emits: ["update:open"],
+  template: '<div v-if="open" class="playback-dialog"><slot /></div>',
+};
+
+function mountDialog() {
+  return mount(PlayerGroupPlaybackDialog, {
+    global: {
+      mocks: {
+        $t: (key: string) => key,
+      },
+      stubs: {
+        Button: {
+          props: ["disabled"],
+          template:
+            '<button v-bind="$attrs" :disabled="disabled"><slot /></button>',
+        },
+        Dialog: DialogStub,
+        DialogContent: passthroughStub,
+        DialogDescription: passthroughStub,
+        DialogFooter: passthroughStub,
+        DialogHeader: passthroughStub,
+        DialogTitle: passthroughStub,
+      },
+    },
+  });
+}
+
+function openDialog(overrides: Partial<PlayerGroupPlaybackDialogEvent> = {}) {
+  const event: PlayerGroupPlaybackDialogEvent = {
+    change: "remove",
+    playerName: "Kitchen",
+    onKeepPlaying: vi.fn(),
+    onStopAndUngroup: vi.fn(),
+    ...overrides,
+  };
+  eventbus.emit("playerGroupPlaybackDialog", event);
+  return event;
+}
+
+describe("PlayerGroupPlaybackDialog", () => {
+  enableAutoUnmount(afterEach);
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    storeMock.dialogActive = false;
+  });
+
+  it("explains a leader removal and offers all choices", async () => {
+    const wrapper = mountDialog();
+    openDialog();
+    await flushPromises();
+
+    expect(wrapper.text()).toContain(
+      "player_group_playback.remove_message:Kitchen",
+    );
+    expect(wrapper.find('[data-testid="keep-playing"]').exists()).toBe(true);
+    expect(wrapper.find('[data-testid="stop-and-ungroup"]').exists()).toBe(
+      true,
+    );
+    expect(wrapper.text()).toContain("cancel");
+    expect(storeMock.dialogActive).toBe(true);
+  });
+
+  it("keeps playback and closes after the action succeeds", async () => {
+    const wrapper = mountDialog();
+    const event = openDialog();
+    await flushPromises();
+
+    await wrapper.get('[data-testid="keep-playing"]').trigger("click");
+    await flushPromises();
+
+    expect(event.onKeepPlaying).toHaveBeenCalledOnce();
+    expect(event.onStopAndUngroup).not.toHaveBeenCalled();
+    expect(wrapper.find(".playback-dialog").exists()).toBe(false);
+    expect(storeMock.dialogActive).toBe(false);
+  });
+
+  it("stops and ungroups when requested", async () => {
+    const wrapper = mountDialog();
+    const event = openDialog({ change: "power_off" });
+    await flushPromises();
+
+    expect(wrapper.text()).toContain(
+      "player_group_playback.power_off_message:Kitchen",
+    );
+    await wrapper.get('[data-testid="stop-and-ungroup"]').trigger("click");
+    await flushPromises();
+
+    expect(event.onStopAndUngroup).toHaveBeenCalledOnce();
+    expect(event.onKeepPlaying).not.toHaveBeenCalled();
+  });
+
+  it("shows an action error and stays open", async () => {
+    const wrapper = mountDialog();
+    openDialog({
+      onKeepPlaying: vi.fn().mockRejectedValue(new Error("Command failed")),
+    });
+    await flushPromises();
+
+    await wrapper.get('[data-testid="keep-playing"]').trigger("click");
+    await flushPromises();
+
+    expect(toastError).toHaveBeenCalledWith("Error: Command failed");
+    expect(wrapper.find(".playback-dialog").exists()).toBe(true);
+  });
+});

--- a/tests/components/VolumeControl.test.ts
+++ b/tests/components/VolumeControl.test.ts
@@ -26,6 +26,10 @@ vi.mock("@/helpers/players", () => ({
   groupMemberPickerVisible: () => true,
 }));
 
+vi.mock("@/helpers/player_group_playback", () => ({
+  requestGroupPlaybackConfirmation: () => false,
+}));
+
 vi.mock("@/layouts/default/PlayerOSD/PlayerVolume.vue", () => ({
   default: {
     props: ["player"],

--- a/tests/helpers/player_group_playback.test.ts
+++ b/tests/helpers/player_group_playback.test.ts
@@ -159,6 +159,9 @@ describe("player group playback", () => {
     );
 
     child.synced_to = null;
+    callbacks[0]();
+    expect(storeMock.activePlayerId).toBe(leader.player_id);
+
     child.active_source = child.player_id;
     apiMock.queues[child.player_id] = playerQueue({
       queue_id: child.player_id,

--- a/tests/helpers/player_group_playback.test.ts
+++ b/tests/helpers/player_group_playback.test.ts
@@ -1,0 +1,238 @@
+import {
+  requestGroupPlaybackConfirmation,
+  togglePlayerPower,
+} from "@/helpers/player_group_playback";
+import type { MusicAssistantApi } from "@/plugins/api";
+import {
+  EventType,
+  type Player,
+  PlaybackState,
+  type PlayerQueue,
+  PlayerType,
+} from "@/plugins/api/interfaces";
+import {
+  eventbus,
+  type PlayerGroupPlaybackDialogEvent,
+} from "@/plugins/eventbus";
+import { playerQueue } from "../fixtures/playerQueue";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { apiMock, callbacks, storeMock, unsubscribe } = vi.hoisted(() => ({
+  apiMock: {
+    players: {} as Record<string, Player>,
+    queues: {} as Record<string, PlayerQueue>,
+    playerCommandPower: vi.fn<MusicAssistantApi["playerCommandPower"]>(),
+    playerCommandSetMembers:
+      vi.fn<MusicAssistantApi["playerCommandSetMembers"]>(),
+    subscribe_multi: vi.fn(),
+  },
+  callbacks: [] as CallableFunction[],
+  storeMock: {
+    activePlayerId: undefined as string | undefined,
+  },
+  unsubscribe: vi.fn(),
+}));
+
+vi.mock("@/plugins/api", () => ({
+  api: apiMock,
+  default: apiMock,
+}));
+
+vi.mock("@/plugins/store", () => ({
+  store: storeMock,
+}));
+
+function createPlayer(overrides: Partial<Player> = {}): Player {
+  return {
+    player_id: "leader",
+    type: PlayerType.PLAYER,
+    name: "Kitchen",
+    available: true,
+    powered: true,
+    group_members: ["leader", "child"],
+    synced_to: null,
+    active_source: "leader",
+    ...overrides,
+  } as Player;
+}
+
+function setActiveGroup(state = PlaybackState.PLAYING) {
+  const leader = createPlayer();
+  const child = createPlayer({
+    player_id: "child",
+    name: "Office",
+    group_members: [],
+    synced_to: leader.player_id,
+    active_source: leader.player_id,
+  });
+  apiMock.players = {
+    [leader.player_id]: leader,
+    [child.player_id]: child,
+  };
+  apiMock.queues = {
+    [leader.player_id]: playerQueue({
+      queue_id: leader.player_id,
+      state,
+    }),
+  };
+  return { child, leader };
+}
+
+let dialogEvent: PlayerGroupPlaybackDialogEvent | undefined;
+const captureDialog = (event: PlayerGroupPlaybackDialogEvent) => {
+  dialogEvent = event;
+};
+
+describe("player group playback", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    callbacks.length = 0;
+    apiMock.players = {};
+    apiMock.queues = {};
+    apiMock.playerCommandPower.mockResolvedValue();
+    apiMock.playerCommandSetMembers.mockResolvedValue();
+    apiMock.subscribe_multi.mockImplementation((_events, callback) => {
+      callbacks.push(callback);
+      return unsubscribe;
+    });
+    storeMock.activePlayerId = undefined;
+    dialogEvent = undefined;
+    eventbus.on("playerGroupPlaybackDialog", captureDialog);
+  });
+
+  afterEach(() => {
+    eventbus.off("playerGroupPlaybackDialog", captureDialog);
+  });
+
+  it.each([PlaybackState.PLAYING, PlaybackState.PAUSED])(
+    "asks what to do with an active %s queue",
+    (state) => {
+      const { leader } = setActiveGroup(state);
+
+      expect(requestGroupPlaybackConfirmation(leader, "remove", vi.fn())).toBe(
+        true,
+      );
+      expect(dialogEvent).toMatchObject({
+        change: "remove",
+        playerName: leader.name,
+      });
+    },
+  );
+
+  it("does not ask when the server cannot transfer playback", () => {
+    const { child, leader } = setActiveGroup(PlaybackState.IDLE);
+    expect(requestGroupPlaybackConfirmation(leader, "remove", vi.fn())).toBe(
+      false,
+    );
+
+    apiMock.queues[leader.player_id].state = PlaybackState.PLAYING;
+    child.available = false;
+    expect(requestGroupPlaybackConfirmation(leader, "remove", vi.fn())).toBe(
+      false,
+    );
+
+    child.available = true;
+    leader.synced_to = "other";
+    expect(requestGroupPlaybackConfirmation(leader, "remove", vi.fn())).toBe(
+      false,
+    );
+
+    leader.synced_to = null;
+    leader.type = PlayerType.GROUP;
+    expect(requestGroupPlaybackConfirmation(leader, "remove", vi.fn())).toBe(
+      false,
+    );
+  });
+
+  it("follows the leader reported by the server", async () => {
+    const { child, leader } = setActiveGroup();
+    const keepPlaying = vi.fn();
+    storeMock.activePlayerId = leader.player_id;
+    requestGroupPlaybackConfirmation(leader, "remove", keepPlaying);
+
+    await dialogEvent?.onKeepPlaying();
+    expect(keepPlaying).toHaveBeenCalledOnce();
+    expect(storeMock.activePlayerId).toBe(leader.player_id);
+    expect(apiMock.subscribe_multi).toHaveBeenCalledWith(
+      [EventType.PLAYER_UPDATED, EventType.QUEUE_UPDATED],
+      expect.any(Function),
+    );
+
+    child.synced_to = null;
+    child.active_source = child.player_id;
+    apiMock.queues[child.player_id] = playerQueue({
+      queue_id: child.player_id,
+      state: PlaybackState.PLAYING,
+    });
+    callbacks[0]();
+    await Promise.resolve();
+
+    expect(storeMock.activePlayerId).toBe(child.player_id);
+    expect(unsubscribe).toHaveBeenCalledOnce();
+  });
+
+  it("does not override a newer player selection", async () => {
+    const { child, leader } = setActiveGroup();
+    storeMock.activePlayerId = leader.player_id;
+    requestGroupPlaybackConfirmation(leader, "remove", vi.fn());
+    await dialogEvent?.onKeepPlaying();
+
+    storeMock.activePlayerId = "bedroom";
+    child.synced_to = null;
+    callbacks[0]();
+    await Promise.resolve();
+
+    expect(storeMock.activePlayerId).toBe("bedroom");
+    expect(unsubscribe).toHaveBeenCalledOnce();
+  });
+
+  it("stops playback by removing every group member", async () => {
+    const { leader } = setActiveGroup();
+    requestGroupPlaybackConfirmation(leader, "remove", vi.fn());
+
+    await dialogEvent?.onStopAndUngroup();
+
+    expect(apiMock.playerCommandSetMembers).toHaveBeenCalledWith(
+      leader.player_id,
+      undefined,
+      ["leader", "child"],
+    );
+    expect(apiMock.playerCommandPower).not.toHaveBeenCalled();
+  });
+
+  it("ungroups before powering off the leader", async () => {
+    const { leader } = setActiveGroup();
+    togglePlayerPower(leader);
+
+    expect(dialogEvent?.change).toBe("power_off");
+    expect(apiMock.playerCommandPower).not.toHaveBeenCalled();
+
+    await dialogEvent?.onStopAndUngroup();
+
+    expect(apiMock.playerCommandSetMembers).toHaveBeenCalledBefore(
+      apiMock.playerCommandPower,
+    );
+    expect(apiMock.playerCommandPower).toHaveBeenCalledWith(
+      leader.player_id,
+      false,
+    );
+  });
+
+  it("changes power directly when no playback transfer is possible", async () => {
+    const { leader } = setActiveGroup(PlaybackState.IDLE);
+
+    await togglePlayerPower(leader);
+    expect(apiMock.playerCommandPower).toHaveBeenCalledWith(
+      leader.player_id,
+      false,
+    );
+    expect(dialogEvent).toBeUndefined();
+
+    leader.powered = false;
+    await togglePlayerPower(leader);
+    expect(apiMock.playerCommandPower).toHaveBeenLastCalledWith(
+      leader.player_id,
+      true,
+    );
+  });
+});

--- a/tests/helpers/player_menu_items.test.ts
+++ b/tests/helpers/player_menu_items.test.ts
@@ -28,6 +28,7 @@ const {
   loadStatus,
   openAnnouncementDialog,
   queueDjStatusRef,
+  togglePlayerPower,
   routerPush,
   sessionsRef,
   setQueueDj,
@@ -44,6 +45,7 @@ const {
   loadStatus: vi.fn().mockResolvedValue(undefined),
   openAnnouncementDialog: vi.fn(),
   queueDjStatusRef: { value: {} as Record<string, string> },
+  togglePlayerPower: vi.fn(),
   routerPush: vi.fn(),
   sessionsRef: { value: [] as AIRadioSession[] },
   setQueueDj: vi.fn(),
@@ -80,6 +82,10 @@ vi.mock("@/plugins/eventbus", () => ({
 
 vi.mock("@/plugins/store", () => ({
   store: storeMock,
+}));
+
+vi.mock("@/helpers/player_group_playback", () => ({
+  togglePlayerPower,
 }));
 
 vi.mock("@/helpers/sleep_timer", () => ({
@@ -233,6 +239,22 @@ describe("getPlayerSetupMenuItem", () => {
       kind: "player",
       playerId: "kitchen",
     });
+  });
+});
+
+describe("getPlayerMenuItems power", () => {
+  it("routes power changes through the group playback guard", () => {
+    const player = makePlayer({
+      power_control: "power",
+      powered: true,
+    });
+    const powerItem = getPlayerMenuItems(player, undefined, {
+      context: "player",
+    }).find((item) => item.label === "power_off_player");
+
+    powerItem?.action?.();
+
+    expect(togglePlayerPower).toHaveBeenCalledWith(player);
   });
 });
 


### PR DESCRIPTION
# What does this implement/fix?

Removing or powering off the active player of a temporary sync group could silently move playback to another player.

- Ask whether to keep playback on the remaining players or stop and ungroup.
- Follow the server-selected player when playback continues so controls stay visible.

**Related issue (if applicable):**

- N/A

**Related backend PR (if applicable):**

- N/A

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm lint:check` passes.
- [x] `pnpm test:run` passes, and tests have been added/updated where applicable.
- [x] `pnpm build` passes.
- [x] I have read and complied with the projects [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.