### PR TITLE
Fix Safari capitalizing the first letter when signing in

### DIFF
--- a/src/views/Login.vue
+++ b/src/views/Login.vue
@@ -68,6 +68,9 @@
                     hide-details="auto"
                     :error-messages="connectionError"
                     :disabled="isConnecting"
+                    autocapitalize="none"
+                    autocorrect="off"
+                    spellcheck="false"
                     @keyup.enter="connectToLocal"
                   />
                   <p class="text-caption text-medium-emphasis mt-2">
@@ -112,6 +115,9 @@
                       bg-color="surface-light"
                       class="remote-id-input"
                       :class="`remote-id-input-${index}`"
+                      autocapitalize="characters"
+                      autocorrect="off"
+                      spellcheck="false"
                       @input="handleRemoteIdInput(index, $event)"
                       @keydown="handleRemoteIdKeydown(index, $event)"
                       @paste="handleRemoteIdPaste(index, $event)"
@@ -187,6 +193,10 @@
                     hide-details="auto"
                     :disabled="isAuthenticating"
                     autofocus
+                    autocomplete="username"
+                    autocapitalize="none"
+                    autocorrect="off"
+                    spellcheck="false"
                   />
                 </div>
 
@@ -209,6 +219,10 @@
                     "
                     :error-messages="loginError"
                     :disabled="isAuthenticating"
+                    autocomplete="current-password"
+                    autocapitalize="none"
+                    autocorrect="off"
+                    spellcheck="false"
                     @click:append-inner="showPassword = !showPassword"
                     @keyup.enter="login"
                   />

--- a/tests/views/Login.test.ts
+++ b/tests/views/Login.test.ts
@@ -899,12 +899,24 @@ describe("credentials field input behavior", () => {
     await wrapper.find("button").trigger("click");
     await flushPromises();
 
-    const usernameInput = wrapper.findAll("input")[0];
-    const passwordInput = wrapper.find('input[type="password"]');
+    const usernameInput = wrapper.find(
+      'input[placeholder="Enter your username"]',
+    );
+    const passwordInput = wrapper.find(
+      'input[placeholder="Enter your password"]',
+    );
 
-    expect(usernameInput.attributes("autocomplete")).toBe("username");
-    expect(usernameInput.attributes("autocapitalize")).toBe("none");
-    expect(passwordInput.attributes("autocomplete")).toBe("current-password");
-    expect(passwordInput.attributes("autocapitalize")).toBe("none");
+    expect(usernameInput.attributes()).toMatchObject({
+      autocomplete: "username",
+      autocapitalize: "none",
+      autocorrect: "off",
+      spellcheck: "false",
+    });
+    expect(passwordInput.attributes()).toMatchObject({
+      autocomplete: "current-password",
+      autocapitalize: "none",
+      autocorrect: "off",
+      spellcheck: "false",
+    });
   });
 });

--- a/tests/views/Login.test.ts
+++ b/tests/views/Login.test.ts
@@ -888,3 +888,23 @@ describe("connection state changes", () => {
     wrapper.unmount();
   });
 });
+
+describe("credentials field input behavior", () => {
+  it("marks username and password inputs for autofill and disables mobile autocorrect", async () => {
+    mockStandaloneFrontend();
+    const wrapper = mountLogin();
+    await flushPromises();
+
+    await wrapper.find("input").setValue("http://music-assistant.local:8095");
+    await wrapper.find("button").trigger("click");
+    await flushPromises();
+
+    const usernameInput = wrapper.findAll("input")[0];
+    const passwordInput = wrapper.find('input[type="password"]');
+
+    expect(usernameInput.attributes("autocomplete")).toBe("username");
+    expect(usernameInput.attributes("autocapitalize")).toBe("none");
+    expect(passwordInput.attributes("autocomplete")).toBe("current-password");
+    expect(passwordInput.attributes("autocapitalize")).toBe("none");
+  });
+});


### PR DESCRIPTION
# What does this implement/fix?

Safari (iOS and macOS) auto-capitalizes and autocorrects the fields on the login screen. On the password field that silently turns the first character into a capital, so signing in fails even though you typed the right password. The fields now tell the browser to leave the input alone, and the username/password fields carry autofill hints so password managers can save and fill the login.

**Related issue (if applicable):**

- n/a, reported directly

**Related backend PR (if applicable):**

<!--
Link the music-assistant/server PR when this change relies on new server
behaviour, so the two can be reviewed and released together.
-->

- n/a

Changes:

- Username and password fields: no autocapitalize, autocorrect or spellcheck, plus `autocomplete="username"` / `"current-password"` for password managers.
- Server address field: no autocapitalize, autocorrect or spellcheck.
- Remote ID fields: keyboard set to capitals to match the value that lands in the field, no autocorrect or spellcheck.
- Test covering the username and password field attributes.

## Types of changes

<!--
Tick exactly one box below. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm lint:check` passes.
- [x] `pnpm test:run` passes, and tests have been added/updated where applicable.
- [x] `pnpm build` passes.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.

