### PR TITLE
Never auto-select players for dashboard viewers

### DIFF
--- a/src/layouts/default/PlayerSelect.vue
+++ b/src/layouts/default/PlayerSelect.vue
@@ -212,6 +212,7 @@ import {
 import { isBuiltinPlayer, isPlayerActive } from "@/helpers/players";
 import { api } from "@/plugins/api";
 import type { Player } from "@/plugins/api/interfaces";
+import { authManager } from "@/plugins/auth";
 import { eventbus } from "@/plugins/eventbus";
 import { store } from "@/plugins/store";
 import { webPlayer } from "@/plugins/web_player";
@@ -341,6 +342,8 @@ watch(
     // would overwrite the player the user actually selected earlier
     if (playerId === autoSelectedPlayerId) return;
     autoSelectedPlayerId = undefined;
+    // dashboard viewer preferences are shared by every dashboard session
+    if (authManager.isDashboardViewer()) return;
     rememberPlayer(playerId);
   },
 );
@@ -464,6 +467,8 @@ function resetPanelState() {
 }
 
 function checkDefaultPlayer() {
+  // dashboard viewers never pick players themselves; the hosting view pins one
+  if (authManager.isDashboardViewer()) return;
   if (store.activePlayer) return;
   const defaultPlayerId = selectDefaultPlayer();
   if (!defaultPlayerId) return;
@@ -481,6 +486,7 @@ function checkDefaultPlayer() {
  * device, which only registers a moment after the app has started.
  */
 function preferBuiltinPlayer() {
+  if (authManager.isDashboardViewer()) return;
   if (store.activePlayerId !== autoSelectedPlayerId) return;
   if (getPreference<string>("activePlayerId").value) return;
   const builtinPlayerId = selectBuiltinPlayer();

--- a/src/layouts/default/PlayerSelect.vue
+++ b/src/layouts/default/PlayerSelect.vue
@@ -484,8 +484,10 @@ function resetPanelState() {
 }
 
 function checkDefaultPlayer() {
-  // dashboard viewers never pick players themselves; the hosting view pins one
-  if (authManager.isDashboardViewer()) return;
+  // dashboard viewers never pick players themselves; the hosting view pins one.
+  // older servers can't resolve the party player, so fall back to auto-select.
+  if (authManager.isDashboardViewer() && api.supportsPartyPlayerResolution)
+    return;
   if (store.activePlayer) return;
   const defaultPlayerId = selectDefaultPlayer();
   if (!defaultPlayerId) return;
@@ -503,7 +505,8 @@ function checkDefaultPlayer() {
  * device, which only registers a moment after the app has started.
  */
 function preferBuiltinPlayer() {
-  if (authManager.isDashboardViewer()) return;
+  if (authManager.isDashboardViewer() && api.supportsPartyPlayerResolution)
+    return;
   if (store.activePlayerId !== autoSelectedPlayerId) return;
   if (getPreference<string>("activePlayerId").value) return;
   const builtinPlayerId = selectBuiltinPlayer();

--- a/src/layouts/default/PlayerSelect.vue
+++ b/src/layouts/default/PlayerSelect.vue
@@ -216,6 +216,7 @@ import {
 } from "@/helpers/players";
 import { api } from "@/plugins/api";
 import { PlayerType, type Player } from "@/plugins/api/interfaces";
+import { authManager } from "@/plugins/auth";
 import { eventbus } from "@/plugins/eventbus";
 import { store } from "@/plugins/store";
 import { webPlayer } from "@/plugins/web_player";
@@ -347,6 +348,8 @@ watch(
     // would overwrite the player the user actually selected earlier
     if (playerId === autoSelectedPlayerId) return;
     autoSelectedPlayerId = undefined;
+    // dashboard viewer preferences are shared by every dashboard session
+    if (authManager.isDashboardViewer()) return;
     rememberPlayer(playerId);
   },
 );
@@ -481,6 +484,8 @@ function resetPanelState() {
 }
 
 function checkDefaultPlayer() {
+  // dashboard viewers never pick players themselves; the hosting view pins one
+  if (authManager.isDashboardViewer()) return;
   if (store.activePlayer) return;
   const defaultPlayerId = selectDefaultPlayer();
   if (!defaultPlayerId) return;
@@ -498,6 +503,7 @@ function checkDefaultPlayer() {
  * device, which only registers a moment after the app has started.
  */
 function preferBuiltinPlayer() {
+  if (authManager.isDashboardViewer()) return;
   if (store.activePlayerId !== autoSelectedPlayerId) return;
   if (getPreference<string>("activePlayerId").value) return;
   const builtinPlayerId = selectBuiltinPlayer();

--- a/src/plugins/api/index.ts
+++ b/src/plugins/api/index.ts
@@ -102,6 +102,9 @@ export interface CommandOptions {
 // The match_policy argument on music/playlists/import_playlist landed in API schema 66.
 const IMPORT_PLAYLIST_MATCH_POLICY_SCHEMA_VERSION = 66;
 
+// Venue-mode party player resolution without guest access landed in API schema 66.
+const PARTY_PLAYER_RESOLUTION_SCHEMA_VERSION = 66;
+
 export interface PlayMediaOptions {
   start_item?: PlayableMediaItemType | string;
   queue_id?: string;
@@ -2983,6 +2986,14 @@ export class MusicAssistantApi {
     return (
       (this.serverInfo.value?.schema_version ?? 0) >=
       IMPORT_PLAYLIST_MATCH_POLICY_SCHEMA_VERSION
+    );
+  }
+
+  /** Whether the connected server resolves the party player without guest access (schema >= 66). */
+  public get supportsPartyPlayerResolution(): boolean {
+    return (
+      (this.serverInfo.value?.schema_version ?? 0) >=
+      PARTY_PLAYER_RESOLUTION_SCHEMA_VERSION
     );
   }
 

--- a/tests/layouts/PlayerSelect.test.ts
+++ b/tests/layouts/PlayerSelect.test.ts
@@ -75,9 +75,13 @@ vi.mock("@/plugins/eventbus", () => ({
   },
 }));
 
+// plain let read lazily by the mock, so tests can flip it per case
+let isDashboardViewer = false;
+
 vi.mock("@/plugins/auth", () => ({
   authManager: {
     isAdmin,
+    isDashboardViewer: () => isDashboardViewer,
   },
 }));
 
@@ -354,6 +358,7 @@ describe("PlayerSelect", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    isDashboardViewer = false;
     const preferenceValues = preferenceState.reactiveValues;
     if (preferenceValues) {
       for (const key of Object.keys(preferenceValues)) {
@@ -570,6 +575,27 @@ describe("PlayerSelect", () => {
     await nextTick();
 
     expect(store.activePlayerId).toBe(builtin.player_id);
+    expect(setPreference).not.toHaveBeenCalled();
+  });
+
+  it("never auto-selects for a dashboard viewer", async () => {
+    isDashboardViewer = true;
+    const attic = createPlayer("attic", "Attic");
+    const builtin = createPlayer("builtin", "This device");
+    api.players = { [attic.player_id]: attic };
+
+    mountPlayerSelect();
+    // no automatic default: the hosting dashboard view pins the player
+    expect(store.activePlayerId).toBeUndefined();
+
+    // a view's pin survives the built-in player registering late...
+    store.activePlayerId = attic.player_id;
+    api.players[builtin.player_id] = builtin;
+    store.companionPlayerId = builtin.player_id;
+    await nextTick();
+    expect(store.activePlayerId).toBe(attic.player_id);
+
+    // ...and is not persisted as the shared viewer user's choice
     expect(setPreference).not.toHaveBeenCalled();
   });
 

--- a/tests/layouts/PlayerSelect.test.ts
+++ b/tests/layouts/PlayerSelect.test.ts
@@ -28,12 +28,18 @@ const { emitEvent, getPreference, isAdmin, preferenceState, setPreference } =
     setPreference: vi.fn(),
   }));
 
+// plain let read lazily by the mock, so tests can flip it per case
+let supportsPartyPlayerResolution = true;
+
 vi.mock("@/plugins/api", async () => {
   const { reactive } = await vi.importActual<typeof import("vue")>("vue");
   const api = reactive({
     players: {} as Record<string, Player>,
     // the menu's ai dj entry derives availability from the provider list
     providers: {},
+    get supportsPartyPlayerResolution() {
+      return supportsPartyPlayerResolution;
+    },
   });
   return { api, default: api };
 });
@@ -366,6 +372,7 @@ describe("PlayerSelect", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     isDashboardViewer = false;
+    supportsPartyPlayerResolution = true;
     const preferenceValues = preferenceState.reactiveValues;
     if (preferenceValues) {
       for (const key of Object.keys(preferenceValues)) {
@@ -604,6 +611,17 @@ describe("PlayerSelect", () => {
 
     // ...and is not persisted as the shared viewer user's choice
     expect(setPreference).not.toHaveBeenCalled();
+  });
+
+  it("still auto-selects for a dashboard viewer on a server that can't resolve the party player", () => {
+    isDashboardViewer = true;
+    supportsPartyPlayerResolution = false;
+    const attic = createPlayer("attic", "Attic");
+    api.players = { [attic.player_id]: attic };
+
+    mountPlayerSelect();
+
+    expect(store.activePlayerId).toBe(attic.player_id);
   });
 
   it("keeps the remembered player when it is unavailable at startup", () => {

--- a/tests/layouts/PlayerSelect.test.ts
+++ b/tests/layouts/PlayerSelect.test.ts
@@ -75,9 +75,13 @@ vi.mock("@/plugins/eventbus", () => ({
   },
 }));
 
+// plain let read lazily by the mock, so tests can flip it per case
+let isDashboardViewer = false;
+
 vi.mock("@/plugins/auth", () => ({
   authManager: {
     isAdmin,
+    isDashboardViewer: () => isDashboardViewer,
   },
 }));
 
@@ -361,6 +365,7 @@ describe("PlayerSelect", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    isDashboardViewer = false;
     const preferenceValues = preferenceState.reactiveValues;
     if (preferenceValues) {
       for (const key of Object.keys(preferenceValues)) {
@@ -577,6 +582,27 @@ describe("PlayerSelect", () => {
     await nextTick();
 
     expect(store.activePlayerId).toBe(builtin.player_id);
+    expect(setPreference).not.toHaveBeenCalled();
+  });
+
+  it("never auto-selects for a dashboard viewer", async () => {
+    isDashboardViewer = true;
+    const attic = createPlayer("attic", "Attic");
+    const builtin = createPlayer("builtin", "This device");
+    api.players = { [attic.player_id]: attic };
+
+    mountPlayerSelect();
+    // no automatic default: the hosting dashboard view pins the player
+    expect(store.activePlayerId).toBeUndefined();
+
+    // a view's pin survives the built-in player registering late...
+    store.activePlayerId = attic.player_id;
+    api.players[builtin.player_id] = builtin;
+    store.companionPlayerId = builtin.player_id;
+    await nextTick();
+    expect(store.activePlayerId).toBe(attic.player_id);
+
+    // ...and is not persisted as the shared viewer user's choice
     expect(setPreference).not.toHaveBeenCalled();
   });
 


### PR DESCRIPTION
# What does this implement/fix?

A dashboard viewer's active player is pinned by its hosting view, but the default layout's player auto-selection fights that pin: it picks a default player, hands it over to the display's own idle built-in player once that registers, and persists accidental picks as deliberate choices for the shared dashboard_viewer user. On a cast party dashboard this ends with the display visualizing itself instead of the intended player.

This disables default selection, the built-in handover, and preference persistence for dashboard viewer sessions only; regular browser sessions are unchanged. The auto-selection also masked a server-side gap: with guest access disabled, `party/player` returned null, so a cast party dashboard relied on the buggy pick to get any player at all. The companion server PR fixes that resolver, so together the dashboard follows the real party player.

**Related issue (if applicable):**

- none

**Related backend PR (if applicable):**

- related backend PR https://github.com/music-assistant/server/pull/5930

## Types of changes

<!--
Tick exactly one box below. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm lint:check` passes.
- [x] `pnpm test:run` passes, and tests have been added/updated where applicable.
- [x] `pnpm build` passes.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
