### PR TITLE
Make provider icon spacing opt-in

### DIFF
--- a/src/components/AudioProcessingDetails.vue
+++ b/src/components/AudioProcessingDetails.vue
@@ -277,7 +277,6 @@ const {
   /* pin the size whatever width the provider icon sets on itself inline */
   width: 18px !important;
   height: 18px;
-  margin: 0;
   overflow: hidden;
 }
 

--- a/src/components/ListviewItem.vue
+++ b/src/components/ListviewItem.vue
@@ -253,6 +253,7 @@
         v-if="getBreakpointValue('bp2') && showProvider"
         :domain="getListItemProviderIconDomain(item)"
         :size="24"
+        class="mx-[10px]"
       />
 
       <!-- fully played or in progress icon -->

--- a/src/components/ProtocolChip.vue
+++ b/src/components/ProtocolChip.vue
@@ -72,7 +72,6 @@ const clickListener = computed(() => {
 }
 
 .chip-icon {
-  margin: 0;
   width: auto !important;
 }
 

--- a/src/components/ProviderDetails.vue
+++ b/src/components/ProviderDetails.vue
@@ -22,6 +22,7 @@
             <ProviderIcon
               :domain="providerMapping.provider_domain"
               :size="30"
+              class="mx-[10px]"
             />
           </template>
           <template #title>
@@ -106,7 +107,7 @@
           "
         >
           <template #prepend>
-            <ProviderIcon domain="library" :size="30" />
+            <ProviderIcon domain="library" :size="30" class="mx-[10px]" />
           </template>
           <template #title>{{ $t("music_assistant_library") }}</template>
           <template #subtitle>

--- a/src/components/ProviderIcon.vue
+++ b/src/components/ProviderIcon.vue
@@ -82,12 +82,6 @@ watchEffect(async () => {
 </script>
 
 <style>
-/* default gutters; unscoped so a call site's own rule outweighs them */
-.provider-icon-wrapper {
-  margin-left: 10px;
-  margin-right: 10px;
-}
-
 .provider-img {
   width: 100%;
   height: 100%;

--- a/src/components/discover/EditorialMediaCard.vue
+++ b/src/components/discover/EditorialMediaCard.vue
@@ -319,7 +319,6 @@ const onMenu = (e: MouseEvent) => {
   top: 6px;
   left: 6px;
   z-index: 2;
-  margin: 0;
 }
 .ed-card__img {
   width: 100%;

--- a/src/components/discover/EditorialShelf.vue
+++ b/src/components/discover/EditorialShelf.vue
@@ -264,8 +264,6 @@ onBeforeUnmount(() => {
 }
 .ed-shelf__provider {
   flex-shrink: 0;
-  /* drop ProviderIcon's default gutters so the aside gap sets the spacing */
-  margin: 0;
 }
 .ed-shelf__actions {
   display: flex;

--- a/src/layouts/default/PlayerOSD/NowPlayingSourceBadge.vue
+++ b/src/layouts/default/PlayerOSD/NowPlayingSourceBadge.vue
@@ -34,9 +34,7 @@ const { nowPlayingSource } = useNowPlayingSource();
 </script>
 
 <style scoped>
-/* drop ProviderIcon's default gutters so the badge's own gap applies */
 .now-playing-source__icon {
-  margin: 0;
   flex-shrink: 0;
 }
 </style>

--- a/src/views/settings/AddPlayerGroupDialog.vue
+++ b/src/views/settings/AddPlayerGroupDialog.vue
@@ -146,8 +146,6 @@ watch(
 
 .provider-icon {
   flex-shrink: 0;
-  /* drop ProviderIcon's default gutters so the row gap sets the spacing */
-  margin: 0;
 }
 
 .provider-content {

--- a/src/views/settings/AddProviderDialog.vue
+++ b/src/views/settings/AddProviderDialog.vue
@@ -341,8 +341,6 @@ watch(
 
 .provider-icon {
   flex-shrink: 0;
-  /* drop ProviderIcon's default gutters so the row gap sets the spacing */
-  margin: 0;
 }
 
 .provider-content {

--- a/src/views/settings/ProtocolConfigSection.vue
+++ b/src/views/settings/ProtocolConfigSection.vue
@@ -59,7 +59,6 @@
                   v-if="getProtocolDomain(panel)"
                   :domain="getProtocolDomain(panel)!"
                   :size="22"
-                  class="mx-0"
                 />
                 <span>{{ getProtocolConfigureTitle(panel) }}</span>
                 <Badge

--- a/src/views/settings/Providers.vue
+++ b/src/views/settings/Providers.vue
@@ -31,11 +31,7 @@
         @menu="(evt) => onMenu(evt, item)"
       >
         <template #prepend>
-          <ProviderIcon
-            :domain="item.domain"
-            :size="40"
-            class="provider-icon"
-          />
+          <ProviderIcon :domain="item.domain" :size="40" />
         </template>
 
         <template #title>
@@ -793,10 +789,6 @@ const getAllFilteredProviders = function () {
     gap: 4px;
     min-width: 0;
   }
-}
-
-.provider-icon {
-  margin-right: 0;
 }
 
 .provider-disabled {

--- a/tests/styles/providerIconGutters.test.ts
+++ b/tests/styles/providerIconGutters.test.ts
@@ -1,0 +1,69 @@
+// @vitest-environment happy-dom
+import listviewItemSource from "@/components/ListviewItem.vue?raw";
+import providerDetailsSource from "@/components/ProviderDetails.vue?raw";
+import providerIconSource from "@/components/ProviderIcon.vue?raw";
+import providersSource from "@/views/settings/Providers.vue?raw";
+import globalStyles from "@/styles/global.css?raw";
+import utilities from "@/styles/style.css?inline";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { selectorsSetting, styleBlocks } from "./cascade";
+
+let styles: HTMLStyleElement[];
+
+function providerIcon(className = "") {
+  const icon = document.createElement("div");
+  icon.className = `provider-icon-wrapper ${className}`;
+  document.body.appendChild(icon);
+  return icon;
+}
+
+function rule(source: string, selector: string) {
+  const escaped = selector.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const match = source.match(new RegExp(`${escaped}\\s*\\{[^}]*\\}`));
+  if (!match) throw new Error(`${selector} no longer has a style rule`);
+  return match[0];
+}
+
+describe("provider icon gutters", () => {
+  beforeEach(() => {
+    styles = [
+      utilities,
+      ...styleBlocks(providerIconSource),
+      rule(globalStyles, ".listitem-media-thumb"),
+    ].map((text) => {
+      const element = document.createElement("style");
+      element.textContent = text;
+      document.head.appendChild(element);
+      return element;
+    });
+  });
+
+  afterEach(() => {
+    styles.forEach((element) => element.remove());
+    document.body.innerHTML = "";
+  });
+
+  it("has no side gutters by default", () => {
+    const icon = providerIcon();
+
+    expect(selectorsSetting(styles[1], icon, "margin")).toHaveLength(0);
+    expect(selectorsSetting(styles[1], icon, "margin-left")).toHaveLength(0);
+    expect(selectorsSetting(styles[1], icon, "margin-right")).toHaveLength(0);
+  });
+
+  it("keeps the list call sites explicitly spaced", () => {
+    expect(listviewItemSource).toContain('class="mx-[10px]"');
+    expect(providerDetailsSource.match(/class="mx-\[10px\]"/g)).toHaveLength(2);
+
+    const icon = providerIcon("mx-[10px]");
+    expect(selectorsSetting(styles[0], icon, "margin-inline")).toHaveLength(1);
+  });
+
+  it("takes the provider card spacing from its thumbnail class", () => {
+    expect(providersSource).toContain('class="listitem-media-thumb"');
+
+    const icon = getComputedStyle(providerIcon("listitem-media-thumb"));
+    expect(icon.marginLeft).toBe("");
+    expect(icon.marginRight).toBe("10px");
+  });
+});

--- a/tests/styles/providerIconGutters.test.ts
+++ b/tests/styles/providerIconGutters.test.ts
@@ -62,8 +62,9 @@ describe("provider icon gutters", () => {
   it("takes the provider card spacing from its thumbnail class", () => {
     expect(providersSource).toContain('class="listitem-media-thumb"');
 
-    const icon = getComputedStyle(providerIcon("listitem-media-thumb"));
-    expect(icon.marginLeft).toBe("");
-    expect(icon.marginRight).toBe("10px");
+    const icon = providerIcon("listitem-media-thumb");
+    expect(selectorsSetting(styles[2], icon, "margin-left")).toHaveLength(0);
+    expect(selectorsSetting(styles[2], icon, "margin-right")).toHaveLength(1);
+    expect(getComputedStyle(icon).marginRight).toBe("10px");
   });
 });


### PR DESCRIPTION
# What does this implement/fix?

Provider icons added 10px side spacing even where their parent layout already controlled spacing.

- Remove the default side gutters from `ProviderIcon`
- Keep explicit spacing on the list rows that rely on it
- Remove obsolete spacing overrides and cover the cascade behavior

**Related issue (if applicable):**

- Follow-up to #2593

**Related backend PR (if applicable):**

- N/A

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm lint:check` passes.
- [x] `pnpm test:run` passes, and tests have been added/updated where applicable.
- [x] `pnpm build` passes.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.