### PR TITLE
Migrate playlists between providers

### DIFF
--- a/src/layouts/default/ItemContextMenu.vue
+++ b/src/layouts/default/ItemContextMenu.vue
@@ -281,6 +281,7 @@ import {
   radioSupported,
 } from "@/helpers/radio";
 import {
+  getPlaylistMigrationProviders,
   isAudioSource,
   isItemInLibrary,
   itemIsAvailable,
@@ -309,6 +310,7 @@ import { toast } from "vue-sonner";
 import GenreIcon from "@/components/icons/GenreIcon.vue";
 import {
   ArrowDown,
+  ArrowRightLeft,
   ArrowUp,
   Disc3,
   Download,
@@ -1004,6 +1006,28 @@ export const getContextMenuItems = async function (
       },
       icon: Download,
     });
+  }
+  // migrate playlist (static library playlists only, to a provider that
+  // supports creating playlists and editing their tracks)
+  if (
+    items.length === 1 &&
+    items[0] == parentItem &&
+    items[0].media_type === MediaType.PLAYLIST &&
+    items[0].provider === "library" &&
+    !(items[0] as Playlist).is_dynamic &&
+    api.supportsPlaylistMigration
+  ) {
+    const playlist = items[0] as Playlist;
+    if (getPlaylistMigrationProviders(playlist).length > 0) {
+      contextMenuItems.push({
+        label: "migrate_playlist.action",
+        labelArgs: [],
+        action: () => {
+          eventbus.emit("migratePlaylistDialog", { playlist });
+        },
+        icon: ArrowRightLeft,
+      });
+    }
   }
   // pin / unpin shortcut in sidebar (playlist, artist, album, track, radio, podcast, audiobook, genre)
   if (items.length === 1 && isShortcutItem(items[0]) && !!items[0].uri) {

--- a/src/layouts/default/MigratePlaylistDialog.vue
+++ b/src/layouts/default/MigratePlaylistDialog.vue
@@ -11,7 +11,7 @@
           $t("migrate_playlist.title")
         }}</DialogTitle>
         <DialogDescription>
-          {{ $t("migrate_playlist.description", [playlist?.name]) }}
+          {{ $t("migrate_playlist.description", [playlist?.name ?? ""]) }}
         </DialogDescription>
       </DialogHeader>
 

--- a/src/layouts/default/MigratePlaylistDialog.vue
+++ b/src/layouts/default/MigratePlaylistDialog.vue
@@ -1,0 +1,200 @@
+<!--
+  Global dialog to migrate a static library playlist to another provider.
+  Because this dialog can be called from various places throughout the app,
+  we steer its visibility through the centralized eventbus.
+-->
+<template>
+  <Dialog :key="dialogKey" v-model:open="showDialog">
+    <DialogContent class="sm:max-w-[500px]">
+      <DialogHeader>
+        <DialogTitle class="mb-2">{{
+          $t("migrate_playlist.title")
+        }}</DialogTitle>
+        <DialogDescription>
+          {{ $t("migrate_playlist.description", [playlist?.name]) }}
+        </DialogDescription>
+      </DialogHeader>
+
+      <div class="flex flex-col gap-4">
+        <div class="flex flex-col gap-2">
+          <Label for="migrate-playlist-destination">
+            {{ $t("migrate_playlist.destination_label") }}
+          </Label>
+          <Select v-model="destinationProviderId">
+            <SelectTrigger id="migrate-playlist-destination" class="w-full">
+              <SelectValue
+                :placeholder="$t('migrate_playlist.destination_placeholder')"
+              />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem
+                v-for="provider in destinationProviders"
+                :key="provider.instance_id"
+                :value="provider.instance_id"
+              >
+                <provider-icon :domain="provider.domain" :size="20" />
+                {{ provider.name }}
+              </SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
+
+        <div class="flex flex-col gap-2">
+          <Label for="migrate-playlist-name">
+            {{ $t("migrate_playlist.name_label") }}
+          </Label>
+          <Input id="migrate-playlist-name" v-model="destinationName" />
+        </div>
+
+        <div class="flex flex-col gap-2">
+          <Label>{{ $t("migrate_playlist.match_policy_label") }}</Label>
+          <RadioGroup v-model="matchPolicy" class="gap-2">
+            <div
+              v-for="option in matchPolicyOptions"
+              :key="option.value"
+              class="flex items-start gap-3 rounded-md border p-3"
+            >
+              <RadioGroupItem
+                :id="`migrate-playlist-policy-${option.value}`"
+                :value="option.value"
+                class="mt-0.5"
+              />
+              <Label
+                :for="`migrate-playlist-policy-${option.value}`"
+                class="flex flex-1 flex-col items-start gap-1 font-normal"
+              >
+                <span class="text-sm font-medium">{{ option.title }}</span>
+                <span
+                  class="text-muted-foreground text-xs leading-relaxed whitespace-pre-wrap"
+                >
+                  {{ option.description }}
+                </span>
+              </Label>
+            </div>
+          </RadioGroup>
+        </div>
+      </div>
+
+      <DialogFooter>
+        <Button variant="outline" @click="showDialog = false">
+          {{ $t("close") }}
+        </Button>
+        <Button :disabled="!canSubmit" @click="doMigrate">
+          {{ $t("migrate_playlist.submit") }}
+        </Button>
+      </DialogFooter>
+    </DialogContent>
+  </Dialog>
+</template>
+
+<script setup lang="ts">
+import ProviderIcon from "@/components/ProviderIcon.vue";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import api from "@/plugins/api";
+import { getPlaylistMigrationProviders } from "@/plugins/api/helpers";
+import {
+  MatchPolicy,
+  type Playlist,
+  type ProviderInstance,
+} from "@/plugins/api/interfaces";
+import { type MigratePlaylistDialogEvent, eventbus } from "@/plugins/eventbus";
+import { $t } from "@/plugins/i18n";
+import { store } from "@/plugins/store";
+import { computed, onBeforeUnmount, onMounted, ref, watch } from "vue";
+import { toast } from "vue-sonner";
+
+const showDialog = ref(false);
+// force Dialog remount via dynamic key to prevent the enter animation from
+// stalling at opacity:0 when opened from a context menu
+const dialogKey = ref(0);
+const playlist = ref<Playlist>();
+const destinationProviders = ref<ProviderInstance[]>([]);
+const destinationProviderId = ref("");
+const destinationName = ref("");
+const matchPolicy = ref<MatchPolicy>(MatchPolicy.SAME_RECORDING);
+
+const matchPolicyOptions = computed(() => [
+  {
+    value: MatchPolicy.EXACT,
+    title: $t("migrate_playlist.match_policy.exact.title"),
+    description: $t("migrate_playlist.match_policy.exact.description"),
+  },
+  {
+    value: MatchPolicy.SAME_RECORDING,
+    title: $t("migrate_playlist.match_policy.same_recording.title"),
+    description: $t("migrate_playlist.match_policy.same_recording.description"),
+  },
+  {
+    value: MatchPolicy.BEST_EFFORT,
+    title: $t("migrate_playlist.match_policy.best_effort.title"),
+    description: $t("migrate_playlist.match_policy.best_effort.description"),
+  },
+]);
+
+const canSubmit = computed(
+  () => !!destinationProviderId.value && !!destinationName.value.trim(),
+);
+
+watch(showDialog, (open) => {
+  store.dialogActive = open;
+});
+
+onMounted(() => {
+  eventbus.on("migratePlaylistDialog", (evt: MigratePlaylistDialogEvent) => {
+    playlist.value = evt.playlist;
+    destinationProviders.value = getPlaylistMigrationProviders(evt.playlist);
+    destinationProviderId.value = "";
+    destinationName.value = evt.playlist.name;
+    matchPolicy.value = MatchPolicy.SAME_RECORDING;
+    dialogKey.value++;
+    showDialog.value = true;
+  });
+});
+
+onBeforeUnmount(() => {
+  eventbus.off("migratePlaylistDialog");
+});
+
+const doMigrate = async () => {
+  if (!playlist.value || !canSubmit.value) return;
+  showDialog.value = false;
+  try {
+    await api.migratePlaylist(
+      playlist.value.item_id,
+      destinationProviderId.value,
+      matchPolicy.value,
+      destinationName.value.trim(),
+    );
+  } catch (e) {
+    toast.error(getErrorMessage(e));
+  }
+};
+
+const getErrorMessage = (error: unknown): string => {
+  if (typeof error === "string" && error.trim()) {
+    return error;
+  }
+  if (error instanceof Error && error.message.trim()) {
+    return error.message;
+  }
+  return $t("error_generic");
+};
+</script>

--- a/src/layouts/default/MigratePlaylistDialog.vue
+++ b/src/layouts/default/MigratePlaylistDialog.vue
@@ -111,7 +111,7 @@ import {
 import api from "@/plugins/api";
 import { getPlaylistMigrationProviders } from "@/plugins/api/helpers";
 import {
-  MatchPolicy,
+  PlaylistMigrationMatchPolicy,
   type Playlist,
   type ProviderInstance,
 } from "@/plugins/api/interfaces";
@@ -129,21 +129,23 @@ const playlist = ref<Playlist>();
 const destinationProviders = ref<ProviderInstance[]>([]);
 const destinationProviderId = ref("");
 const destinationName = ref("");
-const matchPolicy = ref<MatchPolicy>(MatchPolicy.SAME_RECORDING);
+const matchPolicy = ref<PlaylistMigrationMatchPolicy>(
+  PlaylistMigrationMatchPolicy.SAME_RECORDING,
+);
 
 const matchPolicyOptions = computed(() => [
   {
-    value: MatchPolicy.EXACT,
+    value: PlaylistMigrationMatchPolicy.EXACT,
     title: $t("migrate_playlist.match_policy.exact.title"),
     description: $t("migrate_playlist.match_policy.exact.description"),
   },
   {
-    value: MatchPolicy.SAME_RECORDING,
+    value: PlaylistMigrationMatchPolicy.SAME_RECORDING,
     title: $t("migrate_playlist.match_policy.same_recording.title"),
     description: $t("migrate_playlist.match_policy.same_recording.description"),
   },
   {
-    value: MatchPolicy.BEST_EFFORT,
+    value: PlaylistMigrationMatchPolicy.BEST_EFFORT,
     title: $t("migrate_playlist.match_policy.best_effort.title"),
     description: $t("migrate_playlist.match_policy.best_effort.description"),
   },
@@ -163,7 +165,7 @@ onMounted(() => {
     destinationProviders.value = getPlaylistMigrationProviders(evt.playlist);
     destinationProviderId.value = "";
     destinationName.value = evt.playlist.name;
-    matchPolicy.value = MatchPolicy.SAME_RECORDING;
+    matchPolicy.value = PlaylistMigrationMatchPolicy.SAME_RECORDING;
     dialogKey.value++;
     showDialog.value = true;
   });

--- a/src/layouts/default/View.vue
+++ b/src/layouts/default/View.vue
@@ -22,6 +22,7 @@
           <create-playlist-dialog />
           <create-smart-playlist-dialog />
           <import-playlist-dialog />
+          <migrate-playlist-dialog />
           <play-announcement-dialog />
           <merge-genre-dialog />
           <delete-genre-dialog />
@@ -72,6 +73,7 @@ import CreatePlaylistDialog from "./CreatePlaylistDialog.vue";
 import CreateSmartPlaylistDialog from "./CreateSmartPlaylistDialog.vue";
 import ImportPlaylistDialog from "./ImportPlaylistDialog.vue";
 import ItemContextMenu from "./ItemContextMenu.vue";
+import MigratePlaylistDialog from "./MigratePlaylistDialog.vue";
 import PlayAnnouncementDialog from "./PlayAnnouncementDialog.vue";
 import PlayerSelect from "./PlayerSelect.vue";
 

--- a/src/plugins/api/helpers.ts
+++ b/src/plugins/api/helpers.ts
@@ -14,6 +14,7 @@ import {
   PodcastEpisode,
   ProviderFeature,
   ProviderInstance,
+  ProviderType,
   QueueItem,
 } from "./interfaces";
 
@@ -261,18 +262,23 @@ export const getPlaylistMigrationProviders = function (
   playlist: Playlist,
 ): ProviderInstance[] {
   if (playlist.is_dynamic || playlist.provider !== "library") return [];
-  return Object.values(api.providers).filter(
-    (provider) =>
-      provider.available &&
-      (provider.domain === "builtin" || provider.is_streaming_provider) &&
-      (provider.supported_features.includes(ProviderFeature.PLAYLIST_CREATE) ||
+  return Object.values(api.providers)
+    .filter(
+      (provider) =>
+        provider.available &&
+        provider.type === ProviderType.MUSIC &&
+        (provider.domain === "builtin" || provider.is_streaming_provider) &&
+        (provider.supported_features.includes(
+          ProviderFeature.PLAYLIST_CREATE,
+        ) ||
+          provider.supported_features.includes(
+            ProviderFeature.PLAYLIST_CREATE_TRACKS,
+          )) &&
         provider.supported_features.includes(
-          ProviderFeature.PLAYLIST_CREATE_TRACKS,
-        )) &&
-      provider.supported_features.includes(
-        ProviderFeature.PLAYLIST_TRACKS_EDIT,
-      ),
-  );
+          ProviderFeature.PLAYLIST_TRACKS_EDIT,
+        ),
+    )
+    .sort((a, b) => a.name.localeCompare(b.name));
 };
 
 /**

--- a/src/plugins/api/helpers.ts
+++ b/src/plugins/api/helpers.ts
@@ -10,7 +10,10 @@ import {
   MediaType,
   Player,
   PlayerQueue,
+  Playlist,
   PodcastEpisode,
+  ProviderFeature,
+  ProviderInstance,
   QueueItem,
 } from "./interfaces";
 
@@ -246,6 +249,30 @@ export const getCollectionMediaTypeFromItemId = function (itemId: string) {
   return Object.values(MediaType).includes(itemIdType as MediaType)
     ? (itemIdType as MediaType)
     : MediaType.UNKNOWN;
+};
+
+/**
+ * Providers a static library playlist can be migrated to: the builtin
+ * (Music Assistant) provider and streaming providers that can create
+ * playlists and edit their tracks. Dynamic playlists and non-library
+ * playlists have no valid destinations.
+ */
+export const getPlaylistMigrationProviders = function (
+  playlist: Playlist,
+): ProviderInstance[] {
+  if (playlist.is_dynamic || playlist.provider !== "library") return [];
+  return Object.values(api.providers).filter(
+    (provider) =>
+      provider.available &&
+      (provider.domain === "builtin" || provider.is_streaming_provider) &&
+      (provider.supported_features.includes(ProviderFeature.PLAYLIST_CREATE) ||
+        provider.supported_features.includes(
+          ProviderFeature.PLAYLIST_CREATE_TRACKS,
+        )) &&
+      provider.supported_features.includes(
+        ProviderFeature.PLAYLIST_TRACKS_EDIT,
+      ),
+  );
 };
 
 /**

--- a/src/plugins/api/helpers.ts
+++ b/src/plugins/api/helpers.ts
@@ -253,7 +253,7 @@ export const getCollectionMediaTypeFromItemId = function (itemId: string) {
 };
 
 /**
- * Providers a static library playlist can be migrated to: the builtin
+ * Providers that a static library playlist can be migrated to: the builtin
  * (Music Assistant) provider and streaming providers that can create
  * playlists and edit their tracks. Dynamic playlists and non-library
  * playlists have no valid destinations.

--- a/src/plugins/api/index.ts
+++ b/src/plugins/api/index.ts
@@ -24,6 +24,7 @@ import {
   type EventMessage,
   type Genre,
   type MassEvent,
+  type MatchPolicy,
   type MediaItem,
   type MediaItemType,
   type Player,
@@ -81,6 +82,9 @@ const TRANSLATIONS_SCHEMA_VERSION = 32;
 
 // The shuffle argument on player_queues/play_media landed in API schema 51.
 const PLAY_MEDIA_SHUFFLE_SCHEMA_VERSION = 51;
+
+// music/playlists/migrate_playlist landed in API schema 56.
+const MIGRATE_PLAYLIST_SCHEMA_VERSION = 56;
 
 export interface PlayMediaOptions {
   start_item?: PlayableMediaItemType | string;
@@ -909,6 +913,26 @@ export class MusicAssistantApi {
   public exportPlaylist(db_playlist_id: string | number): Promise<string> {
     return this.sendCommand("music/playlists/export_playlist", {
       db_playlist_id,
+    });
+  }
+
+  public migratePlaylist(
+    db_playlist_id: string | number,
+    destination_provider: string,
+    match_policy: MatchPolicy,
+    name?: string,
+  ): Promise<BackgroundTask> {
+    return this.sendCommand<BackgroundTask>(
+      "music/playlists/migrate_playlist",
+      {
+        db_playlist_id,
+        destination_provider,
+        match_policy,
+        name,
+      },
+    ).then((task) => {
+      this._notifyBackgroundTaskStarted(task);
+      return task;
     });
   }
 
@@ -2918,6 +2942,14 @@ export class MusicAssistantApi {
     return (
       (this.serverInfo.value?.schema_version ?? 0) >=
       TRANSLATIONS_SCHEMA_VERSION
+    );
+  }
+
+  /** Whether the connected server can migrate a playlist to another provider (schema >= 56). */
+  public get supportsPlaylistMigration(): boolean {
+    return (
+      (this.serverInfo.value?.schema_version ?? 0) >=
+      MIGRATE_PLAYLIST_SCHEMA_VERSION
     );
   }
 

--- a/src/plugins/api/index.ts
+++ b/src/plugins/api/index.ts
@@ -24,7 +24,7 @@ import {
   type EventMessage,
   type Genre,
   type MassEvent,
-  type MatchPolicy,
+  type PlaylistMigrationMatchPolicy,
   type MediaItem,
   type MediaItemType,
   type Player,
@@ -919,7 +919,7 @@ export class MusicAssistantApi {
   public migratePlaylist(
     db_playlist_id: string | number,
     destination_provider: string,
-    match_policy: MatchPolicy,
+    match_policy: PlaylistMigrationMatchPolicy,
     name?: string,
   ): Promise<BackgroundTask> {
     return this.sendCommand<BackgroundTask>(

--- a/src/plugins/api/index.ts
+++ b/src/plugins/api/index.ts
@@ -83,8 +83,8 @@ const TRANSLATIONS_SCHEMA_VERSION = 32;
 // The shuffle argument on player_queues/play_media landed in API schema 51.
 const PLAY_MEDIA_SHUFFLE_SCHEMA_VERSION = 51;
 
-// music/playlists/migrate_playlist landed in API schema 56.
-const MIGRATE_PLAYLIST_SCHEMA_VERSION = 56;
+// music/playlists/migrate_playlist landed in API schema 57.
+const MIGRATE_PLAYLIST_SCHEMA_VERSION = 57;
 
 export interface PlayMediaOptions {
   start_item?: PlayableMediaItemType | string;
@@ -2945,7 +2945,7 @@ export class MusicAssistantApi {
     );
   }
 
-  /** Whether the connected server can migrate a playlist to another provider (schema >= 56). */
+  /** Whether the connected server can migrate a playlist to another provider (schema >= 57). */
   public get supportsPlaylistMigration(): boolean {
     return (
       (this.serverInfo.value?.schema_version ?? 0) >=

--- a/src/plugins/api/index.ts
+++ b/src/plugins/api/index.ts
@@ -930,6 +930,8 @@ export class MusicAssistantApi {
         match_policy,
         name,
       },
+      // the dialog shows its own error toast; avoid a duplicate global one.
+      { suppressGlobalError: true },
     ).then((task) => {
       this._notifyBackgroundTaskStarted(task);
       return task;

--- a/src/plugins/api/interfaces.ts
+++ b/src/plugins/api/interfaces.ts
@@ -982,7 +982,7 @@ export interface Playlist extends MediaItem {
 // track matching tier accepted when migrating a playlist to another provider.
 // matching always cascades exact -> same_recording -> best_effort; the policy
 // only sets the lowest tier that is still accepted as a match.
-export enum MatchPolicy {
+export enum PlaylistMigrationMatchPolicy {
   EXACT = "exact",
   SAME_RECORDING = "same_recording",
   BEST_EFFORT = "best_effort",

--- a/src/plugins/api/interfaces.ts
+++ b/src/plugins/api/interfaces.ts
@@ -979,6 +979,15 @@ export interface Playlist extends MediaItem {
   is_dynamic: boolean;
 }
 
+// track matching tier accepted when migrating a playlist to another provider.
+// matching always cascades exact -> same_recording -> best_effort; the policy
+// only sets the lowest tier that is still accepted as a match.
+export enum MatchPolicy {
+  EXACT = "exact",
+  SAME_RECORDING = "same_recording",
+  BEST_EFFORT = "best_effort",
+}
+
 export interface Radio extends MediaItem {
   is_dynamic: boolean;
 }

--- a/src/plugins/eventbus.ts
+++ b/src/plugins/eventbus.ts
@@ -64,6 +64,10 @@ export type ImportPlaylistEvent = {
   playlistName: string;
 };
 
+export type MigratePlaylistDialogEvent = {
+  playlist: Playlist;
+};
+
 export type CreateSmartPlaylistEvent = {
   providerId?: string;
 };
@@ -105,6 +109,7 @@ export type Events = {
   playerGroupPlaybackDialog: PlayerGroupPlaybackDialogEvent;
   linkGenreDialog: LinkGenreDialogEvent;
   importPlaylistDialog: ImportPlaylistEvent;
+  migratePlaylistDialog: MigratePlaylistDialogEvent;
   createSmartPlaylist: CreateSmartPlaylistEvent;
   audioOverlayDialog: AudioOverlayDialogEvent;
   playAnnouncementDialog: PlayAnnouncementDialogEvent;

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -2159,8 +2159,8 @@
         "match_policy_label": "Track matching",
         "match_policy": {
             "exact": {
-                "title": "Exact match only",
-                "description": "Only add tracks that match exactly. Tracks that can't be matched exactly are skipped."
+                "title": "Exact release only",
+                "description": "Only add tracks that match the exact release. Tracks that can't be matched this way are skipped."
             },
             "same_recording": {
                 "title": "Same recording (recommended)",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -2149,6 +2149,30 @@
         "op_less_than": "less than",
         "picker_search": "Search {label}"
     },
+    "migrate_playlist": {
+        "action": "Migrate playlist",
+        "title": "Migrate playlist",
+        "description": "Copy \"{0}\" to another provider, matching its tracks along the way.",
+        "destination_label": "Destination",
+        "destination_placeholder": "Choose a destination",
+        "name_label": "Playlist name",
+        "match_policy_label": "Track matching",
+        "match_policy": {
+            "exact": {
+                "title": "Exact match only",
+                "description": "Only add tracks that match exactly. Tracks that can't be matched exactly are skipped."
+            },
+            "same_recording": {
+                "title": "Same recording (recommended)",
+                "description": "Prefer an exact match, otherwise accept the same recording from a different release. Tracks that can't be matched this way are skipped."
+            },
+            "best_effort": {
+                "title": "Best effort",
+                "description": "Prefer an exact match, then the same recording, otherwise accept the closest available match."
+            }
+        },
+        "submit": "Migrate"
+    },
     "explore": "Explore",
     "shortcuts": "Shortcuts",
     "system": "System",

--- a/tests/helpers/migratePlaylistAction.test.ts
+++ b/tests/helpers/migratePlaylistAction.test.ts
@@ -1,0 +1,116 @@
+/**
+ * Tests for the "Migrate playlist" context menu action.
+ *
+ * The action is only offered on the playlist details page (item === parentItem)
+ * for static library playlists, on servers that support the migrate command,
+ * and only when at least one eligible destination provider exists.
+ */
+import {
+  getContextMenuItems,
+  type ContextMenuItem,
+} from "@/layouts/default/ItemContextMenu.vue";
+import { ProviderFeature, ProviderType } from "@/plugins/api/interfaces";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { playlist } from "../fixtures/playlist";
+
+const { apiMock, storeMock, mockEventbusEmit } = vi.hoisted(() => ({
+  apiMock: {
+    providers: {} as Record<string, unknown>,
+    getProvider: vi.fn(),
+    getLibraryItem: vi.fn(),
+    players: {},
+    supportsPlaylistMigration: true,
+  },
+  storeMock: {
+    enabledPlugins: new Set<string>(),
+  },
+  mockEventbusEmit: vi.fn(),
+}));
+
+vi.mock("@/plugins/api", () => ({ default: apiMock, api: apiMock }));
+vi.mock("@/plugins/store", () => ({ store: storeMock }));
+vi.mock("@/plugins/eventbus", () => ({
+  eventbus: {
+    on: vi.fn(),
+    off: vi.fn(),
+    emit: mockEventbusEmit,
+  },
+}));
+vi.mock("@/plugins/i18n", () => ({ $t: (key: string) => key }));
+
+const builtinProvider = () => ({
+  type: ProviderType.MUSIC,
+  domain: "builtin",
+  name: "Music Assistant",
+  instance_id: "builtin",
+  supported_features: [
+    ProviderFeature.PLAYLIST_CREATE,
+    ProviderFeature.PLAYLIST_TRACKS_EDIT,
+  ],
+  available: true,
+  is_streaming_provider: false,
+});
+
+const migrateAction = (items: ContextMenuItem[]): ContextMenuItem | undefined =>
+  items.find((x) => x.label === "migrate_playlist.action");
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  apiMock.providers = { builtin: builtinProvider() };
+  apiMock.getProvider.mockImplementation((id: string) => apiMock.providers[id]);
+  apiMock.supportsPlaylistMigration = true;
+  storeMock.enabledPlugins = new Set();
+});
+
+describe("migrate playlist context menu action", () => {
+  it("is offered for a static library playlist with an eligible destination", async () => {
+    const item = playlist();
+    const items = await getContextMenuItems([item], item);
+    expect(migrateAction(items)).toBeDefined();
+  });
+
+  it("is not offered for a dynamic (smart) playlist", async () => {
+    const item = playlist({ is_dynamic: true });
+    const items = await getContextMenuItems([item], item);
+    expect(migrateAction(items)).toBeUndefined();
+  });
+
+  it("is not offered for a non-library playlist", async () => {
+    const item = playlist({ provider: "spotify" });
+    const items = await getContextMenuItems([item], item);
+    expect(migrateAction(items)).toBeUndefined();
+  });
+
+  it("is not offered from a menu that isn't the playlist's own details page", async () => {
+    const parent = playlist();
+    const otherItem = { ...playlist(), item_id: "other" };
+    const items = await getContextMenuItems([otherItem], parent);
+    expect(migrateAction(items)).toBeUndefined();
+  });
+
+  it("is not offered when the server doesn't support playlist migration", async () => {
+    apiMock.supportsPlaylistMigration = false;
+    const item = playlist();
+    const items = await getContextMenuItems([item], item);
+    expect(migrateAction(items)).toBeUndefined();
+  });
+
+  it("is not offered when there is no eligible destination provider", async () => {
+    apiMock.providers = {};
+    const item = playlist();
+    const items = await getContextMenuItems([item], item);
+    expect(migrateAction(items)).toBeUndefined();
+  });
+
+  it("emits the migrate playlist dialog event with the playlist when triggered", async () => {
+    const item = playlist();
+    const items = await getContextMenuItems([item], item);
+    const action = migrateAction(items);
+
+    await action?.action?.();
+
+    expect(mockEventbusEmit).toHaveBeenCalledWith("migratePlaylistDialog", {
+      playlist: item,
+    });
+  });
+});

--- a/tests/layouts/MigratePlaylistDialog.test.ts
+++ b/tests/layouts/MigratePlaylistDialog.test.ts
@@ -10,9 +10,10 @@ import { enableAutoUnmount, mount, type VueWrapper } from "@vue/test-utils";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { playlist } from "../fixtures/playlist";
 
-const { apiMock, eventHandlers } = vi.hoisted(() => ({
+const { apiMock, eventHandlers, toastMock } = vi.hoisted(() => ({
   apiMock: { migratePlaylist: vi.fn() },
   eventHandlers: {} as Record<string, (payload: unknown) => void>,
+  toastMock: { error: vi.fn() },
 }));
 
 vi.mock("@/plugins/api", () => ({ default: apiMock }));
@@ -37,7 +38,7 @@ vi.mock("@/plugins/i18n", () => ({ $t: (key: string) => key }));
 
 vi.mock("@/plugins/store", () => ({ store: { dialogActive: false } }));
 
-vi.mock("vue-sonner", () => ({ toast: { error: vi.fn() } }));
+vi.mock("vue-sonner", () => ({ toast: toastMock }));
 
 const selectStub = {
   name: "SelectStub",
@@ -172,5 +173,19 @@ describe("MigratePlaylistDialog", () => {
       PlaylistMigrationMatchPolicy.EXACT,
       "Renamed copy",
     );
+  });
+
+  it("shows exactly one local toast when the migration request fails", async () => {
+    apiMock.migratePlaylist.mockRejectedValueOnce(new Error("Server error"));
+    const wrapper = mountDialog();
+    open({ item_id: "42", name: "My Playlist" });
+    await wrapper.vm.$nextTick();
+
+    await select(wrapper).vm.$emit("update:modelValue", "spotify--1");
+    await submitButton(wrapper).trigger("click");
+    await wrapper.vm.$nextTick();
+
+    expect(toastMock.error).toHaveBeenCalledTimes(1);
+    expect(toastMock.error).toHaveBeenCalledWith("Server error");
   });
 });

--- a/tests/layouts/MigratePlaylistDialog.test.ts
+++ b/tests/layouts/MigratePlaylistDialog.test.ts
@@ -1,0 +1,176 @@
+/**
+ * The dialog body relies on reka-ui's Select and RadioGroup for the
+ * destination and match-policy pickers, so those are stubbed with minimal
+ * components that still forward v-model, letting the tests drive them
+ * without needing floating-ui/portals in jsdom.
+ */
+import MigratePlaylistDialog from "@/layouts/default/MigratePlaylistDialog.vue";
+import { PlaylistMigrationMatchPolicy } from "@/plugins/api/interfaces";
+import { enableAutoUnmount, mount, type VueWrapper } from "@vue/test-utils";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { playlist } from "../fixtures/playlist";
+
+const { apiMock, eventHandlers } = vi.hoisted(() => ({
+  apiMock: { migratePlaylist: vi.fn() },
+  eventHandlers: {} as Record<string, (payload: unknown) => void>,
+}));
+
+vi.mock("@/plugins/api", () => ({ default: apiMock }));
+
+vi.mock("@/plugins/api/helpers", () => ({
+  getPlaylistMigrationProviders: vi.fn(() => [
+    { instance_id: "builtin", domain: "builtin", name: "Music Assistant" },
+    { instance_id: "spotify--1", domain: "spotify", name: "Spotify" },
+  ]),
+}));
+
+vi.mock("@/plugins/eventbus", () => ({
+  eventbus: {
+    on: vi.fn((event: string, handler: (payload: unknown) => void) => {
+      eventHandlers[event] = handler;
+    }),
+    off: vi.fn(),
+  },
+}));
+
+vi.mock("@/plugins/i18n", () => ({ $t: (key: string) => key }));
+
+vi.mock("@/plugins/store", () => ({ store: { dialogActive: false } }));
+
+vi.mock("vue-sonner", () => ({ toast: { error: vi.fn() } }));
+
+const selectStub = {
+  name: "SelectStub",
+  props: ["modelValue"],
+  emits: ["update:modelValue"],
+  template: "<div><slot /></div>",
+};
+
+const radioGroupStub = {
+  name: "RadioGroupStub",
+  props: ["modelValue"],
+  emits: ["update:modelValue"],
+  template: "<div><slot /></div>",
+};
+
+const passthrough = { template: "<div><slot /></div>" };
+
+function mountDialog(): VueWrapper {
+  return mount(MigratePlaylistDialog, {
+    global: {
+      stubs: {
+        Dialog: passthrough,
+        DialogContent: passthrough,
+        DialogHeader: passthrough,
+        DialogTitle: passthrough,
+        DialogDescription: passthrough,
+        DialogFooter: passthrough,
+        ProviderIcon: true,
+        Select: selectStub,
+        SelectTrigger: true,
+        SelectContent: true,
+        SelectItem: true,
+        SelectValue: true,
+        RadioGroup: radioGroupStub,
+        RadioGroupItem: true,
+      },
+    },
+  });
+}
+
+function open(overrides: Parameters<typeof playlist>[0] = {}) {
+  eventHandlers.migratePlaylistDialog({ playlist: playlist(overrides) });
+}
+
+function select(wrapper: VueWrapper) {
+  return wrapper.findComponent({ name: "SelectStub" });
+}
+
+function radioGroup(wrapper: VueWrapper) {
+  return wrapper.findComponent({ name: "RadioGroupStub" });
+}
+
+function submitButton(wrapper: VueWrapper) {
+  const buttons = wrapper.findAll("button");
+  return buttons[buttons.length - 1];
+}
+
+enableAutoUnmount(afterEach);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  for (const key of Object.keys(eventHandlers)) delete eventHandlers[key];
+});
+
+describe("MigratePlaylistDialog", () => {
+  it("defaults to the same-recording match policy, no destination, and the playlist's own name", async () => {
+    const wrapper = mountDialog();
+    open({ name: "My Playlist" });
+    await wrapper.vm.$nextTick();
+
+    expect(radioGroup(wrapper).props("modelValue")).toBe(
+      PlaylistMigrationMatchPolicy.SAME_RECORDING,
+    );
+    expect(select(wrapper).props("modelValue")).toBe("");
+    expect(
+      wrapper.get<HTMLInputElement>("#migrate-playlist-name").element.value,
+    ).toBe("My Playlist");
+  });
+
+  it("disables submit until a destination is chosen", async () => {
+    const wrapper = mountDialog();
+    open({ name: "My Playlist" });
+    await wrapper.vm.$nextTick();
+
+    expect(submitButton(wrapper).attributes("disabled")).toBe("");
+
+    await select(wrapper).vm.$emit("update:modelValue", "builtin");
+    expect(submitButton(wrapper).attributes("disabled")).toBeUndefined();
+  });
+
+  it("resets to its defaults each time it's reopened, even after edits", async () => {
+    const wrapper = mountDialog();
+    open({ name: "First playlist" });
+    await wrapper.vm.$nextTick();
+
+    await select(wrapper).vm.$emit("update:modelValue", "builtin");
+    await radioGroup(wrapper).vm.$emit(
+      "update:modelValue",
+      PlaylistMigrationMatchPolicy.BEST_EFFORT,
+    );
+    await wrapper.get("#migrate-playlist-name").setValue("Edited name");
+
+    open({ name: "Second playlist" });
+    await wrapper.vm.$nextTick();
+
+    expect(select(wrapper).props("modelValue")).toBe("");
+    expect(radioGroup(wrapper).props("modelValue")).toBe(
+      PlaylistMigrationMatchPolicy.SAME_RECORDING,
+    );
+    expect(
+      wrapper.get<HTMLInputElement>("#migrate-playlist-name").element.value,
+    ).toBe("Second playlist");
+  });
+
+  it("submits the chosen destination, trimmed name, and match policy", async () => {
+    const wrapper = mountDialog();
+    open({ item_id: "42", name: "My Playlist" });
+    await wrapper.vm.$nextTick();
+
+    await select(wrapper).vm.$emit("update:modelValue", "spotify--1");
+    await radioGroup(wrapper).vm.$emit(
+      "update:modelValue",
+      PlaylistMigrationMatchPolicy.EXACT,
+    );
+    await wrapper.get("#migrate-playlist-name").setValue("  Renamed copy  ");
+
+    await submitButton(wrapper).trigger("click");
+
+    expect(apiMock.migratePlaylist).toHaveBeenCalledWith(
+      "42",
+      "spotify--1",
+      PlaylistMigrationMatchPolicy.EXACT,
+      "Renamed copy",
+    );
+  });
+});

--- a/tests/plugins/api/helpers.test.ts
+++ b/tests/plugins/api/helpers.test.ts
@@ -23,19 +23,26 @@ vi.mock("@/plugins/api", async () => {
 
 import api from "@/plugins/api";
 import {
+  getPlaylistMigrationProviders,
   getProviderRootDomain,
   isAudioSource,
   isQueueInfiniteStream,
   resolvePlayerQueue,
   waitForApiInitialization,
 } from "@/plugins/api/helpers";
-import { MediaType } from "@/plugins/api/interfaces";
+import {
+  MediaType,
+  ProviderFeature,
+  ProviderType,
+} from "@/plugins/api/interfaces";
 import type {
   MediaItemType,
   PlayableMediaItemType,
   Player,
+  ProviderInstance,
 } from "@/plugins/api/interfaces";
 import { playerQueue } from "../../fixtures/playerQueue";
+import { playlist } from "../../fixtures/playlist";
 import { queueItem } from "../../fixtures/queueItem";
 
 describe("isAudioSource", () => {
@@ -203,5 +210,83 @@ describe("getProviderRootDomain", () => {
       getProviderRootDomain({ media_type: MediaType.TRACK } as MediaItemType),
     ).toBe(undefined);
     expect(getProviderRootDomain(undefined)).toBe(undefined);
+  });
+});
+
+describe("getPlaylistMigrationProviders", () => {
+  const provider = (
+    overrides: Partial<ProviderInstance>,
+  ): ProviderInstance => ({
+    type: ProviderType.MUSIC,
+    domain: "spotify",
+    name: "Spotify",
+    instance_id: "spotify--1",
+    supported_features: [
+      ProviderFeature.PLAYLIST_CREATE_TRACKS,
+      ProviderFeature.PLAYLIST_TRACKS_EDIT,
+    ],
+    available: true,
+    is_streaming_provider: true,
+    ...overrides,
+  });
+
+  beforeEach(() => {
+    for (const key of Object.keys(api.providers)) delete api.providers[key];
+    api.providers["builtin"] = provider({
+      domain: "builtin",
+      name: "Music Assistant",
+      instance_id: "builtin",
+      is_streaming_provider: false,
+      supported_features: [
+        ProviderFeature.PLAYLIST_CREATE,
+        ProviderFeature.PLAYLIST_TRACKS_EDIT,
+      ],
+    });
+    api.providers["spotify--1"] = provider({});
+  });
+
+  it("returns an empty list for a dynamic playlist", () => {
+    expect(
+      getPlaylistMigrationProviders(playlist({ is_dynamic: true })),
+    ).toEqual([]);
+  });
+
+  it("returns an empty list for a playlist that isn't in the library", () => {
+    expect(
+      getPlaylistMigrationProviders(playlist({ provider: "spotify" })),
+    ).toEqual([]);
+  });
+
+  it("includes the builtin provider and eligible streaming providers", () => {
+    const result = getPlaylistMigrationProviders(playlist());
+    expect(result.map((p) => p.instance_id).sort()).toEqual([
+      "builtin",
+      "spotify--1",
+    ]);
+  });
+
+  it("excludes providers that can't create playlists, can't edit tracks, are unavailable, or aren't streaming providers", () => {
+    delete api.providers["spotify--1"];
+    api.providers["no-create"] = provider({
+      instance_id: "no-create",
+      supported_features: [ProviderFeature.PLAYLIST_TRACKS_EDIT],
+    });
+    api.providers["no-edit"] = provider({
+      instance_id: "no-edit",
+      supported_features: [ProviderFeature.PLAYLIST_CREATE_TRACKS],
+    });
+    api.providers["unavailable"] = provider({
+      instance_id: "unavailable",
+      available: false,
+    });
+    api.providers["non-streaming"] = provider({
+      instance_id: "non-streaming",
+      is_streaming_provider: false,
+    });
+
+    // only the builtin provider from beforeEach remains eligible
+    expect(
+      getPlaylistMigrationProviders(playlist()).map((p) => p.instance_id),
+    ).toEqual(["builtin"]);
   });
 });

--- a/tests/plugins/api/helpers.test.ts
+++ b/tests/plugins/api/helpers.test.ts
@@ -43,6 +43,7 @@ import type {
 } from "@/plugins/api/interfaces";
 import { playerQueue } from "../../fixtures/playerQueue";
 import { playlist } from "../../fixtures/playlist";
+import { providerMapping } from "../../fixtures/providerMapping";
 import { queueItem } from "../../fixtures/queueItem";
 
 describe("isAudioSource", () => {
@@ -257,15 +258,20 @@ describe("getPlaylistMigrationProviders", () => {
     ).toEqual([]);
   });
 
-  it("includes the builtin provider and eligible streaming providers", () => {
+  it("includes the builtin provider and eligible streaming providers, sorted by name", () => {
+    api.providers["another--1"] = provider({
+      instance_id: "another--1",
+      name: "Another Provider",
+    });
     const result = getPlaylistMigrationProviders(playlist());
-    expect(result.map((p) => p.instance_id).sort()).toEqual([
-      "builtin",
-      "spotify--1",
+    expect(result.map((p) => p.name)).toEqual([
+      "Another Provider",
+      "Music Assistant",
+      "Spotify",
     ]);
   });
 
-  it("excludes providers that can't create playlists, can't edit tracks, are unavailable, or aren't streaming providers", () => {
+  it("excludes providers that can't create playlists, can't edit tracks, are unavailable, aren't streaming providers, or aren't music providers", () => {
     delete api.providers["spotify--1"];
     api.providers["no-create"] = provider({
       instance_id: "no-create",
@@ -283,10 +289,30 @@ describe("getPlaylistMigrationProviders", () => {
       instance_id: "non-streaming",
       is_streaming_provider: false,
     });
+    api.providers["non-music"] = provider({
+      instance_id: "non-music",
+      type: ProviderType.PLAYER,
+    });
 
     // only the builtin provider from beforeEach remains eligible
     expect(
       getPlaylistMigrationProviders(playlist()).map((p) => p.instance_id),
     ).toEqual(["builtin"]);
+  });
+
+  it("still offers a provider the playlist is already mapped to, to allow creating a copy", () => {
+    const source = playlist({
+      provider_mappings: [
+        providerMapping({
+          provider_domain: "spotify",
+          provider_instance: "spotify--1",
+        }),
+      ],
+    });
+    expect(
+      getPlaylistMigrationProviders(source)
+        .map((p) => p.instance_id)
+        .sort(),
+    ).toEqual(["builtin", "spotify--1"]);
   });
 });

--- a/tests/plugins/api/index.test.ts
+++ b/tests/plugins/api/index.test.ts
@@ -270,13 +270,13 @@ describe("MusicAssistantApi error handling", () => {
     );
   });
 
-  it("reports playlist migration support once the server reaches schema 56", () => {
+  it("reports playlist migration support once the server reaches schema 57", () => {
     expect(api.supportsPlaylistMigration).toBe(false);
 
-    api.serverInfo.value = { ...SERVER_INFO, schema_version: 56 };
+    api.serverInfo.value = { ...SERVER_INFO, schema_version: 57 };
     expect(api.supportsPlaylistMigration).toBe(true);
 
-    api.serverInfo.value = { ...SERVER_INFO, schema_version: 55 };
+    api.serverInfo.value = { ...SERVER_INFO, schema_version: 56 };
     expect(api.supportsPlaylistMigration).toBe(false);
   });
 

--- a/tests/plugins/api/index.test.ts
+++ b/tests/plugins/api/index.test.ts
@@ -4,7 +4,7 @@ import {
   CoreState,
   type DSPConfig,
   type ErrorResultMessage,
-  MatchPolicy,
+  PlaylistMigrationMatchPolicy,
   type ServerInfoMessage,
   type SuccessResultMessage,
   TaskStatus,
@@ -221,6 +221,7 @@ describe("MusicAssistantApi error handling", () => {
       id: "task-1",
       name: "Migrate playlist",
       status: TaskStatus.PENDING,
+      report: null,
       logs: [],
       schedule: null,
       last_run: null,
@@ -243,7 +244,7 @@ describe("MusicAssistantApi error handling", () => {
     const result = api.migratePlaylist(
       "1",
       "spotify--1",
-      MatchPolicy.SAME_RECORDING,
+      PlaylistMigrationMatchPolicy.SAME_RECORDING,
       "My playlist",
     );
 
@@ -253,7 +254,7 @@ describe("MusicAssistantApi error handling", () => {
     expect(transport.lastCommand.args).toEqual({
       db_playlist_id: "1",
       destination_provider: "spotify--1",
-      match_policy: MatchPolicy.SAME_RECORDING,
+      match_policy: PlaylistMigrationMatchPolicy.SAME_RECORDING,
       name: "My playlist",
     });
 

--- a/tests/plugins/api/index.test.ts
+++ b/tests/plugins/api/index.test.ts
@@ -1,21 +1,26 @@
 import {
+  type BackgroundTask,
   type CommandMessage,
   CoreState,
   type DSPConfig,
   type ErrorResultMessage,
+  MatchPolicy,
   type ServerInfoMessage,
   type SuccessResultMessage,
+  TaskStatus,
 } from "@/plugins/api/interfaces";
 import { BaseTransport, TransportState } from "@/plugins/remote/transport";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-const { mockToastError } = vi.hoisted(() => ({
+const { mockToastError, mockToastInfo } = vi.hoisted(() => ({
   mockToastError: vi.fn(),
+  mockToastInfo: vi.fn(),
 }));
 
 vi.mock("vue-sonner", () => ({
   toast: {
     error: mockToastError,
+    info: mockToastInfo,
   },
 }));
 
@@ -209,6 +214,69 @@ describe("MusicAssistantApi error handling", () => {
       partial: false,
     });
     await expect(result).resolves.toEqual(config);
+  });
+
+  it("migrates a playlist and notifies the background task toast", async () => {
+    const task: BackgroundTask = {
+      id: "task-1",
+      name: "Migrate playlist",
+      status: TaskStatus.PENDING,
+      logs: [],
+      schedule: null,
+      last_run: null,
+      next_run: null,
+      user_id: null,
+      last_run_user_id: null,
+      created_at: "2024-01-01T00:00:00Z",
+      updated_at: "2024-01-01T00:00:00Z",
+      started_at: null,
+      finished_at: null,
+      last_error: null,
+      failure_count: 0,
+      failure_messages: [],
+      metadata: {},
+      progress: null,
+      progress_text: null,
+      allow_retry: false,
+      allow_cancel: true,
+    };
+    const result = api.migratePlaylist(
+      "1",
+      "spotify--1",
+      MatchPolicy.SAME_RECORDING,
+      "My playlist",
+    );
+
+    expect(transport.lastCommand.command).toBe(
+      "music/playlists/migrate_playlist",
+    );
+    expect(transport.lastCommand.args).toEqual({
+      db_playlist_id: "1",
+      destination_provider: "spotify--1",
+      match_policy: MatchPolicy.SAME_RECORDING,
+      name: "My playlist",
+    });
+
+    transport.receive({
+      message_id: transport.lastCommand.message_id!,
+      result: task,
+      partial: false,
+    });
+    await expect(result).resolves.toEqual(task);
+    expect(mockToastInfo).toHaveBeenCalledWith(
+      "background_tasks.toast.added",
+      expect.anything(),
+    );
+  });
+
+  it("reports playlist migration support once the server reaches schema 56", () => {
+    expect(api.supportsPlaylistMigration).toBe(false);
+
+    api.serverInfo.value = { ...SERVER_INFO, schema_version: 56 };
+    expect(api.supportsPlaylistMigration).toBe(true);
+
+    api.serverInfo.value = { ...SERVER_INFO, schema_version: 55 };
+    expect(api.supportsPlaylistMigration).toBe(false);
   });
 
   it("rejects in-flight commands when the connection closes", async () => {

--- a/tests/plugins/api/index.test.ts
+++ b/tests/plugins/api/index.test.ts
@@ -270,6 +270,24 @@ describe("MusicAssistantApi error handling", () => {
     );
   });
 
+  it("rejects a failed migration without the global error toast", async () => {
+    const result = api.migratePlaylist(
+      "1",
+      "spotify--1",
+      PlaylistMigrationMatchPolicy.SAME_RECORDING,
+      "My playlist",
+    );
+    const error = createErrorResult(transport.lastCommand, "Migration failed");
+    const rejection = expect(result).rejects.toMatchObject({
+      message: "Migration failed",
+    });
+
+    transport.receive(error);
+
+    await rejection;
+    expect(mockToastError).not.toHaveBeenCalled();
+  });
+
   it("reports playlist migration support once the server reaches schema 57", () => {
     expect(api.supportsPlaylistMigration).toBe(false);
 


### PR DESCRIPTION
# What does this implement/fix?

Copying a playlist to a different music provider today means recreating it by hand, track by track. This adds a `Migrate playlist` action for eligible static playlists that:

- Lets you pick a destination — Music Assistant itself, or any connected streaming provider that supports playlist creation and track editing.
- Lets you set the destination name.
- Lets you choose a matching policy: exact release only, same recording (recommended), or best effort — matching always cascades through the tiers, with the policy setting the lowest one that's still accepted.
- Queues the migration as a managed background task, reusing the existing background-task progress UX.

**Related backend PR (if applicable):**

- related backend PR `music-assistant/server` (companion "Playlist migration" work, in progress alongside this PR)

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [x] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm lint:check` passes.
- [x] `pnpm test:run` passes, and tests have been added/updated where applicable.
- [x] `pnpm build` passes.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.