### PR TITLE
Show task reports

### DIFF
--- a/src/components/settings/background-tasks/BackgroundTaskDetailsDialog.vue
+++ b/src/components/settings/background-tasks/BackgroundTaskDetailsDialog.vue
@@ -163,6 +163,17 @@
             </div>
           </div>
 
+          <div v-if="task?.report" class="flex flex-col gap-3">
+            <Separator />
+            <div class="section-title">
+              {{ t("background_tasks.report_title") }}
+            </div>
+            <MarkdownText
+              :text="task.report"
+              class="task-report bg-muted/50 rounded-lg p-4 text-sm leading-relaxed select-text"
+            />
+          </div>
+
           <Separator />
 
           <div class="flex flex-wrap items-center justify-between gap-3">
@@ -207,6 +218,7 @@ import { Copy, Download, Pencil } from "@lucide/vue";
 import { computed } from "vue";
 import { useI18n } from "vue-i18n";
 
+import MarkdownText from "@/components/MarkdownText.vue";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {

--- a/src/plugins/api/interfaces.ts
+++ b/src/plugins/api/interfaces.ts
@@ -1574,6 +1574,7 @@ export interface BackgroundTask {
   id: string;
   name: string;
   status: TaskStatus;
+  report: string | null;
   logs: string[];
   schedule: TaskSchedule | null;
   last_run: string | null;

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1948,6 +1948,7 @@
         "view_details": "View task details",
         "remove_history": "Remove task from history",
         "log_title": "Task log",
+        "report_title": "Task report",
         "details_title": "Task details",
         "no_task_selected": "No task selected",
         "copy": "Copy",

--- a/tests/components/BackgroundTaskDetailsDialog.test.ts
+++ b/tests/components/BackgroundTaskDetailsDialog.test.ts
@@ -1,0 +1,119 @@
+/**
+ * @vitest-environment jsdom
+ */
+import BackgroundTaskDetailsDialog from "@/components/settings/background-tasks/BackgroundTaskDetailsDialog.vue";
+import { type BackgroundTask, TaskStatus } from "@/plugins/api/interfaces";
+import { mount, type VueWrapper } from "@vue/test-utils";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@/plugins/api", () => ({ api: {} }));
+
+vi.mock("@/plugins/breakpoint", () => ({
+  getBreakpointValue: vi.fn(() => false),
+}));
+
+vi.mock("@/plugins/router", () => ({
+  default: { push: vi.fn() },
+}));
+
+vi.mock("@/plugins/store", () => ({
+  store: { currentUser: null },
+}));
+
+vi.mock("vue-i18n", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("vue-i18n")>();
+  return {
+    ...actual,
+    useI18n: () => ({
+      t: (key: string) => key,
+      te: () => false,
+    }),
+  };
+});
+
+const passthrough = { template: "<div><slot /></div>" };
+
+describe("BackgroundTaskDetailsDialog", () => {
+  it.each([
+    TaskStatus.SUCCESS,
+    TaskStatus.PARTIAL_SUCCESS,
+    TaskStatus.FAILED,
+    TaskStatus.CANCELLED,
+  ])("renders a Markdown report for a %s task", (status) => {
+    const wrapper = mountDialog(
+      makeTask({
+        status,
+        report: "Imported **12 playlists**.",
+      }),
+    );
+
+    const report = wrapper.get(".task-report");
+    expect(report.get("strong").text()).toBe("12 playlists");
+    expect(report.text()).not.toContain("**");
+    expect(wrapper.text()).toContain("background_tasks.report_title");
+
+    const sectionTitles = wrapper
+      .findAll(".section-title")
+      .map((title) => title.text());
+    expect(sectionTitles.indexOf("background_tasks.report_title")).toBeLessThan(
+      sectionTitles.indexOf("background_tasks.log_title"),
+    );
+  });
+
+  it("does not render a report section without a report", () => {
+    const wrapper = mountDialog(makeTask());
+
+    expect(wrapper.find(".task-report").exists()).toBe(false);
+    expect(wrapper.text()).not.toContain("background_tasks.report_title");
+  });
+});
+
+function mountDialog(task: BackgroundTask): VueWrapper {
+  return mount(BackgroundTaskDetailsDialog, {
+    props: {
+      open: true,
+      task,
+      logText: "Task log",
+    },
+    global: {
+      stubs: {
+        Badge: passthrough,
+        Button: passthrough,
+        Dialog: passthrough,
+        DialogContent: passthrough,
+        DialogHeader: passthrough,
+        DialogTitle: passthrough,
+        ScrollArea: passthrough,
+        Separator: { template: "<hr />" },
+      },
+    },
+  });
+}
+
+function makeTask(overrides: Partial<BackgroundTask> = {}): BackgroundTask {
+  return {
+    id: "task-1",
+    name: "Import playlists",
+    status: TaskStatus.SUCCESS,
+    report: null,
+    logs: [],
+    schedule: null,
+    last_run: "2026-08-23T00:00:00Z",
+    next_run: null,
+    user_id: null,
+    last_run_user_id: null,
+    created_at: "2026-08-23T00:00:00Z",
+    updated_at: "2026-08-23T00:00:00Z",
+    started_at: "2026-08-23T00:00:00Z",
+    finished_at: "2026-08-23T00:01:00Z",
+    last_error: null,
+    failure_count: 0,
+    failure_messages: [],
+    metadata: {},
+    progress: 1,
+    progress_text: null,
+    allow_retry: false,
+    allow_cancel: false,
+    ...overrides,
+  };
+}


### PR DESCRIPTION
# What does this implement/fix?

Managed tasks can now return human-readable Markdown reports.

- Safely render Markdown reports in task details before logs.
- Cover report visibility and rendering across terminal task states.

**Related issue (if applicable):**

- N/A

**Related backend PR (if applicable):**

- N/A

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [ ] `pnpm lint:check` passes.
- [ ] `pnpm test:run` passes, and tests have been added/updated where applicable.
- [ ] `pnpm build` passes.
- [ ] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.