### PR TITLE
Highlight genre aliases on hover

### DIFF
--- a/src/components/genre/GenreAliasManager.vue
+++ b/src/components/genre/GenreAliasManager.vue
@@ -7,7 +7,12 @@
     />
     <v-divider />
     <v-list v-if="aliasSectionExpanded">
-      <ListItem v-for="alias in aliases" :key="alias">
+      <ListItem
+        v-for="alias in aliases"
+        :key="alias"
+        :link="canPromoteAlias(alias)"
+        @click="canPromoteAlias(alias) && confirmPromoteAlias(alias)"
+      >
         <template #prepend>
           <Route :size="20" />
         </template>
@@ -19,7 +24,7 @@
             size="icon-sm"
             :title="$t('promote_alias')"
             :disabled="operationInProgress"
-            @click="confirmPromoteAlias(alias)"
+            @click.stop="confirmPromoteAlias(alias)"
           >
             <ArrowUpFromLine :size="20" />
           </Button>
@@ -28,7 +33,7 @@
             size="icon-sm"
             :title="$t('remove_alias')"
             :disabled="operationInProgress"
-            @click="confirmRemoveAlias(alias)"
+            @click.stop="confirmRemoveAlias(alias)"
           >
             <Trash2 :size="20" />
           </Button>

--- a/src/components/genre/GenreAliasManager.vue
+++ b/src/components/genre/GenreAliasManager.vue
@@ -10,8 +10,8 @@
       <ListItem
         v-for="alias in aliases"
         :key="alias"
-        :link="canPromoteAlias(alias)"
-        @click="canPromoteAlias(alias) && confirmPromoteAlias(alias)"
+        :link="canPromoteAlias(alias) && !operationInProgress"
+        @click="handleAliasClick(alias)"
       >
         <template #prepend>
           <Route :size="20" />
@@ -157,6 +157,12 @@ const confirmRemoveAlias = (alias: string) => {
 const confirmPromoteAlias = (alias: string) => {
   aliasToPromote.value = alias;
   showPromoteDialog.value = true;
+};
+
+const handleAliasClick = (alias: string) => {
+  if (!operationInProgress.value && canPromoteAlias(alias)) {
+    confirmPromoteAlias(alias);
+  }
 };
 
 const toggleAliasSection = () => {


### PR DESCRIPTION
# What does this implement/fix?

Genre alias rows lacked hover feedback, making it difficult to identify which alias would be promoted.

- Highlight promotable alias rows on hover
- Allow the full row to open the promotion confirmation
- Keep promote and remove buttons independent

**Related issue (if applicable):**

- N/A

**Related backend PR (if applicable):**

- N/A

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm lint:check` passes.
- [x] `pnpm test:run` passes, and tests have been added/updated where applicable.
- [x] `pnpm build` passes.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.