### PR TITLE
Show accurate audio analysis progress

### DIFF
--- a/src/composables/audio-analysis/useAudioAnalysisCoverage.ts
+++ b/src/composables/audio-analysis/useAudioAnalysisCoverage.ts
@@ -78,16 +78,16 @@ export function useAudioAnalysisCoverage(): {
             "audio_analysis/coverage",
             { aa_domain: meta.domain },
           );
-          const total = cov.analyzed + cov.pending;
+          const analyzed = Math.max(0, cov.analyzed - cov.stale_version);
+          const total = analyzed + cov.pending;
           return {
             ...emptyRow(meta),
             available: true,
-            analyzed: cov.analyzed,
+            analyzed,
             pending: cov.pending,
             staleVersion: cov.stale_version,
             analysisVersion: cov.analysis_version,
-            coveragePct:
-              total > 0 ? Math.round((cov.analyzed / total) * 100) : 0,
+            coveragePct: total > 0 ? Math.round((analyzed / total) * 100) : 0,
             hasData: total > 0,
           } satisfies ProviderCoverageRow;
         } catch {

--- a/tests/composables/useAudioAnalysisCoverage.test.ts
+++ b/tests/composables/useAudioAnalysisCoverage.test.ts
@@ -98,16 +98,75 @@ describe("useAudioAnalysisCoverage", () => {
     expect(row.domain).toBe("sonic_analysis");
     expect(row.name).toBe("Sonic Analysis");
     expect(row.available).toBe(true);
-    expect(row.analyzed).toBe(78);
+    expect(row.analyzed).toBe(75);
     expect(row.pending).toBe(22);
     expect(row.staleVersion).toBe(3);
     expect(row.analysisVersion).toBe(5);
-    expect(row.coveragePct).toBe(78);
+    expect(row.coveragePct).toBe(77);
     expect(mockSendCommand).toHaveBeenCalledWith("audio_analysis/coverage", {
       aa_domain: "sonic_analysis",
     });
     // Only one call per AA provider — no /status probe.
     expect(mockSendCommand).toHaveBeenCalledTimes(1);
+  });
+
+  it("excludes stale analyses from the completed count and total", async () => {
+    setProviders([
+      {
+        type: ProviderType.AUDIO_ANALYSIS,
+        domain: "sonic_analysis",
+        name: "Sonic Analysis",
+        instance_id: "sa1",
+        available: true,
+      },
+    ]);
+    mockAa({
+      sonic_analysis: {
+        analyzed: 19696,
+        pending: 18154,
+        stale_version: 18154,
+        analysis_version: 5,
+      },
+    });
+
+    const c = useAudioAnalysisCoverage();
+    await c.refresh();
+
+    const row = c.rows.value[0];
+    expect(row.analyzed).toBe(1542);
+    expect(row.analyzed + row.pending).toBe(19696);
+    expect(row.pending).toBe(18154);
+    expect(row.staleVersion).toBe(18154);
+    expect(row.coveragePct).toBe(8);
+  });
+
+  it("clamps the completed count when stale analyses exceed analyzed", async () => {
+    setProviders([
+      {
+        type: ProviderType.AUDIO_ANALYSIS,
+        domain: "sonic_analysis",
+        name: "Sonic Analysis",
+        instance_id: "sa1",
+        available: true,
+      },
+    ]);
+    mockAa({
+      sonic_analysis: {
+        analyzed: 2,
+        pending: 8,
+        stale_version: 3,
+        analysis_version: 5,
+      },
+    });
+
+    const c = useAudioAnalysisCoverage();
+    await c.refresh();
+
+    const row = c.rows.value[0];
+    expect(row.analyzed).toBe(0);
+    expect(row.pending).toBe(8);
+    expect(row.staleVersion).toBe(3);
+    expect(row.coveragePct).toBe(0);
   });
 
   it("guards divide-by-zero (0 analyzed, 0 pending) -> 0 pct, hasData false", async () => {


### PR DESCRIPTION
# What does this implement/fix?

Stale analyses were counted as both complete and pending after analyzer version upgrades, making audio analysis progress appear further along than it was.

- Calculate completed progress from current-version analyses only.
- Keep the pending and stale counts visible in their existing badges.
- Add regression coverage for the reported count overlap and defensive clamping.

**Related issue (if applicable):**

- related issue https://github.com/music-assistant/support/issues/5942

**Related backend PR (if applicable):**

- N/A

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm lint:check` passes.
- [x] `pnpm test:run` passes, and tests have been added/updated where applicable.
- [x] `pnpm build` passes.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.