### PR TITLE
Show podcast episodes newest first

### DIFF
--- a/src/layouts/default/ItemContextMenu.vue
+++ b/src/layouts/default/ItemContextMenu.vue
@@ -1212,10 +1212,11 @@ export const getPlaybackContextMenuItems = async function (
         disabled: !store.activePlayer,
       });
     }
-    // Play from here (podcast episode)
+    // Play from here (podcast episode). Episodes are listed newest first, so
+    // playback runs the other way: from the chosen episode forward in time.
     if (parentItem.media_type == MediaType.PODCAST) {
       playMenuItems.push({
-        label: "play_from_here",
+        label: "play_from_here_to_latest",
         action: () => {
           api.playMedia(parentItem.uri, undefined, {
             start_item: firstItem.item_id,

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1018,6 +1018,7 @@
     "podcast_episode": "Episode",
     "podcast_episodes": "Episodes",
     "play_from_here": "Play from here",
+    "play_from_here_to_latest": "Play from here to latest",
     "dsp_active": "Active",
     "currently_playing_players": "Currently playing",
     "all_players": "All players",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1017,7 +1017,6 @@
     "global_search": "Global search",
     "podcast_episode": "Episode",
     "podcast_episodes": "Episodes",
-    "play_from_here": "Play from here",
     "play_from_here_to_latest": "Play from here to latest",
     "dsp_active": "Active",
     "currently_playing_players": "Currently playing",

--- a/src/views/PodcastDetails.vue
+++ b/src/views/PodcastDetails.vue
@@ -12,8 +12,8 @@
     :show-refresh-button="true"
     :load-items="loadPodcastEpisodes"
     :sort-keys="[
-      'position',
       'position_desc',
+      'position',
       'name',
       'duration',
       'duration_desc',


### PR DESCRIPTION
# What does this implement/fix?

Podcast episodes are being renumbered on the server so that the newest episode gets the highest number. Sorting by position has to run the other way round now, otherwise a podcast opens with its oldest episode at the top and you have to scroll to the bottom to find the latest one.

Also the play from here menu item is changed reflect what it will actually do now, and what users would want with podcast episodes, queue up the item selected and all newer episodes.

- Sort the episode list newest first by default

**Related issue (if applicable):**

- related issue `<link to issue>`

**Related backend PR (if applicable):**

- related backend PR https://github.com/music-assistant/server/pull/5929

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm lint:check` passes.
- [x] `pnpm test:run` passes, and tests have been added/updated where applicable.
- [x] `pnpm build` passes.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
