### PR TITLE
Ask the server for a track preview url

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -299,8 +299,14 @@ async function handleHttpProxyRequest(event, proxyScope) {
   try {
     const response = await responsePromise;
 
-    // Cache successful responses (200-299)
-    if (response.status >= 200 && response.status < 300) {
+    // Cache successful responses (200-299). Preview clips are addressed by a token that
+    // is fresh on every request, so they could never be hit again and would only push
+    // reusable entries (images) out of a cache with a fixed entry budget.
+    if (
+      response.status >= 200 &&
+      response.status < 300 &&
+      !url.pathname.startsWith("/preview")
+    ) {
       try {
         // Clone the response before caching (can only read body once). The write
         // keeps the worker alive without holding up the image it just fetched.

--- a/src/components/ProviderDetails.vue
+++ b/src/components/ProviderDetails.vue
@@ -166,7 +166,7 @@ const openLinkInNewTab = function (url: string) {
 
 const demoPlayer = reactive<{ [item_id: string]: HTMLAudioElement }>({});
 
-const playBtnClick = function (providerMapping: ProviderMapping) {
+const playBtnClick = async function (providerMapping: ProviderMapping) {
   const key = `${providerMapping.provider_instance}.${providerMapping.item_id}`;
   const existing = demoPlayer[key];
   if (existing) {
@@ -174,16 +174,14 @@ const playBtnClick = function (providerMapping: ProviderMapping) {
     delete demoPlayer[key];
   } else {
     const audio = new Audio(
-      getPreviewUrl(providerMapping.provider_instance, providerMapping.item_id),
+      await api.getTrackPreviewUrl(
+        providerMapping.provider_instance,
+        providerMapping.item_id,
+      ),
     );
     demoPlayer[key] = audio;
     audio.play();
   }
-};
-const getPreviewUrl = function (provider: string, item_id: string) {
-  return `${
-    api.baseUrl
-  }/preview?item_id=${encodeURIComponent(item_id)}&provider=${provider}`;
 };
 
 // just enough of a provider mapping to identify an item: the library entry built for

--- a/src/components/ProviderDetails.vue
+++ b/src/components/ProviderDetails.vue
@@ -166,22 +166,32 @@ const openLinkInNewTab = function (url: string) {
 
 const demoPlayer = reactive<{ [item_id: string]: HTMLAudioElement }>({});
 
-const playBtnClick = async function (providerMapping: ProviderMapping) {
+const playBtnClick = function (providerMapping: ProviderMapping) {
   const key = `${providerMapping.provider_instance}.${providerMapping.item_id}`;
   const existing = demoPlayer[key];
   if (existing) {
     existing.load();
     delete demoPlayer[key];
-  } else {
-    const audio = new Audio(
-      await api.getTrackPreviewUrl(
-        providerMapping.provider_instance,
-        providerMapping.item_id,
-      ),
-    );
-    demoPlayer[key] = audio;
-    audio.play();
+    return;
   }
+  // claim the slot before awaiting the url, so a second click while the request is
+  // in flight cannot start a second clip that the first would then orphan
+  const audio = new Audio();
+  demoPlayer[key] = audio;
+  api
+    .getTrackPreviewUrl(
+      providerMapping.provider_instance,
+      providerMapping.item_id,
+    )
+    .then((url) => {
+      // the stop path clears the slot; do not start playing a clip nobody wants
+      if (demoPlayer[key] !== audio) return;
+      audio.src = url;
+      return audio.play();
+    })
+    .catch(() => {
+      if (demoPlayer[key] === audio) delete demoPlayer[key];
+    });
 };
 
 // just enough of a provider mapping to identify an item: the library entry built for

--- a/src/plugins/api/index.ts
+++ b/src/plugins/api/index.ts
@@ -539,9 +539,11 @@ export class MusicAssistantApi {
   public getTrackPreviewUrl(
     provider_instance_id_or_domain: string,
     item_id: string,
-  ): string {
-    const encItemId = encodeURIComponent(encodeURIComponent(item_id));
-    return `${this.baseUrl}/preview?item_id=${encItemId}&provider=${provider_instance_id_or_domain}`;
+  ): Promise<string> {
+    return this.sendCommand("music/tracks/preview", {
+      provider_instance_id_or_domain,
+      item_id,
+    });
   }
 
   public getLibraryArtistsCount(


### PR DESCRIPTION
# What does this implement/fix?

The preview url was assembled in the client, which meant the frontend had to know the
preview endpoint and its parameters. It now asks the server for the url instead, so the
server decides what to hand out — a provider's own public clip where there is one, or a
short-lived url to our own preview service.

**Related issue (if applicable):**

- n/a

**Related backend PR (if applicable):**

- related backend PR https://github.com/music-assistant/server/pull/5821

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm lint:check` passes.
- [x] `pnpm test:run` passes, and tests have been added/updated where applicable.
