### PR TITLE
Use same sheet for search as the other one on mobile

### DIFF
--- a/src/components/CommandCenter.vue
+++ b/src/components/CommandCenter.vue
@@ -1,16 +1,8 @@
 <template>
-  <CommandDialog
+  <CommandCenterShell
     v-model:open="isOpen"
     :title="$t('search')"
     :description="$t('type_to_search')"
-    :show-close-button="false"
-    :focus-input-on-open="true"
-    :content-class="[
-      'command-center-content',
-      mobileLayout
-        ? 'command-center-content--mobile top-0 left-0 flex h-[100dvh] max-h-none w-screen max-w-none translate-x-0 translate-y-0 flex-col gap-0 rounded-none border-0 sm:max-w-none'
-        : 'top-[10%] flex translate-y-0 flex-col gap-0 sm:max-w-2xl',
-    ]"
   >
     <div
       data-slot="command-input-wrapper"
@@ -36,15 +28,6 @@
         @click="clearQuery"
       >
         <X class="size-4" />
-      </button>
-      <button
-        v-if="mobileLayout"
-        type="button"
-        class="command-center-close"
-        :aria-label="$t('close')"
-        @click="close"
-      >
-        <X class="size-5" />
       </button>
     </div>
 
@@ -236,15 +219,15 @@
         <Kbd>{{ commandCenterHotkeyLabel }}</Kbd>
       </span>
     </div>
-  </CommandDialog>
+  </CommandCenterShell>
 </template>
 
 <script setup lang="ts">
 import MediaItemThumb from "@/components/MediaItemThumb.vue";
 import PlayerIcon from "@/components/PlayerIcon.vue";
 import ProviderIcon from "@/components/ProviderIcon.vue";
+import CommandCenterShell from "@/components/CommandCenterShell.vue";
 import {
-  CommandDialog,
   CommandGroup,
   CommandItem,
   CommandList,
@@ -713,14 +696,5 @@ watch(
   .command-center-play {
     opacity: 1;
   }
-}
-</style>
-
-<style>
-.command-center-content--mobile {
-  padding-top: var(--device-inset-top);
-  padding-right: var(--device-inset-right);
-  padding-bottom: var(--device-inset-bottom);
-  padding-left: var(--device-inset-left);
 }
 </style>

--- a/src/components/CommandCenterShell.vue
+++ b/src/components/CommandCenterShell.vue
@@ -1,0 +1,80 @@
+<script setup lang="ts">
+import PanelDragHandle from "@/components/PanelDragHandle.vue";
+import { Command, CommandDialog } from "@/components/ui/command";
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetTitle,
+} from "@/components/ui/sheet";
+import { focusCommandInputOnOpen } from "@/helpers/dialog_focus";
+import { store } from "@/plugins/store";
+import { computed } from "vue";
+
+const props = defineProps<{
+  title: string;
+  description: string;
+}>();
+
+const open = defineModel<boolean>("open", { default: false });
+
+const asSheet = computed(() => store.mobileLayout);
+</script>
+
+<template>
+  <Sheet v-if="asSheet" v-model:open="open">
+    <SheetContent
+      data-player-panel
+      side="bottom"
+      :show-close="false"
+      class="player-bar-popout command-center-sheet z-[998] gap-0 overflow-hidden rounded-xl p-0"
+      overlay-class="command-center-sheet-overlay z-[997]"
+      @open-auto-focus="focusCommandInputOnOpen"
+    >
+      <PanelDragHandle @dismiss="open = false" />
+      <SheetTitle class="sr-only">{{ props.title }}</SheetTitle>
+      <SheetDescription class="sr-only">
+        {{ props.description }}
+      </SheetDescription>
+      <Command class="flex min-h-0 flex-1 flex-col">
+        <slot></slot>
+      </Command>
+    </SheetContent>
+  </Sheet>
+
+  <CommandDialog
+    v-else
+    v-model:open="open"
+    :title="props.title"
+    :description="props.description"
+    :show-close-button="false"
+    :focus-input-on-open="true"
+    content-class="top-[10%] flex translate-y-0 flex-col gap-0 sm:max-w-2xl"
+  >
+    <slot></slot>
+  </CommandDialog>
+</template>
+
+<style>
+.player-bar-popout.command-center-sheet {
+  right: var(--player-bar-popout-inset-x) !important;
+  bottom: calc(
+    var(--mobile-navigation-height) + var(--player-bar-popout-gap)
+  ) !important;
+  left: var(--player-bar-popout-inset-x) !important;
+  width: auto !important;
+
+  height: calc(
+    100dvh - var(--mobile-navigation-height) - var(--player-bar-popout-gap) -
+      var(--player-bar-popout-top-gap)
+  );
+  max-height: calc(
+    100dvh - var(--mobile-navigation-height) - var(--player-bar-popout-gap) -
+      var(--player-bar-popout-top-gap)
+  );
+}
+
+:root .command-center-sheet-overlay {
+  bottom: var(--mobile-navigation-height) !important;
+}
+</style>

--- a/src/components/ItemsListing.vue
+++ b/src/components/ItemsListing.vue
@@ -57,7 +57,7 @@
       ref="searchInputRef"
       v-model="params.search"
       clearable
-      class="listing-search listing-search--row"
+      class="listing-search listing-search--row mx-2.5 mt-2.5 w-auto"
       :placeholder="searchLabel"
       :aria-label="searchLabel"
       @focus="searchHasFocus = true"
@@ -2179,10 +2179,6 @@ defineExpose({
   width: 100%;
   font-size: 0.9375rem;
   font-weight: 400;
-}
-
-.listing-search--row {
-  margin-top: 10px;
 }
 
 .disc-header {

--- a/tests/components/CommandCenterShell.test.ts
+++ b/tests/components/CommandCenterShell.test.ts
@@ -1,0 +1,84 @@
+import CommandCenterShell from "@/components/CommandCenterShell.vue";
+import { mount } from "@vue/test-utils";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const state = vi.hoisted(() => ({
+  storeMock: { mobileLayout: false },
+}));
+
+vi.mock("@/plugins/store", () => ({ store: state.storeMock }));
+vi.mock("@/plugins/i18n", () => ({ $t: (key: string) => key }));
+
+/** Renders slot content so the frame's own structure stays visible. */
+const passthrough = (tag: string, attrs = "") => ({
+  template: `<${tag} ${attrs}><slot /></${tag}>`,
+});
+
+function mountShell() {
+  return mount(CommandCenterShell, {
+    props: { open: true, title: "search", description: "type_to_search" },
+    global: {
+      mocks: { $t: (key: string) => key },
+      stubs: {
+        Sheet: passthrough("div"),
+        SheetContent: passthrough(
+          "div",
+          'data-player-panel data-testid="sheet"',
+        ),
+        SheetTitle: passthrough("h2"),
+        SheetDescription: passthrough("p"),
+        Command: passthrough("div"),
+        CommandDialog: passthrough("div", 'data-testid="dialog"'),
+      },
+    },
+    slots: { default: '<span data-testid="palette">palette</span>' },
+  });
+}
+
+beforeEach(() => {
+  state.storeMock.mobileLayout = false;
+});
+
+describe("CommandCenterShell", () => {
+  it("keeps the centred dialog on a desktop", () => {
+    const wrapper = mountShell();
+
+    expect(wrapper.find('[data-testid="dialog"]').exists()).toBe(true);
+    expect(wrapper.find('[data-testid="sheet"]').exists()).toBe(false);
+    expect(wrapper.find('[data-testid="palette"]').exists()).toBe(true);
+    // the knob belongs to the phone panel, not to a dialog
+    expect(wrapper.find(".panel-drag-handle").exists()).toBe(false);
+  });
+
+  // the phone gets the app's own panel, the same one the player and volume
+  // popouts use, so it is dismissed the way the rest of them are
+  it("becomes a panel with a knob on a phone", () => {
+    state.storeMock.mobileLayout = true;
+    const wrapper = mountShell();
+
+    expect(wrapper.find('[data-testid="sheet"]').exists()).toBe(true);
+    expect(wrapper.find('[data-testid="dialog"]').exists()).toBe(false);
+    expect(wrapper.find('[data-testid="palette"]').exists()).toBe(true);
+    expect(wrapper.find(".panel-drag-handle").exists()).toBe(true);
+  });
+
+  it("closes when the knob is dragged away", async () => {
+    state.storeMock.mobileLayout = true;
+    const wrapper = mountShell();
+
+    await wrapper
+      .findComponent({ name: "PanelDragHandle" })
+      .vm.$emit("dismiss");
+
+    expect(wrapper.emitted("update:open")?.at(-1)).toEqual([false]);
+  });
+
+  it("names itself for assistive tech without printing a heading", () => {
+    state.storeMock.mobileLayout = true;
+    const wrapper = mountShell();
+
+    const title = wrapper.get("h2");
+    expect(title.text()).toBe("search");
+    expect(title.classes()).toContain("sr-only");
+  });
+});


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes. -->

**Related issue (if applicable):**

- related issue `<link to issue>`

**Related backend PR (if applicable):**

<!--
Link the music-assistant/server PR when this change relies on new server
behaviour, so the two can be reviewed and released together.
-->

- related backend PR `<link to PR>`

## Types of changes

<!--
Tick exactly one box below. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [ ] The code change is tested and works locally.
- [ ] `pnpm lint:check` passes.
- [ ] `pnpm test:run` passes, and tests have been added/updated where applicable.
- [ ] `pnpm build` passes.
- [ ] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
