### PR TITLE
Safer browser media controls

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -25,7 +25,7 @@
     v-if="
       webPlayer.audioSource === WebPlayerMode.CONTROLS_ONLY &&
       webPlayer.interacted == true &&
-      !mediaSessionDisabled
+      selectedPlayerMediaControlsEnabled
     "
     :key="webPlayer.tabMode"
   />
@@ -47,6 +47,7 @@ import { initGlobalShortcutsSync } from "@/composables/useShortcuts";
 import { useThemePreference } from "@/composables/useThemePreference";
 import { sanitizeDashboardViewerPath } from "@/helpers/dashboard_viewer_access";
 import {
+  BrowserMediaControlsMode,
   FORCE_MOBILE_LAYOUT,
   readDeviceSetting,
   subscribeToDeviceSetting,
@@ -86,6 +87,7 @@ import { httpProxyBridge } from "./plugins/remote/http-proxy";
 import type { ITransport } from "./plugins/remote/transport";
 import {
   initializeWebPlayerModeSync,
+  isPlaybackMode,
   webPlayer,
   WebPlayerMode,
 } from "./plugins/web_player";
@@ -98,11 +100,27 @@ const { applyThemePreference: setTheme } = useThemePreference();
 const mediaSessionDisabled = computed(() =>
   isMediaSessionDisabled(route, authManager.isGuestAccessSession()),
 );
+const selectedPlayerMediaControlsEnabled = computed(
+  () =>
+    !mediaSessionDisabled.value &&
+    webPlayer.browserControlsMode === BrowserMediaControlsMode.ACTIVE_PLAYER &&
+    webPlayer.tabMode === WebPlayerMode.CONTROLS_ONLY,
+);
 
 watch(
-  mediaSessionDisabled,
-  (disabled) => {
-    if (disabled) resetMediaSession();
+  [
+    mediaSessionDisabled,
+    () => webPlayer.browserControlsMode,
+    () => webPlayer.tabMode,
+  ],
+  ([disabled, controlsMode, tabMode]) => {
+    if (
+      disabled ||
+      (controlsMode !== BrowserMediaControlsMode.ACTIVE_PLAYER &&
+        !isPlaybackMode(tabMode))
+    ) {
+      resetMediaSession();
+    }
   },
   { immediate: true },
 );

--- a/src/App.vue
+++ b/src/App.vue
@@ -24,7 +24,6 @@
   <PlayerBrowserMediaControls
     v-if="
       webPlayer.audioSource === WebPlayerMode.CONTROLS_ONLY &&
-      webPlayer.interacted == true &&
       selectedPlayerMediaControlsEnabled
     "
     :key="webPlayer.tabMode"
@@ -103,6 +102,7 @@ const mediaSessionDisabled = computed(() =>
 const selectedPlayerMediaControlsEnabled = computed(
   () =>
     !mediaSessionDisabled.value &&
+    webPlayer.interacted &&
     webPlayer.browserControlsMode === BrowserMediaControlsMode.ACTIVE_PLAYER &&
     webPlayer.tabMode === WebPlayerMode.CONTROLS_ONLY,
 );
@@ -110,15 +110,11 @@ const selectedPlayerMediaControlsEnabled = computed(
 watch(
   [
     mediaSessionDisabled,
-    () => webPlayer.browserControlsMode,
+    selectedPlayerMediaControlsEnabled,
     () => webPlayer.tabMode,
   ],
-  ([disabled, controlsMode, tabMode]) => {
-    if (
-      disabled ||
-      (controlsMode !== BrowserMediaControlsMode.ACTIVE_PLAYER &&
-        !isPlaybackMode(tabMode))
-    ) {
+  ([disabled, selectedControlsEnabled, tabMode]) => {
+    if (disabled || (!isPlaybackMode(tabMode) && !selectedControlsEnabled)) {
       resetMediaSession();
     }
   },

--- a/src/App.vue
+++ b/src/App.vue
@@ -22,10 +22,7 @@
   />
 
   <PlayerBrowserMediaControls
-    v-if="
-      webPlayer.audioSource === WebPlayerMode.CONTROLS_ONLY &&
-      selectedPlayerMediaControlsEnabled
-    "
+    v-if="selectedPlayerMediaControlsEnabled"
     :key="webPlayer.tabMode"
   />
   <SendspinPlayer
@@ -104,6 +101,7 @@ const selectedPlayerMediaControlsEnabled = computed(
     !mediaSessionDisabled.value &&
     webPlayer.interacted &&
     webPlayer.browserControlsMode === BrowserMediaControlsMode.ACTIVE_PLAYER &&
+    webPlayer.audioSource === WebPlayerMode.CONTROLS_ONLY &&
     webPlayer.tabMode === WebPlayerMode.CONTROLS_ONLY,
 );
 

--- a/src/components/SendspinPlayer.vue
+++ b/src/components/SendspinPlayer.vue
@@ -11,6 +11,7 @@
 <script setup lang="ts">
 import { resolveActiveElapsedTime } from "@/helpers/activeElapsedTime";
 import { useMediaBrowserMetaData } from "@/helpers/useMediaBrowserMetaData";
+import { BrowserMediaControlsMode } from "@/helpers/device_settings";
 import {
   isMediaSessionDisabled,
   resetMediaSession,
@@ -113,18 +114,16 @@ const resetLastSeekPos = () => {
   }, 2000);
 };
 
-// Determine which player's metadata to show:
-// - Web player's metadata when it's playing
-// - Selected player's metadata otherwise (undefined = uses store.activePlayerId)
-const metadataPlayerId = computed(() => {
-  const thisPlayer = api.players[props.playerId];
-  if (thisPlayer?.playback_state === PlaybackState.PLAYING) {
-    return props.playerId;
-  }
-  return undefined;
-});
-const mediaSessionDisabled = computed(() =>
-  isMediaSessionDisabled(route, authManager.isGuestAccessSession()),
+// An undefined player ID makes the metadata helper follow the selected player.
+const metadataPlayerId = computed(() =>
+  webPlayer.browserControlsMode === BrowserMediaControlsMode.WEB_PLAYER
+    ? props.playerId
+    : undefined,
+);
+const mediaSessionDisabled = computed(
+  () =>
+    webPlayer.browserControlsMode === BrowserMediaControlsMode.DISABLED ||
+    isMediaSessionDisabled(route, authManager.isGuestAccessSession()),
 );
 
 const correctionMode = computed(() => {
@@ -426,6 +425,7 @@ onBeforeUnmount(() => {
   pauseCommandTimeouts.clear();
   if (
     mediaSessionDisabled.value ||
+    webPlayer.browserControlsMode !== BrowserMediaControlsMode.ACTIVE_PLAYER ||
     webPlayer.tabMode !== WebPlayerMode.CONTROLS_ONLY
   ) {
     resetMediaSession();

--- a/src/components/SendspinPlayer.vue
+++ b/src/components/SendspinPlayer.vue
@@ -174,41 +174,23 @@ watch(
   { immediate: true },
 );
 
-// Control silent audio based on interaction and metadata target
 watch(
-  [metadataPlayerId, () => webPlayer.interacted],
-  ([newPlayerId, interacted]) => {
-    if (!interacted) return;
-
-    // Stop silent audio when web player takes over
-    if (newPlayerId !== undefined && silentAudioRef.value) {
-      silentAudioRef.value.pause();
-    }
-  },
-  { immediate: true },
-);
-
-// Watch active player's playback state to control silent audio
-watch(
-  [() => store.activePlayer?.playback_state, mediaSessionDisabled],
-  ([state, disabled]) => {
-    if (disabled) {
-      if (silentAudioInterval) {
-        clearInterval(silentAudioInterval);
-        silentAudioInterval = undefined;
-      }
-      silentAudioRef.value?.pause();
-      return;
-    }
-    // Only control when showing active player metadata (not web player)
-    if (metadataPlayerId.value !== undefined) return;
-    if (!silentAudioRef.value) return;
-
-    // Clear existing interval
+  [
+    () => store.activePlayer?.playback_state,
+    mediaSessionDisabled,
+    metadataPlayerId,
+    () => webPlayer.interacted,
+  ],
+  ([state, disabled, targetPlayerId, interacted]) => {
     if (silentAudioInterval) {
       clearInterval(silentAudioInterval);
       silentAudioInterval = undefined;
     }
+    if (disabled || targetPlayerId !== undefined || !interacted) {
+      silentAudioRef.value?.pause();
+      return;
+    }
+    if (!silentAudioRef.value) return;
 
     if (state === PlaybackState.PLAYING) {
       silentAudioRef.value.play().catch(() => {});

--- a/src/helpers/device_settings.ts
+++ b/src/helpers/device_settings.ts
@@ -7,6 +7,13 @@ const STORAGE_KEY_PREFIX = "frontend.settings.";
 export const MOBILE_SIDEBAR_SIDE = "mobile_sidebar_side";
 export const HA_KIOSK_MODE = "ha_kiosk_mode";
 export const FORCE_MOBILE_LAYOUT = "force_mobile_layout";
+export const BROWSER_MEDIA_CONTROLS = "enable_browser_controls";
+
+export enum BrowserMediaControlsMode {
+  ACTIVE_PLAYER = "active_player",
+  WEB_PLAYER = "web_player",
+  DISABLED = "disabled",
+}
 
 /**
  * Read a per-device setting, or null when it is unset.
@@ -18,6 +25,24 @@ export function readDeviceSetting(key: string): string | null {
     return localStorage.getItem(STORAGE_KEY_PREFIX + key);
   } catch {
     return null;
+  }
+}
+
+/**
+ * Return which players may be exposed to browser media controls.
+ */
+export function getBrowserMediaControlsMode(): BrowserMediaControlsMode {
+  const storedValue = readDeviceSetting(BROWSER_MEDIA_CONTROLS);
+  switch (storedValue) {
+    case BrowserMediaControlsMode.ACTIVE_PLAYER:
+      return BrowserMediaControlsMode.ACTIVE_PLAYER;
+    case BrowserMediaControlsMode.DISABLED:
+    case "false":
+      return BrowserMediaControlsMode.DISABLED;
+    case BrowserMediaControlsMode.WEB_PLAYER:
+    case "true":
+    default:
+      return BrowserMediaControlsMode.WEB_PLAYER;
   }
 }
 

--- a/src/helpers/useMediaBrowserMetaData.ts
+++ b/src/helpers/useMediaBrowserMetaData.ts
@@ -89,7 +89,11 @@ export function useMediaBrowserMetaData(player_id?: string) {
   const unwatch_metadata = watch(
     () => mediaMetadata.value,
     (newMetadata) => {
-      if (!newMetadata) return;
+      if (!newMetadata) {
+        navigator.mediaSession.metadata = null;
+        currentMediaMetadata = undefined;
+        return;
+      }
       //Lets make sure that the new media isn't spammed
       if (
         newMetadata.album === currentMediaMetadata?.album &&

--- a/src/plugins/web_player.ts
+++ b/src/plugins/web_player.ts
@@ -1,6 +1,9 @@
 import { loadSendspinClientIdentity } from "@sendspin/sendspin-js";
 import { reactive, ref, watch } from "vue";
 import {
+  BROWSER_MEDIA_CONTROLS,
+  BrowserMediaControlsMode,
+  getBrowserMediaControlsMode,
   readDeviceSetting,
   subscribeToDeviceSetting,
 } from "@/helpers/device_settings";
@@ -167,14 +170,15 @@ async function isAnotherTabActive(): Promise<boolean> {
 
 // Per-device settings that feed resolvePreferredMode().
 const WEB_PLAYER_ENABLED = "web_player_enabled";
-const BROWSER_CONTROLS_ENABLED = "enable_browser_controls";
 
 let highestPriority: string | undefined;
 let modeSyncInitialized = false;
 let modeSyncInitializationPromise: Promise<void> | null = null;
 let pendingModeApplication = Promise.resolve();
 
-function resolvePreferredMode(): WebPlayerMode {
+function resolvePreferredMode(
+  browserControlsMode: BrowserMediaControlsMode,
+): WebPlayerMode {
   // This route explicitly disables the web player
   const routeDisablesWebPlayer = router.currentRoute.value.matched.some(
     (record) => record.meta.disableWebPlayer === true,
@@ -202,35 +206,23 @@ function resolvePreferredMode(): WebPlayerMode {
     return WebPlayerMode.SENDSPIN_ONLY;
   }
 
-  const webPlayerEnabledPref = readDeviceSetting(WEB_PLAYER_ENABLED) || "true";
-  const browserControlsEnabledPref =
-    readDeviceSetting(BROWSER_CONTROLS_ENABLED) || "true";
-
-  if (
-    webPlayerEnabledPref !== "false" &&
-    browserControlsEnabledPref !== "false"
-  ) {
-    return WebPlayerMode.SENDSPIN_WITH_CONTROLS;
+  const webPlayerEnabled = readDeviceSetting(WEB_PLAYER_ENABLED) !== "false";
+  if (webPlayerEnabled) {
+    return browserControlsMode === BrowserMediaControlsMode.DISABLED
+      ? WebPlayerMode.SENDSPIN_ONLY
+      : WebPlayerMode.SENDSPIN_WITH_CONTROLS;
   }
-  if (
-    webPlayerEnabledPref !== "false" &&
-    browserControlsEnabledPref === "false"
-  ) {
-    return WebPlayerMode.SENDSPIN_ONLY;
-  }
-  if (
-    webPlayerEnabledPref === "false" &&
-    browserControlsEnabledPref !== "false"
-  ) {
-    return WebPlayerMode.CONTROLS_ONLY;
-  }
-  return WebPlayerMode.DISABLED;
+  return browserControlsMode === BrowserMediaControlsMode.ACTIVE_PLAYER
+    ? WebPlayerMode.CONTROLS_ONLY
+    : WebPlayerMode.DISABLED;
 }
 
 // Serializes mode updates so concurrent triggers (init/route/watchers) apply in order.
 function queueModeApplication(): Promise<void> {
   pendingModeApplication = pendingModeApplication.then(async () => {
-    const mode = resolvePreferredMode();
+    const browserControlsMode = getBrowserMediaControlsMode();
+    webPlayer.browserControlsMode = browserControlsMode;
+    const mode = resolvePreferredMode(browserControlsMode);
     if (mode !== webPlayer.mode || mode !== webPlayer.tabMode) {
       await webPlayer.setMode(mode);
     }
@@ -270,7 +262,7 @@ export async function initializeWebPlayerModeSync(): Promise<void> {
     // The settings page writes these straight to localStorage. Follow them here
     // so switching the web player off tears it down right away, in every tab of
     // this browser, instead of at the next navigation.
-    for (const setting of [WEB_PLAYER_ENABLED, BROWSER_CONTROLS_ENABLED]) {
+    for (const setting of [WEB_PLAYER_ENABLED, BROWSER_MEDIA_CONTROLS]) {
       subscribeToDeviceSetting(setting, () => {
         void queueModeApplication();
       });
@@ -307,6 +299,7 @@ async function canTakeControl(): Promise<boolean> {
 }
 
 export const webPlayer = reactive({
+  browserControlsMode: BrowserMediaControlsMode.WEB_PLAYER,
   // This is target mode shared across all tabs
   mode: WebPlayerMode.DISABLED,
   // This is the true mode of this tab.
@@ -359,12 +352,8 @@ export const webPlayer = reactive({
     }
 
     if (isPlaybackMode(mode)) {
-      // Sendspin player is handled separately through the SendspinPlayer component
-      // audioSource determines whether browser media controls are shown
-      this.audioSource =
-        mode === WebPlayerMode.SENDSPIN_WITH_CONTROLS
-          ? WebPlayerMode.CONTROLS_ONLY
-          : WebPlayerMode.DISABLED;
+      // Sendspin owns browser media controls in the playback tab.
+      this.audioSource = WebPlayerMode.DISABLED;
       // The sendspin client id is its Noise public key, so the SDK owns it. Mirror
       // it into localStorage for the tabs and the proxy handshake that read it.
       const player_id = loadSendspinClientIdentity().clientId;

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -554,8 +554,18 @@
             "description": "Allow playback to this device\/browser using the built-in Sendspin web player."
         },
         "enable_browser_controls": {
-            "label": "Enable browser media controls",
-            "description": "Allow control of playback using the browser's built-in media controls (e.g., media keys on your keyboard)."
+            "label": "Browser media controls",
+            "description": "Expose Music Assistant playback to browser and operating-system media controls, such as media keys and lock-screen controls. Device events such as phone calls, sleep, or closing a laptop lid may pause the controlled player.",
+            "options": {
+                "active_player": "Any actively selected player",
+                "web_player": "Built-in web player only",
+                "disabled": "Disabled"
+            },
+            "option_descriptions": {
+                "active_player": "Control the player currently selected in Music Assistant, including speakers elsewhere in your home.",
+                "web_player": "Control only audio played by the built-in web player on this device.",
+                "disabled": "Do not expose Music Assistant playback to browser or operating-system controls."
+            }
         },
         "settings_saved": "Settings saved successfully",
         "protocol_disabled_message": "Enable this protocol to configure its settings",

--- a/src/views/settings/FrontendConfig.vue
+++ b/src/views/settings/FrontendConfig.vue
@@ -44,6 +44,9 @@ import { useUserPreferences } from "@/composables/userPreferences";
 import { DEVICE_SETTING_KEYS } from "@/constants";
 import { hasAdvancedEntries } from "@/helpers/config_entry_ui";
 import {
+  BROWSER_MEDIA_CONTROLS,
+  BrowserMediaControlsMode,
+  getBrowserMediaControlsMode,
   MOBILE_SIDEBAR_SIDE,
   readDeviceSetting,
   saveDeviceSetting,
@@ -146,18 +149,29 @@ onMounted(() => {
       value: null,
     },
     {
-      key: "enable_browser_controls",
-      type: ConfigEntryType.BOOLEAN,
+      key: BROWSER_MEDIA_CONTROLS,
+      type: ConfigEntryType.STRING,
       label: "enable_browser_controls",
-      default_value: true,
+      default_value: BrowserMediaControlsMode.WEB_PLAYER,
       required: false,
-      options: [],
+      options: [
+        {
+          title: "active_player",
+          value: BrowserMediaControlsMode.ACTIVE_PLAYER,
+        },
+        {
+          title: "web_player",
+          value: BrowserMediaControlsMode.WEB_PLAYER,
+        },
+        {
+          title: "disabled",
+          value: BrowserMediaControlsMode.DISABLED,
+        },
+      ],
       multi_value: false,
       category: "display_settings",
       hidden: companionMode.value,
-      value:
-        localStorage.getItem("frontend.settings.enable_browser_controls") !==
-        "false",
+      value: getBrowserMediaControlsMode(),
     },
     {
       key: "force_mobile_layout",
@@ -271,8 +285,8 @@ onMounted(() => {
   }
 
   // These are frontend-only settings, so the frontend owns their translations (server-provided
-  // entries are localized server-side and arrive pre-resolved). ConfigEntryField renders the
-  // label/option titles directly, so resolve the frontend-owned ones here from the settings.* keys.
+  // entries are localized server-side and arrive pre-resolved). ConfigEntryField renders labels
+  // and option content directly, so resolve the frontend-owned ones here from the settings.* keys.
   for (const entry of configEntries) {
     // fall back to the in-code label/category if a locale is missing the string, so we never
     // surface a raw i18n key in the UI.
@@ -287,13 +301,19 @@ onMounted(() => {
     }
     const desc = $t(`settings.${entry.key}.description`);
     if (desc !== `settings.${entry.key}.description`) entry.description = desc;
-    entry.options = entry.options.map((opt) => ({
-      ...opt,
-      title: $t(
-        `settings.${entry.key}.options.${opt.value}`,
-        opt.title ?? String(opt.value),
-      ),
-    }));
+    entry.options = entry.options.map((opt) => {
+      const descriptionKey = `settings.${entry.key}.option_descriptions.${opt.value}`;
+      const description = $t(descriptionKey);
+      return {
+        ...opt,
+        title: $t(
+          `settings.${entry.key}.options.${opt.value}`,
+          opt.title ?? String(opt.value),
+        ),
+        description:
+          description === descriptionKey ? opt.description : description,
+      };
+    });
   }
   config.value = configEntries;
   initialValues = Object.fromEntries(

--- a/tests/App.test.ts
+++ b/tests/App.test.ts
@@ -600,7 +600,7 @@ describe("App initialization", () => {
     webPlayerMock.audioSource = "disabled";
     webPlayerMock.browserControlsMode = "active_player";
     webPlayerMock.interacted = true;
-    webPlayerMock.tabMode = "disabled";
+    webPlayerMock.tabMode = "controls_only";
 
     wrapper = await mountApp();
 

--- a/tests/App.test.ts
+++ b/tests/App.test.ts
@@ -595,6 +595,20 @@ describe("App initialization", () => {
     expect(mediaSession.playbackState).toBe("none");
   });
 
+  it("clears media controls when no component owns them", async () => {
+    const mediaSession = stubMediaSession();
+    webPlayerMock.audioSource = "disabled";
+    webPlayerMock.browserControlsMode = "active_player";
+    webPlayerMock.interacted = true;
+    webPlayerMock.tabMode = "disabled";
+
+    wrapper = await mountApp();
+
+    expect(mediaSession.metadata).toBeNull();
+    expect(mediaSession.playbackState).toBe("none");
+    expect(mediaSession.setActionHandler).toHaveBeenCalledTimes(7);
+  });
+
   it("clears browser media controls on participant routes for regular users", async () => {
     const mediaSession = stubMediaSession();
     webPlayerMock.audioSource = "controls_only";

--- a/tests/App.test.ts
+++ b/tests/App.test.ts
@@ -130,8 +130,9 @@ const {
     },
     webPlayerMock: {
       audioSource: "disabled",
+      browserControlsMode: "active_player",
       interacted: false,
-      player_id: null,
+      player_id: null as string | null,
       setBaseUrl: vi.fn(),
       setInteracted: vi.fn(),
       tabMode: "disabled",
@@ -184,6 +185,8 @@ vi.mock("@/composables/useShortcuts", () => ({
 
 vi.mock("@/plugins/web_player", () => ({
   initializeWebPlayerModeSync: mockInitializeWebPlayerModeSync,
+  isPlaybackMode: (mode: string) =>
+    mode === "sendspin_only" || mode === "sendspin_with_controls",
   webPlayer: webPlayerMock,
   WebPlayerMode: {
     CONTROLS_ONLY: "controls_only",
@@ -348,6 +351,7 @@ describe("App initialization", () => {
     storeMock.isIngressSession = false;
     storeMock.isOnboarding = false;
     webPlayerMock.audioSource = "disabled";
+    webPlayerMock.browserControlsMode = "active_player";
     webPlayerMock.interacted = false;
     webPlayerMock.player_id = null;
     webPlayerMock.tabMode = "disabled";
@@ -555,6 +559,40 @@ describe("App initialization", () => {
     expect(
       wrapper.findComponent({ name: "PlayerBrowserMediaControls" }).exists(),
     ).toBe(true);
+  });
+
+  it("leaves media controls to Sendspin in the playback tab", async () => {
+    stubMediaSession();
+    webPlayerMock.audioSource = "controls_only";
+    webPlayerMock.browserControlsMode = "active_player";
+    webPlayerMock.interacted = true;
+    webPlayerMock.player_id = "web-player";
+    webPlayerMock.tabMode = "sendspin_with_controls";
+
+    wrapper = await mountApp();
+
+    expect(
+      wrapper.findComponent({ name: "PlayerBrowserMediaControls" }).exists(),
+    ).toBe(false);
+    expect(wrapper.findComponent({ name: "SendspinPlayer" }).exists()).toBe(
+      true,
+    );
+  });
+
+  it("does not control the selected player in built-in-only mode", async () => {
+    const mediaSession = stubMediaSession();
+    webPlayerMock.audioSource = "controls_only";
+    webPlayerMock.browserControlsMode = "web_player";
+    webPlayerMock.interacted = true;
+    webPlayerMock.tabMode = "controls_only";
+
+    wrapper = await mountApp();
+
+    expect(
+      wrapper.findComponent({ name: "PlayerBrowserMediaControls" }).exists(),
+    ).toBe(false);
+    expect(mediaSession.metadata).toBeNull();
+    expect(mediaSession.playbackState).toBe("none");
   });
 
   it("clears browser media controls on participant routes for regular users", async () => {

--- a/tests/components/SendspinPlayer.test.ts
+++ b/tests/components/SendspinPlayer.test.ts
@@ -601,6 +601,40 @@ describe("SendspinPlayer MediaSession", () => {
     wrapper.unmount();
   });
 
+  it("starts selected-player controls when their mode becomes active", async () => {
+    const playSpy = vi
+      .spyOn(HTMLMediaElement.prototype, "play")
+      .mockResolvedValue();
+    webPlayer.interacted = true;
+    const wrapper = mount(SendspinPlayer, {
+      props: { playerId: "web-player" },
+    });
+    playSpy.mockClear();
+
+    webPlayer.browserControlsMode = BrowserMediaControlsMode.ACTIVE_PLAYER;
+    await nextTick();
+
+    expect(playSpy).toHaveBeenCalledOnce();
+    wrapper.unmount();
+  });
+
+  it("starts selected-player controls after the first interaction", async () => {
+    const playSpy = vi
+      .spyOn(HTMLMediaElement.prototype, "play")
+      .mockResolvedValue();
+    webPlayer.browserControlsMode = BrowserMediaControlsMode.ACTIVE_PLAYER;
+    const wrapper = mount(SendspinPlayer, {
+      props: { playerId: "web-player" },
+    });
+    playSpy.mockClear();
+
+    webPlayer.interacted = true;
+    await nextTick();
+
+    expect(playSpy).toHaveBeenCalledOnce();
+    wrapper.unmount();
+  });
+
   it("clears media controls when they are disabled", () => {
     webPlayer.browserControlsMode = BrowserMediaControlsMode.DISABLED;
     seedStaleMediaSession();

--- a/tests/components/SendspinPlayer.test.ts
+++ b/tests/components/SendspinPlayer.test.ts
@@ -1,4 +1,5 @@
 import SendspinPlayer from "@/components/SendspinPlayer.vue";
+import { BrowserMediaControlsMode } from "@/helpers/device_settings";
 import type { MusicAssistantApi } from "@/plugins/api";
 import { PlaybackState } from "@/plugins/api/interfaces";
 import { webPlayer, WebPlayerMode } from "@/plugins/web_player";
@@ -167,6 +168,7 @@ vi.mock("@/plugins/web_player", async () => {
       mode === "sendspin_only" || mode === "sendspin_with_controls",
     registerWebPlayerAudioUnlock: mockRegisterWebPlayerAudioUnlock,
     webPlayer: reactive({
+      browserControlsMode: "web_player",
       interacted: false,
       mode: "sendspin_only",
       tabMode: "sendspin_only",
@@ -258,6 +260,7 @@ describe("SendspinPlayer MediaSession", () => {
     mockSendspinUnlock.mockReset();
     mockSendspinUnlock.mockResolvedValue(undefined);
     webPlayer.interacted = false;
+    webPlayer.browserControlsMode = BrowserMediaControlsMode.WEB_PLAYER;
     webPlayer.mode = WebPlayerMode.SENDSPIN_ONLY;
     webPlayer.tabMode = WebPlayerMode.SENDSPIN_ONLY;
     if (routeState.current) routeState.current.meta = {};
@@ -569,6 +572,49 @@ describe("SendspinPlayer MediaSession", () => {
 
     wrapper.unmount();
     expect(actions.every((action) => handlers.get(action) === null)).toBe(true);
+  });
+
+  it("limits built-in-only controls to the web player", () => {
+    webPlayer.browserControlsMode = BrowserMediaControlsMode.WEB_PLAYER;
+    apiMock.players["web-player"].playback_state = PlaybackState.PAUSED;
+
+    const wrapper = mount(SendspinPlayer, {
+      props: { playerId: "web-player" },
+    });
+    invokeAction("play");
+
+    expect(mockUseMediaBrowserMetaData).toHaveBeenCalledWith("web-player");
+    expect(mockPlayerCommandPlay).toHaveBeenCalledWith("web-player");
+    wrapper.unmount();
+  });
+
+  it("targets the selected player when that mode is enabled", () => {
+    webPlayer.browserControlsMode = BrowserMediaControlsMode.ACTIVE_PLAYER;
+
+    const wrapper = mount(SendspinPlayer, {
+      props: { playerId: "web-player" },
+    });
+    invokeAction("play");
+
+    expect(mockUseMediaBrowserMetaData).toHaveBeenCalledWith(undefined);
+    expect(mockPlayerCommandPlay).toHaveBeenCalledWith("active-player");
+    wrapper.unmount();
+  });
+
+  it("clears media controls when they are disabled", () => {
+    webPlayer.browserControlsMode = BrowserMediaControlsMode.DISABLED;
+    seedStaleMediaSession();
+
+    const wrapper = mount(SendspinPlayer, {
+      props: { playerId: "web-player" },
+    });
+
+    expect(mockUseMediaBrowserMetaData).not.toHaveBeenCalled();
+    expect(mediaSession.metadata).toBeNull();
+    expect(actions.every((action) => handlers.get(action) === null)).toBe(true);
+    invokeAllActions();
+    expectPlayerCommandsNotCalled();
+    wrapper.unmount();
   });
 
   it("continues clearing actions when an action is unsupported", () => {

--- a/tests/helpers/device_settings.test.ts
+++ b/tests/helpers/device_settings.test.ts
@@ -1,0 +1,38 @@
+import {
+  BROWSER_MEDIA_CONTROLS,
+  BrowserMediaControlsMode,
+  getBrowserMediaControlsMode,
+  saveDeviceSetting,
+} from "@/helpers/device_settings";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+describe("getBrowserMediaControlsMode", () => {
+  beforeEach(() => {
+    const values = new Map<string, string>();
+    vi.stubGlobal("localStorage", {
+      getItem: (key: string) => values.get(key) ?? null,
+      removeItem: (key: string) => values.delete(key),
+      setItem: (key: string, value: string) => values.set(key, value),
+    });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it.each([
+    [null, BrowserMediaControlsMode.WEB_PLAYER],
+    ["true", BrowserMediaControlsMode.WEB_PLAYER],
+    ["false", BrowserMediaControlsMode.DISABLED],
+    [
+      BrowserMediaControlsMode.ACTIVE_PLAYER,
+      BrowserMediaControlsMode.ACTIVE_PLAYER,
+    ],
+    [BrowserMediaControlsMode.WEB_PLAYER, BrowserMediaControlsMode.WEB_PLAYER],
+    [BrowserMediaControlsMode.DISABLED, BrowserMediaControlsMode.DISABLED],
+  ])("maps %s to %s", (storedValue, expectedMode) => {
+    saveDeviceSetting(BROWSER_MEDIA_CONTROLS, storedValue);
+
+    expect(getBrowserMediaControlsMode()).toBe(expectedMode);
+  });
+});

--- a/tests/helpers/useMediaBrowserMetaData.test.ts
+++ b/tests/helpers/useMediaBrowserMetaData.test.ts
@@ -58,6 +58,10 @@ const QUEUE_ID = "queue-1";
 const ANCHOR = 1_000_000;
 
 const setPositionState = vi.fn();
+const mediaSession = {
+  metadata: null as MediaMetadata | null,
+  setPositionState,
+};
 let serverTime = ANCHOR;
 let teardown: (() => void) | undefined;
 
@@ -96,9 +100,10 @@ beforeEach(() => {
     delete apiMock.queueElapsedTime[key];
   serverTime = ANCHOR;
   setPositionState.mockClear();
+  mediaSession.metadata = null;
   Object.defineProperty(navigator, "mediaSession", {
     configurable: true,
-    value: { setPositionState },
+    value: mediaSession,
   });
 });
 
@@ -286,5 +291,16 @@ describe("useMediaBrowserMetaData position state", () => {
     teardown = useMediaBrowserMetaData(PLAYER_ID);
 
     expect(setPositionState).toHaveBeenCalledWith();
+  });
+});
+
+describe("useMediaBrowserMetaData metadata", () => {
+  it("clears metadata when the target has no current media", () => {
+    mediaSession.metadata = {} as MediaMetadata;
+    apiMock.players[PLAYER_ID] = { player_id: PLAYER_ID } as Player;
+
+    teardown = useMediaBrowserMetaData(PLAYER_ID);
+
+    expect(mediaSession.metadata).toBeNull();
   });
 });

--- a/tests/plugins/web_player.test.ts
+++ b/tests/plugins/web_player.test.ts
@@ -61,6 +61,7 @@ vi.mock("@/plugins/sendspin-connection", () => ({
 }));
 
 import { companionMode } from "@/plugins/companion";
+import { BrowserMediaControlsMode } from "@/helpers/device_settings";
 import {
   clearWebPlayerAudioUnlock,
   initializeWebPlayerModeSync,
@@ -93,16 +94,20 @@ async function applyPreferredMode(): Promise<WebPlayerMode> {
 
 function setRegularPreferences(
   webPlayerEnabled: boolean,
-  browserControlsEnabled: boolean,
+  browserControlsMode: string | null,
 ): void {
   window.localStorage.setItem(
     "frontend.settings.web_player_enabled",
     String(webPlayerEnabled),
   );
-  window.localStorage.setItem(
-    "frontend.settings.enable_browser_controls",
-    String(browserControlsEnabled),
-  );
+  if (browserControlsMode === null) {
+    window.localStorage.removeItem("frontend.settings.enable_browser_controls");
+  } else {
+    window.localStorage.setItem(
+      "frontend.settings.enable_browser_controls",
+      browserControlsMode,
+    );
+  }
 }
 
 // Mirrors saveDeviceSetting: the settings page writes the value and announces it.
@@ -148,7 +153,7 @@ describe("web player preferred mode", () => {
 
   it("uses receive-only Sendspin for Music Quiz guests", async () => {
     authState.guest = "music_quiz";
-    setRegularPreferences(false, true);
+    setRegularPreferences(false, "true");
 
     expect(await applyPreferredMode()).toBe(WebPlayerMode.SENDSPIN_ONLY);
   });
@@ -167,21 +172,77 @@ describe("web player preferred mode", () => {
   );
 
   it.each([
-    [true, true, WebPlayerMode.SENDSPIN_WITH_CONTROLS],
-    [true, false, WebPlayerMode.SENDSPIN_ONLY],
-    [false, true, WebPlayerMode.CONTROLS_ONLY],
-    [false, false, WebPlayerMode.DISABLED],
+    [
+      true,
+      BrowserMediaControlsMode.ACTIVE_PLAYER,
+      WebPlayerMode.SENDSPIN_WITH_CONTROLS,
+      BrowserMediaControlsMode.ACTIVE_PLAYER,
+    ],
+    [
+      true,
+      BrowserMediaControlsMode.WEB_PLAYER,
+      WebPlayerMode.SENDSPIN_WITH_CONTROLS,
+      BrowserMediaControlsMode.WEB_PLAYER,
+    ],
+    [
+      true,
+      BrowserMediaControlsMode.DISABLED,
+      WebPlayerMode.SENDSPIN_ONLY,
+      BrowserMediaControlsMode.DISABLED,
+    ],
+    [
+      false,
+      BrowserMediaControlsMode.ACTIVE_PLAYER,
+      WebPlayerMode.CONTROLS_ONLY,
+      BrowserMediaControlsMode.ACTIVE_PLAYER,
+    ],
+    [
+      false,
+      BrowserMediaControlsMode.WEB_PLAYER,
+      WebPlayerMode.DISABLED,
+      BrowserMediaControlsMode.WEB_PLAYER,
+    ],
+    [
+      false,
+      BrowserMediaControlsMode.DISABLED,
+      WebPlayerMode.DISABLED,
+      BrowserMediaControlsMode.DISABLED,
+    ],
+    [
+      false,
+      "true",
+      WebPlayerMode.DISABLED,
+      BrowserMediaControlsMode.WEB_PLAYER,
+    ],
+    [
+      true,
+      "false",
+      WebPlayerMode.SENDSPIN_ONLY,
+      BrowserMediaControlsMode.DISABLED,
+    ],
+    [
+      true,
+      null,
+      WebPlayerMode.SENDSPIN_WITH_CONTROLS,
+      BrowserMediaControlsMode.WEB_PLAYER,
+    ],
   ])(
-    "keeps regular user preferences (%s, %s) mapped to %s",
-    async (webPlayerEnabled, browserControlsEnabled, expectedMode) => {
-      setRegularPreferences(webPlayerEnabled, browserControlsEnabled);
+    "maps web player %s and browser controls %s to %s",
+    async (
+      webPlayerEnabled,
+      browserControlsMode,
+      expectedMode,
+      expectedControlsMode,
+    ) => {
+      setRegularPreferences(webPlayerEnabled, browserControlsMode);
 
       expect(await applyPreferredMode()).toBe(expectedMode);
+      expect(webPlayer.browserControlsMode).toBe(expectedControlsMode);
     },
   );
 
   it("drops the web player as soon as the setting is switched off", async () => {
-    setRegularPreferences(true, true);
+    setRegularPreferences(true, BrowserMediaControlsMode.ACTIVE_PLAYER);
     expect(await applyPreferredMode()).toBe(
       WebPlayerMode.SENDSPIN_WITH_CONTROLS,
     );

--- a/tests/views/FrontendConfig.test.ts
+++ b/tests/views/FrontendConfig.test.ts
@@ -1,6 +1,8 @@
 import { enableAutoUnmount, flushPromises, mount } from "@vue/test-utils";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import FrontendConfig from "@/views/settings/FrontendConfig.vue";
+import { BrowserMediaControlsMode } from "@/helpers/device_settings";
+import { ConfigEntryType } from "@/plugins/api/interfaces";
 
 const { apiMock, routerMock, storeMock, setPreference } = vi.hoisted(() => ({
   apiMock: { players: {}, providers: {} },
@@ -116,5 +118,32 @@ describe("FrontendConfig save", () => {
 
     expect(setPreference).toHaveBeenCalledWith("theme", "dark");
     expect(reload).toHaveBeenCalled();
+  });
+
+  it("defaults browser media controls to the built-in web player", async () => {
+    const wrapper = await mountPage();
+    const entries = (
+      wrapper.vm as unknown as {
+        config: {
+          key: string;
+          type: ConfigEntryType;
+          default_value: unknown;
+          value: unknown;
+          options: { value: unknown }[];
+        }[];
+      }
+    ).config;
+    const entry = entries.find(({ key }) => key === "enable_browser_controls");
+
+    expect(entry).toMatchObject({
+      type: ConfigEntryType.STRING,
+      default_value: BrowserMediaControlsMode.WEB_PLAYER,
+      value: BrowserMediaControlsMode.WEB_PLAYER,
+    });
+    expect(entry?.options.map(({ value }) => value)).toEqual([
+      BrowserMediaControlsMode.ACTIVE_PLAYER,
+      BrowserMediaControlsMode.WEB_PLAYER,
+      BrowserMediaControlsMode.DISABLED,
+    ]);
   });
 });


### PR DESCRIPTION
# What does this implement/fix?

Browser media controls could affect a selected household player when the device handles a phone call, sleeps, or closes its lid.

- Adds options for the selected player, built-in web player only, or disabled.
- Makes the built-in web player the safer default, including migration from the old enabled setting.
- Keeps browser media controls tied to the intended player.

**Related issue (if applicable):**

N/A

**Related backend PR (if applicable):**

N/A

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm lint:check` passes.
- [x] `pnpm test:run` passes, and tests have been added/updated where applicable.
- [x] `pnpm build` passes.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.