### PR TITLE
Swipe left on subpages comeback to the previous page

### DIFF
--- a/src/components/ui/sidebar/SidebarInset.vue
+++ b/src/components/ui/sidebar/SidebarInset.vue
@@ -7,7 +7,8 @@ const props = defineProps<{
   class?: HTMLAttributes["class"];
 }>();
 
-const { onTouchStart, onTouchMove, onTouchEnd } = useEdgeSwipeNavigation();
+const { onTouchStart, onTouchMove, onTouchEnd, surfaceRef, swipeStyle } =
+  useEdgeSwipeNavigation();
 </script>
 
 <template>
@@ -23,7 +24,14 @@ const { onTouchStart, onTouchMove, onTouchEnd } = useEdgeSwipeNavigation();
     @touchstart.passive="onTouchStart"
     @touchmove.passive="onTouchMove"
     @touchend.passive="onTouchEnd"
+    @touchcancel.passive="onTouchEnd"
   >
-    <slot></slot>
+    <div
+      ref="surfaceRef"
+      class="flex min-h-0 flex-1 flex-col"
+      :style="swipeStyle"
+    >
+      <slot></slot>
+    </div>
   </main>
 </template>

--- a/src/composables/useEdgeSwipeNavigation.ts
+++ b/src/composables/useEdgeSwipeNavigation.ts
@@ -4,12 +4,24 @@ import {
   type MobileSidebarSide,
 } from "@/composables/useMobileSidebarSide";
 import { canGoBack } from "@/helpers/navigation";
-import { ref } from "vue";
+import {
+  capturePageSnapshot,
+  type PageSnapshot,
+} from "@/helpers/page_snapshot";
+import { computed, onScopeDispose, ref, type StyleValue } from "vue";
 import { useRoute, useRouter } from "vue-router";
 
 const EDGE_ZONE_PX = 32;
 const SWIPE_THRESHOLD_PX = 60;
 const VERTICAL_TOLERANCE_PX = 40;
+const DIRECTION_LOCK_PX = 12;
+const SCROLL_END_SLACK_PX = 1;
+const SETTLE_MS = 220;
+const SETTLE_EASING = "cubic-bezier(0.32, 0.72, 0, 1)";
+const RESTORE_MS = 120;
+const REVEAL_PARALLAX = 0.25;
+
+type SwipeAction = "menu" | "back";
 
 /**
  * Touch handlers for the mobile edge-swipe gesture.
@@ -18,10 +30,23 @@ const VERTICAL_TOLERANCE_PX = 40;
  * the navigation sheet on the `discover` route, and navigates back on any
  * other route. When the menu opens from the right, that edge always opens
  * the sheet instead, and the left edge navigates back on every route.
- * Navigating back does nothing when there is nowhere to go back to.
+ * Nothing happens when there is nowhere to go back to.
  *
- * Only active while the mobile sidebar is closed. Bind the returned
- * handlers as passive touchstart/touchmove/touchend listeners.
+ * A back swipe is interactive. The moment it commits, the router goes back
+ * and the view being left is frozen into a snapshot laid over the top, so the
+ * view behind it is on screen and trailing the finger for the whole drag
+ * rather than appearing once the gesture is over. Releasing past the
+ * threshold sees it out; releasing short of it slides the snapshot back and
+ * undoes the navigation. Opening the sheet stays a plain threshold, as the
+ * sheet brings its own animation.
+ *
+ * A carousel under the touch keeps the gesture only while it can still
+ * scroll that way; parked at its start it cannot move, so the swipe belongs
+ * to the navigation. The drag also has to commit to the horizontal axis.
+ *
+ * Only active while the mobile sidebar is closed. Bind the returned handlers
+ * as passive touchstart/touchmove/touchend/touchcancel listeners, and
+ * `surfaceRef` plus `swipeStyle` on the element holding the page.
  */
 export function useEdgeSwipeNavigation() {
   const { isMobile, openMobile, setOpenMobile } = useSidebar();
@@ -32,6 +57,31 @@ export function useEdgeSwipeNavigation() {
   const touchStartX = ref(0);
   const touchStartY = ref(0);
   const swipeEdge = ref<MobileSidebarSide | null>(null);
+  const swipeAction = ref<SwipeAction | null>(null);
+  const surfaceRef = ref<HTMLElement | null>(null);
+  const pageOffset = ref(0);
+  const settling = ref(false);
+  const revealing = ref(false);
+
+  let settleTimer: ReturnType<typeof setTimeout> | undefined;
+  let snapshot: PageSnapshot | null = null;
+  let restoreScroll: (() => void) | null = null;
+  let gestureTarget: EventTarget | null = null;
+
+  const swipeStyle = computed<StyleValue | undefined>(() => {
+    if (!pageOffset.value && !settling.value) return undefined;
+
+    const x = revealing.value
+      ? -(viewportWidth() - pageOffset.value) * REVEAL_PARALLAX
+      : pageOffset.value;
+
+    return {
+      transform: `translate3d(${x}px, 0, 0)`,
+      transition: settling.value
+        ? `transform ${SETTLE_MS}ms ${SETTLE_EASING}`
+        : "none",
+    };
+  });
 
   function onTouchStart(event: TouchEvent) {
     if (!isMobile.value || openMobile.value) return;
@@ -43,12 +93,35 @@ export function useEdgeSwipeNavigation() {
     const edge = edgeAt(touch.clientX, mobileSidebarSide.value);
     // a carousel reaches close enough to the edge to be dragged from inside
     // this zone, and the listeners are passive, so the two would both run
-    swipeEdge.value = edge && !insideHorizontalScroller(event) ? edge : null;
+    const ours = edge && !scrollerOwnsSwipe(horizontalScrollerAt(event), edge);
+    swipeEdge.value = ours ? edge : null;
+    swipeAction.value = ours && edge ? actionFor(edge) : null;
+    if (swipeAction.value === "back") holdGesture(event.target);
+  }
+
+  function holdGesture(target: EventTarget | null) {
+    releaseGesture();
+    if (!target) return;
+    gestureTarget = target;
+    target.addEventListener("touchmove", onGestureMove, { passive: true });
+    target.addEventListener("touchend", onTouchEnd, { passive: true });
+    target.addEventListener("touchcancel", onTouchEnd, { passive: true });
+  }
+
+  const onGestureMove = (event: Event) => onTouchMove(event as TouchEvent);
+
+  function releaseGesture() {
+    if (!gestureTarget) return;
+    gestureTarget.removeEventListener("touchmove", onGestureMove);
+    gestureTarget.removeEventListener("touchend", onTouchEnd);
+    gestureTarget.removeEventListener("touchcancel", onTouchEnd);
+    gestureTarget = null;
   }
 
   function onTouchMove(event: TouchEvent) {
     const edge = swipeEdge.value;
-    if (!edge || !isMobile.value || openMobile.value) return;
+    const action = swipeAction.value;
+    if (!edge || !action || !isMobile.value || openMobile.value) return;
 
     const touch = event.touches[0];
     if (!touch) return;
@@ -56,35 +129,127 @@ export function useEdgeSwipeNavigation() {
     const deltaX = touch.clientX - touchStartX.value;
     const deltaY = touch.clientY - touchStartY.value;
 
-    if (Math.abs(deltaY) > VERTICAL_TOLERANCE_PX) {
-      swipeEdge.value = null;
+    if (
+      Math.abs(deltaX) < DIRECTION_LOCK_PX &&
+      Math.abs(deltaY) < DIRECTION_LOCK_PX
+    ) {
+      return;
+    }
+
+    if (
+      Math.abs(deltaY) > VERTICAL_TOLERANCE_PX ||
+      Math.abs(deltaY) >= Math.abs(deltaX)
+    ) {
+      abandonSwipe();
       return;
     }
 
     const traveled = edge === "left" ? deltaX : -deltaX;
-    if (traveled > SWIPE_THRESHOLD_PX) {
-      triggerSwipeAction(edge);
-      swipeEdge.value = null;
+
+    if (action === "menu") {
+      if (traveled > SWIPE_THRESHOLD_PX) {
+        setOpenMobile(true);
+        swipeEdge.value = null;
+        swipeAction.value = null;
+      }
+      return;
     }
+
+    if (!revealing.value) beginReveal();
+    setOffset(Math.max(0, Math.min(traveled, viewportWidth())));
   }
 
   function onTouchEnd() {
+    const action = swipeAction.value;
     swipeEdge.value = null;
+    swipeAction.value = null;
+    releaseGesture();
+    if (action !== "back" || !revealing.value) return;
+
+    if (pageOffset.value > SWIPE_THRESHOLD_PX) finishReveal();
+    else cancelReveal();
   }
 
-  function triggerSwipeAction(edge: MobileSidebarSide) {
-    const side = mobileSidebarSide.value;
-    const opensMenu =
-      edge === side && (side === "right" || route.name === "discover");
+  function abandonSwipe() {
+    swipeEdge.value = null;
+    swipeAction.value = null;
+    releaseGesture();
+    if (revealing.value) cancelReveal();
+  }
 
-    if (opensMenu) {
-      setOpenMobile(true);
-    } else if (canGoBack(router)) {
-      router.back();
+  function beginReveal() {
+    const surface = surfaceRef.value;
+    if (surface) {
+      restoreScroll = captureScroll(surface);
+      snapshot = capturePageSnapshot(surface);
+      snapshot.place(pageOffset.value);
     }
+    revealing.value = true;
+    router.back();
   }
 
-  return { onTouchStart, onTouchMove, onTouchEnd };
+  function finishReveal() {
+    slide(viewportWidth(), () => {
+      revealing.value = false;
+      setOffset(0);
+      dropSnapshot();
+    });
+  }
+
+  function cancelReveal() {
+    slide(0, () => {
+      revealing.value = false;
+      setOffset(0);
+      clearTimeout(settleTimer);
+      settleTimer = setTimeout(() => {
+        restoreScroll?.();
+        dropSnapshot();
+      }, RESTORE_MS);
+      router.forward();
+    });
+  }
+
+  function setOffset(offset: number) {
+    pageOffset.value = offset;
+    snapshot?.place(offset, settling.value ? SETTLE_MS : undefined);
+  }
+
+  function slide(offset: number, onArrival: () => void) {
+    clearTimeout(settleTimer);
+    if (prefersReducedMotion()) {
+      settling.value = false;
+      onArrival();
+      return;
+    }
+    settling.value = true;
+    setOffset(offset);
+    settleTimer = setTimeout(() => {
+      settling.value = false;
+      onArrival();
+    }, SETTLE_MS);
+  }
+
+  function dropSnapshot() {
+    snapshot?.remove();
+    snapshot = null;
+    restoreScroll = null;
+  }
+
+  function actionFor(edge: MobileSidebarSide): SwipeAction | null {
+    const side = mobileSidebarSide.value;
+    if (edge === side && (side === "right" || route.name === "discover")) {
+      return "menu";
+    }
+    return canGoBack(router) ? "back" : null;
+  }
+
+  onScopeDispose(() => {
+    clearTimeout(settleTimer);
+    releaseGesture();
+    dropSnapshot();
+  });
+
+  return { onTouchStart, onTouchMove, onTouchEnd, surfaceRef, swipeStyle };
 }
 
 /**
@@ -95,19 +260,15 @@ function edgeAt(x: number, side: MobileSidebarSide): MobileSidebarSide | null {
   if (x <= EDGE_ZONE_PX) return "left";
   if (side !== "right") return null;
 
-  const width =
-    window.innerWidth ||
-    (typeof document !== "undefined"
-      ? document.documentElement.clientWidth
-      : 0);
+  const width = viewportWidth();
   return width > 0 && x >= width - EDGE_ZONE_PX ? "right" : null;
 }
 
 /**
- * Whether a touch landed on something that scrolls sideways, looking no
- * further out than the element the handlers are bound to.
+ * The nearest thing that scrolls sideways under a touch, looking no further
+ * out than the element the handlers are bound to.
  */
-function insideHorizontalScroller(event: TouchEvent) {
+function horizontalScrollerAt(event: TouchEvent): Element | null {
   let element = event.target instanceof Element ? event.target : null;
 
   while (element && element !== event.currentTarget) {
@@ -116,9 +277,44 @@ function insideHorizontalScroller(event: TouchEvent) {
       (overflowX === "auto" || overflowX === "scroll") &&
       element.scrollWidth > element.clientWidth
     ) {
-      return true;
+      return element;
     }
     element = element.parentElement;
   }
-  return false;
+  return null;
+}
+
+function scrollerOwnsSwipe(
+  scroller: Element | null,
+  edge: MobileSidebarSide,
+): boolean {
+  if (!scroller) return false;
+  if (edge === "left") return scroller.scrollLeft > SCROLL_END_SLACK_PX;
+  const maxScrollLeft = scroller.scrollWidth - scroller.clientWidth;
+  return scroller.scrollLeft < maxScrollLeft - SCROLL_END_SLACK_PX;
+}
+
+function captureScroll(surface: HTMLElement): (() => void) | null {
+  const scroller = [...surface.querySelectorAll<HTMLElement>("*")].find(
+    (el) => el.scrollTop > 0,
+  );
+  if (!scroller) return null;
+  const top = scroller.scrollTop;
+  // leave it alone if the view already restored itself
+  return () => {
+    if (!scroller.scrollTop) scroller.scrollTop = top;
+  };
+}
+
+function viewportWidth(): number {
+  return (
+    window.innerWidth ||
+    (typeof document !== "undefined" ? document.documentElement.clientWidth : 0)
+  );
+}
+
+function prefersReducedMotion(): boolean {
+  return (
+    window.matchMedia?.("(prefers-reduced-motion: reduce)").matches ?? false
+  );
 }

--- a/src/helpers/page_snapshot.ts
+++ b/src/helpers/page_snapshot.ts
@@ -1,0 +1,79 @@
+/**
+ * A still copy of the page, pinned on top of the real one.
+ *
+ * The back swipe needs the view being left to stay on screen while the view
+ * behind it renders underneath, and the router has already thrown that view
+ * away by then - so a clone stands in for it until the gesture is over.
+ */
+export interface PageSnapshot {
+  el: HTMLElement;
+  place: (offsetX: number, ms?: number) => void;
+  remove: () => void;
+}
+
+const SNAPSHOT_Z_INDEX = "3";
+const EDGE_SHADOW = "-8px 0 24px rgb(0 0 0 / 0.18)";
+
+export function capturePageSnapshot(source: HTMLElement): PageSnapshot {
+  const rect = source.getBoundingClientRect();
+  const el = source.cloneNode(true) as HTMLElement;
+
+  el.setAttribute("aria-hidden", "true");
+  el.setAttribute("inert", "");
+  Object.assign(el.style, {
+    position: "fixed",
+    top: `${rect.top}px`,
+    left: `${rect.left}px`,
+    width: `${rect.width}px`,
+    height: `${rect.height}px`,
+    margin: "0",
+    zIndex: SNAPSHOT_Z_INDEX,
+    pointerEvents: "none",
+    willChange: "transform",
+    backgroundColor: inheritedBackground(source),
+    boxShadow: EDGE_SHADOW,
+  });
+
+  document.body.appendChild(el);
+  copyScrollOffsets(source, el);
+
+  return {
+    el,
+    place: (offsetX: number, ms?: number) => {
+      el.style.transition = ms
+        ? `transform ${ms}ms cubic-bezier(0.32, 0.72, 0, 1)`
+        : "none";
+      el.style.transform = `translate3d(${offsetX}px, 0, 0)`;
+    },
+    remove: () => el.remove(),
+  };
+}
+
+function copyScrollOffsets(source: Element, clone: Element) {
+  const from = [source, ...source.querySelectorAll("*")];
+  const to = [clone, ...clone.querySelectorAll("*")];
+  for (let i = 0; i < from.length && i < to.length; i++) {
+    if (from[i].scrollTop) to[i].scrollTop = from[i].scrollTop;
+    if (from[i].scrollLeft) to[i].scrollLeft = from[i].scrollLeft;
+  }
+}
+
+function inheritedBackground(source: Element): string {
+  for (
+    let el: Element | null = source;
+    el && el !== document.documentElement;
+    el = el.parentElement
+  ) {
+    const { backgroundColor } = getComputedStyle(el);
+    if (backgroundColor && !isTransparent(backgroundColor)) {
+      return backgroundColor;
+    }
+  }
+  return "var(--background)";
+}
+
+function isTransparent(color: string): boolean {
+  if (color === "transparent") return true;
+  const alpha = color.match(/^rgba?\([^)]*[,/]\s*([\d.]+)\s*\)$/)?.[1];
+  return alpha !== undefined && Number(alpha) === 0;
+}

--- a/src/helpers/page_snapshot.ts
+++ b/src/helpers/page_snapshot.ts
@@ -18,6 +18,10 @@ export function capturePageSnapshot(source: HTMLElement): PageSnapshot {
   const rect = source.getBoundingClientRect();
   const el = source.cloneNode(true) as HTMLElement;
 
+  // Avoid duplicate IDs in the document while the snapshot is mounted.
+  el.removeAttribute("id");
+  el.querySelectorAll("[id]").forEach((node) => node.removeAttribute("id"));
+
   el.setAttribute("aria-hidden", "true");
   el.setAttribute("inert", "");
   Object.assign(el.style, {

--- a/tests/composables/useEdgeSwipeNavigation.test.ts
+++ b/tests/composables/useEdgeSwipeNavigation.test.ts
@@ -96,9 +96,9 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+  vi.clearAllTimers();
   vi.useRealTimers();
   vi.clearAllMocks();
-  mobileSidebarSide.value = "left";
   routeState.name = "discover";
   sidebarState.isMobile.value = true;
   sidebarState.openMobile.value = false;

--- a/tests/composables/useEdgeSwipeNavigation.test.ts
+++ b/tests/composables/useEdgeSwipeNavigation.test.ts
@@ -5,6 +5,7 @@ const {
   historyState,
   mobileSidebarSide,
   mockRouterBack,
+  mockRouterForward,
   mockSetOpenMobile,
   routeState,
   sidebarState,
@@ -12,6 +13,7 @@ const {
   historyState: { back: null as string | null },
   mobileSidebarSide: { value: "left" as "left" | "right" },
   mockRouterBack: vi.fn(),
+  mockRouterForward: vi.fn(),
   mockSetOpenMobile: vi.fn(),
   routeState: { name: "discover" as string },
   sidebarState: { isMobile: { value: true }, openMobile: { value: false } },
@@ -33,6 +35,7 @@ vi.mock("vue-router", () => ({
   useRoute: () => routeState,
   useRouter: () => ({
     back: mockRouterBack,
+    forward: mockRouterForward,
     options: { history: { state: historyState } },
   }),
 }));
@@ -51,13 +54,18 @@ function touchEvent(x: number, y: number, target?: Element): TouchEvent {
   } as unknown as TouchEvent;
 }
 
-/** A card inside a shelf that does or does not scroll sideways, under `<main>`. */
-function cardInsideShelf(scrolls: boolean) {
+/**
+ * A card inside a shelf that does or does not scroll sideways, under `<main>`.
+ * `scrollLeft` says how far the shelf is scrolled off its start, which is what
+ * decides whether it still has anywhere to go.
+ */
+function cardInsideShelf(scrolls: boolean, scrollLeft = 0) {
   const main = document.createElement("main");
   const shelf = document.createElement("div");
   shelf.style.overflowX = scrolls ? "auto" : "visible";
   Object.defineProperty(shelf, "scrollWidth", { value: scrolls ? 900 : 375 });
   Object.defineProperty(shelf, "clientWidth", { value: 375 });
+  Object.defineProperty(shelf, "scrollLeft", { value: scrollLeft });
   const card = document.createElement("button");
   shelf.appendChild(card);
   main.appendChild(shelf);
@@ -73,11 +81,22 @@ function setViewportWidth(width: number) {
   });
 }
 
+// how long the page takes to slide out before the view behind it renders
+const SETTLE_MS = 220;
+
+/** Lifts the finger and lets the page finish sliding out of the way. */
+function endSwipe(onTouchEnd: () => void) {
+  onTouchEnd();
+  vi.advanceTimersByTime(SETTLE_MS);
+}
+
 beforeEach(() => {
+  vi.useFakeTimers();
   setViewportWidth(800);
 });
 
 afterEach(() => {
+  vi.useRealTimers();
   vi.clearAllMocks();
   mobileSidebarSide.value = "left";
   routeState.name = "discover";
@@ -105,10 +124,11 @@ describe("useEdgeSwipeNavigation", () => {
   it("goes back on a left-edge swipe off discover, with the menu on the left", () => {
     routeState.name = "album";
     historyState.back = "/discover";
-    const { onTouchStart, onTouchMove } = useEdgeSwipeNavigation();
+    const { onTouchStart, onTouchMove, onTouchEnd } = useEdgeSwipeNavigation();
 
     onTouchStart(touchEvent(10, 100));
     onTouchMove(touchEvent(80, 100));
+    endSwipe(onTouchEnd);
 
     expect(mockRouterBack).toHaveBeenCalledTimes(1);
     expect(mockSetOpenMobile).not.toHaveBeenCalled();
@@ -130,10 +150,11 @@ describe("useEdgeSwipeNavigation", () => {
   it("goes back on a left-edge swipe, with the menu on the right", () => {
     mobileSidebarSide.value = "right";
     historyState.back = "/discover";
-    const { onTouchStart, onTouchMove } = useEdgeSwipeNavigation();
+    const { onTouchStart, onTouchMove, onTouchEnd } = useEdgeSwipeNavigation();
 
     onTouchStart(touchEvent(10, 100));
     onTouchMove(touchEvent(80, 100));
+    endSwipe(onTouchEnd);
 
     expect(mockRouterBack).toHaveBeenCalledTimes(1);
     expect(mockSetOpenMobile).not.toHaveBeenCalled();
@@ -167,10 +188,10 @@ describe("useEdgeSwipeNavigation", () => {
 
   // the shelves reach into the edge zone, and the listeners are passive, so a
   // flick along one would otherwise scroll it and navigate away at once
-  it("leaves a sideways drag on a carousel to the carousel", () => {
+  it("leaves a sideways drag to a carousel that is scrolled off its start", () => {
     routeState.name = "album";
     historyState.back = "/discover";
-    const card = cardInsideShelf(true);
+    const card = cardInsideShelf(true, 240);
     const { onTouchStart, onTouchMove } = useEdgeSwipeNavigation();
 
     onTouchStart(touchEvent(10, 100, card));
@@ -180,18 +201,133 @@ describe("useEdgeSwipeNavigation", () => {
     expect(mockSetOpenMobile).not.toHaveBeenCalled();
   });
 
+  // the home screen is wall to wall carousels sitting at their start, and a
+  // swipe cannot scroll one further that way: handing it the gesture anyway
+  // left dead stripes down the edge where nothing happened at all
+  it("takes the swipe over a carousel parked at its start", () => {
+    routeState.name = "album";
+    historyState.back = "/discover";
+    const card = cardInsideShelf(true);
+    const { onTouchStart, onTouchMove, onTouchEnd } = useEdgeSwipeNavigation();
+
+    onTouchStart(touchEvent(10, 100, card));
+    onTouchMove(touchEvent(80, 100, card));
+    endSwipe(onTouchEnd);
+
+    expect(mockRouterBack).toHaveBeenCalledTimes(1);
+  });
+
+  // mirrored: from the right edge the swipe drags a carousel onwards, so this
+  // time it is the far end that has nothing left to give
+  it("leaves a right-edge drag to a carousel that can still scroll on", () => {
+    mobileSidebarSide.value = "right";
+    routeState.name = "album";
+    const card = cardInsideShelf(true);
+    const { onTouchStart, onTouchMove } = useEdgeSwipeNavigation();
+
+    onTouchStart(touchEvent(790, 100, card));
+    onTouchMove(touchEvent(720, 100, card));
+
+    expect(mockSetOpenMobile).not.toHaveBeenCalled();
+  });
+
   // the same gesture over the same markup, minus the sideways scroll, so the
-  // case above cannot pass on the plumbing alone
+  // cases above cannot pass on the plumbing alone
   it("still goes back over a shelf that has nothing to scroll", () => {
     routeState.name = "album";
     historyState.back = "/discover";
     const card = cardInsideShelf(false);
-    const { onTouchStart, onTouchMove } = useEdgeSwipeNavigation();
+    const { onTouchStart, onTouchMove, onTouchEnd } = useEdgeSwipeNavigation();
 
     onTouchStart(touchEvent(10, 100, card));
     onTouchMove(touchEvent(80, 100, card));
+    endSwipe(onTouchEnd);
 
     expect(mockRouterBack).toHaveBeenCalledTimes(1);
+  });
+
+  // swiping used to drag the page off a blank background and only show where
+  // you were going once it was over: the router now moves at the start of the
+  // gesture so the view behind is real, on screen, and following the finger
+  it("reveals the view behind as soon as the swipe commits", () => {
+    routeState.name = "album";
+    historyState.back = "/discover";
+    const { onTouchStart, onTouchMove, swipeStyle } = useEdgeSwipeNavigation();
+
+    expect(swipeStyle.value).toBeUndefined();
+
+    onTouchStart(touchEvent(10, 100));
+    onTouchMove(touchEvent(55, 100));
+
+    expect(mockRouterBack).toHaveBeenCalledTimes(1);
+    // 45px into an 800px screen, so the incoming view still has a quarter of
+    // the remaining 755px to close before it sits square
+    expect(swipeStyle.value).toMatchObject({
+      transform: "translate3d(-188.75px, 0, 0)",
+      transition: "none",
+    });
+  });
+
+  it("lets go of the page again once it is back in place", () => {
+    routeState.name = "album";
+    historyState.back = "/discover";
+    const { onTouchStart, onTouchMove, onTouchEnd, swipeStyle } =
+      useEdgeSwipeNavigation();
+
+    onTouchStart(touchEvent(10, 100));
+    onTouchMove(touchEvent(80, 100));
+    endSwipe(onTouchEnd);
+
+    // the page is put straight back in the task the previous view renders in,
+    // so it is never painted off to the side under the incoming page
+    expect(mockRouterBack).toHaveBeenCalledTimes(1);
+    expect(swipeStyle.value).toBeUndefined();
+  });
+
+  // the reveal costs a navigation up front, so calling the gesture off has to
+  // put that back rather than leaving the user a page further along
+  it("undoes the navigation when the swipe falls short", () => {
+    routeState.name = "album";
+    historyState.back = "/discover";
+    const { onTouchStart, onTouchMove, onTouchEnd, swipeStyle } =
+      useEdgeSwipeNavigation();
+
+    onTouchStart(touchEvent(10, 100));
+    onTouchMove(touchEvent(50, 100)); // 40px, under the 60px threshold
+    expect(mockRouterBack).toHaveBeenCalledTimes(1);
+
+    endSwipe(onTouchEnd);
+
+    expect(mockRouterForward).toHaveBeenCalledTimes(1);
+    expect(swipeStyle.value).toBeUndefined();
+  });
+
+  // a drag that turns into a scroll has committed just the same, so it owes
+  // the same undo
+  it("undoes the navigation when the drag turns vertical", () => {
+    routeState.name = "album";
+    historyState.back = "/discover";
+    const { onTouchStart, onTouchMove } = useEdgeSwipeNavigation();
+
+    onTouchStart(touchEvent(10, 100));
+    onTouchMove(touchEvent(80, 100));
+    expect(mockRouterBack).toHaveBeenCalledTimes(1);
+
+    onTouchMove(touchEvent(90, 200)); // drifted well past the tolerance
+    vi.advanceTimersByTime(SETTLE_MS);
+
+    expect(mockRouterForward).toHaveBeenCalledTimes(1);
+  });
+
+  // the sheet animates itself in, so that half of the gesture is untouched
+  it("leaves the page alone when the swipe opens the menu", () => {
+    const { onTouchStart, onTouchMove, swipeStyle } = useEdgeSwipeNavigation();
+
+    onTouchStart(touchEvent(10, 100));
+    onTouchMove(touchEvent(80, 100));
+
+    expect(mockSetOpenMobile).toHaveBeenCalledWith(true);
+    expect(swipeStyle.value).toBeUndefined();
   });
 
   it("does nothing when the swipe starts away from any edge", () => {
@@ -199,6 +335,31 @@ describe("useEdgeSwipeNavigation", () => {
 
     onTouchStart(touchEvent(400, 100));
     onTouchMove(touchEvent(470, 100));
+
+    expect(mockRouterBack).not.toHaveBeenCalled();
+    expect(mockSetOpenMobile).not.toHaveBeenCalled();
+  });
+
+  // a drag has no meaningful direction in its first pixels, so reading one out
+  // of the jitter would cancel gestures that were about to go horizontal
+  it("keeps tracking through the jitter at the start of a drag", () => {
+    const { onTouchStart, onTouchMove } = useEdgeSwipeNavigation();
+
+    onTouchStart(touchEvent(10, 100));
+    onTouchMove(touchEvent(13, 108)); // leans vertical, but nothing committed
+    onTouchMove(touchEvent(80, 110));
+
+    expect(mockSetOpenMobile).toHaveBeenCalledWith(true);
+  });
+
+  // a diagonal drag stays under the vertical tolerance while still being a
+  // scroll: whichever axis leads is the one that gets the gesture
+  it("leaves a drag that leans vertical to the page", () => {
+    const { onTouchStart, onTouchMove } = useEdgeSwipeNavigation();
+
+    onTouchStart(touchEvent(10, 100));
+    onTouchMove(touchEvent(35, 135)); // 25 across, 35 down: vertical leads
+    onTouchMove(touchEvent(80, 135)); // would otherwise clear the threshold
 
     expect(mockRouterBack).not.toHaveBeenCalled();
     expect(mockSetOpenMobile).not.toHaveBeenCalled();

--- a/tests/composables/useEdgeSwipeNavigation.test.ts
+++ b/tests/composables/useEdgeSwipeNavigation.test.ts
@@ -99,6 +99,7 @@ afterEach(() => {
   vi.clearAllTimers();
   vi.useRealTimers();
   vi.clearAllMocks();
+  mobileSidebarSide.value = "left";
   routeState.name = "discover";
   sidebarState.isMobile.value = true;
   sidebarState.openMobile.value = false;

--- a/tests/helpers/page_snapshot.test.ts
+++ b/tests/helpers/page_snapshot.test.ts
@@ -11,6 +11,7 @@ function pageWithScroller() {
   const page = document.createElement("div");
   const scroller = document.createElement("div");
   scroller.id = "scroller";
+  scroller.className = "scroller";
   scroller.textContent = "the view being left";
   page.appendChild(scroller);
   frame.appendChild(page);
@@ -59,8 +60,16 @@ describe("capturePageSnapshot", () => {
   it("keeps the page where it was scrolled to", () => {
     const snapshot = capturePageSnapshot(pageWithScroller());
 
-    const clonedScroller = snapshot.el.querySelector("#scroller");
-    expect((clonedScroller as HTMLElement).scrollTop).toBe(640);
+    const clonedScroller = snapshot.el.querySelector<HTMLElement>(".scroller");
+    expect(clonedScroller?.scrollTop).toBe(640);
+  });
+
+  it("strips the ids it would otherwise duplicate", () => {
+    const snapshot = capturePageSnapshot(pageWithScroller());
+
+    expect(snapshot.el.hasAttribute("id")).toBe(false);
+    expect(snapshot.el.querySelectorAll("[id]")).toHaveLength(0);
+    expect(snapshot.el.querySelector(".scroller")).not.toBeNull();
   });
 
   it("moves, animates and cleans up after itself", () => {

--- a/tests/helpers/page_snapshot.test.ts
+++ b/tests/helpers/page_snapshot.test.ts
@@ -1,0 +1,80 @@
+import { capturePageSnapshot } from "@/helpers/page_snapshot";
+import { afterEach, describe, expect, it } from "vitest";
+
+/**
+ * A page with something scrolled inside it, as the back swipe finds it: the
+ * page itself paints nothing and sits on a frame that does.
+ */
+function pageWithScroller() {
+  const frame = document.createElement("main");
+  frame.style.backgroundColor = "rgb(18, 18, 18)";
+  const page = document.createElement("div");
+  const scroller = document.createElement("div");
+  scroller.id = "scroller";
+  scroller.textContent = "the view being left";
+  page.appendChild(scroller);
+  frame.appendChild(page);
+  document.body.appendChild(frame);
+  // jsdom does not lay anything out, so scroll offsets have to be declared
+  Object.defineProperty(scroller, "scrollTop", { value: 640, writable: true });
+  return page;
+}
+
+afterEach(() => {
+  document.body.innerHTML = "";
+});
+
+describe("capturePageSnapshot", () => {
+  it("pins a copy of the page over the top of it", () => {
+    const snapshot = capturePageSnapshot(pageWithScroller());
+
+    expect(snapshot.el.parentElement).toBe(document.body);
+    expect(snapshot.el.textContent).toContain("the view being left");
+    expect(snapshot.el.style.position).toBe("fixed");
+    // it is a picture: nothing should be able to read it or touch it
+    expect(snapshot.el.getAttribute("aria-hidden")).toBe("true");
+    expect(snapshot.el.hasAttribute("inert")).toBe(true);
+    expect(snapshot.el.style.pointerEvents).toBe("none");
+  });
+
+  // the page draws no background of its own, so a bare clone lets the view
+  // underneath show straight through and the two read as a single jumbled page
+  it("carries the background the page was sitting on", () => {
+    const snapshot = capturePageSnapshot(pageWithScroller());
+
+    expect(snapshot.el.style.backgroundColor).toBe("rgb(18, 18, 18)");
+  });
+
+  it("falls back to the theme background when nothing paints one", () => {
+    const bare = document.createElement("div");
+    document.body.appendChild(bare);
+
+    expect(capturePageSnapshot(bare).el.style.backgroundColor).toBe(
+      "var(--background)",
+    );
+  });
+
+  // a clone starts at the top of every scroller it holds, which would show the
+  // page jumping to the top the moment the swipe freezes it
+  it("keeps the page where it was scrolled to", () => {
+    const snapshot = capturePageSnapshot(pageWithScroller());
+
+    const clonedScroller = snapshot.el.querySelector("#scroller");
+    expect((clonedScroller as HTMLElement).scrollTop).toBe(640);
+  });
+
+  it("moves, animates and cleans up after itself", () => {
+    const snapshot = capturePageSnapshot(pageWithScroller());
+
+    snapshot.place(120);
+    expect(snapshot.el.style.transform).toBe("translate3d(120px, 0, 0)");
+    expect(snapshot.el.style.transition).toBe("none");
+
+    snapshot.place(375, 220);
+    expect(snapshot.el.style.transform).toBe("translate3d(375px, 0, 0)");
+    expect(snapshot.el.style.transition).toContain("220ms");
+
+    snapshot.remove();
+    expect(snapshot.el.parentElement).toBeNull();
+  });
+});


### PR DESCRIPTION
# What does this implement/fix?

Swipe left on subpages comeback to the previous page. The swipe left on discover still show the menu.

https://github.com/user-attachments/assets/ae41dc21-033c-4bb2-b51d-23df59af2d49

<!-- Quick description and explanation of changes. -->

**Related issue (if applicable):**

- related issue `<link to issue>`

**Related backend PR (if applicable):**

<!--
Link the music-assistant/server PR when this change relies on new server
behaviour, so the two can be reviewed and released together.
-->

- related backend PR `<link to PR>`

## Types of changes

<!--
Tick exactly one box below. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [ ] The code change is tested and works locally.
- [ ] `pnpm lint:check` passes.
- [ ] `pnpm test:run` passes, and tests have been added/updated where applicable.
- [ ] `pnpm build` passes.
- [ ] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
