### PR TITLE
Fix the cramped merge button on genre pages

### DIFF
--- a/src/components/InfoHeader.vue
+++ b/src/components/InfoHeader.vue
@@ -400,7 +400,7 @@
                   isAdmin
                 "
                 :size="22"
-                class="cursor-pointer -ml-1"
+                class="cursor-pointer"
                 :title="$t('merge_into')"
                 @click="mergeGenre"
               />


### PR DESCRIPTION
# What does this implement/fix?

On a genre page the merge button sits 4px from the provider badge while the rest
of that row uses 8px, so it looks stuck to the badge while the delete button next
to it sits comfortably apart.

The button carries a hand-tuned `-ml-1`, added back when the provider icon still
had its own 10px side margins (it was 8 + 10 − 4 = 14px then). #2600 made those
margins opt-in, so the offset now just eats into the row's own gap.

- Removed the merge button's `-ml-1` so it lines up on the row's 8px like the
  icons around it

Admin-only, and only on genre detail pages.

**Related issue (if applicable):**

- follow-up to #2600

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm lint:check` passes.
- [x] `pnpm test:run` passes, and tests have been added/updated where applicable.
- [x] `pnpm build` passes.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
