### PR TITLE
Clean up leftovers in the players filter

### DIFF
--- a/src/components/PlayerFilters.vue
+++ b/src/components/PlayerFilters.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="filters-container">
     <SearchInput v-model="searchQuery" :placeholder="$t('search')" />
-    <div class="d-flex ga-2 filter-buttons">
+    <div class="filter-buttons">
       <FacetedFilter
         v-model="selectedProviders"
         :title="$t('settings.player_provider')"
@@ -18,7 +18,6 @@
 
 <script setup lang="ts">
 import FacetedFilter from "@/components/FacetedFilter.vue";
-import ProviderIcon from "@/components/ProviderIcon.vue";
 import { SearchInput } from "@/components/ui/search-input";
 import { api } from "@/plugins/api";
 import { PlayerType, ProviderType } from "@/plugins/api/interfaces";
@@ -37,39 +36,21 @@ let searchDebounceTimeout: ReturnType<typeof setTimeout> | null = null;
 let providersDebounceTimeout: ReturnType<typeof setTimeout> | null = null;
 let typesDebounceTimeout: ReturnType<typeof setTimeout> | null = null;
 
-const availableProviders = computed(() => {
-  const providers = Object.values(api.providers)
+const providerOptions = computed(() =>
+  Object.values(api.providers)
     .filter((x) => x.available && x.type === ProviderType.PLAYER)
     .map((x) => ({
-      instance_id: x.instance_id,
-      domain: x.domain,
-      name: x.name || api.providerManifests[x.domain]?.name || x.domain,
+      label: x.name || api.providerManifests[x.domain]?.name || x.domain,
+      value: x.instance_id,
     }))
-    .sort((a, b) => a.name.localeCompare(b.name));
-  return providers;
-});
+    .sort((a, b) => a.label.localeCompare(b.label)),
+);
 
-const playerTypes = computed(() => [
-  { title: $t("player_type.player"), value: PlayerType.PLAYER },
-  { title: $t("player_type.group"), value: PlayerType.GROUP },
-  { title: $t("player_type.stereo_pair"), value: PlayerType.STEREO_PAIR },
+const playerTypeOptions = computed(() => [
+  { label: $t("player_type.player"), value: PlayerType.PLAYER },
+  { label: $t("player_type.group"), value: PlayerType.GROUP },
+  { label: $t("player_type.stereo_pair"), value: PlayerType.STEREO_PAIR },
 ]);
-
-const providerOptions = computed(() =>
-  availableProviders.value.map((p) => ({
-    label: p.name,
-    value: p.instance_id,
-    icon: ProviderIcon,
-    domain: p.domain,
-  })),
-);
-
-const playerTypeOptions = computed(() =>
-  playerTypes.value.map((p) => ({
-    label: p.title,
-    value: p.value,
-  })),
-);
 
 // Emits
 const emit = defineEmits<{
@@ -77,24 +58,6 @@ const emit = defineEmits<{
   (e: "update:providers", value: string[]): void;
   (e: "update:types", value: string[]): void;
 }>();
-
-const toggleProvider = function (provider: string) {
-  const index = selectedProviders.value.indexOf(provider);
-  if (index > -1) {
-    selectedProviders.value.splice(index, 1);
-  } else {
-    selectedProviders.value.push(provider);
-  }
-};
-
-const togglePlayerType = function (type: string) {
-  const index = selectedPlayerTypes.value.indexOf(type);
-  if (index > -1) {
-    selectedPlayerTypes.value.splice(index, 1);
-  } else {
-    selectedPlayerTypes.value.push(type);
-  }
-};
 
 const initializeFromUrl = function () {
   if (route.query.search) {
@@ -196,32 +159,6 @@ initializeFromUrl();
   flex-wrap: wrap;
 }
 
-.filter-buttons .v-btn {
-  min-width: 100px;
-  border-color: rgba(var(--v-theme-on-surface), 0.2);
-  color: rgba(var(--v-theme-on-surface), 0.6);
-}
-
-.filter-buttons .v-btn .v-icon {
-  color: rgba(var(--v-theme-on-surface), 0.6);
-}
-
-.filter-btn {
-  position: relative;
-}
-
-.filter-dot {
-  position: absolute;
-  top: 6px;
-  right: 6px;
-  width: 8px;
-  height: 8px;
-  border-radius: 50%;
-  background-color: rgb(var(--v-theme-primary));
-  z-index: 1;
-  box-shadow: 0 0 0 2px rgb(var(--v-theme-surface));
-}
-
 @media (max-width: 960px) {
   .filters-container {
     flex-direction: column;
@@ -236,29 +173,5 @@ initializeFromUrl();
   .filter-buttons {
     width: 100%;
   }
-
-  .filter-buttons .v-btn {
-    flex: 1 1 auto;
-    min-width: 120px;
-  }
-}
-
-:deep(.v-list-item .v-checkbox-btn) {
-  display: flex;
-  align-items: center;
-}
-
-:deep(.v-list-item .v-checkbox-btn .v-input__control) {
-  display: flex;
-  align-items: center;
-}
-
-:deep(.v-list-item .v-checkbox-btn .v-selection-control) {
-  min-height: auto;
-}
-
-.provider-filter-list {
-  max-height: 300px;
-  overflow-y: auto;
 }
 </style>


### PR DESCRIPTION
# What does this implement/fix?

The Provider filter on the Players settings screen was built with an `icon` and `domain` field on every option, but the faceted filter it feeds only ever renders a checkbox and a label — those fields have never been read. The same refactor that introduced the shared filter also left behind two unused toggle helpers, a set of Vuetify style rules that no longer match any markup, and two utility classes that just repeat what the component's own rule already says.

No behaviour change.

**Changes:**

- Drop the unused `icon`/`domain` option fields and the `ProviderIcon` import they existed for
- Remove the unreferenced `toggleProvider` and `togglePlayerType` helpers
- Remove the Vuetify-era style rules and the redundant `d-flex ga-2` classes
- Fold two single-use computeds into the option lists they feed

**Related issue (if applicable):**

- n/a

**Related backend PR (if applicable):**

- n/a

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm lint:check` passes.
- [x] `pnpm test:run` passes, and tests have been added/updated where applicable.
- [x] `pnpm build` passes.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
