### PR TITLE
Stop player bar icons moving on hover

### DIFF
--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -145,12 +145,8 @@
   color: var(--primary) !important;
 }
 
-/* the label takes the weight that goes with the active colour, as it does in the
-   mobile navigation. The player bar sets the resting weight from its own scoped
-   block, which the two attribute branches only out-rank with the :root here. */
-:root
-  .player-control-button:hover:not([data-suppress-hover="true"])
-  .player-bar-action-label,
+/* the label takes the weight used by active mobile navigation. The player bar
+   sets the resting weight in a scoped block, so :root lets open states win. */
 :root .player-control-button[data-active="true"] .player-bar-action-label,
 :root .player-control-button[data-state="open"] .player-bar-action-label {
   font-weight: 600;

--- a/tests/styles/playerControlButtonState.test.ts
+++ b/tests/styles/playerControlButtonState.test.ts
@@ -122,6 +122,19 @@ describe("player control button state", () => {
     expect(painting.indexOf(cleared!)).toBeGreaterThan(painting.indexOf(fill!));
   });
 
+  it("keeps the label weight unchanged on hover", () => {
+    const hoverWeight = [...(styles.sheet?.cssRules ?? [])]
+      .filter((rule): rule is CSSStyleRule => rule instanceof CSSStyleRule)
+      .find(
+        (rule) =>
+          rule.style.getPropertyValue("font-weight") !== "" &&
+          rule.selectorText.includes(":hover") &&
+          rule.selectorText.includes(".player-bar-action-label"),
+      );
+
+    expect(hoverWeight).toBeUndefined();
+  });
+
   // the colour is the other half of the signal, so a label left at its resting
   // weight reads as half-lit next to the mobile navigation it mirrors
   it("weights the label of a button whose popout is showing", () => {


### PR DESCRIPTION
# What does this implement/fix?

Hovering a player bar control made its label wider and shifted nearby icons.

- Keep label weight stable on hover while preserving the active state styling.
- Add regression coverage for the hover style.

**Related issue (if applicable):**

- N/A

**Related backend PR (if applicable):**

- N/A

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm lint:check` passes.
- [x] `pnpm test:run` passes, and tests have been added/updated where applicable.
- [x] `pnpm build` passes.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.