### PR TITLE
Replace clashing visualizer menu icons and lower default opacity

### DIFF
--- a/src/components/VisualizerCanvas.vue
+++ b/src/components/VisualizerCanvas.vue
@@ -30,7 +30,11 @@ import {
   isVisualizerSupported,
 } from "@/composables/visualizer/useVisualizerEngine";
 import { useUserPreferences } from "@/composables/userPreferences";
-import { currentVisualizerPreset } from "@/composables/visualizer/state";
+import {
+  currentVisualizerPreset,
+  VISUALIZER_BLUR_DEFAULT,
+  VISUALIZER_OPACITY_DEFAULT,
+} from "@/composables/visualizer/state";
 import { randomPresetName } from "@/helpers/visualizer/presetLibrary";
 import { DEFAULT_QUALITY } from "@/helpers/visualizer/quality";
 import api from "@/plugins/api";
@@ -54,8 +58,8 @@ const props = withDefaults(
   }>(),
   {
     preset: "",
-    blur: 0,
-    opacity: 100,
+    blur: VISUALIZER_BLUR_DEFAULT,
+    opacity: VISUALIZER_OPACITY_DEFAULT,
     playerId: "",
     coveredWhenFullscreen: false,
   },

--- a/src/composables/visualizer/state.ts
+++ b/src/composables/visualizer/state.ts
@@ -7,3 +7,8 @@
 import { ref } from "vue";
 
 export const currentVisualizerPreset = ref<string | null>(null);
+
+// Defaults for the blur/opacity preferences, shared by the settings page, the
+// fullscreen menu control and the canvas so they cannot drift apart.
+export const VISUALIZER_BLUR_DEFAULT = 0;
+export const VISUALIZER_OPACITY_DEFAULT = 40;

--- a/src/composables/visualizer/state.ts
+++ b/src/composables/visualizer/state.ts
@@ -1,5 +1,5 @@
 /**
- * Tiny shared state between the visualizer canvas and its controls.
+ * Tiny shared state and defaults for the visualizer.
  * The canvas picks presets internally (random modes), so controls that act
  * on "the preset currently showing" read it from here.
  */
@@ -8,7 +8,8 @@ import { ref } from "vue";
 
 export const currentVisualizerPreset = ref<string | null>(null);
 
-// Defaults for the blur/opacity preferences, shared by the settings page, the
-// fullscreen menu control and the canvas so they cannot drift apart.
+// Defaults for the blur/opacity preferences. Every reader goes through these
+// (settings page, fullscreen menu, useVisualizer, and the canvas prop
+// fallbacks) so the four cannot drift apart.
 export const VISUALIZER_BLUR_DEFAULT = 0;
 export const VISUALIZER_OPACITY_DEFAULT = 40;

--- a/src/composables/visualizer/useVisualizer.ts
+++ b/src/composables/visualizer/useVisualizer.ts
@@ -17,6 +17,10 @@ import {
   setUserPreference,
   useUserPreferences,
 } from "@/composables/userPreferences";
+import {
+  VISUALIZER_BLUR_DEFAULT,
+  VISUALIZER_OPACITY_DEFAULT,
+} from "@/composables/visualizer/state";
 import api from "@/plugins/api";
 import { store } from "@/plugins/store";
 import {
@@ -71,8 +75,14 @@ export function toggleVisualizerForPlayer(playerId?: string): void {
 export function useVisualizer(playerId?: MaybeRefOrGetter<string | undefined>) {
   const { getPreference } = useUserPreferences();
   const visualizerPresetPref = getPreference("visualizer_preset", "");
-  const visualizerBlurPref = getPreference("visualizer_blur", 0);
-  const visualizerOpacityPref = getPreference("visualizer_opacity", 100);
+  const visualizerBlurPref = getPreference(
+    "visualizer_blur",
+    VISUALIZER_BLUR_DEFAULT,
+  );
+  const visualizerOpacityPref = getPreference(
+    "visualizer_opacity",
+    VISUALIZER_OPACITY_DEFAULT,
+  );
 
   const visualizerEnabledPref = computed(() =>
     visualizerEnabledForPlayer(toValue(playerId)),

--- a/src/layouts/default/PlayerOSD/VisualizerMenuControl.vue
+++ b/src/layouts/default/PlayerOSD/VisualizerMenuControl.vue
@@ -1,12 +1,13 @@
 <!--
   Inline visualizer options for the fullscreen player's overflow menu:
-  preset picker (full butterchurn library, "random" default) and blur slider.
+  preset picker (full butterchurn library, "random" default), blur and
+  opacity sliders.
   Rendered as a non-selectable menu row; changes persist as user preferences.
 -->
 <template>
   <div v-if="enabledPref" class="visualizer-menu" @pointerdown.stop @click.stop>
     <div class="visualizer-menu__row">
-      <Sparkles :size="20" class="visualizer-menu__icon" />
+      <SwatchBook :size="20" class="visualizer-menu__icon" />
       <Select :model-value="selectValue" @update:model-value="onPresetChange">
         <SelectTrigger class="visualizer-menu__select" size="sm">
           <span class="visualizer-menu__trigger-label">{{ triggerLabel }}</span>
@@ -60,7 +61,7 @@
       <span class="visualizer-menu__value">{{ blurDraft }}px</span>
     </div>
     <div class="visualizer-menu__row">
-      <Blend :size="20" class="visualizer-menu__icon" />
+      <Contrast :size="20" class="visualizer-menu__icon" />
       <Slider
         :model-value="[opacityDraft]"
         :min="10"
@@ -82,11 +83,11 @@
 <script setup lang="ts">
 import { computed, ref, watch } from "vue";
 import {
-  Blend,
+  Contrast,
   Focus,
   Settings as SettingsIcon,
-  Sparkles,
   Star,
+  SwatchBook,
 } from "@lucide/vue";
 import { DropdownMenuItem } from "@/components/ui/dropdown-menu";
 import {
@@ -97,7 +98,11 @@ import {
 } from "@/components/ui/select";
 import { Slider } from "@/components/ui/slider";
 import { useUserPreferences } from "@/composables/userPreferences";
-import { currentVisualizerPreset } from "@/composables/visualizer/state";
+import {
+  currentVisualizerPreset,
+  VISUALIZER_BLUR_DEFAULT,
+  VISUALIZER_OPACITY_DEFAULT,
+} from "@/composables/visualizer/state";
 import { useVisualizer } from "@/composables/visualizer/useVisualizer";
 import { listPresetNames } from "@/helpers/visualizer/presetLibrary";
 import { $t } from "@/plugins/i18n";
@@ -114,8 +119,11 @@ const { visualizerEnabledPref: enabledPref } = useVisualizer(
   () => store.activePlayer?.player_id,
 );
 const presetPref = getPreference("visualizer_preset", "");
-const blurPref = getPreference("visualizer_blur", 0);
-const opacityPref = getPreference("visualizer_opacity", 100);
+const blurPref = getPreference("visualizer_blur", VISUALIZER_BLUR_DEFAULT);
+const opacityPref = getPreference(
+  "visualizer_opacity",
+  VISUALIZER_OPACITY_DEFAULT,
+);
 const favoritesPref = getPreference<string[]>("visualizer_favorites", []);
 const presetModePref = getPreference<string>(
   "visualizer_preset_mode",
@@ -216,20 +224,23 @@ watch(opacityPref, (value) => (opacityDraft.value = value));
 
 const onBlurChange = (value: number[] | undefined) => {
   if (!value) return;
-  blurDraft.value = value[0] ?? 0;
+  blurDraft.value = value[0] ?? VISUALIZER_BLUR_DEFAULT;
 };
 
 const onBlurCommit = (value: number[]) => {
-  void setPreference("visualizer_blur", value[0] ?? 0);
+  void setPreference("visualizer_blur", value[0] ?? VISUALIZER_BLUR_DEFAULT);
 };
 
 const onOpacityChange = (value: number[] | undefined) => {
   if (!value) return;
-  opacityDraft.value = value[0] ?? 100;
+  opacityDraft.value = value[0] ?? VISUALIZER_OPACITY_DEFAULT;
 };
 
 const onOpacityCommit = (value: number[]) => {
-  void setPreference("visualizer_opacity", value[0] ?? 100);
+  void setPreference(
+    "visualizer_opacity",
+    value[0] ?? VISUALIZER_OPACITY_DEFAULT,
+  );
 };
 
 const openSettings = () => {

--- a/src/views/settings/VisualizerConfig.vue
+++ b/src/views/settings/VisualizerConfig.vue
@@ -104,10 +104,15 @@
               :max="100"
               :step="5"
               @update:model-value="
-                (v: number[] | undefined) => (opacityDraft = v?.[0] ?? 100)
+                (v: number[] | undefined) =>
+                  (opacityDraft = v?.[0] ?? VISUALIZER_OPACITY_DEFAULT)
               "
               @value-commit="
-                (v: number[]) => setPref('visualizer_opacity', v[0] ?? 100)
+                (v: number[]) =>
+                  setPref(
+                    'visualizer_opacity',
+                    v[0] ?? VISUALIZER_OPACITY_DEFAULT,
+                  )
               "
             />
             <span class="w-12 text-right text-sm tabular-nums"
@@ -134,10 +139,12 @@
               :max="30"
               :step="1"
               @update:model-value="
-                (v: number[] | undefined) => (blurDraft = v?.[0] ?? 0)
+                (v: number[] | undefined) =>
+                  (blurDraft = v?.[0] ?? VISUALIZER_BLUR_DEFAULT)
               "
               @value-commit="
-                (v: number[]) => setPref('visualizer_blur', v[0] ?? 0)
+                (v: number[]) =>
+                  setPref('visualizer_blur', v[0] ?? VISUALIZER_BLUR_DEFAULT)
               "
             />
             <span class="w-12 text-right text-sm tabular-nums"
@@ -151,7 +158,7 @@
     <Card>
       <CardHeader>
         <div class="flex items-center gap-2">
-          <Sparkles class="size-4 text-primary" />
+          <SwatchBook class="size-4 text-primary" />
           <CardTitle>{{ $t("visualizer.section_presets") }}</CardTitle>
         </div>
       </CardHeader>
@@ -317,8 +324,8 @@ import {
   Droplet,
   Heart,
   SlidersHorizontal,
-  Sparkles,
   Star,
+  SwatchBook,
   X,
 } from "@lucide/vue";
 import {
@@ -338,6 +345,10 @@ import {
 import { Slider } from "@/components/ui/slider";
 import { Switch } from "@/components/ui/switch";
 import { useUserPreferences } from "@/composables/userPreferences";
+import {
+  VISUALIZER_BLUR_DEFAULT,
+  VISUALIZER_OPACITY_DEFAULT,
+} from "@/composables/visualizer/state";
 import { listPresetNames } from "@/helpers/visualizer/presetLibrary";
 import {
   DEFAULT_QUALITY,
@@ -355,8 +366,11 @@ const qualityPref = getPreference<string>(
   "visualizer_quality",
   DEFAULT_QUALITY,
 );
-const opacityPref = getPreference("visualizer_opacity", 100);
-const blurPref = getPreference("visualizer_blur", 0);
+const opacityPref = getPreference(
+  "visualizer_opacity",
+  VISUALIZER_OPACITY_DEFAULT,
+);
+const blurPref = getPreference("visualizer_blur", VISUALIZER_BLUR_DEFAULT);
 const presetModePref = getPreference<string>(
   "visualizer_preset_mode",
   "random",

--- a/tests/composables/visualizer/useVisualizer.test.ts
+++ b/tests/composables/visualizer/useVisualizer.test.ts
@@ -5,8 +5,13 @@
  */
 import {
   playerSupportsVisualizer,
+  useVisualizer,
   visualizerEnabledForPlayer,
 } from "@/composables/visualizer/useVisualizer";
+import {
+  VISUALIZER_BLUR_DEFAULT,
+  VISUALIZER_OPACITY_DEFAULT,
+} from "@/composables/visualizer/state";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const apiMock = vi.hoisted(() => ({
@@ -23,7 +28,11 @@ vi.mock("@/plugins/store", () => storeMock);
 
 vi.mock("@/composables/userPreferences", () => ({
   setUserPreference: vi.fn(),
-  useUserPreferences: () => ({ getPreference: () => ({ value: undefined }) }),
+  useUserPreferences: () => ({
+    getPreference: (_key: string, defaultValue: unknown) => ({
+      value: defaultValue,
+    }),
+  }),
 }));
 
 vi.mock("@/plugins/visualizer-relay", () => ({
@@ -93,5 +102,28 @@ describe("visualizerEnabledForPlayer", () => {
     storeMock.store.currentUser.preferences["visualizer_enabled.capable"] =
       false;
     expect(visualizerEnabledForPlayer("capable")).toBe(false);
+  });
+});
+
+describe("blur and opacity defaults", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    apiMock.players = { capable: player(["sendspin"]) };
+  });
+
+  // The same two numbers used to sit hardcoded in four places; these assertions
+  // are what stops them drifting apart again.
+  it("falls back to the shared constants when nothing is stored", () => {
+    const { visualizerBlurPref, visualizerOpacityPref } =
+      useVisualizer("capable");
+    expect(visualizerBlurPref.value).toBe(VISUALIZER_BLUR_DEFAULT);
+    expect(visualizerOpacityPref.value).toBe(VISUALIZER_OPACITY_DEFAULT);
+  });
+
+  it("starts unblurred at 40%, on a step the slider can land on", () => {
+    expect(VISUALIZER_BLUR_DEFAULT).toBe(0);
+    expect(VISUALIZER_OPACITY_DEFAULT).toBe(40);
+    // the opacity slider runs 10..100 in steps of 5
+    expect(VISUALIZER_OPACITY_DEFAULT % 5).toBe(0);
   });
 });


### PR DESCRIPTION
# What does this implement/fix?

The preset picker used `Sparkles`, which is also Enable AI Radio DJ one row
above it, and the opacity slider used `Blend`, which is the crossfade mark.
They are now `SwatchBook` and `Contrast`, and the Presets card in visualizer
settings follows. Default opacity drops from 100 to 40, which also applies to
existing users who never moved the slider.

![image](https://github.com/user-attachments/assets/dd71864e-213b-4e5d-8810-7b58ed14d28e)

**Related issue (if applicable):**

- related issue `<link to issue>`

**Related backend PR (if applicable):**

<!--
Link the music-assistant/server PR when this change relies on new server
behaviour, so the two can be reviewed and released together.
-->

- related backend PR `<link to PR>`

## Types of changes

<!--
Tick exactly one box below. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm lint:check` passes.
- [x] `pnpm test:run` passes, and tests have been added/updated where applicable.
- [x] `pnpm build` passes.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.

