### PR TITLE
Show Music Quiz round results in the player header and compact the timeline

### DIFF
--- a/src/components/music-quiz/MusicQuizPlayerHeader.vue
+++ b/src/components/music-quiz/MusicQuizPlayerHeader.vue
@@ -22,6 +22,32 @@
           </span>
         </span>
       </div>
+
+      <div
+        v-if="roundResults?.length"
+        class="flex flex-wrap items-center justify-center gap-2"
+      >
+        <span
+          v-for="result in roundResults"
+          :key="result.key"
+          data-testid="player-round-result"
+          class="flex items-center gap-1.5 rounded-md px-2 py-1 text-sm font-semibold"
+          :class="
+            result.correct
+              ? 'bg-green-500/15 text-green-600 dark:text-green-400'
+              : 'bg-red-500/10 text-destructive'
+          "
+        >
+          <CircleCheck
+            v-if="result.correct"
+            class="size-4"
+            aria-hidden="true"
+          />
+          <CircleX v-else class="size-4" aria-hidden="true" />
+          {{ result.label }}
+          <span>+{{ result.points }}</span>
+        </span>
+      </div>
     </CardContent>
   </Card>
 </template>
@@ -30,11 +56,20 @@
 import MusicQuizAvatar from "@/components/music-quiz/MusicQuizAvatar.vue";
 import { Badge } from "@/components/ui/badge";
 import { Card, CardContent } from "@/components/ui/card";
+import { CircleCheck, CircleX } from "@lucide/vue";
+
+export interface MusicQuizRoundResult {
+  key: string;
+  label: string;
+  correct: boolean;
+  points: number;
+}
 
 defineProps<{
   playerName: string;
   rank: number | null;
   score: number;
   scoreDelta: string;
+  roundResults?: MusicQuizRoundResult[];
 }>();
 </script>

--- a/src/components/music-quiz/MusicQuizPlayerHeader.vue
+++ b/src/components/music-quiz/MusicQuizPlayerHeader.vue
@@ -26,6 +26,7 @@
       <div
         v-if="roundResults?.length"
         class="flex flex-wrap items-center justify-center gap-2"
+        role="status"
       >
         <span
           v-for="result in roundResults"
@@ -44,6 +45,15 @@
             aria-hidden="true"
           />
           <CircleX v-else class="size-4" aria-hidden="true" />
+          <span class="sr-only">
+            {{
+              $t(
+                result.correct
+                  ? "providers.music_quiz.correct"
+                  : "providers.music_quiz.incorrect",
+              )
+            }}
+          </span>
           {{ result.label }}
           <span>+{{ result.points }}</span>
         </span>
@@ -56,6 +66,7 @@
 import MusicQuizAvatar from "@/components/music-quiz/MusicQuizAvatar.vue";
 import { Badge } from "@/components/ui/badge";
 import { Card, CardContent } from "@/components/ui/card";
+import { $t } from "@/plugins/i18n";
 import { CircleCheck, CircleX } from "@lucide/vue";
 
 export interface MusicQuizRoundResult {

--- a/src/components/music-quiz/answer-types/multiple-choice/MultipleChoicePlayerAnswer.vue
+++ b/src/components/music-quiz/answer-types/multiple-choice/MultipleChoicePlayerAnswer.vue
@@ -23,27 +23,13 @@
   </template>
 
   <template v-else-if="state.phase === 'reveal'">
-    <div
-      v-if="state.you.answer?.correct"
-      class="flex items-center justify-center gap-2 rounded-md bg-green-500/15 py-2 font-semibold text-green-600 dark:text-green-400"
+    <p
+      v-if="!state.you.answer"
+      class="text-destructive text-center font-semibold"
       role="status"
     >
-      <CircleCheck class="size-5" />
-      {{ $t("providers.music_quiz.correct") }}
-      <span>+{{ state.you.answer.points ?? 0 }}</span>
-    </div>
-    <div
-      v-else
-      class="text-destructive flex items-center justify-center gap-2 rounded-md bg-red-500/10 py-2 font-semibold"
-      role="status"
-    >
-      <CircleX class="size-5" />
-      {{
-        state.you.answer
-          ? $t("providers.music_quiz.incorrect")
-          : $t("providers.music_quiz.no_answer_submitted")
-      }}
-    </div>
+      {{ $t("providers.music_quiz.no_answer_submitted") }}
+    </p>
   </template>
 </template>
 
@@ -60,7 +46,6 @@ import type {
 } from "@/composables/music-quiz/useMusicQuiz";
 import { getMusicQuizRoundPlayers } from "@/helpers/music_quiz";
 import { $t } from "@/plugins/i18n";
-import { CircleCheck, CircleX } from "@lucide/vue";
 import { computed } from "vue";
 
 const props =

--- a/src/components/music-quiz/answer-types/timeline/TimelineEntryCard.vue
+++ b/src/components/music-quiz/answer-types/timeline/TimelineEntryCard.vue
@@ -40,7 +40,15 @@
       </span>
     </div>
 
-    <div class="flex items-center gap-1.5 self-center">
+    <!-- Compact strips (TV view) are 13rem wide; stacking keeps room for the title -->
+    <div
+      class="self-center"
+      :class="
+        compact
+          ? 'flex flex-col items-end gap-0.5'
+          : 'flex items-center gap-1.5'
+      "
+    >
       <Badge
         v-if="entry.is_anchor"
         variant="secondary"

--- a/src/components/music-quiz/answer-types/timeline/TimelineEntryCard.vue
+++ b/src/components/music-quiz/answer-types/timeline/TimelineEntryCard.vue
@@ -5,8 +5,8 @@
     class="bg-card grid items-center border transition-colors motion-reduce:transition-none"
     :class="[
       compact
-        ? 'h-full grid-cols-[3rem_minmax(0,1fr)] gap-2 rounded-lg p-2 shadow-none'
-        : 'grid-cols-[4.25rem_minmax(0,1fr)] gap-3 rounded-xl p-3 shadow-sm sm:grid-cols-[5rem_minmax(0,1fr)]',
+        ? 'h-full grid-cols-[2.5rem_minmax(0,1fr)_auto] gap-2 rounded-lg p-2 shadow-none'
+        : 'grid-cols-[3.5rem_minmax(0,1fr)_auto] gap-3 rounded-xl p-3 shadow-sm',
       highlighted
         ? 'border-primary bg-primary/5 ring-primary/20 ring-2'
         : 'border-border',
@@ -29,27 +29,6 @@
     </div>
 
     <div class="flex min-w-0 flex-col" :class="compact ? 'gap-0.5' : 'gap-1'">
-      <div class="flex flex-wrap items-center gap-2">
-        <strong
-          class="text-primary leading-none tabular-nums"
-          :class="compact ? 'text-base' : 'text-xl'"
-        >
-          {{ entry.release_year }}
-        </strong>
-        <Badge
-          v-if="entry.is_anchor"
-          variant="secondary"
-          :class="{ 'px-1.5 py-0 text-[0.625rem]': compact }"
-        >
-          {{ $t("providers.music_quiz.timeline_anchor") }}
-        </Badge>
-        <Badge
-          v-if="highlighted"
-          :class="{ 'px-1.5 py-0 text-[0.625rem]': compact }"
-        >
-          {{ $t("providers.music_quiz.timeline_revealed") }}
-        </Badge>
-      </div>
       <span class="truncate font-semibold" :class="{ 'text-sm': compact }">
         {{ entry.title }}
       </span>
@@ -59,6 +38,28 @@
       >
         {{ entry.artist }}
       </span>
+    </div>
+
+    <div class="flex items-center gap-1.5 self-center">
+      <Badge
+        v-if="entry.is_anchor"
+        variant="secondary"
+        :class="{ 'px-1.5 py-0 text-[0.625rem]': compact }"
+      >
+        {{ $t("providers.music_quiz.timeline_anchor") }}
+      </Badge>
+      <Badge
+        v-if="highlighted"
+        :class="{ 'px-1.5 py-0 text-[0.625rem]': compact }"
+      >
+        {{ $t("providers.music_quiz.timeline_revealed") }}
+      </Badge>
+      <strong
+        class="text-primary font-bold tabular-nums"
+        :class="compact ? 'text-base' : 'text-lg'"
+      >
+        {{ entry.release_year }}
+      </strong>
     </div>
   </article>
 </template>

--- a/src/components/music-quiz/answer-types/timeline/TimelinePlayerAnswer.vue
+++ b/src/components/music-quiz/answer-types/timeline/TimelinePlayerAnswer.vue
@@ -114,61 +114,18 @@
       :highlighted-entry-id="currentRound.revealed_entry?.entry_id"
     />
 
-    <div v-if="state.you.answer" class="flex flex-col gap-2" role="status">
-      <div
-        data-testid="timeline-placement-result"
-        class="flex items-center justify-center gap-2 rounded-lg p-3 font-semibold"
-        :class="
-          state.you.answer.correct
-            ? 'bg-green-500/15 text-green-700 dark:text-green-400'
-            : 'bg-red-500/10 text-destructive'
-        "
-      >
-        <CircleCheck
-          v-if="state.you.answer.correct"
-          class="size-5"
-          aria-hidden="true"
-        />
-        <CircleX v-else class="size-5" aria-hidden="true" />
-        {{
-          state.you.answer.correct
-            ? $t("providers.music_quiz.timeline_correct_placement")
-            : $t("providers.music_quiz.timeline_incorrect_placement")
-        }}
-        <span>+{{ state.you.answer.points ?? 0 }}</span>
-      </div>
-      <div
-        v-for="result in state.you.answer.bonus_results"
-        :key="result.bonus_type"
-        :data-testid="`timeline-${result.bonus_type}-result`"
-        class="flex items-center justify-center gap-2 rounded-lg p-2 text-sm font-medium"
-        :class="
-          result.correct
-            ? 'bg-green-500/15 text-green-700 dark:text-green-400'
-            : 'bg-red-500/10 text-destructive'
-        "
-      >
-        <CircleCheck v-if="result.correct" class="size-4" aria-hidden="true" />
-        <CircleX v-else class="size-4" aria-hidden="true" />
-        <span class="sr-only">
-          {{
-            result.correct
-              ? $t("providers.music_quiz.correct")
-              : $t("providers.music_quiz.incorrect")
-          }}
-        </span>
-        {{ bonusTypeLabel(result.bonus_type) }}
-        <span>+{{ result.points }}</span>
-      </div>
-    </div>
     <p
-      v-else-if="!canAnswerRound"
+      v-if="!state.you.answer && !canAnswerRound"
       class="text-muted-foreground text-center"
       role="status"
     >
       {{ $t("providers.music_quiz.waiting_for_next") }}
     </p>
-    <p v-else class="text-destructive text-center font-semibold" role="status">
+    <p
+      v-else-if="!state.you.answer"
+      class="text-destructive text-center font-semibold"
+      role="status"
+    >
       {{ $t("providers.music_quiz.no_answer_submitted") }}
     </p>
   </template>
@@ -193,7 +150,7 @@ import type {
 } from "@/composables/music-quiz/useMusicQuiz";
 import { getMusicQuizRoundPlayers } from "@/helpers/music_quiz";
 import { $t } from "@/plugins/i18n";
-import { CircleCheck, CircleX, Send, SkipForward } from "@lucide/vue";
+import { Send, SkipForward } from "@lucide/vue";
 import { computed, ref, watch } from "vue";
 
 const MAX_BONUS_TEXT_LENGTH = 200;

--- a/src/components/music-quiz/game-types/guess-the-song/GuessTheSongReveal.vue
+++ b/src/components/music-quiz/game-types/guess-the-song/GuessTheSongReveal.vue
@@ -24,7 +24,7 @@
             v-if="imageUrl"
             :src="imageUrl"
             :alt="round.answer_label"
-            class="bg-muted mx-auto aspect-square w-full max-w-72 rounded-lg object-cover"
+            class="bg-muted mx-auto aspect-square w-full max-w-[min(15rem,26dvh)] rounded-lg object-cover"
           />
           <div class="flex items-center justify-center gap-2">
             <h2 class="min-w-0 text-lg font-bold break-words">

--- a/src/components/music-quiz/game-types/music-timeline/MusicTimelinePlayerRound.vue
+++ b/src/components/music-quiz/game-types/music-timeline/MusicTimelinePlayerRound.vue
@@ -5,12 +5,23 @@
     :phase="state.phase"
     :round="currentRound"
     :is-final-round="isFinalRound"
-    :busy="busy"
-    :is-ready="state.you.ready"
-    :ready-label="readyLabel"
-    :show-ready-button="true"
-    @ready="emit('ready')"
   />
+  <!-- order-last + sticky only work as a direct child of the stage's flex section -->
+  <div
+    v-if="state.phase === 'reveal'"
+    class="bg-background sticky bottom-0 order-last z-10 flex justify-center pt-2 pb-1"
+  >
+    <Button
+      class="w-full max-w-sm"
+      size="lg"
+      :disabled="busy || state.you.ready"
+      data-testid="music-timeline-ready"
+      @click="emit('ready')"
+    >
+      <Check class="size-4" />
+      {{ readyLabel }}
+    </Button>
+  </div>
 </template>
 
 <script setup lang="ts">
@@ -18,12 +29,14 @@ import type {
   MusicQuizPlayerGameAdapterEmits,
   MusicQuizPlayerGameAdapterProps,
 } from "@/components/music-quiz/adapter_contracts";
+import { Button } from "@/components/ui/button";
 import MusicTimelineRound from "@/components/music-quiz/game-types/music-timeline/MusicTimelineRound.vue";
 import type {
   MusicQuizTimelinePersonalizedState,
   MusicQuizTimelineRound,
 } from "@/composables/music-quiz/useMusicQuiz";
 import { $t } from "@/plugins/i18n";
+import { Check } from "@lucide/vue";
 import { computed } from "vue";
 
 const props =

--- a/src/components/music-quiz/game-types/music-timeline/MusicTimelinePlayerRound.vue
+++ b/src/components/music-quiz/game-types/music-timeline/MusicTimelinePlayerRound.vue
@@ -9,7 +9,7 @@
   <!-- order-last + sticky only work as a direct child of the stage's flex section -->
   <div
     v-if="state.phase === 'reveal'"
-    class="bg-background sticky bottom-0 order-last z-10 flex justify-center pt-2 pb-1"
+    class="bg-background sticky bottom-[var(--device-inset-bottom,0px)] order-last z-10 flex justify-center pt-2 pb-1"
   >
     <Button
       class="w-full max-w-sm"

--- a/src/components/music-quiz/game-types/music-timeline/MusicTimelineRound.vue
+++ b/src/components/music-quiz/game-types/music-timeline/MusicTimelineRound.vue
@@ -44,12 +44,20 @@
           :src="imageUrl"
           :alt="`${revealedEntry.title} - ${revealedEntry.artist}`"
           class="bg-muted mx-auto aspect-square w-full object-cover"
-          :class="compact ? 'max-w-32 rounded-lg' : 'max-w-56 rounded-xl'"
+          :class="
+            compact
+              ? 'max-w-32 rounded-lg'
+              : 'max-w-[min(11rem,22dvh)] rounded-xl'
+          "
         />
         <div
           v-else
           class="bg-muted text-muted-foreground mx-auto grid aspect-square w-full place-items-center"
-          :class="compact ? 'max-w-32 rounded-lg' : 'max-w-56 rounded-xl'"
+          :class="
+            compact
+              ? 'max-w-32 rounded-lg'
+              : 'max-w-[min(11rem,22dvh)] rounded-xl'
+          "
           aria-hidden="true"
         >
           <Music2 :class="compact ? 'size-8' : 'size-12'" />

--- a/src/components/music-quiz/game-types/music-timeline/MusicTimelineRound.vue
+++ b/src/components/music-quiz/game-types/music-timeline/MusicTimelineRound.vue
@@ -87,25 +87,12 @@
         <Clock3 class="size-4" aria-hidden="true" />
         {{ autoAdvanceText }}
       </div>
-
-      <Button
-        v-if="showReadyButton && phase === 'reveal'"
-        class="w-full max-w-sm self-center"
-        size="lg"
-        :disabled="busy || isReady"
-        data-testid="music-timeline-ready"
-        @click="emit('ready')"
-      >
-        <Check class="size-4" />
-        {{ readyLabel }}
-      </Button>
     </CardContent>
   </Card>
 </template>
 
 <script setup lang="ts">
 import { Badge } from "@/components/ui/badge";
-import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import type {
   MusicQuizTimelineRound,
@@ -114,7 +101,7 @@ import type {
 import { useMusicQuizRevealCountdown } from "@/composables/music-quiz/useMusicQuizRevealCountdown";
 import { getMediaImageUrl } from "@/helpers/utils";
 import { $t } from "@/plugins/i18n";
-import { AudioLines, Check, Clock3, Music2 } from "@lucide/vue";
+import { AudioLines, Clock3, Music2 } from "@lucide/vue";
 import { computed } from "vue";
 
 const props = withDefaults(
@@ -122,21 +109,12 @@ const props = withDefaults(
     phase: MusicQuizPhase;
     round: MusicQuizTimelineRound;
     isFinalRound: boolean;
-    busy?: boolean;
-    isReady?: boolean;
-    readyLabel?: string;
-    showReadyButton?: boolean;
     compact?: boolean;
   }>(),
   {
-    busy: false,
-    isReady: false,
-    readyLabel: "",
-    showReadyButton: false,
     compact: false,
   },
 );
-const emit = defineEmits<{ ready: [] }>();
 
 const revealedEntry = computed(() => props.round.revealed_entry);
 const imageUrl = computed(() =>

--- a/src/composables/music-quiz/useMusicQuizPhaseScroll.ts
+++ b/src/composables/music-quiz/useMusicQuizPhaseScroll.ts
@@ -13,9 +13,8 @@ const SCROLL_PHASES: ReadonlySet<MusicQuizPhase> = new Set([
 ]);
 
 /**
- * Scrolls the round section into view once when a round starts answering and
- * once when it reveals, so the sticky countdown (and later the result with
- * the Ready button) lands at the top of the scroll container.
+ * Scrolls the target into view once when a round starts answering, and
+ * scrolls the whole container to the top once when the round reveals.
  */
 export function useMusicQuizPhaseScroll(options: MusicQuizPhaseScrollOptions) {
   let lastScrolledKey: string | null = null;
@@ -26,16 +25,39 @@ export function useMusicQuizPhaseScroll(options: MusicQuizPhaseScrollOptions) {
       if (!phase || !SCROLL_PHASES.has(phase) || roundIndex === null) return;
       const key = `${roundIndex}:${phase}`;
       if (key === lastScrolledKey) return;
-      if (!target || typeof target.scrollIntoView !== "function") return;
+      if (!target) return;
+      const behavior = scrollBehavior();
+      if (phase === "reveal") {
+        const scrollParent = findScrollParent(target);
+        if (!scrollParent || typeof scrollParent.scrollTo !== "function") {
+          return;
+        }
+        lastScrolledKey = key;
+        scrollParent.scrollTo({ top: 0, behavior });
+        return;
+      }
+      if (typeof target.scrollIntoView !== "function") return;
       lastScrolledKey = key;
-      const reducedMotion =
-        window.matchMedia?.("(prefers-reduced-motion: reduce)").matches ??
-        false;
-      target.scrollIntoView({
-        block: "start",
-        behavior: reducedMotion ? "auto" : "smooth",
-      });
+      target.scrollIntoView({ block: "start", behavior });
     },
     { immediate: true, flush: "post" },
   );
+}
+
+function scrollBehavior(): ScrollBehavior {
+  const reducedMotion =
+    window.matchMedia?.("(prefers-reduced-motion: reduce)").matches ?? false;
+  return reducedMotion ? "auto" : "smooth";
+}
+
+/** Finds the target's scrollable ancestor, falling back to the document. */
+function findScrollParent(target: HTMLElement) {
+  let el: HTMLElement | null = target.parentElement;
+  while (el) {
+    if (["auto", "scroll"].includes(getComputedStyle(el).overflowY)) {
+      return el;
+    }
+    el = el.parentElement;
+  }
+  return document.scrollingElement;
 }

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1637,6 +1637,8 @@
             "timeline_correct_placement": "Correct placement",
             "timeline_incorrect_placement": "Incorrect placement",
             "timeline_round_results": "Round results",
+            "timeline_result_placement": "Placement",
+            "round_result_answer": "Answer",
             "add_music_sources": "Add music sources",
             "genre": "Genre",
             "album": "Album",

--- a/src/views/MusicQuizPlayerView.vue
+++ b/src/views/MusicQuizPlayerView.vue
@@ -111,6 +111,7 @@
         :rank="playerRank"
         :score="activeState.you.score"
         :score-delta="playerRoundScoreLabel"
+        :round-results="playerRoundResults"
       />
 
       <MusicQuizPlayerStage
@@ -165,7 +166,9 @@ import {
 } from "@/components/music-quiz/game_types";
 import MusicQuizJoinForm from "@/components/music-quiz/MusicQuizJoinForm.vue";
 import { type MusicQuizLeaderboardRow } from "@/components/music-quiz/MusicQuizLeaderboard.vue";
-import MusicQuizPlayerHeader from "@/components/music-quiz/MusicQuizPlayerHeader.vue";
+import MusicQuizPlayerHeader, {
+  type MusicQuizRoundResult,
+} from "@/components/music-quiz/MusicQuizPlayerHeader.vue";
 import MusicQuizPlayerStage from "@/components/music-quiz/MusicQuizPlayerStage.vue";
 import MusicQuizSessionHeader from "@/components/music-quiz/MusicQuizSessionHeader.vue";
 import MusicQuizUnsupportedGame from "@/components/music-quiz/MusicQuizUnsupportedGame.vue";
@@ -185,7 +188,6 @@ import {
 } from "@/composables/music-quiz/useMusicQuiz";
 import {
   getMusicQuizErrorMessage,
-  getMusicQuizRoundScore,
   getMusicQuizRoundScoreLabel,
   getMusicQuizWinnerText,
   rankMusicQuizPlayers,
@@ -324,11 +326,47 @@ const playerRoundScoreLabel = computed(() =>
     ? getMusicQuizRoundScoreLabel(activeState.value, activeState.value.you.name)
     : "",
 );
-const playerRoundScore = computed(() =>
-  activeState.value
-    ? getMusicQuizRoundScore(activeState.value, activeState.value.you.name)
-    : undefined,
-);
+
+const playerRoundResults = computed<MusicQuizRoundResult[]>(() => {
+  const currentState = activeState.value;
+  if (!currentState || currentState.phase !== "reveal") return [];
+  const answer = currentState.you.answer;
+  if (!answer) return [];
+  // "bonuses" is required on timeline answers, unlike the optional bonus_results
+  if ("bonuses" in answer) {
+    const results: MusicQuizRoundResult[] = [];
+    if (answer.correct !== undefined) {
+      results.push({
+        key: "placement",
+        label: $t("providers.music_quiz.timeline_result_placement"),
+        correct: answer.correct,
+        points: answer.points ?? 0,
+      });
+    }
+    for (const bonus of answer.bonus_results ?? []) {
+      results.push({
+        key: bonus.bonus_type,
+        label: $t(
+          bonus.bonus_type === "artist"
+            ? "providers.music_quiz.timeline_artist_bonus"
+            : "providers.music_quiz.timeline_title_bonus",
+        ),
+        correct: bonus.correct,
+        points: bonus.points,
+      });
+    }
+    return results;
+  }
+  if (answer.correct === undefined) return [];
+  return [
+    {
+      key: "answer",
+      label: $t("providers.music_quiz.round_result_answer"),
+      correct: answer.correct,
+      points: answer.points ?? 0,
+    },
+  ];
+});
 
 const phaseText = computed(() => {
   const currentState = activeState.value;
@@ -367,32 +405,6 @@ watch(
   (phase) => {
     if (phase === "finished") void celebrate();
   },
-);
-
-watch(
-  [
-    () => activeState.value?.phase,
-    () => currentRound.value?.round_index,
-    () => activeState.value?.you.answer?.correct,
-    () => playerRoundScore.value,
-  ],
-  ([phase, , correct, points]) => {
-    if (phase !== "reveal" || correct === undefined || points === undefined) {
-      return;
-    }
-    const result = $t(
-      correct
-        ? "providers.music_quiz.correct"
-        : "providers.music_quiz.incorrect",
-    );
-    const message = `${result} +${points}`;
-    if (correct) {
-      toast.success(message);
-    } else {
-      toast.error(message);
-    }
-  },
-  { immediate: true },
 );
 
 async function handleJoin(name: string) {

--- a/tests/components/music-quiz/MultipleChoiceAdapters.test.ts
+++ b/tests/components/music-quiz/MultipleChoiceAdapters.test.ts
@@ -104,7 +104,7 @@ describe("multiple-choice adapters", () => {
     wrapper.unmount();
   });
 
-  it("shows the existing reveal result states", () => {
+  it("renders no result banner on reveal since results live in the player header", () => {
     const state = {
       ...playerState,
       phase: "reveal",
@@ -127,8 +127,10 @@ describe("multiple-choice adapters", () => {
       },
     });
 
-    expect(wrapper.text()).toContain("providers.music_quiz.correct");
-    expect(wrapper.text()).toContain("+7");
+    expect(wrapper.text()).not.toContain("providers.music_quiz.correct");
+    expect(wrapper.text()).not.toContain(
+      "providers.music_quiz.no_answer_submitted",
+    );
     wrapper.unmount();
   });
 

--- a/tests/components/music-quiz/MusicQuizPlayerHeader.test.ts
+++ b/tests/components/music-quiz/MusicQuizPlayerHeader.test.ts
@@ -1,6 +1,10 @@
 import MusicQuizPlayerHeader from "@/components/music-quiz/MusicQuizPlayerHeader.vue";
 import { mount } from "@vue/test-utils";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@/plugins/i18n", () => ({
+  $t: (key: string) => key,
+}));
 
 describe("MusicQuizPlayerHeader", () => {
   it("renders no result pills when roundResults is empty or absent", () => {
@@ -46,5 +50,26 @@ describe("MusicQuizPlayerHeader", () => {
     expect(pills[1].classes()).toEqual(
       expect.arrayContaining(["bg-red-500/10", "text-destructive"]),
     );
+  });
+
+  it("announces results with a status role and per-pill outcome text", () => {
+    const wrapper = mount(MusicQuizPlayerHeader, {
+      props: {
+        playerName: "Player",
+        rank: 1,
+        score: 10,
+        scoreDelta: "(+10)",
+        roundResults: [
+          { key: "placement", label: "Placement", correct: true, points: 10 },
+          { key: "artist", label: "Artist bonus", correct: false, points: 0 },
+        ],
+      },
+    });
+
+    expect(wrapper.find('[role="status"]').exists()).toBe(true);
+    expect(wrapper.findAll(".sr-only").map((el) => el.text())).toEqual([
+      "providers.music_quiz.correct",
+      "providers.music_quiz.incorrect",
+    ]);
   });
 });

--- a/tests/components/music-quiz/MusicQuizPlayerHeader.test.ts
+++ b/tests/components/music-quiz/MusicQuizPlayerHeader.test.ts
@@ -1,0 +1,50 @@
+import MusicQuizPlayerHeader from "@/components/music-quiz/MusicQuizPlayerHeader.vue";
+import { mount } from "@vue/test-utils";
+import { describe, expect, it } from "vitest";
+
+describe("MusicQuizPlayerHeader", () => {
+  it("renders no result pills when roundResults is empty or absent", () => {
+    const wrapper = mount(MusicQuizPlayerHeader, {
+      props: {
+        playerName: "Player",
+        rank: 1,
+        score: 10,
+        scoreDelta: "",
+      },
+    });
+
+    expect(wrapper.findAll('[data-testid="player-round-result"]')).toHaveLength(
+      0,
+    );
+  });
+
+  it("renders a pill per round result, styled by correctness", () => {
+    const wrapper = mount(MusicQuizPlayerHeader, {
+      props: {
+        playerName: "Player",
+        rank: 1,
+        score: 10,
+        scoreDelta: "(+15)",
+        roundResults: [
+          { key: "placement", label: "Placement", correct: true, points: 10 },
+          { key: "artist", label: "Artist bonus", correct: false, points: 0 },
+        ],
+      },
+    });
+
+    const pills = wrapper.findAll('[data-testid="player-round-result"]');
+    expect(pills).toHaveLength(2);
+
+    expect(pills[0].text()).toContain("Placement");
+    expect(pills[0].text()).toContain("+10");
+    expect(pills[0].classes()).toEqual(
+      expect.arrayContaining(["bg-green-500/15", "text-green-600"]),
+    );
+
+    expect(pills[1].text()).toContain("Artist bonus");
+    expect(pills[1].text()).toContain("+0");
+    expect(pills[1].classes()).toEqual(
+      expect.arrayContaining(["bg-red-500/10", "text-destructive"]),
+    );
+  });
+});

--- a/tests/components/music-quiz/MusicTimelineAdapters.test.ts
+++ b/tests/components/music-quiz/MusicTimelineAdapters.test.ts
@@ -249,6 +249,26 @@ describe("Music Timeline game adapters", () => {
     );
   });
 
+  it("pins the Ready button to the bottom of the stage during reveal", async () => {
+    const wrapper = mount(MusicTimelinePlayerRound, {
+      props: {
+        state: playerState,
+        currentRound: revealRound,
+        busy: false,
+      },
+    });
+    const readyButton = wrapper.get('[data-testid="music-timeline-ready"]');
+    const footer = readyButton.element.parentElement;
+
+    expect(footer?.classList.contains("sticky")).toBe(true);
+    expect(footer?.classList.contains("bottom-0")).toBe(true);
+    expect(footer?.classList.contains("order-last")).toBe(true);
+
+    await readyButton.trigger("click");
+
+    expect(wrapper.emitted("ready")).toEqual([[]]);
+  });
+
   it("keeps intermediate Ready after song details", async () => {
     const wrapper = mount(MusicTimelinePlayerRound, {
       props: {

--- a/tests/components/music-quiz/MusicTimelineAdapters.test.ts
+++ b/tests/components/music-quiz/MusicTimelineAdapters.test.ts
@@ -261,7 +261,9 @@ describe("Music Timeline game adapters", () => {
     const footer = readyButton.element.parentElement;
 
     expect(footer?.classList.contains("sticky")).toBe(true);
-    expect(footer?.classList.contains("bottom-0")).toBe(true);
+    expect(
+      footer?.classList.contains("bottom-[var(--device-inset-bottom,0px)]"),
+    ).toBe(true);
     expect(footer?.classList.contains("order-last")).toBe(true);
 
     await readyButton.trigger("click");

--- a/tests/components/music-quiz/TimelineDisplay.test.ts
+++ b/tests/components/music-quiz/TimelineDisplay.test.ts
@@ -278,7 +278,7 @@ describe("TimelineDisplay", () => {
     ).toBe(true);
     expect(
       cards.every((card) =>
-        card.classes().includes("grid-cols-[3rem_minmax(0,1fr)]"),
+        card.classes().includes("grid-cols-[2.5rem_minmax(0,1fr)_auto]"),
       ),
     ).toBe(true);
     expect(

--- a/tests/components/music-quiz/TimelinePlayerReveal.test.ts
+++ b/tests/components/music-quiz/TimelinePlayerReveal.test.ts
@@ -22,7 +22,7 @@ vi.mock("@/helpers/utils", () => ({
 }));
 
 describe("Timeline player reveal", () => {
-  it("shows placement and bonus results independently", () => {
+  it("renders no result banners since results live in the player header", () => {
     const revealedEntry = {
       ...anchor,
       entry_id: "current",
@@ -73,33 +73,18 @@ describe("Timeline player reveal", () => {
       },
     });
 
-    expect(wrapper.text()).toContain(
-      "providers.music_quiz.timeline_incorrect_placement",
+    expect(
+      wrapper.find('[data-testid="timeline-placement-result"]').exists(),
+    ).toBe(false);
+    expect(
+      wrapper.find('[data-testid="timeline-artist-result"]').exists(),
+    ).toBe(false);
+    expect(wrapper.find('[data-testid="timeline-title-result"]').exists()).toBe(
+      false,
     );
-    expect(wrapper.text()).toContain("+0");
-    expect(wrapper.text()).toContain("+250");
-    expect(
-      wrapper
-        .get('[data-testid="timeline-placement-result"]')
-        .classes()
-        .includes("text-destructive"),
-    ).toBe(true);
-    expect(
-      wrapper
-        .get('[data-testid="timeline-artist-result"]')
-        .classes()
-        .includes("text-green-700"),
-    ).toBe(true);
-    expect(
-      wrapper
-        .get('[data-testid="timeline-title-result"]')
-        .classes()
-        .includes("text-destructive"),
-    ).toBe(true);
-    expect(wrapper.findAll(".sr-only").map((result) => result.text())).toEqual([
-      "providers.music_quiz.correct",
-      "providers.music_quiz.incorrect",
-    ]);
+    expect(wrapper.text()).not.toContain(
+      "providers.music_quiz.no_answer_submitted",
+    );
   });
 
   it("does not mark a late joiner as missing an answer", () => {

--- a/tests/components/music-quiz/TriviaAdapters.test.ts
+++ b/tests/components/music-quiz/TriviaAdapters.test.ts
@@ -276,8 +276,7 @@ describe("Trivia adapters", () => {
       },
     });
 
-    expect(revealWrapper.text()).toContain("providers.music_quiz.correct");
-    expect(revealWrapper.text()).toContain("+10");
+    expect(revealWrapper.text()).not.toContain("providers.music_quiz.correct");
   });
 
   it.each([

--- a/tests/composables/useMusicQuizPhaseScroll.test.ts
+++ b/tests/composables/useMusicQuizPhaseScroll.test.ts
@@ -4,12 +4,18 @@ import { effectScope, nextTick, ref, type Ref } from "vue";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const scrollIntoView = vi.fn();
+const scrollTo = vi.fn();
 
 beforeEach(() => {
   scrollIntoView.mockReset();
+  scrollTo.mockReset();
   Object.defineProperty(HTMLElement.prototype, "scrollIntoView", {
     configurable: true,
     value: scrollIntoView,
+  });
+  Object.defineProperty(HTMLElement.prototype, "scrollTo", {
+    configurable: true,
+    value: scrollTo,
   });
   setReducedMotion(false);
 });
@@ -51,9 +57,13 @@ describe("useMusicQuizPhaseScroll", () => {
     scope.stop();
   });
 
-  it("scrolls again when the round reveals", async () => {
+  it("scrolls the scroll parent to the top when the round reveals", async () => {
     const { phase, roundIndex, target, scope } = createOptions();
-    target.value = document.createElement("section");
+    const scrollParent = document.createElement("main");
+    scrollParent.style.overflowY = "auto";
+    const section = document.createElement("section");
+    scrollParent.appendChild(section);
+    target.value = section;
     phase.value = "answering";
     roundIndex.value = 0;
 
@@ -64,7 +74,23 @@ describe("useMusicQuizPhaseScroll", () => {
     phase.value = "reveal";
     await nextTick();
 
-    expect(scrollIntoView).toHaveBeenCalledTimes(2);
+    expect(scrollIntoView).toHaveBeenCalledTimes(1);
+    expect(scrollTo).toHaveBeenCalledTimes(1);
+    expect(scrollTo).toHaveBeenCalledWith({ top: 0, behavior: "smooth" });
+    scope.stop();
+  });
+
+  it("falls back to the document's scrolling element when no ancestor scrolls", async () => {
+    const { phase, roundIndex, target, scope } = createOptions();
+    target.value = document.createElement("section");
+    phase.value = "reveal";
+    roundIndex.value = 0;
+
+    createScroller({ phase, roundIndex, target, scope });
+    await nextTick();
+
+    expect(scrollIntoView).not.toHaveBeenCalled();
+    expect(scrollTo).toHaveBeenCalledTimes(1);
     scope.stop();
   });
 

--- a/tests/views/MusicQuizPlayerView.test.ts
+++ b/tests/views/MusicQuizPlayerView.test.ts
@@ -506,6 +506,50 @@ describe("MusicQuizPlayerView routing", () => {
     wrapper.unmount();
   });
 
+  it("passes a single answer result to the player header during a multiple-choice reveal", () => {
+    mockResolveMusicQuizDefinition.mockReturnValue(createDefinition(true));
+    mockUseMusicQuizPlayer.mockReturnValue({
+      info: ref(null),
+      state: ref({
+        ...playerState,
+        phase: "reveal",
+        you: {
+          ...playerState.you,
+          answer: {
+            suggestion_id: "one",
+            answered_at: 1,
+            correct: false,
+            points: 0,
+          },
+        },
+      }),
+      playerId: ref("player-id"),
+      landingSeen: ref(true),
+      gameRemoved: ref(false),
+      busy: ref(false),
+      loading: ref(false),
+      currentRound: ref(currentRound),
+      join: vi.fn(),
+      submitAnswer: vi.fn(),
+      ready: vi.fn(),
+      markLandingSeen: vi.fn(),
+    });
+
+    const wrapper = mountView();
+
+    expect(
+      wrapper.findComponent(MusicQuizPlayerHeader).props("roundResults"),
+    ).toEqual([
+      {
+        key: "answer",
+        label: "providers.music_quiz.round_result_answer",
+        correct: false,
+        points: 0,
+      },
+    ]);
+    wrapper.unmount();
+  });
+
   it("passes the placement and bonus results to the player header during timeline reveal", () => {
     mockResolveMusicQuizDefinition.mockReturnValue(createDefinition(true));
     mockUseMusicQuizPlayer.mockReturnValue({

--- a/tests/views/MusicQuizPlayerView.test.ts
+++ b/tests/views/MusicQuizPlayerView.test.ts
@@ -1,5 +1,6 @@
 import MusicQuizPlayerView from "@/views/MusicQuizPlayerView.vue";
 import MusicQuizJoinForm from "@/components/music-quiz/MusicQuizJoinForm.vue";
+import MusicQuizPlayerHeader from "@/components/music-quiz/MusicQuizPlayerHeader.vue";
 import type { MusicAssistantApi } from "@/plugins/api";
 import { webPlayer } from "@/plugins/web_player";
 import { flushPromises, mount } from "@vue/test-utils";
@@ -480,75 +481,6 @@ describe("MusicQuizPlayerView routing", () => {
     wrapper.unmount();
   });
 
-  it.each([
-    ["correct", true],
-    ["incorrect", false],
-  ] as const)(
-    "shows a toast for %s answers when the result is revealed",
-    async (_result, correct) => {
-      const points = correct ? 7 : 0;
-      mockGetMusicQuizRoundScore.mockReturnValue(points);
-      const state = ref({
-        ...playerState,
-        phase: "answering" as "answering" | "reveal",
-        you: {
-          ...playerState.you,
-          answer: {
-            suggestion_id: "one",
-            answered_at: 1,
-            correct: undefined as boolean | undefined,
-            points: undefined as number | undefined,
-          },
-        },
-      });
-      mockResolveMusicQuizDefinition.mockReturnValue(createDefinition(true));
-      mockUseMusicQuizPlayer.mockReturnValue({
-        info: ref(null),
-        state,
-        playerId: ref("player-id"),
-        landingSeen: ref(true),
-        gameRemoved: ref(false),
-        busy: ref(false),
-        loading: ref(false),
-        currentRound: ref(currentRound),
-        join: vi.fn(),
-        submitAnswer: vi.fn(),
-        ready: vi.fn(),
-        markLandingSeen: vi.fn(),
-      });
-      const wrapper = mountView();
-
-      state.value = {
-        ...state.value,
-        phase: "reveal",
-        you: {
-          ...state.value.you,
-          answer: {
-            ...state.value.you.answer,
-            correct,
-            points,
-          },
-        },
-      };
-      await nextTick();
-
-      const expectedToast = correct ? mockToastSuccess : mockToastError;
-      expect(expectedToast).toHaveBeenCalledOnce();
-      expect(expectedToast).toHaveBeenCalledWith(
-        `${
-          correct
-            ? "providers.music_quiz.correct"
-            : "providers.music_quiz.incorrect"
-        } +${points}`,
-      );
-
-      state.value = { ...state.value };
-      await nextTick();
-      expect(expectedToast).toHaveBeenCalledOnce();
-      wrapper.unmount();
-    },
-  );
-
   it("enables Music Timeline ListenIn on the rejoin landing without fetching lyrics", () => {
     mockResolveMusicQuizDefinition.mockReturnValue(createDefinition(true));
     mockUseMusicQuizPlayer.mockReturnValue({
@@ -571,6 +503,62 @@ describe("MusicQuizPlayerView routing", () => {
     expect(mockListenInSetup).toHaveBeenCalledOnce();
     expect(wrapper.find('[data-testid="listen-in"]').exists()).toBe(true);
     expect(mockGetTrackLyrics).not.toHaveBeenCalled();
+    wrapper.unmount();
+  });
+
+  it("passes the placement and bonus results to the player header during timeline reveal", () => {
+    mockResolveMusicQuizDefinition.mockReturnValue(createDefinition(true));
+    mockUseMusicQuizPlayer.mockReturnValue({
+      info: ref(null),
+      state: ref({
+        ...musicTimelineState,
+        phase: "reveal",
+        you: {
+          ...musicTimelineState.you,
+          answer: {
+            previous_entry_id: null,
+            next_entry_id: "anchor",
+            answered_at: 1,
+            bonuses: [],
+            finished: true,
+            correct: true,
+            points: 10,
+            bonus_results: [
+              { bonus_type: "artist", correct: false, points: 0 },
+            ],
+          },
+        },
+      }),
+      playerId: ref("player-id"),
+      landingSeen: ref(true),
+      gameRemoved: ref(false),
+      busy: ref(false),
+      loading: ref(false),
+      currentRound: ref(musicTimelineRound),
+      join: vi.fn(),
+      submitAnswer: vi.fn(),
+      ready: vi.fn(),
+      markLandingSeen: vi.fn(),
+    });
+
+    const wrapper = mountView();
+
+    expect(
+      wrapper.findComponent(MusicQuizPlayerHeader).props("roundResults"),
+    ).toEqual([
+      {
+        key: "placement",
+        label: "providers.music_quiz.timeline_result_placement",
+        correct: true,
+        points: 10,
+      },
+      {
+        key: "artist",
+        label: "providers.music_quiz.timeline_artist_bonus",
+        correct: false,
+        points: 0,
+      },
+    ]);
     wrapper.unmount();
   });
 


### PR DESCRIPTION
# What does this implement/fix?

Follow-up to #2547. During a Music Quiz round reveal, players had to scroll around to see their result and the "ready" button, and the timeline entries took more vertical space than needed.

- On reveal, the page scrolls to the top and your round result shows as compact badges under your name (placement and bonus outcomes with points)
- The result banners under the timeline and the result popups are gone; the header badges are now the single place for round results
- The "Ready for next round" button stays pinned at the bottom of the screen during the reveal
- Timeline entries are more compact: two lines with a smaller thumbnail, and the year (with the anchor badge) on the right

**Related issue (if applicable):**

**Related backend PR (if applicable):**

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm lint:check` passes.
- [x] `pnpm test:run` passes, and tests have been added/updated where applicable.
- [x] `pnpm build` passes.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
