### PR TITLE
Fix copying provider links over HTTP

### DIFF
--- a/src/helpers/utils.ts
+++ b/src/helpers/utils.ts
@@ -721,6 +721,8 @@ export async function copyToClipboard(text: string): Promise<boolean> {
   textArea.style.height = "1px";
   textArea.style.opacity = "0";
   textArea.style.pointerEvents = "none";
+  textArea.style.setProperty("-webkit-user-select", "text");
+  textArea.style.userSelect = "text";
   host.appendChild(textArea);
   try {
     textArea.focus();

--- a/tests/helpers/utils.test.ts
+++ b/tests/helpers/utils.test.ts
@@ -1,4 +1,5 @@
 import {
+  copyToClipboard,
   formatAliasName,
   formatDuration,
   formatRelativeTime,
@@ -38,6 +39,59 @@ beforeEach(() => {
 
 afterEach(() => {
   vi.restoreAllMocks();
+});
+
+describe("copyToClipboard", () => {
+  it("keeps the fallback textarea selectable", async () => {
+    const secureContextDescriptor = Object.getOwnPropertyDescriptor(
+      window,
+      "isSecureContext",
+    );
+    const execCommandDescriptor = Object.getOwnPropertyDescriptor(
+      document,
+      "execCommand",
+    );
+
+    Object.defineProperty(window, "isSecureContext", {
+      configurable: true,
+      value: false,
+    });
+    Object.defineProperty(document, "execCommand", {
+      configurable: true,
+      value: vi.fn(() => true),
+    });
+    const appendChild = vi.spyOn(document.body, "appendChild");
+
+    try {
+      await expect(copyToClipboard("provider://artist/id")).resolves.toBe(true);
+
+      const appendedNode = appendChild.mock.calls[0][0];
+      expect(appendedNode).toBeInstanceOf(HTMLTextAreaElement);
+      if (!(appendedNode instanceof HTMLTextAreaElement)) {
+        throw new TypeError("Expected clipboard textarea");
+      }
+      expect(appendedNode.style.getPropertyValue("-webkit-user-select")).toBe(
+        "text",
+      );
+      expect(appendedNode.style.userSelect).toBe("text");
+      expect(appendedNode.isConnected).toBe(false);
+    } finally {
+      if (secureContextDescriptor) {
+        Object.defineProperty(
+          window,
+          "isSecureContext",
+          secureContextDescriptor,
+        );
+      } else {
+        Reflect.deleteProperty(window, "isSecureContext");
+      }
+      if (execCommandDescriptor) {
+        Object.defineProperty(document, "execCommand", execCommandDescriptor);
+      } else {
+        Reflect.deleteProperty(document, "execCommand");
+      }
+    }
+  });
 });
 
 describe("getExternalLinkUrl", () => {


### PR DESCRIPTION
# What does this implement/fix?

Copying a provider URI could report success without updating the clipboard when Music Assistant was opened over HTTP.

- Allow the HTTP clipboard fallback to select the provider URI.
- Add regression coverage for the fallback.

**Related issue (if applicable):**

- N/A

**Related backend PR (if applicable):**

- N/A

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm lint:check` passes.
- [x] `pnpm test:run` passes, and tests have been added/updated where applicable.
- [x] `pnpm build` passes.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.