### PR TITLE
Make the protocol documentation chip a real link

### DIFF
--- a/src/components/ProtocolChip.vue
+++ b/src/components/ProtocolChip.vue
@@ -10,7 +10,7 @@
       :size="14"
       class="protocol-chip__icon"
     />
-    {{ manifest?.name || protocol.protocol_domain }}
+    {{ label }}
     <ExternalLink v-if="documentationUrl" aria-hidden="true" />
   </Badge>
 </template>
@@ -22,6 +22,7 @@ import { Badge } from "@/components/ui/badge";
 import { getExternalLinkUrl } from "@/helpers/utils";
 import { api } from "@/plugins/api";
 import type { OutputProtocol } from "@/plugins/api/interfaces";
+import { $t } from "@/plugins/i18n";
 import { ExternalLink } from "@lucide/vue";
 
 export interface Props {
@@ -41,18 +42,29 @@ const documentationUrl = computed(() =>
     : undefined,
 );
 
+const label = computed(
+  () => manifest.value?.name || props.protocol.protocol_domain,
+);
+
 // only chips that have somewhere to go become an anchor; the rest stay a plain
 // span, so the call sites that just label a protocol are not focusable links
-const linkAttrs = computed(() =>
-  documentationUrl.value
-    ? {
-        as: "a",
-        href: documentationUrl.value,
-        target: "_blank",
-        rel: "noopener noreferrer",
-      }
-    : { as: "span" },
-);
+const linkAttrs = computed(() => {
+  const url = documentationUrl.value;
+  if (!url) return { as: "span" };
+
+  // the chip only reads as the provider name, so spell out where the link goes
+  const description = $t("tooltip.open_documentation", {
+    provider: label.value,
+  });
+  return {
+    as: "a",
+    href: url,
+    target: "_blank",
+    rel: "noopener noreferrer",
+    "aria-label": description,
+    title: description,
+  };
+});
 </script>
 
 <style scoped>

--- a/src/components/ProtocolChip.vue
+++ b/src/components/ProtocolChip.vue
@@ -1,32 +1,28 @@
 <template>
-  <v-chip
-    size="x-small"
-    variant="tonal"
-    class="protocol-chip"
-    :class="{
-      'protocol-chip--clickable': documentation,
-      'protocol-chip--unavailable': !protocol.available,
-    }"
-    v-on="clickListener"
+  <Badge
+    v-bind="linkAttrs"
+    variant="secondary"
+    class="protocol-chip h-5 bg-muted px-1.5 text-[10px] tracking-[0.3px] uppercase no-underline"
+    :class="{ 'opacity-40': !protocol.available }"
   >
-    <template #prepend>
-      <ProviderIcon
-        :domain="protocol.protocol_domain"
-        :size="14"
-        class="chip-icon"
-      />
-    </template>
+    <ProviderIcon
+      :domain="protocol.protocol_domain"
+      :size="14"
+      class="protocol-chip__icon"
+    />
     {{ manifest?.name || protocol.protocol_domain }}
-    <v-icon v-if="documentation" size="12" class="ml-1">mdi-open-in-new</v-icon>
-  </v-chip>
+    <ExternalLink v-if="documentationUrl" aria-hidden="true" />
+  </Badge>
 </template>
 
 <script setup lang="ts">
 import { computed } from "vue";
 import ProviderIcon from "@/components/ProviderIcon.vue";
-import { openLinkInNewTab } from "@/helpers/utils";
+import { Badge } from "@/components/ui/badge";
+import { getExternalLinkUrl } from "@/helpers/utils";
 import { api } from "@/plugins/api";
 import type { OutputProtocol } from "@/plugins/api/interfaces";
+import { ExternalLink } from "@lucide/vue";
 
 export interface Props {
   protocol: OutputProtocol;
@@ -39,46 +35,37 @@ const manifest = computed(() =>
   api.getProviderManifest(props.protocol.protocol_domain),
 );
 
-const documentation = computed(() =>
-  props.linkToDocs ? manifest.value?.documentation : undefined,
+const documentationUrl = computed(() =>
+  props.linkToDocs
+    ? getExternalLinkUrl(manifest.value?.documentation)
+    : undefined,
 );
 
-// vuetify renders any chip that has a click listener as interactive (focusable,
-// with a hover overlay), so a chip with nothing to open gets no listener at all
-const clickListener = computed(() => {
-  const url = documentation.value;
-  return url ? { click: () => openLinkInNewTab(url) } : {};
-});
+// only chips that have somewhere to go become an anchor; the rest stay a plain
+// span, so the call sites that just label a protocol are not focusable links
+const linkAttrs = computed(() =>
+  documentationUrl.value
+    ? {
+        as: "a",
+        href: documentationUrl.value,
+        target: "_blank",
+        rel: "noopener noreferrer",
+      }
+    : { as: "span" },
+);
 </script>
 
 <style scoped>
-.protocol-chip {
-  text-transform: uppercase;
-  font-size: 10px;
-  letter-spacing: 0.3px;
-}
+/* the badge fills with --muted rather than the variant's identical --secondary:
+   vuetify's runtime theme stylesheet also defines .bg-secondary and, being
+   injected after the bundle, wins the !important tie and turns the chip teal */
 
-.protocol-chip--clickable {
-  cursor: pointer;
-}
-
-/* the dimming below is less specific, so it has to be excluded explicitly */
-.protocol-chip--clickable:not(.protocol-chip--unavailable):hover {
+/* a plain rule, so the !important dimming of an unavailable chip still wins */
+.protocol-chip[href]:hover {
   opacity: 0.85;
 }
 
-.protocol-chip--unavailable {
-  opacity: 0.4;
-}
-
-.chip-icon {
-  width: auto !important;
-}
-
-.chip-icon :deep(div) {
-  margin-left: 0 !important;
-  margin-right: 4px !important;
-  width: 14px !important;
-  height: 14px !important;
+.protocol-chip__icon {
+  flex-shrink: 0;
 }
 </style>

--- a/src/components/ProtocolChip.vue
+++ b/src/components/ProtocolChip.vue
@@ -2,13 +2,13 @@
   <Badge
     v-bind="linkAttrs"
     variant="secondary"
-    class="protocol-chip h-5 bg-muted px-1.5 text-[10px] tracking-[0.3px] uppercase no-underline"
+    class="protocol-chip h-5 bg-muted px-1.5 text-[10px] tracking-[0.3px] uppercase no-underline [a&]:hover:bg-muted"
     :class="{ 'opacity-40': !protocol.available }"
   >
     <ProviderIcon
       :domain="protocol.protocol_domain"
       :size="14"
-      class="protocol-chip__icon"
+      class="protocol-chip__icon [&:empty]:w-0"
     />
     {{ label }}
     <ExternalLink v-if="documentationUrl" aria-hidden="true" />
@@ -62,7 +62,6 @@ const linkAttrs = computed(() => {
     target: "_blank",
     rel: "noopener noreferrer",
     "aria-label": description,
-    title: description,
   };
 });
 </script>

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -876,6 +876,7 @@
         "filter_favorites": "Only show favorites",
         "favorite": "Mark\/unmark as a favorite",
         "open_provider_link": "Open this item on the provider's website",
+        "open_documentation": "Open the {provider} documentation",
         "collapse_expand": "Collapse\/expand this listing",
         "back": "Back",
         "show_menu": "Show\/hide menu",

--- a/tests/components/ProtocolChip.test.ts
+++ b/tests/components/ProtocolChip.test.ts
@@ -16,6 +16,10 @@ vi.mock("@/plugins/api", () => ({
   api: apiMock,
 }));
 vi.mock("@/helpers/utils", () => ({ getExternalLinkUrl }));
+vi.mock("@/plugins/i18n", () => ({
+  $t: (key: string, named?: Record<string, unknown>) =>
+    named ? `${key}:${Object.values(named).join(",")}` : key,
+}));
 
 enableAutoUnmount(afterEach);
 
@@ -100,6 +104,26 @@ describe("ProtocolChip", () => {
     expect(wrapper.find(".lucide-external-link").exists()).toBe(true);
   });
 
+  it("names the link by its purpose rather than the bare provider name", () => {
+    apiMock.getProviderManifest.mockReturnValue(
+      providerManifest({
+        name: "AirPlay provider",
+        documentation: "https://example.org/airplay",
+      }),
+    );
+
+    const wrapper = mountChip({ protocol: outputProtocol(), linkToDocs: true });
+
+    // the visible text is only the provider name, so the accessible name has to
+    // say where the link goes - and still contain that visible text
+    expect(wrapper.attributes("aria-label")).toBe(
+      "tooltip.open_documentation:AirPlay provider",
+    );
+    expect(wrapper.attributes("title")).toBe(
+      "tooltip.open_documentation:AirPlay provider",
+    );
+  });
+
   it("routes the documentation url through the external link helper", () => {
     apiMock.getProviderManifest.mockReturnValue(
       providerManifest({ documentation: "https://music-assistant.io/docs" }),
@@ -128,6 +152,8 @@ describe("ProtocolChip", () => {
     expect(wrapper.attributes("href")).toBeUndefined();
     expect(wrapper.attributes("tabindex")).toBeUndefined();
     expect(wrapper.find(".lucide-external-link").exists()).toBe(false);
+    expect(wrapper.attributes("aria-label")).toBeUndefined();
+    expect(wrapper.attributes("title")).toBeUndefined();
     expect(getExternalLinkUrl).not.toHaveBeenCalled();
   });
 

--- a/tests/components/ProtocolChip.test.ts
+++ b/tests/components/ProtocolChip.test.ts
@@ -1,8 +1,5 @@
 import { enableAutoUnmount, mount } from "@vue/test-utils";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { createVuetify } from "vuetify";
-import * as components from "vuetify/components";
-import * as directives from "vuetify/directives";
 import ProtocolChip from "@/components/ProtocolChip.vue";
 import type { MusicAssistantApi } from "@/plugins/api";
 import type { OutputProtocol } from "@/plugins/api/interfaces";
@@ -12,15 +9,13 @@ import { providerManifest } from "../fixtures/providerManifest";
 const apiMock = vi.hoisted(() => ({
   getProviderManifest: vi.fn<MusicAssistantApi["getProviderManifest"]>(),
 }));
-const openLinkInNewTab = vi.hoisted(() => vi.fn());
+const getExternalLinkUrl = vi.hoisted(() => vi.fn());
 
 vi.mock("@/plugins/api", () => ({
   default: apiMock,
   api: apiMock,
 }));
-vi.mock("@/helpers/utils", () => ({ openLinkInNewTab }));
-
-const vuetify = createVuetify({ components, directives });
+vi.mock("@/helpers/utils", () => ({ getExternalLinkUrl }));
 
 enableAutoUnmount(afterEach);
 
@@ -28,7 +23,6 @@ function mountChip(props: { protocol: OutputProtocol; linkToDocs?: boolean }) {
   return mount(ProtocolChip, {
     props,
     global: {
-      plugins: [vuetify],
       stubs: {
         ProviderIcon: {
           props: ["domain"],
@@ -43,7 +37,8 @@ function mountChip(props: { protocol: OutputProtocol; linkToDocs?: boolean }) {
 describe("ProtocolChip", () => {
   beforeEach(() => {
     apiMock.getProviderManifest.mockReset();
-    openLinkInNewTab.mockReset();
+    // the helper rewrites docs urls for beta servers, so pass them through
+    getExternalLinkUrl.mockReset().mockImplementation((url?: string) => url);
   });
 
   it("renders the provider name and icon for the protocol", () => {
@@ -75,59 +70,89 @@ describe("ProtocolChip", () => {
       protocol: outputProtocol({ available: false }),
     });
 
-    expect(wrapper.classes()).toContain("protocol-chip--unavailable");
+    expect(wrapper.classes()).toContain("opacity-40");
   });
 
-  it("opens the provider documentation on click when linking is enabled", async () => {
+  it("fills with a background vuetify's theme stylesheet does not claim", () => {
+    apiMock.getProviderManifest.mockReturnValue(providerManifest());
+
+    const wrapper = mountChip({ protocol: outputProtocol() });
+
+    // vuetify defines its own .bg-secondary at runtime and wins the !important
+    // tie, so shipping the variant's fill would turn the chip teal
+    expect(wrapper.classes()).toContain("bg-muted");
+    expect(wrapper.classes()).not.toContain("bg-secondary");
+  });
+
+  it("links to the provider documentation when linking is enabled", () => {
     apiMock.getProviderManifest.mockReturnValue(
       providerManifest({ documentation: "https://example.org/airplay" }),
     );
 
     const wrapper = mountChip({ protocol: outputProtocol(), linkToDocs: true });
-    expect(wrapper.classes()).toContain("protocol-chip--clickable");
-    expect(wrapper.find(".mdi-open-in-new").exists()).toBe(true);
-    // vuetify only renders the chip as interactive once it has a click listener
-    expect(wrapper.classes()).toContain("v-chip--link");
-    expect(wrapper.attributes("tabindex")).toBe("0");
 
-    await wrapper.trigger("click");
+    // a real anchor, so the chip is announced as a link and honours
+    // middle-click / cmd-click / "open in new tab"
+    expect(wrapper.element.tagName).toBe("A");
+    expect(wrapper.attributes("href")).toBe("https://example.org/airplay");
+    expect(wrapper.attributes("target")).toBe("_blank");
+    expect(wrapper.attributes("rel")).toBe("noopener noreferrer");
+    expect(wrapper.find(".lucide-external-link").exists()).toBe(true);
+  });
 
-    expect(openLinkInNewTab).toHaveBeenCalledWith(
-      "https://example.org/airplay",
+  it("routes the documentation url through the external link helper", () => {
+    apiMock.getProviderManifest.mockReturnValue(
+      providerManifest({ documentation: "https://music-assistant.io/docs" }),
+    );
+    getExternalLinkUrl.mockReturnValue("https://beta.music-assistant.io/docs");
+
+    const wrapper = mountChip({ protocol: outputProtocol(), linkToDocs: true });
+
+    expect(getExternalLinkUrl).toHaveBeenCalledWith(
+      "https://music-assistant.io/docs",
+    );
+    expect(wrapper.attributes("href")).toBe(
+      "https://beta.music-assistant.io/docs",
     );
   });
 
-  it("stays inert when the call site does not link to the documentation", async () => {
+  it("stays inert when the call site does not link to the documentation", () => {
     apiMock.getProviderManifest.mockReturnValue(
       providerManifest({ documentation: "https://example.org/airplay" }),
     );
 
     const wrapper = mountChip({ protocol: outputProtocol() });
-    expect(wrapper.classes()).not.toContain("protocol-chip--clickable");
-    expect(wrapper.find(".mdi-open-in-new").exists()).toBe(false);
-    // without a click listener vuetify leaves the chip non-interactive
-    expect(wrapper.classes()).not.toContain("v-chip--link");
+
+    // a plain span, so the two list call sites keep a non-focusable label
+    expect(wrapper.element.tagName).toBe("SPAN");
+    expect(wrapper.attributes("href")).toBeUndefined();
     expect(wrapper.attributes("tabindex")).toBeUndefined();
-
-    await wrapper.trigger("click");
-
-    expect(openLinkInNewTab).not.toHaveBeenCalled();
+    expect(wrapper.find(".lucide-external-link").exists()).toBe(false);
+    expect(getExternalLinkUrl).not.toHaveBeenCalled();
   });
 
-  it("stays inert when the provider has no documentation", async () => {
+  it("stays inert when the provider has no documentation", () => {
     apiMock.getProviderManifest.mockReturnValue(
       providerManifest({ documentation: null }),
     );
 
     const wrapper = mountChip({ protocol: outputProtocol(), linkToDocs: true });
-    expect(wrapper.classes()).not.toContain("protocol-chip--clickable");
-    expect(wrapper.find(".mdi-open-in-new").exists()).toBe(false);
-    // without a click listener vuetify leaves the chip non-interactive
-    expect(wrapper.classes()).not.toContain("v-chip--link");
+
+    expect(wrapper.element.tagName).toBe("SPAN");
+    expect(wrapper.attributes("href")).toBeUndefined();
     expect(wrapper.attributes("tabindex")).toBeUndefined();
+    expect(wrapper.find(".lucide-external-link").exists()).toBe(false);
+  });
 
-    await wrapper.trigger("click");
+  it("stays inert when the documentation url is not a web url", () => {
+    apiMock.getProviderManifest.mockReturnValue(
+      providerManifest({ documentation: "javascript:alert(1)" }),
+    );
+    getExternalLinkUrl.mockReturnValue(undefined);
 
-    expect(openLinkInNewTab).not.toHaveBeenCalled();
+    const wrapper = mountChip({ protocol: outputProtocol(), linkToDocs: true });
+
+    expect(wrapper.element.tagName).toBe("SPAN");
+    expect(wrapper.attributes("href")).toBeUndefined();
   });
 });

--- a/tests/components/ProtocolChip.test.ts
+++ b/tests/components/ProtocolChip.test.ts
@@ -102,6 +102,11 @@ describe("ProtocolChip", () => {
     expect(wrapper.attributes("target")).toBe("_blank");
     expect(wrapper.attributes("rel")).toBe("noopener noreferrer");
     expect(wrapper.find(".lucide-external-link").exists()).toBe(true);
+    // preflight is not imported, so the anchor would render underlined
+    expect(wrapper.classes()).toContain("no-underline");
+    // the variant's own hover would pull the fill back to --secondary
+    expect(wrapper.classes()).toContain("[a&]:hover:bg-muted");
+    expect(wrapper.classes()).not.toContain("[a&]:hover:bg-secondary/90");
   });
 
   it("names the link by its purpose rather than the bare provider name", () => {
@@ -117,9 +122,6 @@ describe("ProtocolChip", () => {
     // the visible text is only the provider name, so the accessible name has to
     // say where the link goes - and still contain that visible text
     expect(wrapper.attributes("aria-label")).toBe(
-      "tooltip.open_documentation:AirPlay provider",
-    );
-    expect(wrapper.attributes("title")).toBe(
       "tooltip.open_documentation:AirPlay provider",
     );
   });
@@ -140,6 +142,22 @@ describe("ProtocolChip", () => {
     );
   });
 
+  it("still links to the documentation while dimmed as unavailable", () => {
+    apiMock.getProviderManifest.mockReturnValue(
+      providerManifest({ documentation: "https://example.org/airplay" }),
+    );
+
+    const wrapper = mountChip({
+      protocol: outputProtocol({ available: false }),
+      linkToDocs: true,
+    });
+
+    // the scoped hover rule is deliberately plain so this !important dimming
+    // survives a hover instead of being brightened back to 0.85
+    expect(wrapper.element.tagName).toBe("A");
+    expect(wrapper.classes()).toContain("opacity-40");
+  });
+
   it("stays inert when the call site does not link to the documentation", () => {
     apiMock.getProviderManifest.mockReturnValue(
       providerManifest({ documentation: "https://example.org/airplay" }),
@@ -153,7 +171,6 @@ describe("ProtocolChip", () => {
     expect(wrapper.attributes("tabindex")).toBeUndefined();
     expect(wrapper.find(".lucide-external-link").exists()).toBe(false);
     expect(wrapper.attributes("aria-label")).toBeUndefined();
-    expect(wrapper.attributes("title")).toBeUndefined();
     expect(getExternalLinkUrl).not.toHaveBeenCalled();
   });
 


### PR DESCRIPTION
# What does this implement/fix?

The protocol chips in the player settings header can link to the provider's documentation, but they opened it from a JavaScript click handler on a Vuetify `v-chip`. That rendered a `<span tabindex="0">` with no `role`, so screen readers did not announce it as a link and middle-click / cmd-click / "open in new tab" did nothing.

The chip is now a shadcn `Badge` rendered as a real `<a>`, matching the rest of the (already converted) settings header. Chips at the call sites that only label a protocol stay a plain `<span>`, so they remain non-interactive.

**Related issue (if applicable):**

- n/a

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

Changes:

- Documentation chips are real links: announced as links, and openable in a new tab/window
- Swapped the Vuetify `v-chip` for the shadcn `Badge` used elsewhere in the header
- Dropped the click handler and the conditional-listener workaround it needed
- Gave the link an accessible name, so it announces where it goes instead of just the provider name
- Kept the chip's look close to before in both light and dark themes - it is now a solid neutral fill rather than a translucent tint, and this applies to the player list and player card chips too, not just the settings header

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm lint:check` passes.
- [x] `pnpm test:run` passes, and tests have been added/updated where applicable.
- [x] `pnpm build` passes.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
