### PR TITLE
Line up the collapsed sidebar icons in one straight column

### DIFF
--- a/src/components/navigation/AppSidebar.vue
+++ b/src/components/navigation/AppSidebar.vue
@@ -131,9 +131,19 @@ onUnmounted(() => {
     <SidebarHeader>
       <SidebarMenu>
         <div class="sidebar-header-row">
+          <!-- collapsed, the 30px logo centres on a margin anchored off the
+               rail's final width (less the header's 1rem side padding), so it
+               holds still while the width animates -->
           <div
             class="sidebar-header"
-            :style="{ marginLeft: collapsed ? '2px' : '7px' }"
+            :style="
+              collapsed
+                ? {
+                    marginLeft:
+                      'calc((var(--sidebar-width-icon) - 1rem - 30px) / 2)',
+                  }
+                : { marginLeft: '7px' }
+            "
             @click="router.push('/')"
           >
             <img
@@ -263,6 +273,15 @@ onUnmounted(() => {
   min-height: 1.75rem !important;
   padding-top: 0.125rem !important;
   padding-bottom: 0.125rem !important;
+}
+
+/* collapsed to the icon rail, the buttons (2rem wide) centre on a margin
+   anchored off the rail's final width — which --sidebar-width-icon always
+   holds, the scrollbar gutter's widening included — rather than the animating
+   one, so they hold still through the collapse animation */
+[data-collapsible="icon"] :deep([data-sidebar="menu-button"]) {
+  margin-left: calc((var(--sidebar-width-icon) - 2rem) / 2) !important;
+  margin-right: 0 !important;
 }
 
 :deep([data-sidebar="menu-button"] > svg) {

--- a/src/components/navigation/NavMain.vue
+++ b/src/components/navigation/NavMain.vue
@@ -190,7 +190,13 @@ const draggedItem = computed(() =>
 
       <!-- Normal mode: navigation links -->
       <SidebarMenu v-else>
-        <SidebarMenuItem v-for="item in items" :key="item.title" class="mr-1.5">
+        <!-- the row gutter would skew the centred icon rail, so it lifts when
+             collapsed -->
+        <SidebarMenuItem
+          v-for="item in items"
+          :key="item.title"
+          class="mr-1.5 group-data-[collapsible=icon]:mr-0"
+        >
           <SidebarMenuButton
             :as="
               item.disabled || item.openInNewTab || item.action

--- a/src/components/navigation/NavShortcuts.vue
+++ b/src/components/navigation/NavShortcuts.vue
@@ -196,12 +196,13 @@ const draggedItem = computed(() =>
                 <SidebarMenuSkeleton :show-icon="true" />
               </SidebarMenuItem>
             </template>
-            <!-- Pinned shortcuts -->
+            <!-- Pinned shortcuts. The row gutter would skew the centred icon
+                 rail, so it lifts when collapsed. -->
             <SidebarMenuItem
               v-for="({ item, url }, index) in pinnedItemsWithUrls"
               :key="item.uri"
               v-hold="(e: Event) => onHold(e, item)"
-              class="mr-1.5"
+              class="mr-1.5 group-data-[collapsible=icon]:mr-0"
               :class="{
                 'shortcut-item': editMode,
                 'shortcut-item-dragging': draggingIndex === index,

--- a/src/components/navigation/NavUser.vue
+++ b/src/components/navigation/NavUser.vue
@@ -67,7 +67,12 @@ const handleLogout = () => {
                 {{ initial }}
               </AvatarFallback>
             </Avatar>
-            <div class="grid min-w-0 flex-1 text-left text-sm leading-tight">
+            <!-- only the avatar fits the collapsed rail, so the name and the
+                 chevron hide the moment collapsing starts rather than linger
+                 over the still-shrinking row -->
+            <div
+              class="grid min-w-0 flex-1 text-left text-sm leading-tight group-data-[collapsible=icon]:hidden"
+            >
               <span class="truncate font-medium">{{ displayName }}</span>
               <span class="text-muted-foreground truncate text-xs">
                 {{ username }}
@@ -75,7 +80,7 @@ const handleLogout = () => {
             </div>
             <MoreVertical
               style="width: 1rem !important"
-              class="ml-auto shrink-0 opacity-70"
+              class="ml-auto shrink-0 opacity-70 group-data-[collapsible=icon]:hidden"
             />
           </SidebarMenuButton>
         </DropdownMenuTrigger>

--- a/src/components/ui/sidebar/SidebarFooter.vue
+++ b/src/components/ui/sidebar/SidebarFooter.vue
@@ -22,7 +22,9 @@ const isCollapsed = computed(() => state.value === "collapsed");
         isMobile
           ? 'p-2'
           : isCollapsed
-            ? 'pl-[1px] pt-2 pb-26'
+            ? // no side padding: collapsed rail items centre themselves, and
+              // any asymmetry here would push them off the rail axis
+              'pt-2 pb-26'
             : 'px-3 pt-2 pb-26',
         props.class,
       )

--- a/src/components/ui/sidebar/SidebarTrigger.vue
+++ b/src/components/ui/sidebar/SidebarTrigger.vue
@@ -24,7 +24,7 @@ const isCollapsed = computed(() => state.value === "collapsed");
     :class="[
       'trigger-container',
       'flex w-full min-w-0 flex-col overflow-hidden',
-      isCollapsed && '-mr-2 trigger-container--collapsed',
+      isCollapsed && 'trigger-container--collapsed',
       props.class,
     ]"
   >
@@ -36,12 +36,17 @@ const isCollapsed = computed(() => state.value === "collapsed");
     >
       <Tooltip>
         <TooltipTrigger as-child>
+          <!-- collapsed, the trigger takes the menu buttons' size so the rail
+               reads as one column -->
           <Button
             data-sidebar="trigger"
             data-slot="sidebar-trigger"
             variant="ghost"
             size="icon"
-            :class="['flex-shrink-0', !isCollapsed && 'ml-auto']"
+            :class="[
+              'flex-shrink-0 group-data-[collapsible=icon]:size-8!',
+              !isCollapsed && 'ml-auto',
+            ]"
             @click="toggleSidebar"
           >
             <PanelLeft />
@@ -95,6 +100,15 @@ const isCollapsed = computed(() => state.value === "collapsed");
   :deep([data-sidebar="menu-button"] .rounded-lg) {
   width: 2rem !important;
   height: 2rem !important;
+}
+
+/* the avatar centres on a margin anchored off the rail's final width, less
+   the 6px the menu ul above keeps per side, so it holds still through the
+   collapse animation */
+.trigger-container--collapsed
+  .navuser-trigger
+  :deep([data-sidebar="menu-button"] [data-slot="avatar"]) {
+  margin-left: calc((var(--sidebar-width-icon) - 2rem) / 2 - 6px);
 }
 
 .trigger-container.flex-col {

--- a/src/components/ui/sidebar/SidebarTrigger.vue
+++ b/src/components/ui/sidebar/SidebarTrigger.vue
@@ -72,7 +72,7 @@ const isCollapsed = computed(() => state.value === "collapsed");
   width: 100%;
 }
 
-.navuser-trigger :deep([data-sidebar="menu-button"]) {
+.trigger-container .navuser-trigger :deep([data-sidebar="menu-button"]) {
   margin-left: 0 !important;
   padding-right: 0;
 }

--- a/tests/styles/collapsedSidebarAlignment.test.ts
+++ b/tests/styles/collapsedSidebarAlignment.test.ts
@@ -177,6 +177,20 @@ describe("collapsed sidebar alignment", () => {
     expect(padding.paddingLeft).not.toBe("");
     expect(padding.paddingLeft).toBe(padding.paddingRight);
     expect(anchor.body).toContain(`- ${padding.paddingLeft})`);
+
+    // the rail's button anchor reaches this button too, at the same
+    // importance, so the flush margin has to out-rank it in every sheet order
+    // for the avatar to be the only anchored piece
+    const flush = cssRule(
+      triggerSource,
+      '\n.trigger-container .navuser-trigger [data-sidebar="menu-button"]',
+    );
+    const buttonAnchor = cssRule(
+      appSource,
+      '[data-collapsible="icon"] [data-sidebar="menu-button"]',
+    );
+    expect(flush.body).toContain("margin-left: 0 !important");
+    expect(rank(flush.selector)).toBeGreaterThan(rank(buttonAnchor.selector));
   });
 
   it("drops the name and chevron from the collapsing row", () => {

--- a/tests/styles/collapsedSidebarAlignment.test.ts
+++ b/tests/styles/collapsedSidebarAlignment.test.ts
@@ -1,0 +1,211 @@
+// happy-dom cannot match the compiled group variants and drops declarations
+// whose values do calc() arithmetic, so those fights are weighed by ranking
+// selectors and reading the rules off the css text; the scoped rules still
+// match probes once :deep is unwrapped
+// @vitest-environment happy-dom
+import appSidebarSource from "@/components/navigation/AppSidebar.vue?raw";
+import navMainSource from "@/components/navigation/NavMain.vue?raw";
+import navShortcutsSource from "@/components/navigation/NavShortcuts.vue?raw";
+import navUserSource from "@/components/navigation/NavUser.vue?raw";
+import sidebarFooterSource from "@/components/ui/sidebar/SidebarFooter.vue?raw";
+import sidebarTriggerSource from "@/components/ui/sidebar/SidebarTrigger.vue?raw";
+import utilities from "@/styles/style.css?inline";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { rank, styleBlocks } from "./cascade";
+
+let triggerStyles: HTMLStyleElement;
+
+// the compiler rewrites `.a :deep(.b)` as `.a[data-v-hash] .b`, so unwrapping
+// the marker leaves a selector that matches; the fights below are all between
+// rules of the same scoped block, so the compound the hash adds cancels out
+function unwrapDeep(source: string) {
+  return styleBlocks(source)[0].replaceAll(/:deep\(([^)]*)\)/g, "$1");
+}
+
+// the scoped blocks, read as text for the declarations happy-dom cannot hold;
+// the trigger block is also injected to back the computed padding read
+const appSource = unwrapDeep(appSidebarSource);
+const triggerSource = unwrapDeep(sidebarTriggerSource);
+
+// rank() counts compounds off a hand-written selector, and a compiled utility
+// is neither: the variant separators live escaped inside the class name, where
+// the backslashed colons read as pseudo-classes, and the group gate arrives as
+// an :is() around a :where(). Emptying the :where() first keeps the outer
+// unwrap from stopping at its closing paren
+function plainSelector(selector: string) {
+  return selector
+    .replaceAll(/\\./g, "")
+    .replaceAll(/:where\([^)]*\)/g, "")
+    .replaceAll(/:is\(([^)]*)\)/g, "$1");
+}
+
+// happy-dom drops every declaration whose value does calc() arithmetic on a
+// var(), which hides the sizing utilities and the anchoring margins from its
+// CSSOM, so those rules are cut straight out of the css text instead
+function cssRule(text: string, fragment: string) {
+  const start = text.indexOf(fragment);
+  if (start === -1) throw new Error(`${fragment} has no rule in this text`);
+  const open = text.indexOf("{", start);
+  return {
+    selector: text.slice(text.lastIndexOf("\n", start) + 1, open).trim(),
+    body: text.slice(open + 1, text.indexOf("}", open)),
+  };
+}
+
+// a menu button inside the desktop rail, which carries data-collapsible="icon"
+// only while collapsed and "" otherwise
+function menuButton(collapsible: string) {
+  const rail = document.createElement("div");
+  rail.className = "group";
+  rail.setAttribute("data-collapsible", collapsible);
+  rail.innerHTML = `<button data-sidebar="menu-button"></button>`;
+  document.body.appendChild(rail);
+  return rail.querySelector("button")!;
+}
+
+// the collapsed footer as SidebarTrigger renders it around NavUser
+function collapsedNavUser() {
+  const container = document.createElement("div");
+  container.className = "trigger-container trigger-container--collapsed";
+  container.innerHTML = `
+    <div class="navuser-trigger">
+      <ul data-sidebar="menu">
+        <li>
+          <button data-sidebar="menu-button">
+            <span data-slot="avatar" class="rounded-lg"></span>
+          </button>
+        </li>
+      </ul>
+    </div>`;
+  document.body.appendChild(container);
+  return {
+    menu: container.querySelector("ul")!,
+    avatar: container.querySelector("span")!,
+  };
+}
+
+describe("collapsed sidebar alignment", () => {
+  beforeEach(() => {
+    triggerStyles = document.createElement("style");
+    triggerStyles.textContent = triggerSource;
+    document.head.appendChild(triggerStyles);
+  });
+
+  afterEach(() => {
+    triggerStyles.remove();
+    document.body.innerHTML = "";
+  });
+
+  it("anchors the menu buttons only while the rail is collapsed", () => {
+    const gutters = cssRule(appSource, '\n[data-sidebar="menu-button"] {');
+    const anchor = cssRule(
+      appSource,
+      '[data-collapsible="icon"] [data-sidebar="menu-button"]',
+    );
+
+    // the fixed gutters and the anchor both land on a collapsed button, and
+    // the anchor has to out-rank them to win their equally-!important fight
+    const collapsed = menuButton("icon");
+    expect(collapsed.matches(gutters.selector)).toBe(true);
+    expect(collapsed.matches(anchor.selector)).toBe(true);
+    expect(rank(anchor.selector)).toBeGreaterThan(rank(gutters.selector));
+
+    // expanded, only the fixed gutters land, so that layout stays untouched
+    expect(menuButton("").matches(anchor.selector)).toBe(false);
+  });
+
+  it("anchors off the rail width at the utilities' importance", () => {
+    const anchor = cssRule(
+      appSource,
+      '[data-collapsible="icon"] [data-sidebar="menu-button"]',
+    );
+
+    // the margin resolves against the rail's final width — the one token that
+    // never animates — so the buttons hold still through the collapse; and
+    // specificity only settles a tie within one importance level
+    expect(anchor.body).toMatch(
+      /margin-left: calc\([^;]*var\(--sidebar-width-icon\)[^;]*\) !important/,
+    );
+    expect(anchor.body).toMatch(/margin-right: 0 !important/);
+  });
+
+  it("lifts the row gutter off the collapsed rows", () => {
+    // the templates pair the gutter with the variant that lifts it, read off
+    // the source so the probes cannot drift from what they render
+    const paired = 'class="mr-1.5 group-data-[collapsible=icon]:mr-0"';
+    expect(navMainSource).toContain(paired);
+    expect(navShortcutsSource).toContain(paired);
+
+    // specificity only settles a tie within one importance level, so the
+    // ranking proves nothing unless both sides are !important
+    const gutter = cssRule(utilities, "\n.mr-1\\.5 {");
+    const lifted = cssRule(utilities, "collapsible\\=icon\\]\\:mr-0");
+    expect(gutter.body).toMatch(/margin-right:.*!important/);
+    expect(lifted.body).toContain("margin-right: 0px !important");
+    expect(rank(plainSelector(lifted.selector))).toBeGreaterThan(
+      rank(plainSelector(gutter.selector)),
+    );
+  });
+
+  it("sizes the collapsed trigger down to the menu button column", () => {
+    expect(sidebarTriggerSource).toContain(
+      "group-data-[collapsible=icon]:size-8!",
+    );
+
+    const resting = cssRule(utilities, "\n.size-9 {");
+    const collapsed = cssRule(utilities, "collapsible\\=icon\\]\\:size-8\\!");
+    expect(resting.body).toMatch(/width:.*!important/);
+    expect(collapsed.body).toMatch(/width:.*!important/);
+    expect(rank(plainSelector(collapsed.selector))).toBeGreaterThan(
+      rank(plainSelector(resting.selector)),
+    );
+  });
+
+  it("anchors the avatar between symmetric footer gutters", () => {
+    const { menu, avatar } = collapsedNavUser();
+
+    // the avatar takes the same rail-width anchor as the buttons above it
+    const anchor = cssRule(triggerSource, '[data-slot="avatar"]');
+    expect(avatar.matches(anchor.selector)).toBe(true);
+    expect(anchor.body).toMatch(
+      /margin-left: calc\([^;]*var\(--sidebar-width-icon\)[^;]*\)/,
+    );
+
+    // the menu carries the only side padding left in the collapsed footer,
+    // and the anchor subtracts exactly what it keeps on the left
+    const padding = getComputedStyle(menu);
+    expect(padding.paddingLeft).not.toBe("");
+    expect(padding.paddingLeft).toBe(padding.paddingRight);
+    expect(anchor.body).toContain(`- ${padding.paddingLeft})`);
+  });
+
+  it("drops the name and chevron from the collapsing row", () => {
+    // the collapsed attribute lands before the width animation ends, so both
+    // hide instantly instead of lingering over the still-shrinking row
+    expect(
+      navUserSource.match(/group-data-\[collapsible=icon\]:hidden/g),
+    ).toHaveLength(2);
+
+    // the name block paints its own display, so hiding it is a specificity
+    // fight between two equally-!important utilities
+    const grid = cssRule(utilities, "\n.grid {");
+    const hidden = cssRule(utilities, "collapsible\\=icon\\]\\:hidden");
+    expect(grid.body).toContain("display: grid !important");
+    expect(hidden.body).toContain("display: none !important");
+    expect(rank(plainSelector(hidden.selector))).toBeGreaterThan(
+      rank(plainSelector(grid.selector)),
+    );
+  });
+
+  it("keeps the collapsed footer clear of side padding", () => {
+    // the collapsed branch of the footer ternary, read off the source; the
+    // `?` skips the computed in the script and anchors into the template
+    const branch = sidebarFooterSource.match(
+      /isCollapsed\s*\?[\s\S]*?'([^']*)'/,
+    );
+    expect(branch).not.toBeNull();
+    for (const utility of branch![1].split(/\s+/)) {
+      expect(utility).not.toMatch(/^(pl-|pr-|px-|p-)/);
+    }
+  });
+});


### PR DESCRIPTION
# What does this implement/fix?

With the sidebar collapsed to its icon rail, the items didn't line up: the nav icons sat slightly left of centre (more so while the shortcuts list showed a scrollbar), the collapse button was bigger than everything else, and the user avatar at the bottom sat on its own offset again. Every item was pinned by its own hard-coded left offset, so any change in rail width pushed them apart.

- Collapsed items now centre themselves in the rail instead of relying on fixed offsets, so they stay in one column whatever the rail width
- The collapse button matches the size of the other rail icons while collapsed
- The user avatar centres like the rest, and the footer's one-sided padding is gone
- A style test pins the alignment rules; the expanded sidebar is untouched

**Related issue (if applicable):**

- related issue `<link to issue>`

**Related backend PR (if applicable):**

- related backend PR `<link to PR>`

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm lint:check` passes.
- [x] `pnpm test:run` passes, and tests have been added/updated where applicable.
- [x] `pnpm build` passes.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
