### PR TITLE
Move the MilkDrop visualizer settings into a menu popout

### DIFF
--- a/src/helpers/context_menu_item.ts
+++ b/src/helpers/context_menu_item.ts
@@ -21,6 +21,10 @@ export interface ContextMenuItem {
   // are ignored except for the list key). Used for inline controls like the
   // lyrics-offset stepper.
   component?: Component;
+  // Submenu popout rendered as this component instead of a subItems list.
+  subComponent?: Component;
+  // Props passed through to `component` or `subComponent`.
+  componentProps?: Record<string, unknown>;
 }
 
 /** The label to show for a menu item, with its arguments filled in. */

--- a/src/helpers/player_menu_items.ts
+++ b/src/helpers/player_menu_items.ts
@@ -13,11 +13,8 @@ import {
 import { getSleepTimerMenuItem, sleepTimerActive } from "@/helpers/sleep_timer";
 import { useAnnouncement } from "@/composables/useAnnouncement";
 import { useAudioOverlay } from "@/composables/useAudioOverlay";
-import {
-  toggleVisualizerForPlayer,
-  visualizerEnabledForPlayer,
-} from "@/composables/visualizer/useVisualizer";
 import { visualizerProviderAvailable } from "@/plugins/visualizer-relay";
+import VisualizerMenuControl from "@/layouts/default/PlayerOSD/VisualizerMenuControl.vue";
 import { Droplet, Megaphone, Sparkles } from "@lucide/vue";
 import { markRaw } from "vue";
 import { useHosts } from "@/composables/ai-radio/useHosts";
@@ -357,6 +354,16 @@ export const getPlayerMenuItems = (
     });
   }
 
+  // MilkDrop visualizer popout (both menus), kept just above the settings entry
+  if (visualizerProviderAvailable()) {
+    menuItems.push({
+      label: "settings.visualizer_enabled.label",
+      icon: markRaw(Droplet),
+      subComponent: markRaw(VisualizerMenuControl),
+      componentProps: { playerId: player.player_id },
+    });
+  }
+
   // open the settings (both menus, admin only)
   if (authManager.isAdmin()) {
     const openSettings = (path: string) => () => {
@@ -400,19 +407,6 @@ export const getPlayerMenuItems = (
         subItems,
       });
     }
-  }
-
-  // MilkDrop visualizer on/off for this player (both menus; a player control,
-  // stored as a per-player user preference). Kept at the bottom, with the
-  // other display/appearance entries rather than the playback controls.
-  if (visualizerProviderAvailable()) {
-    menuItems.push({
-      label: "settings.visualizer_enabled.label",
-      action: () => toggleVisualizerForPlayer(player.player_id),
-      icon: markRaw(Droplet),
-      selected: visualizerEnabledForPlayer(player.player_id),
-      close_on_click: false,
-    });
   }
 
   return menuItems;

--- a/src/layouts/default/ItemContextMenu.vue
+++ b/src/layouts/default/ItemContextMenu.vue
@@ -64,12 +64,15 @@
               menuItemLabel(menuItem)
             }}</span>
           </DropdownMenuSubTrigger>
-          <!-- fixed width so popout content truncates on phones -->
+          <!-- fixed width so popout content truncates on phones; flex column
+               so the component can keep a static header and scroll the rest.
+               capped at the popper's available height (not a viewport fraction)
+               so growing content scrolls instead of shifting the popout up -->
           <DropdownMenuSubContent
             align="start"
             :align-offset="-5"
             :side-offset="6"
-            class="max-h-[70vh] overflow-y-auto w-[min(92vw,350px)]"
+            class="max-h-[min(70vh,var(--reka-dropdown-menu-content-available-height))] w-[min(92vw,350px)] flex flex-col"
           >
             <component
               :is="menuItem.subComponent"

--- a/src/layouts/default/ItemContextMenu.vue
+++ b/src/layouts/default/ItemContextMenu.vue
@@ -217,9 +217,9 @@ const onOpenChange = function (value: boolean) {
 function closeOnOutsidePointer(event: PointerEvent) {
   if (!show.value) return;
   const target = event.target;
-  // Select dropdowns hosted by menu rows (e.g. the visualizer preset picker)
-  // teleport their list to <body>, outside [data-item-context-menu]; touching
-  // one to scroll it must not read as an outside press and close the menu.
+  // Submenu popouts (and any Select a menu row may host) render outside
+  // [data-item-context-menu]; touching one to scroll it must not read as an
+  // outside press and close the menu.
   if (
     target instanceof Element &&
     target.closest(

--- a/src/layouts/default/ItemContextMenu.vue
+++ b/src/layouts/default/ItemContextMenu.vue
@@ -51,7 +51,32 @@
       <template v-for="menuItem of visibleItems" :key="menuItem.label">
         <!-- custom inline control (e.g. a stepper); renders its own row and
              manages its own interaction without closing the menu -->
-        <component :is="menuItem.component" v-if="menuItem.component" />
+        <component
+          :is="menuItem.component"
+          v-if="menuItem.component"
+          v-bind="menuItem.componentProps"
+        />
+        <!-- item whose submenu popout is a custom control -->
+        <DropdownMenuSub v-else-if="menuItem.subComponent">
+          <DropdownMenuSubTrigger class="gap-3">
+            <MenuItemIcon :icon="menuItem.icon" />
+            <span class="flex-1 truncate min-w-0">{{
+              menuItemLabel(menuItem)
+            }}</span>
+          </DropdownMenuSubTrigger>
+          <!-- fixed width so popout content truncates on phones -->
+          <DropdownMenuSubContent
+            align="start"
+            :align-offset="-5"
+            :side-offset="6"
+            class="max-h-[70vh] overflow-y-auto w-[min(92vw,350px)]"
+          >
+            <component
+              :is="menuItem.subComponent"
+              v-bind="menuItem.componentProps"
+            />
+          </DropdownMenuSubContent>
+        </DropdownMenuSub>
         <!-- item with submenu -->
         <DropdownMenuSub
           v-else-if="menuItem.subItems && menuItem.subItems.length"

--- a/src/layouts/default/PlayerOSD/PlayerFullscreen.vue
+++ b/src/layouts/default/PlayerOSD/PlayerFullscreen.vue
@@ -521,7 +521,6 @@ import PlayerFullscreenHeaderControls from "@/layouts/default/PlayerOSD/PlayerFu
 import PlayerVolume from "@/layouts/default/PlayerOSD/PlayerVolume.vue";
 import QueueListItem from "@/layouts/default/PlayerOSD/QueueListItem.vue";
 import QueueModeBanner from "@/layouts/default/PlayerOSD/QueueModeBanner.vue";
-import VisualizerMenuControl from "@/layouts/default/PlayerOSD/VisualizerMenuControl.vue";
 import { useFullscreenQueue } from "@/layouts/default/PlayerOSD/useFullscreenQueue";
 import { useNowPlayingSource } from "@/composables/nowPlayingSource";
 import { resolveActiveElapsedTime } from "@/helpers/activeElapsedTime";
@@ -1175,10 +1174,8 @@ const openQueueMenu = function (evt: Event) {
       icon: "mdi-speedometer",
     });
   }
-  // The waveform toggle slots in above the visualizer entries, keeping the
-  // visualizer toggle + options grouped at the bottom of the menu. The on/off
-  // toggle itself comes from getPlayerMenuItems (it is a player control,
-  // listed last there).
+  // The waveform toggle slots in above the visualizer popout entry (which
+  // comes from getPlayerMenuItems), keeping the display entries grouped.
   const waveformItem = {
     label: "settings.show_waveform.label",
     action: () => {
@@ -1188,20 +1185,13 @@ const openQueueMenu = function (evt: Event) {
     selected: showWaveformPref.value,
     close_on_click: false,
   };
-  const visualizerToggleIndex = menuItems.findIndex(
+  const visualizerEntryIndex = menuItems.findIndex(
     (item) => item.label === "settings.visualizer_enabled.label",
   );
-  if (visualizerToggleIndex === -1) {
+  if (visualizerEntryIndex === -1) {
     menuItems.push(waveformItem);
   } else {
-    menuItems.splice(visualizerToggleIndex, 0, waveformItem);
-    // Always append the options control directly under the toggle (the menu
-    // item list is a snapshot); it renders nothing while the visualizer is
-    // disabled, so it appears and disappears live as the toggle is flipped.
-    menuItems.push({
-      label: "visualizer_options",
-      component: markRaw(VisualizerMenuControl),
-    });
+    menuItems.splice(visualizerEntryIndex, 0, waveformItem);
   }
   // While lyrics are open, surface the sync-offset stepper at the top of the
   // overflow menu (only for players that benefit from a latency offset).

--- a/src/layouts/default/PlayerOSD/VisualizerMenuControl.vue
+++ b/src/layouts/default/PlayerOSD/VisualizerMenuControl.vue
@@ -176,7 +176,7 @@ const sortedPresetNames = computed(() => {
 });
 
 // The star acts on whatever preset is currently showing (random modes pick
-// presets the dropdown does not reflect).
+// presets the list does not reflect).
 const showingPreset = computed(
   () => currentVisualizerPreset.value || presetPref.value || null,
 );
@@ -206,7 +206,7 @@ watch(
   { immediate: true },
 );
 
-// The dropdown reflects and controls the full selection: concrete preset
+// The list reflects and controls the full selection: concrete preset
 // switches to fixed mode; the Random entries switch the mode back.
 const selectValue = computed(() => {
   if (presetModePref.value === "fixed" && presetPref.value)

--- a/src/layouts/default/PlayerOSD/VisualizerMenuControl.vue
+++ b/src/layouts/default/PlayerOSD/VisualizerMenuControl.vue
@@ -13,64 +13,6 @@
       />
     </div>
     <div class="visualizer-menu__row">
-      <SwatchBook :size="20" class="visualizer-menu__icon" />
-      <!-- not a Select: its teleported list loses the focus fight with the modal menu -->
-      <DropdownMenuSub>
-        <!-- preset packs only load while enabled, so the list would be empty -->
-        <DropdownMenuSubTrigger
-          class="visualizer-menu__preset-trigger"
-          :disabled="!enabledPref"
-        >
-          <span class="visualizer-menu__trigger-label">{{ triggerLabel }}</span>
-        </DropdownMenuSubTrigger>
-        <DropdownMenuSubContent
-          align="start"
-          :align-offset="-5"
-          :side-offset="6"
-          class="max-h-[70vh] overflow-y-auto w-[min(92vw,350px)]"
-        >
-          <DropdownMenuItem @select.prevent="onPresetChange(RANDOM_VALUE)">
-            <span class="flex-1 truncate min-w-0">
-              {{ $t("visualizer.preset_random") }}
-            </span>
-            <Check v-if="selectValue === RANDOM_VALUE" class="ml-auto size-4" />
-          </DropdownMenuItem>
-          <DropdownMenuItem
-            v-if="favoritesPref.length > 0"
-            @select.prevent="onPresetChange(RANDOM_FAVORITES_VALUE)"
-          >
-            <span class="flex-1 truncate min-w-0">
-              {{ $t("visualizer.preset_random_favorites") }}
-            </span>
-            <Check
-              v-if="selectValue === RANDOM_FAVORITES_VALUE"
-              class="ml-auto size-4"
-            />
-          </DropdownMenuItem>
-          <DropdownMenuSeparator />
-          <DropdownMenuItem
-            v-for="name in sortedPresetNames"
-            :key="name"
-            @select.prevent="onPresetChange(name)"
-          >
-            <span class="flex-1 truncate min-w-0">
-              {{ favoritesPref.includes(name) ? `★ ${name}` : name }}
-            </span>
-            <Check v-if="selectValue === name" class="ml-auto size-4" />
-          </DropdownMenuItem>
-        </DropdownMenuSubContent>
-      </DropdownMenuSub>
-      <button
-        type="button"
-        class="visualizer-menu__star"
-        :class="{ 'visualizer-menu__star--active': showingIsFavorite }"
-        :aria-label="$t('visualizer.toggle_favorite')"
-        @click.stop="toggleFavorite"
-      >
-        <Star :size="18" :fill="showingIsFavorite ? 'currentColor' : 'none'" />
-      </button>
-    </div>
-    <div class="visualizer-menu__row">
       <Focus :size="20" class="visualizer-menu__icon" />
       <Slider
         :model-value="[blurDraft]"
@@ -96,18 +38,87 @@
       />
       <span class="visualizer-menu__value">{{ opacityDraft }}%</span>
     </div>
+    <!-- preset packs only load while enabled, so the list would be empty -->
+    <template v-if="enabledPref">
+      <DropdownMenuSeparator />
+      <!-- header folds the list; the star acts on the showing preset without
+           toggling the fold -->
+      <div
+        class="visualizer-menu__row visualizer-menu__preset-header"
+        role="button"
+        :aria-expanded="presetsExpanded"
+        @click="presetsExpanded = !presetsExpanded"
+      >
+        <SwatchBook :size="20" class="visualizer-menu__icon" />
+        <span class="visualizer-menu__preset-label">{{ showingLabel }}</span>
+        <button
+          type="button"
+          class="visualizer-menu__star"
+          :class="{ 'visualizer-menu__star--active': showingIsFavorite }"
+          :aria-label="$t('visualizer.toggle_favorite')"
+          @click.stop="toggleFavorite"
+        >
+          <Star
+            :size="18"
+            :fill="showingIsFavorite ? 'currentColor' : 'none'"
+          />
+        </button>
+        <ChevronDown
+          :size="18"
+          class="visualizer-menu__chevron"
+          :class="{ 'visualizer-menu__chevron--open': presetsExpanded }"
+        />
+      </div>
+      <template v-if="presetsExpanded">
+        <!-- inline list (like the AI DJ submenu); scrolls with the popout -->
+        <DropdownMenuItem @select.prevent="onPresetChange(RANDOM_VALUE)">
+          <span class="flex-1 truncate min-w-0">
+            {{ $t("visualizer.preset_random") }}
+          </span>
+          <Check v-if="selectValue === RANDOM_VALUE" class="ml-auto size-4" />
+        </DropdownMenuItem>
+        <DropdownMenuItem
+          v-if="favoritesPref.length > 0"
+          @select.prevent="onPresetChange(RANDOM_FAVORITES_VALUE)"
+        >
+          <span class="flex-1 truncate min-w-0">
+            {{ $t("visualizer.preset_random_favorites") }}
+          </span>
+          <Check
+            v-if="selectValue === RANDOM_FAVORITES_VALUE"
+            class="ml-auto size-4"
+          />
+        </DropdownMenuItem>
+        <DropdownMenuSeparator />
+        <DropdownMenuItem
+          v-for="name in sortedPresetNames"
+          :key="name"
+          @select.prevent="onPresetChange(name)"
+        >
+          <span class="flex-1 truncate min-w-0">
+            {{ favoritesPref.includes(name) ? `★ ${name}` : name }}
+          </span>
+          <Check v-if="selectValue === name" class="ml-auto size-4" />
+        </DropdownMenuItem>
+      </template>
+    </template>
   </div>
 </template>
 
 <script setup lang="ts">
 import { computed, ref, watch } from "vue";
-import { Check, Contrast, Droplet, Focus, Star, SwatchBook } from "@lucide/vue";
+import {
+  Check,
+  ChevronDown,
+  Contrast,
+  Droplet,
+  Focus,
+  Star,
+  SwatchBook,
+} from "@lucide/vue";
 import {
   DropdownMenuItem,
   DropdownMenuSeparator,
-  DropdownMenuSub,
-  DropdownMenuSubContent,
-  DropdownMenuSubTrigger,
 } from "@/components/ui/dropdown-menu";
 import { Slider } from "@/components/ui/slider";
 import { Switch } from "@/components/ui/switch";
@@ -148,6 +159,9 @@ const presetModePref = getPreference<string>(
 );
 
 const presetNames = ref<string[]>([]);
+
+// Folded by default so the popout stays compact; per menu open, not persisted.
+const presetsExpanded = ref(false);
 
 // Favourites float to the top of the picker.
 const sortedPresetNames = computed(() => {
@@ -202,10 +216,10 @@ const selectValue = computed(() => {
   return RANDOM_VALUE;
 });
 
-// The trigger shows what is actually on screen right now, marked with ⟳ when
+// The label row shows what is actually on screen right now, marked with ⟳ when
 // that is not the user's own pick. Beat switching overrides fixed mode too, so
 // even a fixed selection can be showing something else.
-const triggerLabel = computed(() => {
+const showingLabel = computed(() => {
   const showing = currentVisualizerPreset.value;
   if (presetModePref.value === "fixed" && presetPref.value) {
     return showing && showing !== presetPref.value
@@ -305,18 +319,27 @@ const onOpacityCommit = (value: number[]) => {
   color: #f5c518;
 }
 
-.visualizer-menu__preset-trigger {
+.visualizer-menu__preset-header {
+  cursor: pointer;
+  border-radius: 6px;
+}
+
+.visualizer-menu__preset-header:hover {
+  background: var(--accent);
+}
+
+.visualizer-menu__chevron {
+  flex: 0 0 auto;
+  transition: transform 0.15s ease;
+}
+
+.visualizer-menu__chevron--open {
+  transform: rotate(180deg);
+}
+
+.visualizer-menu__preset-label {
   flex: 1 1 auto;
   min-width: 0;
-  border: 1px solid var(--border);
-}
-
-.visualizer-menu__preset-trigger[data-disabled] {
-  opacity: 0.5;
-}
-
-.visualizer-menu__trigger-label {
-  flex: 1 1 auto;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;

--- a/src/layouts/default/PlayerOSD/VisualizerMenuControl.vue
+++ b/src/layouts/default/PlayerOSD/VisualizerMenuControl.vue
@@ -122,7 +122,7 @@ import { listPresetNames } from "@/helpers/visualizer/presetLibrary";
 import { $t } from "@/plugins/i18n";
 import { store } from "@/plugins/store";
 
-// Sentinels because SelectItem values must be non-empty.
+// Sentinels so the random modes can't collide with real preset names.
 const RANDOM_VALUE = "__random__";
 const RANDOM_FAVORITES_VALUE = "__random_favorites__";
 

--- a/src/layouts/default/PlayerOSD/VisualizerMenuControl.vue
+++ b/src/layouts/default/PlayerOSD/VisualizerMenuControl.vue
@@ -3,7 +3,7 @@
   preset picker, blur and opacity sliders; persisted as user preferences.
 -->
 <template>
-  <div class="visualizer-menu" @pointerdown.stop @click.stop>
+  <div ref="menuEl" class="visualizer-menu" @pointerdown.stop @click.stop>
     <div class="visualizer-menu__row">
       <Droplet :size="20" class="visualizer-menu__icon" />
       <span class="visualizer-menu__label">{{ $t("visualizer.enabled") }}</span>
@@ -47,7 +47,7 @@
         class="visualizer-menu__row visualizer-menu__preset-header"
         role="button"
         :aria-expanded="presetsExpanded"
-        @click="presetsExpanded = !presetsExpanded"
+        @click="toggleExpanded"
       >
         <SwatchBook :size="20" class="visualizer-menu__icon" />
         <span class="visualizer-menu__preset-label">{{ showingLabel }}</span>
@@ -69,8 +69,17 @@
           :class="{ 'visualizer-menu__chevron--open': presetsExpanded }"
         />
       </div>
-      <template v-if="presetsExpanded">
-        <!-- inline list (like the AI DJ submenu); scrolls with the popout -->
+      <!-- inline list (like the AI DJ submenu); the only scrolling part, the
+           rows above stay as a static header -->
+      <div
+        v-if="presetsExpanded"
+        class="visualizer-menu__list"
+        :style="
+          listMaxHeight !== null
+            ? { maxHeight: `${listMaxHeight}px` }
+            : undefined
+        "
+      >
         <DropdownMenuItem @select.prevent="onPresetChange(RANDOM_VALUE)">
           <span class="flex-1 truncate min-w-0">
             {{ $t("visualizer.preset_random") }}
@@ -100,7 +109,7 @@
           </span>
           <Check v-if="selectValue === name" class="ml-auto size-4" />
         </DropdownMenuItem>
-      </template>
+      </div>
     </template>
   </div>
 </template>
@@ -162,6 +171,25 @@ const presetNames = ref<string[]>([]);
 
 // Folded by default so the popout stays compact; per menu open, not persisted.
 const presetsExpanded = ref(false);
+const menuEl = ref<HTMLElement | null>(null);
+const listMaxHeight = ref<number | null>(null);
+
+// Cap the list to the free space below the popout, measured when expanding.
+// The popper's available-height allows for relocating the popout, so growing
+// to it makes the whole popout visibly jump (mainly on phones); growing only
+// into the space that is really free below never triggers a reposition. The
+// small floor keeps the fold usable when the popout sits near the bottom, at
+// the cost of a shift of at most that amount in that rare case.
+const toggleExpanded = () => {
+  if (!presetsExpanded.value && menuEl.value) {
+    const panel =
+      menuEl.value.closest("[data-slot='dropdown-menu-sub-content']") ??
+      menuEl.value;
+    const free = window.innerHeight - panel.getBoundingClientRect().bottom - 8;
+    listMaxHeight.value = Math.max(96, free);
+  }
+  presetsExpanded.value = !presetsExpanded.value;
+};
 
 // Favourites float to the top of the picker.
 const sortedPresetNames = computed(() => {
@@ -283,6 +311,13 @@ const onOpacityCommit = (value: number[]) => {
   padding: 6px 8px;
   font-size: 0.875rem;
   min-width: 260px;
+  min-height: 0;
+}
+
+.visualizer-menu__list {
+  overflow-y: auto;
+  overflow-x: hidden;
+  min-height: 0;
 }
 
 .visualizer-menu__row {

--- a/src/layouts/default/PlayerOSD/VisualizerMenuControl.vue
+++ b/src/layouts/default/PlayerOSD/VisualizerMenuControl.vue
@@ -1,42 +1,65 @@
 <!--
-  Inline visualizer options for the fullscreen player's overflow menu:
-  preset picker (full butterchurn library, "random" default), blur and
-  opacity sliders.
-  Rendered as a non-selectable menu row; changes persist as user preferences.
+  Visualizer popout for the player overflow menus: per-player on/off switch,
+  preset picker, blur and opacity sliders; persisted as user preferences.
 -->
 <template>
-  <div v-if="enabledPref" class="visualizer-menu" @pointerdown.stop @click.stop>
+  <div class="visualizer-menu" @pointerdown.stop @click.stop>
+    <div class="visualizer-menu__row">
+      <Droplet :size="20" class="visualizer-menu__icon" />
+      <span class="visualizer-menu__label">{{ $t("visualizer.enabled") }}</span>
+      <Switch
+        :model-value="enabledPref"
+        @update:model-value="toggleVisualizer"
+      />
+    </div>
     <div class="visualizer-menu__row">
       <SwatchBook :size="20" class="visualizer-menu__icon" />
-      <Select :model-value="selectValue" @update:model-value="onPresetChange">
-        <SelectTrigger class="visualizer-menu__select" size="sm">
-          <span class="visualizer-menu__trigger-label">{{ triggerLabel }}</span>
-        </SelectTrigger>
-        <!-- the hosting context menu renders at z-[999999] (above the
-             fullscreen player overlay), so this list must stack above that.
-             cap the width so long preset names wrap instead of growing the
-             panel past the viewport on small screens -->
-        <SelectContent
-          class="visualizer-menu__dropdown !z-[1000000] w-[min(92vw,26rem)]"
+      <!-- not a Select: its teleported list loses the focus fight with the modal menu -->
+      <DropdownMenuSub>
+        <!-- preset packs only load while enabled, so the list would be empty -->
+        <DropdownMenuSubTrigger
+          class="visualizer-menu__preset-trigger"
+          :disabled="!enabledPref"
         >
-          <SelectItem :value="RANDOM_VALUE">
-            {{ $t("visualizer.preset_random") }}
-          </SelectItem>
-          <SelectItem
+          <span class="visualizer-menu__trigger-label">{{ triggerLabel }}</span>
+        </DropdownMenuSubTrigger>
+        <DropdownMenuSubContent
+          align="start"
+          :align-offset="-5"
+          :side-offset="6"
+          class="max-h-[70vh] overflow-y-auto w-[min(92vw,350px)]"
+        >
+          <DropdownMenuItem @select.prevent="onPresetChange(RANDOM_VALUE)">
+            <span class="flex-1 truncate min-w-0">
+              {{ $t("visualizer.preset_random") }}
+            </span>
+            <Check v-if="selectValue === RANDOM_VALUE" class="ml-auto size-4" />
+          </DropdownMenuItem>
+          <DropdownMenuItem
             v-if="favoritesPref.length > 0"
-            :value="RANDOM_FAVORITES_VALUE"
+            @select.prevent="onPresetChange(RANDOM_FAVORITES_VALUE)"
           >
-            {{ $t("visualizer.preset_random_favorites") }}
-          </SelectItem>
-          <SelectItem
+            <span class="flex-1 truncate min-w-0">
+              {{ $t("visualizer.preset_random_favorites") }}
+            </span>
+            <Check
+              v-if="selectValue === RANDOM_FAVORITES_VALUE"
+              class="ml-auto size-4"
+            />
+          </DropdownMenuItem>
+          <DropdownMenuSeparator />
+          <DropdownMenuItem
             v-for="name in sortedPresetNames"
             :key="name"
-            :value="name"
+            @select.prevent="onPresetChange(name)"
           >
-            {{ favoritesPref.includes(name) ? `★ ${name}` : name }}
-          </SelectItem>
-        </SelectContent>
-      </Select>
+            <span class="flex-1 truncate min-w-0">
+              {{ favoritesPref.includes(name) ? `★ ${name}` : name }}
+            </span>
+            <Check v-if="selectValue === name" class="ml-auto size-4" />
+          </DropdownMenuItem>
+        </DropdownMenuSubContent>
+      </DropdownMenuSub>
       <button
         type="button"
         class="visualizer-menu__star"
@@ -73,30 +96,21 @@
       />
       <span class="visualizer-menu__value">{{ opacityDraft }}%</span>
     </div>
-    <DropdownMenuItem class="px-0" @select="openSettings">
-      <SettingsIcon class="visualizer-menu__icon size-5" />
-      <span>{{ $t("visualizer.open_settings") }}</span>
-    </DropdownMenuItem>
   </div>
 </template>
 
 <script setup lang="ts">
 import { computed, ref, watch } from "vue";
+import { Check, Contrast, Droplet, Focus, Star, SwatchBook } from "@lucide/vue";
 import {
-  Contrast,
-  Focus,
-  Settings as SettingsIcon,
-  Star,
-  SwatchBook,
-} from "@lucide/vue";
-import { DropdownMenuItem } from "@/components/ui/dropdown-menu";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-} from "@/components/ui/select";
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger,
+} from "@/components/ui/dropdown-menu";
 import { Slider } from "@/components/ui/slider";
+import { Switch } from "@/components/ui/switch";
 import { useUserPreferences } from "@/composables/userPreferences";
 import {
   currentVisualizerPreset,
@@ -106,17 +120,20 @@ import {
 import { useVisualizer } from "@/composables/visualizer/useVisualizer";
 import { listPresetNames } from "@/helpers/visualizer/presetLibrary";
 import { $t } from "@/plugins/i18n";
-import router from "@/plugins/router";
 import { store } from "@/plugins/store";
 
 // Sentinels because SelectItem values must be non-empty.
 const RANDOM_VALUE = "__random__";
 const RANDOM_FAVORITES_VALUE = "__random_favorites__";
 
+const props = defineProps<{
+  // player whose on/off switch this controls; defaults to the active player
+  playerId?: string;
+}>();
+
 const { getPreference, setPreference } = useUserPreferences();
-// Per-player on/off state, matching the toggle above this control in the menu.
-const { visualizerEnabledPref: enabledPref } = useVisualizer(
-  () => store.activePlayer?.player_id,
+const { visualizerEnabledPref: enabledPref, toggleVisualizer } = useVisualizer(
+  () => props.playerId || store.activePlayer?.player_id,
 );
 const presetPref = getPreference("visualizer_preset", "");
 const blurPref = getPreference("visualizer_blur", VISUALIZER_BLUR_DEFAULT);
@@ -242,11 +259,6 @@ const onOpacityCommit = (value: number[]) => {
     value[0] ?? VISUALIZER_OPACITY_DEFAULT,
   );
 };
-
-const openSettings = () => {
-  store.showFullscreenPlayer = false;
-  void router.push({ name: "visualizer" });
-};
 </script>
 
 <style scoped>
@@ -269,6 +281,10 @@ const openSettings = () => {
   flex: 0 0 auto;
 }
 
+.visualizer-menu__label {
+  flex: 1 1 auto;
+}
+
 .visualizer-menu__star {
   display: inline-flex;
   align-items: center;
@@ -289,15 +305,22 @@ const openSettings = () => {
   color: #f5c518;
 }
 
-.visualizer-menu__select {
+.visualizer-menu__preset-trigger {
   flex: 1 1 auto;
   min-width: 0;
+  border: 1px solid var(--border);
+}
+
+.visualizer-menu__preset-trigger[data-disabled] {
+  opacity: 0.5;
 }
 
 .visualizer-menu__trigger-label {
+  flex: 1 1 auto;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+  text-align: left;
 }
 
 .visualizer-menu__slider {

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -138,7 +138,6 @@ html {
      100000  sheets
      100001  menus opened from a sheet or a player bar popout
      999999  item context menu
-    1000000  popovers opened from inside the item context menu
 
    Values below this range mostly order elements inside a component's own
    stacking context.

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -2332,7 +2332,6 @@
         "title": "MilkDrop",
         "enabled": "Enabled",
         "preset_random": "Random preset",
-        "open_settings": "Visualizer settings",
         "toggle": "Toggle the MilkDrop visualizer",
         "preset_random_favorites": "Random from favorites",
         "toggle_favorite": "Favorite this preset",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -2330,6 +2330,7 @@
     "mark_played_partial_failure": "Could not update {0} episode(s)",
     "visualizer": {
         "title": "MilkDrop",
+        "enabled": "Enabled",
         "preset_random": "Random preset",
         "open_settings": "Visualizer settings",
         "toggle": "Toggle the MilkDrop visualizer",

--- a/tests/helpers/player_menu_items.test.ts
+++ b/tests/helpers/player_menu_items.test.ts
@@ -701,4 +701,19 @@ describe("visualizer menu entry", () => {
 
     expect(menuItems.map((item) => item.label)).toContain(VISUALIZER_LABEL);
   });
+
+  it("is a popout with all settings, targeting this player", () => {
+    const player = makePlayer();
+    api.players = { kitchen: player } as unknown as typeof api.players;
+
+    const menuItems = getPlayerMenuItems(player, undefined, {
+      context: "queue",
+    });
+
+    const entry = menuItems.find((item) => item.label === VISUALIZER_LABEL);
+    expect(entry?.subComponent).toBeTruthy();
+    expect(entry?.componentProps).toEqual({ playerId: player.player_id });
+    // no toggle leaf: the on/off switch lives inside the popout
+    expect(entry?.action).toBeUndefined();
+  });
 });

--- a/tests/layouts/ItemContextMenu.test.ts
+++ b/tests/layouts/ItemContextMenu.test.ts
@@ -1,7 +1,7 @@
 import ItemContextMenu from "@/layouts/default/ItemContextMenu.vue";
 import type { ContextMenuDialogEvent } from "@/plugins/eventbus";
 import { mount } from "@vue/test-utils";
-import { nextTick } from "vue";
+import { markRaw, nextTick } from "vue";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const { eventHandlers, storeMock } = vi.hoisted(() => ({
@@ -129,6 +129,32 @@ describe("ItemContextMenu", () => {
     expect(storeMock.dialogActive).toBe(true);
 
     selectContent.remove();
+    wrapper.unmount();
+  });
+
+  it("renders a subComponent item as a popout with its props", async () => {
+    const popout = markRaw({
+      props: ["playerId"],
+      template: "<div data-test-popout>{{ playerId }}</div>",
+    });
+    const wrapper = mountContextMenu();
+    eventHandlers.get("contextmenu")?.({
+      items: [
+        {
+          label: "settings.visualizer_enabled.label",
+          subComponent: popout,
+          componentProps: { playerId: "kitchen" },
+        },
+      ],
+      posX: 10,
+      posY: 20,
+    });
+    await nextTick();
+    await nextTick();
+
+    // menuItemLabel resolves the label through the real i18n catalog
+    expect(wrapper.text()).toContain("MilkDrop visualizer");
+    expect(wrapper.get("[data-test-popout]").text()).toBe("kitchen");
     wrapper.unmount();
   });
 });


### PR DESCRIPTION
# What does this implement/fix?

Moves the MilkDrop visualizer controls in both player menus into a single popout submenu: per-player on/off switch, preset picker, and blur/opacity sliders. The separate "Visualizer settings" link is dropped (the page stays reachable from the sidebar).

To support this, `ContextMenuItem` gains `subComponent`/`componentProps` so an item can render a custom component as its submenu popout. The preset picker is a foldable list inline in the popout rather than a `Select`, whose teleported list loses the focus fight with the modal context menu on mobile. The header rows stay static and only the list scrolls; expanding caps the list at the measured free space below the popout, since growing past it makes the popper visibly relocate the panel on phones.


https://github.com/user-attachments/assets/28c70151-489e-4a37-b7b1-e30a7129a5e6



**Related issue (if applicable):**

- n/a

**Related backend PR (if applicable):**

- n/a

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm lint:check` passes.
- [x] `pnpm test:run` passes, and tests have been added/updated where applicable.
- [x] `pnpm build` passes.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.


