### PR TITLE
Remove the read-only queue for external sessions

### DIFF
--- a/src/helpers/queue_item_menu_items.ts
+++ b/src/helpers/queue_item_menu_items.ts
@@ -22,9 +22,6 @@ export const getQueueItemMenuItems = (
   if (!queue) return [];
   const queueId = queue.queue_id;
   const locked = index <= (queue.index_in_buffer ?? 0);
-  // an externally managed queue mirrors an external session's queue
-  // (queue_owner set), so the move/remove actions are not offered at all
-  const externallyManaged = !!queue.queue_owner;
 
   const menuItems: ContextMenuItem[] = [
     {
@@ -35,17 +32,14 @@ export const getQueueItemMenuItems = (
       disabled:
         index === queue.current_index || index === queue.index_in_buffer,
     },
-  ];
-
-  if (!externallyManaged) {
-    menuItems.push({
+    {
       label: "play_next",
       labelArgs: [],
       action: () => api.queueCommandMoveNext(queueId, item.queue_item_id),
       icon: "mdi-skip-next-circle-outline",
       disabled: locked,
-    });
-  }
+    },
+  ];
 
   // go to this item's radio (a dynamic playlist generated from it as the seed)
   const mediaItem = item.media_item;
@@ -60,24 +54,22 @@ export const getQueueItemMenuItems = (
   }
 
   // quick reorder / remove (drag the handle for fine-grained moves)
-  if (!externallyManaged) {
-    menuItems.push(
-      {
-        label: "queue_move_end",
-        labelArgs: [],
-        action: () => api.queueCommandMoveItemEnd(queueId, item.queue_item_id),
-        icon: "mdi-arrow-collapse-down",
-        disabled: locked,
-      },
-      {
-        label: "queue_delete",
-        labelArgs: [],
-        action: () => api.queueCommandDelete(queueId, item.queue_item_id),
-        icon: "mdi-delete",
-        disabled: locked,
-      },
-    );
-  }
+  menuItems.push(
+    {
+      label: "queue_move_end",
+      labelArgs: [],
+      action: () => api.queueCommandMoveItemEnd(queueId, item.queue_item_id),
+      icon: "mdi-arrow-collapse-down",
+      disabled: locked,
+    },
+    {
+      label: "queue_delete",
+      labelArgs: [],
+      action: () => api.queueCommandDelete(queueId, item.queue_item_id),
+      icon: "mdi-delete",
+      disabled: locked,
+    },
+  );
 
   // tracks can be opened in their detail page (closes the fullscreen player)
   if (mediaItem?.media_type === MediaType.TRACK) {

--- a/src/layouts/default/PlayerOSD/PlayerControlBtn/RepeatBtn.vue
+++ b/src/layouts/default/PlayerOSD/PlayerControlBtn/RepeatBtn.vue
@@ -63,13 +63,8 @@ const isLoading = computed(() => {
 
 const isDynamic = computed(() => compProps.playerQueue?.is_dynamic === true);
 
-// An external session that owns the queue (queue_owner) handles repeat
-// natively — the server forwards the command — so it is exempt from the
-// infinite-stream disable (the current item is that session's AudioSource).
-const isInfiniteStream = computed(
-  () =>
-    isQueueInfiniteStream(compProps.playerQueue) &&
-    !compProps.playerQueue?.queue_owner,
+const isInfiniteStream = computed(() =>
+  isQueueInfiniteStream(compProps.playerQueue),
 );
 
 // The next repeat mode when the button is pressed: cycle OFF -> ALL -> ONE.

--- a/src/layouts/default/PlayerOSD/PlayerControlBtn/ShuffleBtn.vue
+++ b/src/layouts/default/PlayerOSD/PlayerControlBtn/ShuffleBtn.vue
@@ -58,13 +58,8 @@ const isLoading = computed(() => {
   );
 });
 
-// An external session that owns the queue (queue_owner) handles shuffle
-// natively — the server forwards the command — so it is exempt from the
-// infinite-stream disable (the current item is that session's AudioSource).
-const isInfiniteStream = computed(
-  () =>
-    isQueueInfiniteStream(compProps.playerQueue) &&
-    !compProps.playerQueue?.queue_owner,
+const isInfiniteStream = computed(() =>
+  isQueueInfiniteStream(compProps.playerQueue),
 );
 
 // In dynamic mode the queue manages its own ordering (smart shuffle is implied),

--- a/src/layouts/default/PlayerOSD/PlayerFullscreen.vue
+++ b/src/layouts/default/PlayerOSD/PlayerFullscreen.vue
@@ -220,11 +220,6 @@
             class="queue-items-scroll-box"
             :style="`--queue-title-size: ${queueTitleFontSize}; --queue-subtitle-size: ${queueSubtitleFontSize};`"
           >
-            <!-- an external session owns the queue's ordering: the list is a
-                 read-only mirror, so say who manages it -->
-            <div v-if="queueOwnerName" class="queue-owner-hint">
-              {{ $t("queue_managed_by", [queueOwnerName]) }}
-            </div>
             <!-- the queue played through: say so, rather than leaving its last
                  track looking like it is still the current one -->
             <div v-if="queueEnded" class="queue-ended">
@@ -273,7 +268,6 @@
                   :state="row.state"
                   :is-playing="playerActive"
                   :dragging="draggingIndex === row.index"
-                  :read-only="queueExternallyManaged"
                   :marquee-sync="
                     row.state === 'playing'
                       ? playerMarqueeSync
@@ -777,8 +771,6 @@ const {
   totalItems,
   upNextCount,
   queueEnded,
-  queueExternallyManaged,
-  queueOwnerName,
   totalSize,
   measureRow,
   playerActive,
@@ -1533,13 +1525,6 @@ onBeforeUnmount(() => {
 
 .queue-ended {
   padding: 8px 4px 12px;
-  text-align: center;
-  font-size: 0.85rem;
-  opacity: 0.6;
-}
-
-.queue-owner-hint {
-  padding: 8px 4px 4px;
   text-align: center;
   font-size: 0.85rem;
   opacity: 0.6;

--- a/src/layouts/default/PlayerOSD/PlayerFullscreenHeaderControls.vue
+++ b/src/layouts/default/PlayerOSD/PlayerFullscreenHeaderControls.vue
@@ -261,12 +261,10 @@ const smartFadesActive = computed(
 );
 
 // Crossfade only applies to an active queue that is playing regular tracks.
-// Hide the control entirely for external sources, audiosources and radio
-// streams, and while an external session owns the queue (it crossfades natively).
+// Hide the control entirely for external sources, audiosources and radio streams.
 const showCrossfade = computed(() => {
   const q = queue.value;
   if (!q || !q.active) return false;
-  if (q.queue_owner) return false;
   if (isQueueInfiniteStream(q)) return false;
   return "crossfade_enabled" in q;
 });

--- a/src/layouts/default/PlayerOSD/QueueListItem.vue
+++ b/src/layouts/default/PlayerOSD/QueueListItem.vue
@@ -99,12 +99,11 @@
            grip (only up-next rows are reorderable). -->
       <div class="qitem__actions">
         <!-- drag handle to reorder. Active on up-next items; disabled/grayed on
-             every other row (now playing, buffered, played can't be reordered)
-             and everywhere while the queue is read-only. -->
+             every other row (now playing, buffered, played can't be reordered). -->
         <button
           type="button"
           class="qitem__grip"
-          :disabled="readOnly || state !== 'upcoming'"
+          :disabled="state !== 'upcoming'"
           :aria-label="$t('queue_reorder')"
           @pointerdown.stop.prevent="emit('dragstart', $event)"
           @click.stop
@@ -171,9 +170,6 @@ interface Props {
   dragging?: boolean;
   // Whether this is the floating "ghost" clone that follows the pointer.
   ghost?: boolean;
-  // Whether the queue is read-only (an external session owns its ordering),
-  // disabling the drag handle on every row.
-  readOnly?: boolean;
 }
 
 const props = withDefaults(defineProps<Props>(), {
@@ -183,7 +179,6 @@ const props = withDefaults(defineProps<Props>(), {
   boostBadgeColor: "#ff5722",
   dragging: false,
   ghost: false,
-  readOnly: false,
 });
 
 const emit = defineEmits<{

--- a/src/layouts/default/PlayerOSD/useFullscreenQueue.ts
+++ b/src/layouts/default/PlayerOSD/useFullscreenQueue.ts
@@ -9,7 +9,6 @@ import { getQueueItemMenuItems } from "@/helpers/queue_item_menu_items";
 import { currentQueueIndex, isQueueEnded } from "@/helpers/queue_position";
 import { useQueueDragReorder } from "@/layouts/default/PlayerOSD/useQueueDragReorder";
 import api from "@/plugins/api";
-import { isAudioSource } from "@/plugins/api/helpers";
 import {
   EventMessage,
   EventType,
@@ -97,21 +96,6 @@ export function useFullscreenQueue(showLyrics: Ref<boolean>) {
 
   // Whether the queue played through to its end and can be started over.
   const queueEnded = computed(() => isQueueEnded(store.activePlayerQueue));
-
-  // Whether an external session (e.g. Spotify Connect) owns the queue's
-  // ordering: the list is a mirror the user can't edit, so reorder/move/delete
-  // affordances are withheld.
-  const queueExternallyManaged = computed(
-    () => !!store.activePlayerQueue?.queue_owner,
-  );
-
-  // Display name of the owning session, for the "queue managed by" hint. The
-  // owning AudioSource is the queue's current item, so its name is read there.
-  const queueOwnerName = computed(() => {
-    if (!queueExternallyManaged.value) return "";
-    const mediaItem = store.activePlayerQueue?.current_item?.media_item;
-    return isAudioSource(mediaItem) ? mediaItem.name : "";
-  });
 
   // Whether the player is actually rendering audio (drives the equalizer icon).
   const playerActive = computed(
@@ -423,8 +407,6 @@ export function useFullscreenQueue(showLyrics: Ref<boolean>) {
     totalItems,
     upNextCount,
     queueEnded,
-    queueExternallyManaged,
-    queueOwnerName,
     totalSize,
     measureRow,
     playerActive,

--- a/src/layouts/default/PlayerOSD/useQueueDragReorder.ts
+++ b/src/layouts/default/PlayerOSD/useQueueDragReorder.ts
@@ -171,9 +171,6 @@ export function useQueueDragReorder(options: QueueDragReorderOptions) {
   const startItemDrag = (evt: PointerEvent, index: number) => {
     // Primary mouse button / touch / pen only.
     if (evt.pointerType === "mouse" && evt.button !== 0) return;
-    // An externally managed queue mirrors an external session's queue that
-    // MA cannot reorder.
-    if (store.activePlayerQueue?.queue_owner) return;
     const item = itemAt(index);
     if (!item || index < firstReorderableIndex()) return;
 

--- a/src/layouts/default/PlayerOSD/useQueueModes.ts
+++ b/src/layouts/default/PlayerOSD/useQueueModes.ts
@@ -26,13 +26,11 @@ export function useQueueModes() {
   );
 
   // Autoplay only applies to an active queue playing regular tracks, and is
-  // moot while dynamic mode is active (the queue already refills itself), for
-  // infinite streams, or while an external session owns the queue (it provides
-  // its own continuation).
+  // moot while dynamic mode is active (the queue already refills itself) or for
+  // infinite streams.
   const autoplayApplicable = computed(() => {
     const q = queue.value;
     if (!q || !q.active) return false;
-    if (q.queue_owner) return false;
     if (isQueueInfiniteStream(q)) return false;
     if (dynamicModeActive.value) return false;
     return "autoplay_enabled" in q;

--- a/src/plugins/api/interfaces.ts
+++ b/src/plugins/api/interfaces.ts
@@ -1271,12 +1271,6 @@ export interface PlayerQueue {
   // (is_dynamic), implicitly enabling autoplay and smart shuffle.
   sources: ItemMapping[];
   is_dynamic: boolean;
-  // queue_owner: uri of the AudioSource owning this queue's ordering while queue commands
-  // are delegated to an external session (e.g. Spotify Connect); null when MA owns the
-  // queue (server-derived, read-only; absent on older servers). While set, the items are
-  // a mirror the user can't edit and the session provides crossfade/autoplay natively —
-  // shuffle and repeat keep working (forwarded to the session).
-  queue_owner?: string | null;
   // extra_attributes: additional attributes for this player_queue to store/forward
   // additional data that is not part of the standard model
   // must be serializable types only

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -2191,7 +2191,6 @@
     "up_next": "Up next",
     "queue_buffered_explanation": "This track is already buffered by the player to play next.",
     "queue_reorder": "Drag to reorder",
-    "queue_managed_by": "Queue managed by {0}",
     "lyrics_show": "Show lyrics for this track",
     "lyrics_hide": "Hide lyrics for this track",
     "lyrics_loading": "Lyrics are being fetched...",

--- a/tests/fixtures/playerQueue.ts
+++ b/tests/fixtures/playerQueue.ts
@@ -34,7 +34,6 @@ export function playerQueue(overrides: Partial<PlayerQueue> = {}): PlayerQueue {
     next_item: null,
     sources: [],
     is_dynamic: false,
-    queue_owner: null,
     ...overrides,
   };
 }

--- a/tests/helpers/queue_item_menu_items.test.ts
+++ b/tests/helpers/queue_item_menu_items.test.ts
@@ -41,7 +41,7 @@ describe("getQueueItemMenuItems", () => {
     });
   });
 
-  it("offers the full action set on an MA-owned queue", () => {
+  it("offers the full action set on an up-next item", () => {
     const items = getQueueItemMenuItems(queueItem(), 3);
     expect(labels(items)).toEqual([
       "play_now",
@@ -51,25 +51,14 @@ describe("getQueueItemMenuItems", () => {
     ]);
   });
 
-  it("withholds the move/remove actions on an externally managed queue", () => {
-    storeMock.activePlayerQueue = playerQueue({
-      items: 5,
-      current_index: 0,
-      index_in_buffer: 1,
-      queue_owner: "spotify_connect--abc://audio_source/main",
-    });
-    const items = getQueueItemMenuItems(queueItem(), 3);
-    expect(labels(items)).toEqual(["play_now"]);
-  });
-
-  it("keeps play now and show info on an externally managed queue's track items", () => {
-    storeMock.activePlayerQueue = playerQueue({
-      items: 5,
-      current_index: 0,
-      index_in_buffer: 1,
-      queue_owner: "spotify_connect--abc://audio_source/main",
-    });
+  it("adds show info for track items", () => {
     const items = getQueueItemMenuItems(queueItem({ media_item: track() }), 3);
-    expect(labels(items)).toEqual(["play_now", "show_info"]);
+    expect(labels(items)).toEqual([
+      "play_now",
+      "play_next",
+      "queue_move_end",
+      "queue_delete",
+      "show_info",
+    ]);
   });
 });


### PR DESCRIPTION
> [!WARNING]
> **Blocked — do not merge.** Two of the six removed sites have inverted polarity and turn a
> live Spotify Connect session's shuffle/repeat dead. This needs the server's representation
> switch first. Details below. The branch is complete and green; it is parked, not ready.

# What does this implement/fix?

The "queue managed by an external session" concept has been dropped. A live external source (Spotify Connect and friends) becomes a source on the *player*, not a media item in a queue — so there is no queue to be "managed by" anyone, and `queue_owner` is going away. This unwinds the read-only queue UI from #2604 so every queue is a normal, fully interactive queue again.

- Drag-reorder, "play next", "move to end" and "remove" are available on every queue again
- Shuffle and repeat go back to the plain infinite-stream rule
- Crossfade and autoplay controls are no longer hidden
- Dropped the "Queue managed by …" hint and its translation string
- Removed `queue_owner` from the `PlayerQueue` interface
- Kept the `getQueueItemMenuItems` tests, trimmed to the normal-queue cases

## Why this is blocked

Four of the six sites are plain `if (q.queue_owner) return`-shaped and go inert by themselves once the server stops sending the field — removing them now is a no-op or an improvement:

`useQueueDragReorder.ts:176`, `useQueueModes.ts:35`, `useFullscreenQueue.ts:105`, `PlayerFullscreenHeaderControls.vue:269`

Two of those four were already no-ops: in `PlayerFullscreenHeaderControls.vue:269` and `useQueueModes.ts:35` the `queue_owner` check sat immediately before an `isQueueInfiniteStream` check that is true in the same situation. And the reorder/remove restrictions never had a server counterpart at all — `move_item`, `move_item_end` and `delete_item` carry only the `index_in_buffer` guard, which the frontend already mirrors, so #2604 was over-restrictive there from the start.

That makes the read-only half removable on its own, but it buys nothing today: while an AudioSource is the current item the queue holds just that one live item, and `index_in_buffer` blocks touching it anyway — there is nothing else to reorder. Hence one clean revert, held until the two button sites can move with it.

The other two are **inverted**. `ShuffleBtn.vue:67` and `RepeatBtn.vue:72` guarded on `isQueueInfiniteStream(queue) && !queue.queue_owner` — #2604 made shuffle/repeat *reachable* on an infinite stream precisely *because* a session owned the queue. And `isQueueInfiniteStream()` ([helpers.ts:44](src/plugins/api/helpers.ts#L44)) is true when the current item's media type is `RADIO` **or `AUDIO_SOURCE`**.

So while the server still puts AudioSources in queues, removing those two guards makes shuffle and repeat go dead on a live Connect session — and the server does still forward both to the session (`set_shuffle` / `set_repeat` → `on_source_control` via `_get_delegated_source`). That is a user-visible regression, not a no-op. It degrades correctly only once an AudioSource is no longer a queue item.

**Unblocks on:** the server representation switch — `select_source` becomes primary, `play_media(uri)` its shim, AudioSource stops being a queue item. Step 1 is music-assistant/server#5913 (draft); the representation switch itself is not written yet.

**End state:** shuffle and repeat become part of the AudioSource / PlayerSource capability surface, i.e. source controls rather than queue controls, so the queue's own shuffle/repeat being inapplicable to a session is then correct.

**Companion work, landing in this same chunk rather than after it — deliberately not in this PR:** `nowPlayingSource.ts` branches 1 and 3 collapse at the switch. Branch 1 reads the source name off the queue item, branch 3 off the player's `source_list`; afterwards branch 3 subsumes branch 1, and the `albumSubtitle` hack goes with them.

## Re-verify on rebase, once the switch has landed

Not a checklist for this PR — a checklist for the rebase, since a green build proves nothing about a control that merely greys out:

- Exercise the two button sites with an external source **active**, confirming shuffle and repeat are *enabled and act on the MA queue* — not merely that the guard is gone. After the switch the queue's current item is the user's own content while the source plays, so the guard's absence and the control working are separate facts.
- Re-diff every touched file against its pre-#2604 state (`e0938528^`) to catch main drift silently reverting merged work.
- Confirm `isQueueInfiniteStream()` no longer sees `AUDIO_SOURCE` as the current item, which is the precondition this PR waits on — but note it is **not** what disables the two buttons for a live source afterwards. `resolvePlayerQueue()` returns `undefined` for a player owned by an external source (`active_source` is the source uri, so neither of its branches matches), and `ShuffleBtn`'s `disabled` opens with `!playerQueue || !playerQueue.active`. The exemption removed here becomes moot rather than load-bearing, which is what makes the removal a true no-op.
- Not fixed by this PR, and worth knowing before it reads as a regression: shuffle/repeat for a live source are then **unreachable**, because the frontend has no `players/cmd/shuffle` / `players/cmd/repeat` call at all. Wiring those and routing the buttons on source-vs-queue is separate follow-up work.

**Related issue (if applicable):**

- related issue `n/a`

**Related backend PR (if applicable):**

<!--
Link the music-assistant/server PR when this change relies on new server
behaviour, so the two can be reviewed and released together.
-->

- related backend PR `blocked on the server representation switch; step 1 is https://github.com/music-assistant/server/pull/5913`

## Types of changes

<!--
Tick exactly one box below. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm lint:check` passes.
- [x] `pnpm test:run` passes, and tests have been added/updated where applicable.
- [x] `pnpm build` passes.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
