### PR TITLE
Add skip controls when listening to long-form media

### DIFF
--- a/src/layouts/default/PlayerOSD/PlayerBrowserMediaControls.vue
+++ b/src/layouts/default/PlayerOSD/PlayerBrowserMediaControls.vue
@@ -14,10 +14,12 @@
 import audio from "@/assets/almost_silent.mp3";
 import { resolveActiveElapsedTime } from "@/helpers/activeElapsedTime";
 import { useMediaBrowserMetaData } from "@/helpers/useMediaBrowserMetaData";
+import { useUserPreferences } from "@/composables/userPreferences";
 import api from "@/plugins/api";
+import { itemSupportsPlayLog } from "@/plugins/api/helpers";
 import { PlaybackState } from "@/plugins/api/interfaces";
 import { store } from "@/plugins/store";
-import { onMounted, ref, watch } from "vue";
+import { computed, onMounted, ref, watch } from "vue";
 
 const audioRef = ref<HTMLAudioElement>();
 
@@ -101,6 +103,12 @@ const lastSeekPosTimeout = function () {
 
 useMediaBrowserMetaData();
 
+const { getPreference } = useUserPreferences();
+const skipAmount = getPreference("audiobook_skip_seconds", 30);
+const isLongForm = computed(() =>
+  itemSupportsPlayLog(store.curQueueItem?.media_item),
+);
+
 const seekHandler = function (
   evt: MediaSessionActionDetails,
   player_id: string,
@@ -109,6 +117,16 @@ const seekHandler = function (
   if (evt.action === "seekto" && evt.seekTime != null) {
     to = evt.seekTime;
   } else if (evt.action === "seekforward" || evt.action === "seekbackward") {
+    if (isLongForm.value) {
+      const queueId = store.activePlayerQueue?.queue_id;
+      if (!queueId) return;
+      const seconds = evt.seekOffset || skipAmount.value;
+      api.queueCommandSkip(
+        queueId,
+        evt.action === "seekbackward" ? -seconds : seconds,
+      );
+      return;
+    }
     const offset = evt.seekOffset || 10;
     const elapsed_time = lastSeekPos ?? resolveActiveElapsedTime(player_id);
     if (elapsed_time == null) return;

--- a/src/layouts/default/PlayerOSD/PlayerControlBtn/SkipBackBtn.vue
+++ b/src/layouts/default/PlayerOSD/PlayerControlBtn/SkipBackBtn.vue
@@ -1,0 +1,46 @@
+<template>
+  <Icon
+    v-if="isVisible"
+    v-bind="{ ...icon, ...$attrs }"
+    :disabled="!canSkip"
+    variant="button"
+    :title="$t('skip_backward_seconds', [skipAmount])"
+    :aria-label="$t('skip_backward_seconds', [skipAmount])"
+    @click="skip"
+  >
+    <Rewind :size="size" />
+  </Icon>
+</template>
+
+<script setup lang="ts">
+defineOptions({ inheritAttrs: false });
+import Icon, { IconProps } from "@/components/Icon.vue";
+import api from "@/plugins/api";
+import { PlayerQueue } from "@/plugins/api/interfaces";
+import { $t } from "@/plugins/i18n";
+import { Rewind } from "@lucide/vue";
+import { computed } from "vue";
+
+export interface Props {
+  playerQueue: PlayerQueue | undefined;
+  skipAmount: number;
+  isVisible?: boolean;
+  icon?: IconProps;
+  size?: number;
+}
+const props = withDefaults(defineProps<Props>(), {
+  isVisible: true,
+  icon: undefined,
+  size: 20,
+});
+
+const canSkip = computed(
+  () => !!props.playerQueue?.active && !!props.playerQueue.current_item,
+);
+
+function skip() {
+  if (canSkip.value) {
+    api.queueCommandSkip(props.playerQueue!.queue_id, -props.skipAmount);
+  }
+}
+</script>

--- a/src/layouts/default/PlayerOSD/PlayerControlBtn/SkipForwardBtn.vue
+++ b/src/layouts/default/PlayerOSD/PlayerControlBtn/SkipForwardBtn.vue
@@ -1,0 +1,46 @@
+<template>
+  <Icon
+    v-if="isVisible"
+    v-bind="{ ...icon, ...$attrs }"
+    :disabled="!canSkip"
+    variant="button"
+    :title="$t('skip_forward_seconds', [skipAmount])"
+    :aria-label="$t('skip_forward_seconds', [skipAmount])"
+    @click="skip"
+  >
+    <FastForward :size="size" />
+  </Icon>
+</template>
+
+<script setup lang="ts">
+defineOptions({ inheritAttrs: false });
+import Icon, { IconProps } from "@/components/Icon.vue";
+import api from "@/plugins/api";
+import { PlayerQueue } from "@/plugins/api/interfaces";
+import { $t } from "@/plugins/i18n";
+import { FastForward } from "@lucide/vue";
+import { computed } from "vue";
+
+export interface Props {
+  playerQueue: PlayerQueue | undefined;
+  skipAmount: number;
+  isVisible?: boolean;
+  icon?: IconProps;
+  size?: number;
+}
+const props = withDefaults(defineProps<Props>(), {
+  isVisible: true,
+  icon: undefined,
+  size: 20,
+});
+
+const canSkip = computed(
+  () => !!props.playerQueue?.active && !!props.playerQueue.current_item,
+);
+
+function skip() {
+  if (canSkip.value) {
+    api.queueCommandSkip(props.playerQueue!.queue_id, props.skipAmount);
+  }
+}
+</script>

--- a/src/layouts/default/PlayerOSD/PlayerControls.vue
+++ b/src/layouts/default/PlayerOSD/PlayerControls.vue
@@ -23,6 +23,15 @@
         :icon="visibleComponents.previous.icon"
       />
     </div>
+    <!-- skip back button for audiobooks and podcast episodes -->
+    <div v-if="showSkipControls" class="player-controls-elements">
+      <SkipBackBtn
+        :player-queue="store.activePlayerQueue"
+        :skip-amount="skipAmount"
+        class="media-controls-item"
+        :size="20"
+      />
+    </div>
     <!-- play/pause button -->
     <div
       v-if="visibleComponents && visibleComponents.play?.isVisible"
@@ -34,6 +43,15 @@
         class="media-controls-item"
         :icon="visibleComponents.play.icon"
         :size="visibleComponents.play.size"
+      />
+    </div>
+    <!-- skip forward button for audiobooks and podcast episodes -->
+    <div v-if="showSkipControls" class="player-controls-elements">
+      <SkipForwardBtn
+        :player-queue="store.activePlayerQueue"
+        :skip-amount="skipAmount"
+        class="media-controls-item"
+        :size="20"
       />
     </div>
     <!-- next button -->
@@ -66,8 +84,13 @@
 
 <script setup lang="ts">
 import { IconProps } from "@/components/Icon.vue";
-import RepeatBtn from "@/layouts/default/PlayerOSD/PlayerControlBtn/RepeatBtn.vue";
+import SkipBackBtn from "@/layouts/default/PlayerOSD/PlayerControlBtn/SkipBackBtn.vue";
+import SkipForwardBtn from "@/layouts/default/PlayerOSD/PlayerControlBtn/SkipForwardBtn.vue";
+import { useUserPreferences } from "@/composables/userPreferences";
+import { itemSupportsPlayLog } from "@/plugins/api/helpers";
 import { store } from "@/plugins/store";
+import { computed } from "vue";
+import RepeatBtn from "./PlayerControlBtn/RepeatBtn.vue";
 import NextBtn from "./PlayerControlBtn/NextBtn.vue";
 import PlayBtn from "./PlayerControlBtn/PlayBtn.vue";
 import PreviousBtn from "./PlayerControlBtn/PreviousBtn.vue";
@@ -110,6 +133,12 @@ withDefaults(defineProps<Props>(), {
     next: { isVisible: true },
   }),
 });
+
+const { getPreference } = useUserPreferences();
+const skipAmount = getPreference("audiobook_skip_seconds", 30);
+const showSkipControls = computed(() =>
+  itemSupportsPlayLog(store.curQueueItem?.media_item),
+);
 </script>
 
 <style>

--- a/src/layouts/default/PlayerOSD/PlayerFullscreen.vue
+++ b/src/layouts/default/PlayerOSD/PlayerFullscreen.vue
@@ -405,6 +405,14 @@
             max-height="45px"
             :size="28"
           />
+          <SkipBackBtn
+            v-if="showSkipControls"
+            :player-queue="store.activePlayerQueue"
+            :skip-amount="skipAmount"
+            class="media-controls-item"
+            max-height="45px"
+            :size="28"
+          />
           <div class="play-btn-wrapper" :style="playBtnStyle">
             <PlayBtn
               :player="store.activePlayer"
@@ -416,6 +424,14 @@
               :play-offset="2"
             />
           </div>
+          <SkipForwardBtn
+            v-if="showSkipControls"
+            :player-queue="store.activePlayerQueue"
+            :skip-amount="skipAmount"
+            class="media-controls-item"
+            max-height="45px"
+            :size="28"
+          />
           <NextBtn
             :player="store.activePlayer"
             :player-queue="store.activePlayerQueue"
@@ -505,6 +521,8 @@ import { useLyricsOffset } from "@/composables/lyrics/useLyricsOffset";
 import { useActiveTrackWaveform } from "@/composables/useActiveTrackWaveform";
 import { setStatusBarColorOverride } from "@/composables/useStatusBarColor";
 import { useUserPreferences } from "@/composables/userPreferences";
+import SkipBackBtn from "@/layouts/default/PlayerOSD/PlayerControlBtn/SkipBackBtn.vue";
+import SkipForwardBtn from "@/layouts/default/PlayerOSD/PlayerControlBtn/SkipForwardBtn.vue";
 import { useVisualizer } from "@/composables/visualizer/useVisualizer";
 import { playbackSpeedSupported } from "@/helpers/elapsed";
 import { MarqueeTextSync } from "@/helpers/marquee_text_sync";
@@ -533,7 +551,7 @@ import { useFullscreenQueue } from "@/layouts/default/PlayerOSD/useFullscreenQue
 import { resolveActiveElapsedTime } from "@/helpers/activeElapsedTime";
 import { resolveCurrentChapter } from "@/helpers/chapters";
 import api from "@/plugins/api";
-import { getSourceName } from "@/plugins/api/helpers";
+import { getSourceName, itemSupportsPlayLog } from "@/plugins/api/helpers";
 import {
   MediaItemChapter,
   MediaType,
@@ -577,6 +595,10 @@ const showAlbumSubtitle = computed(
   () => vuetify.display.height.value > MIN_HEIGHT_SHOW_FULL_DETAILS,
 );
 const { getPreference, setPreference } = useUserPreferences();
+const skipAmount = getPreference("audiobook_skip_seconds", 30);
+const showSkipControls = computed(() =>
+  itemSupportsPlayLog(store.curQueueItem?.media_item),
+);
 const showWaveformPref = getPreference("show_waveform", true);
 const showChapterProgress = getPreference("audiobook_chapter_progress", true);
 const nowTick = ref(0);

--- a/src/plugins/api/helpers.ts
+++ b/src/plugins/api/helpers.ts
@@ -64,7 +64,7 @@ export const isAudioSource = function (
  * resume_position_ms): podcast episodes and audiobooks.
  */
 export const itemSupportsPlayLog = function (
-  item: MediaItemType | ItemMapping | undefined,
+  item: MediaItemType | ItemMapping | null | undefined,
 ): item is Audiobook | PodcastEpisode {
   return (
     item?.media_type === MediaType.PODCAST_EPISODE ||

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -712,6 +712,10 @@
             "label": "Show audiobook chapter progress",
             "description": "Show elapsed and remaining time for the current audiobook chapter instead of the full audiobook."
         },
+        "audiobook_skip_seconds": {
+            "label": "Audiobook and podcast skip amount",
+            "description": "Number of seconds to skip forward or backward with the skip controls."
+        },
         "download_diagnostics": "Download diagnostics",
         "diagnostics": "Diagnostics",
         "diagnostics_description": "View server logs and download a diagnostics report for troubleshooting",
@@ -1003,6 +1007,8 @@
     "shuffle_disable": "Disable shuffle",
     "shuffle_enable": "Enable shuffle",
     "open_dsp_settings": "Open DSP settings",
+    "skip_forward_seconds": "Skip forward {0} seconds",
+    "skip_backward_seconds": "Skip backward {0} seconds",
     "audiobook": "Audiobook",
     "audiobooks": "Audiobooks",
     "chapter": "Chapter",

--- a/src/views/settings/FrontendConfig.vue
+++ b/src/views/settings/FrontendConfig.vue
@@ -87,6 +87,7 @@ const valueChanged = (key: string, value: ConfigValueType): boolean =>
 const RELOAD_EXEMPT_PREFERENCE_KEYS = new Set([
   "volume_slider_mode",
   "volume_haptics",
+  "audiobook_skip_seconds",
 ]);
 
 onMounted(() => {
@@ -195,6 +196,24 @@ onMounted(() => {
       value:
         (store.currentUser?.preferences
           ?.audiobook_chapter_progress as boolean) ?? true,
+    },
+    {
+      key: "audiobook_skip_seconds",
+      type: ConfigEntryType.INTEGER,
+      label: "audiobook_skip_seconds",
+      default_value: 30,
+      required: false,
+      options: [
+        { title: "10", value: 10 },
+        { title: "15", value: 15 },
+        { title: "30", value: 30 },
+        { title: "60", value: 60 },
+      ],
+      multi_value: false,
+      category: "audiobooks",
+      value:
+        (store.currentUser?.preferences?.audiobook_skip_seconds as number) ??
+        30,
     },
     {
       key: "mobile_sidebar_side",

--- a/tests/helpers/mediaTypeHelpers.test.ts
+++ b/tests/helpers/mediaTypeHelpers.test.ts
@@ -1,0 +1,20 @@
+import { itemSupportsPlayLog } from "@/plugins/api/helpers";
+import { MediaType, type MediaItemType } from "@/plugins/api/interfaces";
+import { describe, expect, it } from "vitest";
+
+const mediaItem = (media_type: MediaType) => ({ media_type }) as MediaItemType;
+
+describe("itemSupportsPlayLog", () => {
+  it("recognizes audiobooks and podcast episodes as long-form content", () => {
+    expect(itemSupportsPlayLog(mediaItem(MediaType.AUDIOBOOK))).toBe(true);
+    expect(itemSupportsPlayLog(mediaItem(MediaType.PODCAST_EPISODE))).toBe(
+      true,
+    );
+  });
+
+  it("does not treat podcast collections or tracks as long-form playback items", () => {
+    expect(itemSupportsPlayLog(mediaItem(MediaType.PODCAST))).toBe(false);
+    expect(itemSupportsPlayLog(mediaItem(MediaType.TRACK))).toBe(false);
+    expect(itemSupportsPlayLog(null)).toBe(false);
+  });
+});

--- a/tests/layouts/PlayerBrowserMediaControls.test.ts
+++ b/tests/layouts/PlayerBrowserMediaControls.test.ts
@@ -9,22 +9,31 @@ interface MockPlayer {
   player_id?: string;
   active_source?: string;
   playback_state?: PlaybackState;
+  current_media?: { media_type?: string };
+}
+
+interface MockQueueItem {
+  media_item?: { media_type?: string };
 }
 
 interface MockQueue {
   queue_id: string;
   state?: PlaybackState;
   active?: boolean;
-  current_item?: { extra_attributes?: { playback_speed?: number } };
+  current_item?: MockQueueItem & {
+    extra_attributes?: { playback_speed?: number };
+  };
 }
 
 const {
   apiMock,
   storeMock,
   mockPlayerCommandSeek,
+  mockQueueCommandSkip,
   mockUseMediaBrowserMetaData,
 } = vi.hoisted(() => {
   const mockPlayerCommandSeek = vi.fn<MusicAssistantApi["playerCommandSeek"]>();
+  const mockQueueCommandSkip = vi.fn<MusicAssistantApi["queueCommandSkip"]>();
   return {
     apiMock: {
       players: {} as Record<string, MockPlayer>,
@@ -39,11 +48,15 @@ const {
       playerCommandPrevious:
         vi.fn<MusicAssistantApi["playerCommandPrevious"]>(),
       playerCommandSeek: mockPlayerCommandSeek,
+      queueCommandSkip: mockQueueCommandSkip,
     },
     storeMock: {
       activePlayer: undefined as MockPlayer | undefined,
+      activePlayerQueue: undefined as MockQueue | undefined,
+      curQueueItem: undefined as MockQueueItem | undefined,
     },
     mockPlayerCommandSeek,
+    mockQueueCommandSkip,
     mockUseMediaBrowserMetaData: vi.fn(),
   };
 });
@@ -97,7 +110,10 @@ describe("PlayerBrowserMediaControls seek handling", () => {
     // same player up in api.players.
     apiMock.players = { "player-1": { player_id: "player-1" } };
     storeMock.activePlayer = apiMock.players["player-1"];
+    storeMock.activePlayerQueue = undefined;
+    storeMock.curQueueItem = undefined;
     mockPlayerCommandSeek.mockClear();
+    mockQueueCommandSkip.mockClear();
     mockUseMediaBrowserMetaData.mockClear();
   });
 
@@ -116,6 +132,42 @@ describe("PlayerBrowserMediaControls seek handling", () => {
     // Displayed position is 30 + 3s * 2x = 36, so a +10s skip lands on 46; the
     // raw stored position would give 40.
     expect(mockPlayerCommandSeek).toHaveBeenCalledWith("player-1", 46);
+    wrapper.unmount();
+  });
+
+  it("uses the configured queue skip for long-form media", () => {
+    seedPlayingQueue({
+      elapsed_time: 30,
+      secondsAgo: 3,
+      playback_speed: 2,
+      mediaType: "audiobook",
+    });
+
+    const wrapper = mount(PlayerBrowserMediaControls);
+    invokeAction("seekforward");
+    invokeAction("seekbackward");
+
+    expect(mockQueueCommandSkip).toHaveBeenNthCalledWith(1, "queue", 30);
+    expect(mockQueueCommandSkip).toHaveBeenNthCalledWith(2, "queue", -30);
+    expect(mockPlayerCommandSeek).not.toHaveBeenCalled();
+    wrapper.unmount();
+  });
+
+  it("does nothing for long-form media without an active queue", () => {
+    seedPlayingQueue({
+      elapsed_time: 30,
+      secondsAgo: 3,
+      playback_speed: 2,
+      mediaType: "audiobook",
+    });
+    storeMock.activePlayerQueue = undefined;
+
+    const wrapper = mount(PlayerBrowserMediaControls);
+    invokeAction("seekforward");
+    invokeAction("seekbackward");
+
+    expect(mockQueueCommandSkip).not.toHaveBeenCalled();
+    expect(mockPlayerCommandSeek).not.toHaveBeenCalled();
     wrapper.unmount();
   });
 
@@ -168,20 +220,29 @@ function seedPlayingQueue(timing: {
   elapsed_time: number;
   secondsAgo: number;
   playback_speed: number;
+  mediaType?: "audiobook" | "track";
 }): void {
   apiMock.players["player-1"] = {
     player_id: "player-1",
     active_source: "queue",
   };
   storeMock.activePlayer = apiMock.players["player-1"];
+  storeMock.activePlayer.current_media = {
+    media_type: timing.mediaType ?? "track",
+  };
+  storeMock.curQueueItem = {
+    media_item: { media_type: timing.mediaType ?? "track" },
+  };
   apiMock.queues.queue = {
     queue_id: "queue",
     state: PlaybackState.PLAYING,
     active: true,
     current_item: {
+      media_item: { media_type: timing.mediaType ?? "track" },
       extra_attributes: { playback_speed: timing.playback_speed },
     },
-  };
+  } as MockQueue;
+  storeMock.activePlayerQueue = apiMock.queues.queue;
   apiMock.queueElapsedTime.queue = {
     elapsed_time: timing.elapsed_time,
     elapsed_time_last_updated: ANCHOR - timing.secondsAgo,

--- a/tests/layouts/PlayerControls.test.ts
+++ b/tests/layouts/PlayerControls.test.ts
@@ -1,0 +1,90 @@
+import PlayerControls from "@/layouts/default/PlayerOSD/PlayerControls.vue";
+import SkipBackBtn from "@/layouts/default/PlayerOSD/PlayerControlBtn/SkipBackBtn.vue";
+import SkipForwardBtn from "@/layouts/default/PlayerOSD/PlayerControlBtn/SkipForwardBtn.vue";
+import { MediaType } from "@/plugins/api/interfaces";
+import { mount } from "@vue/test-utils";
+import { nextTick } from "vue";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { store } = vi.hoisted(() => ({
+  store: {
+    activePlayerQueue: undefined as unknown,
+    curQueueItem: undefined as
+      | { media_item?: { media_type?: MediaType } }
+      | undefined,
+  },
+}));
+
+vi.mock("@/plugins/store", () => ({ store }));
+
+vi.mock("@/composables/userPreferences", () => ({
+  useUserPreferences: () => ({ getPreference: () => ({ value: 30 }) }),
+}));
+
+vi.mock("@/plugins/api/helpers", () => ({
+  itemSupportsPlayLog: (item?: { media_type?: MediaType } | null) =>
+    item?.media_type === MediaType.AUDIOBOOK ||
+    item?.media_type === MediaType.PODCAST_EPISODE,
+}));
+
+vi.mock("@/layouts/default/PlayerOSD/PlayerControlBtn/SkipBackBtn.vue", () => ({
+  default: { name: "SkipBackBtn", template: "<button data-skip-back />" },
+}));
+
+vi.mock(
+  "@/layouts/default/PlayerOSD/PlayerControlBtn/SkipForwardBtn.vue",
+  () => ({
+    default: {
+      name: "SkipForwardBtn",
+      template: "<button data-skip-forward />",
+    },
+  }),
+);
+
+vi.mock("@/layouts/default/PlayerOSD/PlayerControlBtn/PreviousBtn.vue", () => ({
+  default: { template: "<button data-previous />" },
+}));
+vi.mock("@/layouts/default/PlayerOSD/PlayerControlBtn/NextBtn.vue", () => ({
+  default: { template: "<button data-next />" },
+}));
+vi.mock("@/layouts/default/PlayerOSD/PlayerControlBtn/PlayBtn.vue", () => ({
+  default: { template: "<button data-play />" },
+}));
+vi.mock("@/layouts/default/PlayerOSD/PlayerControlBtn/ShuffleBtn.vue", () => ({
+  default: { template: "<button data-shuffle />" },
+}));
+vi.mock("@/layouts/default/PlayerOSD/PlayerControlBtn/RepeatBtn.vue", () => ({
+  default: { template: "<button data-repeat />" },
+}));
+
+describe("PlayerControls long-form skip visibility", () => {
+  beforeEach(() => {
+    store.curQueueItem = undefined;
+  });
+
+  it.each([MediaType.AUDIOBOOK, MediaType.PODCAST_EPISODE])(
+    "shows both skip controls for %s",
+    async (mediaType) => {
+      store.curQueueItem = { media_item: { media_type: mediaType } };
+      const wrapper = mount(PlayerControls);
+
+      await nextTick();
+
+      expect(wrapper.find("[data-skip-back]").exists()).toBe(true);
+      expect(wrapper.find("[data-skip-forward]").exists()).toBe(true);
+    },
+  );
+
+  it.each([MediaType.TRACK, MediaType.PODCAST])(
+    "hides both skip controls for %s",
+    async (mediaType) => {
+      store.curQueueItem = { media_item: { media_type: mediaType } };
+      const wrapper = mount(PlayerControls);
+
+      await nextTick();
+
+      expect(wrapper.find("[data-skip-back]").exists()).toBe(false);
+      expect(wrapper.find("[data-skip-forward]").exists()).toBe(false);
+    },
+  );
+});

--- a/tests/layouts/PlayerFullscreen.test.ts
+++ b/tests/layouts/PlayerFullscreen.test.ts
@@ -1,5 +1,7 @@
 import { EMPTY_COLOR_PALETTE } from "@/helpers/utils";
 import PlayerFullscreen from "@/layouts/default/PlayerOSD/PlayerFullscreen.vue";
+import SkipBackBtn from "@/layouts/default/PlayerOSD/PlayerControlBtn/SkipBackBtn.vue";
+import SkipForwardBtn from "@/layouts/default/PlayerOSD/PlayerControlBtn/SkipForwardBtn.vue";
 import type { MusicAssistantApi } from "@/plugins/api";
 import { MediaType, PlaybackState } from "@/plugins/api/interfaces";
 import { shallowMount, type VueWrapper } from "@vue/test-utils";
@@ -319,6 +321,37 @@ describe("PlayerFullscreen chapter queue", () => {
     expect(
       fullscreen.findAll(".queue-chapter")[0].attributes("aria-current"),
     ).toBeUndefined();
+  });
+
+  it("shows skip controls for long-form media", async () => {
+    const fullscreen = await mountChapterQueue();
+
+    expect(fullscreen.findAllComponents(SkipBackBtn)).toHaveLength(1);
+    expect(fullscreen.findAllComponents(SkipForwardBtn)).toHaveLength(1);
+  });
+
+  it("hides skip controls for regular tracks", async () => {
+    await seedPlayingQueue();
+    const { store } = await import("@/plugins/store");
+    const testStore = store as unknown as TestStore;
+    testStore.activePlayer!.current_media!.media_type = MediaType.TRACK;
+    testStore.curQueueItem!.media_item!.media_type = MediaType.TRACK;
+    testStore.showFullscreenPlayer = true;
+    testStore.showQueueItems = true;
+    wrapper = shallowMount(PlayerFullscreen, {
+      props: { colorPalette: EMPTY_COLOR_PALETTE },
+      global: {
+        mocks: { $vuetify: { display: { height: 900, mdAndUp: true } } },
+        stubs: {
+          "v-dialog": { template: "<div><slot /></div>" },
+          "v-card": { template: "<div><slot /></div>" },
+        },
+      },
+    });
+    await nextTick();
+
+    expect(wrapper.findAllComponents(SkipBackBtn)).toHaveLength(0);
+    expect(wrapper.findAllComponents(SkipForwardBtn)).toHaveLength(0);
   });
 
   it("seeks to a chapter start without reloading the media", async () => {

--- a/tests/layouts/PlayerSkipButtons.test.ts
+++ b/tests/layouts/PlayerSkipButtons.test.ts
@@ -1,0 +1,91 @@
+import SkipBackBtn from "@/layouts/default/PlayerOSD/PlayerControlBtn/SkipBackBtn.vue";
+import SkipForwardBtn from "@/layouts/default/PlayerOSD/PlayerControlBtn/SkipForwardBtn.vue";
+import type { MusicAssistantApi } from "@/plugins/api";
+import type { PlayerQueue } from "@/plugins/api/interfaces";
+import { mount } from "@vue/test-utils";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { queueCommandSkip } = vi.hoisted(() => ({
+  queueCommandSkip: vi.fn<MusicAssistantApi["queueCommandSkip"]>(),
+}));
+
+vi.mock("@/plugins/api", () => ({
+  default: { queueCommandSkip },
+}));
+
+vi.mock("@/components/Icon.vue", () => ({
+  default: {
+    props: ["disabled", "title", "ariaLabel"],
+    emits: ["click"],
+    template:
+      '<button :disabled="disabled" :title="title" @click="$emit(\'click\', $event)"><slot /></button>',
+  },
+}));
+
+vi.mock("@/plugins/i18n", () => ({
+  $t: (key: string, args?: unknown[]) =>
+    args ? `${key}:${args.join(",")}` : key,
+}));
+
+const queue = (active = true): PlayerQueue =>
+  ({
+    queue_id: "queue-1",
+    active,
+    current_item: { media_item: { media_type: "audiobook" } },
+  }) as PlayerQueue;
+
+const queueWithoutCurrentItem = (): PlayerQueue =>
+  ({
+    queue_id: "queue-1",
+    active: true,
+    current_item: undefined,
+  }) as unknown as PlayerQueue;
+
+describe("long-form skip buttons", () => {
+  beforeEach(() => queueCommandSkip.mockClear());
+
+  it("skips backward by the configured amount", async () => {
+    const wrapper = mount(SkipBackBtn, {
+      props: { playerQueue: queue(), skipAmount: 15 },
+    });
+
+    await wrapper.trigger("click");
+
+    expect(queueCommandSkip).toHaveBeenCalledWith("queue-1", -15);
+  });
+
+  it("skips forward by the configured amount", async () => {
+    const wrapper = mount(SkipForwardBtn, {
+      props: { playerQueue: queue(), skipAmount: 60 },
+    });
+
+    await wrapper.trigger("click");
+
+    expect(queueCommandSkip).toHaveBeenCalledWith("queue-1", 60);
+  });
+
+  it("does not issue a command for an inactive queue", async () => {
+    const wrapper = mount(SkipForwardBtn, {
+      props: { playerQueue: queue(false), skipAmount: 30 },
+    });
+
+    expect(wrapper.attributes("disabled")).toBeDefined();
+    await wrapper.trigger("click");
+
+    expect(queueCommandSkip).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["an undefined queue", undefined],
+    ["an active queue without a current item", queueWithoutCurrentItem()],
+  ])("does not issue a command for %s", async (_label, playerQueue) => {
+    const wrapper = mount(SkipForwardBtn, {
+      props: { playerQueue, skipAmount: 30 },
+    });
+
+    expect(wrapper.attributes("disabled")).toBeDefined();
+    await wrapper.trigger("click");
+
+    expect(queueCommandSkip).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
# What does this implement/fix?

Adds "fast-forward" and "rewind" buttons when listening to long-form content (audiobooks and podcasts). The amount of time is configurable, with 10, 15, 30, and 60 seconds as the options.

<img width="1371" height="806" alt="Screenshot 2026-08-18 at 8 13 36 PM" src="https://github.com/user-attachments/assets/26b889e5-1c58-47fb-8fc5-654cb7dceeec" />

<img width="1231" height="90" alt="Screenshot 2026-08-18 at 8 13 49 PM" src="https://github.com/user-attachments/assets/9d29a77f-060c-4259-979b-9c69b49251cb" />

<img width="1085" height="283" alt="Screenshot 2026-08-18 at 8 15 13 PM" src="https://github.com/user-attachments/assets/9eadda84-2914-4bda-871f-c484c44000dc" />

## Types of changes

<!--
Tick exactly one box below. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [X] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [X] The code change is tested and works locally.
- [X] `pnpm lint:check` passes.
- [X] `pnpm test:run` passes, and tests have been added/updated where applicable.
- [X] `pnpm build` passes.
- [X] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
