### PR TITLE
Polish the styling of the Music Quiz a bit

### DIFF
--- a/src/components/MediaSearch.vue
+++ b/src/components/MediaSearch.vue
@@ -1,8 +1,11 @@
 <template>
   <div class="media-search">
     <Popover :open="panelOpen">
-      <PopoverAnchor ref="anchorRef">
-        <SearchInput
+      <PopoverAnchor
+        ref="anchorRef"
+        @pointerdown="dismissed = false"
+        @focusin="dismissed = false"
+      >
           :id="inputId"
           v-model="query"
           clearable

--- a/src/components/MediaSearch.vue
+++ b/src/components/MediaSearch.vue
@@ -1,38 +1,74 @@
 <template>
   <div class="media-search">
-    <SearchInput
-      :id="inputId"
-      v-model="query"
-      clearable
-      :placeholder="placeholder || $t('type_to_search')"
-      :aria-label="$t('search')"
-    >
-      <!-- media type filter inlined in the search box -->
-      <template v-if="showMediaTypeFilter" #append>
-        <FacetedFilter
-          v-model="selectedMediaTypes"
-          :title="$t('media_type')"
-          :options="mediaTypeOptions"
+    <Popover :open="panelOpen">
+      <PopoverAnchor ref="anchorRef">
+        <SearchInput
+          :id="inputId"
+          v-model="query"
+          clearable
+          :placeholder="placeholder || $t('type_to_search')"
+          :aria-label="$t('search')"
         >
-          <template #trigger>
-            <InputGroupButton
-              type="button"
-              class="media-search-type-trigger"
+          <template v-if="showMediaTypeFilter" #append>
+            <FacetedFilter
+              v-model="selectedMediaTypes"
               :title="$t('media_type')"
-              :aria-label="$t('media_type')"
+              :options="mediaTypeOptions"
             >
-              <ListFilter class="size-4" />
-              <span
-                v-if="selectedMediaTypes.length"
-                class="media-search-type-count"
-              >
-                {{ selectedMediaTypes.length }}
-              </span>
-            </InputGroupButton>
+              <template #trigger>
+                <InputGroupButton
+                  type="button"
+                  class="media-search-type-trigger"
+                  :title="$t('media_type')"
+                  :aria-label="$t('media_type')"
+                >
+                  <ListFilter class="size-4" />
+                  <span
+                    v-if="selectedMediaTypes.length"
+                    class="media-search-type-count"
+                  >
+                    {{ selectedMediaTypes.length }}
+                  </span>
+                </InputGroupButton>
+              </template>
+            </FacetedFilter>
           </template>
-        </FacetedFilter>
-      </template>
-    </SearchInput>
+        </SearchInput>
+      </PopoverAnchor>
+
+      <PopoverContent
+        class="media-search-results max-h-[min(18rem,var(--reka-popover-content-available-height))] w-(--reka-popover-trigger-width) overflow-y-auto p-1"
+        align="start"
+        :side="panelSide"
+        :side-offset="PANEL_OFFSET"
+        :avoid-collisions="false"
+        @open-auto-focus.prevent
+        @close-auto-focus.prevent
+        @focus-outside.prevent
+        @escape-key-down="dismissed = true"
+        @pointer-down-outside="onPointerDownOutside"
+      >
+        <button
+          v-for="item in flatResults"
+          :key="item.uri"
+          type="button"
+          class="media-search-result"
+          @click="onResultClick(item)"
+        >
+          <MediaItemThumb :item="item" :size="44" />
+          <span class="media-search-result-text">
+            <strong class="truncate">{{ item.name }}</strong>
+            <small class="truncate">{{ itemSubtitle(item) }}</small>
+          </span>
+        </button>
+        <p v-if="loading" class="media-search-note">
+          {{ $t("searching") }}
+        </p>
+        <p v-else-if="flatResults.length === 0" class="media-search-note">
+          {{ $t("no_content") }}
+        </p>
+      </PopoverContent>
+    </Popover>
 
     <div
       v-if="showProviderFilter && providerTargets.length"
@@ -44,29 +80,6 @@
         :options="providerOptions"
       />
     </div>
-
-    <!-- results panel: filled progressively while targets respond -->
-    <div v-if="panelVisible" class="media-search-results">
-      <button
-        v-for="item in flatResults"
-        :key="item.uri"
-        type="button"
-        class="media-search-result"
-        @click="onResultClick(item)"
-      >
-        <MediaItemThumb :item="item" :size="44" />
-        <span class="media-search-result-text">
-          <strong class="truncate">{{ item.name }}</strong>
-          <small class="truncate">{{ itemSubtitle(item) }}</small>
-        </span>
-      </button>
-      <p v-if="loading" class="media-search-note">
-        {{ $t("searching") }}
-      </p>
-      <p v-else-if="flatResults.length === 0" class="media-search-note">
-        {{ $t("no_content") }}
-      </p>
-    </div>
   </div>
 </template>
 
@@ -74,6 +87,11 @@
 import FacetedFilter from "@/components/FacetedFilter.vue";
 import MediaItemThumb from "@/components/MediaItemThumb.vue";
 import { InputGroupButton } from "@/components/ui/input-group";
+import {
+  Popover,
+  PopoverAnchor,
+  PopoverContent,
+} from "@/components/ui/popover";
 import { SearchInput } from "@/components/ui/search-input";
 import {
   LIBRARY_SEARCH_TARGET,
@@ -87,7 +105,17 @@ import {
 } from "@/plugins/api/interfaces";
 import { $t } from "@/plugins/i18n";
 import { ListFilter } from "@lucide/vue";
-import { computed, onBeforeUnmount, ref, watch } from "vue";
+import { unrefElement, useElementBounding, useWindowSize } from "@vueuse/core";
+import {
+  computed,
+  onBeforeUnmount,
+  ref,
+  watch,
+  type ComponentPublicInstance,
+} from "vue";
+
+const PANEL_OFFSET = 4;
+const PANEL_MAX_HEIGHT = 288;
 
 export interface Props {
   // media types this search can return (also the media type filter options)
@@ -132,6 +160,9 @@ const selectedMediaTypes = ref<MediaType[]>(
   ),
 );
 const selectedProviders = ref<string[]>([]);
+const anchorRef = ref<ComponentPublicInstance | null>(null);
+const dismissed = ref(false);
+
 let debounceTimer: ReturnType<typeof setTimeout> | undefined;
 
 const { loading, providerTargets, search, filteredItems } =
@@ -164,6 +195,25 @@ const providerOptions = computed(() => [
 const panelVisible = computed(
   () => query.value.trim().length >= props.minLength,
 );
+const panelOpen = computed(() => panelVisible.value && !dismissed.value);
+
+const { top: anchorTop, bottom: anchorBottom } = useElementBounding(anchorRef);
+const { height: viewportHeight } = useWindowSize();
+const panelSide = computed<"top" | "bottom">(() => {
+  const below = viewportHeight.value - anchorBottom.value - PANEL_OFFSET;
+  const above = anchorTop.value - PANEL_OFFSET;
+  return below < PANEL_MAX_HEIGHT && above > below ? "top" : "bottom";
+});
+
+function onPointerDownOutside(event: CustomEvent<{ originalEvent: Event }>) {
+  const target = event.detail.originalEvent.target;
+  const anchor = unrefElement(anchorRef);
+  if (target instanceof Node && anchor?.contains(target)) {
+    event.preventDefault();
+    return;
+  }
+  dismissed.value = true;
+}
 
 // The results show no provider information, so the same item returned by
 // multiple providers reads as a plain duplicate: collapse by name (and
@@ -217,6 +267,7 @@ const onResultClick = function (item: MediaItemTypeOrItemMapping) {
 };
 
 watch(query, () => {
+  dismissed.value = false;
   clearTimeout(debounceTimer);
   const trimmed = query.value.trim();
   if (trimmed.length < props.minLength) {
@@ -261,13 +312,7 @@ onBeforeUnmount(() => {
 }
 
 .media-search-results {
-  max-height: 288px;
-  overflow-y: auto;
   overscroll-behavior: contain;
-  border: 1px solid rgba(var(--v-border-color), var(--v-border-opacity));
-  border-radius: 8px;
-  padding: 4px;
-  background: rgb(var(--v-theme-background));
 }
 
 .media-search-result {

--- a/src/components/MediaSearch.vue
+++ b/src/components/MediaSearch.vue
@@ -1,16 +1,15 @@
 <template>
   <div class="media-search">
     <Popover :open="panelOpen">
-      <PopoverAnchor
-        ref="anchorRef"
-        @pointerdown="dismissed = false"
-        @focusin="dismissed = false"
-      >
+      <PopoverAnchor ref="anchorRef">
+        <SearchInput
           :id="inputId"
           v-model="query"
           clearable
           :placeholder="placeholder || $t('type_to_search')"
           :aria-label="$t('search')"
+          @focus="dismissed = false"
+          @pointerdown="dismissed = false"
         >
           <template v-if="showMediaTypeFilter" #append>
             <FacetedFilter
@@ -164,6 +163,9 @@ const selectedMediaTypes = ref<MediaType[]>(
 );
 const selectedProviders = ref<string[]>([]);
 const anchorRef = ref<ComponentPublicInstance | null>(null);
+// Escape / an outside click hides the panel without clearing the query, so the
+// query alone cannot decide whether it is open. Refocusing or clicking the field
+// brings it back, as does editing the query (see the watcher below).
 const dismissed = ref(false);
 
 let debounceTimer: ReturnType<typeof setTimeout> | undefined;

--- a/src/components/music-quiz/MusicQuizLeaderboard.vue
+++ b/src/components/music-quiz/MusicQuizLeaderboard.vue
@@ -10,9 +10,13 @@
     <CardHeader :class="compact ? 'px-3' : 'px-4'">
       <CardTitle :class="compact ? 'text-sm' : 'text-base'">
         {{ title ?? $t("providers.music_quiz.leaderboard") }}
+        <span class="text-muted-foreground font-normal">
+          ({{ rows.length }})
+        </span>
       </CardTitle>
     </CardHeader>
     <CardContent
+      v-if="rows.length"
       :class="[
         compact
           ? scrollable
@@ -58,15 +62,11 @@
           >
             {{ row.name }}
           </span>
-          <span
-            class="flex min-w-0 max-w-[45%] items-center gap-1 tabular-nums"
-          >
-            <strong class="min-w-0 flex-1 truncate leading-none">
-              {{ row.score }}
-            </strong>
+          <span class="flex shrink-0 items-center gap-1 tabular-nums">
+            <strong class="leading-none">{{ row.score }}</strong>
             <span
               v-if="row.roundScoreLabel"
-              class="text-primary quiz-score-pop min-w-0 flex-1 truncate text-xs leading-none font-semibold"
+              class="text-primary quiz-score-pop text-xs leading-none font-semibold"
             >
               {{ row.roundScoreLabel }}
             </span>

--- a/src/components/music-quiz/MusicQuizLeaderboard.vue
+++ b/src/components/music-quiz/MusicQuizLeaderboard.vue
@@ -59,12 +59,14 @@
             {{ row.name }}
           </span>
           <span
-            class="flex min-w-0 max-w-[45%] items-baseline gap-1 tabular-nums"
+            class="flex min-w-0 max-w-[45%] items-center gap-1 tabular-nums"
           >
-            <strong class="min-w-0 flex-1 truncate">{{ row.score }}</strong>
+            <strong class="min-w-0 flex-1 truncate leading-none">
+              {{ row.score }}
+            </strong>
             <span
               v-if="row.roundScoreLabel"
-              class="text-primary quiz-score-pop min-w-0 flex-1 truncate text-xs font-semibold"
+              class="text-primary quiz-score-pop min-w-0 flex-1 truncate text-xs leading-none font-semibold"
             >
               {{ row.roundScoreLabel }}
             </span>

--- a/src/components/music-quiz/MusicQuizPlaybackControls.vue
+++ b/src/components/music-quiz/MusicQuizPlaybackControls.vue
@@ -58,63 +58,69 @@
         >
           <label
             for="music-quiz-playback-venue"
-            class="flex min-w-0 items-start gap-3 rounded-lg border p-3 transition-colors"
+            class="grid min-w-0 grid-cols-[auto_minmax(0,1fr)] items-center gap-x-3 gap-y-1 rounded-lg border p-3 transition-colors"
             :class="modeCardClasses('venue', venueAvailable)"
           >
             <RadioGroupItem
               id="music-quiz-playback-venue"
               value="venue"
+              class="rounded-[4px] data-[state=checked]:border-primary data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground dark:data-[state=checked]:bg-primary dark:data-[state=unchecked]:bg-transparent"
               :disabled="disabled || !venueAvailable"
               aria-describedby="music-quiz-playback-venue-description"
-            />
-            <span class="flex min-w-0 flex-col gap-1">
-              <span class="font-medium">
-                {{ $t("providers.music_quiz.playback_venue") }}
-              </span>
-              <span
-                id="music-quiz-playback-venue-description"
-                class="text-muted-foreground text-sm"
-              >
-                {{ $t("providers.music_quiz.playback_venue_help") }}
-              </span>
-              <span
-                v-if="!venueAvailable"
-                class="text-destructive text-xs"
-                data-testid="music-quiz-venue-unavailable"
-              >
-                {{ venueUnavailableReason }}
-              </span>
+            >
+              <Check
+                class="absolute top-1/2 left-1/2 size-3.5 -translate-x-1/2 -translate-y-1/2"
+              />
+            </RadioGroupItem>
+            <span class="min-w-0 font-medium">
+              {{ $t("providers.music_quiz.playback_venue") }}
+            </span>
+            <span
+              id="music-quiz-playback-venue-description"
+              class="text-muted-foreground col-start-2 text-sm"
+            >
+              {{ $t("providers.music_quiz.playback_venue_help") }}
+            </span>
+            <span
+              v-if="!venueAvailable"
+              class="text-destructive col-start-2 text-xs"
+              data-testid="music-quiz-venue-unavailable"
+            >
+              {{ venueUnavailableReason }}
             </span>
           </label>
 
           <label
             for="music-quiz-playback-remote"
-            class="flex min-w-0 items-start gap-3 rounded-lg border p-3 transition-colors"
+            class="grid min-w-0 grid-cols-[auto_minmax(0,1fr)] items-center gap-x-3 gap-y-1 rounded-lg border p-3 transition-colors"
             :class="modeCardClasses('remote', options.remote_available)"
           >
             <RadioGroupItem
               id="music-quiz-playback-remote"
               value="remote"
+              class="rounded-[4px] data-[state=checked]:border-primary data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground dark:data-[state=checked]:bg-primary dark:data-[state=unchecked]:bg-transparent"
               :disabled="disabled || !options.remote_available"
               aria-describedby="music-quiz-playback-remote-description"
-            />
-            <span class="flex min-w-0 flex-col gap-1">
-              <span class="font-medium">
-                {{ $t("providers.music_quiz.playback_remote") }}
-              </span>
-              <span
-                id="music-quiz-playback-remote-description"
-                class="text-muted-foreground text-sm"
-              >
-                {{ $t("providers.music_quiz.playback_remote_help") }}
-              </span>
-              <span
-                v-if="!options.remote_available"
-                class="text-destructive text-xs"
-                data-testid="music-quiz-remote-unavailable"
-              >
-                {{ $t("providers.music_quiz.playback_remote_unavailable") }}
-              </span>
+            >
+              <Check
+                class="absolute top-1/2 left-1/2 size-3.5 -translate-x-1/2 -translate-y-1/2"
+              />
+            </RadioGroupItem>
+            <span class="min-w-0 font-medium">
+              {{ $t("providers.music_quiz.playback_remote") }}
+            </span>
+            <span
+              id="music-quiz-playback-remote-description"
+              class="text-muted-foreground col-start-2 text-sm"
+            >
+              {{ $t("providers.music_quiz.playback_remote_help") }}
+            </span>
+            <span
+              v-if="!options.remote_available"
+              class="text-destructive col-start-2 text-xs"
+              data-testid="music-quiz-remote-unavailable"
+            >
+              {{ $t("providers.music_quiz.playback_remote_unavailable") }}
             </span>
           </label>
         </RadioGroup>
@@ -124,24 +130,28 @@
         <FieldLabel for="music-quiz-venue-player">
           {{ $t("providers.music_quiz.player") }}
         </FieldLabel>
-        <NativeSelect
-          id="music-quiz-venue-player"
-          v-model="venuePlayerId"
-          class="w-full"
-          :disabled="disabled || !venueAvailable"
-          :aria-invalid="!disabled && venueAvailable && !venueSelectionValid"
-        >
-          <option value="" disabled>
-            {{ $t("providers.music_quiz.choose_player") }}
-          </option>
-          <option
-            v-for="player in options.venue_players"
-            :key="player.player_id"
-            :value="player.player_id"
+        <Select v-model="venuePlayerId" :disabled="disabled || !venueAvailable">
+          <SelectTrigger
+            id="music-quiz-venue-player"
+            class="w-full"
+            :aria-invalid="!disabled && venueAvailable && !venueSelectionValid"
           >
-            {{ player.name }}
-          </option>
-        </NativeSelect>
+            <SelectValue
+              :placeholder="$t('providers.music_quiz.choose_player')"
+            >
+              {{ venuePlayerName ?? $t("providers.music_quiz.choose_player") }}
+            </SelectValue>
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem
+              v-for="player in options.venue_players"
+              :key="player.player_id"
+              :value="player.player_id"
+            >
+              {{ player.name }}
+            </SelectItem>
+          </SelectContent>
+        </Select>
       </Field>
 
       <p
@@ -157,22 +167,28 @@
 </template>
 
 <script setup lang="ts">
+import { Button } from "@/components/ui/button";
 import {
   Field,
   FieldLabel,
   FieldLegend,
   FieldSet,
 } from "@/components/ui/field";
-import { Button } from "@/components/ui/button";
-import { NativeSelect } from "@/components/ui/native-select";
 import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import type {
   MusicQuizMode,
   MusicQuizPlaybackOptions,
 } from "@/composables/music-quiz/useMusicQuiz";
 import type { MusicQuizPlaybackSelection } from "@/helpers/music_quiz_playback";
 import { $t } from "@/plugins/i18n";
-import { LoaderCircle, RefreshCw, TriangleAlert } from "@lucide/vue";
+import { Check, LoaderCircle, RefreshCw, TriangleAlert } from "@lucide/vue";
 import type { AcceptableValue } from "reka-ui";
 import { computed } from "vue";
 
@@ -203,9 +219,15 @@ const venueSelectionValid = computed(
     ),
 );
 const venuePlayerId = computed({
-  get: () => props.modelValue.venuePlayerId ?? "",
+  get: () => props.modelValue.venuePlayerId ?? undefined,
   set: (value: AcceptableValue) => updateVenuePlayer(value),
 });
+const venuePlayerName = computed(
+  () =>
+    props.options?.venue_players.find(
+      (player) => player.player_id === props.modelValue.venuePlayerId,
+    )?.name,
+);
 const venueUnavailableReason = computed(() =>
   props.options?.venue_players.length === 0
     ? $t("providers.music_quiz.no_available_players")

--- a/src/components/music-quiz/MusicQuizPlayerHeader.vue
+++ b/src/components/music-quiz/MusicQuizPlayerHeader.vue
@@ -9,16 +9,15 @@
         <div class="min-w-0 flex-1">
           <div class="flex items-center gap-2">
             <h1 class="truncate text-lg font-bold">{{ playerName }}</h1>
-            <Badge v-if="rank" variant="secondary" class="shrink-0">
-              #{{ rank }}
-            </Badge>
+            <Badge v-if="rank" class="shrink-0">#{{ rank }}</Badge>
           </div>
         </div>
-        <span
-          class="flex shrink-0 items-baseline gap-1 text-xl font-bold tabular-nums"
-        >
-          {{ score }}
-          <span v-if="scoreDelta" class="text-primary text-sm">
+        <span class="flex shrink-0 items-baseline gap-1 tabular-nums">
+          <span class="text-xl leading-none font-bold">{{ score }}</span>
+          <span
+            v-if="scoreDelta"
+            class="text-primary text-sm leading-none font-semibold"
+          >
             {{ scoreDelta }}
           </span>
         </span>

--- a/src/components/music-quiz/MusicQuizPlayerHeader.vue
+++ b/src/components/music-quiz/MusicQuizPlayerHeader.vue
@@ -12,7 +12,7 @@
             <Badge v-if="rank" class="shrink-0">#{{ rank }}</Badge>
           </div>
         </div>
-        <span class="flex shrink-0 items-baseline gap-1 tabular-nums">
+        <span class="flex shrink-0 items-center gap-1 tabular-nums">
           <span class="text-xl leading-none font-bold">{{ score }}</span>
           <span
             v-if="scoreDelta"

--- a/src/components/music-quiz/MusicQuizSessionHeader.vue
+++ b/src/components/music-quiz/MusicQuizSessionHeader.vue
@@ -33,12 +33,7 @@
           class="flex flex-wrap items-center"
           :class="present ? 'mt-0.5 gap-1.5' : 'mt-1 gap-2'"
         >
-          <Badge
-            variant="secondary"
-            role="status"
-            aria-live="polite"
-            aria-atomic="true"
-          >
+          <Badge role="status" aria-live="polite" aria-atomic="true">
             {{ phaseLabel }}
           </Badge>
           <Badge v-if="roundLabel" variant="outline">{{ roundLabel }}</Badge>

--- a/src/components/music-quiz/MusicQuizSetupWizard.vue
+++ b/src/components/music-quiz/MusicQuizSetupWizard.vue
@@ -7,45 +7,51 @@
     />
 
     <div
-      class="flex-col gap-2"
-      :class="busy ? 'hidden' : 'flex'"
-      data-testid="music-quiz-setup-progress"
+      class="flex min-w-0 items-center gap-2 pr-8"
+      :class="{ hidden: busy }"
+      data-testid="music-quiz-setup-header"
     >
-      <div class="flex items-center justify-between gap-3">
-        <Button
-          v-if="step > 1"
-          variant="ghost"
-          size="sm"
-          :disabled="busy"
-          @click="back"
-        >
-          <ArrowLeft class="size-4" />
-          {{ $t("back") }}
-        </Button>
-        <span v-else></span>
-        <span class="text-muted-foreground text-sm font-medium">
-          {{ $t("providers.music_quiz.setup_step", [step, TOTAL_STEPS]) }}
-        </span>
-      </div>
-      <Progress :model-value="(step / TOTAL_STEPS) * 100" />
+      <Button
+        v-if="step === 2"
+        variant="ghost"
+        size="icon"
+        class="-ml-2 shrink-0"
+        :aria-label="$t('back')"
+        :title="$t('back')"
+        :disabled="busy"
+        @click="back"
+      >
+        <ArrowLeft class="size-4" />
+      </Button>
+      <component
+        :is="selectedType.icon"
+        v-if="step === 2 && selectedType"
+        class="text-primary size-5 shrink-0"
+        aria-hidden="true"
+      />
+      <h2
+        ref="stepHeading"
+        class="truncate text-lg font-semibold"
+        tabindex="-1"
+        data-testid="music-quiz-setup-heading"
+      >
+        {{ headingText }}
+      </h2>
     </div>
 
-    <section v-if="!busy && step === 1" class="flex flex-col gap-3">
-      <h2 ref="chooseHeading" class="text-lg font-semibold" tabindex="-1">
-        {{ $t("providers.music_quiz.choose_game_type") }}
-      </h2>
-      <div class="grid gap-3 sm:grid-cols-2">
+    <section v-if="!busy && step === 1" class="flex flex-col gap-3 mt-2">
+      <div class="grid auto-rows-fr gap-3 sm:grid-cols-2">
         <button
           v-for="type in availableGameTypes"
           :key="type.id"
           type="button"
-          class="hover:border-primary focus-visible:ring-ring flex items-start gap-3 rounded-xl border bg-card p-4 text-left transition-colors focus-visible:ring-2 focus-visible:outline-none"
+          class="hover:border-primary focus-visible:ring-ring bg-card flex items-center gap-3 rounded-xl border p-4 text-left transition-colors focus-visible:ring-2 focus-visible:outline-none"
           @click="selectType(type)"
         >
           <span
-            class="bg-primary/10 text-primary grid size-10 shrink-0 place-items-center rounded-lg"
+            class="bg-primary/10 text-primary grid size-12 shrink-0 place-items-center rounded-md"
           >
-            <component :is="type.icon" class="size-5" />
+            <component :is="type.icon" class="size-6" />
           </span>
           <span class="flex min-w-0 flex-col gap-1">
             <span class="flex items-center gap-2 font-semibold">
@@ -64,16 +70,6 @@
       :class="!busy && step === 2 ? 'flex' : 'hidden'"
       data-testid="music-quiz-configure-step"
     >
-      <div class="flex items-center gap-2">
-        <component
-          :is="selectedType.icon"
-          v-if="selectedType"
-          class="text-primary size-5"
-        />
-        <h2 ref="configureHeading" class="text-lg font-semibold" tabindex="-1">
-          {{ $t("providers.music_quiz.configure_game") }}
-        </h2>
-      </div>
       <MusicQuizPlaybackControls
         v-if="playbackOptionsLoading || playbackOptions || playbackOptionsError"
         v-model="playbackSelection"
@@ -130,7 +126,6 @@ import MusicQuizPlaybackControls from "@/components/music-quiz/MusicQuizPlayback
 import MusicQuizPreparingState from "@/components/music-quiz/MusicQuizPreparingState.vue";
 import { Button } from "@/components/ui/button";
 import { Field, FieldDescription, FieldLabel } from "@/components/ui/field";
-import { Progress } from "@/components/ui/progress";
 import { Switch } from "@/components/ui/switch";
 import type {
   MusicQuizCreateRequest,
@@ -146,7 +141,6 @@ import { $t } from "@/plugins/i18n";
 import { ArrowLeft } from "@lucide/vue";
 import { computed, defineComponent, nextTick, ref, watch } from "vue";
 
-const TOTAL_STEPS = 2;
 const MusicQuizSetupPlaceholder = defineComponent({
   inheritAttrs: false,
   setup: () => () => null,
@@ -191,8 +185,14 @@ const availableGameTypes = computed(() =>
 const step = ref<1 | 2>(1);
 const selectedType = ref<MusicQuizGameDefinition | null>(null);
 const includeSimilarMusic = ref(false);
-const chooseHeading = ref<HTMLHeadingElement | null>(null);
-const configureHeading = ref<HTMLHeadingElement | null>(null);
+const stepHeading = ref<HTMLHeadingElement | null>(null);
+const headingText = computed(() =>
+  step.value === 1
+    ? $t("providers.music_quiz.choose_game_type")
+    : selectedType.value
+      ? $t(selectedType.value.labelKey)
+      : $t("providers.music_quiz.configure_game"),
+);
 const sharedConfigValid = computed(() => {
   if (props.playbackOptionsLoading) return false;
   if (props.playbackOptions) {
@@ -225,13 +225,13 @@ async function selectType(type: MusicQuizGameDefinition) {
   await nextTick();
   step.value = 2;
   await nextTick();
-  configureHeading.value?.focus({ preventScroll: true });
+  stepHeading.value?.focus({ preventScroll: true });
 }
 
 async function back() {
   step.value = 1;
   await nextTick();
-  chooseHeading.value?.focus({ preventScroll: true });
+  stepHeading.value?.focus({ preventScroll: true });
 }
 
 function onConfigCreate(request: MusicQuizCreateRequest) {

--- a/src/components/music-quiz/MusicQuizSetupWizard.vue
+++ b/src/components/music-quiz/MusicQuizSetupWizard.vue
@@ -1,5 +1,8 @@
 <template>
-  <div class="relative flex flex-col gap-5" :class="{ 'min-h-64': busy }">
+  <div
+    class="relative isolate flex flex-col gap-5"
+    :class="{ 'min-h-64': busy }"
+  >
     <MusicQuizPreparingState
       v-if="busy"
       autofocus

--- a/src/components/music-quiz/MusicQuizSourceSelector.vue
+++ b/src/components/music-quiz/MusicQuizSourceSelector.vue
@@ -22,7 +22,7 @@
         <span class="text-muted-foreground">
           {{ $t("providers.music_quiz.selected_music") }}
         </span>
-        <Badge variant="secondary">{{ selectedSummary }}</Badge>
+        <Badge>{{ selectedSummary }}</Badge>
       </div>
       <div
         v-if="selectedSources.length"

--- a/src/components/music-quiz/answer-types/multiple-choice/MultipleChoiceProgress.vue
+++ b/src/components/music-quiz/answer-types/multiple-choice/MultipleChoiceProgress.vue
@@ -5,9 +5,7 @@
         {{ $t("providers.music_quiz.answers") }}
       </CardTitle>
       <CardAction>
-        <Badge variant="secondary"
-          >{{ answeredCount }} / {{ statuses.length }}</Badge
-        >
+        <Badge>{{ answeredCount }} / {{ statuses.length }}</Badge>
       </CardAction>
     </CardHeader>
     <CardContent

--- a/src/components/music-quiz/answer-types/timeline/TimelineProgress.vue
+++ b/src/components/music-quiz/answer-types/timeline/TimelineProgress.vue
@@ -8,9 +8,7 @@
         <Badge variant="outline">
           {{ $t("providers.music_quiz.timeline_placed_count", [placedCount]) }}
         </Badge>
-        <Badge variant="secondary">
-          {{ completedCount }} / {{ statuses.length }}
-        </Badge>
+        <Badge>{{ completedCount }} / {{ statuses.length }}</Badge>
       </CardAction>
     </CardHeader>
     <CardContent

--- a/src/components/music-quiz/game-types/guess-the-song/GuessTheSongSetup.vue
+++ b/src/components/music-quiz/game-types/guess-the-song/GuessTheSongSetup.vue
@@ -59,17 +59,20 @@
         <FieldLabel for="quiz-difficulty">
           {{ $t("providers.music_quiz.difficulty") }}
         </FieldLabel>
-        <NativeSelect id="quiz-difficulty" v-model="difficulty" class="w-full">
-          <option value="easy">
-            {{ $t("providers.music_quiz.difficulty_easy") }}
-          </option>
-          <option value="normal">
-            {{ $t("providers.music_quiz.difficulty_normal") }}
-          </option>
-          <option value="hard">
-            {{ $t("providers.music_quiz.difficulty_hard") }}
-          </option>
-        </NativeSelect>
+        <Select v-model="difficulty">
+          <SelectTrigger id="quiz-difficulty" class="w-full">
+            <SelectValue>{{ difficultyLabel }}</SelectValue>
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem
+              v-for="option in difficultyOptions"
+              :key="option.value"
+              :value="option.value"
+            >
+              {{ option.label }}
+            </SelectItem>
+          </SelectContent>
+        </Select>
       </Field>
     </div>
 
@@ -85,7 +88,7 @@
       :disabled="busy || !canCreate || !sharedConfigValid"
       @click="create"
     >
-      <PartyPopper class="size-4" />
+      <Plus class="size-4" />
       {{ $t("create") }}
     </Button>
   </div>
@@ -100,7 +103,13 @@ import type {
 } from "@/components/music-quiz/adapter_contracts";
 import { Button } from "@/components/ui/button";
 import { Field, FieldLabel } from "@/components/ui/field";
-import { NativeSelect } from "@/components/ui/native-select";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import {
   NumberField,
   NumberFieldContent,
@@ -112,8 +121,9 @@ import type {
   MusicQuizDifficulty,
   MusicQuizGuessTheSongConfig,
 } from "@/composables/music-quiz/useMusicQuiz";
+import { getMusicQuizDifficultyOptions } from "@/helpers/music_quiz";
 import { $t } from "@/plugins/i18n";
-import { PartyPopper } from "@lucide/vue";
+import { Plus } from "@lucide/vue";
 import { computed, ref } from "vue";
 
 const MIN_ROUNDS = 2;
@@ -135,6 +145,12 @@ const answerDuration = ref(30);
 const difficulty = ref<MusicQuizDifficulty>("normal");
 const sourceUris = ref<string[]>([]);
 const canCreate = computed(() => sourceUris.value.length > 0);
+const difficultyOptions = computed(() => getMusicQuizDifficultyOptions());
+const difficultyLabel = computed(
+  () =>
+    difficultyOptions.value.find((option) => option.value === difficulty.value)
+      ?.label ?? "",
+);
 
 function create() {
   if (!canCreate.value || !props.sharedConfigValid) return;

--- a/src/components/music-quiz/game-types/music-timeline/MusicTimelineSetup.vue
+++ b/src/components/music-quiz/game-types/music-timeline/MusicTimelineSetup.vue
@@ -41,38 +41,40 @@
         <FieldLabel for="music-timeline-artist-bonus">
           {{ $t("providers.music_quiz.timeline_artist_bonus") }}
         </FieldLabel>
-        <NativeSelect
-          id="music-timeline-artist-bonus"
-          v-model="artistBonusMode"
-          class="w-full"
-        >
-          <option
-            v-for="option in bonusModeOptions"
-            :key="option.value"
-            :value="option.value"
-          >
-            {{ option.label }}
-          </option>
-        </NativeSelect>
+        <Select v-model="artistBonusMode">
+          <SelectTrigger id="music-timeline-artist-bonus" class="w-full">
+            <SelectValue>{{ bonusModeLabel(artistBonusMode) }}</SelectValue>
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem
+              v-for="option in bonusModeOptions"
+              :key="option.value"
+              :value="option.value"
+            >
+              {{ option.label }}
+            </SelectItem>
+          </SelectContent>
+        </Select>
       </Field>
 
       <Field>
         <FieldLabel for="music-timeline-title-bonus">
           {{ $t("providers.music_quiz.timeline_title_bonus") }}
         </FieldLabel>
-        <NativeSelect
-          id="music-timeline-title-bonus"
-          v-model="titleBonusMode"
-          class="w-full"
-        >
-          <option
-            v-for="option in bonusModeOptions"
-            :key="option.value"
-            :value="option.value"
-          >
-            {{ option.label }}
-          </option>
-        </NativeSelect>
+        <Select v-model="titleBonusMode">
+          <SelectTrigger id="music-timeline-title-bonus" class="w-full">
+            <SelectValue>{{ bonusModeLabel(titleBonusMode) }}</SelectValue>
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem
+              v-for="option in bonusModeOptions"
+              :key="option.value"
+              :value="option.value"
+            >
+              {{ option.label }}
+            </SelectItem>
+          </SelectContent>
+        </Select>
       </Field>
     </div>
 
@@ -88,7 +90,7 @@
       :disabled="busy || !canCreate || !sharedConfigValid"
       @click="create"
     >
-      <ListPlus class="size-4" />
+      <Plus class="size-4" />
       {{ $t("create") }}
     </Button>
   </div>
@@ -103,7 +105,13 @@ import type {
 } from "@/components/music-quiz/adapter_contracts";
 import { Button } from "@/components/ui/button";
 import { Field, FieldLabel } from "@/components/ui/field";
-import { NativeSelect } from "@/components/ui/native-select";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import {
   NumberField,
   NumberFieldContent,
@@ -116,7 +124,7 @@ import type {
   MusicQuizTimelineBonusMode,
 } from "@/composables/music-quiz/useMusicQuiz";
 import { $t } from "@/plugins/i18n";
-import { ListPlus } from "@lucide/vue";
+import { Plus } from "@lucide/vue";
 import { computed, ref } from "vue";
 
 const MIN_ROUNDS = 1;
@@ -150,6 +158,12 @@ const bonusModeOptions = computed(() => [
     label: $t("providers.music_quiz.timeline_bonus_multiple_choice"),
   },
 ]);
+
+function bonusModeLabel(mode: MusicQuizTimelineBonusMode) {
+  return (
+    bonusModeOptions.value.find((option) => option.value === mode)?.label ?? ""
+  );
+}
 
 function create() {
   if (!canCreate.value || !props.sharedConfigValid) return;

--- a/src/components/music-quiz/game-types/trivia/TriviaSetup.vue
+++ b/src/components/music-quiz/game-types/trivia/TriviaSetup.vue
@@ -59,36 +59,40 @@
         <FieldLabel for="trivia-difficulty">
           {{ $t("providers.music_quiz.difficulty") }}
         </FieldLabel>
-        <NativeSelect
-          id="trivia-difficulty"
-          v-model="difficulty"
-          class="w-full"
-        >
-          <option value="easy">
-            {{ $t("providers.music_quiz.difficulty_easy") }}
-          </option>
-          <option value="normal">
-            {{ $t("providers.music_quiz.difficulty_normal") }}
-          </option>
-          <option value="hard">
-            {{ $t("providers.music_quiz.difficulty_hard") }}
-          </option>
-        </NativeSelect>
+        <Select v-model="difficulty">
+          <SelectTrigger id="trivia-difficulty" class="w-full">
+            <SelectValue>{{ difficultyLabel }}</SelectValue>
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem
+              v-for="option in difficultyOptions"
+              :key="option.value"
+              :value="option.value"
+            >
+              {{ option.label }}
+            </SelectItem>
+          </SelectContent>
+        </Select>
       </Field>
 
       <Field class="sm:col-span-2">
         <FieldLabel for="trivia-language">
           {{ $t("providers.music_quiz.question_language") }}
         </FieldLabel>
-        <NativeSelect id="trivia-language" v-model="language" class="w-full">
-          <option
-            v-for="option in languageOptions"
-            :key="option.value"
-            :value="option.value"
-          >
-            {{ option.label }}
-          </option>
-        </NativeSelect>
+        <Select v-model="language">
+          <SelectTrigger id="trivia-language" class="w-full">
+            <SelectValue>{{ languageLabel }}</SelectValue>
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem
+              v-for="option in languageOptions"
+              :key="option.value"
+              :value="option.value"
+            >
+              {{ option.label }}
+            </SelectItem>
+          </SelectContent>
+        </Select>
       </Field>
 
       <Field
@@ -123,7 +127,7 @@
       :disabled="busy || !canCreate || !sharedConfigValid"
       @click="create"
     >
-      <Brain class="size-4" />
+      <Plus class="size-4" />
       {{ $t("create") }}
     </Button>
   </div>
@@ -138,7 +142,13 @@ import type {
 } from "@/components/music-quiz/adapter_contracts";
 import { Button } from "@/components/ui/button";
 import { Field, FieldDescription, FieldLabel } from "@/components/ui/field";
-import { NativeSelect } from "@/components/ui/native-select";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import {
   NumberField,
   NumberFieldContent,
@@ -151,8 +161,9 @@ import type {
   MusicQuizDifficulty,
   MusicQuizTriviaConfig,
 } from "@/composables/music-quiz/useMusicQuiz";
+import { getMusicQuizDifficultyOptions } from "@/helpers/music_quiz";
 import { $t, canonicalizeLocale, getLocaleOptions, i18n } from "@/plugins/i18n";
-import { Brain } from "@lucide/vue";
+import { Plus } from "@lucide/vue";
 import { computed, ref } from "vue";
 
 const MIN_ROUNDS = 1;
@@ -178,6 +189,17 @@ const sourceUris = ref<string[]>([]);
 const canCreate = computed(() => sourceUris.value.length > 0);
 const languageOptions = computed(() =>
   getLocaleOptions(i18n.global.availableLocales, i18n.global.locale.value),
+);
+const difficultyOptions = computed(() => getMusicQuizDifficultyOptions());
+const difficultyLabel = computed(
+  () =>
+    difficultyOptions.value.find((option) => option.value === difficulty.value)
+      ?.label ?? "",
+);
+const languageLabel = computed(
+  () =>
+    languageOptions.value.find((option) => option.value === language.value)
+      ?.label ?? "",
 );
 
 function create() {

--- a/src/components/music-quiz/game_types.ts
+++ b/src/components/music-quiz/game_types.ts
@@ -25,7 +25,7 @@ import type {
   MusicQuizSupportedPublicState,
   MusicQuizType,
 } from "@/composables/music-quiz/useMusicQuiz";
-import { Brain, Disc3, ListMusic } from "@lucide/vue";
+import { CalendarClock, Disc3, WandSparkles } from "@lucide/vue";
 import { markRaw, type Component } from "vue";
 
 export const DEFAULT_MUSIC_QUIZ_GAME_TYPE: MusicQuizType = "guess_the_song";
@@ -97,7 +97,7 @@ const MUSIC_QUIZ_GAME_TYPE_REGISTRY = {
     descriptionKey: "providers.music_quiz.game_type_music_timeline_description",
     howToPlayDescriptionKey:
       "providers.music_quiz.music_timeline_listen_description",
-    icon: markRaw(ListMusic),
+    icon: markRaw(CalendarClock),
     requiresBackendAvailability: false,
     supportsListenIn: true,
     revealPhaseLabelKey: "providers.music_quiz.phase_enjoy_track",
@@ -117,7 +117,7 @@ const MUSIC_QUIZ_GAME_TYPE_REGISTRY = {
     descriptionKey: "providers.music_quiz.game_type_trivia_description",
     howToPlayDescriptionKey:
       "providers.music_quiz.how_to_play_trivia_description",
-    icon: markRaw(Brain),
+    icon: markRaw(WandSparkles),
     requiresBackendAvailability: true,
     supportsListenIn: (state) =>
       state.quiz_type === "trivia" && state.play_reveal_audio === true,

--- a/src/helpers/music_quiz.ts
+++ b/src/helpers/music_quiz.ts
@@ -1,5 +1,5 @@
 import type {
-  MusicQuizPhase,
+  MusicQuizDifficulty,
   MusicQuizPlayer,
   MusicQuizSupportedPublicState,
 } from "@/composables/music-quiz/useMusicQuiz";
@@ -249,6 +249,17 @@ export function getMusicQuizRoundScoreLabel(
 ) {
   const points = getMusicQuizRoundScore(state, playerName);
   return points === undefined ? "" : `(+${points})`;
+}
+
+export function getMusicQuizDifficultyOptions(): {
+  value: MusicQuizDifficulty;
+  label: string;
+}[] {
+  return [
+    { value: "easy", label: $t("providers.music_quiz.difficulty_easy") },
+    { value: "normal", label: $t("providers.music_quiz.difficulty_normal") },
+    { value: "hard", label: $t("providers.music_quiz.difficulty_hard") },
+  ];
 }
 
 export function getMusicQuizErrorMessage(err: unknown, fallback = "") {

--- a/src/views/MusicQuizDashboardView.vue
+++ b/src/views/MusicQuizDashboardView.vue
@@ -5,7 +5,7 @@
     :class="
       presentMode
         ? 'w-full lg:h-full lg:min-h-0 lg:overflow-hidden'
-        : 'mx-auto w-full max-w-6xl p-4 sm:p-5'
+        : 'mx-auto flex min-h-full w-full max-w-6xl flex-col p-4 sm:p-5'
     "
   >
     <MusicQuizPresentStage
@@ -25,7 +25,7 @@
       @exit="exitPresentMode"
     />
 
-    <section v-else class="flex flex-col gap-4">
+    <section v-else class="flex flex-1 flex-col gap-4">
       <header class="flex items-center justify-between gap-3">
         <div class="min-w-0">
           <h1 class="text-2xl font-bold">
@@ -58,33 +58,39 @@
 
       <MusicQuizConnectionBanners :degraded="isConnectionDegraded" />
 
-      <Card v-if="!state && !loading" class="mx-auto w-full max-w-xl">
-        <CardContent
-          class="flex flex-col items-center gap-4 px-5 py-8 text-center sm:px-8"
+      <div
+        v-if="!state && !loading"
+        class="flex flex-1 items-center justify-center"
+      >
+        <Empty
+          class="bg-card w-full max-w-xl rounded-xl border border-solid px-5 py-10 shadow-sm sm:px-8"
         >
-          <span
-            class="bg-primary/10 text-primary grid size-14 place-items-center rounded-full"
-          >
-            <PartyPopper class="size-7" />
-          </span>
-          <div class="flex flex-col gap-1">
-            <h2 class="text-xl font-bold">
+          <EmptyHeader>
+            <EmptyMedia
+              variant="icon"
+              class="bg-primary/10 text-primary size-14 rounded-full"
+            >
+              <MicVocal class="size-7" />
+            </EmptyMedia>
+            <EmptyTitle class="text-xl font-bold">
               {{ $t("providers.music_quiz.no_active_game") }}
-            </h2>
-            <p class="text-muted-foreground">
+            </EmptyTitle>
+            <EmptyDescription class="text-base">
               {{ $t("providers.music_quiz.create_intro") }}
-            </p>
-          </div>
-          <Button
-            size="lg"
-            data-testid="new-game-empty"
-            @click="openSetupDialog"
-          >
-            <Plus class="size-4" />
-            {{ $t("providers.music_quiz.new_game") }}
-          </Button>
-        </CardContent>
-      </Card>
+            </EmptyDescription>
+          </EmptyHeader>
+          <EmptyContent>
+            <Button
+              size="lg"
+              data-testid="new-game-empty"
+              @click="openSetupDialog"
+            >
+              <Plus class="size-4" />
+              {{ $t("providers.music_quiz.new_game") }}
+            </Button>
+          </EmptyContent>
+        </Empty>
+      </div>
 
       <MusicQuizUnsupportedGame
         v-else-if="state && !activeState"
@@ -176,7 +182,7 @@
         data-testid="setup-dialog"
         class="max-h-[calc(100dvh-1rem)] overflow-y-auto p-4 sm:max-w-[calc(100%-2rem)] sm:p-6 lg:max-w-3xl"
       >
-        <DialogHeader class="pr-8 text-left">
+        <DialogHeader class="sr-only">
           <DialogTitle>{{ $t("providers.music_quiz.new_game") }}</DialogTitle>
           <DialogDescription>
             {{ $t("providers.music_quiz.create_intro") }}
@@ -206,26 +212,25 @@
 </template>
 
 <script setup lang="ts">
-import MusicQuizConnectionBanners from "@/components/music-quiz/MusicQuizConnectionBanners.vue";
-import MusicQuizEndGameDialog from "@/components/music-quiz/MusicQuizEndGameDialog.vue";
 import {
   getMusicQuizPhaseLabelKey,
   resolveMusicQuizDefinition,
   supportsMusicQuizListenIn,
 } from "@/components/music-quiz/game_types";
+import MusicQuizConnectionBanners from "@/components/music-quiz/MusicQuizConnectionBanners.vue";
+import MusicQuizEndGameDialog from "@/components/music-quiz/MusicQuizEndGameDialog.vue";
 import MusicQuizHostPanel from "@/components/music-quiz/MusicQuizHostPanel.vue";
 import MusicQuizLeaderboard, {
   type MusicQuizLeaderboardRow,
 } from "@/components/music-quiz/MusicQuizLeaderboard.vue";
-import MusicQuizPresentStage from "@/components/music-quiz/MusicQuizPresentStage.vue";
 import MusicQuizPreparingState from "@/components/music-quiz/MusicQuizPreparingState.vue";
+import MusicQuizPresentStage from "@/components/music-quiz/MusicQuizPresentStage.vue";
 import MusicQuizSessionHeader from "@/components/music-quiz/MusicQuizSessionHeader.vue";
 import MusicQuizSessionPanels from "@/components/music-quiz/MusicQuizSessionPanels.vue";
 import MusicQuizSetupWizard from "@/components/music-quiz/MusicQuizSetupWizard.vue";
 import MusicQuizUnsupportedGame from "@/components/music-quiz/MusicQuizUnsupportedGame.vue";
 import ShowDashboardButton from "@/components/ShowDashboardButton.vue";
 import { Button } from "@/components/ui/button";
-import { Card, CardContent } from "@/components/ui/card";
 import {
   Dialog,
   DialogContent,
@@ -233,6 +238,14 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
+import {
+  Empty,
+  EmptyContent,
+  EmptyDescription,
+  EmptyHeader,
+  EmptyMedia,
+  EmptyTitle,
+} from "@/components/ui/empty";
 import {
   isSupportedMusicQuiz,
   type MusicQuizCreateRequest,
@@ -248,7 +261,7 @@ import api, { ConnectionState } from "@/plugins/api";
 import { ProviderType } from "@/plugins/api/interfaces";
 import { authManager } from "@/plugins/auth";
 import { $t } from "@/plugins/i18n";
-import { Gamepad2, PartyPopper, Plus, Settings } from "@lucide/vue";
+import { Gamepad2, MicVocal, Plus, Settings } from "@lucide/vue";
 import { computed, onBeforeUnmount, onMounted, ref, watch } from "vue";
 import { useRouter } from "vue-router";
 import { toast } from "vue-sonner";

--- a/tests/components/MediaSearch.test.ts
+++ b/tests/components/MediaSearch.test.ts
@@ -292,6 +292,33 @@ describe("MediaSearch", () => {
     vi.useRealTimers();
   });
 
+  it("reopens a dismissed panel when the field is focused again", async () => {
+    mockSearch.mockResolvedValue(
+      searchResults({
+        playlists: [playlistFixture({ uri: "playlist:1", name: "Some list" })],
+      }),
+    );
+    const wrapper = mountSearch({ allowedMediaTypes: [MediaType.PLAYLIST] });
+    const input = wrapper.find("input");
+
+    await input.setValue("test");
+    await vi.advanceTimersByTimeAsync(300);
+    await flushPromises();
+    expect(resultsPanel()).not.toBeNull();
+
+    // Escape hides the panel without clearing the query, so nothing about the
+    // query can bring it back
+    window.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
+    await flushPromises();
+    expect(resultsPanel()).toBeNull();
+
+    await input.trigger("focus");
+    await flushPromises();
+
+    expect(resultsPanel()).not.toBeNull();
+    vi.useRealTimers();
+  });
+
   it.each([
     { room: "too little", boxBottom: 560, viewport: 600, side: "top" },
     { room: "enough", boxBottom: 120, viewport: 900, side: "bottom" },

--- a/tests/components/MediaSearch.test.ts
+++ b/tests/components/MediaSearch.test.ts
@@ -10,9 +10,9 @@ import {
   type Track,
 } from "@/plugins/api/interfaces";
 import type { MusicAssistantApi } from "@/plugins/api";
-import { mount } from "@vue/test-utils";
+import { enableAutoUnmount, mount } from "@vue/test-utils";
 import { nextTick } from "vue";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { track } from "../fixtures/track";
 import { playlist } from "../fixtures/playlist";
 import { genre } from "../fixtures/genre";
@@ -67,7 +67,45 @@ async function flushPromises() {
 function mountSearch(
   props: Partial<InstanceType<typeof MediaSearch>["$props"]>,
 ) {
-  return mount(MediaSearch, { props });
+  return mount(MediaSearch, { props, attachTo: document.body });
+}
+
+// the results float in a popover portalled out of the wrapper, so they are only
+// reachable through the document
+function resultRows() {
+  return Array.from(
+    document.querySelectorAll<HTMLElement>(".media-search-result"),
+  );
+}
+
+function resultsPanel() {
+  return document.querySelector<HTMLElement>(".media-search-results");
+}
+
+/**
+ * Pins the search box `bottom` pixels from the top of a `viewport`-tall window,
+ * so a case can say how much room the panel has underneath it.
+ */
+function placeSearchBox(bottom: number, viewport: number) {
+  vi.stubGlobal("innerHeight", viewport);
+  const original = Element.prototype.getBoundingClientRect;
+  vi.spyOn(Element.prototype, "getBoundingClientRect").mockImplementation(
+    function (this: Element) {
+      if (!this.matches('[data-slot="popover-anchor"]'))
+        return original.call(this);
+      return {
+        top: bottom - 36,
+        bottom,
+        left: 0,
+        right: 320,
+        width: 320,
+        height: 36,
+        x: 0,
+        y: bottom - 36,
+        toJSON: () => ({}),
+      } as DOMRect;
+    },
+  );
 }
 
 // api.search always returns every result list, so fill the ones a case does not
@@ -84,9 +122,16 @@ const searchResults = (lists: Partial<SearchResults> = {}): SearchResults => ({
   ...lists,
 });
 
+// an open results popover keeps document-level listeners and portalled nodes,
+// so tear it down even when an assertion fails
+enableAutoUnmount(afterEach);
+
 describe("MediaSearch", () => {
   beforeEach(() => {
     vi.useFakeTimers();
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+    document.body.innerHTML = "";
     mockSearch.mockReset();
     mockGetLibraryGenres.mockReset();
     mockGetLibraryGenres.mockResolvedValue([]);
@@ -140,9 +185,7 @@ describe("MediaSearch", () => {
     await flushPromises();
 
     expect(
-      wrapper
-        .findAll(".media-search-result")
-        .map((result) => result.find("strong").text()),
+      resultRows().map((result) => result.querySelector("strong")?.textContent),
     ).toEqual([
       "Some track",
       "Some playlist",
@@ -170,7 +213,8 @@ describe("MediaSearch", () => {
     await wrapper.find("input").setValue("test");
     await vi.advanceTimersByTimeAsync(300);
     await flushPromises();
-    await wrapper.find(".media-search-result").trigger("click");
+    resultRows()[0]!.click();
+    await flushPromises();
 
     expect(wrapper.emitted("select")?.[0]?.[0]).toMatchObject({
       uri: "playlist:1",
@@ -198,7 +242,7 @@ describe("MediaSearch", () => {
     await vi.advanceTimersByTimeAsync(300);
     await flushPromises();
 
-    expect(wrapper.find(".media-search-result").exists()).toBe(false);
+    expect(resultRows()).toHaveLength(0);
     vi.useRealTimers();
   });
 
@@ -237,12 +281,43 @@ describe("MediaSearch", () => {
     await vi.advanceTimersByTimeAsync(300);
     await flushPromises();
 
-    const rows = wrapper.findAll(".media-search-result");
+    const rows = resultRows();
     // the duplicate track collapses, same-named playlists never do
-    expect(rows.filter((row) => row.text().includes("Song"))).toHaveLength(1);
-    expect(rows.filter((row) => row.text().includes("Party"))).toHaveLength(2);
+    expect(
+      rows.filter((row) => row.textContent?.includes("Song")),
+    ).toHaveLength(1);
+    expect(
+      rows.filter((row) => row.textContent?.includes("Party")),
+    ).toHaveLength(2);
     vi.useRealTimers();
   });
+
+  it.each([
+    { room: "too little", boxBottom: 560, viewport: 600, side: "top" },
+    { room: "enough", boxBottom: 120, viewport: 900, side: "bottom" },
+  ])(
+    "opens the results $side of the search box when there is $room room below",
+    async ({ boxBottom, viewport, side }) => {
+      placeSearchBox(boxBottom, viewport);
+      mockSearch.mockResolvedValue(
+        searchResults({
+          playlists: [
+            playlistFixture({ uri: "playlist:1", name: "Some list" }),
+          ],
+        }),
+      );
+      const wrapper = mountSearch({
+        allowedMediaTypes: [MediaType.PLAYLIST],
+      });
+
+      await wrapper.find("input").setValue("test");
+      await vi.advanceTimersByTimeAsync(300);
+      await flushPromises();
+
+      expect(resultsPanel()?.getAttribute("data-side")).toBe(side);
+      vi.useRealTimers();
+    },
+  );
 
   it("collapses duplicates of a track that lists no artists", async () => {
     mockSearch.mockResolvedValue(
@@ -267,10 +342,9 @@ describe("MediaSearch", () => {
     await vi.advanceTimersByTimeAsync(300);
     await flushPromises();
 
-    const rows = wrapper.findAll(".media-search-result");
-    expect(rows.filter((row) => row.text().includes("Untitled"))).toHaveLength(
-      1,
-    );
+    expect(
+      resultRows().filter((row) => row.textContent?.includes("Untitled")),
+    ).toHaveLength(1);
 
     vi.useRealTimers();
   });

--- a/tests/components/music-quiz/GuessTheSongSetup.test.ts
+++ b/tests/components/music-quiz/GuessTheSongSetup.test.ts
@@ -1,11 +1,15 @@
 import GuessTheSongSetup from "@/components/music-quiz/game-types/guess-the-song/GuessTheSongSetup.vue";
 import type { MusicAssistantApi } from "@/plugins/api";
 import { MediaType, type SearchResults } from "@/plugins/api/interfaces";
-import { mount } from "@vue/test-utils";
+import { enableAutoUnmount, mount } from "@vue/test-utils";
 import { nextTick } from "vue";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { genre } from "../../fixtures/genre";
 import { playlist } from "../../fixtures/playlist";
+import {
+  searchResultButton,
+  searchResultButtons,
+} from "../../fixtures/mediaSearchResults";
 
 const { mockSearch, mockGetLibraryGenres } = vi.hoisted(() => ({
   mockSearch: vi.fn<MusicAssistantApi["search"]>(),
@@ -86,8 +90,13 @@ const searchResults = (lists: Partial<SearchResults> = {}): SearchResults => ({
   ...lists,
 });
 
+// the search results are portalled out of the wrapper, so tear them down even
+// when an assertion fails
+enableAutoUnmount(afterEach);
+
 describe("GuessTheSongSetup", () => {
   beforeEach(() => {
+    document.body.innerHTML = "";
     vi.useFakeTimers();
     mockSearch.mockReset();
     mockGetLibraryGenres.mockReset();
@@ -135,7 +144,7 @@ describe("GuessTheSongSetup", () => {
       }),
     );
     await flushPromises();
-    expect(wrapper.text()).toContain("Newest result");
+    expect(document.body.textContent).toContain("Newest result");
 
     oldSearch.resolve(
       searchResults({
@@ -145,8 +154,8 @@ describe("GuessTheSongSetup", () => {
     );
     await flushPromises();
 
-    expect(wrapper.text()).toContain("Newest result");
-    expect(wrapper.text()).not.toContain("Older result");
+    expect(document.body.textContent).toContain("Newest result");
+    expect(document.body.textContent).not.toContain("Older result");
   });
 
   it("emits a name-free discriminated create request", async () => {
@@ -165,10 +174,8 @@ describe("GuessTheSongSetup", () => {
       .setValue("test");
     await vi.advanceTimersByTimeAsync(300);
     await flushPromises();
-    await wrapper
-      .findAll("button")
-      .find((button) => button.text().includes("Test playlist"))
-      ?.trigger("click");
+    searchResultButton("Test playlist").click();
+    await flushPromises();
     await wrapper
       .findAll("button")
       .find((button) => button.text().includes("create"))
@@ -202,10 +209,8 @@ describe("GuessTheSongSetup", () => {
       .setValue("test");
     await vi.advanceTimersByTimeAsync(300);
     await flushPromises();
-    await wrapper
-      .findAll("button")
-      .find((button) => button.text().includes("Test playlist"))
-      ?.trigger("click");
+    searchResultButton("Test playlist").click();
+    await flushPromises();
     const createButton = wrapper
       .findAll("button")
       .find((button) => button.text().includes("create"));
@@ -229,17 +234,16 @@ describe("GuessTheSongSetup", () => {
       .setValue("test");
     await vi.advanceTimersByTimeAsync(300);
     await flushPromises();
-    await wrapper
-      .findAll("button")
-      .find((button) => button.text().includes("Test playlist"))
-      ?.trigger("click");
+    searchResultButton("Test playlist").click();
+    await flushPromises();
     await flushPromises();
 
     // still selected (removable) but no longer offered as a search result
-    const resultButtons = wrapper
-      .findAll(".media-search-result")
-      .filter((button) => button.text().includes("Test playlist"));
-    expect(resultButtons).toHaveLength(0);
+    expect(
+      searchResultButtons().filter((button) =>
+        button.textContent?.includes("Test playlist"),
+      ),
+    ).toHaveLength(0);
     expect(wrapper.text()).toContain("Test playlist");
   });
 
@@ -259,18 +263,14 @@ describe("GuessTheSongSetup", () => {
     await searchInput.setValue("test");
     await vi.advanceTimersByTimeAsync(300);
     await flushPromises();
-    await wrapper
-      .findAll("button")
-      .find((button) => button.text().includes("Test playlist"))
-      ?.trigger("click");
+    searchResultButton("Test playlist").click();
+    await flushPromises();
     // picking a result clears the search, so search again for the next pick
     await searchInput.setValue("test");
     await vi.advanceTimersByTimeAsync(300);
     await flushPromises();
-    await wrapper
-      .findAll("button")
-      .find((button) => button.text().includes("Rock"))
-      ?.trigger("click");
+    searchResultButton("Rock").click();
+    await flushPromises();
     await wrapper
       .findAll("button")
       .find((button) => button.text().includes("create"))
@@ -298,10 +298,8 @@ describe("GuessTheSongSetup", () => {
       .setValue("test");
     await vi.advanceTimersByTimeAsync(300);
     await flushPromises();
-    await wrapper
-      .findAll("button")
-      .find((button) => button.text().includes("Test playlist"))
-      ?.trigger("click");
+    searchResultButton("Test playlist").click();
+    await flushPromises();
     await flushPromises();
 
     // remove via the selected-source chip (not the search-result entry)

--- a/tests/components/music-quiz/MusicQuizLeaderboard.test.ts
+++ b/tests/components/music-quiz/MusicQuizLeaderboard.test.ts
@@ -98,17 +98,27 @@ describe("MusicQuizLeaderboard", () => {
       ]),
     );
     expect(wrapper.findAll("li")).toHaveLength(30);
+    // the name is the column that gives way; the score and its round delta are
+    // short and must never clip
     expect(wrapper.get("li span.min-w-0.flex-1").classes()).toContain(
       "truncate",
     );
-    const score = wrapper.get("li span.max-w-\\[45\\%\\]");
-    expect(score.classes()).toContain("max-w-[45%]");
-    expect(score.classes()).not.toContain("shrink-0");
-    expect(score.get("strong").classes()).toEqual(
-      expect.arrayContaining(["min-w-0", "flex-1", "truncate"]),
-    );
-    expect(score.get("span").classes()).toEqual(
-      expect.arrayContaining(["min-w-0", "flex-1", "truncate"]),
-    );
+    const score = wrapper.get("li > span:last-child");
+    expect(score.get("strong").classes()).not.toContain("truncate");
+    expect(score.get("span").classes()).not.toContain("truncate");
+  });
+
+  it("counts the ranked players next to the title", () => {
+    const wrapper = mount(MusicQuizLeaderboard, { props: { rows } });
+
+    expect(wrapper.get('[data-slot="card-title"]').text()).toContain("(2)");
+  });
+
+  it("drops the list entirely when nobody has joined", () => {
+    const wrapper = mount(MusicQuizLeaderboard, { props: { rows: [] } });
+
+    // an empty list still cost the card a content row plus the flex gap above it
+    expect(wrapper.find('[data-slot="card-content"]').exists()).toBe(false);
+    expect(wrapper.get('[data-slot="card-title"]').text()).toContain("(0)");
   });
 });

--- a/tests/components/music-quiz/MusicQuizPlaybackControls.test.ts
+++ b/tests/components/music-quiz/MusicQuizPlaybackControls.test.ts
@@ -78,9 +78,7 @@ describe("MusicQuizPlaybackControls", () => {
     expect(
       wrapper.get("#music-quiz-playback-venue").attributes("aria-checked"),
     ).toBe("true");
-    expect(
-      wrapper.get<HTMLSelectElement>("#music-quiz-venue-player").element.value,
-    ).toBe("living-room");
+    expect(wrapper.get("#music-quiz-venue-player").text()).toBe("Living Room");
     wrapper.unmount();
   });
 });

--- a/tests/components/music-quiz/MusicQuizSetupWizard.test.ts
+++ b/tests/components/music-quiz/MusicQuizSetupWizard.test.ts
@@ -1,8 +1,9 @@
 import MusicQuizSetupWizard from "@/components/music-quiz/MusicQuizSetupWizard.vue";
 import type { MusicQuizPlaybackOptions } from "@/composables/music-quiz/useMusicQuiz";
-import { mount } from "@vue/test-utils";
+import { enableAutoUnmount, mount } from "@vue/test-utils";
 import { nextTick } from "vue";
-import { describe, expect, it, vi } from "vitest";
+import { pickSelectOption } from "../../fixtures/rekaSelect";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@/plugins/i18n", () => ({
   $t: (key: string) => key,
@@ -144,7 +145,15 @@ const GAME_CASES = [
   },
 ] as const;
 
+// the venue player listbox is portalled out of the wrapper, so tear it down even
+// when an assertion fails
+enableAutoUnmount(afterEach);
+
 describe("MusicQuizSetupWizard", () => {
+  beforeEach(() => {
+    document.body.innerHTML = "";
+  });
+
   it("shows Trivia only when the backend reports it available", async () => {
     const wrapper = mountWizard();
 
@@ -165,52 +174,43 @@ describe("MusicQuizSetupWizard", () => {
     await gameTypeButton.trigger("click");
     await nextTick();
 
-    const configureHeading = wrapper
-      .findAll("h2")
-      .find((heading) =>
-        heading.text().includes("providers.music_quiz.configure_game"),
-      );
-    expect(configureHeading?.attributes("tabindex")).toBe("-1");
-    expect(document.activeElement).toBe(configureHeading?.element);
+    const heading = wrapper.get('[data-testid="music-quiz-setup-heading"]');
+    expect(heading.text()).toBe("game_type");
+    expect(heading.attributes("tabindex")).toBe("-1");
+    expect(document.activeElement).toBe(heading.element);
 
-    const backButton = wrapper
-      .findAll("button")
-      .find((button) => button.text().includes("back"));
-    backButton?.element.focus();
-    await backButton?.trigger("click");
+    const backButton = wrapper.get<HTMLButtonElement>(
+      'button[aria-label="back"]',
+    );
+    backButton.element.focus();
+    await backButton.trigger("click");
     await nextTick();
 
-    const chooseHeading = wrapper
-      .findAll("h2")
-      .find((heading) =>
-        heading.text().includes("providers.music_quiz.choose_game_type"),
-      );
-    expect(chooseHeading?.attributes("tabindex")).toBe("-1");
-    expect(document.activeElement).toBe(chooseHeading?.element);
+    expect(heading.text()).toBe("providers.music_quiz.choose_game_type");
+    expect(document.activeElement).toBe(heading.element);
     wrapper.unmount();
   });
 
   it("uses mutually exclusive display classes for wizard visibility", async () => {
     const wrapper = mountWizard();
-    const progress = wrapper.get('[data-testid="music-quiz-setup-progress"]');
     const configureStep = wrapper.get(
       '[data-testid="music-quiz-configure-step"]',
     );
+    const chooseStep = () => wrapper.find("section:not([data-testid])");
 
-    expect(progress.classes()).toContain("flex");
-    expect(progress.classes()).not.toContain("hidden");
+    expect(chooseStep().exists()).toBe(true);
     expect(configureStep.classes()).toContain("hidden");
     expect(configureStep.classes()).not.toContain("flex");
 
     await selectGame(wrapper, "game_type");
 
+    expect(chooseStep().exists()).toBe(false);
     expect(configureStep.classes()).toContain("flex");
     expect(configureStep.classes()).not.toContain("hidden");
 
     await wrapper.setProps({ busy: true });
 
-    expect(progress.classes()).toContain("hidden");
-    expect(progress.classes()).not.toContain("flex");
+    expect(chooseStep().exists()).toBe(false);
     expect(configureStep.classes()).toContain("hidden");
     expect(configureStep.classes()).not.toContain("flex");
   });
@@ -250,10 +250,9 @@ describe("MusicQuizSetupWizard", () => {
       expect(
         wrapper.get("#music-quiz-playback-venue").attributes("aria-checked"),
       ).toBe("true");
-      expect(
-        wrapper.get<HTMLSelectElement>("#music-quiz-venue-player").element
-          .value,
-      ).toBe("living-room");
+      expect(wrapper.get("#music-quiz-venue-player").text()).toBe(
+        "Living Room",
+      );
       expect(wrapper.text()).not.toContain("Automatic");
 
       await wrapper
@@ -301,7 +300,7 @@ describe("MusicQuizSetupWizard", () => {
       .get('[data-testid="quiz-include-similar-music"]')
       .trigger("click");
     await wrapper.get('[data-testid="change-guess_the_song"]').trigger("click");
-    await wrapper.get("#music-quiz-venue-player").setValue("kitchen");
+    await pickSelectOption(wrapper, "#music-quiz-venue-player", "Kitchen");
 
     await goBack(wrapper);
     expect(
@@ -316,9 +315,7 @@ describe("MusicQuizSetupWizard", () => {
         .get('[data-testid="quiz-include-similar-music"]')
         .attributes("aria-checked"),
     ).toBe("true");
-    expect(
-      wrapper.get<HTMLSelectElement>("#music-quiz-venue-player").element.value,
-    ).toBe("kitchen");
+    expect(wrapper.get("#music-quiz-venue-player").text()).toBe("Kitchen");
     expect(wrapper.get('[data-testid="setting-trivia"]').text()).toBe("2");
 
     await goBack(wrapper);
@@ -327,15 +324,13 @@ describe("MusicQuizSetupWizard", () => {
     expect(wrapper.get('[data-testid="setting-guess_the_song"]').text()).toBe(
       "1",
     );
-    expect(
-      wrapper.get<HTMLSelectElement>("#music-quiz-venue-player").element.value,
-    ).toBe("kitchen");
+    expect(wrapper.get("#music-quiz-venue-player").text()).toBe("Kitchen");
   });
 
   it("resets from newly supplied server defaults in a fresh setup", async () => {
     const wrapper = mountWizard({ playbackOptions: PLAYBACK_OPTIONS });
     await selectGame(wrapper, "game_type");
-    await wrapper.get("#music-quiz-venue-player").setValue("kitchen");
+    await pickSelectOption(wrapper, "#music-quiz-venue-player", "Kitchen");
     wrapper.unmount();
 
     const freshOptions = {
@@ -359,10 +354,7 @@ describe("MusicQuizSetupWizard", () => {
     ).toBe("false");
 
     await freshWrapper.get("#music-quiz-playback-venue").trigger("click");
-    expect(
-      freshWrapper.get<HTMLSelectElement>("#music-quiz-venue-player").element
-        .value,
-    ).toBe("kitchen");
+    expect(freshWrapper.get("#music-quiz-venue-player").text()).toBe("Kitchen");
   });
 
   it("does not emit when refreshed options keep the selection unchanged", async () => {
@@ -539,7 +531,7 @@ describe("MusicQuizSetupWizard", () => {
     const createButton = wrapper.get('[data-testid="create-guess_the_song"]');
     expect(createButton.attributes("disabled")).toBeDefined();
 
-    await wrapper.get("#music-quiz-venue-player").setValue("living-room");
+    await pickSelectOption(wrapper, "#music-quiz-venue-player", "Living Room");
     expect(createButton.attributes("disabled")).toBeUndefined();
   });
 });
@@ -580,9 +572,6 @@ async function selectGame(
 }
 
 async function goBack(wrapper: ReturnType<typeof mountWizard>) {
-  await wrapper
-    .findAll("button")
-    .find((button) => button.text().includes("back"))
-    ?.trigger("click");
+  await wrapper.get('button[aria-label="back"]').trigger("click");
   await nextTick();
 }

--- a/tests/components/music-quiz/MusicQuizSetupWizard.test.ts
+++ b/tests/components/music-quiz/MusicQuizSetupWizard.test.ts
@@ -191,6 +191,18 @@ describe("MusicQuizSetupWizard", () => {
     wrapper.unmount();
   });
 
+  it("keeps the preparing overlay from covering the dialog's close button", () => {
+    const wrapper = mountWizard({}, true);
+
+    // The overlay is z-10 and the dialog's own header is sr-only, so without a
+    // stacking context here that z-index resolves against the dialog and paints
+    // over its close button.
+    expect(
+      wrapper.get('[data-testid="music-quiz-setup-header"]').element
+        .parentElement?.className,
+    ).toContain("isolate");
+  });
+
   it("uses mutually exclusive display classes for wizard visibility", async () => {
     const wrapper = mountWizard();
     const configureStep = wrapper.get(

--- a/tests/components/music-quiz/MusicTimelineSetup.test.ts
+++ b/tests/components/music-quiz/MusicTimelineSetup.test.ts
@@ -1,10 +1,12 @@
 import MusicTimelineSetup from "@/components/music-quiz/game-types/music-timeline/MusicTimelineSetup.vue";
 import type { MusicAssistantApi } from "@/plugins/api";
 import type { SearchResults } from "@/plugins/api/interfaces";
-import { mount } from "@vue/test-utils";
+import { enableAutoUnmount, mount } from "@vue/test-utils";
 import { nextTick } from "vue";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { playlist } from "../../fixtures/playlist";
+import { pickSelectOption } from "../../fixtures/rekaSelect";
+import { searchResultButton } from "../../fixtures/mediaSearchResults";
 
 const { mockSearch, mockGetLibraryGenres } = vi.hoisted(() => ({
   mockSearch: vi.fn<MusicAssistantApi["search"]>(),
@@ -70,9 +72,14 @@ const mountTimeline = (
     },
   });
 
+// the search results and the select listboxes are portalled out of the wrapper,
+// so tear them down even when an assertion fails
+enableAutoUnmount(afterEach);
+
 describe("MusicTimelineSetup", () => {
   beforeEach(() => {
     vi.useFakeTimers();
+    document.body.innerHTML = "";
     mockSearch.mockReset();
     mockGetLibraryGenres.mockReset();
     mockGetLibraryGenres.mockResolvedValue([]);
@@ -100,10 +107,8 @@ describe("MusicTimelineSetup", () => {
       .setValue("test");
     await vi.advanceTimersByTimeAsync(300);
     await flushPromises();
-    await wrapper
-      .findAll("button")
-      .find((button) => button.text().includes("Test playlist"))
-      ?.trigger("click");
+    searchResultButton("Test playlist").click();
+    await flushPromises();
     await wrapper
       .findAll("button")
       .find((button) => button.text().includes("create"))
@@ -131,10 +136,8 @@ describe("MusicTimelineSetup", () => {
       .setValue("test");
     await vi.advanceTimersByTimeAsync(300);
     await flushPromises();
-    await wrapper
-      .findAll("button")
-      .find((button) => button.text().includes("Test playlist"))
-      ?.trigger("click");
+    searchResultButton("Test playlist").click();
+    await flushPromises();
     const createButton = wrapper
       .findAll("button")
       .find((button) => button.text().includes("create"));
@@ -147,19 +150,23 @@ describe("MusicTimelineSetup", () => {
   it("keeps bonus modes independent without adding a name", async () => {
     const wrapper = mountTimeline({ includeSimilarMusic: true });
 
-    await wrapper.get("#music-timeline-artist-bonus").setValue("free_text");
-    await wrapper
-      .get("#music-timeline-title-bonus")
-      .setValue("multiple_choice");
+    await pickSelectOption(
+      wrapper,
+      "#music-timeline-artist-bonus",
+      "providers.music_quiz.timeline_bonus_free_text",
+    );
+    await pickSelectOption(
+      wrapper,
+      "#music-timeline-title-bonus",
+      "providers.music_quiz.timeline_bonus_multiple_choice",
+    );
     await wrapper
       .find('input[placeholder="providers.music_quiz.search_music"]')
       .setValue("test");
     await vi.advanceTimersByTimeAsync(300);
     await flushPromises();
-    await wrapper
-      .findAll("button")
-      .find((button) => button.text().includes("Test playlist"))
-      ?.trigger("click");
+    searchResultButton("Test playlist").click();
+    await flushPromises();
     await wrapper
       .findAll("button")
       .find((button) => button.text().includes("create"))
@@ -184,10 +191,8 @@ describe("MusicTimelineSetup", () => {
       .setValue("test");
     await vi.advanceTimersByTimeAsync(300);
     await flushPromises();
-    await wrapper
-      .findAll("button")
-      .find((button) => button.text().includes("Test playlist"))
-      ?.trigger("click");
+    searchResultButton("Test playlist").click();
+    await flushPromises();
 
     expect(
       wrapper

--- a/tests/components/music-quiz/TriviaSetup.test.ts
+++ b/tests/components/music-quiz/TriviaSetup.test.ts
@@ -1,8 +1,14 @@
 import TriviaSetup from "@/components/music-quiz/game-types/trivia/TriviaSetup.vue";
 import type { MusicAssistantApi } from "@/plugins/api";
-import { mount } from "@vue/test-utils";
+import { getLocaleOptions } from "@/plugins/i18n";
+import { enableAutoUnmount, mount } from "@vue/test-utils";
 import { nextTick } from "vue";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  openSelect,
+  pickSelectOption,
+  selectOptions,
+} from "../../fixtures/rekaSelect";
 
 const { mockI18n } = vi.hoisted(() => ({
   mockI18n: {
@@ -39,8 +45,22 @@ vi.mock("@/components/MediaItemThumb.vue", () => ({
   },
 }));
 
+// the select listboxes are portalled out of the wrapper, so tear them down even
+// when an assertion fails
+enableAutoUnmount(afterEach);
+
+// the localized label reka shows for a locale, so a test can pick it by sight
+const localeLabels = () =>
+  getLocaleOptions(
+    mockI18n.global.availableLocales,
+    mockI18n.global.locale.value,
+  );
+const localeLabel = (locale: string) =>
+  localeLabels().find((option) => option.value === locale)!.label;
+
 describe("TriviaSetup", () => {
   beforeEach(() => {
+    document.body.innerHTML = "";
     mockI18n.global.locale.value = "en";
   });
 
@@ -52,8 +72,12 @@ describe("TriviaSetup", () => {
     const wrapper = mountSetup(true);
 
     await wrapper.get('[data-testid="select-sources"]').trigger("click");
-    await wrapper.get("#trivia-difficulty").setValue("hard");
-    await wrapper.get("#trivia-language").setValue("sr_Latn");
+    await pickSelectOption(
+      wrapper,
+      "#trivia-difficulty",
+      "providers.music_quiz.difficulty_hard",
+    );
+    await pickSelectOption(wrapper, "#trivia-language", localeLabel("sr_Latn"));
     await nextTick();
     await wrapper
       .findAll("button")
@@ -150,23 +174,21 @@ describe("TriviaSetup", () => {
 
     const wrapper = mountSetup();
 
-    expect(
-      (wrapper.get("#trivia-language").element as HTMLSelectElement).value,
-    ).toBe("pt_BR");
+    expect(wrapper.get("#trivia-language").text()).toBe(localeLabel("pt_BR"));
   });
 
-  it("offers only shipped locales with localized, predictable labels", () => {
+  it("offers only shipped locales with localized, predictable labels", async () => {
     mockI18n.global.locale.value = "de";
     const wrapper = mountSetup();
-    const options = wrapper
-      .get("#trivia-language")
-      .findAll("option")
-      .map((option) => ({
-        value: option.attributes("value"),
-        label: option.text(),
-      }));
+    const options = localeLabels();
     const labelByValue = Object.fromEntries(
       options.map((option) => [option.value, option.label]),
+    );
+
+    // the listbox renders every option the helper offers, in its order
+    await openSelect(wrapper, "#trivia-language");
+    expect(selectOptions().map((option) => option.textContent?.trim())).toEqual(
+      options.map((option) => option.label),
     );
     const displayNames = new Intl.DisplayNames(["de"], {
       type: "language",

--- a/tests/fixtures/mediaSearchResults.ts
+++ b/tests/fixtures/mediaSearchResults.ts
@@ -1,0 +1,24 @@
+/**
+ * Reaches MediaSearch's results, which float in a portalled popover and so are
+ * outside the mounted wrapper.
+ */
+export function searchResultButtons(): HTMLElement[] {
+  return Array.from(
+    document.querySelectorAll<HTMLElement>(".media-search-result"),
+  );
+}
+
+/** The result row whose text contains `label`. */
+export function searchResultButton(label: string): HTMLElement {
+  const row = searchResultButtons().find((button) =>
+    button.textContent?.includes(label),
+  );
+  if (!row) {
+    throw new Error(
+      `no search result matching "${label}"; found: ${searchResultButtons()
+        .map((button) => button.textContent?.trim())
+        .join(", ")}`,
+    );
+  }
+  return row;
+}

--- a/tests/fixtures/rekaSelect.ts
+++ b/tests/fixtures/rekaSelect.ts
@@ -1,0 +1,56 @@
+/**
+ * Drives a reka-ui Select the way a pointer does.
+ *
+ * The listbox is portalled out of the wrapper and reka settles its focus on a
+ * timer rather than a microtask, so a test cannot reach an option through the
+ * wrapper or after a plain flush.
+ */
+import { flushPromises, type VueWrapper } from "@vue/test-utils";
+import { vi } from "vitest";
+
+const settle = async () => {
+  await flushPromises();
+  // suites that fake timers have to advance them for reka's focus timer to run
+  if (vi.isFakeTimers()) await vi.advanceTimersByTimeAsync(30);
+  else await new Promise((resolve) => setTimeout(resolve, 30));
+  await flushPromises();
+};
+
+/** Opens the select whose trigger carries `triggerSelector`. */
+export async function openSelect(wrapper: VueWrapper, triggerSelector: string) {
+  const trigger = wrapper.get(triggerSelector);
+  await trigger.trigger("pointerdown", { button: 0, pointerType: "mouse" });
+  await trigger.trigger("click");
+  await settle();
+}
+
+/** Every option of the currently open select, in render order. */
+export function selectOptions(): HTMLElement[] {
+  return Array.from(
+    document.querySelectorAll<HTMLElement>('[data-slot="select-item"]'),
+  );
+}
+
+/**
+ * Picks the option whose label contains `label` from the select whose trigger
+ * carries `triggerSelector`.
+ */
+export async function pickSelectOption(
+  wrapper: VueWrapper,
+  triggerSelector: string,
+  label: string,
+) {
+  await openSelect(wrapper, triggerSelector);
+  const option = selectOptions().find((item) =>
+    item.textContent?.includes(label),
+  );
+  if (!option) {
+    throw new Error(
+      `no option matching "${label}" in ${triggerSelector}; found: ${selectOptions()
+        .map((item) => item.textContent?.trim())
+        .join(", ")}`,
+    );
+  }
+  option.dispatchEvent(new PointerEvent("pointerup", { bubbles: true }));
+  await settle();
+}


### PR DESCRIPTION
# What does this implement/fix?

A polish pass over the Music Quiz plugin, plus several bugs found along the way.

**Dashboard**

- "No active game" now uses the shared `Empty` component, vertically centred, with a `MicVocal` icon matching the sidebar entry.
- Quiz badges use the primary variant. `variant="secondary"` was painting Vuetify's teal `#48A9A6`: Vuetify 3 ships its own `.bg-secondary`, and since Tailwind's utilities are `!important` and Vuetify's stylesheet loads later, Vuetify wins. **That collision is app-wide and not fixed here** — worth a follow-up.
- The leaderboard shows a muted `(n)` player count next to its title, and collapses to just that title when nobody has joined, instead of keeping an empty content row and the gap above it.
- The leaderboard's score column no longer clips. The score and the round delta both carried `flex-1` inside a `max-w-[45%]` column, so they split it evenly and each truncated regardless of how much room the row had — `(+1000)` rendered as `(...`, and a four-digit score clipped too. The column now sizes to its content, and the name absorbs the pressure.
- The round delta is centred against the score in both the player header and the leaderboard. Baseline alignment leaves the parentheses hanging below the number, and in the leaderboard `truncate`'s `overflow: hidden` made each box report its bottom edge as its baseline anyway, so `items-baseline` could never line the two up.

**New game wizard**

- Dropped the progress bar and "Step 1 of 2". A single heading serves both steps and doubles as the dialog title — "Choose a game type", then a back arrow and the chosen game's name. The dialog's own title/description are now `sr-only`.
- Game type cards share one height, with centred content and a larger icon tile.
- New icons for Music Timeline (`CalendarClock`) and Music Trivia (`WandSparkles`).
- The "preparing game" overlay no longer covers the dialog's close button. Its `z-10` resolved against the dialog rather than the wizard, and now that the dialog's own header is `sr-only` the wizard's box starts at the top and spans where the X sits, so the wizard root is a stacking context (`isolate`) to keep that z-index local.

**Setup fields**

- The five native selects (difficulty ×2, question language, artist/title bonus) and the venue player picker are now the styled `Select`. Each passes its own label to `SelectValue`, because reka only learns option labels once the listbox has mounted — a preselected value otherwise rendered **blank**.
- Playback mode indicators now match the app's `Checkbox` (square, tick when selected) and align with their titles, keeping `RadioGroup` semantics underneath so the modes stay mutually exclusive and arrow-key navigable.

**Search results** — `MediaSearch`, also used by the party guest page

- Results float in a popover instead of pushing the form down, and open *above* the search box when there is no room below. reka's own collision handling shrinks the panel to fit rather than moving it, and a `max-height` reading `--reka-popover-content-available-height` feeds back into that decision, so its flip can never fire; the side is computed from the anchor's own room instead.

Tests were updated for the portalled results and listboxes, with two new fixtures (`tests/fixtures/rekaSelect.ts`, `tests/fixtures/mediaSearchResults.ts`) and a regression test covering the panel flipping in both directions.

**Related issue (if applicable):**

- related issue `<link to issue>`

**Related backend PR (if applicable):**

<!--
Link the music-assistant/server PR when this change relies on new server
behaviour, so the two can be reviewed and released together.
-->

- related backend PR `<link to PR>`

## Types of changes

<!--
Tick exactly one box below. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [ ] The code change is tested and works locally.
- [ ] `pnpm lint:check` passes.
- [ ] `pnpm test:run` passes, and tests have been added/updated where applicable.
- [ ] `pnpm build` passes.
- [ ] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.


