### PR TITLE
Fix remaining double-spaced provider icons

### DIFF
--- a/src/components/CommandCenter.vue
+++ b/src/components/CommandCenter.vue
@@ -130,9 +130,11 @@
             >
               <Play :size="14" fill="currentColor" :stroke-width="0" />
             </button>
+            <!-- mx-0: the row gap sets the spacing, not ProviderIcon's gutters -->
             <ProviderIcon
               :domain="getListItemProviderIconDomain(item)"
               :size="18"
+              class="mx-0"
             />
           </div>
         </CommandItem>

--- a/src/components/InfoHeader.vue
+++ b/src/components/InfoHeader.vue
@@ -405,7 +405,7 @@
                   isAdmin
                 "
                 :size="22"
-                class="cursor-pointer -ml-1"
+                class="cursor-pointer"
                 :title="$t('merge_into')"
                 @click="mergeGenre"
               />

--- a/src/components/InfoHeader.vue
+++ b/src/components/InfoHeader.vue
@@ -384,7 +384,12 @@
               />
               <!-- details can be reached out of library context, so always show
               the membership badge (bookshelf when in library, else source) -->
-              <provider-icon :domain="getProviderIconDomain(item)" :size="25" />
+              <!-- mx-0: the row gap sets the spacing, not ProviderIcon's gutters -->
+              <provider-icon
+                :domain="getProviderIconDomain(item)"
+                :size="25"
+                class="mx-0"
+              />
               <!-- audio analysis details (full track details only) -->
               <AudioAnalysisMetadata
                 v-if="item.media_type == MediaType.TRACK"

--- a/src/components/SetupFlowDialog.vue
+++ b/src/components/SetupFlowDialog.vue
@@ -11,7 +11,13 @@
         class="flex-row items-center gap-3 border-b px-5 py-4 pr-12 text-left"
       >
         <span class="flex shrink-0 items-center justify-center">
-          <ProviderIcon v-if="iconDomain" :domain="iconDomain" :size="32" />
+          <!-- mx-0: the row gap sets the spacing, not ProviderIcon's gutters -->
+          <ProviderIcon
+            v-if="iconDomain"
+            :domain="iconDomain"
+            :size="32"
+            class="mx-0"
+          />
           <Settings2 v-else :size="28" />
         </span>
         <DialogTitle class="min-w-0 flex-1 truncate">

--- a/src/layouts/default/AddToPlaylistDialog.vue
+++ b/src/layouts/default/AddToPlaylistDialog.vue
@@ -34,11 +34,12 @@
                 {{ playlist.owner }}
               </div>
             </div>
+            <!-- mx-0: the row gap sets the spacing, not ProviderIcon's gutters -->
             <provider-icon
               v-if="playlist.provider_mappings"
               :domain="playlist.provider_mappings[0].provider_domain"
               :size="20"
-              class="shrink-0"
+              class="mx-0 shrink-0"
             />
           </button>
 
@@ -53,9 +54,11 @@
             @click="newPlaylist(providerId)"
           >
             <div class="shrink-0">
+              <!-- mx-0: the row gap sets the spacing, not ProviderIcon's gutters -->
               <provider-icon
                 :domain="api.providers[providerId].domain"
                 :size="50"
+                class="mx-0"
               />
             </div>
             <div class="min-w-0 flex-1">
@@ -66,10 +69,11 @@
                 {{ $t("create_playlist_on", [api.providers[providerId].name]) }}
               </div>
             </div>
+            <!-- mx-0: the row gap sets the spacing, not ProviderIcon's gutters -->
             <provider-icon
               :domain="api.providers[providerId].domain"
               :size="20"
-              class="shrink-0"
+              class="mx-0 shrink-0"
             />
           </button>
         </div>

--- a/src/layouts/default/AddToPlaylistDialog.vue
+++ b/src/layouts/default/AddToPlaylistDialog.vue
@@ -54,7 +54,6 @@
             @click="newPlaylist(providerId)"
           >
             <div class="shrink-0">
-              <!-- mx-0: the row gap sets the spacing, not ProviderIcon's gutters -->
               <provider-icon
                 :domain="api.providers[providerId].domain"
                 :size="50"
@@ -69,7 +68,6 @@
                 {{ $t("create_playlist_on", [api.providers[providerId].name]) }}
               </div>
             </div>
-            <!-- mx-0: the row gap sets the spacing, not ProviderIcon's gutters -->
             <provider-icon
               :domain="api.providers[providerId].domain"
               :size="20"

--- a/src/views/settings/EditProvider.vue
+++ b/src/views/settings/EditProvider.vue
@@ -91,7 +91,12 @@
       <!-- Header card -->
       <Card class="mb-4 gap-0 py-0">
         <CardHeader class="relative flex flex-col gap-4 p-6 pr-16 sm:flex-row">
-          <ProviderIcon :domain="config.domain" :size="48" class="shrink-0" />
+          <!-- mx-0: the row gap sets the spacing, not ProviderIcon's gutters -->
+          <ProviderIcon
+            :domain="config.domain"
+            :size="48"
+            class="mx-0 shrink-0"
+          />
           <div class="min-w-0 flex-1">
             <div class="flex flex-wrap items-center gap-2">
               <h2 class="text-xl leading-tight font-semibold">

--- a/src/views/settings/Providers.vue
+++ b/src/views/settings/Providers.vue
@@ -795,6 +795,8 @@ const getAllFilteredProviders = function () {
   }
 }
 
+/* the list item's own 32px prepend spacer separates the icon from the title,
+   so only the trailing gutter is dropped; the leading one is the row's inset */
 .provider-icon {
   margin-right: 0;
 }

--- a/src/views/settings/Providers.vue
+++ b/src/views/settings/Providers.vue
@@ -796,7 +796,7 @@ const getAllFilteredProviders = function () {
 }
 
 /* the list item's own 32px prepend spacer separates the icon from the title,
-   so only the trailing gutter is dropped; the leading one is the row's inset */
+   so only the trailing gutter is dropped; the leading one is left as-is */
 .provider-icon {
   margin-right: 0;
 }


### PR DESCRIPTION
# What does this implement/fix?

The provider icon component carries its own 10px side margins. Where a call site
places it in a row that already sets a gap, the two stack up: the icon sits
further in than its neighbours, and one gap in the row ends up wider than the
rest. #2593 fixed the two "add" dialogs — this covers the rest of the app.

- Search results, media detail headers, the provider setup dialog, the "add to
  playlist" sheet and the provider settings header no longer double up the
  spacing around the provider icon
- Documented the providers list rule, which keeps the icon's leading margin on
  purpose (it is the row's inset, not a half-finished reset) so it does not read
  as a bug next time

Call sites where the 10px is the only spacing (track rows, mapped providers, the
system settings tiles) are unchanged, and the component's default is untouched.

**Related issue (if applicable):**

- follow-up to #2593

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm lint:check` passes.
- [x] `pnpm test:run` passes, and tests have been added/updated where applicable.
- [x] `pnpm build` passes.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
