### PR TITLE
Fix provider icon spacing on the Discover shelf and settings screens

### DIFF
--- a/src/components/AudioProcessingDetails.vue
+++ b/src/components/AudioProcessingDetails.vue
@@ -276,7 +276,7 @@ const {
   flex: 0 0 18px;
   width: 18px !important;
   height: 18px !important;
-  margin: 0 !important;
+  margin: 0;
   overflow: hidden;
 }
 

--- a/src/components/ProviderIcon.vue
+++ b/src/components/ProviderIcon.vue
@@ -1,7 +1,5 @@
 <template>
-  <div
-    :style="`width:${size}px;margin-left:10px;margin-right:10px;content-align:center`"
-  >
+  <div class="provider-icon-wrapper" :style="{ width: `${size}px` }">
     <!-- the library is not a real provider, so render its membership badge directly -->
     <div
       v-if="domain === 'library'"
@@ -85,6 +83,12 @@ watchEffect(async () => {
 </script>
 
 <style>
+/* default gutters; unscoped so a call site's own rule outweighs them */
+.provider-icon-wrapper {
+  margin-left: 10px;
+  margin-right: 10px;
+}
+
 .provider-img {
   width: 100%;
   height: 100%;

--- a/src/components/SettingsPlayerCard.vue
+++ b/src/components/SettingsPlayerCard.vue
@@ -293,7 +293,7 @@ const handleSetup = () => {
 }
 
 .chip-icon {
-  margin: 0 !important;
+  margin: 0;
   width: auto !important;
 }
 

--- a/src/components/discover/EditorialMediaCard.vue
+++ b/src/components/discover/EditorialMediaCard.vue
@@ -319,7 +319,7 @@ const onMenu = (e: MouseEvent) => {
   top: 6px;
   left: 6px;
   z-index: 2;
-  margin: 0 !important;
+  margin: 0;
 }
 .ed-card__img {
   width: 100%;

--- a/src/components/discover/EditorialShelf.vue
+++ b/src/components/discover/EditorialShelf.vue
@@ -264,10 +264,8 @@ onBeforeUnmount(() => {
 }
 .ed-shelf__provider {
   flex-shrink: 0;
-  /* ProviderIcon ships with its own horizontal margins; cancel them so it
-     lines up with the shelf gutter and the aside gap is consistent. */
-  margin-left: -10px;
-  margin-right: -10px;
+  /* drop ProviderIcon's default gutters so the aside gap sets the spacing */
+  margin: 0;
 }
 .ed-shelf__actions {
   display: flex;

--- a/src/layouts/default/PlayerOSD/NowPlayingSourceBadge.vue
+++ b/src/layouts/default/PlayerOSD/NowPlayingSourceBadge.vue
@@ -34,11 +34,9 @@ const { nowPlayingSource } = useNowPlayingSource();
 </script>
 
 <style scoped>
-/* ProviderIcon writes its 10px side margins into a style attribute, so only an
-   !important rule can cancel them and let the badge's own gap apply */
+/* drop ProviderIcon's default gutters so the badge's own gap applies */
 .now-playing-source__icon {
-  margin-left: -10px !important;
-  margin-right: -10px !important;
+  margin: 0;
   flex-shrink: 0;
 }
 </style>

--- a/src/views/settings/EditPlayer.vue
+++ b/src/views/settings/EditPlayer.vue
@@ -682,7 +682,7 @@ function resetPlayerState(playerId?: string) {
 }
 
 .chip-icon {
-  margin: 0 !important;
+  margin: 0;
   width: auto !important;
 }
 

--- a/src/views/settings/Players.vue
+++ b/src/views/settings/Players.vue
@@ -503,7 +503,7 @@ watch(
 }
 
 .chip-icon {
-  margin: 0 !important;
+  margin: 0;
   width: auto !important;
 }
 

--- a/src/views/settings/ProtocolConfigSection.vue
+++ b/src/views/settings/ProtocolConfigSection.vue
@@ -59,7 +59,7 @@
                   v-if="getProtocolDomain(panel)"
                   :domain="getProtocolDomain(panel)!"
                   :size="22"
-                  class="!ml-0"
+                  class="mx-0"
                 />
                 <span>{{ getProtocolConfigureTitle(panel) }}</span>
                 <Badge


### PR DESCRIPTION
# What does this implement/fix?

The provider icon component wrote its own 10px side margins straight into the
element's `style` attribute. That made the spacing impossible to change from
the outside without an `!important` override, so screens that place the icon
themselves had to fight it. Three that tried with a normal style rule were
silently ignored, leaving the icon misaligned, and the one in the player bar
pushed the icon into its own label.

The default 10px spacing now lives in a regular class, so any screen can
simply override it. Spacing is unchanged everywhere it was already correct.

**Related issue (if applicable):**

- n/a

**Related backend PR (if applicable):**

- n/a

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

### Changes

- Provider icon spacing moved from an inline style into a class that call sites can override.
- Fixed the source badge in the player bar, where the icon overlapped the name next to it.
- Fixed the icon alignment on the Discover shelf header, the settings Providers list and the protocol accordion, where the intended spacing never applied.
- Dropped the `!important` workarounds in the Discover card, the audio processing details and the player protocol chips.

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm lint:check` passes.
- [x] `pnpm test:run` passes, and tests have been added/updated where applicable.
- [x] `pnpm build` passes.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
