### PR TITLE
Remove an unused option from the provider icon component

### DIFF
--- a/src/components/ProviderIcon.vue
+++ b/src/components/ProviderIcon.vue
@@ -31,7 +31,6 @@ import { ProviderIconVariant } from "@/plugins/api/interfaces";
 export interface Props {
   domain: string;
   size: number;
-  dark?: boolean;
   monochrome?: boolean;
 }
 const props = defineProps<Props>();


### PR DESCRIPTION
# What does this implement/fix?

`ProviderIcon` declared a `dark` prop that nothing ever used. The component works out light/dark itself from the active theme, and no call site has ever passed it — it has been dead since the prop was added. Removing it keeps the component's interface honest about what it actually accepts.

No behaviour change.

**Related issue (if applicable):**

- n/a

**Related backend PR (if applicable):**

- n/a

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm lint:check` passes.
- [x] `pnpm test:run` passes, and tests have been added/updated where applicable.
- [x] `pnpm build` passes.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
