### PR TITLE
Only offer Play now for audio sources

### DIFF
--- a/src/layouts/default/ItemContextMenu.vue
+++ b/src/layouts/default/ItemContextMenu.vue
@@ -252,6 +252,7 @@ import {
 import { runWithConcurrency } from "@/helpers/concurrency";
 import { backFromMediaDetails } from "@/helpers/navigation";
 import {
+  isAudioSource,
   isItemInLibrary,
   itemIsAvailable,
   itemSupportsPlayLog,
@@ -402,34 +403,15 @@ export const showPlayMenuForMediaItem = async function (
   const firstItem = playableItems[0];
 
   let playMenuItems: ContextMenuItem[] = [];
-  const LiveSourceTypes = [MediaType.RADIO, MediaType.AUDIO_SOURCE];
-  const enqueueConfigKey = LiveSourceTypes.includes(firstItem.media_type)
-    ? "default_enqueue_option_live_sources"
-    : `default_enqueue_option_${firstItem.media_type}`;
-  const defaultEnqueueOption = (await api.getCoreConfigValue(
-    "player_queues",
-    enqueueConfigKey,
-  )) as QueueOption;
-  for (const option of [
-    QueueOption.PLAY,
-    QueueOption.NEXT,
-    QueueOption.ADD,
-    QueueOption.REPLACE,
-    QueueOption.REPLACE_NEXT,
-  ]) {
-    playMenuItems.push({
-      label: $t(`queue_option.${option}`),
-      action: () => {
-        api.playMedia(
-          playableItems.map((x) => x.uri),
-          option,
-        );
-      },
-      icon: queueOptionIconMap[option],
-      labelArgs: [],
-      disabled: !store.activePlayer,
-      selected: option === defaultEnqueueOption,
-    });
+  const defaultEnqueueOption = await getDefaultEnqueueOption(firstItem);
+  if (isAudioSource(firstItem)) {
+    playMenuItems.push(
+      startAudioSourceMenuItem(playableItems, defaultEnqueueOption),
+    );
+  } else {
+    playMenuItems.push(
+      ...buildEnqueueMenuItems(playableItems, defaultEnqueueOption),
+    );
   }
   // Starting the media shuffled is its own action rather than a state indicator:
   // the queue's shuffle flag says nothing about what the media about to be started
@@ -1137,7 +1119,8 @@ export const getContextMenuItems = async function (
 
 /**
   Generates playback-related context menu items based on the given media items and their parent.
-  This includes options like "Play now", "Enqueue", "Play radio", and "Play from here" (for playlists/albums).
+  This includes "Play now", the "Enqueue options" submenu and "Play from here" (for playlists/albums).
+  An AudioSource only gets "Play now": it cannot be queued for later.
 */
 export const getPlaybackContextMenuItems = async function (
   items: MediaItemTypeOrItemMapping[],
@@ -1153,16 +1136,16 @@ export const getPlaybackContextMenuItems = async function (
   if (playableItems.length == 0) return playMenuItems;
   const firstItem = playableItems[0];
 
-  const LiveSourceTypes = [MediaType.RADIO, MediaType.AUDIO_SOURCE];
-  const enqueueConfigKey = LiveSourceTypes.includes(firstItem.media_type)
-    ? "default_enqueue_option_live_sources"
-    : `default_enqueue_option_${firstItem.media_type}`;
-  const defaultEnqueueOption = (await api.getCoreConfigValue(
-    "player_queues",
-    enqueueConfigKey,
-  )) as QueueOption;
+  const defaultEnqueueOption = await getDefaultEnqueueOption(firstItem);
 
   if (!store.activePlayer) return playMenuItems;
+
+  if (isAudioSource(firstItem)) {
+    playMenuItems.push(
+      startAudioSourceMenuItem(playableItems, defaultEnqueueOption),
+    );
+    return playMenuItems;
+  }
 
   // Play from here...
   if (
@@ -1234,31 +1217,9 @@ export const getPlaybackContextMenuItems = async function (
   }
 
   // "Enqueue..." submenu with all enqueue options
-  const enqueueSubItems: ContextMenuItem[] = [];
-  for (const option of [
-    QueueOption.PLAY,
-    QueueOption.NEXT,
-    QueueOption.ADD,
-    QueueOption.REPLACE,
-    QueueOption.REPLACE_NEXT,
-  ]) {
-    enqueueSubItems.push({
-      label: $t(`queue_option.${option}`),
-      action: () => {
-        api.playMedia(
-          items.map((x) => x.uri),
-          option,
-        );
-      },
-      icon: queueOptionIconMap[option],
-      labelArgs: [],
-      disabled: !store.activePlayer,
-      selected: option === defaultEnqueueOption,
-    });
-  }
   playMenuItems.push({
     label: "enqueue",
-    subItems: enqueueSubItems,
+    subItems: buildEnqueueMenuItems(items, defaultEnqueueOption),
     icon: ListMusic,
     labelArgs: [],
   });
@@ -1345,6 +1306,83 @@ export const getPlaybackContextMenuItems = async function (
     }
   }
   return playMenuItems;
+};
+
+// Radio and AudioSource are both live, infinite streams and share a single enqueue
+// default on the server; every other media type has its own config key.
+const LIVE_SOURCE_MEDIA_TYPES = [MediaType.RADIO, MediaType.AUDIO_SOURCE];
+
+/**
+ * The configured default enqueue option for the given item's media type.
+ *
+ * Only "play" and "replace" are configurable, so the result always starts
+ * playback right away.
+ */
+const getDefaultEnqueueOption = async function (
+  item: MediaItemTypeOrItemMapping,
+): Promise<QueueOption> {
+  const configKey = LIVE_SOURCE_MEDIA_TYPES.includes(item.media_type)
+    ? "default_enqueue_option_live_sources"
+    : `default_enqueue_option_${item.media_type}`;
+  return (await api.getCoreConfigValue(
+    "player_queues",
+    configKey,
+  )) as QueueOption;
+};
+
+/**
+ * Menu entries for every way the given items can be started or queued, with the
+ * configured default marked as selected.
+ */
+const buildEnqueueMenuItems = function (
+  items: MediaItemTypeOrItemMapping[],
+  defaultEnqueueOption: QueueOption,
+): ContextMenuItem[] {
+  return [
+    QueueOption.PLAY,
+    QueueOption.NEXT,
+    QueueOption.ADD,
+    QueueOption.REPLACE,
+    QueueOption.REPLACE_NEXT,
+  ].map((option) => ({
+    label: $t(`queue_option.${option}`),
+    action: () => {
+      api.playMedia(
+        items.map((x) => x.uri),
+        option,
+      );
+    },
+    icon: queueOptionIconMap[option],
+    labelArgs: [],
+    disabled: !store.activePlayer,
+    selected: option === defaultEnqueueOption,
+  }));
+};
+
+/**
+ * The single "Play now" entry offered for an AudioSource.
+ *
+ * An AudioSource hands the player over to a live external source (Spotify Connect,
+ * an AirPlay receiver, ...) that never ends, so anything placed behind it in the
+ * queue would never be reached: starting it is the only meaningful action. The
+ * configured default decides whether the existing queue is kept or replaced.
+ */
+const startAudioSourceMenuItem = function (
+  items: MediaItemTypeOrItemMapping[],
+  defaultEnqueueOption: QueueOption,
+): ContextMenuItem {
+  return {
+    label: "play_now",
+    action: () => {
+      api.playMedia(
+        items.map((x) => x.uri),
+        defaultEnqueueOption,
+      );
+    },
+    icon: PlayCircle,
+    labelArgs: [],
+    disabled: !store.activePlayer,
+  };
 };
 
 // media types whose contents have an order that is worth shuffling. Audiobooks and

--- a/tests/helpers/playMenuShuffle.test.ts
+++ b/tests/helpers/playMenuShuffle.test.ts
@@ -68,6 +68,7 @@ vi.mock("@/helpers/icon", () => ({
 }));
 
 vi.mock("@/plugins/api/helpers", () => ({
+  isAudioSource: vi.fn(() => false),
   isItemInLibrary: vi.fn(() => true),
   itemIsAvailable: vi.fn(() => true),
   itemSupportsPlayLog: vi.fn(() => false),

--- a/tests/layouts/ItemContextMenuPlayback.test.ts
+++ b/tests/layouts/ItemContextMenuPlayback.test.ts
@@ -1,0 +1,109 @@
+import {
+  getPlaybackContextMenuItems,
+  showPlayMenuForMediaItem,
+  type ContextMenuItem,
+} from "@/layouts/default/ItemContextMenu.vue";
+import type { ContextMenuDialogEvent } from "@/plugins/eventbus";
+import { QueueOption } from "@/plugins/api/interfaces";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { audioSource } from "../fixtures/audioSource";
+import { providerMapping } from "../fixtures/providerMapping";
+import { radio } from "../fixtures/radio";
+import { track } from "../fixtures/track";
+
+const { apiMock, emittedMenus, storeMock } = vi.hoisted(() => ({
+  emittedMenus: [] as ContextMenuDialogEvent[],
+  apiMock: {
+    getCoreConfigValue: vi.fn(),
+    playMedia: vi.fn(),
+    providers: { "test_provider--1": { available: true } },
+    players: {},
+    supportsPlayMediaShuffle: true,
+  },
+  storeMock: {
+    activePlayer: { player_id: "player-1" },
+    activePlayerId: "player-1",
+  },
+}));
+
+vi.mock("@/plugins/api", () => ({ default: apiMock, api: apiMock }));
+vi.mock("@/plugins/store", () => ({ store: storeMock }));
+vi.mock("@/plugins/eventbus", () => ({
+  eventbus: {
+    on: vi.fn(),
+    off: vi.fn(),
+    emit: vi.fn((_type: string, payload: ContextMenuDialogEvent) => {
+      emittedMenus.push(payload);
+    }),
+  },
+}));
+
+// an item only counts as available when one of its mappings resolves to a loaded provider
+const mappings = [providerMapping()];
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  emittedMenus.length = 0;
+  apiMock.getCoreConfigValue.mockResolvedValue(QueueOption.REPLACE);
+});
+
+describe("getPlaybackContextMenuItems", () => {
+  it("offers a single play action for an audio source", async () => {
+    const source = audioSource({ provider_mappings: mappings });
+
+    const items = await getPlaybackContextMenuItems([source]);
+    items[0].action?.();
+
+    expect(items.map((x) => x.label)).toEqual(["play_now"]);
+    expect(apiMock.playMedia).toHaveBeenCalledWith(
+      [source.uri],
+      QueueOption.REPLACE,
+    );
+  });
+
+  it("keeps the queue for an audio source when the configured default does", async () => {
+    apiMock.getCoreConfigValue.mockResolvedValue(QueueOption.PLAY);
+    const source = audioSource({ provider_mappings: mappings });
+
+    const items = await getPlaybackContextMenuItems([source]);
+    items[0].action?.();
+
+    expect(items.map((x) => x.label)).toEqual(["play_now"]);
+    expect(apiMock.playMedia).toHaveBeenCalledWith(
+      [source.uri],
+      QueueOption.PLAY,
+    );
+  });
+
+  it("keeps the enqueue options for radio, which shares the live sources default", async () => {
+    const items = await getPlaybackContextMenuItems([
+      radio({ provider_mappings: mappings }),
+    ]);
+
+    expect(items.find((x) => x.label == "enqueue")?.subItems).toHaveLength(5);
+  });
+
+  it("keeps the enqueue options for a track", async () => {
+    const items = await getPlaybackContextMenuItems([
+      track({ provider_mappings: mappings }),
+    ]);
+
+    expect(items.find((x) => x.label == "enqueue")?.subItems).toHaveLength(5);
+  });
+});
+
+describe("showPlayMenuForMediaItem", () => {
+  const emittedItems = (): ContextMenuItem[] => emittedMenus[0].items;
+
+  it("offers a single play action for an audio source", async () => {
+    await showPlayMenuForMediaItem(audioSource());
+
+    expect(emittedItems().map((x) => x.label)).toEqual(["play_now"]);
+  });
+
+  it("offers every enqueue option for a track", async () => {
+    await showPlayMenuForMediaItem(track());
+
+    expect(emittedItems()).toHaveLength(5);
+  });
+});


### PR DESCRIPTION
# What does this implement/fix?

The play menu offered every enqueue option for audio sources (Spotify Connect,
AirPlay receivers, Snapcast, ...) — including "Play next" and "Add to the
queue". An audio source is a live external stream that never ends, so a queued
one would only start once everything before it had played out, which is never.
Audio sources now offer a single "Play now" instead.

**Related issue (if applicable):**

- related issue `<link to issue>`

**Related backend PR (if applicable):**

- related backend PR `<link to PR>`

## Changes

- Audio sources show one "Play now" action; the "Enqueue options" submenu is
  gone for them. It still follows the configured default for live sources, which
  decides whether the current queue is kept or replaced.
- Radio keeps all its enqueue options — queueing a station after an album is
  still useful.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm lint:check` passes.
- [x] `pnpm test:run` passes, and tests have been added/updated where applicable.
- [x] `pnpm build` passes.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
