### PR TITLE
Call the group picker's visualizers section "Screens"

### DIFF
--- a/src/components/PlayerGroupMembers.vue
+++ b/src/components/PlayerGroupMembers.vue
@@ -56,10 +56,7 @@ import { Checkbox } from "@/components/ui/checkbox";
 import { Separator } from "@/components/ui/separator";
 import type { PlayerGroupFilter } from "@/helpers/player_group";
 import { requestGroupPlaybackConfirmation } from "@/helpers/player_group_playback";
-import {
-  groupMemberPickerVisible,
-  isVisualizerPlayer,
-} from "@/helpers/players";
+import { groupMemberPickerVisible, isScreenPlayer } from "@/helpers/players";
 import { api } from "@/plugins/api";
 import {
   type Player,
@@ -129,8 +126,7 @@ const candidateSections = computed(() => {
       label: "players",
       translateLabel: true,
       players: availableCandidates.filter(
-        (player) =>
-          player.type !== PlayerType.LIGHT && !isVisualizerPlayer(player),
+        (player) => player.type !== PlayerType.LIGHT && !isScreenPlayer(player),
       ),
     },
     {
@@ -142,12 +138,10 @@ const candidateSections = computed(() => {
       ),
     },
     {
-      type: "visualizers",
-      label: "visualizers",
+      type: "screens",
+      label: "screens",
       translateLabel: true,
-      players: availableCandidates.filter((player) =>
-        isVisualizerPlayer(player),
-      ),
+      players: availableCandidates.filter((player) => isScreenPlayer(player)),
     },
   ];
   if (groupedPlayers.length > 0) {
@@ -196,10 +190,8 @@ function canGroupWithPlayer(player: Player) {
 function matchesFilter(player: Player) {
   if (props.filter === "all") return true;
   if (props.filter === "lights") return player.type === PlayerType.LIGHT;
-  if (props.filter === "visualizers") {
-    return isVisualizerPlayer(player);
-  }
-  return player.type !== PlayerType.LIGHT && !isVisualizerPlayer(player);
+  if (props.filter === "screens") return isScreenPlayer(player);
+  return player.type !== PlayerType.LIGHT && !isScreenPlayer(player);
 }
 
 function sortPlayers(players: Player[]) {

--- a/src/helpers/player_group.ts
+++ b/src/helpers/player_group.ts
@@ -1,10 +1,10 @@
-export type PlayerGroupFilter = "all" | "players" | "lights" | "visualizers";
+export type PlayerGroupFilter = "all" | "players" | "lights" | "screens";
 
 const PLAYER_GROUP_FILTERS: PlayerGroupFilter[] = [
   "all",
   "players",
   "lights",
-  "visualizers",
+  "screens",
 ];
 
 export function isPlayerGroupFilter(

--- a/src/helpers/players.ts
+++ b/src/helpers/players.ts
@@ -87,10 +87,10 @@ export const groupMemberPickerVisible = function (player: Player): boolean {
 /**
  * Check if the player renders a now-playing view instead of audio.
  *
- * Screens and visualizers share a section in the group pickers, so the UI
- * treats them as one category.
+ * Visualizers and metadata-only displays are both screens to the user, so the
+ * group pickers offer them as one category.
  */
-export const isVisualizerPlayer = function (player: Player): boolean {
+export const isScreenPlayer = function (player: Player): boolean {
   return (
     player.type === PlayerType.VISUALIZER || player.type === PlayerType.DISPLAY
   );

--- a/src/layouts/default/PlayerOSD/PlayerBarGroupControl.vue
+++ b/src/layouts/default/PlayerOSD/PlayerBarGroupControl.vue
@@ -83,7 +83,7 @@
           :player="player"
           :members="groupMembers"
           :has-lights="hasLights"
-          :has-visualizers="hasVisualizers"
+          :has-screens="hasScreens"
           @dismiss="handleOpenChange(false)"
         />
       </PopoverContent>
@@ -111,7 +111,7 @@ import {
   canEditPlayerGroup,
   getPlayerGroupMemberCount,
   groupMemberPickerVisible,
-  isVisualizerPlayer,
+  isScreenPlayer,
 } from "@/helpers/players";
 import { api } from "@/plugins/api";
 import { type Player, PlayerType } from "@/plugins/api/interfaces";
@@ -191,8 +191,8 @@ const hasLights = computed(() =>
     (candidate) => candidate.type === PlayerType.LIGHT,
   ),
 );
-const hasVisualizers = computed(() =>
-  groupCandidates.value.some((candidate) => isVisualizerPlayer(candidate)),
+const hasScreens = computed(() =>
+  groupCandidates.value.some((candidate) => isScreenPlayer(candidate)),
 );
 
 watch(
@@ -200,10 +200,10 @@ watch(
   () => handleOpenChange(false),
 );
 
-watch([hasLights, hasVisualizers], () => {
+watch([hasLights, hasScreens], () => {
   if (
     (filter.value === "lights" && !hasLights.value) ||
-    (filter.value === "visualizers" && !hasVisualizers.value)
+    (filter.value === "screens" && !hasScreens.value)
   ) {
     filter.value = "all";
   }

--- a/src/layouts/default/PlayerOSD/PlayerGroupPanel.vue
+++ b/src/layouts/default/PlayerOSD/PlayerGroupPanel.vue
@@ -43,8 +43,8 @@
           <DropdownMenuRadioItem v-if="hasLights" value="lights">
             {{ $t("lights") }}
           </DropdownMenuRadioItem>
-          <DropdownMenuRadioItem v-if="hasVisualizers" value="visualizers">
-            {{ $t("visualizers") }}
+          <DropdownMenuRadioItem v-if="hasScreens" value="screens">
+            {{ $t("screens") }}
           </DropdownMenuRadioItem>
         </DropdownMenuRadioGroup>
       </DropdownMenuContent>
@@ -89,7 +89,7 @@ defineProps<{
   members: Player[];
   filter: PlayerGroupFilter;
   hasLights: boolean;
-  hasVisualizers: boolean;
+  hasScreens: boolean;
 }>();
 
 const emit = defineEmits<{

--- a/src/translations/de.json
+++ b/src/translations/de.json
@@ -2234,7 +2234,6 @@
     "artist_no_library_audiobooks": "In deiner Bibliothek befinden sich keine Hörbücher dieses Autors bzw. Sprechers.",
     "artist_all_audiobooks": "Alle Hörbücher",
     "lights": "Lichter",
-    "visualizers": "Visualizers",
     "volume": "Lautstärke",
     "grouped_volume": "Lautstärke der Gruppe",
     "player_select": {

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -2309,7 +2309,6 @@
     "artist_all_audiobooks": "All audiobooks",
     "lights": "Lights",
     "players_in_group": "Players in group",
-    "visualizers": "Visualizers",
     "volume": "Volume",
     "grouped_volume": "Grouped volume",
     "player_select": {
@@ -2376,5 +2375,6 @@
     "recent_searches": "Recent searches",
     "command_center_navigate": "navigate",
     "command_center_open": "open",
-    "command_center_keep_typing": "Keep typing to search..."
+    "command_center_keep_typing": "Keep typing to search...",
+    "screens": "Screens"
 }

--- a/src/translations/es.json
+++ b/src/translations/es.json
@@ -2234,7 +2234,6 @@
     "artist_no_library_audiobooks": "No tienes audiolibros de este autor\/narrador en tu biblioteca.",
     "artist_all_audiobooks": "Todos los audiolibros",
     "lights": "Luces",
-    "visualizers": "Visualizadores",
     "volume": "Volumen",
     "grouped_volume": "Volumen agrupado",
     "player_select": {

--- a/src/translations/nl.json
+++ b/src/translations/nl.json
@@ -2234,7 +2234,6 @@
     "artist_no_library_audiobooks": "Je hebt geen luisterboeken van deze auteur\/voorlezer in je bibliotheek.",
     "artist_all_audiobooks": "Alle luisterboeken",
     "lights": "Lichten",
-    "visualizers": "Visualizers",
     "volume": "Volume",
     "grouped_volume": "Gegroepeerd volume",
     "player_select": {

--- a/src/translations/ru_RU.json
+++ b/src/translations/ru_RU.json
@@ -2226,7 +2226,6 @@
     "artist_no_library_audiobooks": "В вашей библиотеке нет аудиокниг этого автора\/рассказчика.",
     "artist_all_audiobooks": "Все аудиокниги",
     "lights": "Свет",
-    "visualizers": "Визуализаторы",
     "volume": "Громкость",
     "grouped_volume": "Групповая громкость",
     "player_select": {

--- a/src/translations/sr_Latn.json
+++ b/src/translations/sr_Latn.json
@@ -2234,7 +2234,6 @@
     "artist_no_library_audiobooks": "Nemate nijednu audio-knjigu u svojoj biblioteci za ovog autora\/naratora.",
     "artist_all_audiobooks": "Sve audio-knjige",
     "lights": "Svetla",
-    "visualizers": "Vizuelizatori",
     "volume": "Jačina zvuka",
     "grouped_volume": "Grupna jačina zvuka",
     "player_select": {

--- a/src/translations/sv_SE.json
+++ b/src/translations/sv_SE.json
@@ -2231,7 +2231,6 @@
     "artist_no_library_audiobooks": "Du har inga ljudböcker i ditt bibliotek för den här författaren\/berättaren.",
     "artist_all_audiobooks": "Alla ljudböcker",
     "lights": "Ljus",
-    "visualizers": "Visualiserar",
     "volume": "Volym",
     "grouped_volume": "Grupperad volym",
     "player_select": {

--- a/tests/components/PlayerGroupMembers.test.ts
+++ b/tests/components/PlayerGroupMembers.test.ts
@@ -173,7 +173,7 @@ describe("PlayerGroupMembers", () => {
     );
   });
 
-  it("separates players, lights, and visualizers", () => {
+  it("separates players, lights, and screens", () => {
     const speaker = createPlayer({
       player_id: "speaker",
       name: "Office",
@@ -208,10 +208,10 @@ describe("PlayerGroupMembers", () => {
       wrapper
         .findAll(".player-group-section > p")
         .map((section) => section.text()),
-    ).toEqual(["players", "lights", "visualizers"]);
+    ).toEqual(["players", "lights", "screens"]);
   });
 
-  it("lists a screen alongside the visualizers", () => {
+  it("lists a display player under screens", () => {
     const screen = createPlayer({
       player_id: "screen",
       name: "Kitchen screen",
@@ -229,7 +229,7 @@ describe("PlayerGroupMembers", () => {
       wrapper
         .findAll(".player-group-section > p")
         .map((section) => section.text()),
-    ).toEqual(["visualizers"]);
+    ).toEqual(["screens"]);
   });
 
   it("separates current members from available players", () => {

--- a/tests/components/PlayerGroupMembers.test.ts
+++ b/tests/components/PlayerGroupMembers.test.ts
@@ -232,6 +232,34 @@ describe("PlayerGroupMembers", () => {
     ).toEqual(["screens"]);
   });
 
+  it("keeps only screens when filtering on screens", () => {
+    const speaker = createPlayer({
+      player_id: "speaker",
+      name: "Office",
+    });
+    const screen = createPlayer({
+      player_id: "screen",
+      name: "Kitchen screen",
+      type: PlayerType.DISPLAY,
+    });
+    const parent = createPlayer({
+      can_group_with: [speaker.player_id, screen.player_id],
+    });
+    api.players = {
+      [parent.player_id]: parent,
+      [speaker.player_id]: speaker,
+      [screen.player_id]: screen,
+    };
+
+    const wrapper = mountGroupMembers(parent, [], { filter: "screens" });
+
+    expect(
+      wrapper
+        .findAll(".member-checkbox")
+        .map((checkbox) => checkbox.attributes("aria-label")),
+    ).toEqual(["Kitchen screen"]);
+  });
+
   it("separates current members from available players", () => {
     const child = createPlayer({
       player_id: "child",


### PR DESCRIPTION
# What does this implement/fix?

The "Visualizers" section in the player group pickers also lists screens that only
show now-playing info (metadata-only Sendspin clients), which do not visualize
anything. Since hidden players became groupable these turn up there for the first
time, so the heading now says "Screens" — a word that covers both a MilkDrop
visualizer and a now-playing display.

- Renamed the group picker section and its filter option from "Visualizers" to "Screens"
- Same players as before, only the wording changes

**Related issue (if applicable):**

- n/a

**Related backend PR (if applicable):**

- n/a

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm lint:check` passes.
- [x] `pnpm test:run` passes, and tests have been added/updated where applicable.
- [x] `pnpm build` passes.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
