### PR TITLE
Fix copy to clipboard over plain http

### DIFF
--- a/src/helpers/utils.ts
+++ b/src/helpers/utils.ts
@@ -680,20 +680,17 @@ export const markdownToHtml = function (text: string): string {
 };
 
 /**
- * Copy text to clipboard with proper error handling.
+ * Copy text to the clipboard.
  *
- * Handles scenarios where navigator.clipboard is unavailable (non-HTTPS contexts,
- * unsupported browsers, or permission issues) by falling back to a temporary
- * textarea element.
- *
- * :param text: The text to copy to the clipboard.
- * :return: Promise that resolves to true if successful, false otherwise.
+ * :param text: The text to copy.
+ * :return: Promise that resolves to true only when the text actually reached
+ *   the clipboard.
  */
 export async function copyToClipboard(text: string): Promise<boolean> {
   if (!text) return false;
 
-  // Modern Clipboard API: only available in secure contexts (HTTPS / localhost).
-  if (window.isSecureContext && navigator.clipboard?.writeText) {
+  // Only exposed in secure contexts (https / localhost).
+  if (navigator.clipboard?.writeText) {
     try {
       await navigator.clipboard.writeText(text);
       return true;
@@ -705,37 +702,66 @@ export async function copyToClipboard(text: string): Promise<boolean> {
     }
   }
 
-  // Fallback for non-secure contexts. Append inside the active dialog (if any)
-  // so a focus trap (e.g. Reka UI Dialog) does not steal focus and clear the
-  // textarea's selection before execCommand("copy") runs.
+  return legacyCopy(text);
+}
+
+/**
+ * Copy text by selecting it and running the copy command, for contexts without
+ * the Clipboard API.
+ *
+ * :param text: The text to copy.
+ * :return: True when the text reached the clipboard.
+ */
+const legacyCopy = function (text: string): boolean {
+  // Reka UI menus and dialogs trap focus and pull it back into themselves, which
+  // clears a selection made anywhere else, so keep the node inside the trap.
   const host =
-    document.activeElement?.closest<HTMLElement>("[role=dialog]") ??
-    document.body;
-  const textArea = document.createElement("textarea");
-  textArea.value = text;
-  textArea.setAttribute("readonly", "");
-  textArea.style.position = "fixed";
-  textArea.style.top = "0";
-  textArea.style.left = "0";
-  textArea.style.width = "1px";
-  textArea.style.height = "1px";
-  textArea.style.opacity = "0";
-  textArea.style.pointerEvents = "none";
-  textArea.style.setProperty("-webkit-user-select", "text");
-  textArea.style.userSelect = "text";
-  host.appendChild(textArea);
+    document.activeElement?.closest<HTMLElement>(
+      "[role=dialog], [role=menu]",
+    ) ?? document.body;
+
+  const node = document.createElement("span");
+  node.textContent = text;
+  node.setAttribute("aria-hidden", "true");
+  // Browsers refuse to copy from a node they treat as not rendered, so clip it
+  // out of sight instead of hiding it.
+  node.style.all = "unset";
+  node.style.position = "fixed";
+  node.style.top = "0";
+  node.style.clip = "rect(0, 0, 0, 0)";
+  node.style.whiteSpace = "pre";
+  // global.css disables selection on every element
+  node.style.setProperty("-webkit-user-select", "text");
+  node.style.userSelect = "text";
+
+  let copied = false;
+  const onCopy = function (event: ClipboardEvent) {
+    event.preventDefault();
+    event.clipboardData?.setData("text/plain", text);
+    copied = true;
+  };
+  node.addEventListener("copy", onCopy);
+
+  const selection = window.getSelection();
+  host.appendChild(node);
   try {
-    textArea.focus();
-    textArea.select();
-    textArea.setSelectionRange(0, text.length);
-    return document.execCommand("copy");
+    const range = document.createRange();
+    range.selectNodeContents(node);
+    selection?.removeAllRanges();
+    selection?.addRange(range);
+    // The command reports success even when nothing was written, so the handler
+    // above is what tells us whether the text really got there.
+    document.execCommand("copy");
   } catch (error) {
     console.error("Failed to copy to clipboard:", error);
-    return false;
   } finally {
-    host.removeChild(textArea);
+    selection?.removeAllRanges();
+    node.removeEventListener("copy", onCopy);
+    host.removeChild(node);
   }
-}
+
+  return copied;
+};
 
 /**
  * Check if a player config should be hidden from settings due to being a

--- a/src/helpers/utils.ts
+++ b/src/helpers/utils.ts
@@ -689,7 +689,8 @@ export const markdownToHtml = function (text: string): string {
 export async function copyToClipboard(text: string): Promise<boolean> {
   if (!text) return false;
 
-  // Only exposed in secure contexts (https / localhost).
+  // Only exposed in secure contexts (https / localhost); the catch also
+  // covers a permission the browser refuses.
   if (navigator.clipboard?.writeText) {
     try {
       await navigator.clipboard.writeText(text);
@@ -736,8 +737,11 @@ const legacyCopy = function (text: string): boolean {
 
   let copied = false;
   const onCopy = function (event: ClipboardEvent) {
+    // without a clipboard to write to, leave the copy to the browser and let
+    // the caller report a failure rather than an unverifiable success
+    if (!event.clipboardData) return;
     event.preventDefault();
-    event.clipboardData?.setData("text/plain", text);
+    event.clipboardData.setData("text/plain", text);
     copied = true;
   };
   node.addEventListener("copy", onCopy);
@@ -757,7 +761,7 @@ const legacyCopy = function (text: string): boolean {
   } finally {
     selection?.removeAllRanges();
     node.removeEventListener("copy", onCopy);
-    host.removeChild(node);
+    node.remove();
   }
 
   return copied;

--- a/tests/helpers/utils.test.ts
+++ b/tests/helpers/utils.test.ts
@@ -42,54 +42,83 @@ afterEach(() => {
 });
 
 describe("copyToClipboard", () => {
-  it("keeps the fallback textarea selectable", async () => {
-    const secureContextDescriptor = Object.getOwnPropertyDescriptor(
-      window,
-      "isSecureContext",
-    );
-    const execCommandDescriptor = Object.getOwnPropertyDescriptor(
+  const restore: (() => void)[] = [];
+
+  /**
+   * Replace a property for the duration of the test.
+   */
+  const stub = function (target: object, key: string, value: unknown) {
+    const descriptor = Object.getOwnPropertyDescriptor(target, key);
+    Object.defineProperty(target, key, { configurable: true, value });
+    restore.push(() => {
+      if (descriptor) Object.defineProperty(target, key, descriptor);
+      else Reflect.deleteProperty(target, key);
+    });
+  };
+
+  /**
+   * Force the legacy path by hiding the Clipboard API, and run the given
+   * callback in place of the browser's copy command.
+   */
+  const stubBrowser = function (onCommand: () => void) {
+    stub(navigator, "clipboard", undefined);
+    stub(
       document,
       "execCommand",
+      vi.fn(() => {
+        onCommand();
+        // browsers report success even when nothing was written
+        return true;
+      }),
     );
+  };
 
-    Object.defineProperty(window, "isSecureContext", {
-      configurable: true,
-      value: false,
+  /** The node the helper selects from, while it is still mounted. */
+  const clipboardNode = () =>
+    document.querySelector<HTMLElement>("span[aria-hidden='true']");
+
+  afterEach(() => {
+    for (const undo of restore.splice(0)) undo();
+  });
+
+  it("copies the text when the browser accepts the copy", async () => {
+    const setData = vi.fn();
+    stubBrowser(() => {
+      const event = new Event("copy", { bubbles: true, cancelable: true });
+      Object.defineProperty(event, "clipboardData", { value: { setData } });
+      clipboardNode()?.dispatchEvent(event);
     });
-    Object.defineProperty(document, "execCommand", {
-      configurable: true,
-      value: vi.fn(() => true),
+
+    await expect(copyToClipboard("provider://artist/id")).resolves.toBe(true);
+    expect(setData).toHaveBeenCalledWith("text/plain", "provider://artist/id");
+    expect(clipboardNode()).toBeNull();
+  });
+
+  it("reports failure when the copy is silently ignored", async () => {
+    stubBrowser(() => {});
+
+    await expect(copyToClipboard("provider://artist/id")).resolves.toBe(false);
+    expect(clipboardNode()).toBeNull();
+  });
+
+  it("keeps the node inside a menu that traps focus", async () => {
+    const menu = document.createElement("div");
+    menu.setAttribute("role", "menu");
+    const menuItem = document.createElement("button");
+    menu.appendChild(menuItem);
+    document.body.appendChild(menu);
+    menuItem.focus();
+
+    let host: HTMLElement | null | undefined;
+    stubBrowser(() => {
+      host = clipboardNode()?.parentElement;
     });
-    const appendChild = vi.spyOn(document.body, "appendChild");
 
     try {
-      await expect(copyToClipboard("provider://artist/id")).resolves.toBe(true);
-
-      const appendedNode = appendChild.mock.calls[0][0];
-      expect(appendedNode).toBeInstanceOf(HTMLTextAreaElement);
-      if (!(appendedNode instanceof HTMLTextAreaElement)) {
-        throw new TypeError("Expected clipboard textarea");
-      }
-      expect(appendedNode.style.getPropertyValue("-webkit-user-select")).toBe(
-        "text",
-      );
-      expect(appendedNode.style.userSelect).toBe("text");
-      expect(appendedNode.isConnected).toBe(false);
+      await copyToClipboard("provider://artist/id");
+      expect(host).toBe(menu);
     } finally {
-      if (secureContextDescriptor) {
-        Object.defineProperty(
-          window,
-          "isSecureContext",
-          secureContextDescriptor,
-        );
-      } else {
-        Reflect.deleteProperty(window, "isSecureContext");
-      }
-      if (execCommandDescriptor) {
-        Object.defineProperty(document, "execCommand", execCommandDescriptor);
-      } else {
-        Reflect.deleteProperty(document, "execCommand");
-      }
+      document.body.removeChild(menu);
     }
   });
 });

--- a/tests/helpers/utils.test.ts
+++ b/tests/helpers/utils.test.ts
@@ -73,7 +73,9 @@ describe("copyToClipboard", () => {
     );
   };
 
-  /** The node the helper selects from, while it is still mounted. */
+  /**
+   * The node the helper selects from, while it is still mounted.
+   */
   const clipboardNode = () =>
     document.querySelector<HTMLElement>("span[aria-hidden='true']");
 
@@ -99,6 +101,16 @@ describe("copyToClipboard", () => {
 
     await expect(copyToClipboard("provider://artist/id")).resolves.toBe(false);
     expect(clipboardNode()).toBeNull();
+  });
+
+  it("reports failure when the copy event carries no clipboard", async () => {
+    stubBrowser(() => {
+      clipboardNode()?.dispatchEvent(
+        new Event("copy", { bubbles: true, cancelable: true }),
+      );
+    });
+
+    await expect(copyToClipboard("provider://artist/id")).resolves.toBe(false);
   });
 
   it("keeps the node inside a menu that traps focus", async () => {


### PR DESCRIPTION
# What does this implement/fix?

Copying a URI or a token did nothing when Music Assistant is opened over plain http, while the app still showed a message saying the text was copied.

Over http the browser clipboard API is not available, so copying falls back to selecting the text by hand. That fallback focused a hidden field, and an open menu takes focus straight back, so nothing was selected by the time the copy ran. The copy command reports success either way, which is why the confirmation appeared with an empty clipboard.

Changes:

- keep the text to copy inside the open menu or dialog, so it stays selected
- write the text from the copy handler instead of relying on the browser reading the selection
- only report success when the copy actually happened, so a failure now shows an error instead of a false confirmation
- tests for the success case, the silent failure case and the menu case

Reported on Chrome and on Safari. The Safari side is not verified on a device yet, but the same change covers it.

**Related issue (if applicable):**

- related issue https://github.com/music-assistant/support/issues/6008
- related issue https://github.com/music-assistant/support/issues/5977

**Related backend PR (if applicable):**

- none

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm lint:check` passes.
- [x] `pnpm test:run` passes, and tests have been added/updated where applicable.
- [x] `pnpm build` passes.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
