### PR TITLE
Fill the MilkDrop droplet icon while the visualizer is enabled

### DIFF
--- a/src/helpers/player_menu_items.ts
+++ b/src/helpers/player_menu_items.ts
@@ -14,9 +14,10 @@ import { getSleepTimerMenuItem, sleepTimerActive } from "@/helpers/sleep_timer";
 import { useAnnouncement } from "@/composables/useAnnouncement";
 import { useAudioOverlay } from "@/composables/useAudioOverlay";
 import { visualizerProviderAvailable } from "@/plugins/visualizer-relay";
+import { visualizerEnabledForPlayer } from "@/composables/visualizer/useVisualizer";
 import VisualizerMenuControl from "@/layouts/default/PlayerOSD/VisualizerMenuControl.vue";
 import { Droplet, Megaphone, Sparkles } from "@lucide/vue";
-import { markRaw } from "vue";
+import { h, markRaw } from "vue";
 import { useHosts } from "@/composables/ai-radio/useHosts";
 import { useShows } from "@/composables/ai-radio/useShows";
 import { authManager } from "@/plugins/auth";
@@ -354,11 +355,19 @@ export const getPlayerMenuItems = (
     });
   }
 
-  // MilkDrop visualizer popout (both menus), kept just above the settings entry
+  // MilkDrop visualizer popout (both menus), kept just above the settings
+  // entry; the droplet fills while enabled for this player (live, since the
+  // enabled preference is reactive store state)
   if (visualizerProviderAvailable()) {
     menuItems.push({
       label: "settings.visualizer_enabled.label",
-      icon: markRaw(Droplet),
+      icon: markRaw(() =>
+        h(Droplet, {
+          fill: visualizerEnabledForPlayer(player.player_id)
+            ? "currentColor"
+            : "none",
+        }),
+      ),
       subComponent: markRaw(VisualizerMenuControl),
       componentProps: { playerId: player.player_id },
     });

--- a/src/layouts/default/PlayerOSD/VisualizerMenuControl.vue
+++ b/src/layouts/default/PlayerOSD/VisualizerMenuControl.vue
@@ -5,7 +5,11 @@
 <template>
   <div ref="menuEl" class="visualizer-menu" @pointerdown.stop @click.stop>
     <div class="visualizer-menu__row">
-      <Droplet :size="20" class="visualizer-menu__icon" />
+      <Droplet
+        :size="20"
+        class="visualizer-menu__icon"
+        :fill="enabledPref ? 'currentColor' : 'none'"
+      />
       <span class="visualizer-menu__label">{{ $t("visualizer.enabled") }}</span>
       <Switch
         :model-value="enabledPref"


### PR DESCRIPTION
# What does this implement/fix?

Fills the MilkDrop droplet icon with `currentColor` while the visualizer is enabled, matching the party dashboard's toggle. Applies to the player menu entry (live per player, since the enabled preference is reactive store state) and the "Enabled" row inside the popout.

**Related issue (if applicable):**

- n/a

**Related backend PR (if applicable):**

- n/a

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm lint:check` passes.
- [x] `pnpm test:run` passes, and tests have been added/updated where applicable.
- [x] `pnpm build` passes.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
