### PR TITLE
Stop reporting a format conversion Music Assistant did not make

### DIFF
--- a/src/composables/useAudioProcessingDetails.ts
+++ b/src/composables/useAudioProcessingDetails.ts
@@ -885,7 +885,7 @@ function hasMeaningfulInternalConversion(
 ): boolean {
   if (
     formatValueDiffers(sourceFormat.sample_rate, internalFormat.sample_rate) ||
-    formatValueDiffers(sourceFormat.bit_depth, internalFormat.bit_depth) ||
+    internalNarrowsBitDepth(sourceFormat, internalFormat) ||
     formatValueDiffers(sourceFormat.channels, internalFormat.channels)
   ) {
     return true;
@@ -904,6 +904,20 @@ function formatValueDiffers(
   internalValue: number,
 ): boolean {
   return sourceValue > 0 && internalValue > 0 && sourceValue !== internalValue;
+}
+
+// a wider internal container carries the source samples untouched: it is either
+// processing headroom or a provider that decoded upstream and handed over PCM
+// wider than the tier it advertises. Only narrowing drops bits.
+function internalNarrowsBitDepth(
+  sourceFormat: AudioFormat,
+  internalFormat: AudioFormat,
+): boolean {
+  return (
+    sourceFormat.bit_depth > 0 &&
+    internalFormat.bit_depth > 0 &&
+    internalFormat.bit_depth < sourceFormat.bit_depth
+  );
 }
 
 function audioFormatCodec(format: AudioFormat): string {

--- a/tests/composables/useAudioProcessingDetails.test.ts
+++ b/tests/composables/useAudioProcessingDetails.test.ts
@@ -605,6 +605,74 @@ describe("buildAudioProcessingDetailsDisplay", () => {
     );
   });
 
+  it("does not call a provider's own wider handoff an internal conversion", () => {
+    // a Spotify soloist stream: a 24-bit tier decoded upstream and handed over as
+    // 32-bit PCM, so Music Assistant received the wider container rather than made it
+    const sourceFormat = makeFormat({
+      content_type: ContentType.FLAC,
+      codec_type: ContentType.FLAC,
+      sample_rate: 44100,
+      bit_depth: 24,
+    });
+    const display = buildDisplay(
+      {
+        queue_processing: audioQueueProcessing({
+          pcm_format: makeFormat({
+            content_type: ContentType.PCM_S32LE,
+            codec_type: ContentType.PCM_S32LE,
+            sample_rate: 44100,
+            bit_depth: 32,
+          }),
+        }),
+        outputs: [
+          audioOutputDetails({
+            player_ids: ["kitchen"],
+            output_format: sourceFormat,
+            fidelity: audioFidelity({ bit_perfect: true }),
+          }),
+        ],
+      },
+      sourceFormat,
+    );
+
+    expect(display.processingStages.map((stage) => stage.title)).toEqual([
+      "Direct signal path",
+    ]);
+  });
+
+  it("still reports an internal format that narrows the source", () => {
+    const sourceFormat = makeFormat({
+      content_type: ContentType.FLAC,
+      codec_type: ContentType.FLAC,
+      sample_rate: 44100,
+      bit_depth: 24,
+    });
+    const display = buildDisplay(
+      {
+        queue_processing: audioQueueProcessing({
+          pcm_format: makeFormat({
+            content_type: ContentType.PCM_S16LE,
+            codec_type: ContentType.PCM_S16LE,
+            sample_rate: 44100,
+            bit_depth: 16,
+          }),
+        }),
+        outputs: [
+          audioOutputDetails({
+            player_ids: ["kitchen"],
+            output_format: sourceFormat,
+            fidelity: audioFidelity({ bit_perfect: false }),
+          }),
+        ],
+      },
+      sourceFormat,
+    );
+
+    expect(display.processingStages.map((stage) => stage.title)).toEqual([
+      "Internal format conversion",
+    ]);
+  });
+
   it("does not contradict itself when only the source processed the audio", () => {
     const sourceFormat = makeFormat({ sample_rate: 44100, bit_depth: 16 });
     const display = buildDisplay(


### PR DESCRIPTION
# What does this implement/fix?

A music service that decodes upstream (Spotify's soloist engines, go-librespot, an AirPlay receiver) hands Music Assistant PCM that is wider than the quality tier it advertises — 32-bit PCM for a 24-bit lossless tier. The audio pipeline panel read that as **Internal format conversion (32-bit PCM)**, a step Music Assistant never performed, and it could never show a direct signal path for such a stream.

A wider container carries the same samples, so only a narrower internal format is reported as a conversion now.

**Related issue (if applicable):**

- related issue <link to issue>

**Related backend PR (if applicable):**

- related backend PR https://github.com/music-assistant/server/pull/5942

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm lint:check` passes.
- [x] `pnpm test:run` passes, and tests have been added/updated where applicable.
- [x] `pnpm build` passes.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
