### PR TITLE
Restore mobile footer blur

### DIFF
--- a/src/components/navigation/BottomNavigation.vue
+++ b/src/components/navigation/BottomNavigation.vue
@@ -114,7 +114,8 @@ function closePlayersMenu() {
 
 /* one surface for the whole dock: it reaches up behind the player, which then
    sits on it as its own card. The player's measured height is published by the
-   footer, so the two always meet. */
+   footer, so the two always meet. Only a tint - the blur comes from the scrim
+   behind it, which ramps up from above the player. */
 .mobile-bottom-navigation::before {
   position: absolute;
   z-index: -1;
@@ -128,19 +129,11 @@ function closePlayersMenu() {
   /* the top stays concentric with the player card sitting on it; the bottom is
      far rounder so it does not fight the screen's own corner curve */
   border-radius: 20px 20px 32px 32px;
-  background: var(--background);
+  background: color-mix(in srgb, var(--background) 70%, transparent);
   box-shadow:
     0 10px 15px -3px rgb(0 0 0 / 0.1),
     0 4px 6px -4px rgb(0 0 0 / 0.1);
   content: "";
-}
-
-@supports (backdrop-filter: blur(1px)) or (-webkit-backdrop-filter: blur(1px)) {
-  .mobile-bottom-navigation::before {
-    background: color-mix(in srgb, var(--background) 70%, transparent);
-    backdrop-filter: blur(14px);
-    -webkit-backdrop-filter: blur(14px);
-  }
 }
 
 /* darker than the muted grey the player controls use elsewhere, so the labels

--- a/src/layouts/default/Footer.vue
+++ b/src/layouts/default/Footer.vue
@@ -91,21 +91,27 @@ function clearOverlay() {
   bottom: 0;
   width: 100%;
   height: var(--mobile-player-scrim-height);
+  /* it only exists to soften what is behind it, so it never takes a tap */
   pointer-events: none;
   z-index: 999;
-}
-
-/* Fade the dock blur out without masking the dock surface itself. */
-.player-scrim::before {
-  position: absolute;
-  top: 0;
-  width: 100%;
-  height: var(--mobile-player-scrim-fade-height);
   backdrop-filter: blur(14px);
   -webkit-backdrop-filter: blur(14px);
-  mask-image: linear-gradient(to top, #000, transparent);
-  -webkit-mask-image: linear-gradient(to top, #000, transparent);
-  content: "";
+  /* the mask is what makes the blur ramp up towards the player instead of
+     ending on a visible line */
+  mask-image: linear-gradient(
+    to top,
+    #000 0%,
+    #000 35%,
+    rgba(0, 0, 0, 0.55) 65%,
+    transparent 100%
+  );
+  -webkit-mask-image: linear-gradient(
+    to top,
+    #000 0%,
+    #000 35%,
+    rgba(0, 0, 0, 0.55) 65%,
+    transparent 100%
+  );
 }
 
 .v-footer {

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -66,14 +66,14 @@ html {
   --mobile-navigation-height: calc(
     var(--mobile-navigation-item-height) + var(--mobile-navigation-inset-bottom)
   );
-  /* Height over which the dock blur fades into the page. */
-  --mobile-player-scrim-fade-height: 16px;
-  /* Height from the viewport bottom through the dock and its blur fade. The card
-     is measured at runtime, so this follows it rather than assuming a height the
-     card is free to outgrow. */
+  /* Height of the blur behind the dock. It softens what scrolls under it without
+     hiding it, and fades out towards the top, so it clears the dock's own top by
+     a further 16px for the fade to finish above it rather than across it. The
+     card is measured at runtime, so this follows it rather than assuming a height
+     the card is free to outgrow. */
   --mobile-player-scrim-height: calc(
     var(--mobile-navigation-height) + var(--player-bar-overlay-height, 0px) +
-      var(--mobile-dock-rim) + var(--mobile-player-scrim-fade-height)
+      var(--mobile-dock-rim) + 16px
   );
   /* Space the player bar occupies in the desktop layout, where it sits flush
      against the bottom of the screen. The mobile player bar floats and varies

--- a/tests/styles/playerScrim.test.ts
+++ b/tests/styles/playerScrim.test.ts
@@ -86,17 +86,20 @@ describe("player scrim height", () => {
   });
 
   it("uses one masked blur layer behind the dock", () => {
-    const dockRule =
-      navigationSource.match(
-        /\.mobile-bottom-navigation::before\s*\{([^}]*)\}/,
-      )?.[1] ?? "";
+    const dockRules = [
+      ...navigationSource.matchAll(
+        /\.mobile-bottom-navigation::before\s*\{([^}]*)\}/g,
+      ),
+    ]
+      .map((match) => match[1])
+      .join("\n");
     const scrimRule =
       footerSource.match(/\.player-scrim\s*\{([^}]*)\}/)?.[1] ?? "";
 
     expect(scrimRule).toMatch(/(?:^|\s)backdrop-filter:\s*blur\(14px\)/);
     expect(scrimRule).toContain("-webkit-backdrop-filter: blur(14px)");
     expect(scrimRule).toMatch(/(?:^|\s)mask-image:\s*linear-gradient/);
-    expect(dockRule).not.toContain("backdrop-filter");
+    expect(dockRules).not.toContain("backdrop-filter");
     expect(footerSource).not.toMatch(/\.player-scrim::before\s*\{/);
   });
 });

--- a/tests/styles/playerScrim.test.ts
+++ b/tests/styles/playerScrim.test.ts
@@ -2,7 +2,6 @@
 // observable under happy-dom
 // @vitest-environment happy-dom
 import navigationSource from "@/components/navigation/BottomNavigation.vue?raw";
-import footerSource from "@/layouts/default/Footer.vue?raw";
 import css from "@/styles/global.css?inline";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
@@ -12,7 +11,6 @@ const NAVIGATION_INSET =
   "max( 12px, calc(env(safe-area-inset-bottom, 0px) * 0.65) )";
 const NAVIGATION_HEIGHT = `calc( 72px + ${NAVIGATION_INSET} )`;
 const DOCK_RIM = "4px";
-const SCRIM_FADE_PROPERTY = "--mobile-player-scrim-fade-height";
 const SCRIM_FADE = "16px";
 
 let appStyles: HTMLStyleElement;
@@ -33,18 +31,13 @@ function scrimHeight() {
 // happy-dom drops a calc() holding a var() from anything but a custom property,
 // so the navigation's own offset is only observable in its source
 function dockSurfaceTop() {
-  const rule = styleRule(
-    navigationSource,
-    String.raw`\.mobile-bottom-navigation::before`,
-  );
+  const rule = navigationSource.match(
+    /\.mobile-bottom-navigation::before\s*\{([^}]*)\}/,
+  )?.[1];
   return rule
     ?.match(/top:([^;]*);/)?.[1]
     .replace(/\s+/g, " ")
     .trim();
-}
-
-function styleRule(source: string, selectorPattern: string) {
-  return source.match(new RegExp(`${selectorPattern}\\s*\\{([^}]*)\\}`))?.[1];
 }
 
 describe("player scrim height", () => {
@@ -62,53 +55,32 @@ describe("player scrim height", () => {
   it("reaches past the dock so the fade finishes clear of it", () => {
     document.documentElement.style.setProperty(OVERLAY_HEIGHT, BAR_HEIGHT);
 
-    // The fade occupies the wrapper's top edge, so the wrapper must grow with
-    // the dock to keep that edge above the player.
+    // the blur fades out towards its own top. Sized from anything other than the
+    // dock it stops short of it once the card grows, leaving the see-through
+    // dock on unblurred content with the fade ending across it.
     expect(scrimHeight()).toBe(
       `calc( ${NAVIGATION_HEIGHT} + ${BAR_HEIGHT} + ${DOCK_RIM} + ${SCRIM_FADE} )`,
     );
   });
 
   it("keeps that clearance before the card has been measured", () => {
-    // Until the footer publishes the card's height, the wrapper and dock both
-    // use the same zero-height fallback.
+    // the footer publishes the card's height once it is on screen. Until it
+    // does, the blur takes the same unmeasured card the dock does, so the two
+    // still line up.
     expect(scrimHeight()).toBe(
       `calc( ${NAVIGATION_HEIGHT} + 0px + ${DOCK_RIM} + ${SCRIM_FADE} )`,
     );
   });
 
   it("clears the same dock top the navigation lifts its surface to", () => {
-    // The fade meets the dock only while both use the same card and rim height.
+    // the blur clears the dock only while both measure it the same way. The rim
+    // is shared, but the composition is not, so this is what catches the two
+    // drifting apart again.
     expect(
       dockSurfaceTop(),
       "the navigation's ::before must lift its surface by the card plus the rim",
     ).toBe(
       `calc( -1 * (var(${OVERLAY_HEIGHT}, 0px) + var(--mobile-dock-rim)) )`,
     );
-  });
-
-  it("keeps the required dock blur separate from the masked fade", () => {
-    const dockRules = [
-      ...navigationSource.matchAll(
-        /\.mobile-bottom-navigation::before\s*\{([^}]*)\}/g,
-      ),
-    ]
-      .map((match) => match[1])
-      .join("\n");
-    const scrimRule = styleRule(footerSource, String.raw`\.player-scrim`);
-    const fadeRule = styleRule(
-      footerSource,
-      String.raw`\.player-scrim::before`,
-    );
-
-    expect(dockRules).toMatch(/(?:^|\s)backdrop-filter:\s*blur\(14px\)/);
-    expect(dockRules).toContain("-webkit-backdrop-filter: blur(14px)");
-    expect(dockRules).toContain("background: var(--background)");
-    expect(dockRules).not.toContain("mask-image");
-    expect(scrimRule).not.toContain("backdrop-filter");
-    expect(scrimRule).not.toContain("mask-image");
-    expect(fadeRule).toContain(`height: var(${SCRIM_FADE_PROPERTY})`);
-    expect(fadeRule).toContain("backdrop-filter: blur(14px)");
-    expect(fadeRule).toContain("mask-image: linear-gradient");
   });
 });

--- a/tests/styles/playerScrim.test.ts
+++ b/tests/styles/playerScrim.test.ts
@@ -2,6 +2,7 @@
 // observable under happy-dom
 // @vitest-environment happy-dom
 import navigationSource from "@/components/navigation/BottomNavigation.vue?raw";
+import footerSource from "@/layouts/default/Footer.vue?raw";
 import css from "@/styles/global.css?inline";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
@@ -82,5 +83,20 @@ describe("player scrim height", () => {
     ).toBe(
       `calc( -1 * (var(${OVERLAY_HEIGHT}, 0px) + var(--mobile-dock-rim)) )`,
     );
+  });
+
+  it("uses one masked blur layer behind the dock", () => {
+    const dockRule =
+      navigationSource.match(
+        /\.mobile-bottom-navigation::before\s*\{([^}]*)\}/,
+      )?.[1] ?? "";
+    const scrimRule =
+      footerSource.match(/\.player-scrim\s*\{([^}]*)\}/)?.[1] ?? "";
+
+    expect(scrimRule).toMatch(/(?:^|\s)backdrop-filter:\s*blur\(14px\)/);
+    expect(scrimRule).toContain("-webkit-backdrop-filter: blur(14px)");
+    expect(scrimRule).toMatch(/(?:^|\s)mask-image:\s*linear-gradient/);
+    expect(dockRule).not.toContain("backdrop-filter");
+    expect(footerSource).not.toMatch(/\.player-scrim::before\s*\{/);
   });
 });


### PR DESCRIPTION
# What does this implement/fix?

Restores the mobile footer blur after #2536 left page content visible around the player and bottom menu.

- Use one continuous masked blur behind the full mobile dock.
- Keep the rounded dock surface translucent without a separate blur layer.
- Restore the smooth fade above the player without a visible edge.

**Related issue (if applicable):**

- N/A

**Related backend PR (if applicable):**

- N/A

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm lint:check` passes.
- [x] `pnpm test:run` passes, and tests have been added/updated where applicable.
- [x] `pnpm build` passes.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.