### PR TITLE
Better styling for the now playing source badge

### DIFF
--- a/src/layouts/default/PlayerOSD/NowPlayingSourceBadge.vue
+++ b/src/layouts/default/PlayerOSD/NowPlayingSourceBadge.vue
@@ -10,7 +10,12 @@
     v-if="nowPlayingSource"
     as="span"
     variant="outline"
-    class="now-playing-source bg-background/40 border-transparent text-inherit shadow-none backdrop-blur-md"
+    class="now-playing-source border-transparent text-inherit shadow-none"
+    :class="
+      plain
+        ? 'border-0 bg-transparent px-0'
+        : 'bg-background/40 backdrop-blur-md'
+    "
     role="img"
     :aria-label="$t('tooltip.playing_from', [nowPlayingSource.name])"
     :title="$t('tooltip.playing_from', [nowPlayingSource.name])"
@@ -21,7 +26,9 @@
       :domain="nowPlayingSource.iconDomain"
       :size="14"
     />
-    <span class="truncate">{{ nowPlayingSource.name }}</span>
+    <span v-if="!iconOnly || !nowPlayingSource.iconDomain" class="truncate">
+      {{ nowPlayingSource.name }}
+    </span>
   </Badge>
 </template>
 
@@ -29,6 +36,21 @@
 import ProviderIcon from "@/components/ProviderIcon.vue";
 import { Badge } from "@/components/ui/badge";
 import { useNowPlayingSource } from "@/composables/nowPlayingSource";
+
+interface Props {
+  /**
+   * Let the icon name the source on its own; the name stays available in the
+   * label and tooltip. Sources without an icon keep showing their name.
+   */
+  iconOnly?: boolean;
+  /**
+   * Drop the pill background and padding so the badge lines up with the text
+   * around it, for surfaces with a background of their own.
+   */
+  plain?: boolean;
+}
+
+defineProps<Props>();
 
 const { nowPlayingSource } = useNowPlayingSource();
 </script>

--- a/src/layouts/default/PlayerOSD/NowPlayingSourceBadge.vue
+++ b/src/layouts/default/PlayerOSD/NowPlayingSourceBadge.vue
@@ -44,8 +44,9 @@ interface Props {
    */
   iconOnly?: boolean;
   /**
-   * Drop the pill background and padding so the badge lines up with the text
-   * around it, for surfaces with a background of their own.
+   * Drop the pill background, border and horizontal padding so the badge
+   * lines up with the text around it, for surfaces with a background of
+   * their own.
    */
   plain?: boolean;
 }

--- a/src/layouts/default/PlayerOSD/PlayerFullscreen.vue
+++ b/src/layouts/default/PlayerOSD/PlayerFullscreen.vue
@@ -1581,18 +1581,19 @@ onBeforeUnmount(() => {
   justify-content: flex-start;
   align-items: center;
   text-align: center;
-  padding: min(5%, 5vh) 0 10px;
+  --track-info-padding-top: min(5%, 5vh);
+  padding: var(--track-info-padding-top) 0 10px;
   overflow: hidden;
+}
+
+/* the badge already fills part of the gap below the artwork and hugs the
+   title, so the block trades half its top padding for it */
+.main-media-details-track-info:has(.main-media-details-source) {
+  --track-info-padding-top: min(2.5%, 2.5vh);
 }
 
 .main-media-details-track-info > * {
   max-width: 100%;
-}
-
-/* the badge introduces the title under it, so it pairs with the title rather
-   than sitting halfway up the block's own top padding */
-.main-media-details-source {
-  margin-bottom: 8px;
 }
 
 .player-bottom {

--- a/src/layouts/default/PlayerOSD/PlayerTrackDetails.vue
+++ b/src/layouts/default/PlayerOSD/PlayerTrackDetails.vue
@@ -113,62 +113,77 @@
     <!-- subtitle: off state or artist(s) + album, led by the active source -->
     <template #subtitle>
       <div class="player-track-subtitle" :style="{ color: primaryColor }">
-        <!-- the source the audio comes from, when the line beside it describes
-             the track that source is streaming -->
-        <NowPlayingSourceBadge class="player-track-source" />
-        <!-- player powered off -->
-        <div
-          v-if="store.activePlayer?.powered == false"
-          style="cursor: pointer"
-          @click.stop="store.showPlayersMenu = true"
-        >
-          {{ $t("off") }}
-        </div>
-        <button
-          v-else-if="currentChapter"
-          type="button"
-          class="player-track-chapter-button"
-          @click.stop="store.showFullscreenPlayer = true"
-        >
-          <div class="ma-line-clamp-1">
-            <MarqueeText :sync="marqueeSync">
-              {{ currentChapter.chapter.name }}
-            </MarqueeText>
+        <div class="player-track-subtitle-line">
+          <!-- the source the audio comes from; the compact bar only has room
+               for its icon beside the track metadata -->
+          <NowPlayingSourceBadge
+            v-if="props.compact"
+            icon-only
+            plain
+            class="player-track-source"
+          />
+          <!-- player powered off -->
+          <div
+            v-if="store.activePlayer?.powered == false"
+            style="cursor: pointer"
+            @click.stop="store.showPlayersMenu = true"
+          >
+            {{ $t("off") }}
           </div>
-        </button>
-        <div
-          v-else-if="
-            store.activePlayer?.current_media?.title &&
-            (store.activePlayer?.current_media?.artist || albumSubtitle)
-          "
-          class="player-track-subtitle-text"
-          style="cursor: pointer"
-          @click.stop="store.showFullscreenPlayer = true"
-        >
-          <div class="ma-line-clamp-1">
-            <MarqueeText :sync="marqueeSync">
-              <!-- artists(s) + album -->
-              <span
-                v-if="
-                  store.activePlayer?.current_media?.artist &&
-                  albumSubtitle &&
-                  !props.showOnlyArtist
-                "
-              >
-                {{ store.activePlayer?.current_media?.artist }} •
-                {{ albumSubtitle }}
-              </span>
-              <!-- artists(s) only -->
-              <span v-else-if="store.activePlayer?.current_media?.artist">
-                {{ store.activePlayer?.current_media?.artist }}
-              </span>
-              <!-- album only -->
-              <span v-else-if="albumSubtitle">
-                {{ albumSubtitle }}
-              </span>
-            </MarqueeText>
+          <button
+            v-else-if="currentChapter"
+            type="button"
+            class="player-track-chapter-button"
+            @click.stop="store.showFullscreenPlayer = true"
+          >
+            <div class="ma-line-clamp-1">
+              <MarqueeText :sync="marqueeSync">
+                {{ currentChapter.chapter.name }}
+              </MarqueeText>
+            </div>
+          </button>
+          <div
+            v-else-if="
+              store.activePlayer?.current_media?.title &&
+              (store.activePlayer?.current_media?.artist || albumSubtitle)
+            "
+            class="player-track-subtitle-text"
+            style="cursor: pointer"
+            @click.stop="store.showFullscreenPlayer = true"
+          >
+            <div class="ma-line-clamp-1">
+              <MarqueeText :sync="marqueeSync">
+                <!-- artists(s) + album -->
+                <span
+                  v-if="
+                    store.activePlayer?.current_media?.artist &&
+                    albumSubtitle &&
+                    !props.showOnlyArtist
+                  "
+                >
+                  {{ store.activePlayer?.current_media?.artist }} •
+                  {{ albumSubtitle }}
+                </span>
+                <!-- artists(s) only -->
+                <span v-else-if="store.activePlayer?.current_media?.artist">
+                  {{ store.activePlayer?.current_media?.artist }}
+                </span>
+                <!-- album only -->
+                <span v-else-if="albumSubtitle">
+                  {{ albumSubtitle }}
+                </span>
+              </MarqueeText>
+            </div>
           </div>
         </div>
+        <!-- the full bar has the height for the source to take a line of its
+             own under the track metadata; plain, so it aligns with the text
+             above instead of hanging indented in its pill -->
+        <NowPlayingSourceBadge
+          v-if="!props.compact"
+          plain
+          class="player-track-source"
+        />
       </div>
     </template>
   </v-list-item>
@@ -307,9 +322,16 @@ function onTitleClick() {
   margin-right: 10px;
 }
 
-/* the source badge leads the line and keeps its width; the track metadata
-   beside it is what gives way as the bar narrows */
 .player-track-subtitle {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+
+/* the icon badge leads the line and keeps its width; the track metadata
+   beside it is what gives way as the bar narrows */
+.player-track-subtitle-line {
   display: flex;
   align-items: center;
   gap: 6px;
@@ -318,7 +340,7 @@ function onTitleClick() {
 
 .player-track-source {
   flex-shrink: 0;
-  max-width: 50%;
+  max-width: 100%;
 }
 
 .player-track-subtitle-text {

--- a/src/layouts/default/PlayerOSD/PlayerTrackDetails.vue
+++ b/src/layouts/default/PlayerOSD/PlayerTrackDetails.vue
@@ -343,6 +343,12 @@ function onTitleClick() {
   max-width: 100%;
 }
 
+/* on the line itself (compact bar) an icon-less source shows its name, which
+   must leave the metadata beside it half the width */
+.player-track-subtitle-line .player-track-source {
+  max-width: 50%;
+}
+
 .player-track-subtitle-text {
   min-width: 0;
 }

--- a/tests/layouts/NowPlayingSourceBadge.test.ts
+++ b/tests/layouts/NowPlayingSourceBadge.test.ts
@@ -28,8 +28,9 @@ const { store } = await import("@/plugins/store");
 
 enableAutoUnmount(afterEach);
 
-function mountBadge() {
+function mountBadge(props: { iconOnly?: boolean; plain?: boolean } = {}) {
   return mount(NowPlayingSourceBadge, {
+    props,
     global: {
       mocks: { $t: (key: string, args: string[]) => `${key}:${args?.[0]}` },
       // ProviderIcon fetches its artwork from the real api singleton
@@ -94,5 +95,65 @@ describe("NowPlayingSourceBadge", () => {
 
     expect(badge.text()).toContain("Line In");
     expect(badge.find("[data-provider-icon]").exists()).toBe(false);
+  });
+
+  it("hands the name to the tooltip when only the icon is asked for", () => {
+    playing(
+      queueItem({
+        media_item: audioSource({
+          name: "Spotify Connect",
+          provider_mappings: [
+            providerMapping({ provider_domain: "spotify_connect" }),
+          ],
+        }),
+      }),
+    );
+
+    const badge = mountBadge({ iconOnly: true });
+
+    expect(badge.text()).not.toContain("Spotify Connect");
+    expect(badge.find("[data-provider-icon]").exists()).toBe(true);
+    expect(badge.get("[data-slot=badge]").attributes("title")).toBe(
+      "tooltip.playing_from:Spotify Connect",
+    );
+  });
+
+  // the player bars have a background of their own, so the badge sheds its
+  // pill there and lines up with the text around it
+  it("drops the pill when asked to render plain", () => {
+    playing(
+      queueItem({
+        media_item: audioSource({
+          name: "Spotify Connect",
+          provider_mappings: [
+            providerMapping({ provider_domain: "spotify_connect" }),
+          ],
+        }),
+      }),
+    );
+
+    const pill = mountBadge().get("[data-slot=badge]").classes();
+    const plain = mountBadge({ plain: true })
+      .get("[data-slot=badge]")
+      .classes();
+
+    expect(pill).toContain("bg-background/40");
+    expect(plain).not.toContain("bg-background/40");
+    expect(plain).toEqual(
+      expect.arrayContaining(["border-0", "bg-transparent", "px-0"]),
+    );
+  });
+
+  it("keeps the name when a source has no icon to fall back on", () => {
+    store.activePlayer = {
+      player_id: "player-1",
+      powered: true,
+      active_source: "line-in",
+      source_list: [{ id: "line-in", name: "Line In" }],
+    } as unknown as Player;
+
+    const badge = mountBadge({ iconOnly: true });
+
+    expect(badge.text()).toContain("Line In");
   });
 });

--- a/tests/layouts/PlayerTrackDetails.test.ts
+++ b/tests/layouts/PlayerTrackDetails.test.ts
@@ -86,7 +86,10 @@ function mountDetails(compact: boolean, titleOpensDetails = false) {
     },
     global: {
       plugins: [vuetify],
-      mocks: { $t: (key: string) => key },
+      mocks: {
+        $t: (key: string, args?: string[]) =>
+          args?.length ? `${key}:${args[0]}` : key,
+      },
       stubs: {
         MarqueeText: { template: "<span><slot /></span>" },
       },
@@ -309,9 +312,7 @@ describe("PlayerTrackDetails source badge", () => {
     };
   });
 
-  // the server puts the station name in the album slot when the station has no
-  // real album, so the badge would otherwise repeat what is already on the line
-  it("names the station and drops it from the metadata line", () => {
+  function playRadioStation() {
     store.activePlayerQueue = { queue_id: "q1", active: true } as never;
     store.curQueueItem = {
       media_item: radio({ name: "Radio 538" }),
@@ -333,11 +334,46 @@ describe("PlayerTrackDetails source badge", () => {
       artist: "Artist",
       album: "Radio 538",
     };
+  }
+
+  // the server puts the station name in the album slot when the station has no
+  // real album, so the badge would otherwise repeat what is already on the line
+  it("names the station and drops it from the metadata line", () => {
+    playRadioStation();
 
     const details = mountDetails(false);
 
     expect(details.get(".player-track-source").text()).toBe("Radio 538");
     expect(details.get(".player-track-subtitle-text").text()).toBe("Artist");
+  });
+
+  // the full bar has the height for a third line, so the badge does not fight
+  // the metadata for the width of the subtitle line
+  it("gives the badge its own line under the metadata on the full bar", () => {
+    playRadioStation();
+
+    const details = mountDetails(false);
+
+    expect(
+      details.find(".player-track-subtitle-line .player-track-source").exists(),
+    ).toBe(false);
+    expect(
+      details.find(".player-track-subtitle > .player-track-source").exists(),
+    ).toBe(true);
+  });
+
+  // the compact bar keeps its two shallow lines, so the badge shrinks to its
+  // icon beside the metadata and hands the name to the tooltip
+  it("shrinks the badge to its icon on the compact bar", () => {
+    playRadioStation();
+
+    const details = mountDetails(true);
+
+    const badge = details.get(
+      ".player-track-subtitle-line .player-track-source",
+    );
+    expect(badge.text()).toBe("");
+    expect(badge.attributes("title")).toContain("Radio 538");
   });
 
   it("leaves an ordinary album on the metadata line", () => {

--- a/tests/layouts/PlayerTrackDetails.test.ts
+++ b/tests/layouts/PlayerTrackDetails.test.ts
@@ -4,6 +4,7 @@ import { openCurrentTrackDetails } from "@/helpers/now_playing";
 import { store } from "@/plugins/store";
 import { EMPTY_COLOR_PALETTE } from "@/helpers/utils";
 import { mount, type VueWrapper } from "@vue/test-utils";
+import { providerMapping } from "../fixtures/providerMapping";
 import { radio } from "../fixtures/radio";
 import { streamDetails } from "../fixtures/streamDetails";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -315,7 +316,10 @@ describe("PlayerTrackDetails source badge", () => {
   function playRadioStation() {
     store.activePlayerQueue = { queue_id: "q1", active: true } as never;
     store.curQueueItem = {
-      media_item: radio({ name: "Radio 538" }),
+      media_item: radio({
+        name: "Radio 538",
+        provider_mappings: [providerMapping({ provider_domain: "tunein" })],
+      }),
       streamdetails: streamDetails({
         stream_metadata: {
           title: "Live track",


### PR DESCRIPTION
# What does this implement/fix?

Polish the "now playing source" badge (Spotify Connect, AirPlay, radio station, ...) that was added in #2567:

- Player bar: the badge now gets its own third line under the artist/album line, as plain icon + name (no pill), lined up with the text above it.
- Floating mobile player: only the provider icon is shown beside the artist, so the badge no longer eats the whole second line; the source name stays in the tooltip/label.
- Fullscreen player: the badge sits snug above the title instead of floating in a large gap between artwork and title.

**Related issue (if applicable):**

- related issue N/A

**Related backend PR (if applicable):**

- related backend PR N/A

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm lint:check` passes.
- [x] `pnpm test:run` passes, and tests have been added/updated where applicable.
- [x] `pnpm build` passes.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
