### PR TITLE
Swiping back no longer shows the previous page twice

### DIFF
--- a/src/composables/useEdgeSwipeNavigation.ts
+++ b/src/composables/useEdgeSwipeNavigation.ts
@@ -81,8 +81,9 @@ export function useEdgeSwipeNavigation() {
   let unregisterLanding: (() => void) | null = null;
   let preview: PagePreview | null = null;
   let previewKey: string | null = null;
-  // the entry behind the page at drag start is what the abort compares
-  // against, so an in-place query sync can be told apart from real movement
+  // the entry behind the page when the gesture arms is what the abort
+  // compares against, so an in-place query sync can be told apart from real
+  // movement
   let dragStartBack: unknown = null;
 
   // the DOM still shows the outgoing page when afterEach runs, which is the
@@ -97,14 +98,15 @@ export function useEdgeSwipeNavigation() {
     storePagePreview(from.fullPath, capturePagePreview(surface));
   });
 
-  // a navigation can land while a drag or its settle is still on stage — the
-  // OS back gesture, a background push, a hardware back button — pulling a new
-  // page onto the live surface while a still of it sits behind, so everything
-  // stops on the spot. A failed navigation moved nothing, and neither does a
-  // same-page query sync replacing in place; those leave the drag alone.
+  // a navigation can land while a gesture is armed, dragging, or settling —
+  // the OS back gesture, a background push, a hardware back button — pulling
+  // a new page onto the live surface, so everything stops on the spot: even
+  // an action still waiting on its direction lock was decided for the page
+  // that just left. A failed navigation moved nothing, and neither does a
+  // same-page query sync replacing in place; those leave the gesture alone.
   const unregisterAbort = router.afterEach((to, from, failure) => {
     if (failure || parked.value) return;
-    if (!dragging.value && !settling.value) return;
+    if (!swipeAction.value && !dragging.value && !settling.value) return;
     if (
       to.path === from.path &&
       router.options.history.state.back === dragStartBack
@@ -163,7 +165,10 @@ export function useEdgeSwipeNavigation() {
     swipeEdge.value = ours ? edge : null;
     swipeAction.value = ours && edge ? actionFor(edge) : null;
     trackedTouchId = swipeAction.value ? (touch.identifier ?? 0) : null;
-    if (swipeAction.value) holdGesture(event.target);
+    if (swipeAction.value) {
+      dragStartBack = router.options.history.state.back;
+      holdGesture(event.target);
+    }
   }
 
   function onTouchMove(event: TouchEvent) {
@@ -192,7 +197,6 @@ export function useEdgeSwipeNavigation() {
         return;
       }
       dragging.value = true;
-      dragStartBack = router.options.history.state.back;
       if (action === "back") mountPreview();
     }
 

--- a/src/composables/useEdgeSwipeNavigation.ts
+++ b/src/composables/useEdgeSwipeNavigation.ts
@@ -3,6 +3,7 @@ import {
   useMobileSidebarSide,
   type MobileSidebarSide,
 } from "@/composables/useMobileSidebarSide";
+import { isEmbedded } from "@/helpers/embedded";
 import { canGoBack } from "@/helpers/navigation";
 import {
   capturePagePreview,
@@ -47,10 +48,11 @@ type SwipeAction = "menu" | "back";
  * to the navigation. The drag also has to commit to the horizontal axis, and
  * once it has, it keeps the gesture for the rest of the touch.
  *
- * Installed iOS web apps bring their own back gesture over the same edge,
- * so the back half of this gesture stands down there and the OS animation is
- * the only one that runs. A navigation that lands mid-gesture from anywhere
- * else resets the drag on the spot.
+ * Mobile browsers bring their own back gesture over the same edge, so the
+ * back half of this gesture only runs when a host page frames the app (see
+ * `isEmbedded`) and keeps that gesture to itself; everywhere else the
+ * browser's animation is the only one. The menu edge is unaffected. A
+ * navigation that lands mid-gesture resets the drag on the spot.
  *
  * Only active while the mobile sidebar is closed. Bind the returned handlers
  * as passive touchstart/touchmove/touchend/touchcancel listeners, and
@@ -86,8 +88,8 @@ export function useEdgeSwipeNavigation() {
   // the DOM still shows the outgoing page when afterEach runs, which is the
   // last chance to photograph it for the swipe that later returns to it; only
   // a forward navigation leaves that page one step back, so anything else
-  // (replace, back, failed) would store a still no swipe can ever reveal —
-  // and with the back swipe left to the OS, no drag reveals one either
+  // (replace, back, failed) would store a still no swipe can ever reveal, and
+  // where the browser owns the back swipe no drag reveals one either
   const unregisterCapture = router.afterEach((to, from, failure) => {
     const surface = surfaceRef.value;
     if (failure || !isMobile.value || !surface || systemOwnsBackSwipe()) return;
@@ -371,8 +373,8 @@ export function useEdgeSwipeNavigation() {
     if (edge === side && (side === "right" || route.name === "discover")) {
       return "menu";
     }
-    // the OS gesture owns this edge in installed apps; claiming the touch
-    // too would paint the previous page twice
+    // outside a host the browser owns this edge; claiming the touch too
+    // would paint the previous page twice
     if (systemOwnsBackSwipe()) return null;
     return canGoBack(router) ? "back" : null;
   }
@@ -430,14 +432,13 @@ function horizontalScrollerAt(event: TouchEvent): Element | null {
   return null;
 }
 
-/** Whether the OS brings its own back-swipe gesture to this page. */
+/** Whether the browser brings its own back-swipe gesture to this page. */
 function systemOwnsBackSwipe(): boolean {
-  // only iOS home-screen web apps expose this property; their OS gesture
-  // navigates history by itself, and a second drag run next to it would
-  // paint the previous page twice
-  return (
-    (navigator as Navigator & { standalone?: boolean }).standalone === true
-  );
+  // every mobile browser we run in claims the same edge: iOS animates a system
+  // snapshot of the previous page, Android chains the system back gesture. A
+  // second drag run next to one of those paints the previous page twice, so
+  // the gesture is only ours inside a host that keeps navigation to itself.
+  return !isEmbedded();
 }
 
 function scrollerOwnsSwipe(

--- a/src/composables/useEdgeSwipeNavigation.ts
+++ b/src/composables/useEdgeSwipeNavigation.ts
@@ -47,6 +47,11 @@ type SwipeAction = "menu" | "back";
  * to the navigation. The drag also has to commit to the horizontal axis, and
  * once it has, it keeps the gesture for the rest of the touch.
  *
+ * Installed iOS web apps bring their own back gesture over the same edge,
+ * so the back half of this gesture stands down there and the OS animation is
+ * the only one that runs. A navigation that lands mid-gesture from anywhere
+ * else resets the drag on the spot.
+ *
  * Only active while the mobile sidebar is closed. Bind the returned handlers
  * as passive touchstart/touchmove/touchend/touchcancel listeners, and
  * `surfaceRef` plus `swipeStyle` on the element holding the page.
@@ -74,16 +79,40 @@ export function useEdgeSwipeNavigation() {
   let unregisterLanding: (() => void) | null = null;
   let preview: PagePreview | null = null;
   let previewKey: string | null = null;
+  // the entry behind the page at drag start is what the abort compares
+  // against, so an in-place query sync can be told apart from real movement
+  let dragStartBack: unknown = null;
 
   // the DOM still shows the outgoing page when afterEach runs, which is the
   // last chance to photograph it for the swipe that later returns to it; only
   // a forward navigation leaves that page one step back, so anything else
-  // (replace, back, failed) would store a still no swipe can ever reveal
+  // (replace, back, failed) would store a still no swipe can ever reveal —
+  // and with the back swipe left to the OS, no drag reveals one either
   const unregisterCapture = router.afterEach((to, from, failure) => {
     const surface = surfaceRef.value;
-    if (failure || !isMobile.value || !surface) return;
+    if (failure || !isMobile.value || !surface || systemOwnsBackSwipe()) return;
     if (router.options.history.state.back !== from.fullPath) return;
     storePagePreview(from.fullPath, capturePagePreview(surface));
+  });
+
+  // a navigation can land while a drag or its settle is still on stage — the
+  // OS back gesture, a background push, a hardware back button — pulling a new
+  // page onto the live surface while a still of it sits behind, so everything
+  // stops on the spot. A failed navigation moved nothing, and neither does a
+  // same-page query sync replacing in place; those leave the drag alone.
+  const unregisterAbort = router.afterEach((to, from, failure) => {
+    if (failure || parked.value) return;
+    if (!dragging.value && !settling.value) return;
+    if (
+      to.path === from.path &&
+      router.options.history.state.back === dragStartBack
+    )
+      return;
+    clearTimeout(settleTimer);
+    settling.value = false;
+    clearGesture();
+    pageOffset.value = 0;
+    shelvePreview();
   });
 
   const swipeStyle = computed<StyleValue | undefined>(() => {
@@ -161,6 +190,7 @@ export function useEdgeSwipeNavigation() {
         return;
       }
       dragging.value = true;
+      dragStartBack = router.options.history.state.back;
       if (action === "back") mountPreview();
     }
 
@@ -264,15 +294,7 @@ export function useEdgeSwipeNavigation() {
   }
 
   function commit() {
-    const fromPath = route.fullPath;
     slide(viewportWidth(), () => {
-      // something else navigated while the page was sliding out; a back now
-      // would pop whatever that navigation put on top instead
-      if (route.fullPath !== fromPath) {
-        pageOffset.value = 0;
-        dropPreview();
-        return;
-      }
       parked.value = true;
       router.back();
       awaitLanding();
@@ -349,6 +371,9 @@ export function useEdgeSwipeNavigation() {
     if (edge === side && (side === "right" || route.name === "discover")) {
       return "menu";
     }
+    // the OS gesture owns this edge in installed apps; claiming the touch
+    // too would paint the previous page twice
+    if (systemOwnsBackSwipe()) return null;
     return canGoBack(router) ? "back" : null;
   }
 
@@ -357,6 +382,7 @@ export function useEdgeSwipeNavigation() {
     clearTimeout(landingTimer);
     unregisterLanding?.();
     unregisterCapture();
+    unregisterAbort();
     releaseGesture();
     dropPreview();
     clearPagePreviews();
@@ -402,6 +428,16 @@ function horizontalScrollerAt(event: TouchEvent): Element | null {
     element = element.parentElement;
   }
   return null;
+}
+
+/** Whether the OS brings its own back-swipe gesture to this page. */
+function systemOwnsBackSwipe(): boolean {
+  // only iOS home-screen web apps expose this property; their OS gesture
+  // navigates history by itself, and a second drag run next to it would
+  // paint the previous page twice
+  return (
+    (navigator as Navigator & { standalone?: boolean }).standalone === true
+  );
 }
 
 function scrollerOwnsSwipe(

--- a/src/helpers/embedded.ts
+++ b/src/helpers/embedded.ts
@@ -1,0 +1,9 @@
+/**
+ * Whether a host page frames the app, such as the Home Assistant panel.
+ *
+ * A host keeps navigation to itself, so gestures the browser normally runs
+ * over the whole window do not reach us there and are ours to bring.
+ */
+export function isEmbedded(): boolean {
+  return window.self !== window.top;
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -42,6 +42,7 @@ import App from "./App.vue";
 import { createApp } from "vue";
 
 // Plugins
+import { isEmbedded } from "@/helpers/embedded";
 import { registerPlugins } from "@/plugins";
 
 // Install Sendspin WebSocket interceptor for authenticated connections
@@ -54,7 +55,7 @@ installSendspinInterceptor();
 // Safari reports the ones belonging to the page around us. A host that hands
 // the safe area over instead reports what it stopped covering, and those
 // values land on the same properties inline, above this.
-if (window.self !== window.top) {
+if (isEmbedded()) {
   document.documentElement.setAttribute("data-embedded-layout", "");
 }
 

--- a/tests/composables/useEdgeSwipeNavigation.test.ts
+++ b/tests/composables/useEdgeSwipeNavigation.test.ts
@@ -624,6 +624,39 @@ describe("useEdgeSwipeNavigation", () => {
     expect(main.querySelectorAll("[inert]").length).toBe(1);
   });
 
+  // the same landing in the window between the touch starting and the 12px
+  // direction lock: the armed action was decided for the page that just left,
+  // so letting the finger carry on would commit a back it never asked for
+  it("disarms a pending gesture when something else navigates before the lock", () => {
+    routeState.name = "album";
+    historyState.back = "/discover";
+    const { onTouchStart, onTouchMove, onTouchEnd } = useEdgeSwipeNavigation();
+
+    onTouchStart(touchEvent(10, 100));
+    fireNavigation("/other", "/album");
+
+    onTouchMove(touchEvent(150, 100));
+    endSwipe(onTouchEnd);
+
+    expect(mockRouterBack).not.toHaveBeenCalled();
+  });
+
+  // the query-sync exemption holds in that window too: the page never moved,
+  // so the armed gesture is still about the right page
+  it("keeps a pending gesture through a same-page query sync", () => {
+    routeState.name = "album";
+    historyState.back = "/discover";
+    const { onTouchStart, onTouchMove, onTouchEnd } = useEdgeSwipeNavigation();
+
+    onTouchStart(touchEvent(10, 100));
+    fireNavigation("/album", "/album");
+
+    onTouchMove(touchEvent(150, 100));
+    endSwipe(onTouchEnd);
+
+    expect(mockRouterBack).toHaveBeenCalledTimes(1);
+  });
+
   // the same landing during the slide back into place after a swipe fell
   // short: the settle must not carry on over the freshly navigated page
   it("resets a settling cancel when something else navigates", () => {

--- a/tests/composables/useEdgeSwipeNavigation.test.ts
+++ b/tests/composables/useEdgeSwipeNavigation.test.ts
@@ -70,10 +70,22 @@ function touchEvent(x: number, y: number, target?: Element): TouchEvent {
   } as unknown as TouchEvent;
 }
 
-/** Makes the page look like it runs inside an installed (home screen) app. */
-function runAsInstalledApp() {
-  Object.defineProperty(window.navigator, "standalone", {
-    value: true,
+/**
+ * Frames the page in a host, as the Home Assistant panel does. The back half
+ * of the gesture is only ours there, so this is the default for these tests
+ * and `runInBrowserTab` is what opts out of it.
+ */
+function runInsideHost() {
+  Object.defineProperty(window, "top", {
+    value: {} as Window,
+    configurable: true,
+  });
+}
+
+/** Puts the page back at the top level, where the browser owns the back edge. */
+function runInBrowserTab() {
+  Object.defineProperty(window, "top", {
+    value: window,
     configurable: true,
   });
 }
@@ -144,6 +156,7 @@ async function landNavigation() {
 beforeEach(() => {
   vi.useFakeTimers();
   setViewportWidth(800);
+  runInsideHost();
 });
 
 afterEach(() => {
@@ -159,7 +172,7 @@ afterEach(() => {
   historyState.back = null;
   document.body.innerHTML = "";
   clearPagePreviews();
-  delete (window.navigator as { standalone?: boolean }).standalone;
+  runInBrowserTab();
   if (originalInnerWidth) {
     Object.defineProperty(window, "innerWidth", originalInnerWidth);
   }
@@ -375,11 +388,11 @@ describe("useEdgeSwipeNavigation", () => {
     expect(swipeStyle.value).toBeUndefined();
   });
 
-  // installed web apps get an OS back gesture over the same edge, animating a
-  // system snapshot of the previous page by itself; a second drag run next to
-  // it would paint the previous page twice, so ours stands down
-  it("leaves the back swipe to the OS in an installed web app", () => {
-    runAsInstalledApp();
+  // every mobile browser animates its own snapshot of the previous page over
+  // this edge, in a plain tab as much as in an installed app; a second drag
+  // run next to it would paint the previous page twice, so ours stands down
+  it("leaves the back swipe to the browser outside a host", () => {
+    runInBrowserTab();
     routeState.name = "album";
     historyState.back = "/discover";
     const { onTouchStart, onTouchMove, onTouchEnd, swipeStyle } =
@@ -397,9 +410,9 @@ describe("useEdgeSwipeNavigation", () => {
     expect(swipeStyle.value).toBeUndefined();
   });
 
-  // the OS gesture only takes the back half; the menu edge stays ours
-  it("still opens the menu in an installed web app", () => {
-    runAsInstalledApp();
+  // the browser gesture only takes the back half; the menu edge stays ours
+  it("still opens the menu outside a host", () => {
+    runInBrowserTab();
     historyState.back = "/settings";
     const { onTouchStart, onTouchMove } = useEdgeSwipeNavigation();
 

--- a/tests/composables/useEdgeSwipeNavigation.test.ts
+++ b/tests/composables/useEdgeSwipeNavigation.test.ts
@@ -12,7 +12,11 @@ const {
   routeState,
   sidebarState,
 } = vi.hoisted(() => ({
-  afterEachHooks: [] as ((to: unknown, from: unknown) => void)[],
+  afterEachHooks: [] as ((
+    to: unknown,
+    from: unknown,
+    failure?: unknown,
+  ) => void)[],
   historyState: { back: null as string | null },
   mobileSidebarSide: { value: "left" as "left" | "right" },
   mockRouterBack: vi.fn(),
@@ -37,7 +41,9 @@ vi.mock("vue-router", () => ({
   useRoute: () => routeState,
   useRouter: () => ({
     back: mockRouterBack,
-    afterEach: (hook: (to: unknown, from: unknown) => void) => {
+    afterEach: (
+      hook: (to: unknown, from: unknown, failure?: unknown) => void,
+    ) => {
       afterEachHooks.push(hook);
       return () => {
         const at = afterEachHooks.indexOf(hook);
@@ -62,6 +68,14 @@ function touchEvent(x: number, y: number, target?: Element): TouchEvent {
     target,
     currentTarget: target?.closest("main"),
   } as unknown as TouchEvent;
+}
+
+/** Makes the page look like it runs inside an installed (home screen) app. */
+function runAsInstalledApp() {
+  Object.defineProperty(window.navigator, "standalone", {
+    value: true,
+    configurable: true,
+  });
 }
 
 /**
@@ -100,11 +114,30 @@ function endSwipe(onTouchEnd: () => void) {
   vi.advanceTimersByTime(SETTLE_MS);
 }
 
+/** Mounts the swipeable page surface under a fresh `<main>` in the body. */
+function mountSurface(surfaceRef: { value: HTMLElement | null }): HTMLElement {
+  const main = document.createElement("main");
+  const surface = document.createElement("div");
+  main.appendChild(surface);
+  document.body.appendChild(main);
+  surfaceRef.value = surface;
+  return main;
+}
+
+/** Runs the router's afterEach hooks as a navigation between two paths. */
+function fireNavigation(toPath: string, fromPath: string, failure?: unknown) {
+  for (const hook of afterEachHooks) {
+    hook(
+      { path: toPath, fullPath: toPath },
+      { path: fromPath, fullPath: fromPath },
+      failure,
+    );
+  }
+}
+
 /** Tells the composable the back navigation it asked for has finished. */
 async function landNavigation() {
-  for (const hook of afterEachHooks) {
-    hook({ fullPath: "/discover" }, { fullPath: "/album" });
-  }
+  fireNavigation("/discover", "/album");
   await nextTick();
 }
 
@@ -126,6 +159,7 @@ afterEach(() => {
   historyState.back = null;
   document.body.innerHTML = "";
   clearPagePreviews();
+  delete (window.navigator as { standalone?: boolean }).standalone;
   if (originalInnerWidth) {
     Object.defineProperty(window, "innerWidth", originalInnerWidth);
   }
@@ -341,6 +375,40 @@ describe("useEdgeSwipeNavigation", () => {
     expect(swipeStyle.value).toBeUndefined();
   });
 
+  // installed web apps get an OS back gesture over the same edge, animating a
+  // system snapshot of the previous page by itself; a second drag run next to
+  // it would paint the previous page twice, so ours stands down
+  it("leaves the back swipe to the OS in an installed web app", () => {
+    runAsInstalledApp();
+    routeState.name = "album";
+    historyState.back = "/discover";
+    const { onTouchStart, onTouchMove, onTouchEnd, swipeStyle } =
+      useEdgeSwipeNavigation();
+
+    onTouchStart(touchEvent(10, 100));
+    onTouchMove(touchEvent(150, 100));
+
+    // the page must not follow the finger next to the OS animation either
+    expect(swipeStyle.value).toBeUndefined();
+
+    endSwipe(onTouchEnd);
+
+    expect(mockRouterBack).not.toHaveBeenCalled();
+    expect(swipeStyle.value).toBeUndefined();
+  });
+
+  // the OS gesture only takes the back half; the menu edge stays ours
+  it("still opens the menu in an installed web app", () => {
+    runAsInstalledApp();
+    historyState.back = "/settings";
+    const { onTouchStart, onTouchMove } = useEdgeSwipeNavigation();
+
+    onTouchStart(touchEvent(10, 100));
+    onTouchMove(touchEvent(80, 100));
+
+    expect(mockSetOpenMobile).toHaveBeenCalledWith(true);
+  });
+
   // a stray thumb or palm landing mid-drag must not re-litigate a gesture
   // already under way
   it("ignores a second finger landing mid-drag", () => {
@@ -445,16 +513,10 @@ describe("useEdgeSwipeNavigation", () => {
     historyState.back = "/discover";
     const { onTouchStart, onTouchMove, onTouchEnd, surfaceRef } =
       useEdgeSwipeNavigation();
-    const main = document.createElement("main");
-    const surface = document.createElement("div");
-    main.appendChild(surface);
-    document.body.appendChild(main);
-    surfaceRef.value = surface;
+    const main = mountSurface(surfaceRef);
 
     // the page behind was photographed when it was navigated away from
-    for (const hook of afterEachHooks) {
-      hook({ fullPath: "/album" }, { fullPath: "/discover" });
-    }
+    fireNavigation("/album", "/discover");
 
     onTouchStart(touchEvent(10, 100));
     onTouchMove(touchEvent(150, 100));
@@ -462,6 +524,8 @@ describe("useEdgeSwipeNavigation", () => {
     endSwipe(onTouchEnd);
 
     await landNavigation();
+    // still covering the incoming page's first frame at this point
+    expect(main.querySelectorAll("[inert]").length).toBe(1);
     vi.advanceTimersByTime(20); // the removal is deferred one frame
 
     expect(main.querySelectorAll("[inert]").length).toBe(0);
@@ -497,16 +561,10 @@ describe("useEdgeSwipeNavigation", () => {
     historyState.back = "/discover";
     const { onTouchStart, onTouchMove, onTouchEnd, surfaceRef } =
       useEdgeSwipeNavigation();
-    const main = document.createElement("main");
-    const surface = document.createElement("div");
-    main.appendChild(surface);
-    document.body.appendChild(main);
-    surfaceRef.value = surface;
+    const main = mountSurface(surfaceRef);
 
     // the page behind was photographed when it was navigated away from
-    for (const hook of afterEachHooks) {
-      hook({ fullPath: "/album" }, { fullPath: "/discover" });
-    }
+    fireNavigation("/album", "/discover");
 
     onTouchStart(touchEvent(10, 100));
     onTouchMove(touchEvent(50, 100)); // 40px, under the 60px threshold
@@ -519,6 +577,110 @@ describe("useEdgeSwipeNavigation", () => {
     onTouchMove(touchEvent(50, 100));
 
     expect(main.querySelectorAll("[inert]").length).toBe(1);
+  });
+
+  // a navigation landing mid-drag — a background push, a hardware back
+  // button — pulls a new page onto the live surface while the drag still
+  // shows a still behind it, so the whole drag stops on the spot
+  it("resets the drag when something else navigates mid-gesture", () => {
+    routeState.name = "album";
+    historyState.back = "/discover";
+    const { onTouchStart, onTouchMove, onTouchEnd, surfaceRef, swipeStyle } =
+      useEdgeSwipeNavigation();
+    const main = mountSurface(surfaceRef);
+
+    // the page behind was photographed when it was navigated away from
+    fireNavigation("/album", "/discover");
+
+    onTouchStart(touchEvent(10, 100));
+    onTouchMove(touchEvent(150, 100));
+    expect(main.querySelectorAll("[inert]").length).toBe(1);
+
+    fireNavigation("/other", "/album");
+
+    expect(main.querySelectorAll("[inert]").length).toBe(0);
+    expect(swipeStyle.value).toBeUndefined();
+
+    // the finger lifting afterwards has nothing left to commit
+    endSwipe(onTouchEnd);
+    expect(mockRouterBack).not.toHaveBeenCalled();
+
+    // the still went back on the shelf, so a retried swipe re-mounts it
+    onTouchStart(touchEvent(10, 100));
+    onTouchMove(touchEvent(150, 100));
+    expect(main.querySelectorAll("[inert]").length).toBe(1);
+  });
+
+  // the same landing during the slide back into place after a swipe fell
+  // short: the settle must not carry on over the freshly navigated page
+  it("resets a settling cancel when something else navigates", () => {
+    routeState.name = "album";
+    historyState.back = "/discover";
+    const { onTouchStart, onTouchMove, onTouchEnd, surfaceRef, swipeStyle } =
+      useEdgeSwipeNavigation();
+    const main = mountSurface(surfaceRef);
+
+    // the page behind was photographed when it was navigated away from
+    fireNavigation("/album", "/discover");
+
+    onTouchStart(touchEvent(10, 100));
+    onTouchMove(touchEvent(50, 100)); // 40px, under the 60px threshold
+    onTouchEnd();
+    vi.advanceTimersByTime(100); // mid-settle
+
+    fireNavigation("/other", "/album");
+
+    expect(main.querySelectorAll("[inert]").length).toBe(0);
+    expect(swipeStyle.value).toBeUndefined();
+  });
+
+  // a navigation that failed moved nothing, so the drag has nothing to
+  // yield to and carries on
+  it("keeps the drag through a failed navigation", () => {
+    routeState.name = "album";
+    historyState.back = "/discover";
+    const { onTouchStart, onTouchMove, onTouchEnd, surfaceRef, swipeStyle } =
+      useEdgeSwipeNavigation();
+    const main = mountSurface(surfaceRef);
+
+    // the page behind was photographed when it was navigated away from
+    fireNavigation("/album", "/discover");
+
+    onTouchStart(touchEvent(10, 100));
+    onTouchMove(touchEvent(150, 100));
+
+    fireNavigation("/album", "/album", new Error("duplicated"));
+
+    expect(main.querySelectorAll("[inert]").length).toBe(1);
+    expect(swipeStyle.value).toBeDefined();
+
+    endSwipe(onTouchEnd);
+    expect(mockRouterBack).toHaveBeenCalledTimes(1);
+  });
+
+  // a query tucked into the URL mid-drag replaces the route in place: same
+  // path, same entry behind it, so the page never moved and neither does
+  // the drag
+  it("keeps the drag through a same-page query sync", () => {
+    routeState.name = "album";
+    historyState.back = "/discover";
+    const { onTouchStart, onTouchMove, onTouchEnd, surfaceRef, swipeStyle } =
+      useEdgeSwipeNavigation();
+    const main = mountSurface(surfaceRef);
+
+    // the page behind was photographed when it was navigated away from
+    fireNavigation("/album", "/discover");
+
+    onTouchStart(touchEvent(10, 100));
+    onTouchMove(touchEvent(150, 100));
+
+    fireNavigation("/album", "/album");
+
+    expect(main.querySelectorAll("[inert]").length).toBe(1);
+    expect(swipeStyle.value).toBeDefined();
+
+    endSwipe(onTouchEnd);
+    expect(mockRouterBack).toHaveBeenCalledTimes(1);
   });
 
   // a thumb naturally arcs upward as it crosses the screen; once the drag has


### PR DESCRIPTION
# What does this implement/fix?

Slowly swiping back on mobile showed the previous page twice, stacked side by side: the browser's own back-swipe snapshot animated right next to our swipe-back preview. This was first reported in the installed web app (iOS 18.4 added the OS gesture there), but it reproduces in a plain iOS Safari tab as well, confirmed on device: Safari has run its own edge back-swipe since iOS 7, and Android Chrome brings its own edge navigation too. So this was never PWA-specific.

Rather than fighting the browser gesture (which would cost scrolling and taps along the screen edge, and cannot be suppressed reliably on iOS anyway), our swipe-back now steps aside wherever the browser brings its own. That is everywhere except when a host page frames the app, which in practice is the Home Assistant panel; that is detected by the same iframe signal that already drives the embedded layout.

- In browser tabs and installed web apps the back swipe is left to the browser/OS, which navigates and animates it natively; our own swipe-back keeps working in the Home Assistant apps, whose webviews bring no back gesture of their own (the iOS app never enables WKWebView's back-forward gesture, and the Android app maps system back to webview history itself)
- The edge swipe that opens the menu is unaffected
- A navigation that lands mid-swipe from anywhere else (a background page change, a hardware back button) resets the drag on the spot instead of lingering over the new page, now also when it lands before the drag's direction lock, so an armed gesture can no longer commit a back that was decided for a page that already left; filter/query updates and failed navigations still leave the drag alone

**Related issue (if applicable):**

- related issue ``

**Related backend PR (if applicable):**

- related backend PR ``

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm lint:check` passes.
- [x] `pnpm test:run` passes, and tests have been added/updated where applicable.
- [x] `pnpm build` passes.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
