### PR TITLE
Add click actions for more media types

### DIFF
--- a/src/helpers/media_item_actions.ts
+++ b/src/helpers/media_item_actions.ts
@@ -23,7 +23,8 @@ const CLICK_ACTION_PLAY = "play";
 const PLAY_ACTION_PLAY_TRACK = "play_track";
 
 // radio and audio source are both "live" sources and share one setting
-const CLICK_ACTION_LIVE_SOURCES = "default_click_action_live_sources";
+const CLICK_ACTION_CONFIG_KEY_LIVE_SOURCES =
+  "default_click_action_live_sources";
 
 // media types for which clicking the item itself is configurable
 const CLICK_ACTION_CONFIG_KEYS: Partial<Record<MediaType, string>> = {
@@ -32,8 +33,8 @@ const CLICK_ACTION_CONFIG_KEYS: Partial<Record<MediaType, string>> = {
   [MediaType.PLAYLIST]: "default_click_action_playlist",
   [MediaType.TRACK]: "default_click_action_track",
   [MediaType.GENRE]: "default_click_action_genre",
-  [MediaType.RADIO]: CLICK_ACTION_LIVE_SOURCES,
-  [MediaType.AUDIO_SOURCE]: CLICK_ACTION_LIVE_SOURCES,
+  [MediaType.RADIO]: CLICK_ACTION_CONFIG_KEY_LIVE_SOURCES,
+  [MediaType.AUDIO_SOURCE]: CLICK_ACTION_CONFIG_KEY_LIVE_SOURCES,
 };
 
 /**

--- a/src/helpers/media_item_actions.ts
+++ b/src/helpers/media_item_actions.ts
@@ -22,9 +22,8 @@ import { toast } from "vue-sonner";
 const CLICK_ACTION_PLAY = "play";
 const PLAY_ACTION_PLAY_TRACK = "play_track";
 
-// radio and audio source are both "live" sources and share one setting
-const CLICK_ACTION_CONFIG_KEY_LIVE_SOURCES =
-  "default_click_action_live_sources";
+// radio has meaningful browse/play behaviour; other live sources always play directly
+const CLICK_ACTION_CONFIG_KEY_RADIO = "default_click_action_radio";
 
 // media types for which clicking the item itself is configurable
 const CLICK_ACTION_CONFIG_KEYS: Partial<Record<MediaType, string>> = {
@@ -33,8 +32,7 @@ const CLICK_ACTION_CONFIG_KEYS: Partial<Record<MediaType, string>> = {
   [MediaType.PLAYLIST]: "default_click_action_playlist",
   [MediaType.TRACK]: "default_click_action_track",
   [MediaType.GENRE]: "default_click_action_genre",
-  [MediaType.RADIO]: CLICK_ACTION_CONFIG_KEY_LIVE_SOURCES,
-  [MediaType.AUDIO_SOURCE]: CLICK_ACTION_CONFIG_KEY_LIVE_SOURCES,
+  [MediaType.RADIO]: CLICK_ACTION_CONFIG_KEY_RADIO,
 };
 
 /**
@@ -126,6 +124,11 @@ export const handleMediaItemClick = async function (
     return handlePlayBtnClick(item, posX, posY, parentItem, true);
   }
 
+  // audio sources (e.g. Spotify Connect, AirPlay) have no browse view: always play them
+  if (item.media_type == MediaType.AUDIO_SOURCE) {
+    return handlePlayBtnClick(item, posX, posY, parentItem);
+  }
+
   // open menu for collection items
   if (item.media_type == MediaType.COLLECTION) {
     router.push({
@@ -142,6 +145,7 @@ export const handleMediaItemClick = async function (
   const clickActionKey = CLICK_ACTION_CONFIG_KEYS[item.media_type];
   if (
     clickActionKey &&
+    item.is_playable &&
     (await readClickSetting(clickActionKey)) == CLICK_ACTION_PLAY
   ) {
     return handlePlayBtnClick(item, posX, posY, parentItem);

--- a/src/helpers/media_item_actions.ts
+++ b/src/helpers/media_item_actions.ts
@@ -22,9 +22,6 @@ import { toast } from "vue-sonner";
 const CLICK_ACTION_PLAY = "play";
 const PLAY_ACTION_PLAY_TRACK = "play_track";
 
-// radio has meaningful browse/play behaviour; other live sources always play directly
-const CLICK_ACTION_CONFIG_KEY_RADIO = "default_click_action_radio";
-
 // media types for which clicking the item itself is configurable
 const CLICK_ACTION_CONFIG_KEYS: Partial<Record<MediaType, string>> = {
   [MediaType.ARTIST]: "default_click_action_artist",
@@ -32,7 +29,7 @@ const CLICK_ACTION_CONFIG_KEYS: Partial<Record<MediaType, string>> = {
   [MediaType.PLAYLIST]: "default_click_action_playlist",
   [MediaType.TRACK]: "default_click_action_track",
   [MediaType.GENRE]: "default_click_action_genre",
-  [MediaType.RADIO]: CLICK_ACTION_CONFIG_KEY_RADIO,
+  [MediaType.RADIO]: "default_click_action_radio",
 };
 
 /**

--- a/src/helpers/media_item_actions.ts
+++ b/src/helpers/media_item_actions.ts
@@ -22,11 +22,18 @@ import { toast } from "vue-sonner";
 const CLICK_ACTION_PLAY = "play";
 const PLAY_ACTION_PLAY_TRACK = "play_track";
 
+// radio and audio source are both "live" sources and share one setting
+const CLICK_ACTION_LIVE_SOURCES = "default_click_action_live_sources";
+
 // media types for which clicking the item itself is configurable
 const CLICK_ACTION_CONFIG_KEYS: Partial<Record<MediaType, string>> = {
   [MediaType.ARTIST]: "default_click_action_artist",
   [MediaType.ALBUM]: "default_click_action_album",
   [MediaType.PLAYLIST]: "default_click_action_playlist",
+  [MediaType.TRACK]: "default_click_action_track",
+  [MediaType.GENRE]: "default_click_action_genre",
+  [MediaType.RADIO]: CLICK_ACTION_LIVE_SOURCES,
+  [MediaType.AUDIO_SOURCE]: CLICK_ACTION_LIVE_SOURCES,
 };
 
 /**
@@ -130,7 +137,7 @@ export const handleMediaItemClick = async function (
     return;
   }
 
-  // artist/album/playlist: play the item straight away if configured to do so
+  // play the item straight away if its configured click-action is "play"
   const clickActionKey = CLICK_ACTION_CONFIG_KEYS[item.media_type];
   if (
     clickActionKey &&

--- a/tests/fixtures/audioSource.ts
+++ b/tests/fixtures/audioSource.ts
@@ -1,0 +1,28 @@
+import { type AudioSource, MediaType } from "@/plugins/api/interfaces";
+import { withUri } from "./mediaItem";
+
+/**
+ * A complete audio source (plugin source such as Spotify Connect or AirPlay),
+ * for tests that only care about a few of its fields but should still model
+ * a payload the server can send.
+ */
+export function audioSource(overrides: Partial<AudioSource> = {}): AudioSource {
+  return withUri<Omit<AudioSource, "uri">>({
+    item_id: "1",
+    provider: "library",
+    name: "Audio Source",
+    version: "",
+    external_ids: [],
+    is_playable: true,
+    media_type: MediaType.AUDIO_SOURCE,
+    provider_mappings: [],
+    metadata: {},
+    favorite: false,
+    can_play_pause: true,
+    can_seek: false,
+    can_next_previous: false,
+    exclusive: false,
+    allow_external_trigger: false,
+    ...overrides,
+  });
+}

--- a/tests/helpers/mediaItemClickActions.test.ts
+++ b/tests/helpers/mediaItemClickActions.test.ts
@@ -157,7 +157,10 @@ describe("handleMediaItemClick honours default_click_action_*", () => {
       key: "default_click_action_playlist",
     },
     { item: track({ item_id: "t1" }), key: "default_click_action_track" },
-    { item: genre({ item_id: "g1" }), key: "default_click_action_genre" },
+    {
+      item: genre({ item_id: "g1", is_playable: true }),
+      key: "default_click_action_genre",
+    },
     {
       item: radio({ item_id: "r1" }),
       key: "default_click_action_live_sources",

--- a/tests/helpers/mediaItemClickActions.test.ts
+++ b/tests/helpers/mediaItemClickActions.test.ts
@@ -72,7 +72,10 @@ import {
 } from "@/helpers/media_item_actions";
 import { album } from "../fixtures/album";
 import { artist } from "../fixtures/artist";
+import { audioSource } from "../fixtures/audioSource";
+import { genre } from "../fixtures/genre";
 import { playlist } from "../fixtures/playlist";
+import { radio } from "../fixtures/radio";
 import { track } from "../fixtures/track";
 
 const playedTrack = track({ item_id: "track1", name: "Track 1" });
@@ -153,6 +156,16 @@ describe("handleMediaItemClick honours default_click_action_*", () => {
       item: playlist({ item_id: "pl2" }),
       key: "default_click_action_playlist",
     },
+    { item: track({ item_id: "t1" }), key: "default_click_action_track" },
+    { item: genre({ item_id: "g1" }), key: "default_click_action_genre" },
+    {
+      item: radio({ item_id: "r1" }),
+      key: "default_click_action_live_sources",
+    },
+    {
+      item: audioSource({ item_id: "as1" }),
+      key: "default_click_action_live_sources",
+    },
   ])(
     "plays $item.media_type directly when its click-action setting is 'play'",
     async ({ item, key }) => {
@@ -170,6 +183,10 @@ describe("handleMediaItemClick honours default_click_action_*", () => {
     { item: album({ item_id: "a1" }) },
     { item: artist({ item_id: "ar1" }) },
     { item: playlist({ item_id: "pl2" }) },
+    { item: track({ item_id: "t1" }) },
+    { item: genre({ item_id: "g1" }) },
+    { item: radio({ item_id: "r1" }) },
+    { item: audioSource({ item_id: "as1" }) },
   ])(
     "opens the details view for $item.media_type when the setting is 'browse'",
     async ({ item }) => {

--- a/tests/helpers/mediaItemClickActions.test.ts
+++ b/tests/helpers/mediaItemClickActions.test.ts
@@ -163,11 +163,7 @@ describe("handleMediaItemClick honours default_click_action_*", () => {
     },
     {
       item: radio({ item_id: "r1" }),
-      key: "default_click_action_live_sources",
-    },
-    {
-      item: audioSource({ item_id: "as1" }),
-      key: "default_click_action_live_sources",
+      key: "default_click_action_radio",
     },
   ])(
     "plays $item.media_type directly when its click-action setting is 'play'",
@@ -182,6 +178,32 @@ describe("handleMediaItemClick honours default_click_action_*", () => {
     },
   );
 
+  it("plays an audio source directly without reading a click-action setting", async () => {
+    const source = audioSource({ item_id: "as1" });
+
+    await handleMediaItemClick(source, 0, 0);
+
+    expect(mockGetCoreConfigValue).not.toHaveBeenCalled();
+    expect(mockPlayMedia).toHaveBeenCalledWith(source);
+    expect(mockRouterPush).not.toHaveBeenCalled();
+  });
+
+  it("keeps a non-playable genre on the details view even when its setting is 'play'", async () => {
+    const nonPlayableGenre = genre({ item_id: "g2" });
+    mockGetCoreConfigValue.mockResolvedValue("play");
+
+    await handleMediaItemClick(nonPlayableGenre, 0, 0);
+
+    expect(mockRouterPush).toHaveBeenCalledWith({
+      name: nonPlayableGenre.media_type,
+      params: {
+        itemId: nonPlayableGenre.item_id,
+        provider: nonPlayableGenre.provider,
+      },
+    });
+    expect(mockPlayMedia).not.toHaveBeenCalled();
+  });
+
   it.each([
     { item: album({ item_id: "a1" }) },
     { item: artist({ item_id: "ar1" }) },
@@ -189,7 +211,6 @@ describe("handleMediaItemClick honours default_click_action_*", () => {
     { item: track({ item_id: "t1" }) },
     { item: genre({ item_id: "g1" }) },
     { item: radio({ item_id: "r1" }) },
-    { item: audioSource({ item_id: "as1" }) },
   ])(
     "opens the details view for $item.media_type when the setting is 'browse'",
     async ({ item }) => {

--- a/tests/helpers/mediaItemClickActions.test.ts
+++ b/tests/helpers/mediaItemClickActions.test.ts
@@ -209,7 +209,7 @@ describe("handleMediaItemClick honours default_click_action_*", () => {
     { item: artist({ item_id: "ar1" }) },
     { item: playlist({ item_id: "pl2" }) },
     { item: track({ item_id: "t1" }) },
-    { item: genre({ item_id: "g1" }) },
+    { item: genre({ item_id: "g1", is_playable: true }) },
     { item: radio({ item_id: "r1" }) },
   ])(
     "opens the details view for $item.media_type when the setting is 'browse'",


### PR DESCRIPTION
# What does this implement/fix?

Extends configurable click behavior to tracks, genres, and radio stations. Audio sources have no browse view, so clicking one now always starts playback instead.

- Add Open/Play settings for tracks, genres, and radio stations.
- Play audio sources directly without a redundant setting.
- Keep non-playable items opening their details view.

**Related issue (if applicable):**

- n/a

**Related backend PR (if applicable):**

<!--
Link the music-assistant/server PR when this change relies on new server
behaviour, so the two can be reviewed and released together.
-->

- related backend PR https://github.com/music-assistant/server/pull/5764

## Types of changes

<!--
Tick exactly one box below. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm lint:check` passes.
- [x] `pnpm test:run` passes, and tests have been added/updated where applicable.
- [x] `pnpm build` passes.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.