### PR TITLE
Show when a music service handles loudness and crossfade itself

### DIFF
--- a/src/composables/useAudioProcessingDetails.ts
+++ b/src/composables/useAudioProcessingDetails.ts
@@ -226,7 +226,9 @@ function buildProcessingStages(
   const { translate } = dependencies;
   const stages: AudioProcessingDisplayStage[] = [];
   const processing = chain.queue_processing;
-  // a step the source performed is listed too, but it leaves the shared path direct
+  // a step the source performed is named after the service that did it
+  const sourceName = dependencies.getProviderName(streamDetails.provider);
+  // such a step is listed too, but it leaves the shared path direct
   let serverAltersAudio = false;
   if (
     processing?.normalization &&
@@ -237,6 +239,7 @@ function buildProcessingStages(
         processing.normalization,
         translate,
         dependencies.locale,
+        sourceName,
       ),
     );
     serverAltersAudio ||= normalizationAppliedByServer(
@@ -258,7 +261,7 @@ function buildProcessingStages(
       key: "crossfade",
       icon: CrossfadeIcon,
       title: translate("streamdetails.audio_processing.crossfade", [
-        crossfadeModeLabel(processing.crossfade_mode, translate),
+        crossfadeModeLabel(processing.crossfade_mode, translate, sourceName),
       ]),
     });
     serverAltersAudio ||= crossfadeAppliedByServer(processing.crossfade_mode);
@@ -501,6 +504,7 @@ function normalizationStage(
   normalization: AudioNormalizationDetails,
   translate: Translate,
   locale: string,
+  sourceName: string,
 ): AudioProcessingDisplayStage {
   // the source names neither a target nor a measurement, so it has no details to show
   const details: string[] =
@@ -536,7 +540,9 @@ function normalizationStage(
     key: "normalization",
     icon: AudioLines,
     title: translate("streamdetails.audio_processing.normalization_title"),
-    subtitleParts: [normalizationModeLabel(normalization.mode, translate)],
+    subtitleParts: [
+      normalizationModeLabel(normalization.mode, translate, sourceName),
+    ],
     details,
   };
 }
@@ -1007,6 +1013,7 @@ function audioQualityLabel(
 function normalizationModeLabel(
   mode: string | undefined,
   translate: Translate,
+  sourceName: string,
 ): string {
   switch (mode) {
     case VolumeNormalizationMode.DISABLED:
@@ -1036,6 +1043,7 @@ function normalizationModeLabel(
     case VolumeNormalizationMode.SOURCE:
       return translate(
         "streamdetails.audio_processing.normalization_mode.source",
+        [sourceName],
       );
     default:
       return translate("streamdetails.audio_processing.unknown");
@@ -1053,7 +1061,11 @@ function measurementSourceLabel(
   return translate(`streamdetails.audio_processing.measurement.${source}`);
 }
 
-function crossfadeModeLabel(mode: string, translate: Translate): string {
+function crossfadeModeLabel(
+  mode: string,
+  translate: Translate,
+  sourceName: string,
+): string {
   switch (mode) {
     case CrossfadeMode.SMART_CROSSFADE:
       return translate("streamdetails.audio_processing.crossfade_mode.smart");
@@ -1066,7 +1078,9 @@ function crossfadeModeLabel(mode: string, translate: Translate): string {
         "streamdetails.audio_processing.crossfade_mode.disabled",
       );
     case CrossfadeMode.SOURCE:
-      return translate("streamdetails.audio_processing.crossfade_mode.source");
+      return translate("streamdetails.audio_processing.crossfade_mode.source", [
+        sourceName,
+      ]);
     default:
       return translate("streamdetails.audio_processing.unknown");
   }

--- a/src/composables/useAudioProcessingDetails.ts
+++ b/src/composables/useAudioProcessingDetails.ts
@@ -226,6 +226,8 @@ function buildProcessingStages(
   const { translate } = dependencies;
   const stages: AudioProcessingDisplayStage[] = [];
   const processing = chain.queue_processing;
+  // a step the source performed is listed too, but it leaves the shared path direct
+  let serverAltersAudio = false;
   if (
     processing?.normalization &&
     processing.normalization.mode !== VolumeNormalizationMode.DISABLED
@@ -237,6 +239,9 @@ function buildProcessingStages(
         dependencies.locale,
       ),
     );
+    serverAltersAudio ||= normalizationAppliedByServer(
+      processing.normalization,
+    );
   }
   if (processing && processing.playback_speed !== 1) {
     stages.push({
@@ -246,6 +251,7 @@ function buildProcessingStages(
         formatNumber(processing.playback_speed, 2, dependencies.locale),
       ]),
     });
+    serverAltersAudio = true;
   }
   if (processing && processing.crossfade_mode !== CrossfadeMode.DISABLED) {
     stages.push({
@@ -255,6 +261,7 @@ function buildProcessingStages(
         crossfadeModeLabel(processing.crossfade_mode, translate),
       ]),
     });
+    serverAltersAudio ||= crossfadeAppliedByServer(processing.crossfade_mode);
   }
   if (processing?.overlay_active) {
     stages.push({
@@ -262,13 +269,14 @@ function buildProcessingStages(
       icon: AudioLines,
       title: translate("streamdetails.audio_processing.overlay_active"),
     });
+    serverAltersAudio = true;
   }
   if (processing?.pcm_format) {
     const contextStage = processingContextStage(
       streamDetails.audio_format,
       processing.pcm_format,
       chain,
-      stages.length === 0,
+      !serverAltersAudio,
       translate,
       dependencies.locale,
     );
@@ -494,11 +502,15 @@ function normalizationStage(
   translate: Translate,
   locale: string,
 ): AudioProcessingDisplayStage {
-  const details: string[] = [
-    translate("streamdetails.audio_processing.measurement_source", [
-      measurementSourceLabel(normalization.measurement_source, translate),
-    ]),
-  ];
+  // the source names neither a target nor a measurement, so it has no details to show
+  const details: string[] =
+    normalization.mode === VolumeNormalizationMode.SOURCE
+      ? []
+      : [
+          translate("streamdetails.audio_processing.measurement_source", [
+            measurementSourceLabel(normalization.measurement_source, translate),
+          ]),
+        ];
   addDetail(
     details,
     "streamdetails.audio_processing.target_lufs",
@@ -720,10 +732,7 @@ function processingHeadroomReasons(
 ): string[] {
   const reasons = new Set<string>();
   const processing = chain.queue_processing;
-  if (
-    processing?.normalization &&
-    processing.normalization.mode !== VolumeNormalizationMode.DISABLED
-  ) {
+  if (normalizationAppliedByServer(processing?.normalization)) {
     reasons.add(
       translate("streamdetails.audio_processing.normalization_title"),
     );
@@ -733,7 +742,7 @@ function processingHeadroomReasons(
       translate("streamdetails.audio_processing.playback_speed_title"),
     );
   }
-  if (processing && processing.crossfade_mode !== CrossfadeMode.DISABLED) {
+  if (crossfadeAppliedByServer(processing?.crossfade_mode)) {
     reasons.add(translate("streamdetails.audio_processing.crossfade_title"));
   }
   if (processing?.overlay_active) {
@@ -745,6 +754,33 @@ function processingHeadroomReasons(
     }
   }
   return [...reasons];
+}
+
+/**
+ * Whether the server itself corrected the level, rather than the source.
+ *
+ * A step the source performed is reported for context, but the server applied
+ * nothing: it neither reserved headroom for it nor altered the samples.
+ */
+function normalizationAppliedByServer(
+  normalization: AudioNormalizationDetails | null | undefined,
+): boolean {
+  return (
+    !!normalization &&
+    normalization.mode !== VolumeNormalizationMode.DISABLED &&
+    normalization.mode !== VolumeNormalizationMode.SOURCE
+  );
+}
+
+/**
+ * Whether the server itself mixed the overlap, rather than the source.
+ */
+function crossfadeAppliedByServer(mode: CrossfadeMode | undefined): boolean {
+  return (
+    mode !== undefined &&
+    mode !== CrossfadeMode.DISABLED &&
+    mode !== CrossfadeMode.SOURCE
+  );
 }
 
 function addDetail(
@@ -997,6 +1033,10 @@ function normalizationModeLabel(
       return translate(
         "streamdetails.audio_processing.normalization_mode.fallback_dynamic",
       );
+    case VolumeNormalizationMode.SOURCE:
+      return translate(
+        "streamdetails.audio_processing.normalization_mode.source",
+      );
     default:
       return translate("streamdetails.audio_processing.unknown");
   }
@@ -1025,6 +1065,8 @@ function crossfadeModeLabel(mode: string, translate: Translate): string {
       return translate(
         "streamdetails.audio_processing.crossfade_mode.disabled",
       );
+    case CrossfadeMode.SOURCE:
+      return translate("streamdetails.audio_processing.crossfade_mode.source");
     default:
       return translate("streamdetails.audio_processing.unknown");
   }

--- a/src/layouts/default/PlayerOSD/PlayerFullscreenHeaderControls.vue
+++ b/src/layouts/default/PlayerOSD/PlayerFullscreenHeaderControls.vue
@@ -124,7 +124,9 @@
             <CrossfadeIcon
               :size="16"
               :active="crossfadeEnabled"
-              :smart="crossfadeEnabled && smartFadesActive"
+              :smart="
+                crossfadeEnabled && smartFadesActive && !sourceCrossfadeName
+              "
             />
             <span v-if="showLabel">{{ $t("crossfade") }}</span>
           </Button>
@@ -138,7 +140,13 @@
             }}
           </p>
           <p
-            v-if="crossfadeEnabled && smartFadesActive"
+            v-if="crossfadeEnabled && sourceCrossfadeName"
+            class="mt-1 opacity-80"
+          >
+            {{ $t("crossfade_source_active", [sourceCrossfadeName]) }}
+          </p>
+          <p
+            v-else-if="crossfadeEnabled && smartFadesActive"
             class="mt-1 opacity-80"
           >
             {{ $t("crossfade_smart_active") }}
@@ -200,7 +208,10 @@ import CrossfadeIcon from "@/layouts/default/PlayerOSD/PlayerControlBtn/Crossfad
 import { useQueueModes } from "@/layouts/default/PlayerOSD/useQueueModes";
 import { useAudioOverlay } from "@/composables/useAudioOverlay";
 import api from "@/plugins/api";
-import { isQueueInfiniteStream } from "@/plugins/api/helpers";
+import {
+  isQueueInfiniteStream,
+  queueSourceCrossfadeProvider,
+} from "@/plugins/api/helpers";
 import { $t } from "@/plugins/i18n";
 import { store } from "@/plugins/store";
 import { AudioLines, MicVocal } from "@lucide/vue";
@@ -259,6 +270,14 @@ const crossfadeEnabled = computed(
 const smartFadesActive = computed(
   () => queue.value?.smart_fades_active === true,
 );
+
+// A source that fades its own playback does so instead of us: smart_fades_active
+// still reflects the queue setting, but none of our timing is applied, so the
+// display name of the service replaces the smart wording and its animation.
+const sourceCrossfadeName = computed(() => {
+  const provider = queueSourceCrossfadeProvider(queue.value);
+  return provider ? api.getProviderName(provider) : undefined;
+});
 
 // Crossfade only applies to an active queue that is playing regular tracks.
 // Hide the control entirely for external sources, audiosources and radio streams.

--- a/src/plugins/api/helpers.ts
+++ b/src/plugins/api/helpers.ts
@@ -5,6 +5,7 @@ import api, { ConnectionState } from ".";
 import {
   Audiobook,
   AudioSource,
+  CrossfadeMode,
   MediaItemType,
   ItemMapping,
   MediaType,
@@ -46,6 +47,25 @@ export const isQueueInfiniteStream = function (
 ): boolean {
   const mediaType = queue?.current_item?.media_item?.media_type;
   return mediaType === MediaType.RADIO || mediaType === MediaType.AUDIO_SOURCE;
+};
+
+/**
+ * Returns the provider serving a queue's current item when that source is the one
+ * crossfading it, or undefined when Music Assistant applies the fade (or none is).
+ *
+ * The queue's crossfade settings say nothing about who acts on them: a source that
+ * fades its own playback is handed the setting and does the overlap itself, so none
+ * of our timing reaches the audio.
+ */
+export const queueSourceCrossfadeProvider = function (
+  queue: PlayerQueue | undefined,
+): string | undefined {
+  const streamDetails = queue?.current_item?.streamdetails;
+  const crossfadeMode =
+    streamDetails?.audio_processing?.queue_processing?.crossfade_mode;
+  return crossfadeMode === CrossfadeMode.SOURCE
+    ? streamDetails?.provider
+    : undefined;
 };
 
 /**

--- a/src/plugins/api/interfaces.ts
+++ b/src/plugins/api/interfaces.ts
@@ -536,6 +536,9 @@ export enum VolumeNormalizationMode {
   FALLBACK_FIXED_GAIN = "fallback_fixed_gain",
   FIXED_GAIN = "fixed_gain",
   FALLBACK_DYNAMIC = "fallback_dynamic",
+  // the source levelled its own audio, so the server left it alone: distinct from
+  // DISABLED, which means nothing normalized it at all
+  SOURCE = "source",
   UNKNOWN = "unknown",
 }
 
@@ -543,6 +546,8 @@ export enum CrossfadeMode {
   SMART_CROSSFADE = "smart_crossfade",
   STANDARD_CROSSFADE = "standard_crossfade",
   DISABLED = "disabled",
+  // the source crossfades its own playback, so the server does not
+  SOURCE = "source",
   UNKNOWN = "unknown",
 }
 

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1084,7 +1084,7 @@
                 "fallback_fixed_gain": "Fallback fixed gain",
                 "fixed_gain": "Fixed gain",
                 "fallback_dynamic": "Fallback dynamic",
-                "source": "Handled by the source"
+                "source": "Applied by {0}"
             },
             "measurement": {
                 "track": "Track",
@@ -1096,7 +1096,7 @@
                 "smart": "Smart",
                 "standard": "Standard",
                 "disabled": "Disabled",
-                "source": "Handled by the source"
+                "source": "Applied by {0}"
             },
             "dsp_state": {
                 "enabled": "DSP active",
@@ -1111,7 +1111,7 @@
             "direct_signal_path_detail": "Audio passes through queue processing unchanged.",
             "direct_signal_path_inactive_detail": "Music Assistant applies no volume normalization, crossfade, playback speed adjustment, or audio overlay.",
             "no_shared_transforms": "No shared transforms reported",
-            "no_shared_transforms_detail": "No normalization, crossfade, playback speed adjustment, or audio overlay is reported by the processing model.",
+            "no_shared_transforms_detail": "Music Assistant applies no normalization, crossfade, playback speed adjustment, or audio overlay.",
             "processing_headroom": "Processing headroom",
             "processing_headroom_detail": "Music Assistant converts audio to floating point internally to create headroom and reduce clipping or precision loss during normalization, mixing, crossfade, DSP, and limiting.",
             "processing_headroom_reasons": "Floating-point headroom is available for: {0}.",
@@ -2177,6 +2177,7 @@
     "crossfade_active": "Crossfade is active.",
     "crossfade_active_with_smart": "Crossfade is active with smart fades.",
     "crossfade_smart_active": "The fade timing is chosen automatically to suit each track.",
+    "crossfade_source_active": "{0} applies the fade to this track, not Music Assistant.",
     "lyrics": "Lyrics",
     "lyrics_unavailable_song": "There are no lyrics available for this track (yet).",
     "lyrics_unavailable_content": "Lyrics are not available for this media type.",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1083,7 +1083,8 @@
                 "measurement_only": "Measured loudness",
                 "fallback_fixed_gain": "Fallback fixed gain",
                 "fixed_gain": "Fixed gain",
-                "fallback_dynamic": "Fallback dynamic"
+                "fallback_dynamic": "Fallback dynamic",
+                "source": "Handled by the source"
             },
             "measurement": {
                 "track": "Track",
@@ -1094,7 +1095,8 @@
             "crossfade_mode": {
                 "smart": "Smart",
                 "standard": "Standard",
-                "disabled": "Disabled"
+                "disabled": "Disabled",
+                "source": "Handled by the source"
             },
             "dsp_state": {
                 "enabled": "DSP active",
@@ -1107,7 +1109,7 @@
             "integer_pcm": "{0}-bit PCM",
             "direct_signal_path": "Direct signal path",
             "direct_signal_path_detail": "Audio passes through queue processing unchanged.",
-            "direct_signal_path_inactive_detail": "No volume normalization, crossfade, playback speed adjustment, or audio overlay is active.",
+            "direct_signal_path_inactive_detail": "Music Assistant applies no volume normalization, crossfade, playback speed adjustment, or audio overlay.",
             "no_shared_transforms": "No shared transforms reported",
             "no_shared_transforms_detail": "No normalization, crossfade, playback speed adjustment, or audio overlay is reported by the processing model.",
             "processing_headroom": "Processing headroom",

--- a/tests/components/AudioProcessingDetails.test.ts
+++ b/tests/components/AudioProcessingDetails.test.ts
@@ -636,7 +636,7 @@ describe("AudioProcessingDetails", () => {
     expect(directPath.findAll("li").map((detail) => detail.text())).toEqual([
       "Audio passes through queue processing unchanged.",
       "Internal format: 16-bit PCM · 44.1 kHz · Stereo",
-      "No volume normalization, crossfade, playback speed adjustment, or audio overlay is active.",
+      "Music Assistant applies no volume normalization, crossfade, playback speed adjustment, or audio overlay.",
     ]);
     expect(wrapper.find('[data-stage="dsp-state-0"]').exists()).toBe(false);
     const destination = wrapper.find('[data-stage="destination"]');

--- a/tests/components/AudioProcessingDetails.test.ts
+++ b/tests/components/AudioProcessingDetails.test.ts
@@ -683,7 +683,7 @@ describe("AudioProcessingDetails", () => {
     );
     expect(context.text()).not.toContain("Direct signal path");
     expect(context.findAll("li").map((detail) => detail.text())).toEqual([
-      "No normalization, crossfade, playback speed adjustment, or audio overlay is reported by the processing model.",
+      "Music Assistant applies no normalization, crossfade, playback speed adjustment, or audio overlay.",
       "Internal format: 16-bit PCM · 44.1 kHz · Stereo",
     ]);
   });

--- a/tests/composables/useAudioProcessingDetails.test.ts
+++ b/tests/composables/useAudioProcessingDetails.test.ts
@@ -501,6 +501,75 @@ describe("buildAudioProcessingDetailsDisplay", () => {
     );
   });
 
+  it("keeps the path direct when the source handled the processing", () => {
+    const sourceFormat = makeFormat({ sample_rate: 44100, bit_depth: 16 });
+    const display = buildDisplay(
+      {
+        queue_processing: audioQueueProcessing({
+          pcm_format: makeFormat({
+            content_type: ContentType.PCM_S16LE,
+            codec_type: ContentType.PCM_S16LE,
+            sample_rate: 44100,
+            bit_depth: 16,
+          }),
+          normalization: audioNormalizationDetails({
+            mode: VolumeNormalizationMode.SOURCE,
+          }),
+          crossfade_mode: CrossfadeMode.SOURCE,
+        }),
+        outputs: [
+          audioOutputDetails({
+            player_ids: ["kitchen"],
+            output_format: sourceFormat,
+            fidelity: audioFidelity({ bit_perfect: true }),
+          }),
+        ],
+      },
+      sourceFormat,
+    );
+
+    // both steps are reported, but neither is ours, so the shared path stays direct
+    expect(display.processingStages.map((stage) => stage.title)).toEqual([
+      "Direct signal path",
+      "Volume normalization",
+      "Crossfade: Handled by the source",
+    ]);
+    const normalization = display.processingStages[1];
+    expect(normalization.subtitleParts).toEqual(["Handled by the source"]);
+    // our target and measurement describe neither, so there is nothing to list
+    expect(normalization.details).toEqual([]);
+  });
+
+  it("excludes source-handled processing from headroom reasons", () => {
+    const display = buildDisplay({
+      queue_processing: audioQueueProcessing({
+        pcm_format: makeFormat({
+          content_type: ContentType.PCM_F32LE,
+          codec_type: ContentType.PCM_F32LE,
+          bit_depth: 32,
+        }),
+        normalization: audioNormalizationDetails({
+          mode: VolumeNormalizationMode.SOURCE,
+        }),
+        crossfade_mode: CrossfadeMode.SOURCE,
+      }),
+      outputs: [
+        audioOutputDetails({
+          player_ids: ["kitchen"],
+          output_format: makeFormat(),
+          fidelity: audioFidelity({ bit_perfect: false }),
+          dsp: audioDSPDetails({ state: DSPState.ENABLED, output_gain: -3 }),
+        }),
+      ],
+    });
+
+    const headroom = display.processingStages[0];
+    expect(headroom.title).toBe("Processing headroom");
+    expect(headroom.details).toContain(
+      "Floating-point headroom is available for: DSP.",
+    );
+  });
+
   it("formats every numeric detail with the supplied locale", () => {
     const format = makeFormat({
       content_type: ContentType.MP3,

--- a/tests/composables/useAudioProcessingDetails.test.ts
+++ b/tests/composables/useAudioProcessingDetails.test.ts
@@ -532,12 +532,114 @@ describe("buildAudioProcessingDetailsDisplay", () => {
     expect(display.processingStages.map((stage) => stage.title)).toEqual([
       "Direct signal path",
       "Volume normalization",
-      "Crossfade: Handled by the source",
+      "Crossfade: Applied by Test provider",
     ]);
     const normalization = display.processingStages[1];
-    expect(normalization.subtitleParts).toEqual(["Handled by the source"]);
+    expect(normalization.subtitleParts).toEqual(["Applied by Test provider"]);
     // our target and measurement describe neither, so there is nothing to list
     expect(normalization.details).toEqual([]);
+  });
+
+  it("still reports a transform of ours alongside a source-handled one", () => {
+    const sourceFormat = makeFormat({ sample_rate: 44100, bit_depth: 16 });
+    const display = buildDisplay(
+      {
+        queue_processing: audioQueueProcessing({
+          pcm_format: makeFormat({
+            content_type: ContentType.PCM_S16LE,
+            codec_type: ContentType.PCM_S16LE,
+            sample_rate: 44100,
+            bit_depth: 16,
+          }),
+          normalization: audioNormalizationDetails({
+            mode: VolumeNormalizationMode.SOURCE,
+          }),
+          playback_speed: 1.25,
+        }),
+        outputs: [
+          audioOutputDetails({
+            player_ids: ["kitchen"],
+            output_format: sourceFormat,
+            fidelity: audioFidelity({ bit_perfect: true }),
+          }),
+        ],
+      },
+      sourceFormat,
+    );
+
+    // the speed change is ours, so the path is no longer direct
+    expect(display.processingStages.map((stage) => stage.title)).toEqual([
+      "Volume normalization",
+      "Playback speed: 1.25x",
+    ]);
+  });
+
+  it("lets a normalization of ours suppress the direct path", () => {
+    const sourceFormat = makeFormat({ sample_rate: 44100, bit_depth: 16 });
+    const display = buildDisplay(
+      {
+        queue_processing: audioQueueProcessing({
+          pcm_format: makeFormat({
+            content_type: ContentType.PCM_S16LE,
+            codec_type: ContentType.PCM_S16LE,
+            sample_rate: 44100,
+            bit_depth: 16,
+          }),
+          normalization: audioNormalizationDetails({
+            mode: VolumeNormalizationMode.MEASUREMENT_ONLY,
+          }),
+        }),
+        outputs: [
+          audioOutputDetails({
+            player_ids: ["kitchen"],
+            output_format: sourceFormat,
+            fidelity: audioFidelity({ bit_perfect: true }),
+          }),
+        ],
+      },
+      sourceFormat,
+    );
+
+    expect(display.processingStages.map((stage) => stage.title)).not.toContain(
+      "Direct signal path",
+    );
+  });
+
+  it("does not contradict itself when only the source processed the audio", () => {
+    const sourceFormat = makeFormat({ sample_rate: 44100, bit_depth: 16 });
+    const display = buildDisplay(
+      {
+        queue_processing: audioQueueProcessing({
+          pcm_format: makeFormat({
+            content_type: ContentType.PCM_S16LE,
+            codec_type: ContentType.PCM_S16LE,
+            sample_rate: 44100,
+            bit_depth: 16,
+          }),
+          normalization: audioNormalizationDetails({
+            mode: VolumeNormalizationMode.SOURCE,
+          }),
+          crossfade_mode: CrossfadeMode.SOURCE,
+        }),
+        outputs: [
+          audioOutputDetails({
+            player_ids: ["kitchen"],
+            output_format: sourceFormat,
+            // an output that is not bit-perfect takes the other half of the fork
+            fidelity: audioFidelity({ bit_perfect: false }),
+          }),
+        ],
+      },
+      sourceFormat,
+    );
+
+    const context = display.processingStages[0];
+    expect(context.title).toBe("No shared transforms reported");
+    // the panel lists the source's two steps two rows below, so this line has to
+    // speak for us rather than for the processing model as a whole
+    expect(context.details).toContain(
+      "Music Assistant applies no normalization, crossfade, playback speed adjustment, or audio overlay.",
+    );
   });
 
   it("excludes source-handled processing from headroom reasons", () => {

--- a/tests/layouts/PlayerFullscreenHeaderControls.test.ts
+++ b/tests/layouts/PlayerFullscreenHeaderControls.test.ts
@@ -1,0 +1,101 @@
+import PlayerFullscreenHeaderControls from "@/layouts/default/PlayerOSD/PlayerFullscreenHeaderControls.vue";
+import CrossfadeIcon from "@/layouts/default/PlayerOSD/PlayerControlBtn/CrossfadeIcon.vue";
+import { CrossfadeMode, type PlayerQueue } from "@/plugins/api/interfaces";
+import { shallowMount } from "@vue/test-utils";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ref } from "vue";
+
+// Only what the crossfade control reads is mocked; the rest of the header is
+// stubbed out by shallowMount.
+const queue = ref<Partial<PlayerQueue> | undefined>(undefined);
+
+vi.mock("@/plugins/api", () => ({
+  default: {
+    getProviderName: (providerId: string) =>
+      providerId === "spotify--1" ? "Spotify" : providerId,
+    queueCommandCrossfade: vi.fn(),
+  },
+}));
+vi.mock("@/plugins/store", () => ({ store: { mobileLayout: false } }));
+vi.mock("@/composables/useAudioOverlay", () => ({
+  useAudioOverlay: () => ({ openOverlayDialog: vi.fn() }),
+}));
+vi.mock("@/layouts/default/PlayerOSD/useQueueModes", () => ({
+  useQueueModes: () => ({
+    queue,
+    sources: ref([]),
+    dynamicModeActive: ref(false),
+    autoplayEnabled: ref(false),
+    autoplayApplicable: ref(false),
+    setAutoplay: vi.fn(),
+  }),
+}));
+
+// the tooltip parts are stubbed but keep rendering their slots, so the control
+// and its explanation are reachable without opening a real tooltip
+const slotStub = { template: "<div><slot /></div>" };
+
+function mountControls() {
+  return shallowMount(PlayerFullscreenHeaderControls, {
+    global: {
+      stubs: {
+        TooltipProvider: slotStub,
+        Tooltip: slotStub,
+        TooltipTrigger: slotStub,
+        TooltipContent: slotStub,
+        Button: { template: "<button><slot /></button>" },
+      },
+    },
+  });
+}
+
+function seedQueue(crossfadeMode: CrossfadeMode): void {
+  queue.value = {
+    queue_id: "queue-1",
+    active: true,
+    crossfade_enabled: true,
+    smart_fades_active: true,
+    current_item: {
+      streamdetails: {
+        provider: "spotify--1",
+        audio_processing: {
+          queue_processing: { crossfade_mode: crossfadeMode },
+        },
+      },
+    },
+  } as unknown as Partial<PlayerQueue>;
+}
+
+describe("PlayerFullscreenHeaderControls", () => {
+  beforeEach(() => {
+    queue.value = undefined;
+  });
+
+  it("does not animate a fade the source applied", () => {
+    // smart_fades_active only reflects the queue setting: none of our timing is
+    // applied here, so the twinkle would claim a fade we did not render
+    seedQueue(CrossfadeMode.SOURCE);
+
+    const icon = mountControls().findComponent(CrossfadeIcon);
+
+    expect(icon.props("active")).toBe(true);
+    expect(icon.props("smart")).toBe(false);
+  });
+
+  it("animates our own smart fade", () => {
+    seedQueue(CrossfadeMode.SMART_CROSSFADE);
+
+    expect(mountControls().findComponent(CrossfadeIcon).props("smart")).toBe(
+      true,
+    );
+  });
+
+  it("names the service that applies the fade", () => {
+    seedQueue(CrossfadeMode.SOURCE);
+
+    const text = mountControls().text();
+
+    expect(text).toContain("Spotify applies the fade to this track");
+    expect(text).not.toContain("The fade timing is chosen automatically");
+  });
+});

--- a/tests/plugins/api/helpers.test.ts
+++ b/tests/plugins/api/helpers.test.ts
@@ -26,14 +26,16 @@ import {
   getProviderRootDomain,
   isAudioSource,
   isQueueInfiniteStream,
+  queueSourceCrossfadeProvider,
   resolvePlayerQueue,
   waitForApiInitialization,
 } from "@/plugins/api/helpers";
-import { MediaType } from "@/plugins/api/interfaces";
+import { CrossfadeMode, MediaType } from "@/plugins/api/interfaces";
 import type {
   MediaItemType,
   PlayableMediaItemType,
   Player,
+  QueueItem,
 } from "@/plugins/api/interfaces";
 import { playerQueue } from "../../fixtures/playerQueue";
 import { queueItem } from "../../fixtures/queueItem";
@@ -59,6 +61,44 @@ describe("isAudioSource", () => {
 
   it("returns false for undefined", () => {
     expect(isAudioSource(undefined)).toBe(false);
+  });
+});
+
+describe("queueSourceCrossfadeProvider", () => {
+  const makeQueue = (crossfadeMode: CrossfadeMode | undefined) =>
+    playerQueue({
+      current_item: queueItem({
+        streamdetails: {
+          provider: "spotify--1",
+          audio_processing: crossfadeMode
+            ? { queue_processing: { crossfade_mode: crossfadeMode } }
+            : undefined,
+        },
+      } as unknown as Partial<QueueItem>),
+    });
+
+  it("returns the provider that applies the fade itself", () => {
+    expect(queueSourceCrossfadeProvider(makeQueue(CrossfadeMode.SOURCE))).toBe(
+      "spotify--1",
+    );
+  });
+
+  it("returns undefined when the fade is ours or absent", () => {
+    for (const mode of [
+      CrossfadeMode.SMART_CROSSFADE,
+      CrossfadeMode.STANDARD_CROSSFADE,
+      CrossfadeMode.DISABLED,
+      undefined,
+    ]) {
+      expect(queueSourceCrossfadeProvider(makeQueue(mode))).toBeUndefined();
+    }
+  });
+
+  it("returns undefined without a queue or a current item", () => {
+    expect(queueSourceCrossfadeProvider(undefined)).toBeUndefined();
+    expect(
+      queueSourceCrossfadeProvider(playerQueue({ current_item: null })),
+    ).toBeUndefined();
   });
 });
 


### PR DESCRIPTION
# What does this implement/fix?

Some music services level the loudness and crossfade their own playback — Spotify's playback engine is the case in hand — and Music Assistant deliberately stays out of both. The server now says so instead of reporting them as off, so the stream details can show what is really happening to the audio, and by whom.

Volume normalization and crossfade now read "Applied by <service>" for such a stream. Because Music Assistant applied nothing, the panel still shows it as a direct signal path and no longer blames the floating-point headroom on a step it did not perform.

On the fullscreen player, the crossfade pill now says which service applies the fade, and stops running the smart-fade animation for it — the queue's smart setting is still on, but none of our timing reaches the audio.

**Related issue (if applicable):**

- n/a

**Related backend PR (if applicable):**

- https://github.com/music-assistant/server/pull/5937

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm lint:check` passes.
- [x] `pnpm test:run` passes, and tests have been added/updated where applicable.
- [x] `pnpm build` passes.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
