### PR TITLE
Fix hi / low pass graph calculation

### DIFF
--- a/src/components/dsp/DSPParametricEQ.vue
+++ b/src/components/dsp/DSPParametricEQ.vue
@@ -782,7 +782,12 @@ const createBiquadFilter = (
       break;
   }
   filter.frequency.value = band.frequency;
-  filter.Q.value = band.q;
+  // Web Audio interprets Q in dB for highpass/lowpass, but MA stores linear Q
+  if (filter.type === "highpass" || filter.type === "lowpass") {
+    filter.Q.value = 20 * Math.log10(band.q);
+  } else {
+    filter.Q.value = band.q;
+  }
   filter.gain.value = band.gain;
   return filter;
 };


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes. -->

A bug was found by a user in the PEQ graph calulation for high and low pass filters. Before and after screen shots

<img width="1347" height="1102" alt="image" src="https://github.com/user-attachments/assets/7faaae43-2f71-4353-b64b-fc0540904844" />


**Related issue (if applicable):**

- related issue https://github.com/music-assistant/support/issues/6138

**Related backend PR (if applicable):**

<!--
Link the music-assistant/server PR when this change relies on new server
behaviour, so the two can be reviewed and released together.
-->

- related backend PR `<link to PR>`

## Types of changes

<!--
Tick exactly one box below. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [X] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [X] The code change is tested and works locally.
- [X] `pnpm lint:check` passes.
- [X] `pnpm test:run` passes, and tests have been added/updated where applicable.
- [X] `pnpm build` passes.
- [X] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
