### PR TITLE
Fix external source badges

### DIFF
--- a/src/composables/nowPlayingSource.ts
+++ b/src/composables/nowPlayingSource.ts
@@ -1,13 +1,9 @@
 import { computed } from "vue";
-import {
-  MediaType,
-  type PlayableMediaItemType,
-} from "@/plugins/api/interfaces";
-import { getSourceName, isAudioSource } from "@/plugins/api/helpers";
+import { resolveExternalSource } from "@/composables/externalSource";
 import { store } from "@/plugins/store";
 
 /**
- * The source the active player is playing from, ready for display.
+ * The active external source, ready for display.
  */
 export interface NowPlayingSource {
   name: string;
@@ -16,49 +12,25 @@ export interface NowPlayingSource {
 }
 
 /**
- * Composable that exposes the source producing the audio on the active player,
- * or undefined when the media on screen already names itself.
- *
- * Live sources publish the track they are currently streaming as the player's
- * media, so the title and artist on screen describe the audio but never its
- * origin: a plugin source (Spotify Connect, AirPlay, …), a radio station once
- * live stream metadata takes over its title, or a source outside Music
- * Assistant that took the player over.
+ * Composable that exposes the external source active on the current player.
  */
 export function useNowPlayingSource() {
   const nowPlayingSource = computed((): NowPlayingSource | undefined => {
     const player = store.activePlayer;
     if (!player || player.powered === false) return undefined;
 
-    const queueItem = store.curQueueItem;
-    const mediaItem = queueItem?.media_item;
-
-    // a plugin source is itself the queue item; the player's media carries
-    // whatever that source happens to be streaming
-    if (isAudioSource(mediaItem)) {
-      return { name: mediaItem.name, iconDomain: iconDomain(mediaItem) };
-    }
-
-    // a station only loses its name to the running track once it sends stream
-    // metadata; without it the title already is the station
-    if (
-      mediaItem?.media_type === MediaType.RADIO &&
-      queueItem?.streamdetails?.stream_metadata
-    ) {
-      return { name: mediaItem.name, iconDomain: iconDomain(mediaItem) };
-    }
-
-    // the player left Music Assistant altogether, so there is no queue item to
-    // read the source from and its name comes from the player's source list
-    if (!store.activePlayerQueue && player.active_source) {
-      return { name: getSourceName(player) };
-    }
-
-    return undefined;
+    const externalSource = resolveExternalSource(
+      player,
+      store.activePlayerQueue,
+    );
+    if (!externalSource) return undefined;
+    return {
+      name: externalSource.name,
+      iconDomain: sourceProviderId(externalSource.id),
+    };
   });
 
-  // a live source with no real album lands its own name in the album slot, so
-  // the album line is blanked wherever the badge already states it
+  // an external source with no real album lands its own name in the album slot
   const albumSubtitle = computed(() => {
     const album = store.activePlayer?.current_media?.album;
     if (!album || album === nowPlayingSource.value?.name) return "";
@@ -68,11 +40,7 @@ export function useNowPlayingSource() {
   return { nowPlayingSource, albumSubtitle };
 }
 
-// the provider behind the source rather than the library: a station saved to
-// the library still streams from the provider that identifies it
-function iconDomain(item: PlayableMediaItemType): string {
-  if (item.provider_mappings.length) {
-    return item.provider_mappings[0].provider_domain;
-  }
-  return item.provider;
+function sourceProviderId(sourceId: string): string | undefined {
+  const separator = sourceId.indexOf("://");
+  return separator > 0 ? sourceId.slice(0, separator) : undefined;
 }

--- a/src/layouts/default/PlayerOSD/NowPlayingSourceBadge.vue
+++ b/src/layouts/default/PlayerOSD/NowPlayingSourceBadge.vue
@@ -1,9 +1,5 @@
 <!--
-  Names the source producing the audio on the active player.
-
-  Live sources put the track they are streaming in the player's media, so this
-  is the only place the origin of that audio is stated outside the queue list.
-  Renders nothing while the media on screen already names itself.
+  Names the external source active on the player.
 -->
 <template>
   <Badge
@@ -20,27 +16,35 @@
     :aria-label="$t('tooltip.playing_from', [nowPlayingSource.name])"
     :title="$t('tooltip.playing_from', [nowPlayingSource.name])"
   >
-    <ProviderIcon
-      v-if="nowPlayingSource.iconDomain"
+    <img
+      v-if="iconDataUri"
       class="now-playing-source__icon"
-      :domain="nowPlayingSource.iconDomain"
-      :size="14"
+      :src="iconDataUri"
+      alt=""
+      :style="{ filter: applyInvert ? 'invert(1)' : undefined }"
     />
-    <span v-if="!iconOnly || !nowPlayingSource.iconDomain" class="truncate">
+    <AudioLines
+      v-else
+      class="now-playing-source__icon now-playing-source__fallback"
+      :size="14"
+      aria-hidden="true"
+    />
+    <span v-if="!iconOnly" class="truncate">
       {{ nowPlayingSource.name }}
     </span>
   </Badge>
 </template>
 
 <script setup lang="ts">
-import ProviderIcon from "@/components/ProviderIcon.vue";
 import { Badge } from "@/components/ui/badge";
 import { useNowPlayingSource } from "@/composables/nowPlayingSource";
+import { useProviderIcon } from "@/composables/useProviderIcon";
+import { AudioLines } from "@lucide/vue";
 
 interface Props {
   /**
-   * Let the icon name the source on its own; the name stays available in the
-   * label and tooltip. Sources without an icon keep showing their name.
+   * Show only the provider or fallback icon. The name stays in the tooltip and
+   * accessible label.
    */
   iconOnly?: boolean;
   /**
@@ -54,10 +58,16 @@ interface Props {
 defineProps<Props>();
 
 const { nowPlayingSource } = useNowPlayingSource();
+const { iconDataUri, applyInvert } = useProviderIcon(
+  () => nowPlayingSource.value?.iconDomain,
+);
 </script>
 
 <style scoped>
 .now-playing-source__icon {
+  width: 14px;
+  height: 14px;
   flex-shrink: 0;
+  object-fit: contain;
 }
 </style>

--- a/src/layouts/default/PlayerOSD/PlayerFullscreen.vue
+++ b/src/layouts/default/PlayerOSD/PlayerFullscreen.vue
@@ -99,8 +99,7 @@
             </div>
           </div>
           <div class="main-media-details-track-info">
-            <!-- the source the audio comes from, when the title below is the
-                 track that source is streaming rather than the source itself -->
+            <!-- the external source streaming the media shown below -->
             <NowPlayingSourceBadge class="main-media-details-source" />
             <!-- player name as title if its powered off-->
             <v-card-title

--- a/src/layouts/default/PlayerOSD/PlayerTrackDetails.vue
+++ b/src/layouts/default/PlayerOSD/PlayerTrackDetails.vue
@@ -114,8 +114,7 @@
     <template #subtitle>
       <div class="player-track-subtitle" :style="{ color: primaryColor }">
         <div class="player-track-subtitle-line">
-          <!-- the source the audio comes from; the compact bar only has room
-               for its icon beside the track metadata -->
+          <!-- the external source; the compact bar only has room for its icon -->
           <NowPlayingSourceBadge
             v-if="props.compact"
             icon-only

--- a/tests/composables/nowPlayingSource.test.ts
+++ b/tests/composables/nowPlayingSource.test.ts
@@ -1,30 +1,16 @@
 import { reactive } from "vue";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import type {
+import {
+  MediaType,
+  type PlayerMedia,
   Player,
   PlayerQueue,
-  QueueItem,
-  StreamMetadata,
 } from "@/plugins/api/interfaces";
-import { audioSource } from "../fixtures/audioSource";
 import { playerSource } from "../fixtures/playerSource";
-import { providerMapping } from "../fixtures/providerMapping";
-import { queueItem } from "../fixtures/queueItem";
-import { radio } from "../fixtures/radio";
-import { streamDetails } from "../fixtures/streamDetails";
-import { track } from "../fixtures/track";
-
-// getSourceName resolves the player's active source against these
-const { apiMock } = vi.hoisted(() => ({
-  apiMock: { queues: {} as Record<string, unknown> },
-}));
-
-vi.mock("@/plugins/api", () => ({ api: apiMock, default: apiMock }));
 
 const storeMock = reactive({
   activePlayer: undefined as Player | undefined,
   activePlayerQueue: undefined as PlayerQueue | undefined,
-  curQueueItem: undefined as QueueItem | undefined,
 });
 
 vi.mock("@/plugins/store", () => ({ store: storeMock }));
@@ -42,42 +28,39 @@ function player(overrides: Partial<Player> = {}): Player {
   } as Player;
 }
 
-function metadata(overrides: Partial<StreamMetadata> = {}): StreamMetadata {
+function playerMedia(overrides: Partial<PlayerMedia> = {}): PlayerMedia {
   return {
-    title: "Live track",
+    uri: "test://media",
+    media_type: MediaType.TRACK,
+    title: null,
     artist: null,
     album: null,
     image_url: null,
+    palette: null,
     duration: null,
-    uri: null,
+    source_id: null,
+    elapsed_time: null,
+    elapsed_time_last_updated: null,
+    queue_item_id: null,
     ...overrides,
   };
 }
 
-/** Puts the item on an active queue, the way the server reports playback. */
-function playing(item: QueueItem) {
-  storeMock.activePlayerQueue = { queue_id: "player-1" } as PlayerQueue;
-  storeMock.curQueueItem = item;
-}
-
 beforeEach(() => {
-  apiMock.queues = {};
   storeMock.activePlayer = player();
   storeMock.activePlayerQueue = undefined;
-  storeMock.curQueueItem = undefined;
 });
 
 describe("useNowPlayingSource", () => {
-  it("names the plugin source playing on the queue", () => {
-    playing(
-      queueItem({
-        media_item: audioSource({
-          name: "Spotify Connect",
-          provider: "spotify_connect--abc",
-          provider_mappings: [],
-        }),
-      }),
-    );
+  it("names the active external player source", () => {
+    const source = playerSource({
+      id: "spotify_connect--abc://audio_source/main",
+      name: "Spotify Connect",
+    });
+    storeMock.activePlayer = player({
+      active_source: source.id,
+      source_list: [source],
+    });
 
     const { nowPlayingSource } = useNowPlayingSource();
 
@@ -87,63 +70,53 @@ describe("useNowPlayingSource", () => {
     });
   });
 
-  it("names the station once live metadata takes over the title", () => {
-    playing(
-      queueItem({
-        media_item: radio({
-          name: "Radio 538",
-          provider: "library",
-          provider_mappings: [providerMapping({ provider_domain: "tunein" })],
-        }),
-        streamdetails: streamDetails({ stream_metadata: metadata() }),
-      }),
-    );
-
-    const { nowPlayingSource } = useNowPlayingSource();
-
-    // the library is where the station is saved, not what streams it
-    expect(nowPlayingSource.value).toEqual({
-      name: "Radio 538",
-      iconDomain: "tunein",
-    });
-  });
-
-  it("stays silent for a station that still shows its own name", () => {
-    playing(
-      queueItem({
-        media_item: radio({ name: "Radio 538" }),
-        streamdetails: streamDetails({ stream_metadata: null }),
-      }),
-    );
-
-    const { nowPlayingSource } = useNowPlayingSource();
-
-    expect(nowPlayingSource.value).toBeUndefined();
-  });
-
-  it("stays silent for ordinary track playback", () => {
-    playing(queueItem({ media_item: track() }));
-
-    const { nowPlayingSource } = useNowPlayingSource();
-
-    expect(nowPlayingSource.value).toBeUndefined();
-  });
-
-  it("names an external source that took the player over", () => {
+  it("does not infer a provider for a native player source", () => {
+    const source = playerSource({ id: "line-in", name: "Line In" });
     storeMock.activePlayer = player({
-      active_source: "line-in",
-      source_list: [playerSource({ id: "line-in", name: "Line In" })],
+      active_source: source.id,
+      source_list: [source],
     });
 
     const { nowPlayingSource } = useNowPlayingSource();
 
-    // no queue to read the source from, so it comes from the source list
-    expect(nowPlayingSource.value).toEqual({ name: "Line In" });
+    expect(nowPlayingSource.value).toEqual({
+      name: "Line In",
+      iconDomain: undefined,
+    });
+  });
+
+  it("keeps a radio station in the album subtitle", () => {
+    storeMock.activePlayer = player({
+      current_media: playerMedia({
+        media_type: MediaType.RADIO,
+        title: "Live track",
+        album: "Radio 538",
+      }),
+    });
+
+    const { nowPlayingSource, albumSubtitle } = useNowPlayingSource();
+
+    expect(nowPlayingSource.value).toBeUndefined();
+    expect(albumSubtitle.value).toBe("Radio 538");
+  });
+
+  it("stays silent for the player's own queue source", () => {
+    storeMock.activePlayer = player({
+      source_list: [playerSource({ id: "player-1", name: "Queue" })],
+    });
+
+    const { nowPlayingSource } = useNowPlayingSource();
+
+    expect(nowPlayingSource.value).toBeUndefined();
   });
 
   it("stays silent while the player is off", () => {
-    storeMock.activePlayer = player({ powered: false });
-    playing(queueItem({ media_item: audioSource({ name: "AirPlay" }) }));
+    const source = playerSource({ id: "airplay", name: "AirPlay" });
+    storeMock.activePlayer = player({
+      powered: false,
+      active_source: source.id,
+      source_list: [source],
+    });
 
     const { nowPlayingSource } = useNowPlayingSource();
 
@@ -158,13 +131,21 @@ describe("useNowPlayingSource", () => {
     expect(nowPlayingSource.value).toBeUndefined();
   });
 
-  it("follows the queue item as playback moves on", () => {
+  it("follows active source changes", () => {
+    const airplay = playerSource({
+      id: "airplay_receiver--abc://audio_source/main",
+      name: "AirPlay",
+    });
+    const queue = playerSource({ id: "player-1", name: "Queue" });
+    storeMock.activePlayer = player({
+      active_source: airplay.id,
+      source_list: [airplay, queue],
+    });
     const { nowPlayingSource } = useNowPlayingSource();
-    playing(queueItem({ media_item: audioSource({ name: "AirPlay" }) }));
 
     expect(nowPlayingSource.value?.name).toBe("AirPlay");
 
-    storeMock.curQueueItem = queueItem({ media_item: track() });
+    storeMock.activePlayer.active_source = queue.id;
 
     expect(nowPlayingSource.value).toBeUndefined();
   });

--- a/tests/layouts/NowPlayingSourceBadge.test.ts
+++ b/tests/layouts/NowPlayingSourceBadge.test.ts
@@ -1,17 +1,25 @@
 import NowPlayingSourceBadge from "@/layouts/default/PlayerOSD/NowPlayingSourceBadge.vue";
 import { enableAutoUnmount, mount } from "@vue/test-utils";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import type { Player, PlayerQueue, QueueItem } from "@/plugins/api/interfaces";
-import { audioSource } from "../fixtures/audioSource";
-import { providerMapping } from "../fixtures/providerMapping";
-import { queueItem } from "../fixtures/queueItem";
-import { track } from "../fixtures/track";
+import type { Player } from "@/plugins/api/interfaces";
+import { playerSource } from "../fixtures/playerSource";
 
-const { apiMock } = vi.hoisted(() => ({
-  apiMock: { queues: {} as Record<string, unknown> },
-}));
-
-vi.mock("@/plugins/api", () => ({ api: apiMock, default: apiMock }));
+vi.mock("@/composables/useProviderIcon", async () => {
+  const { computed, toValue } =
+    await vi.importActual<typeof import("vue")>("vue");
+  return {
+    useProviderIcon: (domain: () => string | undefined) => ({
+      iconDataUri: computed(() =>
+        ["airplay_receiver--abc", "spotify_connect--abc"].includes(
+          toValue(domain) ?? "",
+        )
+          ? "data:image/svg+xml;base64,PHN2Zy8+"
+          : null,
+      ),
+      applyInvert: computed(() => false),
+    }),
+  };
+});
 
 vi.mock("@/plugins/store", async () => {
   const { reactive } = await vi.importActual<typeof import("vue")>("vue");
@@ -19,7 +27,6 @@ vi.mock("@/plugins/store", async () => {
     store: reactive({
       activePlayer: undefined,
       activePlayerQueue: undefined,
-      curQueueItem: undefined,
     }),
   };
 });
@@ -39,9 +46,14 @@ function mountBadge(props: { iconOnly?: boolean; plain?: boolean } = {}) {
   });
 }
 
-function playing(item: QueueItem) {
-  store.activePlayerQueue = { queue_id: "player-1" } as PlayerQueue;
-  store.curQueueItem = item;
+function activateSource(id: string, name: string) {
+  const source = playerSource({ id, name });
+  store.activePlayer = {
+    player_id: "player-1",
+    powered: true,
+    active_source: source.id,
+    source_list: [source],
+  } as unknown as Player;
 }
 
 beforeEach(() => {
@@ -52,20 +64,13 @@ beforeEach(() => {
     source_list: [],
   } as unknown as Player;
   store.activePlayerQueue = undefined;
-  store.curQueueItem = undefined;
 });
 
 describe("NowPlayingSourceBadge", () => {
   it("names the active source and labels it for assistive tech", () => {
-    playing(
-      queueItem({
-        media_item: audioSource({
-          name: "Spotify Connect",
-          provider_mappings: [
-            providerMapping({ provider_domain: "spotify_connect" }),
-          ],
-        }),
-      }),
+    activateSource(
+      "spotify_connect--abc://audio_source/main",
+      "Spotify Connect",
     );
 
     const badge = mountBadge();
@@ -74,63 +79,51 @@ describe("NowPlayingSourceBadge", () => {
     expect(badge.get("[data-slot=badge]").attributes("title")).toBe(
       "tooltip.playing_from:Spotify Connect",
     );
-    expect(badge.find("[data-provider-icon]").exists()).toBe(true);
+    expect(badge.find("img").exists()).toBe(true);
+    expect(badge.find(".now-playing-source__fallback").exists()).toBe(false);
   });
 
-  it("renders nothing while the media names itself", () => {
-    playing(queueItem({ media_item: track() }));
-
-    expect(mountBadge().find("[data-slot=badge]").exists()).toBe(false);
-  });
-
-  it("drops the icon for a source with no provider behind it", () => {
-    store.activePlayer = {
-      player_id: "player-1",
-      powered: true,
-      active_source: "line-in",
-      source_list: [{ id: "line-in", name: "Line In" }],
-    } as unknown as Player;
+  it("uses the AirPlay provider icon", () => {
+    activateSource("airplay_receiver--abc://audio_source/main", "AirPlay");
 
     const badge = mountBadge();
 
-    expect(badge.text()).toContain("Line In");
-    expect(badge.find("[data-provider-icon]").exists()).toBe(false);
+    expect(badge.find("img").exists()).toBe(true);
+    expect(badge.find(".now-playing-source__fallback").exists()).toBe(false);
+  });
+
+  it("renders nothing while the Music Assistant queue is active", () => {
+    expect(mountBadge().find("[data-slot=badge]").exists()).toBe(false);
+  });
+
+  it.each([
+    ["line-in", "Line In"],
+    ["unknown--abc://audio_source/main", "Unknown source"],
+  ])("falls back to a generic icon for %s", (id, name) => {
+    activateSource(id, name);
+
+    const badge = mountBadge();
+
+    expect(badge.find("img").exists()).toBe(false);
+    expect(badge.find(".now-playing-source__fallback").exists()).toBe(true);
   });
 
   it("hands the name to the tooltip when only the icon is asked for", () => {
-    playing(
-      queueItem({
-        media_item: audioSource({
-          name: "Spotify Connect",
-          provider_mappings: [
-            providerMapping({ provider_domain: "spotify_connect" }),
-          ],
-        }),
-      }),
-    );
+    activateSource("line-in", "Line In");
 
     const badge = mountBadge({ iconOnly: true });
 
-    expect(badge.text()).not.toContain("Spotify Connect");
-    expect(badge.find("[data-provider-icon]").exists()).toBe(true);
+    expect(badge.text()).not.toContain("Line In");
+    expect(badge.find(".now-playing-source__fallback").exists()).toBe(true);
     expect(badge.get("[data-slot=badge]").attributes("title")).toBe(
-      "tooltip.playing_from:Spotify Connect",
+      "tooltip.playing_from:Line In",
     );
   });
 
   // the player bars have a background of their own, so the badge sheds its
   // pill there and lines up with the text around it
   it("drops the pill when asked to render plain", () => {
-    playing(
-      queueItem({
-        media_item: audioSource({
-          name: "Spotify Connect",
-          provider_mappings: [
-            providerMapping({ provider_domain: "spotify_connect" }),
-          ],
-        }),
-      }),
-    );
+    activateSource("line-in", "Line In");
 
     const pill = mountBadge().get("[data-slot=badge]").classes();
     const plain = mountBadge({ plain: true })
@@ -142,18 +135,5 @@ describe("NowPlayingSourceBadge", () => {
     expect(plain).toEqual(
       expect.arrayContaining(["border-0", "bg-transparent", "px-0"]),
     );
-  });
-
-  it("keeps the name when a source has no icon to fall back on", () => {
-    store.activePlayer = {
-      player_id: "player-1",
-      powered: true,
-      active_source: "line-in",
-      source_list: [{ id: "line-in", name: "Line In" }],
-    } as unknown as Player;
-
-    const badge = mountBadge({ iconOnly: true });
-
-    expect(badge.text()).toContain("Line In");
   });
 });

--- a/tests/layouts/PlayerFullscreen.test.ts
+++ b/tests/layouts/PlayerFullscreen.test.ts
@@ -5,8 +5,6 @@ import { MediaType, PlaybackState } from "@/plugins/api/interfaces";
 import { shallowMount, type VueWrapper } from "@vue/test-utils";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { nextTick } from "vue";
-import { radio } from "../fixtures/radio";
-import { streamDetails } from "../fixtures/streamDetails";
 
 // Only the fields the lyrics clock and its gate read are mocked; the elapsed
 // time resolver reaches the queue through the player's active_source, so both
@@ -559,7 +557,7 @@ describe("PlayerFullscreen source badge", () => {
     return fullscreen.findAll(".sub")[0];
   }
 
-  it("names the station instead of repeating it as the album", async () => {
+  it("keeps the radio station name in the album line", async () => {
     const { store } = await import("@/plugins/store");
     const testStore = store as unknown as TestStore;
     testStore.activePlayer = {
@@ -574,29 +572,11 @@ describe("PlayerFullscreen source badge", () => {
         album: "Radio 538",
       },
     };
-    testStore.curQueueItem = {
-      queue_item_id: "qi-1",
-      media_item: radio({ name: "Radio 538" }),
-      streamdetails: streamDetails({
-        stream_metadata: {
-          title: "Live track",
-          artist: null,
-          album: null,
-          image_url: null,
-          duration: null,
-          uri: null,
-        },
-      }),
-    } as never;
 
     const fullscreen = await mountDetails();
 
-    expect(
-      fullscreen.findComponent({ name: "NowPlayingSourceBadge" }).exists(),
-    ).toBe(true);
-    // blanked, but still rendered so the artwork above keeps its height
     expect(albumLine(fullscreen).exists()).toBe(true);
-    expect(albumLine(fullscreen).text()).not.toContain("Radio 538");
+    expect(albumLine(fullscreen).text()).toContain("Radio 538");
   });
 
   it("leaves a real album on its line", async () => {

--- a/tests/layouts/PlayerTrackDetails.test.ts
+++ b/tests/layouts/PlayerTrackDetails.test.ts
@@ -4,9 +4,7 @@ import { openCurrentTrackDetails } from "@/helpers/now_playing";
 import { store } from "@/plugins/store";
 import { EMPTY_COLOR_PALETTE } from "@/helpers/utils";
 import { mount, type VueWrapper } from "@vue/test-utils";
-import { providerMapping } from "../fixtures/providerMapping";
-import { radio } from "../fixtures/radio";
-import { streamDetails } from "../fixtures/streamDetails";
+import { playerSource } from "../fixtures/playerSource";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { nextTick } from "vue";
 import { createVuetify } from "vuetify";
@@ -294,9 +292,11 @@ describe("PlayerTrackDetails title", () => {
 
 describe("PlayerTrackDetails source badge", () => {
   beforeEach(() => {
-    (
-      store.activePlayer as unknown as { active_source?: string }
-    ).active_source = undefined;
+    Object.assign(store.activePlayer!, {
+      player_id: "player-1",
+      active_source: "player-1",
+      source_list: [],
+    });
   });
 
   afterEach(() => {
@@ -314,23 +314,6 @@ describe("PlayerTrackDetails source badge", () => {
   });
 
   function playRadioStation() {
-    store.activePlayerQueue = { queue_id: "q1", active: true } as never;
-    store.curQueueItem = {
-      media_item: radio({
-        name: "Radio 538",
-        provider_mappings: [providerMapping({ provider_domain: "tunein" })],
-      }),
-      streamdetails: streamDetails({
-        stream_metadata: {
-          title: "Live track",
-          artist: null,
-          album: null,
-          image_url: null,
-          duration: null,
-          uri: null,
-        },
-      }),
-    } as never;
     (
       store.activePlayer as unknown as { current_media: unknown }
     ).current_media = {
@@ -340,21 +323,29 @@ describe("PlayerTrackDetails source badge", () => {
     };
   }
 
-  // the server puts the station name in the album slot when the station has no
-  // real album, so the badge would otherwise repeat what is already on the line
-  it("names the station and drops it from the metadata line", () => {
+  function playExternalSource() {
+    const source = playerSource({ id: "line-in", name: "Line In" });
+    Object.assign(store.activePlayer!, {
+      active_source: source.id,
+      source_list: [source],
+    });
+  }
+
+  it("keeps the radio station in the metadata line without a badge", () => {
     playRadioStation();
 
     const details = mountDetails(false);
 
-    expect(details.get(".player-track-source").text()).toBe("Radio 538");
-    expect(details.get(".player-track-subtitle-text").text()).toBe("Artist");
+    expect(details.find(".player-track-source").exists()).toBe(false);
+    expect(details.get(".player-track-subtitle-text").text()).toContain(
+      "Radio 538",
+    );
   });
 
   // the full bar has the height for a third line, so the badge does not fight
   // the metadata for the width of the subtitle line
   it("gives the badge its own line under the metadata on the full bar", () => {
-    playRadioStation();
+    playExternalSource();
 
     const details = mountDetails(false);
 
@@ -369,7 +360,7 @@ describe("PlayerTrackDetails source badge", () => {
   // the compact bar keeps its two shallow lines, so the badge shrinks to its
   // icon beside the metadata and hands the name to the tooltip
   it("shrinks the badge to its icon on the compact bar", () => {
-    playRadioStation();
+    playExternalSource();
 
     const details = mountDetails(true);
 
@@ -377,7 +368,7 @@ describe("PlayerTrackDetails source badge", () => {
       ".player-track-subtitle-line .player-track-source",
     );
     expect(badge.text()).toBe("");
-    expect(badge.attributes("title")).toContain("Radio 538");
+    expect(badge.attributes("title")).toContain("Line In");
   });
 
   it("leaves an ordinary album on the metadata line", () => {


### PR DESCRIPTION
# What does this implement/fix?

The source badge still treated queue audio items and radio metadata as external sources after external playback moved to the player source model.

- Show the badge only for the active external player source
- Keep radio station names in the album line
- Use provider icons when available, with a generic fallback

**Related issue (if applicable):**

- N/A

**Related backend PR (if applicable):**

- N/A

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm lint:check` passes.
- [x] `pnpm test:run` passes, and tests have been added/updated where applicable.
- [x] `pnpm build` passes.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.