### PR TITLE
Add the daily weather placeholder to AI Radio segment guards

### DIFF
--- a/src/helpers/ai_radio.ts
+++ b/src/helpers/ai_radio.ts
@@ -210,7 +210,11 @@ export const GENERIC_HOST_SEGMENTS: ShowSegment[] =
 export const MERGE_SECTION_PROMPT =
   "Merge the drafts below into one coherent radio break. Preserve factual content, remove duplication, and make the final segment sound like one host speaking naturally.\n<section_drafts>";
 
-const GUARD_PLACEHOLDER_TOKENS = ["<weather_hourly>", "<timestamp>"] as const;
+const GUARD_PLACEHOLDER_TOKENS = [
+  "<weather_hourly>",
+  "<timestamp>",
+  "<weather_daily>",
+] as const;
 
 const detectRequiredPlaceholders = (prompt: string): string[] => {
   return GUARD_PLACEHOLDER_TOKENS.filter((token) => prompt.includes(token));


### PR DESCRIPTION
# What does this implement/fix?

The host compiler derives `require_placeholders_present` guards from the segment prompt, but the token list missed `<weather_daily>`. A segment using only the daily forecast placeholder got no guard, so it was scheduled even when no weather data was available and the DJ invented a forecast.

- Add `<weather_daily>` to `GUARD_PLACEHOLDER_TOKENS` in the host compiler

**Related issue (if applicable):**

- related issue N/A (user reports via Discord)

**Related backend PR (if applicable):**

- related backend PR https://github.com/music-assistant/server/pull/5838

## Types of changes

<!--
Tick exactly one box below. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm lint:check` passes.
- [x] `pnpm test:run` passes, and tests have been added/updated where applicable.
- [x] `pnpm build` passes.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
