### PR TITLE
Use one shared component for the player protocol chips

### DIFF
--- a/src/components/AudioProcessingDetails.vue
+++ b/src/components/AudioProcessingDetails.vue
@@ -274,7 +274,7 @@ const {
   align-items: center;
   justify-content: center;
   flex: 0 0 18px;
-  /* the provider icon sets its own width inline, so it has to be overridden */
+  /* pin the size whatever width the provider icon sets on itself inline */
   width: 18px !important;
   height: 18px;
   margin: 0;

--- a/src/components/AudioProcessingDetails.vue
+++ b/src/components/AudioProcessingDetails.vue
@@ -274,8 +274,9 @@ const {
   align-items: center;
   justify-content: center;
   flex: 0 0 18px;
+  /* the provider icon sets its own width inline, so it has to be overridden */
   width: 18px !important;
-  height: 18px !important;
+  height: 18px;
   margin: 0;
   overflow: hidden;
 }

--- a/src/components/ProtocolChip.vue
+++ b/src/components/ProtocolChip.vue
@@ -7,7 +7,7 @@
       'protocol-chip--clickable': documentation,
       'protocol-chip--unavailable': !protocol.available,
     }"
-    v-on="clickHandler"
+    v-on="clickListener"
   >
     <template #prepend>
       <ProviderIcon
@@ -45,7 +45,7 @@ const documentation = computed(() =>
 
 // vuetify renders any chip that has a click listener as interactive (focusable,
 // with a hover overlay), so a chip with nothing to open gets no listener at all
-const clickHandler = computed(() => {
+const clickListener = computed(() => {
   const url = documentation.value;
   return url ? { click: () => openLinkInNewTab(url) } : {};
 });

--- a/src/components/ProtocolChip.vue
+++ b/src/components/ProtocolChip.vue
@@ -7,7 +7,7 @@
       'protocol-chip--clickable': documentation,
       'protocol-chip--unavailable': !protocol.available,
     }"
-    v-on="documentation ? { click: openDocumentation } : {}"
+    v-on="clickHandler"
   >
     <template #prepend>
       <ProviderIcon
@@ -26,7 +26,7 @@ import { computed } from "vue";
 import ProviderIcon from "@/components/ProviderIcon.vue";
 import { openLinkInNewTab } from "@/helpers/utils";
 import { api } from "@/plugins/api";
-import { OutputProtocol } from "@/plugins/api/interfaces";
+import type { OutputProtocol } from "@/plugins/api/interfaces";
 
 export interface Props {
   protocol: OutputProtocol;
@@ -43,11 +43,12 @@ const documentation = computed(() =>
   props.linkToDocs ? manifest.value?.documentation : undefined,
 );
 
-// bound conditionally: vuetify renders a chip with a click listener as
-// interactive, so an unclickable chip must not have one at all
-function openDocumentation() {
-  if (documentation.value) openLinkInNewTab(documentation.value);
-}
+// vuetify renders any chip that has a click listener as interactive (focusable,
+// with a hover overlay), so a chip with nothing to open gets no listener at all
+const clickHandler = computed(() => {
+  const url = documentation.value;
+  return url ? { click: () => openLinkInNewTab(url) } : {};
+});
 </script>
 
 <style scoped>
@@ -61,7 +62,8 @@ function openDocumentation() {
   cursor: pointer;
 }
 
-.protocol-chip--clickable:hover {
+/* the dimming below is less specific, so it has to be excluded explicitly */
+.protocol-chip--clickable:not(.protocol-chip--unavailable):hover {
   opacity: 0.85;
 }
 

--- a/src/components/ProtocolChip.vue
+++ b/src/components/ProtocolChip.vue
@@ -1,0 +1,83 @@
+<template>
+  <v-chip
+    size="x-small"
+    variant="tonal"
+    class="protocol-chip"
+    :class="{
+      'protocol-chip--clickable': documentation,
+      'protocol-chip--unavailable': !protocol.available,
+    }"
+    v-on="documentation ? { click: openDocumentation } : {}"
+  >
+    <template #prepend>
+      <ProviderIcon
+        :domain="protocol.protocol_domain"
+        :size="14"
+        class="chip-icon"
+      />
+    </template>
+    {{ manifest?.name || protocol.protocol_domain }}
+    <v-icon v-if="documentation" size="12" class="ml-1">mdi-open-in-new</v-icon>
+  </v-chip>
+</template>
+
+<script setup lang="ts">
+import { computed } from "vue";
+import ProviderIcon from "@/components/ProviderIcon.vue";
+import { openLinkInNewTab } from "@/helpers/utils";
+import { api } from "@/plugins/api";
+import { OutputProtocol } from "@/plugins/api/interfaces";
+
+export interface Props {
+  protocol: OutputProtocol;
+  // turn the chip into a link to the protocol provider's documentation, if it has any
+  linkToDocs?: boolean;
+}
+const props = defineProps<Props>();
+
+const manifest = computed(() =>
+  api.getProviderManifest(props.protocol.protocol_domain),
+);
+
+const documentation = computed(() =>
+  props.linkToDocs ? manifest.value?.documentation : undefined,
+);
+
+// bound conditionally: vuetify renders a chip with a click listener as
+// interactive, so an unclickable chip must not have one at all
+function openDocumentation() {
+  if (documentation.value) openLinkInNewTab(documentation.value);
+}
+</script>
+
+<style scoped>
+.protocol-chip {
+  text-transform: uppercase;
+  font-size: 10px;
+  letter-spacing: 0.3px;
+}
+
+.protocol-chip--clickable {
+  cursor: pointer;
+}
+
+.protocol-chip--clickable:hover {
+  opacity: 0.85;
+}
+
+.protocol-chip--unavailable {
+  opacity: 0.4;
+}
+
+.chip-icon {
+  margin: 0;
+  width: auto !important;
+}
+
+.chip-icon :deep(div) {
+  margin-left: 0 !important;
+  margin-right: 4px !important;
+  width: 14px !important;
+  height: 14px !important;
+}
+</style>

--- a/src/components/SettingsPlayerCard.vue
+++ b/src/components/SettingsPlayerCard.vue
@@ -51,26 +51,11 @@
 
       <div class="card-footer">
         <div class="protocol-chips">
-          <v-chip
+          <ProtocolChip
             v-for="protocol in outputProtocols"
             :key="protocol.output_protocol_id"
-            size="x-small"
-            variant="tonal"
-            class="protocol-chip"
-            :class="{ 'protocol-chip--unavailable': !protocol.available }"
-          >
-            <template #prepend>
-              <ProviderIcon
-                :domain="protocol.protocol_domain"
-                :size="14"
-                class="chip-icon"
-              />
-            </template>
-            {{
-              api.getProviderManifest(protocol.protocol_domain)?.name ||
-              protocol.protocol_domain
-            }}
-          </v-chip>
+            :protocol="protocol"
+          />
         </div>
         <div class="status-icons">
           <v-icon
@@ -101,7 +86,7 @@
 </template>
 
 <script setup lang="ts">
-import ProviderIcon from "@/components/ProviderIcon.vue";
+import ProtocolChip from "@/components/ProtocolChip.vue";
 import PlayerIcon from "@/components/PlayerIcon.vue";
 import { api } from "@/plugins/api";
 import { PlayerConfig } from "@/plugins/api/interfaces";
@@ -276,41 +261,9 @@ const handleSetup = () => {
   flex: 1;
 }
 
-.protocol-chip {
-  text-transform: uppercase;
-  font-size: 10px;
-  letter-spacing: 0.3px;
-}
-
-.protocol-chip--unavailable {
-  opacity: 0.4;
-}
-
 .status-icons {
   display: flex;
   gap: 4px;
   flex-shrink: 0;
-}
-
-.chip-icon {
-  margin: 0;
-  width: auto !important;
-}
-
-.chip-icon :deep(div) {
-  margin-left: 0 !important;
-  margin-right: 4px !important;
-  width: 14px !important;
-  height: 14px !important;
-}
-
-.chip-icon :deep(.svg-wrapper) {
-  width: 14px !important;
-  height: 14px !important;
-}
-
-.chip-icon :deep(.svg-wrapper svg) {
-  width: 14px !important;
-  height: 14px !important;
 }
 </style>

--- a/src/views/settings/EditPlayer.vue
+++ b/src/views/settings/EditPlayer.vue
@@ -74,49 +74,13 @@
               v-if="api.players[config.player_id]?.output_protocols.length"
               class="protocol-chips"
             >
-              <v-chip
+              <ProtocolChip
                 v-for="protocol in api.players[config.player_id]
                   .output_protocols"
                 :key="protocol.output_protocol_id"
-                size="x-small"
-                variant="tonal"
-                class="protocol-chip"
-                :class="{
-                  'protocol-chip--clickable': api.getProviderManifest(
-                    protocol.protocol_domain,
-                  )?.documentation,
-                  'protocol-chip--unavailable': !protocol.available,
-                }"
-                @click="
-                  api.getProviderManifest(protocol.protocol_domain)
-                    ?.documentation &&
-                  openLinkInNewTab(
-                    api.getProviderManifest(protocol.protocol_domain)!
-                      .documentation!,
-                  )
-                "
-              >
-                <template #prepend>
-                  <ProviderIcon
-                    :domain="protocol.protocol_domain"
-                    :size="14"
-                    class="chip-icon"
-                  />
-                </template>
-                {{
-                  api.getProviderManifest(protocol.protocol_domain)?.name ||
-                  protocol.protocol_domain
-                }}
-                <v-icon
-                  v-if="
-                    api.getProviderManifest(protocol.protocol_domain)
-                      ?.documentation
-                  "
-                  size="12"
-                  class="ml-1"
-                  >mdi-open-in-new</v-icon
-                >
-              </v-chip>
+                :protocol="protocol"
+                link-to-docs
+              />
             </div>
           </div>
           <Button
@@ -243,7 +207,7 @@
 import { computed, markRaw, onBeforeUnmount, ref, watch } from "vue";
 import { useRouter } from "vue-router";
 import { toast } from "vue-sonner";
-import ProviderIcon from "@/components/ProviderIcon.vue";
+import ProtocolChip from "@/components/ProtocolChip.vue";
 import PlayerIcon from "@/components/PlayerIcon.vue";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader } from "@/components/ui/card";
@@ -276,7 +240,6 @@ import {
   getPlayerSettingsMenuItems,
 } from "@/helpers/player_settings_actions";
 import { useConfigAction } from "@/composables/useConfigAction";
-import { openLinkInNewTab } from "@/helpers/utils";
 import { eventbus } from "@/plugins/eventbus";
 import { $t } from "@/plugins/i18n";
 import { MoreVertical, Pencil, RefreshCw, RotateCcw } from "@lucide/vue";
@@ -661,46 +624,6 @@ function resetPlayerState(playerId?: string) {
   gap: 4px;
   flex-wrap: wrap;
   margin-top: 8px;
-}
-
-.protocol-chip {
-  text-transform: uppercase;
-  font-size: 10px;
-  letter-spacing: 0.3px;
-}
-
-.protocol-chip--clickable {
-  cursor: pointer;
-}
-
-.protocol-chip--clickable:hover {
-  opacity: 0.85;
-}
-
-.protocol-chip--unavailable {
-  opacity: 0.4;
-}
-
-.chip-icon {
-  margin: 0;
-  width: auto !important;
-}
-
-.chip-icon :deep(div) {
-  margin-left: 0 !important;
-  margin-right: 4px !important;
-  width: 14px !important;
-  height: 14px !important;
-}
-
-.chip-icon :deep(.svg-wrapper) {
-  width: 14px !important;
-  height: 14px !important;
-}
-
-.chip-icon :deep(.svg-wrapper svg) {
-  width: 14px !important;
-  height: 14px !important;
 }
 
 @media (max-width: 600px) {

--- a/src/views/settings/Players.vue
+++ b/src/views/settings/Players.vue
@@ -90,26 +90,11 @@
                 }}
               </span>
               <span class="protocol-chips">
-                <v-chip
+                <ProtocolChip
                   v-for="protocol in getOutputProtocols(item.player_id)"
                   :key="protocol.output_protocol_id"
-                  size="x-small"
-                  variant="tonal"
-                  class="protocol-chip"
-                  :class="{ 'protocol-chip--unavailable': !protocol.available }"
-                >
-                  <template #prepend>
-                    <ProviderIcon
-                      :domain="protocol.protocol_domain"
-                      :size="14"
-                      class="chip-icon"
-                    />
-                  </template>
-                  {{
-                    api.getProviderManifest(protocol.protocol_domain)?.name ||
-                    protocol.protocol_domain
-                  }}
-                </v-chip>
+                  :protocol="protocol"
+                />
               </span>
             </div>
           </template>
@@ -187,7 +172,7 @@
 import Container from "@/components/Container.vue";
 import ListItem from "@/components/ListItem.vue";
 import PlayerFilters from "@/components/PlayerFilters.vue";
-import ProviderIcon from "@/components/ProviderIcon.vue";
+import ProtocolChip from "@/components/ProtocolChip.vue";
 import PlayerIcon from "@/components/PlayerIcon.vue";
 import SettingsPlayerCard from "@/components/SettingsPlayerCard.vue";
 import { Button } from "@/components/ui/button";
@@ -490,38 +475,6 @@ watch(
   display: inline-flex;
   gap: 4px;
   flex-wrap: wrap;
-}
-
-.protocol-chip {
-  text-transform: uppercase;
-  font-size: 10px;
-  letter-spacing: 0.3px;
-}
-
-.protocol-chip--unavailable {
-  opacity: 0.4;
-}
-
-.chip-icon {
-  margin: 0;
-  width: auto !important;
-}
-
-.chip-icon :deep(div) {
-  margin-left: 0 !important;
-  margin-right: 4px !important;
-  width: 14px !important;
-  height: 14px !important;
-}
-
-.chip-icon :deep(.svg-wrapper) {
-  width: 14px !important;
-  height: 14px !important;
-}
-
-.chip-icon :deep(.svg-wrapper svg) {
-  width: 14px !important;
-  height: 14px !important;
 }
 
 @media (max-width: 960px) {

--- a/tests/components/ProtocolChip.test.ts
+++ b/tests/components/ProtocolChip.test.ts
@@ -48,12 +48,13 @@ describe("ProtocolChip", () => {
 
   it("renders the provider name and icon for the protocol", () => {
     apiMock.getProviderManifest.mockReturnValue(
-      providerManifest({ domain: "airplay", name: "AirPlay" }),
+      providerManifest({ domain: "airplay", name: "AirPlay provider" }),
     );
 
     const wrapper = mountChip({ protocol: outputProtocol() });
 
-    expect(wrapper.text()).toContain("AirPlay");
+    // the fixture's own name differs, so this pins the manifest as the source
+    expect(wrapper.text()).toContain("AirPlay provider");
     expect(
       wrapper.get('[data-testid="provider-icon"]').attributes("data-domain"),
     ).toBe("airplay");

--- a/tests/components/ProtocolChip.test.ts
+++ b/tests/components/ProtocolChip.test.ts
@@ -6,6 +6,7 @@ import * as directives from "vuetify/directives";
 import ProtocolChip from "@/components/ProtocolChip.vue";
 import type { MusicAssistantApi } from "@/plugins/api";
 import type { OutputProtocol } from "@/plugins/api/interfaces";
+import { outputProtocol } from "../fixtures/outputProtocol";
 import { providerManifest } from "../fixtures/providerManifest";
 
 const apiMock = vi.hoisted(() => ({
@@ -22,21 +23,6 @@ vi.mock("@/helpers/utils", () => ({ openLinkInNewTab }));
 const vuetify = createVuetify({ components, directives });
 
 enableAutoUnmount(afterEach);
-
-function outputProtocol(
-  overrides: Partial<OutputProtocol> = {},
-): OutputProtocol {
-  return {
-    output_protocol_id: "native",
-    name: "Native",
-    is_native: true,
-    protocol_domain: "airplay",
-    priority: 0,
-    available: true,
-    derived_from: null,
-    ...overrides,
-  };
-}
 
 function mountChip(props: { protocol: OutputProtocol; linkToDocs?: boolean }) {
   return mount(ProtocolChip, {
@@ -98,6 +84,10 @@ describe("ProtocolChip", () => {
 
     const wrapper = mountChip({ protocol: outputProtocol(), linkToDocs: true });
     expect(wrapper.classes()).toContain("protocol-chip--clickable");
+    expect(wrapper.find(".mdi-open-in-new").exists()).toBe(true);
+    // vuetify only renders the chip as interactive once it has a click listener
+    expect(wrapper.classes()).toContain("v-chip--link");
+    expect(wrapper.attributes("tabindex")).toBe("0");
 
     await wrapper.trigger("click");
 
@@ -113,6 +103,10 @@ describe("ProtocolChip", () => {
 
     const wrapper = mountChip({ protocol: outputProtocol() });
     expect(wrapper.classes()).not.toContain("protocol-chip--clickable");
+    expect(wrapper.find(".mdi-open-in-new").exists()).toBe(false);
+    // without a click listener vuetify leaves the chip non-interactive
+    expect(wrapper.classes()).not.toContain("v-chip--link");
+    expect(wrapper.attributes("tabindex")).toBeUndefined();
 
     await wrapper.trigger("click");
 
@@ -126,6 +120,10 @@ describe("ProtocolChip", () => {
 
     const wrapper = mountChip({ protocol: outputProtocol(), linkToDocs: true });
     expect(wrapper.classes()).not.toContain("protocol-chip--clickable");
+    expect(wrapper.find(".mdi-open-in-new").exists()).toBe(false);
+    // without a click listener vuetify leaves the chip non-interactive
+    expect(wrapper.classes()).not.toContain("v-chip--link");
+    expect(wrapper.attributes("tabindex")).toBeUndefined();
 
     await wrapper.trigger("click");
 

--- a/tests/components/ProtocolChip.test.ts
+++ b/tests/components/ProtocolChip.test.ts
@@ -1,0 +1,134 @@
+import { enableAutoUnmount, mount } from "@vue/test-utils";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createVuetify } from "vuetify";
+import * as components from "vuetify/components";
+import * as directives from "vuetify/directives";
+import ProtocolChip from "@/components/ProtocolChip.vue";
+import type { MusicAssistantApi } from "@/plugins/api";
+import type { OutputProtocol } from "@/plugins/api/interfaces";
+import { providerManifest } from "../fixtures/providerManifest";
+
+const apiMock = vi.hoisted(() => ({
+  getProviderManifest: vi.fn<MusicAssistantApi["getProviderManifest"]>(),
+}));
+const openLinkInNewTab = vi.hoisted(() => vi.fn());
+
+vi.mock("@/plugins/api", () => ({
+  default: apiMock,
+  api: apiMock,
+}));
+vi.mock("@/helpers/utils", () => ({ openLinkInNewTab }));
+
+const vuetify = createVuetify({ components, directives });
+
+enableAutoUnmount(afterEach);
+
+function outputProtocol(
+  overrides: Partial<OutputProtocol> = {},
+): OutputProtocol {
+  return {
+    output_protocol_id: "native",
+    name: "Native",
+    is_native: true,
+    protocol_domain: "airplay",
+    priority: 0,
+    available: true,
+    derived_from: null,
+    ...overrides,
+  };
+}
+
+function mountChip(props: { protocol: OutputProtocol; linkToDocs?: boolean }) {
+  return mount(ProtocolChip, {
+    props,
+    global: {
+      plugins: [vuetify],
+      stubs: {
+        ProviderIcon: {
+          props: ["domain"],
+          template:
+            '<span data-testid="provider-icon" :data-domain="domain" />',
+        },
+      },
+    },
+  });
+}
+
+describe("ProtocolChip", () => {
+  beforeEach(() => {
+    apiMock.getProviderManifest.mockReset();
+    openLinkInNewTab.mockReset();
+  });
+
+  it("renders the provider name and icon for the protocol", () => {
+    apiMock.getProviderManifest.mockReturnValue(
+      providerManifest({ domain: "airplay", name: "AirPlay" }),
+    );
+
+    const wrapper = mountChip({ protocol: outputProtocol() });
+
+    expect(wrapper.text()).toContain("AirPlay");
+    expect(
+      wrapper.get('[data-testid="provider-icon"]').attributes("data-domain"),
+    ).toBe("airplay");
+  });
+
+  it("falls back to the protocol domain when the provider is unknown", () => {
+    apiMock.getProviderManifest.mockReturnValue(undefined);
+
+    const wrapper = mountChip({ protocol: outputProtocol() });
+
+    expect(wrapper.text()).toContain("airplay");
+  });
+
+  it("dims the chip when the protocol is unavailable", () => {
+    apiMock.getProviderManifest.mockReturnValue(providerManifest());
+
+    const wrapper = mountChip({
+      protocol: outputProtocol({ available: false }),
+    });
+
+    expect(wrapper.classes()).toContain("protocol-chip--unavailable");
+  });
+
+  it("opens the provider documentation on click when linking is enabled", async () => {
+    apiMock.getProviderManifest.mockReturnValue(
+      providerManifest({ documentation: "https://example.org/airplay" }),
+    );
+
+    const wrapper = mountChip({ protocol: outputProtocol(), linkToDocs: true });
+    expect(wrapper.classes()).toContain("protocol-chip--clickable");
+
+    await wrapper.trigger("click");
+
+    expect(openLinkInNewTab).toHaveBeenCalledWith(
+      "https://example.org/airplay",
+    );
+  });
+
+  it("stays inert when the call site does not link to the documentation", async () => {
+    apiMock.getProviderManifest.mockReturnValue(
+      providerManifest({ documentation: "https://example.org/airplay" }),
+    );
+
+    const wrapper = mountChip({ protocol: outputProtocol() });
+    expect(wrapper.classes()).not.toContain("protocol-chip--clickable");
+
+    await wrapper.trigger("click");
+
+    expect(openLinkInNewTab).not.toHaveBeenCalled();
+  });
+
+  it("stays inert when the provider has no documentation", async () => {
+    apiMock.getProviderManifest.mockReturnValue(
+      providerManifest({ documentation: null }),
+    );
+
+    const wrapper = mountChip({ protocol: outputProtocol(), linkToDocs: true });
+    expect(wrapper.classes()).not.toContain("protocol-chip--clickable");
+
+    await wrapper.trigger("click");
+
+    expect(openLinkInNewTab).not.toHaveBeenCalled();
+  });
+});

--- a/tests/composables/useAudioProcessingDetails.test.ts
+++ b/tests/composables/useAudioProcessingDetails.test.ts
@@ -17,7 +17,6 @@ import {
   ContentType,
   CrossfadeMode,
   DSPState,
-  type OutputProtocol,
   type StreamDetails,
   VolumeNormalizationMode,
 } from "@/plugins/api/interfaces";
@@ -30,6 +29,7 @@ import {
   audioQueueProcessing,
 } from "../fixtures/audioProcessing";
 import { audioFormat } from "../fixtures/audioFormat";
+import { outputProtocol } from "../fixtures/outputProtocol";
 import { streamDetails } from "../fixtures/streamDetails";
 
 vi.mock("@/plugins/api", async () => {
@@ -140,7 +140,7 @@ describe("buildAudioProcessingDetailsDisplay", () => {
       const protocolId = `${protocolDomain}-kitchen`;
       dependencies.players.kitchen.active_output_protocol = protocolId;
       dependencies.players.kitchen.output_protocols = [
-        makeOutputProtocol({
+        outputProtocol({
           output_protocol_id: protocolId,
           protocol_domain: protocolDomain,
         }),
@@ -278,7 +278,7 @@ describe("buildAudioProcessingDetailsDisplay", () => {
   it("uses a shared active protocol icon for grouped output", () => {
     dependencies.players.office.active_output_protocol = "airplay-office";
     dependencies.players.office.output_protocols = [
-      makeOutputProtocol({ output_protocol_id: "airplay-office" }),
+      outputProtocol({ output_protocol_id: "airplay-office" }),
     ];
     let destination = buildDisplay({
       outputs: [
@@ -614,7 +614,7 @@ function makePlayers(): AudioProcessingDetailsDependencies["players"] {
       provider: "sonos--main",
       active_output_protocol: "airplay-kitchen",
       output_protocols: [
-        makeOutputProtocol({ output_protocol_id: "airplay-kitchen" }),
+        outputProtocol({ output_protocol_id: "airplay-kitchen" }),
       ],
     },
     office: {
@@ -624,21 +624,6 @@ function makePlayers(): AudioProcessingDetailsDependencies["players"] {
       active_output_protocol: null,
       output_protocols: [],
     },
-  };
-}
-
-function makeOutputProtocol(
-  overrides: Partial<OutputProtocol> = {},
-): OutputProtocol {
-  return {
-    output_protocol_id: "airplay-kitchen",
-    name: "AirPlay",
-    is_native: false,
-    protocol_domain: "airplay",
-    priority: 1,
-    available: true,
-    derived_from: null,
-    ...overrides,
   };
 }
 

--- a/tests/fixtures/outputProtocol.ts
+++ b/tests/fixtures/outputProtocol.ts
@@ -1,8 +1,8 @@
 import type { OutputProtocol } from "@/plugins/api/interfaces";
 
 /**
- * One of the ways a player can be played to, for tests that only care about a
- * few of its fields but should still model a payload the server can send.
+ * An output protocol for a player, for tests that only care about a few of its
+ * fields but should still model a payload the server can send.
  */
 export function outputProtocol(
   overrides: Partial<OutputProtocol> = {},

--- a/tests/fixtures/outputProtocol.ts
+++ b/tests/fixtures/outputProtocol.ts
@@ -1,0 +1,20 @@
+import type { OutputProtocol } from "@/plugins/api/interfaces";
+
+/**
+ * One of the ways a player can be played to, for tests that only care about a
+ * few of its fields but should still model a payload the server can send.
+ */
+export function outputProtocol(
+  overrides: Partial<OutputProtocol> = {},
+): OutputProtocol {
+  return {
+    output_protocol_id: "airplay-kitchen",
+    name: "AirPlay",
+    is_native: false,
+    protocol_domain: "airplay",
+    priority: 1,
+    available: true,
+    derived_from: null,
+    ...overrides,
+  };
+}

--- a/tests/views/Players.test.ts
+++ b/tests/views/Players.test.ts
@@ -216,7 +216,6 @@ async function mountPlayers(viewMode: "list" | "card") {
         ListItem: ListItemStub,
         PlayerFilters: true,
         PlayerIcon: true,
-        ProviderIcon: true,
         RouterLink: true,
         SettingsPlayerCard: SettingsPlayerCardStub,
         VCol: passthroughStub,


### PR DESCRIPTION
# What does this implement/fix?

The protocol chips shown on the player list, the player cards and the player
settings screen were three copies of the same markup and styling. Part of that
copied styling had also gone stale: a block of rules still targeted the wrapper
element the provider icon used back when it rendered inline SVG, which it no
longer does, so those rules matched nothing.

All three now render a single shared `ProtocolChip` component.

**Related issue (if applicable):**

- n/a

## Changes

- Added a shared `ProtocolChip` component and used it on the player list, the
  player cards and the player settings screen.
- Removed the styling rules that no longer matched anything.
- On the player settings screen, a protocol chip without provider documentation
  is no longer focusable and no longer highlights on hover — it never did
  anything when clicked.
- An unavailable protocol chip no longer brightens when you hover it.
- Dropped an unnecessary `!important` on the provider icon height in the audio
  processing details.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm lint:check` passes.
- [x] `pnpm test:run` passes, and tests have been added/updated where applicable.
- [x] `pnpm build` passes.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
