### PR TITLE
Keep hidden players available for grouping

### DIFF
--- a/src/components/PlayerGroupMembers.vue
+++ b/src/components/PlayerGroupMembers.vue
@@ -56,7 +56,10 @@ import { Checkbox } from "@/components/ui/checkbox";
 import { Separator } from "@/components/ui/separator";
 import type { PlayerGroupFilter } from "@/helpers/player_group";
 import { requestGroupPlaybackConfirmation } from "@/helpers/player_group_playback";
-import { groupMemberPickerVisible } from "@/helpers/players";
+import {
+  groupMemberPickerVisible,
+  isVisualizerPlayer,
+} from "@/helpers/players";
 import { api } from "@/plugins/api";
 import {
   type Player,
@@ -127,8 +130,7 @@ const candidateSections = computed(() => {
       translateLabel: true,
       players: availableCandidates.filter(
         (player) =>
-          player.type !== PlayerType.LIGHT &&
-          player.type !== PlayerType.VISUALIZER,
+          player.type !== PlayerType.LIGHT && !isVisualizerPlayer(player),
       ),
     },
     {
@@ -143,8 +145,8 @@ const candidateSections = computed(() => {
       type: "visualizers",
       label: "visualizers",
       translateLabel: true,
-      players: availableCandidates.filter(
-        (player) => player.type === PlayerType.VISUALIZER,
+      players: availableCandidates.filter((player) =>
+        isVisualizerPlayer(player),
       ),
     },
   ];
@@ -195,11 +197,9 @@ function matchesFilter(player: Player) {
   if (props.filter === "all") return true;
   if (props.filter === "lights") return player.type === PlayerType.LIGHT;
   if (props.filter === "visualizers") {
-    return player.type === PlayerType.VISUALIZER;
+    return isVisualizerPlayer(player);
   }
-  return (
-    player.type !== PlayerType.LIGHT && player.type !== PlayerType.VISUALIZER
-  );
+  return player.type !== PlayerType.LIGHT && !isVisualizerPlayer(player);
 }
 
 function sortPlayers(players: Player[]) {

--- a/src/helpers/players.ts
+++ b/src/helpers/players.ts
@@ -73,15 +73,15 @@ export const playerVisible = function (
   return true;
 };
 
-// Keep hidden players out of group pickers unless they represent this device or
-// are player types intended to be grouped with audio players.
+/**
+ * Check if the player may be offered as a group member.
+ *
+ * Hiding a player only removes it from the main listings, so it stays pickable
+ * here. Players private to another device are the exception: they only show up
+ * once their owner unhides them.
+ */
 export const groupMemberPickerVisible = function (player: Player): boolean {
-  return (
-    !player.hide_in_ui ||
-    isBuiltinPlayer(player) ||
-    player.type === PlayerType.LIGHT ||
-    player.type === PlayerType.VISUALIZER
-  );
+  return !player.hide_in_ui || !player.private || isBuiltinPlayer(player);
 };
 
 export const canEditPlayerGroup = function (player: Player): boolean {

--- a/src/helpers/players.ts
+++ b/src/helpers/players.ts
@@ -77,11 +77,23 @@ export const playerVisible = function (
  * Check if the player may be offered as a group member.
  *
  * Hiding a player only removes it from the main listings, so it stays pickable
- * here. Players private to another device are the exception: they only show up
- * once their owner unhides them.
+ * here. Private players are the exception, because they belong to someone
+ * else's device or to the server itself: those only show up once unhidden.
  */
 export const groupMemberPickerVisible = function (player: Player): boolean {
-  return !player.hide_in_ui || !player.private || isBuiltinPlayer(player);
+  return isBuiltinPlayer(player) || !(player.hide_in_ui && player.private);
+};
+
+/**
+ * Check if the player renders a now-playing view instead of audio.
+ *
+ * Screens and visualizers share a section in the group pickers, so the UI
+ * treats them as one category.
+ */
+export const isVisualizerPlayer = function (player: Player): boolean {
+  return (
+    player.type === PlayerType.VISUALIZER || player.type === PlayerType.DISPLAY
+  );
 };
 
 export const canEditPlayerGroup = function (player: Player): boolean {

--- a/src/layouts/default/PlayerOSD/PlayerBarGroupControl.vue
+++ b/src/layouts/default/PlayerOSD/PlayerBarGroupControl.vue
@@ -111,6 +111,7 @@ import {
   canEditPlayerGroup,
   getPlayerGroupMemberCount,
   groupMemberPickerVisible,
+  isVisualizerPlayer,
 } from "@/helpers/players";
 import { api } from "@/plugins/api";
 import { type Player, PlayerType } from "@/plugins/api/interfaces";
@@ -191,9 +192,7 @@ const hasLights = computed(() =>
   ),
 );
 const hasVisualizers = computed(() =>
-  groupCandidates.value.some(
-    (candidate) => candidate.type === PlayerType.VISUALIZER,
-  ),
+  groupCandidates.value.some((candidate) => isVisualizerPlayer(candidate)),
 );
 
 watch(

--- a/src/plugins/api/interfaces.ts
+++ b/src/plugins/api/interfaces.ts
@@ -1416,6 +1416,9 @@ export interface Player {
   group_volume: number | null;
   group_volume_muted: boolean | null;
   hide_in_ui: boolean;
+  // private: the player belongs to a single device (a web/app client) or is an
+  // internal anchor, so it must not be offered as a playback or grouping target
+  private: boolean;
   icon: string;
   power_control: string;
   volume_control: string;

--- a/src/plugins/api/interfaces.ts
+++ b/src/plugins/api/interfaces.ts
@@ -1417,7 +1417,8 @@ export interface Player {
   group_volume_muted: boolean | null;
   hide_in_ui: boolean;
   // private: the player belongs to a single device (a web/app client) or is an
-  // internal anchor, so it must not be offered as a playback or grouping target
+  // internal anchor; together with hide_in_ui it keeps the player out of the
+  // pickers on every other device
   private: boolean;
   icon: string;
   power_control: string;

--- a/tests/components/PlayerCard.test.ts
+++ b/tests/components/PlayerCard.test.ts
@@ -175,6 +175,7 @@ function createPlayer(overrides: Partial<Player> = {}): Player {
     group_volume: null,
     group_volume_muted: null,
     hide_in_ui: false,
+    private: false,
     icon: "speaker",
     power_control: "power",
     volume_control: "volume",

--- a/tests/components/PlayerGroupMembers.test.ts
+++ b/tests/components/PlayerGroupMembers.test.ts
@@ -82,6 +82,7 @@ function createPlayer(overrides: Partial<Player> = {}): Player {
     group_volume: null,
     group_volume_muted: null,
     hide_in_ui: false,
+    private: false,
     icon: "speaker",
     power_control: "power",
     volume_control: "volume",

--- a/tests/components/PlayerGroupMembers.test.ts
+++ b/tests/components/PlayerGroupMembers.test.ts
@@ -27,7 +27,8 @@ vi.mock("@/plugins/api", async () => {
   return { api, default: api };
 });
 
-vi.mock("@/helpers/players", () => ({
+vi.mock("@/helpers/players", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/helpers/players")>()),
   groupMemberPickerVisible: () => true,
 }));
 
@@ -208,6 +209,27 @@ describe("PlayerGroupMembers", () => {
         .findAll(".player-group-section > p")
         .map((section) => section.text()),
     ).toEqual(["players", "lights", "visualizers"]);
+  });
+
+  it("lists a screen alongside the visualizers", () => {
+    const screen = createPlayer({
+      player_id: "screen",
+      name: "Kitchen screen",
+      type: PlayerType.DISPLAY,
+    });
+    const parent = createPlayer({ can_group_with: [screen.player_id] });
+    api.players = {
+      [parent.player_id]: parent,
+      [screen.player_id]: screen,
+    };
+
+    const wrapper = mountGroupMembers(parent, []);
+
+    expect(
+      wrapper
+        .findAll(".player-group-section > p")
+        .map((section) => section.text()),
+    ).toEqual(["visualizers"]);
   });
 
   it("separates current members from available players", () => {

--- a/tests/components/VolumeControl.test.ts
+++ b/tests/components/VolumeControl.test.ts
@@ -22,7 +22,8 @@ vi.mock("@/plugins/api", async () => {
   return { api, default: api };
 });
 
-vi.mock("@/helpers/players", () => ({
+vi.mock("@/helpers/players", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/helpers/players")>()),
   groupMemberPickerVisible: () => true,
 }));
 

--- a/tests/components/VolumeControl.test.ts
+++ b/tests/components/VolumeControl.test.ts
@@ -91,6 +91,7 @@ function createPlayer(overrides: Partial<Player> = {}): Player {
     group_volume: 25,
     group_volume_muted: false,
     hide_in_ui: false,
+    private: false,
     icon: "speaker",
     power_control: "power",
     volume_control: "volume",

--- a/tests/helpers/players.test.ts
+++ b/tests/helpers/players.test.ts
@@ -62,6 +62,7 @@ function createPlayer(overrides: Partial<Player> = {}): Player {
     group_volume: null,
     group_volume_muted: null,
     hide_in_ui: false,
+    private: false,
     icon: "speaker",
     power_control: "power",
     volume_control: "volume",
@@ -254,24 +255,32 @@ describe("playerVisible", () => {
 });
 
 describe("groupMemberPickerVisible", () => {
-  it("shows the hidden web player owned by this browser", () => {
+  it("shows the private web player owned by this browser", () => {
     const player = createPlayer({
       player_id: "local-web-player",
       hide_in_ui: true,
+      private: true,
     });
     webPlayer.player_id = player.player_id;
 
     expect(groupMemberPickerVisible(player)).toBe(true);
   });
 
-  it("shows the hidden companion player owned by this app", () => {
+  it("shows the private companion player owned by this app", () => {
     const player = createPlayer({
       player_id: "local-companion-player",
       hide_in_ui: true,
+      private: true,
     });
     store.companionPlayerId = player.player_id;
 
     expect(groupMemberPickerVisible(player)).toBe(true);
+  });
+
+  it("shows a hidden player, so it can still be grouped", () => {
+    expect(groupMemberPickerVisible(createPlayer({ hide_in_ui: true }))).toBe(
+      true,
+    );
   });
 
   it.each([PlayerType.LIGHT, PlayerType.VISUALIZER])(
@@ -283,14 +292,25 @@ describe("groupMemberPickerVisible", () => {
     },
   );
 
-  it("keeps unrelated hidden players out of the picker", () => {
+  it("keeps another device's private player out of the picker", () => {
     const player = createPlayer({
       player_id: "remote-web-player",
       hide_in_ui: true,
+      private: true,
     });
     webPlayer.player_id = "local-web-player";
 
     expect(groupMemberPickerVisible(player)).toBe(false);
+  });
+
+  it("shows a private player once its owner unhides it", () => {
+    const player = createPlayer({
+      player_id: "remote-web-player",
+      private: true,
+    });
+    webPlayer.player_id = "local-web-player";
+
+    expect(groupMemberPickerVisible(player)).toBe(true);
   });
 });
 

--- a/tests/helpers/players.test.ts
+++ b/tests/helpers/players.test.ts
@@ -283,15 +283,6 @@ describe("groupMemberPickerVisible", () => {
     );
   });
 
-  it.each([PlayerType.LIGHT, PlayerType.VISUALIZER])(
-    "shows a hidden %s player",
-    (type) => {
-      const player = createPlayer({ type, hide_in_ui: true });
-
-      expect(groupMemberPickerVisible(player)).toBe(true);
-    },
-  );
-
   it("keeps another device's private player out of the picker", () => {
     const player = createPlayer({
       player_id: "remote-web-player",

--- a/tests/layouts/PlayerBarGroupControl.test.ts
+++ b/tests/layouts/PlayerBarGroupControl.test.ts
@@ -22,7 +22,8 @@ vi.mock("@/plugins/store", async () => {
 
 vi.mock("@/plugins/i18n", () => ({ $t: (key: string) => key }));
 
-vi.mock("@/helpers/players", () => ({
+vi.mock("@/helpers/players", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/helpers/players")>()),
   canEditPlayerGroup: () => true,
   getPlayerGroupMemberCount: () => groupSize.value,
   groupMemberPickerVisible: () => true,

--- a/tests/layouts/PlayerBarVolumeControl.test.ts
+++ b/tests/layouts/PlayerBarVolumeControl.test.ts
@@ -122,6 +122,7 @@ function createPlayer(overrides: Partial<Player> = {}): Player {
     group_volume: 25,
     group_volume_muted: false,
     hide_in_ui: false,
+    private: false,
     icon: "speaker",
     power_control: "power",
     volume_control: "volume",

--- a/tests/layouts/PlayerSelect.test.ts
+++ b/tests/layouts/PlayerSelect.test.ts
@@ -246,6 +246,7 @@ function createPlayer(
     group_volume: null,
     group_volume_muted: null,
     hide_in_ui: false,
+    private: false,
     icon: "speaker",
     power_control: "power",
     volume_control: "volume",

--- a/tests/layouts/PlayerVolume.test.ts
+++ b/tests/layouts/PlayerVolume.test.ts
@@ -87,6 +87,7 @@ function createPlayer(overrides: Partial<Player> = {}): Player {
     group_volume: 25,
     group_volume_muted: false,
     hide_in_ui: false,
+    private: false,
     icon: "speaker",
     power_control: "power",
     volume_control: "volume",

--- a/tests/layouts/PlayerVolumeLiveDrag.test.ts
+++ b/tests/layouts/PlayerVolumeLiveDrag.test.ts
@@ -85,6 +85,7 @@ function createPlayer(overrides: Partial<Player> = {}): Player {
     group_volume: START_VOLUME,
     group_volume_muted: false,
     hide_in_ui: false,
+    private: false,
     icon: "speaker",
     power_control: "power",
     volume_control: "volume",

--- a/tests/layouts/PlayerVolumeRelative.test.ts
+++ b/tests/layouts/PlayerVolumeRelative.test.ts
@@ -99,6 +99,7 @@ function createPlayer(overrides: Partial<Player> = {}): Player {
     group_volume: START_VOLUME,
     group_volume_muted: false,
     hide_in_ui: false,
+    private: false,
     icon: "speaker",
     power_control: "power",
     volume_control: "volume",


### PR DESCRIPTION
# What does this implement/fix?

Turning on "Hide this player in the user interface" also removed the player from the group-member picker, so speakers you only ever use as sync-group children could no longer be added to a group at all. Hiding a player is meant to clear it out of the main listings, not to make it unusable — if you want a player gone entirely, you disable it.

Hidden players now stay pickable as group members. Player selection, the play button menu and "transfer queue" keep leaving them out, as before.

Screens (metadata-only clients) are now listed with the visualizers rather than among the speakers, since they become selectable for the first time here.

The one exception is players that are private to a single device — a phone, the mobile app, a browser tab — plus internal helper players. Those stay out of the picker until their owner unhides them, which is the existing consent step. The server now marks them with a new `private` flag, so the UI can finally tell "I hid this speaker" apart from "this is someone else's phone".

**Related issue (if applicable):**

- n/a

**Related backend PR (if applicable):**

- https://github.com/music-assistant/models/pull/367 (models field)
- https://github.com/music-assistant/server/pull/5831 (sets the flag)

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm lint:check` passes.
- [x] `pnpm test:run` passes, and tests have been added/updated where applicable.



