### PR TITLE
Keep the Discover page in place when navigating back

### DIFF
--- a/src/components/HomeWidgetRows.vue
+++ b/src/components/HomeWidgetRows.vue
@@ -993,7 +993,7 @@ onMounted(async () => {
     // Refresh everything in the background so the restored page stays current.
     await loadRecommendationRows();
     if (unmounted) return;
-    await fetchMissingRowItems();
+    await refreshShownRowItems();
     if (unmounted) return;
     resolveHeroPicks();
     nextTick(() => {

--- a/src/components/HomeWidgetRows.vue
+++ b/src/components/HomeWidgetRows.vue
@@ -988,6 +988,7 @@ onMounted(async () => {
         ".content-section",
       ) as HTMLElement | null;
       if (el) el.scrollTop = snapshot.scrollPos;
+      observeHero();
     });
 
     // Refresh everything in the background so the restored page stays current.

--- a/src/components/HomeWidgetRows.vue
+++ b/src/components/HomeWidgetRows.vue
@@ -340,6 +340,26 @@
   </div>
 </template>
 
+<script lang="ts">
+import type {
+  Genre,
+  ItemMapping,
+  MediaItemTypeOrItemMapping,
+  RecommendationFolder,
+} from "@/plugins/api/interfaces";
+
+// Snapshot taken on unmount so a back/forward navigation back to Discover
+// renders the previous page instantly instead of refetching from empty.
+interface DiscoverSnapshot {
+  recommendations: RecommendationFolder[];
+  recentlyPlayed: ItemMapping[];
+  rowItemsMap: Map<string, MediaItemTypeOrItemMapping[]>;
+  genres: Genre[];
+  scrollPos: number;
+}
+let prevState: DiscoverSnapshot | undefined;
+</script>
+
 <script setup lang="ts">
 import EditorialCardSkeleton from "@/components/discover/EditorialCardSkeleton.vue";
 import EditorialGenreTile from "@/components/discover/EditorialGenreTile.vue";
@@ -381,11 +401,7 @@ import {
   PlaybackState,
   RecommendationFolderType,
   type EventMessage,
-  type Genre,
-  type ItemMapping,
-  type MediaItemTypeOrItemMapping,
   type Player,
-  type RecommendationFolder,
 } from "@/plugins/api/interfaces";
 import { getBreakpointValue } from "@/plugins/breakpoint";
 import { $t } from "@/plugins/i18n";
@@ -407,10 +423,13 @@ import {
   ref,
   watch,
 } from "vue";
+import { useRouter } from "vue-router";
 
 const props = withDefaults(defineProps<{ editMode?: boolean }>(), {
   editMode: false,
 });
+
+const router = useRouter();
 
 const loading = ref(true);
 const playersShelf = ref<EditorialShelfExpose | null>(null);
@@ -954,6 +973,35 @@ onMounted(async () => {
   loadGenres();
   window.addEventListener("resize", updateHeroNav);
 
+  // A history back/forward traversal sets `forward` on the entry we're
+  // returning to; a fresh navigation leaves it null.
+  if (prevState && router.options.history.state.forward != null) {
+    const snapshot = prevState;
+    recommendations.value = snapshot.recommendations;
+    recentlyPlayed.value = snapshot.recentlyPlayed;
+    rowItemsMap.value = snapshot.rowItemsMap;
+    genres.value = snapshot.genres;
+    resolveHeroPicks();
+    loading.value = false;
+    nextTick(() => {
+      const el = document.querySelector(
+        ".content-section",
+      ) as HTMLElement | null;
+      if (el) el.scrollTop = snapshot.scrollPos;
+    });
+
+    // Refresh everything in the background so the restored page stays current.
+    await loadRecommendationRows();
+    if (unmounted) return;
+    await fetchMissingRowItems();
+    if (unmounted) return;
+    resolveHeroPicks();
+    nextTick(() => {
+      if (!unmounted) observeHero();
+    });
+    return;
+  }
+
   await loadRecommendationRows();
   if (unmounted) return;
   loading.value = false;
@@ -975,6 +1023,15 @@ onBeforeUnmount(() => {
   heroRo?.disconnect();
   heroRo = undefined;
   observedHeroGrid = null;
+
+  const el = document.querySelector(".content-section");
+  prevState = {
+    recommendations: recommendations.value,
+    recentlyPlayed: recentlyPlayed.value,
+    rowItemsMap: rowItemsMap.value,
+    genres: genres.value,
+    scrollPos: el?.scrollTop ?? 0,
+  };
 });
 </script>
 


### PR DESCRIPTION
# What does this implement/fix?

On iOS, going back to the Discover page (native swipe-back, in-app back button) looked like a full app reload: the page flashed empty skeletons, refetched everything and jumped back to the top. The history navigation itself was fine — Discover just rebuilt itself from scratch on every visit and nothing remembered how far you had scrolled.

- Discover now keeps a snapshot of its content when you leave the page and restores it instantly when you come back via a back/forward navigation, including the exact scroll position.
- The content still silently refreshes in the background after such a restore, so nothing goes stale.
- Opening Discover fresh (e.g. from the navigation bar) behaves as before: fresh fetch, top of the page.

**Related issue (if applicable):**

- related issue `<link to issue>`

**Related backend PR (if applicable):**

- related backend PR `<link to PR>`

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm lint:check` passes.
- [x] `pnpm test:run` passes, and tests have been added/updated where applicable.
- [x] `pnpm build` passes.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
