### PR TITLE
Rename the external source composable

### DIFF
--- a/src/composables/externalSource.ts
+++ b/src/composables/externalSource.ts
@@ -2,12 +2,14 @@ import { computed, type MaybeRef, unref } from "vue";
 import { Player, PlayerQueue, PlayerSource } from "@/plugins/api/interfaces";
 
 /**
- * The live external source playing on a player in place of a queue, or
- * undefined when Music Assistant's own queue is what is playing.
+ * The source playing on a player in place of a queue, or undefined when Music
+ * Assistant's own queue is what is playing.
  *
- * A source that takes the player over (Spotify Connect, AirPlay, Ynison, …) is
- * attached to no queue, so the commands it can handle reach its own session
- * through the player and the state to render comes off the source itself.
+ * Covers any source that is not the queue, whichever side provides it: one
+ * Music Assistant bridges as a live session (Spotify Connect, AirPlay, Ynison,
+ * …) and one the device runs natively alike. Either way there is no queue to
+ * read from, so what the control can do and what it shows both come off the
+ * source entry itself.
  *
  * Unlike `useActiveSource`, which answers with whichever source list entry is
  * active and so happily returns the Music Assistant queue's own entry, this
@@ -17,15 +19,15 @@ import { Player, PlayerQueue, PlayerSource } from "@/plugins/api/interfaces";
  *
  * Pass the queue belonging to the same player, i.e. `resolvePlayerQueue(player)`.
  */
-export function resolveLiveSource(
+export function resolveExternalSource(
   player: Player | undefined,
   playerQueue: PlayerQueue | undefined,
 ): PlayerSource | undefined {
   // a resolved queue means Music Assistant owns the playback
   if (playerQueue) return undefined;
   if (!player?.active_source) return undefined;
-  // the MA queue is always in the source list under the player's own id, and a
-  // live source is always there under its uri — so this is the own queue,
+  // the MA queue is always in the source list under the player's own id, and an
+  // external source is always there under its uri — so this is the own queue,
   // reachable before that queue has arrived in the client's state
   if (player.active_source === player.player_id) return undefined;
   return player.source_list?.find(
@@ -33,14 +35,14 @@ export function resolveLiveSource(
   );
 }
 
-/** Reactive {@link resolveLiveSource}, for components tracking a player. */
-export function useLiveSource(
+/** Reactive {@link resolveExternalSource}, for components tracking a player. */
+export function useExternalSource(
   player: MaybeRef<Player | undefined>,
   playerQueue: MaybeRef<PlayerQueue | undefined>,
 ) {
-  const liveSource = computed(() =>
-    resolveLiveSource(unref(player), unref(playerQueue)),
+  const externalSource = computed(() =>
+    resolveExternalSource(unref(player), unref(playerQueue)),
   );
 
-  return { liveSource };
+  return { externalSource };
 }

--- a/src/helpers/player_menu_items.ts
+++ b/src/helpers/player_menu_items.ts
@@ -11,7 +11,7 @@ import {
   PLAYER_CONTROL_NONE,
 } from "@/plugins/api/interfaces";
 import { getSleepTimerMenuItem, sleepTimerActive } from "@/helpers/sleep_timer";
-import { resolveLiveSource } from "@/composables/liveSource";
+import { resolveExternalSource } from "@/composables/externalSource";
 import { useAnnouncement } from "@/composables/useAnnouncement";
 import { useAudioOverlay } from "@/composables/useAudioOverlay";
 import { visualizerProviderAvailable } from "@/plugins/visualizer-relay";
@@ -107,11 +107,13 @@ export const getPlayerMenuItems = (
   }
 
   const isDynamic = playerQueue?.is_dynamic === true;
-  // a live source orders its own session, so it takes these instead of the
+  // an external source orders its own session, so it takes these instead of the
   // queue — and it has no queue to read the state or the dynamic flag from
-  const liveSource = resolveLiveSource(player, playerQueue);
-  const shuffleSource = liveSource?.can_shuffle ? liveSource : undefined;
-  const repeatSource = liveSource?.can_repeat ? liveSource : undefined;
+  const externalSource = resolveExternalSource(player, playerQueue);
+  const shuffleSource = externalSource?.can_shuffle
+    ? externalSource
+    : undefined;
+  const repeatSource = externalSource?.can_repeat ? externalSource : undefined;
   const orderableQueue = playerQueue && !isDynamic ? playerQueue : undefined;
 
   // shuffle (queue menu only; hidden when the dedicated control is visible)
@@ -128,14 +130,14 @@ export const getPlayerMenuItems = (
         // settled at click time — the source list is a fresh array by then,
         // hence the re-resolve
         if (shuffleSource) {
-          const live = resolveLiveSource(player, playerQueue);
+          const current = resolveExternalSource(player, playerQueue);
           // the source can end while the menu sits open, and the queue that
           // takes the player back would otherwise be shuffled by a command
           // meant for the session — with the value the entry offered inverted
-          if (!live?.can_shuffle) return;
+          if (!current?.can_shuffle) return;
           api.playerCommandShuffle(
             player.player_id,
-            live.shuffle_enabled !== true,
+            current.shuffle_enabled !== true,
           );
         } else {
           api.queueCommandShuffle(
@@ -160,7 +162,7 @@ export const getPlayerMenuItems = (
       if (repeatSource) {
         // the source can end while the menu sits open; a mode meant for its
         // session must not land on the queue that took the player back
-        if (!resolveLiveSource(player, playerQueue)?.can_repeat) return;
+        if (!resolveExternalSource(player, playerQueue)?.can_repeat) return;
         api.playerCommandRepeat(player.player_id, mode);
       } else {
         api.queueCommandRepeat(orderableQueue!.queue_id, mode);

--- a/src/layouts/default/PlayerOSD/PlayerControlBtn/RepeatBtn.vue
+++ b/src/layouts/default/PlayerOSD/PlayerControlBtn/RepeatBtn.vue
@@ -23,7 +23,7 @@
 defineOptions({ inheritAttrs: false });
 import Icon, { IconProps } from "@/components/Icon.vue";
 import { getValueFromSources } from "@/helpers/utils";
-import { useLiveSource } from "@/composables/liveSource";
+import { useExternalSource } from "@/composables/externalSource";
 import api from "@/plugins/api";
 import { Player, PlayerQueue, RepeatMode } from "@/plugins/api/interfaces";
 import { isQueueInfiniteStream } from "@/plugins/api/helpers";
@@ -43,16 +43,16 @@ const compProps = withDefaults(defineProps<Props>(), {
   size: 20,
 });
 
-const { liveSource } = useLiveSource(
+const { externalSource } = useExternalSource(
   toRef(compProps, "player"),
   toRef(compProps, "playerQueue"),
 );
 
-// A live source that repeats within its own session takes the command instead
-// of the queue; one that cannot leaves the button disabled rather than
+// An external source that repeats within its own session takes the command
+// instead of the queue; one that cannot leaves the button disabled rather than
 // silently inert.
 const orderingSource = computed(() =>
-  liveSource.value?.can_repeat ? liveSource.value : undefined,
+  externalSource.value?.can_repeat ? externalSource.value : undefined,
 );
 
 const isLoading = computed(() => {
@@ -67,8 +67,8 @@ const isInfiniteStream = computed(() =>
   isQueueInfiniteStream(compProps.playerQueue),
 );
 
-// The repeat mode in effect: what the live source reports for its own session,
-// or the queue's. A source that has not reported one reads as off.
+// The repeat mode in effect: what the external source reports for its own
+// session, or the queue's. A source that has not reported one reads as off.
 const repeatMode = computed<RepeatMode>(() => {
   if (orderingSource.value) {
     return orderingSource.value.repeat_mode ?? RepeatMode.OFF;
@@ -84,8 +84,8 @@ const nextRepeatMode = computed<RepeatMode>(() => {
   return RepeatMode.OFF;
 });
 
-// A live source needs no queue to act on, so only the queue path carries the
-// queue's own reasons for being unavailable.
+// An external source needs no queue to act on, so only the queue path carries
+// the queue's own reasons for being unavailable.
 const isDisabled = computed(() => {
   if (isLoading.value) return true;
   if (orderingSource.value) return false;

--- a/src/layouts/default/PlayerOSD/PlayerControlBtn/ShuffleBtn.vue
+++ b/src/layouts/default/PlayerOSD/PlayerControlBtn/ShuffleBtn.vue
@@ -23,7 +23,7 @@ defineOptions({ inheritAttrs: false });
 import Icon, { IconProps } from "@/components/Icon.vue";
 import ShuffleIcon from "@/layouts/default/PlayerOSD/PlayerControlBtn/ShuffleIcon.vue";
 import { getValueFromSources } from "@/helpers/utils";
-import { useLiveSource } from "@/composables/liveSource";
+import { useExternalSource } from "@/composables/externalSource";
 import api from "@/plugins/api";
 import { isQueueInfiniteStream } from "@/plugins/api/helpers";
 import { Player, PlayerQueue } from "@/plugins/api/interfaces";
@@ -43,15 +43,16 @@ const compProps = withDefaults(defineProps<Props>(), {
   size: 20,
 });
 
-const { liveSource } = useLiveSource(
+const { externalSource } = useExternalSource(
   toRef(compProps, "player"),
   toRef(compProps, "playerQueue"),
 );
 
-// A live source that orders its own session takes the command instead of the
-// queue; one that cannot leaves the button disabled rather than silently inert.
+// An external source that orders its own session takes the command instead of
+// the queue; one that cannot leaves the button disabled rather than silently
+// inert.
 const orderingSource = computed(() =>
-  liveSource.value?.can_shuffle ? liveSource.value : undefined,
+  externalSource.value?.can_shuffle ? externalSource.value : undefined,
 );
 
 const isLoading = computed(() => {
@@ -84,8 +85,8 @@ const shuffleActive = computed(() =>
     : compProps.playerQueue?.shuffle_enabled === true,
 );
 
-// A live source needs no queue to act on, so only the queue path carries the
-// queue's own reasons for being unavailable.
+// An external source needs no queue to act on, so only the queue path carries
+// the queue's own reasons for being unavailable.
 const isDisabled = computed(() => {
   if (isLoading.value) return true;
   if (orderingSource.value) return false;


### PR DESCRIPTION
# What does this implement/fix?

Renames the composable that answers "what is this player playing, if not its queue". It was called `liveSource`, but "live source" means a session Music Assistant bridges (Spotify Connect, AirPlay, …) everywhere else in the codebase — and this also answers with a source the device runs natively, such as a speaker running its own Connect session. The old name invited reading it as MA-only, which is the opposite of what it does.

No behaviour change.

**Related issue (if applicable):**

- n/a

**Related backend PR (if applicable):**

- n/a

- `resolveLiveSource` / `useLiveSource` → `resolveExternalSource` / `useExternalSource`
- Docstring now says plainly that a device-native source counts too

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm lint:check` passes.
- [x] `pnpm test:run` passes, and tests have been added/updated where applicable.
- [x] `pnpm build` passes.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
