### PR TITLE
Make the queue read-only while an external session manages it

### DIFF
--- a/src/helpers/queue_item_menu_items.ts
+++ b/src/helpers/queue_item_menu_items.ts
@@ -22,6 +22,9 @@ export const getQueueItemMenuItems = (
   if (!queue) return [];
   const queueId = queue.queue_id;
   const locked = index <= (queue.index_in_buffer ?? 0);
+  // a session-owned queue mirrors an external session's queue (queue_owner set),
+  // so the move/remove actions are not offered at all
+  const sessionOwned = !!queue.queue_owner;
 
   const menuItems: ContextMenuItem[] = [
     {
@@ -32,14 +35,17 @@ export const getQueueItemMenuItems = (
       disabled:
         index === queue.current_index || index === queue.index_in_buffer,
     },
-    {
+  ];
+
+  if (!sessionOwned) {
+    menuItems.push({
       label: "play_next",
       labelArgs: [],
       action: () => api.queueCommandMoveNext(queueId, item.queue_item_id),
       icon: "mdi-skip-next-circle-outline",
       disabled: locked,
-    },
-  ];
+    });
+  }
 
   // go to this item's radio (a dynamic playlist generated from it as the seed)
   const mediaItem = item.media_item;
@@ -54,22 +60,24 @@ export const getQueueItemMenuItems = (
   }
 
   // quick reorder / remove (drag the handle for fine-grained moves)
-  menuItems.push(
-    {
-      label: "queue_move_end",
-      labelArgs: [],
-      action: () => api.queueCommandMoveItemEnd(queueId, item.queue_item_id),
-      icon: "mdi-arrow-collapse-down",
-      disabled: locked,
-    },
-    {
-      label: "queue_delete",
-      labelArgs: [],
-      action: () => api.queueCommandDelete(queueId, item.queue_item_id),
-      icon: "mdi-delete",
-      disabled: locked,
-    },
-  );
+  if (!sessionOwned) {
+    menuItems.push(
+      {
+        label: "queue_move_end",
+        labelArgs: [],
+        action: () => api.queueCommandMoveItemEnd(queueId, item.queue_item_id),
+        icon: "mdi-arrow-collapse-down",
+        disabled: locked,
+      },
+      {
+        label: "queue_delete",
+        labelArgs: [],
+        action: () => api.queueCommandDelete(queueId, item.queue_item_id),
+        icon: "mdi-delete",
+        disabled: locked,
+      },
+    );
+  }
 
   // tracks can be opened in their detail page (closes the fullscreen player)
   if (mediaItem?.media_type === MediaType.TRACK) {

--- a/src/helpers/queue_item_menu_items.ts
+++ b/src/helpers/queue_item_menu_items.ts
@@ -22,9 +22,9 @@ export const getQueueItemMenuItems = (
   if (!queue) return [];
   const queueId = queue.queue_id;
   const locked = index <= (queue.index_in_buffer ?? 0);
-  // a session-owned queue mirrors an external session's queue (queue_owner set),
-  // so the move/remove actions are not offered at all
-  const sessionOwned = !!queue.queue_owner;
+  // an externally managed queue mirrors an external session's queue
+  // (queue_owner set), so the move/remove actions are not offered at all
+  const externallyManaged = !!queue.queue_owner;
 
   const menuItems: ContextMenuItem[] = [
     {
@@ -37,7 +37,7 @@ export const getQueueItemMenuItems = (
     },
   ];
 
-  if (!sessionOwned) {
+  if (!externallyManaged) {
     menuItems.push({
       label: "play_next",
       labelArgs: [],
@@ -60,7 +60,7 @@ export const getQueueItemMenuItems = (
   }
 
   // quick reorder / remove (drag the handle for fine-grained moves)
-  if (!sessionOwned) {
+  if (!externallyManaged) {
     menuItems.push(
       {
         label: "queue_move_end",

--- a/src/layouts/default/PlayerOSD/PlayerControlBtn/RepeatBtn.vue
+++ b/src/layouts/default/PlayerOSD/PlayerControlBtn/RepeatBtn.vue
@@ -63,8 +63,13 @@ const isLoading = computed(() => {
 
 const isDynamic = computed(() => compProps.playerQueue?.is_dynamic === true);
 
-const isInfiniteStream = computed(() =>
-  isQueueInfiniteStream(compProps.playerQueue),
+// An external session that owns the queue (queue_owner) handles repeat
+// natively — the server forwards the command — so it is exempt from the
+// infinite-stream disable (the current item is that session's AudioSource).
+const isInfiniteStream = computed(
+  () =>
+    isQueueInfiniteStream(compProps.playerQueue) &&
+    !compProps.playerQueue?.queue_owner,
 );
 
 // The next repeat mode when the button is pressed: cycle OFF -> ALL -> ONE.

--- a/src/layouts/default/PlayerOSD/PlayerControlBtn/ShuffleBtn.vue
+++ b/src/layouts/default/PlayerOSD/PlayerControlBtn/ShuffleBtn.vue
@@ -58,8 +58,13 @@ const isLoading = computed(() => {
   );
 });
 
-const isInfiniteStream = computed(() =>
-  isQueueInfiniteStream(compProps.playerQueue),
+// An external session that owns the queue (queue_owner) handles shuffle
+// natively — the server forwards the command — so it is exempt from the
+// infinite-stream disable (the current item is that session's AudioSource).
+const isInfiniteStream = computed(
+  () =>
+    isQueueInfiniteStream(compProps.playerQueue) &&
+    !compProps.playerQueue?.queue_owner,
 );
 
 // In dynamic mode the queue manages its own ordering (smart shuffle is implied),

--- a/src/layouts/default/PlayerOSD/PlayerFullscreen.vue
+++ b/src/layouts/default/PlayerOSD/PlayerFullscreen.vue
@@ -273,7 +273,7 @@
                   :state="row.state"
                   :is-playing="playerActive"
                   :dragging="draggingIndex === row.index"
-                  :read-only="queueSessionOwned"
+                  :read-only="queueExternallyManaged"
                   :marquee-sync="
                     row.state === 'playing'
                       ? playerMarqueeSync
@@ -777,7 +777,7 @@ const {
   totalItems,
   upNextCount,
   queueEnded,
-  queueSessionOwned,
+  queueExternallyManaged,
   queueOwnerName,
   totalSize,
   measureRow,

--- a/src/layouts/default/PlayerOSD/PlayerFullscreen.vue
+++ b/src/layouts/default/PlayerOSD/PlayerFullscreen.vue
@@ -220,6 +220,11 @@
             class="queue-items-scroll-box"
             :style="`--queue-title-size: ${queueTitleFontSize}; --queue-subtitle-size: ${queueSubtitleFontSize};`"
           >
+            <!-- an external session owns the queue's ordering: the list is a
+                 read-only mirror, so say who manages it -->
+            <div v-if="queueOwnerName" class="queue-owner-hint">
+              {{ $t("queue_managed_by", [queueOwnerName]) }}
+            </div>
             <!-- the queue played through: say so, rather than leaving its last
                  track looking like it is still the current one -->
             <div v-if="queueEnded" class="queue-ended">
@@ -268,6 +273,7 @@
                   :state="row.state"
                   :is-playing="playerActive"
                   :dragging="draggingIndex === row.index"
+                  :read-only="queueSessionOwned"
                   :marquee-sync="
                     row.state === 'playing'
                       ? playerMarqueeSync
@@ -771,6 +777,8 @@ const {
   totalItems,
   upNextCount,
   queueEnded,
+  queueSessionOwned,
+  queueOwnerName,
   totalSize,
   measureRow,
   playerActive,
@@ -1525,6 +1533,13 @@ onBeforeUnmount(() => {
 
 .queue-ended {
   padding: 8px 4px 12px;
+  text-align: center;
+  font-size: 0.85rem;
+  opacity: 0.6;
+}
+
+.queue-owner-hint {
+  padding: 8px 4px 4px;
   text-align: center;
   font-size: 0.85rem;
   opacity: 0.6;

--- a/src/layouts/default/PlayerOSD/PlayerFullscreenHeaderControls.vue
+++ b/src/layouts/default/PlayerOSD/PlayerFullscreenHeaderControls.vue
@@ -261,10 +261,12 @@ const smartFadesActive = computed(
 );
 
 // Crossfade only applies to an active queue that is playing regular tracks.
-// Hide the control entirely for external sources, audiosources and radio streams.
+// Hide the control entirely for external sources, audiosources and radio
+// streams, and while an external session owns the queue (it crossfades natively).
 const showCrossfade = computed(() => {
   const q = queue.value;
   if (!q || !q.active) return false;
+  if (q.queue_owner) return false;
   if (isQueueInfiniteStream(q)) return false;
   return "crossfade_enabled" in q;
 });

--- a/src/layouts/default/PlayerOSD/QueueListItem.vue
+++ b/src/layouts/default/PlayerOSD/QueueListItem.vue
@@ -99,11 +99,12 @@
            grip (only up-next rows are reorderable). -->
       <div class="qitem__actions">
         <!-- drag handle to reorder. Active on up-next items; disabled/grayed on
-             every other row (now playing, buffered, played can't be reordered). -->
+             every other row (now playing, buffered, played can't be reordered)
+             and everywhere while the queue is read-only. -->
         <button
           type="button"
           class="qitem__grip"
-          :disabled="state !== 'upcoming'"
+          :disabled="readOnly || state !== 'upcoming'"
           :aria-label="$t('queue_reorder')"
           @pointerdown.stop.prevent="emit('dragstart', $event)"
           @click.stop
@@ -170,6 +171,9 @@ interface Props {
   dragging?: boolean;
   // Whether this is the floating "ghost" clone that follows the pointer.
   ghost?: boolean;
+  // Whether the queue is read-only (an external session owns its ordering),
+  // disabling the drag handle on every row.
+  readOnly?: boolean;
 }
 
 const props = withDefaults(defineProps<Props>(), {
@@ -179,6 +183,7 @@ const props = withDefaults(defineProps<Props>(), {
   boostBadgeColor: "#ff5722",
   dragging: false,
   ghost: false,
+  readOnly: false,
 });
 
 const emit = defineEmits<{

--- a/src/layouts/default/PlayerOSD/useFullscreenQueue.ts
+++ b/src/layouts/default/PlayerOSD/useFullscreenQueue.ts
@@ -7,6 +7,7 @@ import { usePartyConfig } from "@/composables/usePartyConfig";
 import { MarqueeTextSync } from "@/helpers/marquee_text_sync";
 import { getQueueItemMenuItems } from "@/helpers/queue_item_menu_items";
 import { currentQueueIndex, isQueueEnded } from "@/helpers/queue_position";
+import { isAudioSource } from "@/plugins/api/helpers";
 import { useQueueDragReorder } from "@/layouts/default/PlayerOSD/useQueueDragReorder";
 import api from "@/plugins/api";
 import {
@@ -96,6 +97,21 @@ export function useFullscreenQueue(showLyrics: Ref<boolean>) {
 
   // Whether the queue played through to its end and can be started over.
   const queueEnded = computed(() => isQueueEnded(store.activePlayerQueue));
+
+  // Whether an external session (e.g. Spotify Connect) owns the queue's
+  // ordering: the list is a mirror the user can't edit, so reorder/move/delete
+  // affordances are withheld.
+  const queueSessionOwned = computed(
+    () => !!store.activePlayerQueue?.queue_owner,
+  );
+
+  // Display name of the owning session, for the "queue managed by" hint. The
+  // owning AudioSource is the queue's current item, so its name is read there.
+  const queueOwnerName = computed(() => {
+    if (!queueSessionOwned.value) return "";
+    const mediaItem = store.activePlayerQueue?.current_item?.media_item;
+    return isAudioSource(mediaItem) ? mediaItem.name : "";
+  });
 
   // Whether the player is actually rendering audio (drives the equalizer icon).
   const playerActive = computed(
@@ -407,6 +423,8 @@ export function useFullscreenQueue(showLyrics: Ref<boolean>) {
     totalItems,
     upNextCount,
     queueEnded,
+    queueSessionOwned,
+    queueOwnerName,
     totalSize,
     measureRow,
     playerActive,

--- a/src/layouts/default/PlayerOSD/useFullscreenQueue.ts
+++ b/src/layouts/default/PlayerOSD/useFullscreenQueue.ts
@@ -7,9 +7,9 @@ import { usePartyConfig } from "@/composables/usePartyConfig";
 import { MarqueeTextSync } from "@/helpers/marquee_text_sync";
 import { getQueueItemMenuItems } from "@/helpers/queue_item_menu_items";
 import { currentQueueIndex, isQueueEnded } from "@/helpers/queue_position";
-import { isAudioSource } from "@/plugins/api/helpers";
 import { useQueueDragReorder } from "@/layouts/default/PlayerOSD/useQueueDragReorder";
 import api from "@/plugins/api";
+import { isAudioSource } from "@/plugins/api/helpers";
 import {
   EventMessage,
   EventType,

--- a/src/layouts/default/PlayerOSD/useFullscreenQueue.ts
+++ b/src/layouts/default/PlayerOSD/useFullscreenQueue.ts
@@ -101,14 +101,14 @@ export function useFullscreenQueue(showLyrics: Ref<boolean>) {
   // Whether an external session (e.g. Spotify Connect) owns the queue's
   // ordering: the list is a mirror the user can't edit, so reorder/move/delete
   // affordances are withheld.
-  const queueSessionOwned = computed(
+  const queueExternallyManaged = computed(
     () => !!store.activePlayerQueue?.queue_owner,
   );
 
   // Display name of the owning session, for the "queue managed by" hint. The
   // owning AudioSource is the queue's current item, so its name is read there.
   const queueOwnerName = computed(() => {
-    if (!queueSessionOwned.value) return "";
+    if (!queueExternallyManaged.value) return "";
     const mediaItem = store.activePlayerQueue?.current_item?.media_item;
     return isAudioSource(mediaItem) ? mediaItem.name : "";
   });
@@ -423,7 +423,7 @@ export function useFullscreenQueue(showLyrics: Ref<boolean>) {
     totalItems,
     upNextCount,
     queueEnded,
-    queueSessionOwned,
+    queueExternallyManaged,
     queueOwnerName,
     totalSize,
     measureRow,

--- a/src/layouts/default/PlayerOSD/useQueueDragReorder.ts
+++ b/src/layouts/default/PlayerOSD/useQueueDragReorder.ts
@@ -171,6 +171,8 @@ export function useQueueDragReorder(options: QueueDragReorderOptions) {
   const startItemDrag = (evt: PointerEvent, index: number) => {
     // Primary mouse button / touch / pen only.
     if (evt.pointerType === "mouse" && evt.button !== 0) return;
+    // a session-owned queue mirrors an external session's queue - not reorderable
+    if (store.activePlayerQueue?.queue_owner) return;
     const item = itemAt(index);
     if (!item || index < firstReorderableIndex()) return;
 

--- a/src/layouts/default/PlayerOSD/useQueueDragReorder.ts
+++ b/src/layouts/default/PlayerOSD/useQueueDragReorder.ts
@@ -171,7 +171,8 @@ export function useQueueDragReorder(options: QueueDragReorderOptions) {
   const startItemDrag = (evt: PointerEvent, index: number) => {
     // Primary mouse button / touch / pen only.
     if (evt.pointerType === "mouse" && evt.button !== 0) return;
-    // a session-owned queue mirrors an external session's queue - not reorderable
+    // A session-owned queue mirrors an external session's queue that MA
+    // cannot reorder.
     if (store.activePlayerQueue?.queue_owner) return;
     const item = itemAt(index);
     if (!item || index < firstReorderableIndex()) return;

--- a/src/layouts/default/PlayerOSD/useQueueDragReorder.ts
+++ b/src/layouts/default/PlayerOSD/useQueueDragReorder.ts
@@ -171,8 +171,8 @@ export function useQueueDragReorder(options: QueueDragReorderOptions) {
   const startItemDrag = (evt: PointerEvent, index: number) => {
     // Primary mouse button / touch / pen only.
     if (evt.pointerType === "mouse" && evt.button !== 0) return;
-    // A session-owned queue mirrors an external session's queue that MA
-    // cannot reorder.
+    // An externally managed queue mirrors an external session's queue that
+    // MA cannot reorder.
     if (store.activePlayerQueue?.queue_owner) return;
     const item = itemAt(index);
     if (!item || index < firstReorderableIndex()) return;

--- a/src/layouts/default/PlayerOSD/useQueueModes.ts
+++ b/src/layouts/default/PlayerOSD/useQueueModes.ts
@@ -26,11 +26,13 @@ export function useQueueModes() {
   );
 
   // Autoplay only applies to an active queue playing regular tracks, and is
-  // moot while dynamic mode is active (the queue already refills itself) or for
-  // infinite streams.
+  // moot while dynamic mode is active (the queue already refills itself), for
+  // infinite streams, or while an external session owns the queue (it provides
+  // its own continuation).
   const autoplayApplicable = computed(() => {
     const q = queue.value;
     if (!q || !q.active) return false;
+    if (q.queue_owner) return false;
     if (isQueueInfiniteStream(q)) return false;
     if (dynamicModeActive.value) return false;
     return "autoplay_enabled" in q;

--- a/src/plugins/api/interfaces.ts
+++ b/src/plugins/api/interfaces.ts
@@ -1271,6 +1271,12 @@ export interface PlayerQueue {
   // (is_dynamic), implicitly enabling autoplay and smart shuffle.
   sources: ItemMapping[];
   is_dynamic: boolean;
+  // queue_owner: uri of the AudioSource owning this queue's ordering while queue commands
+  // are delegated to an external session (e.g. Spotify Connect); null when MA owns the
+  // queue (server-derived, read-only; absent on older servers). While set, the items are
+  // a mirror the user can't edit and the session provides crossfade/autoplay natively —
+  // shuffle and repeat keep working (forwarded to the session).
+  queue_owner?: string | null;
   // extra_attributes: additional attributes for this player_queue to store/forward
   // additional data that is not part of the standard model
   // must be serializable types only

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -2191,6 +2191,7 @@
     "up_next": "Up next",
     "queue_buffered_explanation": "This track is already buffered by the player to play next.",
     "queue_reorder": "Drag to reorder",
+    "queue_managed_by": "Queue managed by {0}",
     "lyrics_show": "Show lyrics for this track",
     "lyrics_hide": "Hide lyrics for this track",
     "lyrics_loading": "Lyrics are being fetched...",

--- a/tests/fixtures/playerQueue.ts
+++ b/tests/fixtures/playerQueue.ts
@@ -34,6 +34,7 @@ export function playerQueue(overrides: Partial<PlayerQueue> = {}): PlayerQueue {
     next_item: null,
     sources: [],
     is_dynamic: false,
+    queue_owner: null,
     ...overrides,
   };
 }

--- a/tests/helpers/queue_item_menu_items.test.ts
+++ b/tests/helpers/queue_item_menu_items.test.ts
@@ -3,6 +3,7 @@ import type { PlayerQueue } from "@/plugins/api/interfaces";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { playerQueue } from "../fixtures/playerQueue";
 import { queueItem } from "../fixtures/queueItem";
+import { track } from "../fixtures/track";
 
 const { storeMock } = vi.hoisted(() => ({
   storeMock: {
@@ -13,6 +14,7 @@ const { storeMock } = vi.hoisted(() => ({
 
 vi.mock("@/plugins/api", () => ({
   default: {
+    providers: {},
     queueCommandPlayIndex: vi.fn(),
     queueCommandMoveNext: vi.fn(),
     queueCommandMoveItemEnd: vi.fn(),
@@ -58,5 +60,16 @@ describe("getQueueItemMenuItems", () => {
     });
     const items = getQueueItemMenuItems(queueItem(), 3);
     expect(labels(items)).toEqual(["play_now"]);
+  });
+
+  it("keeps play now and show info on a session-owned queue's track items", () => {
+    storeMock.activePlayerQueue = playerQueue({
+      items: 5,
+      current_index: 0,
+      index_in_buffer: 1,
+      queue_owner: "spotify_connect--abc://audio_source/main",
+    });
+    const items = getQueueItemMenuItems(queueItem({ media_item: track() }), 3);
+    expect(labels(items)).toEqual(["play_now", "show_info"]);
   });
 });

--- a/tests/helpers/queue_item_menu_items.test.ts
+++ b/tests/helpers/queue_item_menu_items.test.ts
@@ -1,0 +1,62 @@
+import { getQueueItemMenuItems } from "@/helpers/queue_item_menu_items";
+import type { PlayerQueue } from "@/plugins/api/interfaces";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { playerQueue } from "../fixtures/playerQueue";
+import { queueItem } from "../fixtures/queueItem";
+
+const { storeMock } = vi.hoisted(() => ({
+  storeMock: {
+    activePlayerQueue: undefined as PlayerQueue | undefined,
+    showFullscreenPlayer: true,
+  },
+}));
+
+vi.mock("@/plugins/api", () => ({
+  default: {
+    queueCommandPlayIndex: vi.fn(),
+    queueCommandMoveNext: vi.fn(),
+    queueCommandMoveItemEnd: vi.fn(),
+    queueCommandDelete: vi.fn(),
+  },
+}));
+
+vi.mock("@/plugins/router", () => ({
+  default: { push: vi.fn() },
+}));
+
+vi.mock("@/plugins/store", () => ({
+  store: storeMock,
+}));
+
+const labels = (items: { label: string }[]) => items.map((i) => i.label);
+
+describe("getQueueItemMenuItems", () => {
+  beforeEach(() => {
+    storeMock.activePlayerQueue = playerQueue({
+      items: 5,
+      current_index: 0,
+      index_in_buffer: 1,
+    });
+  });
+
+  it("offers the full action set on an MA-owned queue", () => {
+    const items = getQueueItemMenuItems(queueItem(), 3);
+    expect(labels(items)).toEqual([
+      "play_now",
+      "play_next",
+      "queue_move_end",
+      "queue_delete",
+    ]);
+  });
+
+  it("withholds the move/remove actions on a session-owned queue", () => {
+    storeMock.activePlayerQueue = playerQueue({
+      items: 5,
+      current_index: 0,
+      index_in_buffer: 1,
+      queue_owner: "spotify_connect--abc://audio_source/main",
+    });
+    const items = getQueueItemMenuItems(queueItem(), 3);
+    expect(labels(items)).toEqual(["play_now"]);
+  });
+});

--- a/tests/helpers/queue_item_menu_items.test.ts
+++ b/tests/helpers/queue_item_menu_items.test.ts
@@ -51,7 +51,7 @@ describe("getQueueItemMenuItems", () => {
     ]);
   });
 
-  it("withholds the move/remove actions on a session-owned queue", () => {
+  it("withholds the move/remove actions on an externally managed queue", () => {
     storeMock.activePlayerQueue = playerQueue({
       items: 5,
       current_index: 0,
@@ -62,7 +62,7 @@ describe("getQueueItemMenuItems", () => {
     expect(labels(items)).toEqual(["play_now"]);
   });
 
-  it("keeps play now and show info on a session-owned queue's track items", () => {
+  it("keeps play now and show info on an externally managed queue's track items", () => {
     storeMock.activePlayerQueue = playerQueue({
       items: 5,
       current_index: 0,


### PR DESCRIPTION
# What does this implement/fix?

Frontend companion (phase 1) for the Spotify Connect queue delegation on the server. The server now sets `PlayerQueue.queue_owner` to the owning AudioSource's uri while an external session (e.g. Spotify Connect) owns the queue's ordering; `null`/absent means MA owns the queue as before.

While a queue is session-owned, the queue view no longer advertises editing a mirror it can't change:

- Queue items render read-only: drag-to-reorder and the per-item play next / move to end / remove actions are withheld (play now and show info keep working).
- The crossfade and autoplay toggles are hidden — the session provides those natively. Shuffle and repeat keep working (the server forwards them to the session), including the dedicated buttons that were previously disabled for any live-source queue.
- Queue-level clear and transfer stay available on purpose: the server releases or re-targets the session for those.
- A subtle "Queue managed by <source name>" hint is shown above the queue list.

Older servers never send the field, so nothing changes there.

**Related backend PR (if applicable):**

- related backend PR https://github.com/music-assistant/server/pull/5880

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm lint:check` passes.
- [x] `pnpm test:run` passes, and tests have been added/updated where applicable.
- [x] `pnpm build` passes.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
