### PR TITLE
Enter in mobile search hides the keyboard instead of opening the first result

### DIFF
--- a/src/components/CommandCenter.vue
+++ b/src/components/CommandCenter.vue
@@ -7,6 +7,7 @@
     <div
       data-slot="command-input-wrapper"
       class="flex h-14 shrink-0 items-center gap-3 border-b px-4"
+      @keydown.enter.capture="dismissKeyboardOnTouch"
     >
       <Search class="size-5 shrink-0 opacity-50" />
       <ListboxFilter
@@ -14,6 +15,7 @@
         v-model="query"
         data-slot="command-input"
         auto-focus
+        enterkeyhint="done"
         :placeholder="$t('type_to_search')"
         class="placeholder:text-muted-foreground flex h-12 w-full rounded-md bg-transparent py-3 text-base outline-hidden disabled:cursor-not-allowed disabled:opacity-50"
       />
@@ -333,6 +335,19 @@ const focusInput = function () {
   inputEl?.focus();
 };
 
+// on the mobile sheet on a touch screen the on-screen keyboard drives the
+// interaction, and the return key's job is to put it away — the results are
+// already live — while reka would click the highlighted row, so the enter is
+// settled here on the wrapper before it can reach the input
+const dismissKeyboardOnTouch = function (event: KeyboardEvent) {
+  // the enter that commits an IME conversion belongs to the composition, not
+  // to us; keyCode 229 covers webkit reporting that keydown as not composing
+  if (event.isComposing || event.keyCode === 229) return;
+  if (!store.isTouchscreen || !store.mobileLayout) return;
+  event.stopPropagation();
+  (filterRef.value?.$el as HTMLElement | undefined)?.blur();
+};
+
 const dedupeKey = (item: MediaItemTypeOrItemMapping): string | null => {
   if (!item.name || item.media_type === MediaType.PLAYLIST) return null;
   const artist =
@@ -584,10 +599,15 @@ watch([query, pagesOnly], () => {
   }, DEBOUNCE_MS);
 });
 
+// highlight the first row as results land so a desktop enter opens the top
+// hit; on the mobile sheet on a touch screen the on-screen keyboard drives
+// the interaction — there is no enter contract there and the phantom
+// highlight would read as a selection nobody made
 watch(
   () =>
     mediaSections.value.map((section) => section.items[0]?.uri ?? "").join("|"),
   async () => {
+    if (store.isTouchscreen && store.mobileLayout) return;
     if (!isOpen.value || !queryActive.value) return;
     await nextTick();
     const listEl = listRef.value?.$el as HTMLElement | undefined;

--- a/tests/components/CommandCenter.test.ts
+++ b/tests/components/CommandCenter.test.ts
@@ -138,7 +138,9 @@ function makeTrack(id: string, name: string) {
   };
 }
 
-const CommandDialogStub = {
+// the shell picks a sheet or a dialog by layout; the palette under test only
+// hands it the open flag and a slot, so one stub covers both
+const CommandCenterShellStub = {
   props: ["open"],
   emits: ["update:open"],
   template: '<div v-if="open" data-testid="command-center"><slot /></div>',
@@ -160,7 +162,7 @@ function mountPalette() {
   return mount(CommandCenter, {
     global: {
       stubs: {
-        CommandDialog: CommandDialogStub,
+        CommandCenterShell: CommandCenterShellStub,
         CommandList: { template: "<div><slot /></div>" },
         CommandGroup: {
           props: ["heading"],
@@ -222,6 +224,7 @@ beforeEach(() => {
   state.storeMock.dialogActive = false;
   state.storeMock.activePlayerId = undefined;
   state.storeMock.mobileLayout = false;
+  state.storeMock.isTouchscreen = false;
   vi.clearAllMocks();
 });
 
@@ -660,6 +663,145 @@ describe("CommandCenter", () => {
     await itemByText(wrapper, "Kitchen").trigger("click");
     expect(state.storeMock.activePlayerId).toBe("p1");
     expect(wrapper.find('[data-testid="command-center"]').exists()).toBe(false);
+
+    wrapper.unmount();
+  });
+
+  it("puts the on-screen keyboard away on enter instead of picking a result", async () => {
+    state.storeMock.isTouchscreen = true;
+    state.storeMock.mobileLayout = true;
+    state.resultsByType[MediaType.TRACK] = [
+      makeTrack("t1", "Bohemian Rhapsody"),
+    ];
+    const wrapper = mountPalette();
+    useCommandCenter().open();
+    await flushPromises();
+
+    await typeQuery(wrapper, "bohemian");
+
+    const input = wrapper.get('[data-testid="palette-input"]')
+      .element as HTMLInputElement;
+    const blurSpy = vi.spyOn(input, "blur");
+    // reka's own enter handler sits on the input itself, so an enter that
+    // reaches it would open the highlighted row
+    const reachedInput: string[] = [];
+    input.addEventListener("keydown", (event) => reachedInput.push(event.key));
+
+    input.dispatchEvent(
+      new KeyboardEvent("keydown", { key: "Enter", bubbles: true }),
+    );
+
+    expect(blurSpy).toHaveBeenCalled();
+    expect(reachedInput).not.toContain("Enter");
+
+    wrapper.unmount();
+  });
+
+  it("skips the first-result highlight on the mobile sheet", async () => {
+    state.storeMock.isTouchscreen = true;
+    state.storeMock.mobileLayout = true;
+    state.resultsByType[MediaType.TRACK] = [
+      makeTrack("t1", "Bohemian Rhapsody"),
+    ];
+    const wrapper = mountPalette();
+    useCommandCenter().open();
+    await flushPromises();
+
+    const seen: string[] = [];
+    (
+      wrapper.get('[data-testid="palette-input"]').element as HTMLInputElement
+    ).addEventListener("keydown", (event) => seen.push(event.key));
+
+    await typeQuery(wrapper, "bohemian");
+    expect(wrapper.text()).toContain("Bohemian Rhapsody");
+    // no synthetic ArrowDown: there is no enter contract to prepare for
+    expect(seen).not.toContain("ArrowDown");
+
+    wrapper.unmount();
+  });
+
+  it("leaves the enter that commits an IME conversion to the composition", async () => {
+    state.storeMock.isTouchscreen = true;
+    state.storeMock.mobileLayout = true;
+    const wrapper = mountPalette();
+    useCommandCenter().open();
+    await flushPromises();
+
+    await typeQuery(wrapper, "bohemian");
+
+    const input = wrapper.get('[data-testid="palette-input"]')
+      .element as HTMLInputElement;
+    const blurSpy = vi.spyOn(input, "blur");
+    const reachedInput: string[] = [];
+    input.addEventListener("keydown", (event) => reachedInput.push(event.key));
+
+    // this enter picks the IME candidate; it is not a return-key press
+    input.dispatchEvent(
+      new KeyboardEvent("keydown", {
+        key: "Enter",
+        bubbles: true,
+        isComposing: true,
+      }),
+    );
+
+    expect(blurSpy).not.toHaveBeenCalled();
+    expect(reachedInput).toContain("Enter");
+
+    wrapper.unmount();
+  });
+
+  it("keeps the desktop enter contract on a touchscreen laptop", async () => {
+    // a touch screen with the desktop dialog: the footer still advertises
+    // enter, so it must keep opening the top hit
+    state.storeMock.isTouchscreen = true;
+    state.resultsByType[MediaType.TRACK] = [
+      makeTrack("t1", "Bohemian Rhapsody"),
+    ];
+    const wrapper = mountPalette();
+    useCommandCenter().open();
+    await flushPromises();
+
+    const input = wrapper.get('[data-testid="palette-input"]')
+      .element as HTMLInputElement;
+    const seen: string[] = [];
+    input.addEventListener("keydown", (event) => seen.push(event.key));
+
+    await typeQuery(wrapper, "bohemian");
+    expect(seen).toContain("ArrowDown");
+
+    const blurSpy = vi.spyOn(input, "blur");
+    input.dispatchEvent(
+      new KeyboardEvent("keydown", { key: "Enter", bubbles: true }),
+    );
+    expect(blurSpy).not.toHaveBeenCalled();
+    expect(seen).toContain("Enter");
+
+    wrapper.unmount();
+  });
+
+  it("highlights the first result on desktop and leaves focus alone on enter", async () => {
+    state.resultsByType[MediaType.TRACK] = [
+      makeTrack("t1", "Bohemian Rhapsody"),
+    ];
+    const wrapper = mountPalette();
+    useCommandCenter().open();
+    await flushPromises();
+
+    const input = wrapper.get('[data-testid="palette-input"]')
+      .element as HTMLInputElement;
+    const seen: string[] = [];
+    input.addEventListener("keydown", (event) => seen.push(event.key));
+
+    await typeQuery(wrapper, "bohemian");
+    // the synthetic ArrowDown that highlights the top hit for enter to open
+    expect(seen).toContain("ArrowDown");
+
+    const blurSpy = vi.spyOn(input, "blur");
+    input.dispatchEvent(
+      new KeyboardEvent("keydown", { key: "Enter", bubbles: true }),
+    );
+    expect(blurSpy).not.toHaveBeenCalled();
+    expect(seen).toContain("Enter");
 
     wrapper.unmount();
   });


### PR DESCRIPTION
# What does this implement/fix?

On mobile, pressing enter in the search screen opened the first result instead of just putting the keyboard away. Search results already appear live while typing, so on a phone the return key's only useful job is to dismiss the keyboard.

- On touch devices, enter now hides the on-screen keyboard and leaves the results as they are
- The mobile return key is labeled "Done"
- The first result is no longer pre-highlighted on touch devices, since there is no enter shortcut there
- Desktop is unchanged: enter still opens the top hit, as the footer hint advertises

**Related issue (if applicable):**

- related issue `<link to issue>`

**Related backend PR (if applicable):**

- related backend PR `<link to PR>`

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm lint:check` passes.
- [x] `pnpm test:run` passes, and tests have been added/updated where applicable.
- [x] `pnpm build` passes.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
