### PR TITLE
Fix silent group members from line-in capture devices

### DIFF
--- a/src/components/PlayerGroupMembers.vue
+++ b/src/components/PlayerGroupMembers.vue
@@ -56,7 +56,11 @@ import { Checkbox } from "@/components/ui/checkbox";
 import { Separator } from "@/components/ui/separator";
 import type { PlayerGroupFilter } from "@/helpers/player_group";
 import { requestGroupPlaybackConfirmation } from "@/helpers/player_group_playback";
-import { groupMemberPickerVisible, isScreenPlayer } from "@/helpers/players";
+import {
+  canBeGroupMember,
+  groupMemberPickerVisible,
+  isScreenPlayer,
+} from "@/helpers/players";
 import { api } from "@/plugins/api";
 import {
   type Player,
@@ -100,6 +104,7 @@ const candidates = computed(() => {
       !canGroupWithPlayer(player) ||
       !player.available ||
       !groupMemberPickerVisible(player) ||
+      !canBeGroupMember(player) ||
       player.type === PlayerType.GROUP ||
       (player.active_group && player.active_group !== props.player.player_id)
     ) {

--- a/src/helpers/players.ts
+++ b/src/helpers/players.ts
@@ -85,6 +85,17 @@ export const groupMemberPickerVisible = function (player: Player): boolean {
 };
 
 /**
+ * Check if the player can take part in grouping.
+ *
+ * Capture-only devices report an unknown type: they exist so the device still
+ * has a settings page, but they render nothing, so they are never offered as
+ * a group member.
+ */
+export const canBeGroupMember = function (player: Player): boolean {
+  return player.type !== PlayerType.UNKNOWN;
+};
+
+/**
  * Check if the player renders a now-playing view instead of audio.
  *
  * Visualizers and metadata-only displays are both screens to the user, so the

--- a/src/layouts/default/PlayerOSD/PlayerBarGroupControl.vue
+++ b/src/layouts/default/PlayerOSD/PlayerBarGroupControl.vue
@@ -108,6 +108,7 @@ import {
 } from "@/helpers/player_bar";
 import type { PlayerGroupFilter } from "@/helpers/player_group";
 import {
+  canBeGroupMember,
   canEditPlayerGroup,
   getPlayerGroupMemberCount,
   groupMemberPickerVisible,
@@ -176,6 +177,7 @@ const groupCandidates = computed(() => {
     (candidate) =>
       candidate.available &&
       groupMemberPickerVisible(candidate) &&
+      canBeGroupMember(candidate) &&
       candidate.type !== PlayerType.GROUP &&
       (!candidate.active_group ||
         candidate.active_group === player.value?.player_id) &&

--- a/src/views/settings/AddPlayerGroup.vue
+++ b/src/views/settings/AddPlayerGroup.vue
@@ -92,7 +92,7 @@ import { computed, ref } from "vue";
 import { useRouter } from "vue-router";
 import { api } from "@/plugins/api";
 import { goBack } from "@/helpers/navigation";
-import { groupMemberPickerVisible } from "@/helpers/players";
+import { canBeGroupMember, groupMemberPickerVisible } from "@/helpers/players";
 import { markdownToHtml } from "@/helpers/utils";
 import { PlayerFeature, PlayerType } from "@/plugins/api/interfaces";
 
@@ -122,7 +122,8 @@ const syncPlayers = computed(() => {
         (x) =>
           x.available &&
           x.type != PlayerType.GROUP &&
-          groupMemberPickerVisible(x),
+          groupMemberPickerVisible(x) &&
+          canBeGroupMember(x),
       )
       .sort((a, b) =>
         (a.name ?? "")
@@ -137,7 +138,8 @@ const syncPlayers = computed(() => {
         if (
           !x.available ||
           x.type === PlayerType.GROUP ||
-          !groupMemberPickerVisible(x)
+          !groupMemberPickerVisible(x) ||
+          !canBeGroupMember(x)
         )
           return false;
         if (!x.supported_features.includes(PlayerFeature.SET_MEMBERS))
@@ -169,6 +171,7 @@ const syncPlayers = computed(() => {
         x.available &&
         x.type != PlayerType.GROUP &&
         groupMemberPickerVisible(x) &&
+        canBeGroupMember(x) &&
         x.provider == providerDetails.value?.instance_id,
     )
     .sort((a, b) =>

--- a/tests/components/PlayerGroupMembers.test.ts
+++ b/tests/components/PlayerGroupMembers.test.ts
@@ -260,6 +260,61 @@ describe("PlayerGroupMembers", () => {
     ).toEqual(["Kitchen screen"]);
   });
 
+  it("keeps a capture-only device out of the picker", () => {
+    const speaker = createPlayer({
+      player_id: "speaker",
+      name: "Office",
+    });
+    // a line-in device reports an unknown type and renders nothing, but its
+    // provider still advertises it as groupable
+    const captureDevice = createPlayer({
+      player_id: "line-in",
+      name: "Line-in",
+      type: PlayerType.UNKNOWN,
+      supported_features: [],
+    });
+    const parent = createPlayer({
+      can_group_with: [speaker.player_id, captureDevice.player_id],
+    });
+    api.players = {
+      [parent.player_id]: parent,
+      [speaker.player_id]: speaker,
+      [captureDevice.player_id]: captureDevice,
+    };
+
+    const wrapper = mountGroupMembers(parent, []);
+
+    expect(
+      wrapper
+        .findAll(".member-checkbox")
+        .map((checkbox) => checkbox.attributes("aria-label")),
+    ).toEqual(["Office"]);
+  });
+
+  it("keeps an already grouped capture-only device removable", () => {
+    const captureDevice = createPlayer({
+      player_id: "line-in",
+      name: "Line-in",
+      type: PlayerType.UNKNOWN,
+      supported_features: [],
+    });
+    const parent = createPlayer({
+      group_members: ["parent", captureDevice.player_id],
+    });
+    api.players = {
+      [parent.player_id]: parent,
+      [captureDevice.player_id]: captureDevice,
+    };
+
+    const wrapper = mountGroupMembers(parent, [parent, captureDevice]);
+
+    expect(
+      wrapper
+        .findAll(".member-checkbox")
+        .map((checkbox) => checkbox.attributes("aria-label")),
+    ).toEqual(["Kitchen", "Line-in"]);
+  });
+
   it("separates current members from available players", () => {
     const child = createPlayer({
       player_id: "child",

--- a/tests/helpers/players.test.ts
+++ b/tests/helpers/players.test.ts
@@ -1,4 +1,5 @@
 import {
+  canBeGroupMember,
   canEditPlayerGroup,
   getPlayerGroupMemberCount,
   groupMemberPickerVisible,
@@ -302,6 +303,36 @@ describe("groupMemberPickerVisible", () => {
     webPlayer.player_id = "local-web-player";
 
     expect(groupMemberPickerVisible(player)).toBe(true);
+  });
+});
+
+describe("canBeGroupMember", () => {
+  it("offers a regular player", () => {
+    expect(canBeGroupMember(createPlayer())).toBe(true);
+  });
+
+  it("offers a light, which joins a group without playing audio", () => {
+    expect(canBeGroupMember(createPlayer({ type: PlayerType.LIGHT }))).toBe(
+      true,
+    );
+  });
+
+  it("offers a visualizer, which joins a group without playing audio", () => {
+    expect(
+      canBeGroupMember(createPlayer({ type: PlayerType.VISUALIZER })),
+    ).toBe(true);
+  });
+
+  it("offers a metadata display, which joins a group without playing audio", () => {
+    expect(canBeGroupMember(createPlayer({ type: PlayerType.DISPLAY }))).toBe(
+      true,
+    );
+  });
+
+  it("keeps a capture-only device out of the picker", () => {
+    expect(canBeGroupMember(createPlayer({ type: PlayerType.UNKNOWN }))).toBe(
+      false,
+    );
   });
 });
 


### PR DESCRIPTION
# What does this implement/fix?

Some devices only feed audio into Music Assistant, such as a line-in capture
device. They exist purely so the device still has a settings page for pairing
and configuration, and they play nothing themselves. Their provider still
advertises them as groupable though, so they turned up in the group member
pickers as a pickable member that stays silent when you add it.

They are now left out of the group member pickers, while lights, screens and
visualizers keep working as group members.

**Related issue (if applicable):**

- n/a

**Related backend PR (if applicable):**

- n/a

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Changes

- Added a shared `canBeGroupMember` check that leaves out capture-only devices
- Applied it in the group members list, the player bar group control and the
  add-player-group screen (all three provider branches)
- Devices already in a group stay visible so they can still be removed
- Added tests

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm lint:check` passes.
- [x] `pnpm test:run` passes, and tests have been added/updated where applicable.
