### PR TITLE
Various improvements to the App startup tests

### DIFF
--- a/tests/App.test.ts
+++ b/tests/App.test.ts
@@ -1,3 +1,6 @@
+// Imported once, outside any test: evaluating the app graph is the expensive
+// part, and the import phase is not on a test's clock.
+import App from "@/App.vue";
 import {
   EventType,
   ProviderStatus,
@@ -286,19 +289,11 @@ vi.mock("@/views/Login.vue", () => ({
   },
 }));
 
-// Every test here resets the module registry and re-imports App.vue, so each
-// one pays for evaluating the whole app graph before it asserts anything. That
-// cost scales with how busy the machine is, and on a loaded CI worker it alone
-// can outlast the 5s default - at which point the mount finishes during the
-// next test and inflates its call counts.
-vi.setConfig({ testTimeout: 20_000 });
-
 let wrapper: VueWrapper | undefined;
 
 describe("App initialization", () => {
   beforeEach(() => {
-    vi.clearAllMocks();
-    vi.resetModules();
+    vi.resetAllMocks();
     guestType.value = null;
     i18nMock.global.locale.value = "en";
     apiMock.state.value = "authenticated";
@@ -320,6 +315,7 @@ describe("App initialization", () => {
     apiMock.fetchState.mockResolvedValue(undefined);
     apiMock.fetchProviders.mockResolvedValue(undefined);
     apiMock.initialize.mockResolvedValue(undefined);
+    apiMock.setLocale.mockResolvedValue(undefined);
     apiMock.getProviderConfigs.mockResolvedValue([partyPluginConfig()]);
     for (const method of [
       apiMock.getLibraryAlbumsCount,
@@ -367,6 +363,10 @@ describe("App initialization", () => {
       configurable: true,
       value: vi.fn().mockReturnValue({
         addEventListener: vi.fn(),
+        // The theme composable keeps its "auto" listener in module state for
+        // the whole file, so a later mount on a fixed theme unregisters it
+        // against the MediaQueryList an earlier test handed out.
+        removeEventListener: vi.fn(),
         matches: false,
       }),
     });
@@ -474,7 +474,7 @@ describe("App initialization", () => {
     const pluginConfigs = createDeferred<ProviderConfig[]>();
     apiMock.fetchState.mockReturnValue(serverState.promise);
     apiMock.getProviderConfigs.mockReturnValue(pluginConfigs.promise);
-    wrapper = await mountAppWithoutSettling();
+    wrapper = mountAppWithoutSettling();
 
     await flushPromises();
     expect(apiMock.fetchState).toHaveBeenCalledOnce();
@@ -503,6 +503,9 @@ describe("App initialization", () => {
     "does not mount browser media controls for a %s guest fallback tab",
     async (type) => {
       guestType.value = type;
+      // Hand the tab a media session, so being a guest is the only thing left
+      // that can withhold the controls.
+      stubMediaSession();
       apiMock.getCurrentUserInfo.mockResolvedValue(
         user({
           role: UserRole.GUEST,
@@ -523,10 +526,7 @@ describe("App initialization", () => {
   );
 
   it("keeps browser media controls for regular fallback tabs", async () => {
-    Object.defineProperty(navigator, "mediaSession", {
-      configurable: true,
-      value: {},
-    });
+    stubMediaSession();
     webPlayerMock.audioSource = "controls_only";
     webPlayerMock.interacted = true;
     webPlayerMock.tabMode = "controls_only";
@@ -539,16 +539,7 @@ describe("App initialization", () => {
   });
 
   it("clears browser media controls on participant routes for regular users", async () => {
-    const mediaSession = {
-      metadata: {} as MediaMetadata | null,
-      playbackState: "playing" as MediaSessionPlaybackState,
-      setActionHandler: vi.fn(),
-      setPositionState: vi.fn(),
-    };
-    Object.defineProperty(navigator, "mediaSession", {
-      configurable: true,
-      value: mediaSession,
-    });
+    const mediaSession = stubMediaSession();
     webPlayerMock.audioSource = "controls_only";
     webPlayerMock.interacted = true;
     webPlayerMock.tabMode = "controls_only";
@@ -577,7 +568,7 @@ describe("App initialization", () => {
 
   it("remembers a temporary remote connection after regular login", async () => {
     apiMock.state.value = "auth_required";
-    wrapper = await mountAppWithoutSettling();
+    wrapper = mountAppWithoutSettling();
 
     wrapper.findComponent({ name: "Login" }).vm.$emit("authenticated", {
       token: "regular-token",
@@ -599,7 +590,7 @@ describe("App initialization", () => {
 
   it("clears proxy mode before connecting to a local server", async () => {
     apiMock.state.value = "disconnected";
-    wrapper = await mountAppWithoutSettling();
+    wrapper = mountAppWithoutSettling();
 
     wrapper
       .findComponent({ name: "Login" })
@@ -889,7 +880,7 @@ async function mountAuthenticatedApp() {
  * a timer anywhere in that path would need vi.waitFor instead.
  */
 async function mountApp() {
-  const mounted = await mountAppWithoutSettling();
+  const mounted = mountAppWithoutSettling();
   await flushPromises();
   expect(apiMock.state.value).toBe("initialized");
   expect(mockInitializeWebPlayerModeSync).toHaveBeenCalledOnce();
@@ -901,8 +892,7 @@ async function mountApp() {
  * Mount the app and register it for teardown, without waiting for
  * initialization to settle; the test drives what happens next.
  */
-async function mountAppWithoutSettling() {
-  const { default: App } = await import("@/App.vue");
+function mountAppWithoutSettling() {
   // Registered at mount time so afterEach unmounts the app even when a
   // caller's assertion throws: a live instance keeps reacting to api.state
   // and corrupts every later test.
@@ -979,6 +969,23 @@ function createDeferred<T = void>() {
     resolve = resolvePromise;
   });
   return { promise, resolve };
+}
+
+/**
+ * Give the tab a media session, as a browser that supports one would.
+ */
+function stubMediaSession() {
+  const session = {
+    metadata: {} as MediaMetadata | null,
+    playbackState: "playing" as MediaSessionPlaybackState,
+    setActionHandler: vi.fn(),
+    setPositionState: vi.fn(),
+  };
+  Object.defineProperty(navigator, "mediaSession", {
+    configurable: true,
+    value: session,
+  });
+  return session;
 }
 
 function createStorage(): Storage {


### PR DESCRIPTION
# What does this implement/fix?

A few reliability fixes to the App startup tests, which were flaky on busy CI
machines and were quietly not checking one of the things they were written to
check.

The tests reloaded the entire app before every single test, so the first test
absorbed the whole cost of loading the app — around two seconds even on a fast
machine — before it checked anything. On a busy CI machine that alone could
pass the 5 second limit, and the abandoned work then finished during the *next*
test and made unrelated tests fail with confusing "called twice" errors. The
file passed fine on its own, which made it hard to place. It had been patched
by raising the limit to 20 seconds, which also hid any genuine slowdown in the
other 30 tests.

That reload turned out to be papering over an incomplete `matchMedia` test stub
rather than over anything in `App.vue`, so the stub is now complete and the
reload is gone.

Two other things surfaced while checking that nothing had been weakened: mock
behaviour set up by one test could leak into later ones, and the two tests that
check a guest doesn't get browser media controls were passing for the wrong
reason — the tab had no media session at all, so the guest check never came
into it. Both are fixed, and the guest tests now fail if the guest check is
removed.

**Related issue (if applicable):**

- related issue `n/a`

**Related backend PR (if applicable):**

- related backend PR `n/a`

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

Changes:

- Load the app once for the whole file instead of once per test, and drop the
  per-test module registry reset
- Complete the `matchMedia` stub so the theme listener can be removed again
- Reset mock behaviour between tests, not just call counts
- Give the guest media-controls tests a media session, so they actually test
  the guest check
- Share one media session stub between the three tests that need one
- Remove the 20 second timeout override

No test assertions were relaxed, and no app code changed. The slowest test in
the file drops from roughly two seconds to well under two hundred milliseconds,
and the file now passes in a randomised order.

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm lint:check` passes.
- [x] `pnpm test:run` passes, and tests have been added/updated where applicable.
- [x] `pnpm build` passes.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
