### PR TITLE
Use named play media options

### DIFF
--- a/src/components/Chapters.vue
+++ b/src/components/Chapters.vue
@@ -69,6 +69,8 @@ const toolbarMenuItems = computed(() => {
 
 const chapterClicked = function (chapter: MediaItemChapter) {
   if (!props.itemDetails || !itemIsAvailable(props.itemDetails)) return;
-  api.playMedia(props.itemDetails.uri, undefined, chapter.position.toString());
+  api.playMedia(props.itemDetails.uri, undefined, {
+    start_item: chapter.position.toString(),
+  });
 };
 </script>

--- a/src/helpers/media_item_actions.ts
+++ b/src/helpers/media_item_actions.ts
@@ -69,7 +69,10 @@ export const handlePlayBtnClick = async function (
       );
       if (playAction != PLAY_ACTION_PLAY_TRACK) {
         api
-          .playMedia(parentItem.uri, undefined, item.item_id, undefined, sortBy)
+          .playMedia(parentItem.uri, undefined, {
+            start_item: item.item_id,
+            sort_by: sortBy,
+          })
           .catch(onPlayError);
         return;
       }

--- a/src/layouts/default/ItemContextMenu.vue
+++ b/src/layouts/default/ItemContextMenu.vue
@@ -442,11 +442,7 @@ export const showPlayMenuForMediaItem = async function (
         api.playMedia(
           playableItems.map((x) => x.uri),
           QueueOption.REPLACE,
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          true,
+          { shuffle: true },
         );
       },
       icon: Shuffle,
@@ -877,14 +873,9 @@ export const getContextMenuItems = async function (
           label: "play_from_beginning",
           icon: RotateCcw,
           action: () => {
-            api.playMedia(
-              item.uri,
-              QueueOption.PLAY,
-              undefined,
-              undefined,
-              undefined,
-              true,
-            );
+            api.playMedia(item.uri, QueueOption.PLAY, {
+              start_from_beginning: true,
+            });
           },
           disabled: !store.activePlayer,
         });
@@ -1184,13 +1175,10 @@ export const getPlaybackContextMenuItems = async function (
       playMenuItems.push({
         label: "play_playlist_from",
         action: () => {
-          api.playMedia(
-            parentItem.uri,
-            undefined,
-            playableItems[0].item_id,
-            undefined,
-            sortBy,
-          );
+          api.playMedia(parentItem.uri, undefined, {
+            start_item: playableItems[0].item_id,
+            sort_by: sortBy,
+          });
         },
         icon: PlayCircle,
         labelArgs: [],
@@ -1202,13 +1190,10 @@ export const getPlaybackContextMenuItems = async function (
       playMenuItems.push({
         label: "play_album_from",
         action: () => {
-          api.playMedia(
-            parentItem.uri,
-            undefined,
-            firstItem.item_id,
-            undefined,
-            sortBy,
-          );
+          api.playMedia(parentItem.uri, undefined, {
+            start_item: firstItem.item_id,
+            sort_by: sortBy,
+          });
         },
         icon: PlayCircle,
         labelArgs: [],
@@ -1220,7 +1205,9 @@ export const getPlaybackContextMenuItems = async function (
       playMenuItems.push({
         label: "play_from_here",
         action: () => {
-          api.playMedia(parentItem.uri, undefined, firstItem.item_id);
+          api.playMedia(parentItem.uri, undefined, {
+            start_item: firstItem.item_id,
+          });
         },
         icon: PlayCircle,
         labelArgs: [],

--- a/src/layouts/default/PlayerOSD/PlayerTimeline.vue
+++ b/src/layouts/default/PlayerOSD/PlayerTimeline.vue
@@ -395,11 +395,9 @@ const stopDragging = () => {
 
 const chapterClicked = function (chapter: MediaItemChapter) {
   if (!store.curQueueItem?.media_item) return;
-  api.playMedia(
-    store.curQueueItem.media_item.uri,
-    undefined,
-    chapter.position.toString(),
-  );
+  api.playMedia(store.curQueueItem.media_item.uri, undefined, {
+    start_item: chapter.position.toString(),
+  });
 };
 
 const setPendingSeek = (position: number) => {

--- a/src/layouts/default/PlayerOSD/useFullscreenQueue.ts
+++ b/src/layouts/default/PlayerOSD/useFullscreenQueue.ts
@@ -287,7 +287,9 @@ export function useFullscreenQueue(showLyrics: Ref<boolean>) {
   };
 
   const chapterClicked = (item: MediaItemType, chapter: MediaItemChapter) => {
-    api.playMedia(item.uri, QueueOption.PLAY, chapter.position.toString());
+    api.playMedia(item.uri, QueueOption.PLAY, {
+      start_item: chapter.position.toString(),
+    });
   };
 
   // ---- drag-to-reorder (up-next items only) --------------------------------

--- a/src/plugins/api/index.ts
+++ b/src/plugins/api/index.ts
@@ -82,6 +82,15 @@ const TRANSLATIONS_SCHEMA_VERSION = 32;
 // The shuffle argument on player_queues/play_media landed in API schema 51.
 const PLAY_MEDIA_SHUFFLE_SCHEMA_VERSION = 51;
 
+export interface PlayMediaOptions {
+  start_item?: PlayableMediaItemType | string;
+  queue_id?: string;
+  sort_by?: string;
+  start_from_beginning?: boolean;
+  /** Set playback order for immediate-play options; omit to let the server decide. */
+  shuffle?: boolean;
+}
+
 export enum ConnectionState {
   DISCONNECTED = "disconnected", // Not connected
   CONNECTING = "connecting", // Establishing connection
@@ -2057,14 +2066,9 @@ export class MusicAssistantApi {
       | string
       | string[],
     option?: QueueOption,
-    start_item?: PlayableMediaItemType | string,
-    queue_id?: string,
-    sort_by?: string,
-    start_from_beginning?: boolean,
-    // play the media shuffled (or explicitly in order); only applies to the options
-    // that start playing right away. Omit to leave the choice to the server.
-    shuffle?: boolean,
+    options: PlayMediaOptions = {},
   ): Promise<void> {
+    let queue_id = options.queue_id;
     if (
       !queue_id &&
       store.activePlayer?.active_source &&
@@ -2078,10 +2082,10 @@ export class MusicAssistantApi {
       queue_id,
       media,
       option,
-      start_item,
-      sort_by,
-      start_from_beginning,
-      shuffle,
+      start_item: options.start_item,
+      sort_by: options.sort_by,
+      start_from_beginning: options.start_from_beginning,
+      shuffle: options.shuffle,
     });
   }
 

--- a/tests/helpers/mediaItemClickActions.test.ts
+++ b/tests/helpers/mediaItemClickActions.test.ts
@@ -116,13 +116,10 @@ describe("handlePlayBtnClick honours default_play_action_*_track", () => {
 
     await handlePlayBtnClick(playedTrack, 0, 0, parentPlaylist, false, "name");
 
-    expect(mockPlayMedia).toHaveBeenCalledWith(
-      parentPlaylist.uri,
-      undefined,
-      playedTrack.item_id,
-      undefined,
-      "name",
-    );
+    expect(mockPlayMedia).toHaveBeenCalledWith(parentPlaylist.uri, undefined, {
+      start_item: playedTrack.item_id,
+      sort_by: "name",
+    });
   });
 
   it("plays the album from the track when the setting is any other/unexpected value", async () => {
@@ -130,13 +127,10 @@ describe("handlePlayBtnClick honours default_play_action_*_track", () => {
 
     await handlePlayBtnClick(playedTrack, 0, 0, parentAlbum);
 
-    expect(mockPlayMedia).toHaveBeenCalledWith(
-      parentAlbum.uri,
-      undefined,
-      playedTrack.item_id,
-      undefined,
-      undefined,
-    );
+    expect(mockPlayMedia).toHaveBeenCalledWith(parentAlbum.uri, undefined, {
+      start_item: playedTrack.item_id,
+      sort_by: undefined,
+    });
   });
 
   it("falls back to play-from-here when the config read rejects", async () => {
@@ -144,13 +138,10 @@ describe("handlePlayBtnClick honours default_play_action_*_track", () => {
 
     await handlePlayBtnClick(playedTrack, 0, 0, parentPlaylist);
 
-    expect(mockPlayMedia).toHaveBeenCalledWith(
-      parentPlaylist.uri,
-      undefined,
-      playedTrack.item_id,
-      undefined,
-      undefined,
-    );
+    expect(mockPlayMedia).toHaveBeenCalledWith(parentPlaylist.uri, undefined, {
+      start_item: playedTrack.item_id,
+      sort_by: undefined,
+    });
   });
 });
 

--- a/tests/helpers/playFromHereSort.test.ts
+++ b/tests/helpers/playFromHereSort.test.ts
@@ -108,13 +108,10 @@ describe("handlePlayBtnClick with sortBy", () => {
 
     await handlePlayBtnClick(playedTrack, 0, 0, parentPlaylist, false, "name");
 
-    expect(mockPlayMedia).toHaveBeenCalledWith(
-      parentPlaylist.uri,
-      undefined,
-      playedTrack.item_id,
-      undefined,
-      "name",
-    );
+    expect(mockPlayMedia).toHaveBeenCalledWith(parentPlaylist.uri, undefined, {
+      start_item: playedTrack.item_id,
+      sort_by: "name",
+    });
   });
 
   it("passes undefined sortBy when not provided", async () => {
@@ -123,13 +120,10 @@ describe("handlePlayBtnClick with sortBy", () => {
 
     await handlePlayBtnClick(playedTrack, 0, 0, parentPlaylist);
 
-    expect(mockPlayMedia).toHaveBeenCalledWith(
-      parentPlaylist.uri,
-      undefined,
-      playedTrack.item_id,
-      undefined,
-      undefined,
-    );
+    expect(mockPlayMedia).toHaveBeenCalledWith(parentPlaylist.uri, undefined, {
+      start_item: playedTrack.item_id,
+      sort_by: undefined,
+    });
   });
 
   it("passes sortBy for album play-from-here", async () => {
@@ -138,13 +132,10 @@ describe("handlePlayBtnClick with sortBy", () => {
 
     await handlePlayBtnClick(playedTrack, 0, 0, parentAlbum, false, "name");
 
-    expect(mockPlayMedia).toHaveBeenCalledWith(
-      parentAlbum.uri,
-      undefined,
-      playedTrack.item_id,
-      undefined,
-      "name",
-    );
+    expect(mockPlayMedia).toHaveBeenCalledWith(parentAlbum.uri, undefined, {
+      start_item: playedTrack.item_id,
+      sort_by: "name",
+    });
   });
 
   it("passes different sort keys correctly", async () => {
@@ -170,9 +161,10 @@ describe("handlePlayBtnClick with sortBy", () => {
       expect(mockPlayMedia).toHaveBeenCalledWith(
         parentPlaylist.uri,
         undefined,
-        playedTrack.item_id,
-        undefined,
-        sortKey,
+        {
+          start_item: playedTrack.item_id,
+          sort_by: sortKey,
+        },
       );
     }
   });

--- a/tests/helpers/playMenuShuffle.test.ts
+++ b/tests/helpers/playMenuShuffle.test.ts
@@ -156,11 +156,7 @@ describe("play shuffled action behaviour", () => {
     expect(mockApi.playMedia).toHaveBeenCalledWith(
       [theAlbum.uri],
       QueueOption.REPLACE,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      true,
+      { shuffle: true },
     );
   });
 
@@ -173,11 +169,7 @@ describe("play shuffled action behaviour", () => {
     expect(mockApi.playMedia).toHaveBeenCalledWith(
       [first.uri, second.uri],
       QueueOption.REPLACE,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      true,
+      { shuffle: true },
     );
   });
 

--- a/tests/plugins/api/playMedia.test.ts
+++ b/tests/plugins/api/playMedia.test.ts
@@ -12,14 +12,9 @@ describe("playMedia start_from_beginning passthrough", () => {
       .spyOn(api, "sendCommand")
       .mockResolvedValue(undefined as never);
 
-    api.playMedia(
-      "library://podcast_episode/1",
-      QueueOption.PLAY,
-      undefined,
-      undefined,
-      undefined,
-      true,
-    );
+    api.playMedia("library://podcast_episode/1", QueueOption.PLAY, {
+      start_from_beginning: true,
+    });
 
     expect(spy).toHaveBeenCalledWith(
       "player_queues/play_media",


### PR DESCRIPTION
# What does this implement/fix?

`playMedia` accepted five optional positional values after `media` and `option`, forcing callers to pass placeholder `undefined` values.

- Replaces the trailing values with named options.
- Updates all frontend callers and exact call-shape tests.
- Keeps request payloads and playback behavior unchanged.

**Related issue (if applicable):**

- N/A

**Related backend PR (if applicable):**

- N/A

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) - `bugfix`
- [ ] New feature (non-breaking change which adds functionality) - `new-feature`
- [ ] Enhancement to an existing feature - `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) - `breaking-change`
- [ ] Refactor (no behaviour change) - `refactor`
- [x] Maintenance / chore - `maintenance`
- [ ] CI / workflow change - `ci`
- [ ] Dependencies bump - `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm lint:check` passes.
- [x] `pnpm test:run` passes, and tests have been added/updated where applicable.
- [x] `pnpm build` passes.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
