### PR TITLE
Remove the duplicate help icon from settings

### DIFF
--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -420,7 +420,6 @@
         "users_description": "Manage user accounts, roles, and permissions",
         "system_description": "Configure Music Assistant server settings and core modules",
         "system": "System",
-        "view_documentation": "View documentation",
         "about": "About",
         "about_description": "Version information, credits and more",
         "auto_refresh_log": "Auto-refresh",

--- a/src/views/settings/Settings.vue
+++ b/src/views/settings/Settings.vue
@@ -44,13 +44,6 @@
           :title="t('tooltip.toggle_view_mode')"
           @click="toggleSystemViewMode()"
         />
-        <v-btn
-          v-if="documentationUrl"
-          icon="mdi-help-circle"
-          variant="text"
-          :title="t('settings.view_documentation')"
-          @click="openLinkInNewTab(documentationUrl)"
-        />
       </template>
     </Toolbar>
 
@@ -299,7 +292,6 @@ import {
   CardTitle,
 } from "@/components/ui/card";
 import { useUserPreferences } from "@/composables/userPreferences";
-import { openLinkInNewTab } from "@/helpers/utils";
 import { api } from "@/plugins/api";
 import { requireServerVersion } from "@/plugins/api/helpers";
 import { ProviderType } from "@/plugins/api/interfaces";
@@ -880,29 +872,6 @@ const breadcrumbItems = computed(() => {
     });
 
   return items;
-});
-
-const documentationUrl = computed(() => {
-  const route = router.currentRoute.value;
-  const name = route.name?.toString() || "";
-
-  // Show documentation link for editcore and editprovider routes
-  if (name === "editcore") {
-    const domain = route.params.domain as string;
-    if (domain && api.providerManifests[domain]) {
-      return api.providerManifests[domain].documentation || null;
-    }
-  } else if (name === "editprovider") {
-    const instanceId = route.params.instanceId as string;
-    if (instanceId) {
-      const provider = api.getProvider(instanceId);
-      if (provider && api.providerManifests[provider.domain]) {
-        return api.providerManifests[provider.domain].documentation || null;
-      }
-    }
-  }
-
-  return null;
 });
 </script>
 


### PR DESCRIPTION
# What does this implement/fix?

The settings pages showed a question mark icon in the top right that opened the provider documentation. Provider pages already have a Documentation button in the banner, so the icon was a second link to the same page.

Changes:

- removed the question mark icon from the settings header
- removed the code and the text string that were only used by it

The icon only ever appeared on provider pages, so nothing else loses a link to the documentation. The help buttons on the individual settings are untouched.

**Related issue (if applicable):**

- none

**Related backend PR (if applicable):**

- none

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [ ] The code change is tested and works locally.
- [ ] `pnpm lint:check` passes.
- [ ] `pnpm test:run` passes, and tests have been added/updated where applicable.
- [ ] `pnpm build` passes.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
