### PR TITLE
Fix shuffle and repeat while an external source is playing

### DIFF
--- a/src/composables/liveSource.ts
+++ b/src/composables/liveSource.ts
@@ -1,8 +1,6 @@
-import { computed, ComputedRef, Ref, unref } from "vue";
+import { computed, type MaybeRef, unref } from "vue";
 import { useActiveSource } from "@/composables/activeSource";
 import { Player, PlayerQueue, PlayerSource } from "@/plugins/api/interfaces";
-
-type MaybeRef<T> = ComputedRef<T> | Ref<T> | T;
 
 /**
  * Composable that exposes the live external source playing on a player in place
@@ -11,6 +9,14 @@ type MaybeRef<T> = ComputedRef<T> | Ref<T> | T;
  * A source that takes the player over (Spotify Connect, AirPlay, Ynison, …) is
  * attached to no queue, so the commands it can handle reach its own session
  * through the player and the state to render comes off the source itself.
+ *
+ * Unlike `useActiveSource`, which answers with whichever source list entry is
+ * active and so happily returns the Music Assistant queue's own entry, this
+ * narrows to a source that has genuinely taken the player over — the caller
+ * routes a command on the answer rather than merely greying a button out, and
+ * sending an MA queue's shuffle to the player command would be wrong.
+ *
+ * Pass the queue that belongs to the same player, i.e. `resolvePlayerQueue(player)`.
  */
 export function useLiveSource(
   player: MaybeRef<Player | undefined>,
@@ -21,9 +27,13 @@ export function useLiveSource(
   const liveSource = computed((): PlayerSource | undefined => {
     // a resolved queue means Music Assistant owns the playback
     if (unref(playerQueue)) return undefined;
-    // the MA queue is always in the source list, so a player sitting on its own
-    // queue would otherwise resolve to it through the player_id fallback
-    if (!unref(player)?.active_source) return undefined;
+    const playerObj = unref(player);
+    // nothing selected: useActiveSource would fall back to the player's own id
+    if (!playerObj?.active_source) return undefined;
+    // the MA queue is always in the source list under the player's own id, and
+    // a live source is always there under its uri — so this is the own queue,
+    // reachable before its queue has arrived in the client's state
+    if (playerObj.active_source === playerObj.player_id) return undefined;
     return activeSource.value;
   });
 

--- a/src/composables/liveSource.ts
+++ b/src/composables/liveSource.ts
@@ -1,10 +1,9 @@
 import { computed, type MaybeRef, unref } from "vue";
-import { useActiveSource } from "@/composables/activeSource";
 import { Player, PlayerQueue, PlayerSource } from "@/plugins/api/interfaces";
 
 /**
- * Composable that exposes the live external source playing on a player in place
- * of a queue, or undefined when Music Assistant's own queue is what is playing.
+ * The live external source playing on a player in place of a queue, or
+ * undefined when Music Assistant's own queue is what is playing.
  *
  * A source that takes the player over (Spotify Connect, AirPlay, Ynison, …) is
  * attached to no queue, so the commands it can handle reach its own session
@@ -12,30 +11,36 @@ import { Player, PlayerQueue, PlayerSource } from "@/plugins/api/interfaces";
  *
  * Unlike `useActiveSource`, which answers with whichever source list entry is
  * active and so happily returns the Music Assistant queue's own entry, this
- * narrows to a source that has genuinely taken the player over — the caller
- * routes a command on the answer rather than merely greying a button out, and
- * sending an MA queue's shuffle to the player command would be wrong.
+ * narrows to a source that has genuinely taken the player over — callers route
+ * a command on the answer rather than merely greying a control out, and sending
+ * an MA queue's shuffle to the player command would be wrong.
  *
- * Pass the queue that belongs to the same player, i.e. `resolvePlayerQueue(player)`.
+ * Pass the queue belonging to the same player, i.e. `resolvePlayerQueue(player)`.
  */
+export function resolveLiveSource(
+  player: Player | undefined,
+  playerQueue: PlayerQueue | undefined,
+): PlayerSource | undefined {
+  // a resolved queue means Music Assistant owns the playback
+  if (playerQueue) return undefined;
+  if (!player?.active_source) return undefined;
+  // the MA queue is always in the source list under the player's own id, and a
+  // live source is always there under its uri — so this is the own queue,
+  // reachable before that queue has arrived in the client's state
+  if (player.active_source === player.player_id) return undefined;
+  return player.source_list?.find(
+    (source) => source.id === player.active_source,
+  );
+}
+
+/** Reactive {@link resolveLiveSource}, for components tracking a player. */
 export function useLiveSource(
   player: MaybeRef<Player | undefined>,
   playerQueue: MaybeRef<PlayerQueue | undefined>,
 ) {
-  const { activeSource } = useActiveSource(player);
-
-  const liveSource = computed((): PlayerSource | undefined => {
-    // a resolved queue means Music Assistant owns the playback
-    if (unref(playerQueue)) return undefined;
-    const playerObj = unref(player);
-    // nothing selected: useActiveSource would fall back to the player's own id
-    if (!playerObj?.active_source) return undefined;
-    // the MA queue is always in the source list under the player's own id, and
-    // a live source is always there under its uri — so this is the own queue,
-    // reachable before its queue has arrived in the client's state
-    if (playerObj.active_source === playerObj.player_id) return undefined;
-    return activeSource.value;
-  });
+  const liveSource = computed(() =>
+    resolveLiveSource(unref(player), unref(playerQueue)),
+  );
 
   return { liveSource };
 }

--- a/src/composables/liveSource.ts
+++ b/src/composables/liveSource.ts
@@ -1,0 +1,31 @@
+import { computed, ComputedRef, Ref, unref } from "vue";
+import { useActiveSource } from "@/composables/activeSource";
+import { Player, PlayerQueue, PlayerSource } from "@/plugins/api/interfaces";
+
+type MaybeRef<T> = ComputedRef<T> | Ref<T> | T;
+
+/**
+ * Composable that exposes the live external source playing on a player in place
+ * of a queue, or undefined when Music Assistant's own queue is what is playing.
+ *
+ * A source that takes the player over (Spotify Connect, AirPlay, Ynison, …) is
+ * attached to no queue, so the commands it can handle reach its own session
+ * through the player and the state to render comes off the source itself.
+ */
+export function useLiveSource(
+  player: MaybeRef<Player | undefined>,
+  playerQueue: MaybeRef<PlayerQueue | undefined>,
+) {
+  const { activeSource } = useActiveSource(player);
+
+  const liveSource = computed((): PlayerSource | undefined => {
+    // a resolved queue means Music Assistant owns the playback
+    if (unref(playerQueue)) return undefined;
+    // the MA queue is always in the source list, so a player sitting on its own
+    // queue would otherwise resolve to it through the player_id fallback
+    if (!unref(player)?.active_source) return undefined;
+    return activeSource.value;
+  });
+
+  return { liveSource };
+}

--- a/src/helpers/player_menu_items.ts
+++ b/src/helpers/player_menu_items.ts
@@ -11,6 +11,7 @@ import {
   PLAYER_CONTROL_NONE,
 } from "@/plugins/api/interfaces";
 import { getSleepTimerMenuItem, sleepTimerActive } from "@/helpers/sleep_timer";
+import { resolveLiveSource } from "@/composables/liveSource";
 import { useAnnouncement } from "@/composables/useAnnouncement";
 import { useAudioOverlay } from "@/composables/useAudioOverlay";
 import { visualizerProviderAvailable } from "@/plugins/visualizer-relay";
@@ -106,52 +107,63 @@ export const getPlayerMenuItems = (
   }
 
   const isDynamic = playerQueue?.is_dynamic === true;
+  // a live source orders its own session, so it takes these instead of the
+  // queue — and it has no queue to read the state or the dynamic flag from
+  const liveSource = resolveLiveSource(player, playerQueue);
+  const shuffleSource = liveSource?.can_shuffle ? liveSource : undefined;
+  const repeatSource = liveSource?.can_repeat ? liveSource : undefined;
+  const orderableQueue = playerQueue && !isDynamic ? playerQueue : undefined;
 
   // shuffle (queue menu only; hidden when the dedicated control is visible)
-  if (isQueue && playerQueue && !isDynamic && !hideShuffleRepeat) {
+  if (isQueue && (shuffleSource || orderableQueue) && !hideShuffleRepeat) {
+    const shuffleEnabled = shuffleSource
+      ? shuffleSource.shuffle_enabled === true
+      : orderableQueue!.shuffle_enabled;
     menuItems.push({
-      label: playerQueue.shuffle_enabled ? "shuffle_disable" : "shuffle_enable",
+      label: shuffleEnabled ? "shuffle_disable" : "shuffle_enable",
       labelArgs: [],
       action: () => {
-        api.queueCommandShuffleToggle(playerQueue.queue_id);
+        if (shuffleSource) {
+          api.playerCommandShuffle(player.player_id, !shuffleEnabled);
+        } else {
+          api.queueCommandShuffle(orderableQueue!.queue_id, !shuffleEnabled);
+        }
       },
-      icon: playerQueue.shuffle_enabled
-        ? "mdi-shuffle-disabled"
-        : "mdi-shuffle",
+      icon: shuffleEnabled ? "mdi-shuffle-disabled" : "mdi-shuffle",
     });
   }
 
   // repeat (queue menu only; hidden when the dedicated control is visible)
-  if (isQueue && playerQueue && !isDynamic && !hideShuffleRepeat) {
+  if (isQueue && (repeatSource || orderableQueue) && !hideShuffleRepeat) {
+    // a source that has not reported its mode reads as off
+    const repeatMode = repeatSource
+      ? (repeatSource.repeat_mode ?? RepeatMode.OFF)
+      : orderableQueue!.repeat_mode;
+    const setRepeatMode = (mode: RepeatMode) => {
+      if (repeatSource) {
+        api.playerCommandRepeat(player.player_id, mode);
+      } else {
+        api.queueCommandRepeat(orderableQueue!.queue_id, mode);
+      }
+    };
     menuItems.push({
       label: "select_repeat_mode",
       labelArgs: [],
-      subItems: [
-        {
-          label: "repeat_mode.off",
-          labelArgs: [],
-          action: () => {
-            api.queueCommandRepeat(playerQueue!.queue_id, RepeatMode.OFF);
-          },
-          selected: playerQueue.repeat_mode == RepeatMode.OFF,
+      // keys spelled out so they stay greppable for the translation sync
+      subItems: (
+        [
+          ["repeat_mode.off", RepeatMode.OFF],
+          ["repeat_mode.all", RepeatMode.ALL],
+          ["repeat_mode.one", RepeatMode.ONE],
+        ] as const
+      ).map(([label, mode]) => ({
+        label,
+        labelArgs: [],
+        action: () => {
+          setRepeatMode(mode);
         },
-        {
-          label: "repeat_mode.all",
-          labelArgs: [],
-          action: () => {
-            api.queueCommandRepeat(playerQueue!.queue_id, RepeatMode.ALL);
-          },
-          selected: playerQueue.repeat_mode == RepeatMode.ALL,
-        },
-        {
-          label: "repeat_mode.one",
-          labelArgs: [],
-          action: () => {
-            api.queueCommandRepeat(playerQueue!.queue_id, RepeatMode.ONE);
-          },
-          selected: playerQueue.repeat_mode == RepeatMode.ONE,
-        },
-      ],
+        selected: repeatMode == mode,
+      })),
       icon: "mdi-repeat",
     });
   }

--- a/src/helpers/player_menu_items.ts
+++ b/src/helpers/player_menu_items.ts
@@ -124,13 +124,18 @@ export const getPlayerMenuItems = (
       labelArgs: [],
       action: () => {
         // the menu can sit open while the state moves, and an update lands as
-        // an Object.assign onto these, so the target is read at click time —
-        // the source list is a fresh array by then, hence the re-resolve
+        // an Object.assign onto these, so both the target and the value are
+        // settled at click time — the source list is a fresh array by then,
+        // hence the re-resolve
         if (shuffleSource) {
           const live = resolveLiveSource(player, playerQueue);
+          // the source can end while the menu sits open, and the queue that
+          // takes the player back would otherwise be shuffled by a command
+          // meant for the session — with the value the entry offered inverted
+          if (!live?.can_shuffle) return;
           api.playerCommandShuffle(
             player.player_id,
-            live?.shuffle_enabled !== true,
+            live.shuffle_enabled !== true,
           );
         } else {
           api.queueCommandShuffle(
@@ -153,6 +158,9 @@ export const getPlayerMenuItems = (
     // to be settled at click time rather than the mode itself
     const setRepeatMode = (mode: RepeatMode) => {
       if (repeatSource) {
+        // the source can end while the menu sits open; a mode meant for its
+        // session must not land on the queue that took the player back
+        if (!resolveLiveSource(player, playerQueue)?.can_repeat) return;
         api.playerCommandRepeat(player.player_id, mode);
       } else {
         api.queueCommandRepeat(orderableQueue!.queue_id, mode);

--- a/src/helpers/player_menu_items.ts
+++ b/src/helpers/player_menu_items.ts
@@ -123,10 +123,20 @@ export const getPlayerMenuItems = (
       label: shuffleEnabled ? "shuffle_disable" : "shuffle_enable",
       labelArgs: [],
       action: () => {
+        // the menu can sit open while the state moves, and an update lands as
+        // an Object.assign onto these, so the target is read at click time —
+        // the source list is a fresh array by then, hence the re-resolve
         if (shuffleSource) {
-          api.playerCommandShuffle(player.player_id, !shuffleEnabled);
+          const live = resolveLiveSource(player, playerQueue);
+          api.playerCommandShuffle(
+            player.player_id,
+            live?.shuffle_enabled !== true,
+          );
         } else {
-          api.queueCommandShuffle(orderableQueue!.queue_id, !shuffleEnabled);
+          api.queueCommandShuffle(
+            orderableQueue!.queue_id,
+            !orderableQueue!.shuffle_enabled,
+          );
         }
       },
       icon: shuffleEnabled ? "mdi-shuffle-disabled" : "mdi-shuffle",
@@ -139,6 +149,8 @@ export const getPlayerMenuItems = (
     const repeatMode = repeatSource
       ? (repeatSource.repeat_mode ?? RepeatMode.OFF)
       : orderableQueue!.repeat_mode;
+    // each entry sets an explicit mode, so only the target of the command has
+    // to be settled at click time rather than the mode itself
     const setRepeatMode = (mode: RepeatMode) => {
       if (repeatSource) {
         api.playerCommandRepeat(player.player_id, mode);

--- a/src/layouts/default/PlayerOSD/PlayerControlBtn/RepeatBtn.vue
+++ b/src/layouts/default/PlayerOSD/PlayerControlBtn/RepeatBtn.vue
@@ -2,33 +2,19 @@
   <!-- repeat button -->
   <Icon
     v-bind="{ ...icon, ...$attrs }"
-    :disabled="
-      !playerQueue ||
-      !playerQueue.active ||
-      isLoading ||
-      isInfiniteStream ||
-      isDynamic
-    "
+    :disabled="isDisabled"
     :color="
       getValueFromSources(icon?.color, [
-        [playerQueue?.repeat_mode == RepeatMode.OFF, undefined],
-        [playerQueue?.repeat_mode == RepeatMode.ALL, 'primary'],
-        [playerQueue?.repeat_mode == RepeatMode.ONE, 'primary'],
+        [repeatMode !== RepeatMode.OFF, 'primary'],
       ])
     "
     :title="repeatTitle"
     :data-dynamic="isDynamic || undefined"
     variant="button"
-    @click="api.queueCommandRepeat(playerQueue?.queue_id || '', nextRepeatMode)"
+    @click="cycleRepeatMode"
   >
-    <IconRepeatOff
-      v-if="playerQueue?.repeat_mode == RepeatMode.OFF"
-      :size="size"
-    />
-    <IconRepeat
-      v-else-if="playerQueue?.repeat_mode == RepeatMode.ALL"
-      :size="size"
-    />
+    <IconRepeatOff v-if="repeatMode === RepeatMode.OFF" :size="size" />
+    <IconRepeat v-else-if="repeatMode === RepeatMode.ALL" :size="size" />
     <IconRepeatOnce v-else :size="size" />
   </Icon>
 </template>
@@ -37,15 +23,17 @@
 defineOptions({ inheritAttrs: false });
 import Icon, { IconProps } from "@/components/Icon.vue";
 import { getValueFromSources } from "@/helpers/utils";
+import { useLiveSource } from "@/composables/liveSource";
 import api from "@/plugins/api";
-import { PlayerQueue, RepeatMode } from "@/plugins/api/interfaces";
+import { Player, PlayerQueue, RepeatMode } from "@/plugins/api/interfaces";
 import { isQueueInfiniteStream } from "@/plugins/api/helpers";
 import { $t } from "@/plugins/i18n";
-import { computed } from "vue";
+import { computed, toRef } from "vue";
 import { IconRepeat, IconRepeatOff, IconRepeatOnce } from "@tabler/icons-vue";
 
 // properties
 export interface Props {
+  player: Player | undefined;
   playerQueue: PlayerQueue | undefined;
   icon?: IconProps;
   size?: number;
@@ -54,6 +42,18 @@ const compProps = withDefaults(defineProps<Props>(), {
   icon: undefined,
   size: 20,
 });
+
+const { liveSource } = useLiveSource(
+  toRef(compProps, "player"),
+  toRef(compProps, "playerQueue"),
+);
+
+// A live source that repeats within its own session takes the command instead
+// of the queue; one that cannot leaves the button disabled rather than
+// silently inert.
+const orderingSource = computed(() =>
+  liveSource.value?.can_repeat ? liveSource.value : undefined,
+);
 
 const isLoading = computed(() => {
   return (
@@ -67,19 +67,51 @@ const isInfiniteStream = computed(() =>
   isQueueInfiniteStream(compProps.playerQueue),
 );
 
+// The repeat mode in effect: what the live source reports for its own session,
+// or the queue's. A source that has not reported one reads as off.
+const repeatMode = computed<RepeatMode>(() => {
+  if (orderingSource.value) {
+    return orderingSource.value.repeat_mode ?? RepeatMode.OFF;
+  }
+  return compProps.playerQueue?.repeat_mode ?? RepeatMode.OFF;
+});
+
 // The next repeat mode when the button is pressed: cycle OFF -> ALL -> ONE.
 // (The button is disabled for radio/dynamic queues, so those don't apply here.)
 const nextRepeatMode = computed<RepeatMode>(() => {
-  const current = compProps.playerQueue?.repeat_mode ?? RepeatMode.OFF;
-  if (current === RepeatMode.OFF) return RepeatMode.ALL;
-  if (current === RepeatMode.ALL) return RepeatMode.ONE;
+  if (repeatMode.value === RepeatMode.OFF) return RepeatMode.ALL;
+  if (repeatMode.value === RepeatMode.ALL) return RepeatMode.ONE;
   return RepeatMode.OFF;
+});
+
+// A live source needs no queue to act on, so only the queue path carries the
+// queue's own reasons for being unavailable.
+const isDisabled = computed(() => {
+  if (isLoading.value) return true;
+  if (orderingSource.value) return false;
+  return (
+    !compProps.playerQueue ||
+    !compProps.playerQueue.active ||
+    isInfiniteStream.value ||
+    isDynamic.value
+  );
 });
 
 // In dynamic mode the button is disabled; the tooltip explains why.
 const repeatTitle = computed<string | undefined>(() =>
   isDynamic.value ? $t("repeat_dynamic_unavailable") : undefined,
 );
+
+function cycleRepeatMode() {
+  if (orderingSource.value && compProps.player) {
+    api.playerCommandRepeat(compProps.player.player_id, nextRepeatMode.value);
+    return;
+  }
+  api.queueCommandRepeat(
+    compProps.playerQueue?.queue_id || "",
+    nextRepeatMode.value,
+  );
+}
 </script>
 
 <style scoped>

--- a/src/layouts/default/PlayerOSD/PlayerControlBtn/ShuffleBtn.vue
+++ b/src/layouts/default/PlayerOSD/PlayerControlBtn/ShuffleBtn.vue
@@ -2,23 +2,12 @@
   <!-- shuffle button -->
   <Icon
     v-bind="{ ...icon, ...$attrs }"
-    :disabled="
-      !playerQueue ||
-      !playerQueue.active ||
-      isLoading ||
-      isInfiniteStream ||
-      isDynamic
-    "
+    :disabled="isDisabled"
     :color="getValueFromSources(icon?.color, [[shuffleActive, 'primary', '']])"
     :title="shuffleTitle"
     :data-dynamic="isDynamic || undefined"
     variant="button"
-    @click="
-      api.queueCommandShuffle(
-        playerQueue?.queue_id || '',
-        playerQueue?.shuffle_enabled ? false : true,
-      )
-    "
+    @click="toggleShuffle"
   >
     <ShuffleIcon
       v-if="shuffleActive"
@@ -34,15 +23,17 @@ defineOptions({ inheritAttrs: false });
 import Icon, { IconProps } from "@/components/Icon.vue";
 import ShuffleIcon from "@/layouts/default/PlayerOSD/PlayerControlBtn/ShuffleIcon.vue";
 import { getValueFromSources } from "@/helpers/utils";
+import { useLiveSource } from "@/composables/liveSource";
 import api from "@/plugins/api";
 import { isQueueInfiniteStream } from "@/plugins/api/helpers";
-import { PlayerQueue } from "@/plugins/api/interfaces";
+import { Player, PlayerQueue } from "@/plugins/api/interfaces";
 import { $t } from "@/plugins/i18n";
 import { IconArrowsRight } from "@tabler/icons-vue";
-import { computed } from "vue";
+import { computed, toRef } from "vue";
 
 // properties
 export interface Props {
+  player: Player | undefined;
   playerQueue: PlayerQueue | undefined;
   icon?: IconProps;
   size?: number;
@@ -51,6 +42,17 @@ const compProps = withDefaults(defineProps<Props>(), {
   icon: undefined,
   size: 20,
 });
+
+const { liveSource } = useLiveSource(
+  toRef(compProps, "player"),
+  toRef(compProps, "playerQueue"),
+);
+
+// A live source that orders its own session takes the command instead of the
+// queue; one that cannot leaves the button disabled rather than silently inert.
+const orderingSource = computed(() =>
+  liveSource.value?.can_shuffle ? liveSource.value : undefined,
+);
 
 const isLoading = computed(() => {
   return (
@@ -74,21 +76,45 @@ const smartShuffleActive = computed(
 );
 
 // Whether shuffle is enabled — drives the icon choice and the primary
-// highlight. The backend owns the smart/plain relationship, so this stays a
-// pure read of shuffle_enabled (smart state is surfaced via smartShuffleActive).
-const shuffleActive = computed(
-  () => compProps.playerQueue?.shuffle_enabled === true,
+// highlight. Read from whichever side is playing; the backend owns the
+// smart/plain relationship, so smart state is surfaced via smartShuffleActive.
+const shuffleActive = computed(() =>
+  orderingSource.value
+    ? orderingSource.value.shuffle_enabled === true
+    : compProps.playerQueue?.shuffle_enabled === true,
 );
+
+// A live source needs no queue to act on, so only the queue path carries the
+// queue's own reasons for being unavailable.
+const isDisabled = computed(() => {
+  if (isLoading.value) return true;
+  if (orderingSource.value) return false;
+  return (
+    !compProps.playerQueue ||
+    !compProps.playerQueue.active ||
+    isInfiniteStream.value ||
+    isDynamic.value
+  );
+});
 
 // State-aware tooltip. In dynamic mode the button is disabled and shuffle is
 // managed by the queue, so explain that rather than offering a toggle.
 const shuffleTitle = computed(() => {
   if (isDynamic.value) return $t("shuffle_dynamic_active");
   if (smartShuffleActive.value) return $t("shuffle_smart_active");
-  return compProps.playerQueue?.shuffle_enabled
-    ? $t("shuffle_disable")
-    : $t("shuffle_enable");
+  return shuffleActive.value ? $t("shuffle_disable") : $t("shuffle_enable");
 });
+
+function toggleShuffle() {
+  if (orderingSource.value && compProps.player) {
+    api.playerCommandShuffle(compProps.player.player_id, !shuffleActive.value);
+    return;
+  }
+  api.queueCommandShuffle(
+    compProps.playerQueue?.queue_id || "",
+    !shuffleActive.value,
+  );
+}
 </script>
 
 <style scoped>

--- a/src/layouts/default/PlayerOSD/PlayerControls.vue
+++ b/src/layouts/default/PlayerOSD/PlayerControls.vue
@@ -6,6 +6,7 @@
       class="player-controls-elements"
     >
       <ShuffleBtn
+        :player="store.activePlayer"
         :player-queue="store.activePlayerQueue"
         class="media-controls-item"
         :icon="visibleComponents.shuffle.icon"
@@ -55,6 +56,7 @@
       class="player-controls-elements"
     >
       <RepeatBtn
+        :player="store.activePlayer"
         :player-queue="store.activePlayerQueue"
         :icon="visibleComponents.repeat.icon"
         static-height="24px"

--- a/src/layouts/default/PlayerOSD/PlayerFullscreen.vue
+++ b/src/layouts/default/PlayerOSD/PlayerFullscreen.vue
@@ -386,6 +386,7 @@
           </div>
           <ShuffleBtn
             v-if="$vuetify.display.mdAndUp"
+            :player="store.activePlayer"
             :player-queue="store.activePlayerQueue"
             class="media-controls-item"
             max-height="30px"
@@ -417,6 +418,7 @@
           />
           <RepeatBtn
             v-if="$vuetify.display.mdAndUp"
+            :player="store.activePlayer"
             :player-queue="store.activePlayerQueue"
             class="media-controls-item"
             max-height="35px"

--- a/src/plugins/api/index.ts
+++ b/src/plugins/api/index.ts
@@ -1820,6 +1820,22 @@ export class MusicAssistantApi {
   public playerCommandSeek(playerId: string, position: number) {
     this.playerCommand(playerId, "seek", { position });
   }
+  public playerCommandShuffle(
+    playerId: string,
+    shuffle_enabled: boolean,
+  ): Promise<void> {
+    // Configure shuffle on whatever the player is playing: a live external
+    // source orders its own session, an MA queue orders its own items.
+    return this.playerCommand(playerId, "shuffle", { shuffle_enabled });
+  }
+  public playerCommandRepeat(
+    playerId: string,
+    repeat_mode: RepeatMode,
+  ): Promise<void> {
+    // Configure repeat on whatever the player is playing: a live external
+    // source repeats within its own session, an MA queue repeats its own items.
+    return this.playerCommand(playerId, "repeat", { repeat_mode });
+  }
 
   public playerCommandPower(playerId: string, powered: boolean): Promise<void> {
     return this.playerCommand(playerId, "power", { powered });

--- a/src/plugins/api/index.ts
+++ b/src/plugins/api/index.ts
@@ -1685,24 +1685,9 @@ export class MusicAssistantApi {
     // Configure shuffle setting on the the queue.
     this.playerQueueCommand(queueId, "shuffle", { shuffle_enabled });
   }
-  public queueCommandShuffleToggle(queueId: string) {
-    // Toggle shuffle mode for a queue
-    this.queueCommandShuffle(queueId, !this.queues[queueId].shuffle_enabled);
-  }
   public queueCommandRepeat(queueId: string, repeat_mode: RepeatMode) {
     // Configure repeat setting on the the queue.
     this.playerQueueCommand(queueId, "repeat", { repeat_mode });
-  }
-  public queueCommandRepeatToggle(queueId: string) {
-    // Toggle repeat mode of a queue
-    const queue = this.queues[queueId];
-    if (this.queues[queueId].repeat_mode == RepeatMode.OFF) {
-      this.queueCommandRepeat(queueId, RepeatMode.ONE);
-    } else if (this.queues[queueId].repeat_mode == RepeatMode.ONE) {
-      this.queueCommandRepeat(queueId, RepeatMode.ALL);
-    } else {
-      this.queueCommandRepeat(queueId, RepeatMode.OFF);
-    }
   }
   public queueCommandCrossfade(queueId: string, crossfade_enabled: boolean) {
     // Enable or disable crossfade on the queue.

--- a/src/plugins/api/interfaces.ts
+++ b/src/plugins/api/interfaces.ts
@@ -1338,6 +1338,11 @@ export interface PlayerSource {
   can_play_pause: boolean;
   can_seek: boolean;
   can_next_previous: boolean;
+  can_shuffle: boolean;
+  can_repeat: boolean;
+  // the ordering the source reports for itself; null = it has not said
+  shuffle_enabled: boolean | null;
+  repeat_mode: RepeatMode | null;
 }
 
 export interface PlayerSoundMode {

--- a/tests/composables/nowPlayingSource.test.ts
+++ b/tests/composables/nowPlayingSource.test.ts
@@ -7,6 +7,7 @@ import type {
   StreamMetadata,
 } from "@/plugins/api/interfaces";
 import { audioSource } from "../fixtures/audioSource";
+import { playerSource } from "../fixtures/playerSource";
 import { providerMapping } from "../fixtures/providerMapping";
 import { queueItem } from "../fixtures/queueItem";
 import { radio } from "../fixtures/radio";
@@ -131,16 +132,7 @@ describe("useNowPlayingSource", () => {
   it("names an external source that took the player over", () => {
     storeMock.activePlayer = player({
       active_source: "line-in",
-      source_list: [
-        {
-          id: "line-in",
-          name: "Line In",
-          passive: true,
-          can_play_pause: false,
-          can_seek: false,
-          can_next_previous: false,
-        },
-      ],
+      source_list: [playerSource({ id: "line-in", name: "Line In" })],
     });
 
     const { nowPlayingSource } = useNowPlayingSource();

--- a/tests/fixtures/playerSource.ts
+++ b/tests/fixtures/playerSource.ts
@@ -1,0 +1,25 @@
+import type { PlayerSource } from "@/plugins/api/interfaces";
+
+/**
+ * A source in a player's source list, for tests that only care about a few of
+ * its fields but should still model a payload the server can send.
+ *
+ * Defaults to a transport-only source: it names itself and nothing more.
+ */
+export function playerSource(
+  overrides: Partial<PlayerSource> = {},
+): PlayerSource {
+  return {
+    id: "line-in",
+    name: "Line In",
+    passive: true,
+    can_play_pause: false,
+    can_seek: false,
+    can_next_previous: false,
+    can_shuffle: false,
+    can_repeat: false,
+    shuffle_enabled: null,
+    repeat_mode: null,
+    ...overrides,
+  };
+}

--- a/tests/helpers/player_menu_items.test.ts
+++ b/tests/helpers/player_menu_items.test.ts
@@ -775,6 +775,39 @@ describe("shuffle and repeat", () => {
     expect(api.playerCommandShuffle).toHaveBeenCalledWith("kitchen", false);
   });
 
+  // the menu can sit open while a websocket update lands; updates Object.assign
+  // onto the player, so the click must act on what is true then, not at build
+  it("shuffles against the state at click time, not at build time", () => {
+    const player = playerOnSource({
+      can_shuffle: true,
+      shuffle_enabled: false,
+    });
+    const item = entry(player, "shuffle_enable");
+
+    // the source list arrives as a fresh array on a player update
+    player.source_list = [
+      playerSource({
+        id: SPOTIFY,
+        name: "Spotify Connect",
+        can_shuffle: true,
+        shuffle_enabled: true,
+      }),
+    ];
+    item?.action?.();
+
+    expect(api.playerCommandShuffle).toHaveBeenCalledWith("kitchen", false);
+  });
+
+  it("shuffles the queue against the state at click time", () => {
+    const queue = makeQueue({ shuffle_enabled: false });
+    const item = entry(makePlayer(), "shuffle_enable", queue);
+
+    queue.shuffle_enabled = true;
+    item?.action?.();
+
+    expect(api.queueCommandShuffle).toHaveBeenCalledWith("kitchen", false);
+  });
+
   it("repeats within a live source's own session through the player", () => {
     const player = playerOnSource({ can_repeat: true });
 

--- a/tests/helpers/player_menu_items.test.ts
+++ b/tests/helpers/player_menu_items.test.ts
@@ -17,6 +17,7 @@ import {
 } from "@/plugins/api/interfaces";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { playerQueue } from "../fixtures/playerQueue";
+import { playerSource } from "../fixtures/playerSource";
 
 const {
   aiRadioAvailableRef,
@@ -627,22 +628,15 @@ describe("getPlayerMenuItems ai dj", () => {
     hostsRef.value = [makeHost()];
     const player = makePlayer({
       source_list: [
-        {
+        playerSource({
           id: "kitchen",
           name: "Kitchen",
           passive: false,
           can_play_pause: true,
           can_seek: true,
           can_next_previous: true,
-        },
-        {
-          id: "line_in",
-          name: "Line-in",
-          passive: false,
-          can_play_pause: false,
-          can_seek: false,
-          can_next_previous: false,
-        },
+        }),
+        playerSource({ id: "line_in", name: "Line-in", passive: false }),
       ],
       active_source: "kitchen",
     });

--- a/tests/helpers/player_menu_items.test.ts
+++ b/tests/helpers/player_menu_items.test.ts
@@ -14,6 +14,8 @@ import {
   type Player,
   type PlayerOption,
   type PlayerQueue,
+  type PlayerSource,
+  RepeatMode,
 } from "@/plugins/api/interfaces";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { playerQueue } from "../fixtures/playerQueue";
@@ -64,6 +66,10 @@ vi.mock("@/plugins/api", () => ({
     providers: {
       milkdrop_visualizer: { domain: "milkdrop_visualizer", available: true },
     },
+    queueCommandShuffle: vi.fn(),
+    queueCommandRepeat: vi.fn(),
+    playerCommandShuffle: vi.fn(),
+    playerCommandRepeat: vi.fn(),
   },
 }));
 
@@ -709,5 +715,128 @@ describe("visualizer menu entry", () => {
     expect(entry?.componentProps).toEqual({ playerId: player.player_id });
     // no toggle leaf: the on/off switch lives inside the popout
     expect(entry?.action).toBeUndefined();
+  });
+});
+
+describe("shuffle and repeat", () => {
+  const SPOTIFY = "spotify://audio_source/main";
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  /** A player taken over by a live external source, as the server publishes it. */
+  function playerOnSource(source: Partial<PlayerSource> = {}): Player {
+    const live = playerSource({
+      id: SPOTIFY,
+      name: "Spotify Connect",
+      ...source,
+    });
+    return makePlayer({ active_source: SPOTIFY, source_list: [live] });
+  }
+
+  function labels(player: Player, queue?: PlayerQueue): string[] {
+    return getPlayerMenuItems(player, queue, { context: "queue" }).map(
+      (item) => item.label,
+    );
+  }
+
+  function entry(
+    player: Player,
+    label: string,
+    queue?: PlayerQueue,
+  ): ContextMenuItem | undefined {
+    return getPlayerMenuItems(player, queue, { context: "queue" }).find(
+      (item) => item.label === label,
+    );
+  }
+
+  it("shuffles the queue when one is playing", () => {
+    entry(makePlayer(), "shuffle_enable", makeQueue())?.action?.();
+
+    expect(api.queueCommandShuffle).toHaveBeenCalledWith("kitchen", true);
+    expect(api.playerCommandShuffle).not.toHaveBeenCalled();
+  });
+
+  it("shuffles a live source's own session through the player", () => {
+    const player = playerOnSource({ can_shuffle: true });
+
+    entry(player, "shuffle_enable")?.action?.();
+
+    expect(api.playerCommandShuffle).toHaveBeenCalledWith("kitchen", true);
+    expect(api.queueCommandShuffle).not.toHaveBeenCalled();
+  });
+
+  it("reads the shuffle state the source reports", () => {
+    const player = playerOnSource({ can_shuffle: true, shuffle_enabled: true });
+
+    entry(player, "shuffle_disable")?.action?.();
+
+    expect(api.playerCommandShuffle).toHaveBeenCalledWith("kitchen", false);
+  });
+
+  it("repeats within a live source's own session through the player", () => {
+    const player = playerOnSource({ can_repeat: true });
+
+    entry(player, "select_repeat_mode")?.subItems?.[1]?.action?.();
+
+    expect(api.playerCommandRepeat).toHaveBeenCalledWith(
+      "kitchen",
+      RepeatMode.ALL,
+    );
+    expect(api.queueCommandRepeat).not.toHaveBeenCalled();
+  });
+
+  it("marks the repeat mode the source reports", () => {
+    const player = playerOnSource({
+      can_repeat: true,
+      repeat_mode: RepeatMode.ONE,
+    });
+
+    const subItems = entry(player, "select_repeat_mode")?.subItems;
+
+    expect(subItems?.map((item) => item.selected)).toEqual([
+      false,
+      false,
+      true,
+    ]);
+  });
+
+  // a source that cannot be reordered would accept the command and do nothing,
+  // so it must not be offered at all
+  it("offers neither for a source that cannot be reordered", () => {
+    const shown = labels(playerOnSource());
+
+    expect(shown).not.toContain("shuffle_enable");
+    expect(shown).not.toContain("select_repeat_mode");
+  });
+
+  it("offers neither with nothing playing", () => {
+    const shown = labels(makePlayer());
+
+    expect(shown).not.toContain("shuffle_enable");
+    expect(shown).not.toContain("select_repeat_mode");
+  });
+
+  // the MA queue sits in the source list under the player's own id
+  it("never mistakes the player's own queue for a source", () => {
+    const own = playerSource({
+      id: "kitchen",
+      can_shuffle: true,
+      can_repeat: true,
+    });
+    const player = makePlayer({
+      active_source: "kitchen",
+      source_list: [own],
+    });
+
+    expect(labels(player)).not.toContain("shuffle_enable");
+  });
+
+  it("offers neither on a dynamic queue", () => {
+    const shown = labels(makePlayer(), makeQueue({ is_dynamic: true }));
+
+    expect(shown).not.toContain("shuffle_enable");
+    expect(shown).not.toContain("select_repeat_mode");
   });
 });

--- a/tests/helpers/player_menu_items.test.ts
+++ b/tests/helpers/player_menu_items.test.ts
@@ -808,6 +808,21 @@ describe("shuffle and repeat", () => {
     expect(api.queueCommandShuffle).toHaveBeenCalledWith("kitchen", false);
   });
 
+  // the source can end while the menu sits open, and the player's own queue
+  // takes it back — a command meant for the session must not land there
+  it("does nothing when the source ended while the menu was open", () => {
+    const player = playerOnSource({ can_shuffle: true, shuffle_enabled: true });
+    const item = entry(player, "shuffle_disable");
+
+    // MA's queue is back, so the player reports itself as its own source
+    player.active_source = "kitchen";
+    player.source_list = [playerSource({ id: "kitchen", name: "Queue" })];
+    item?.action?.();
+
+    expect(api.playerCommandShuffle).not.toHaveBeenCalled();
+    expect(api.queueCommandShuffle).not.toHaveBeenCalled();
+  });
+
   it("repeats within a live source's own session through the player", () => {
     const player = playerOnSource({ can_repeat: true });
 
@@ -817,6 +832,32 @@ describe("shuffle and repeat", () => {
       "kitchen",
       RepeatMode.ALL,
     );
+    expect(api.queueCommandRepeat).not.toHaveBeenCalled();
+  });
+
+  it("repeats the queue when one is playing", () => {
+    entry(
+      makePlayer(),
+      "select_repeat_mode",
+      makeQueue(),
+    )?.subItems?.[1]?.action?.();
+
+    expect(api.queueCommandRepeat).toHaveBeenCalledWith(
+      "kitchen",
+      RepeatMode.ALL,
+    );
+    expect(api.playerCommandRepeat).not.toHaveBeenCalled();
+  });
+
+  it("sets no repeat mode when the source ended while the menu was open", () => {
+    const player = playerOnSource({ can_repeat: true });
+    const item = entry(player, "select_repeat_mode");
+
+    player.active_source = "kitchen";
+    player.source_list = [playerSource({ id: "kitchen", name: "Queue" })];
+    item?.subItems?.[1]?.action?.();
+
+    expect(api.playerCommandRepeat).not.toHaveBeenCalled();
     expect(api.queueCommandRepeat).not.toHaveBeenCalled();
   });
 

--- a/tests/layouts/RepeatBtn.test.ts
+++ b/tests/layouts/RepeatBtn.test.ts
@@ -10,6 +10,7 @@ import {
 import { enableAutoUnmount, mount } from "@vue/test-utils";
 import { IconRepeat, IconRepeatOff, IconRepeatOnce } from "@tabler/icons-vue";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { nextTick, reactive } from "vue";
 import { playerQueue } from "../fixtures/playerQueue";
 import { playerSource } from "../fixtures/playerSource";
 import { queueItem } from "../fixtures/queueItem";
@@ -154,6 +155,28 @@ describe("RepeatBtn", () => {
         "player-1",
         RepeatMode.ONE,
       );
+    });
+
+    // a player update lands as an in-place assign with a fresh source list, so
+    // the control has to re-read what the source reports rather than keep what
+    // it read when it was built
+    it("follows the mode the source reports as it changes", async () => {
+      const live = reactive(playerOnSource({ repeat_mode: RepeatMode.OFF }));
+      const wrapper = mountButton({ player: live });
+
+      expect(wrapper.findComponent(IconRepeatOff).exists()).toBe(true);
+
+      live.source_list = [
+        playerSource({
+          id: live.active_source!,
+          name: "Spotify Connect",
+          can_repeat: true,
+          repeat_mode: RepeatMode.ALL,
+        }),
+      ];
+      await nextTick();
+
+      expect(wrapper.findComponent(IconRepeat).exists()).toBe(true);
     });
 
     it("renders repeat-one when the source reports it", () => {

--- a/tests/layouts/RepeatBtn.test.ts
+++ b/tests/layouts/RepeatBtn.test.ts
@@ -235,6 +235,31 @@ describe("RepeatBtn", () => {
       expect(playerCommandRepeat).not.toHaveBeenCalled();
     });
 
+    // the OSD passes store.activePlayer, a computed that yields a different
+    // object when the user switches player — so the source has to be resolved
+    // from the prop as it stands, not from the one captured at setup
+    it("re-reads the source when the active player changes", async () => {
+      const wrapper = mountButton({ player: playerOnSource() });
+
+      expect(isDisabled(wrapper)).toBe(false);
+
+      await wrapper.setProps({
+        player: player({
+          player_id: "player-2",
+          active_source: "line-in",
+          source_list: [playerSource({ id: "line-in", name: "Line In" })],
+        }),
+      });
+
+      // line-in orders nothing, so the control on the newly selected player
+      // must go dead rather than keep commanding the player left behind
+      expect(isDisabled(wrapper)).toBe(true);
+
+      await button(wrapper).trigger("click");
+
+      expect(playerCommandRepeat).not.toHaveBeenCalled();
+    });
+
     it("prefers the queue whenever one is playing", async () => {
       const wrapper = mountButton({
         player: playerOnSource(),

--- a/tests/layouts/RepeatBtn.test.ts
+++ b/tests/layouts/RepeatBtn.test.ts
@@ -97,7 +97,20 @@ describe("RepeatBtn", () => {
     });
 
     it("is disabled without a queue to repeat", () => {
-      expect(isDisabled(mountButton())).toBe(true);
+      const wrapper = mountButton();
+
+      expect(isDisabled(wrapper)).toBe(true);
+      // nothing is playing, so the button reads off rather than showing the
+      // repeat-one icon it falls through to when no mode is set at all
+      expect(wrapper.findComponent(IconRepeatOff).exists()).toBe(true);
+    });
+
+    it("is disabled on an inactive queue", () => {
+      const wrapper = mountButton({
+        playerQueue: playerQueue({ active: false }),
+      });
+
+      expect(isDisabled(wrapper)).toBe(true);
     });
 
     it("is disabled on an infinite stream", () => {
@@ -173,15 +186,30 @@ describe("RepeatBtn", () => {
       expect(queueCommandRepeat).not.toHaveBeenCalled();
     });
 
-    // the player's own queue is always in the source list, so a player sitting
-    // on it must not be mistaken for one a source has taken over
-    it("leaves an idle player on its own source list alone", () => {
+    it("leaves an idle player alone", () => {
       const own = playerSource({ id: "player-1", can_repeat: true });
       const wrapper = mountButton({
         player: player({ active_source: null, source_list: [own] }),
       });
 
       expect(isDisabled(wrapper)).toBe(true);
+    });
+
+    // the MA queue sits in the source list under the player's own id, so a
+    // player on its own queue must never be taken for one a source took over —
+    // reachable before that queue has arrived in the client's state, which is
+    // the only moment no queue resolves for it
+    it("never mistakes the player's own queue for a source", async () => {
+      const own = playerSource({ id: "player-1", can_repeat: true });
+      const wrapper = mountButton({
+        player: player({ active_source: "player-1", source_list: [own] }),
+      });
+
+      expect(isDisabled(wrapper)).toBe(true);
+
+      await button(wrapper).trigger("click");
+
+      expect(playerCommandRepeat).not.toHaveBeenCalled();
     });
 
     it("prefers the queue whenever one is playing", async () => {

--- a/tests/layouts/RepeatBtn.test.ts
+++ b/tests/layouts/RepeatBtn.test.ts
@@ -1,0 +1,202 @@
+import RepeatBtn from "@/layouts/default/PlayerOSD/PlayerControlBtn/RepeatBtn.vue";
+import api from "@/plugins/api";
+import {
+  MediaType,
+  type Player,
+  type PlayerQueue,
+  type PlayerSource,
+  RepeatMode,
+} from "@/plugins/api/interfaces";
+import { enableAutoUnmount, mount } from "@vue/test-utils";
+import { IconRepeat, IconRepeatOff, IconRepeatOnce } from "@tabler/icons-vue";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { playerQueue } from "../fixtures/playerQueue";
+import { playerSource } from "../fixtures/playerSource";
+import { queueItem } from "../fixtures/queueItem";
+import { radio } from "../fixtures/radio";
+
+vi.mock("@/plugins/api", () => {
+  const api = {
+    queueCommandRepeat: vi.fn(),
+    playerCommandRepeat: vi.fn(),
+  };
+  return { api, default: api };
+});
+
+vi.mock("@/plugins/i18n", () => ({ $t: (key: string) => key }));
+
+const queueCommandRepeat = vi.mocked(api.queueCommandRepeat);
+const playerCommandRepeat = vi.mocked(api.playerCommandRepeat);
+
+// Vuetify is not installed in the test app, and Icon.vue renders its icon
+// inside a v-badge it never imports itself.
+const stubs = {
+  VIcon: { template: "<i><slot /></i>" },
+  VBadge: { template: "<div><slot /></div>" },
+};
+
+function player(overrides: Partial<Player> = {}): Player {
+  return {
+    player_id: "player-1",
+    active_source: null,
+    source_list: [],
+    ...overrides,
+  } as unknown as Player;
+}
+
+/** A player taken over by a live external source, as the server publishes it. */
+function playerOnSource(source: Partial<PlayerSource> = {}) {
+  const live = playerSource({
+    id: "spotify://audio_source/main",
+    name: "Spotify Connect",
+    can_repeat: true,
+    ...source,
+  });
+  return player({ active_source: live.id, source_list: [live] });
+}
+
+function mountButton(
+  props: {
+    player?: Player;
+    playerQueue?: PlayerQueue;
+  } = {},
+) {
+  return mount(RepeatBtn, {
+    props: { player: undefined, playerQueue: undefined, ...props },
+    global: { stubs },
+  });
+}
+
+const button = (wrapper: ReturnType<typeof mountButton>) =>
+  wrapper.get(".icon-container");
+
+const isDisabled = (wrapper: ReturnType<typeof mountButton>) =>
+  button(wrapper).classes().includes("icon-container--disabled");
+
+enableAutoUnmount(afterEach);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("RepeatBtn", () => {
+  describe("on a Music Assistant queue", () => {
+    it.each([
+      { from: RepeatMode.OFF, to: RepeatMode.ALL },
+      { from: RepeatMode.ALL, to: RepeatMode.ONE },
+      { from: RepeatMode.ONE, to: RepeatMode.OFF },
+    ])("cycles the queue from $from to $to", async ({ from, to }) => {
+      const wrapper = mountButton({
+        playerQueue: playerQueue({ repeat_mode: from }),
+      });
+
+      await button(wrapper).trigger("click");
+
+      expect(queueCommandRepeat).toHaveBeenCalledWith("queue-1", to);
+      expect(playerCommandRepeat).not.toHaveBeenCalled();
+    });
+
+    it("is disabled without a queue to repeat", () => {
+      expect(isDisabled(mountButton())).toBe(true);
+    });
+
+    it("is disabled on an infinite stream", () => {
+      const wrapper = mountButton({
+        playerQueue: playerQueue({
+          current_item: queueItem({
+            media_item: radio({ media_type: MediaType.RADIO }),
+          }),
+        }),
+      });
+
+      expect(isDisabled(wrapper)).toBe(true);
+    });
+  });
+
+  describe("on a live external source", () => {
+    it("repeats within the source's own session through the player", async () => {
+      const wrapper = mountButton({ player: playerOnSource() });
+
+      expect(isDisabled(wrapper)).toBe(false);
+
+      await button(wrapper).trigger("click");
+
+      expect(playerCommandRepeat).toHaveBeenCalledWith(
+        "player-1",
+        RepeatMode.ALL,
+      );
+      expect(queueCommandRepeat).not.toHaveBeenCalled();
+    });
+
+    it("cycles on from the mode the source reports", async () => {
+      const wrapper = mountButton({
+        player: playerOnSource({ repeat_mode: RepeatMode.ALL }),
+      });
+
+      expect(wrapper.findComponent(IconRepeat).exists()).toBe(true);
+
+      await button(wrapper).trigger("click");
+
+      expect(playerCommandRepeat).toHaveBeenCalledWith(
+        "player-1",
+        RepeatMode.ONE,
+      );
+    });
+
+    it("renders repeat-one when the source reports it", () => {
+      const wrapper = mountButton({
+        player: playerOnSource({ repeat_mode: RepeatMode.ONE }),
+      });
+
+      expect(wrapper.findComponent(IconRepeatOnce).exists()).toBe(true);
+    });
+
+    // the source has not reported its ordering yet, so the control reads as off
+    // and actionable rather than stuck on a mode nobody chose
+    it("reads as off when the source has not reported", () => {
+      const wrapper = mountButton({ player: playerOnSource() });
+
+      expect(isDisabled(wrapper)).toBe(false);
+      expect(wrapper.findComponent(IconRepeatOff).exists()).toBe(true);
+    });
+
+    it("is disabled for a source that cannot repeat", async () => {
+      const wrapper = mountButton({
+        player: playerOnSource({ can_repeat: false }),
+      });
+
+      expect(isDisabled(wrapper)).toBe(true);
+
+      await button(wrapper).trigger("click");
+
+      expect(playerCommandRepeat).not.toHaveBeenCalled();
+      expect(queueCommandRepeat).not.toHaveBeenCalled();
+    });
+
+    // the player's own queue is always in the source list, so a player sitting
+    // on it must not be mistaken for one a source has taken over
+    it("leaves an idle player on its own source list alone", () => {
+      const own = playerSource({ id: "player-1", can_repeat: true });
+      const wrapper = mountButton({
+        player: player({ active_source: null, source_list: [own] }),
+      });
+
+      expect(isDisabled(wrapper)).toBe(true);
+    });
+
+    it("prefers the queue whenever one is playing", async () => {
+      const wrapper = mountButton({
+        player: playerOnSource(),
+        playerQueue: playerQueue(),
+      });
+
+      await button(wrapper).trigger("click");
+
+      expect(queueCommandRepeat).toHaveBeenCalledWith(
+        "queue-1",
+        RepeatMode.ALL,
+      );
+      expect(playerCommandRepeat).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/tests/layouts/ShuffleBtn.test.ts
+++ b/tests/layouts/ShuffleBtn.test.ts
@@ -9,6 +9,7 @@ import {
 } from "@/plugins/api/interfaces";
 import { enableAutoUnmount, mount } from "@vue/test-utils";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { nextTick, reactive } from "vue";
 import { playerQueue } from "../fixtures/playerQueue";
 import { playerSource } from "../fixtures/playerSource";
 import { queueItem } from "../fixtures/queueItem";
@@ -140,6 +141,29 @@ describe("ShuffleBtn", () => {
       const wrapper = mountButton({
         player: playerOnSource({ shuffle_enabled: true }),
       });
+
+      expect(wrapper.findComponent(ShuffleIcon).exists()).toBe(true);
+      expect(button(wrapper).attributes("title")).toBe("shuffle_disable");
+    });
+
+    // a player update lands as an in-place assign with a fresh source list, so
+    // the control has to re-read what the source reports rather than keep what
+    // it read when it was built
+    it("follows the state the source reports as it changes", async () => {
+      const live = reactive(playerOnSource({ shuffle_enabled: false }));
+      const wrapper = mountButton({ player: live });
+
+      expect(wrapper.findComponent(ShuffleIcon).exists()).toBe(false);
+
+      live.source_list = [
+        playerSource({
+          id: live.active_source!,
+          name: "Spotify Connect",
+          can_shuffle: true,
+          shuffle_enabled: true,
+        }),
+      ];
+      await nextTick();
 
       expect(wrapper.findComponent(ShuffleIcon).exists()).toBe(true);
       expect(button(wrapper).attributes("title")).toBe("shuffle_disable");

--- a/tests/layouts/ShuffleBtn.test.ts
+++ b/tests/layouts/ShuffleBtn.test.ts
@@ -1,0 +1,204 @@
+import ShuffleBtn from "@/layouts/default/PlayerOSD/PlayerControlBtn/ShuffleBtn.vue";
+import ShuffleIcon from "@/layouts/default/PlayerOSD/PlayerControlBtn/ShuffleIcon.vue";
+import api from "@/plugins/api";
+import {
+  MediaType,
+  type Player,
+  type PlayerQueue,
+  type PlayerSource,
+} from "@/plugins/api/interfaces";
+import { enableAutoUnmount, mount } from "@vue/test-utils";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { playerQueue } from "../fixtures/playerQueue";
+import { playerSource } from "../fixtures/playerSource";
+import { queueItem } from "../fixtures/queueItem";
+import { radio } from "../fixtures/radio";
+
+vi.mock("@/plugins/api", () => {
+  const api = {
+    queueCommandShuffle: vi.fn(),
+    playerCommandShuffle: vi.fn(),
+  };
+  return { api, default: api };
+});
+
+vi.mock("@/plugins/i18n", () => ({ $t: (key: string) => key }));
+
+const queueCommandShuffle = vi.mocked(api.queueCommandShuffle);
+const playerCommandShuffle = vi.mocked(api.playerCommandShuffle);
+
+// Vuetify is not installed in the test app, and Icon.vue renders its icon
+// inside a v-badge it never imports itself.
+const stubs = {
+  VIcon: { template: "<i><slot /></i>" },
+  VBadge: { template: "<div><slot /></div>" },
+};
+
+function player(overrides: Partial<Player> = {}): Player {
+  return {
+    player_id: "player-1",
+    active_source: null,
+    source_list: [],
+    ...overrides,
+  } as unknown as Player;
+}
+
+/** A player taken over by a live external source, as the server publishes it. */
+function playerOnSource(source: Partial<PlayerSource> = {}) {
+  const live = playerSource({
+    id: "spotify://audio_source/main",
+    name: "Spotify Connect",
+    can_shuffle: true,
+    ...source,
+  });
+  return player({ active_source: live.id, source_list: [live] });
+}
+
+function mountButton(
+  props: {
+    player?: Player;
+    playerQueue?: PlayerQueue;
+  } = {},
+) {
+  return mount(ShuffleBtn, {
+    props: { player: undefined, playerQueue: undefined, ...props },
+    global: { stubs },
+  });
+}
+
+const button = (wrapper: ReturnType<typeof mountButton>) =>
+  wrapper.get(".icon-container");
+
+const isDisabled = (wrapper: ReturnType<typeof mountButton>) =>
+  button(wrapper).classes().includes("icon-container--disabled");
+
+enableAutoUnmount(afterEach);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("ShuffleBtn", () => {
+  describe("on a Music Assistant queue", () => {
+    it("shuffles the queue", async () => {
+      const wrapper = mountButton({ playerQueue: playerQueue() });
+
+      await button(wrapper).trigger("click");
+
+      expect(queueCommandShuffle).toHaveBeenCalledWith("queue-1", true);
+      expect(playerCommandShuffle).not.toHaveBeenCalled();
+    });
+
+    it("turns shuffle back off", async () => {
+      const wrapper = mountButton({
+        playerQueue: playerQueue({ shuffle_enabled: true }),
+      });
+
+      await button(wrapper).trigger("click");
+
+      expect(queueCommandShuffle).toHaveBeenCalledWith("queue-1", false);
+    });
+
+    it("is disabled without a queue to shuffle", () => {
+      expect(isDisabled(mountButton())).toBe(true);
+    });
+
+    it("is disabled on an inactive queue", () => {
+      const wrapper = mountButton({
+        playerQueue: playerQueue({ active: false }),
+      });
+
+      expect(isDisabled(wrapper)).toBe(true);
+    });
+
+    it("is disabled on an infinite stream", () => {
+      const wrapper = mountButton({
+        playerQueue: playerQueue({
+          current_item: queueItem({
+            media_item: radio({ media_type: MediaType.RADIO }),
+          }),
+        }),
+      });
+
+      expect(isDisabled(wrapper)).toBe(true);
+    });
+  });
+
+  describe("on a live external source", () => {
+    it("shuffles the source's own session through the player", async () => {
+      const wrapper = mountButton({ player: playerOnSource() });
+
+      expect(isDisabled(wrapper)).toBe(false);
+
+      await button(wrapper).trigger("click");
+
+      expect(playerCommandShuffle).toHaveBeenCalledWith("player-1", true);
+      expect(queueCommandShuffle).not.toHaveBeenCalled();
+    });
+
+    it("renders the state the source reports", () => {
+      const wrapper = mountButton({
+        player: playerOnSource({ shuffle_enabled: true }),
+      });
+
+      expect(wrapper.findComponent(ShuffleIcon).exists()).toBe(true);
+      expect(button(wrapper).attributes("title")).toBe("shuffle_disable");
+    });
+
+    it("turns shuffle back off when the source reports it on", async () => {
+      const wrapper = mountButton({
+        player: playerOnSource({ shuffle_enabled: true }),
+      });
+
+      await button(wrapper).trigger("click");
+
+      expect(playerCommandShuffle).toHaveBeenCalledWith("player-1", false);
+    });
+
+    // the source has not reported its ordering yet, so the control still has to
+    // read as actionable rather than stuck
+    it("offers to turn shuffle on when the source has not reported", () => {
+      const wrapper = mountButton({ player: playerOnSource() });
+
+      expect(isDisabled(wrapper)).toBe(false);
+      expect(wrapper.findComponent(ShuffleIcon).exists()).toBe(false);
+      expect(button(wrapper).attributes("title")).toBe("shuffle_enable");
+    });
+
+    it("is disabled for a source that cannot shuffle", async () => {
+      const wrapper = mountButton({
+        player: playerOnSource({ can_shuffle: false }),
+      });
+
+      expect(isDisabled(wrapper)).toBe(true);
+
+      await button(wrapper).trigger("click");
+
+      expect(playerCommandShuffle).not.toHaveBeenCalled();
+      expect(queueCommandShuffle).not.toHaveBeenCalled();
+    });
+
+    // the player's own queue is always in the source list, so a player sitting
+    // on it must not be mistaken for one a source has taken over
+    it("leaves an idle player on its own source list alone", () => {
+      const own = playerSource({ id: "player-1", can_shuffle: true });
+      const wrapper = mountButton({
+        player: player({ active_source: null, source_list: [own] }),
+      });
+
+      expect(isDisabled(wrapper)).toBe(true);
+    });
+
+    it("prefers the queue whenever one is playing", async () => {
+      const wrapper = mountButton({
+        player: playerOnSource(),
+        playerQueue: playerQueue(),
+      });
+
+      await button(wrapper).trigger("click");
+
+      expect(queueCommandShuffle).toHaveBeenCalledWith("queue-1", true);
+      expect(playerCommandShuffle).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/tests/layouts/ShuffleBtn.test.ts
+++ b/tests/layouts/ShuffleBtn.test.ts
@@ -228,6 +228,31 @@ describe("ShuffleBtn", () => {
       expect(playerCommandShuffle).not.toHaveBeenCalled();
     });
 
+    // the OSD passes store.activePlayer, a computed that yields a different
+    // object when the user switches player — so the source has to be resolved
+    // from the prop as it stands, not from the one captured at setup
+    it("re-reads the source when the active player changes", async () => {
+      const wrapper = mountButton({ player: playerOnSource() });
+
+      expect(isDisabled(wrapper)).toBe(false);
+
+      await wrapper.setProps({
+        player: player({
+          player_id: "player-2",
+          active_source: "line-in",
+          source_list: [playerSource({ id: "line-in", name: "Line In" })],
+        }),
+      });
+
+      // line-in orders nothing, so the control on the newly selected player
+      // must go dead rather than keep commanding the player left behind
+      expect(isDisabled(wrapper)).toBe(true);
+
+      await button(wrapper).trigger("click");
+
+      expect(playerCommandShuffle).not.toHaveBeenCalled();
+    });
+
     it("prefers the queue whenever one is playing", async () => {
       const wrapper = mountButton({
         player: playerOnSource(),

--- a/tests/layouts/ShuffleBtn.test.ts
+++ b/tests/layouts/ShuffleBtn.test.ts
@@ -178,15 +178,30 @@ describe("ShuffleBtn", () => {
       expect(queueCommandShuffle).not.toHaveBeenCalled();
     });
 
-    // the player's own queue is always in the source list, so a player sitting
-    // on it must not be mistaken for one a source has taken over
-    it("leaves an idle player on its own source list alone", () => {
+    it("leaves an idle player alone", () => {
       const own = playerSource({ id: "player-1", can_shuffle: true });
       const wrapper = mountButton({
         player: player({ active_source: null, source_list: [own] }),
       });
 
       expect(isDisabled(wrapper)).toBe(true);
+    });
+
+    // the MA queue sits in the source list under the player's own id, so a
+    // player on its own queue must never be taken for one a source took over —
+    // reachable before that queue has arrived in the client's state, which is
+    // the only moment no queue resolves for it
+    it("never mistakes the player's own queue for a source", async () => {
+      const own = playerSource({ id: "player-1", can_shuffle: true });
+      const wrapper = mountButton({
+        player: player({ active_source: "player-1", source_list: [own] }),
+      });
+
+      expect(isDisabled(wrapper)).toBe(true);
+
+      await button(wrapper).trigger("click");
+
+      expect(playerCommandShuffle).not.toHaveBeenCalled();
     });
 
     it("prefers the queue whenever one is playing", async () => {


### PR DESCRIPTION
# What does this implement/fix?

Shuffle and repeat stopped working while a live external source (Spotify Connect, AirPlay, …) is playing.

A live source is now a source on the player rather than an item in its queue, so no queue resolves for it — and both buttons were keyed on there being one, which left them greyed out. They now follow whatever is actually playing: a source that orders its own session takes the new player commands, and a Music Assistant queue keeps using the queue commands.

**Related issue (if applicable):**

- n/a

**Related backend PR (if applicable):**

- music-assistant/server#5914 (merged) and music-assistant/models#372 — the source fields and player commands this reads

- Shuffle and repeat work again on a live source that supports them, and show the state that source reports
- Both stay greyed out for a source that cannot be reordered, instead of looking usable and doing nothing
- Queue behaviour is unchanged

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm lint:check` passes.
- [x] `pnpm test:run` passes, and tests have been added/updated where applicable.
- [x] `pnpm build` passes.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.

