### PR TITLE
Fix provider icon spacing in the add provider and add group player dialogs

### DIFF
--- a/src/views/settings/AddPlayerGroupDialog.vue
+++ b/src/views/settings/AddPlayerGroupDialog.vue
@@ -146,6 +146,8 @@ watch(
 
 .provider-icon {
   flex-shrink: 0;
+  /* drop ProviderIcon's default gutters so the row gap sets the spacing */
+  margin: 0;
 }
 
 .provider-content {

--- a/src/views/settings/AddProviderDialog.vue
+++ b/src/views/settings/AddProviderDialog.vue
@@ -341,6 +341,8 @@ watch(
 
 .provider-icon {
   flex-shrink: 0;
+  /* drop ProviderIcon's default gutters so the row gap sets the spacing */
+  margin: 0;
 }
 
 .provider-content {


### PR DESCRIPTION
# What does this implement/fix?

The provider rows in the "Add provider" and "Add group player" dialogs were spaced
inconsistently. `ProviderIcon` applies a default 10px gutter on each side, and both
dialogs add their own `gap: 12px` on top of it. The result: the icon sat 22px inside
the row while the chevron on the other side sat at 12px, and the gap between icon and
text was the widest gap in the row.

Both rows now cancel the icon's default gutters so the row's own `gap` sets the
spacing — icon, text and chevron all line up on the same 12px rhythm.

This became fixable without `!important` in #2587, which moved the icon's default
gutters out of an inline style and into a class.

**Related issue (if applicable):**

- n/a

**Related backend PR (if applicable):**

- n/a

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm lint:check` passes.
- [x] `pnpm test:run` passes, and tests have been added/updated where applicable.
- [x] `pnpm build` passes.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
