### PR TITLE
Make crossfade details consistent

### DIFF
--- a/src/components/AudioProcessingDetails.vue
+++ b/src/components/AudioProcessingDetails.vue
@@ -110,12 +110,14 @@ import { qualityTierToColor } from "@/composables/useStreamQuality";
 import { $t } from "@/plugins/i18n";
 import type {
   AudioProcessingChain,
+  CrossfadeMode,
   StreamDetails,
 } from "@/plugins/api/interfaces";
 
 const props = defineProps<{
   chain: AudioProcessingChain;
   streamDetails: StreamDetails;
+  crossfadeIntent?: CrossfadeMode;
 }>();
 
 const {
@@ -127,6 +129,7 @@ const {
 } = useAudioProcessingDetails(
   toRef(props, "chain"),
   toRef(props, "streamDetails"),
+  toRef(props, "crossfadeIntent"),
 );
 </script>
 

--- a/src/components/QualityDetailsBtn.vue
+++ b/src/components/QualityDetailsBtn.vue
@@ -39,6 +39,7 @@
         <AudioProcessingDetails
           :chain="audioProcessing"
           :stream-details="streamDetails"
+          :crossfade-intent="crossfadeIntent"
         />
       </div>
     </PopoverContent>
@@ -61,6 +62,7 @@ import {
   qualityTierToColor,
   useStreamQuality,
 } from "@/composables/useStreamQuality";
+import { CrossfadeMode } from "@/plugins/api/interfaces";
 
 // render the quality indicator as a rounded "pill" (matching the shadcn player
 // header controls) instead of the default square chip
@@ -72,6 +74,13 @@ const streamDetails = computed(
 const audioProcessing = computed(
   () => streamDetails.value?.audio_processing ?? undefined,
 );
+const crossfadeIntent = computed(() => {
+  const queue = store.activePlayerQueue;
+  if (!queue?.crossfade_enabled) return CrossfadeMode.DISABLED;
+  return queue.smart_fades_active
+    ? CrossfadeMode.SMART_CROSSFADE
+    : CrossfadeMode.STANDARD_CROSSFADE;
+});
 
 const { minOutputQualityTier, maxOutputQualityTier } =
   useStreamQuality(audioProcessing);

--- a/src/composables/useAudioProcessingDetails.ts
+++ b/src/composables/useAudioProcessingDetails.ts
@@ -147,6 +147,7 @@ const LOSSY_AUDIO_CODECS = new Set<string>([
 export function useAudioProcessingDetails(
   chain: MaybeRefOrGetter<AudioProcessingChain>,
   streamDetails: MaybeRefOrGetter<StreamDetails>,
+  crossfadeIntent: MaybeRefOrGetter<CrossfadeMode | undefined> = undefined,
 ) {
   const { t, locale } = useI18n({ useScope: "global" });
   const { getPresetName } = useDSPPresets({ optional: true });
@@ -168,6 +169,7 @@ export function useAudioProcessingDetails(
         getIRName,
         players: api.players,
       },
+      toValue(crossfadeIntent),
     );
   });
 
@@ -184,6 +186,7 @@ export function buildAudioProcessingDetailsDisplay(
   chain: AudioProcessingChain,
   streamDetails: StreamDetails,
   dependencies: AudioProcessingDetailsDependencies,
+  crossfadeIntent?: CrossfadeMode,
 ): AudioProcessingDetailsDisplay {
   return {
     inputQualityTier: audioQualityToTier(chain.input_fidelity.quality),
@@ -192,7 +195,12 @@ export function buildAudioProcessingDetailsDisplay(
       dependencies.translate,
     ),
     inputStages: buildInputStages(streamDetails, dependencies),
-    processingStages: buildProcessingStages(streamDetails, chain, dependencies),
+    processingStages: buildProcessingStages(
+      streamDetails,
+      chain,
+      dependencies,
+      crossfadeIntent,
+    ),
     outputPaths: chain.outputs.map((output, index) =>
       buildOutputDisplay(output, index, dependencies),
     ),
@@ -222,6 +230,7 @@ function buildProcessingStages(
   streamDetails: StreamDetails,
   chain: AudioProcessingChain,
   dependencies: AudioProcessingDetailsDependencies,
+  crossfadeIntent?: CrossfadeMode,
 ): AudioProcessingDisplayStage[] {
   const { translate } = dependencies;
   const stages: AudioProcessingDisplayStage[] = [];
@@ -256,15 +265,20 @@ function buildProcessingStages(
     });
     serverAltersAudio = true;
   }
-  if (processing && processing.crossfade_mode !== CrossfadeMode.DISABLED) {
+  const reportedCrossfadeMode = processing?.crossfade_mode;
+  // Keep source attribution; otherwise show the queue's current intent.
+  const crossfadeMode =
+    reportedCrossfadeMode === CrossfadeMode.SOURCE
+      ? reportedCrossfadeMode
+      : (crossfadeIntent ?? reportedCrossfadeMode);
+  serverAltersAudio ||= crossfadeAppliedByServer(reportedCrossfadeMode);
+  if (crossfadeMode && crossfadeMode !== CrossfadeMode.DISABLED) {
     stages.push({
       key: "crossfade",
       icon: CrossfadeIcon,
-      title: translate("streamdetails.audio_processing.crossfade", [
-        crossfadeModeLabel(processing.crossfade_mode, translate, sourceName),
-      ]),
+      title: translate("streamdetails.audio_processing.crossfade_title"),
+      subtitleParts: [crossfadeModeLabel(crossfadeMode, translate, sourceName)],
     });
-    serverAltersAudio ||= crossfadeAppliedByServer(processing.crossfade_mode);
   }
   if (processing?.overlay_active) {
     stages.push({

--- a/src/layouts/default/PlayerOSD/PlayerControlBtn/CrossfadeIcon.vue
+++ b/src/layouts/default/PlayerOSD/PlayerControlBtn/CrossfadeIcon.vue
@@ -1,7 +1,7 @@
 <template>
   <svg
     class="crossfade-icon"
-    :class="{ 'is-smart': smart, 'is-active': active && !smart }"
+    :class="{ 'is-smart': smart }"
     :width="size"
     :height="size"
     viewBox="0 0 24 24"
@@ -30,12 +30,10 @@
 withDefaults(
   defineProps<{
     size?: number | string;
-    active?: boolean;
     smart?: boolean;
   }>(),
   {
     size: 24,
-    active: false,
     smart: false,
   },
 );
@@ -46,14 +44,6 @@ withDefaults(
   display: inline-block;
   vertical-align: middle;
   overflow: visible;
-}
-
-.crossfade-icon.is-active .crossfade-ring {
-  animation: crossfade-ring-fade 2.4s ease-in-out infinite;
-}
-
-.crossfade-icon.is-active .crossfade-ring--b {
-  animation-delay: -1.2s;
 }
 
 .crossfade-icon.is-smart {
@@ -75,16 +65,6 @@ withDefaults(
 
 .crossfade-spark--delayed {
   animation-delay: -1.2s;
-}
-
-@keyframes crossfade-ring-fade {
-  0%,
-  100% {
-    opacity: 1;
-  }
-  50% {
-    opacity: 0.35;
-  }
 }
 
 @keyframes crossfade-spark-travel {
@@ -115,8 +95,7 @@ withDefaults(
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .crossfade-icon.is-smart,
-  .crossfade-icon.is-active .crossfade-ring {
+  .crossfade-icon.is-smart {
     animation: none;
   }
   .crossfade-spark {

--- a/src/layouts/default/PlayerOSD/PlayerFullscreenHeaderControls.vue
+++ b/src/layouts/default/PlayerOSD/PlayerFullscreenHeaderControls.vue
@@ -109,8 +109,7 @@
       </Tooltip>
     </TooltipProvider>
 
-    <!-- crossfade: direct toggle (primary while enabled). The icon slowly
-         crossfades while enabled and twinkles while smart fades are active. -->
+    <!-- crossfade: direct toggle (primary while enabled) -->
     <TooltipProvider v-if="showCrossfade && queue" :delay-duration="200">
       <Tooltip>
         <TooltipTrigger as-child>
@@ -121,39 +120,13 @@
             :aria-label="$t('crossfade')"
             @click="toggleCrossfade"
           >
-            <CrossfadeIcon
-              :size="16"
-              :active="crossfadeEnabled"
-              :smart="
-                crossfadeEnabled && smartFadesActive && !sourceCrossfadeName
-              "
-            />
+            <CrossfadeIcon :size="16" :smart="smartCrossfadeActive" />
             <span v-if="showLabel">{{ $t("crossfade") }}</span>
           </Button>
         </TooltipTrigger>
         <TooltipContent side="bottom" class="z-[10001] max-w-[240px]">
-          <p class="font-medium">
-            {{
-              crossfadeEnabled
-                ? $t("crossfade_disable")
-                : $t("crossfade_enable")
-            }}
-          </p>
-          <p
-            v-if="crossfadeEnabled && sourceCrossfadeName"
-            class="mt-1 opacity-80"
-          >
-            {{ $t("crossfade_source_active", [sourceCrossfadeName]) }}
-          </p>
-          <p
-            v-else-if="crossfadeEnabled && smartFadesActive"
-            class="mt-1 opacity-80"
-          >
-            {{ $t("crossfade_smart_active") }}
-          </p>
-          <p v-else-if="!crossfadeEnabled" class="mt-1 opacity-80">
-            {{ $t("crossfade_explanation") }}
-          </p>
+          <p class="font-medium">{{ $t("crossfade") }}</p>
+          <p class="mt-1 opacity-80">{{ crossfadeDescription }}</p>
         </TooltipContent>
       </Tooltip>
     </TooltipProvider>
@@ -271,12 +244,26 @@ const smartFadesActive = computed(
   () => queue.value?.smart_fades_active === true,
 );
 
-// A source that fades its own playback does so instead of us: smart_fades_active
-// still reflects the queue setting, but none of our timing is applied, so the
-// display name of the service replaces the smart wording and its animation.
 const sourceCrossfadeName = computed(() => {
   const provider = queueSourceCrossfadeProvider(queue.value);
   return provider ? api.getProviderName(provider) : undefined;
+});
+const smartCrossfadeActive = computed(
+  () =>
+    crossfadeEnabled.value &&
+    smartFadesActive.value &&
+    !sourceCrossfadeName.value,
+);
+const crossfadeDescription = computed(() => {
+  if (!crossfadeEnabled.value) return $t("crossfade_explanation");
+  if (sourceCrossfadeName.value) {
+    return $t("streamdetails.audio_processing.crossfade_mode.source", [
+      sourceCrossfadeName.value,
+    ]);
+  }
+  return smartFadesActive.value
+    ? $t("streamdetails.audio_processing.crossfade_mode.smart")
+    : $t("streamdetails.audio_processing.crossfade_mode.standard");
 });
 
 // Crossfade only applies to an active queue that is playing regular tracks.

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -2187,7 +2187,6 @@
     "crossfade_active": "Crossfade is active.",
     "crossfade_active_with_smart": "Crossfade is active with smart fades.",
     "crossfade_smart_active": "The fade timing is chosen automatically to suit each track.",
-    "crossfade_source_active": "{0} applies the fade to this track, not Music Assistant.",
     "lyrics": "Lyrics",
     "lyrics_unavailable_song": "There are no lyrics available for this track (yet).",
     "lyrics_unavailable_content": "Lyrics are not available for this media type.",

--- a/tests/components/AudioProcessingDetails.test.ts
+++ b/tests/components/AudioProcessingDetails.test.ts
@@ -210,7 +210,13 @@ describe("AudioProcessingDetails", () => {
     ).toBe("Test provider");
     expect(text).toContain("32-bit float PCM");
     expect(text).toContain("Playback speed: 1.25x");
-    expect(text).toContain("Crossfade: Smart");
+    const crossfade = wrapper.find('[data-stage="crossfade"]');
+    expect(crossfade.find(".audio-processing-stage-title").text()).toBe(
+      "Crossfade",
+    );
+    expect(crossfade.find(".audio-processing-stage-subtitle").text()).toBe(
+      "Smart",
+    );
     expect(text).toContain("Audio overlay active");
     expect(
       wrapper
@@ -291,7 +297,13 @@ describe("AudioProcessingDetails", () => {
 
     const text = wrapper.text();
     expect(text).toContain("Quality unknown");
-    expect(text).toContain("Crossfade: Unknown");
+    const crossfade = wrapper.find('[data-stage="crossfade"]');
+    expect(crossfade.find(".audio-processing-stage-title").text()).toBe(
+      "Crossfade",
+    );
+    expect(crossfade.find(".audio-processing-stage-subtitle").text()).toBe(
+      "Unknown",
+    );
     expect(text).toContain("DSP state unknown");
     expect(text).toContain("Source channel: Unknown");
     expect(text).not.toContain("future");
@@ -347,6 +359,26 @@ describe("AudioProcessingDetails", () => {
         .findAll("li")
         .map((detail) => detail.text()),
     ).not.toContain("Floating-point headroom is available for: Crossfade.");
+  });
+
+  it("renders the queue crossfade intent before a transition is reported", () => {
+    const wrapper = mountDetails(
+      {
+        queue_processing: audioQueueProcessing({
+          crossfade_mode: CrossfadeMode.DISABLED,
+        }),
+      },
+      makeStreamDetails(),
+      CrossfadeMode.STANDARD_CROSSFADE,
+    );
+    const crossfade = wrapper.find('[data-stage="crossfade"]');
+
+    expect(crossfade.find(".audio-processing-stage-title").text()).toBe(
+      "Crossfade",
+    );
+    expect(crossfade.find(".audio-processing-stage-subtitle").text()).toBe(
+      "Standard",
+    );
   });
 
   it("renders audio formats as titles with atomic technical details", () => {
@@ -903,11 +935,13 @@ describe("AudioProcessingDetails", () => {
 function mountDetails(
   chain: Partial<AudioProcessingChain> = {},
   streamDetails = makeStreamDetails(),
+  crossfadeIntent?: CrossfadeMode,
 ) {
   return mount(AudioProcessingDetails, {
     props: {
       chain: audioProcessingChain(chain),
       streamDetails,
+      crossfadeIntent,
     },
     global: {
       plugins: [i18n],

--- a/tests/components/QualityDetailsBtn.test.ts
+++ b/tests/components/QualityDetailsBtn.test.ts
@@ -4,6 +4,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import QualityDetailsBtn from "@/components/QualityDetailsBtn.vue";
 import {
   AudioQuality,
+  CrossfadeMode,
   PlaybackState,
   type PlayerQueue,
   type StreamDetails,
@@ -27,7 +28,9 @@ vi.mock("@/plugins/store", () => ({
 }));
 vi.mock("@/components/AudioProcessingDetails.vue", () => ({
   default: {
-    template: '<div data-testid="audio-processing-details" />',
+    props: ["crossfadeIntent"],
+    template:
+      '<div data-testid="audio-processing-details" :data-crossfade-intent="crossfadeIntent" />',
   },
 }));
 
@@ -79,6 +82,28 @@ describe("QualityDetailsBtn", () => {
       "Show audio pipeline details (LQ-HR)",
     );
   });
+
+  it.each([
+    [false, false, CrossfadeMode.DISABLED],
+    [true, false, CrossfadeMode.STANDARD_CROSSFADE],
+    [true, true, CrossfadeMode.SMART_CROSSFADE],
+  ])(
+    "passes the effective crossfade intent to the pipeline",
+    (enabled, smart, expectedMode) => {
+      storeMock.activePlayerQueue = makeQueue({
+        ...makeStreamDetails(),
+        audio_processing: audioProcessingChain(),
+      });
+      storeMock.activePlayerQueue.crossfade_enabled = enabled;
+      storeMock.activePlayerQueue.smart_fades_active = smart;
+
+      expect(
+        mountButton()
+          .get('[data-testid="audio-processing-details"]')
+          .attributes("data-crossfade-intent"),
+      ).toBe(expectedMode);
+    },
+  );
 
   it.each([
     { pill: false, side: "top" },

--- a/tests/composables/useAudioProcessingDetails.test.ts
+++ b/tests/composables/useAudioProcessingDetails.test.ts
@@ -44,6 +44,50 @@ vi.mock("@/plugins/api", async () => {
     },
   };
 });
+
+it.each([
+  [CrossfadeMode.SMART_CROSSFADE, "Smart"],
+  [CrossfadeMode.STANDARD_CROSSFADE, "Standard"],
+])(
+  "shows %s crossfade intent before a transition is reported",
+  (crossfadeIntent, label) => {
+    const display = buildDisplay(
+      {
+        queue_processing: audioQueueProcessing({
+          crossfade_mode: CrossfadeMode.DISABLED,
+        }),
+      },
+      makeFormat(),
+      crossfadeIntent,
+    );
+
+    expect(
+      display.processingStages.find((stage) => stage.key === "crossfade"),
+    ).toMatchObject({
+      title: "Crossfade",
+      subtitleParts: [label],
+    });
+  },
+);
+
+it("prefers crossfade intent over the reported fallback mode", () => {
+  const display = buildDisplay(
+    {
+      queue_processing: audioQueueProcessing({
+        crossfade_mode: CrossfadeMode.STANDARD_CROSSFADE,
+      }),
+    },
+    makeFormat(),
+    CrossfadeMode.SMART_CROSSFADE,
+  );
+
+  expect(
+    display.processingStages.find((stage) => stage.key === "crossfade"),
+  ).toMatchObject({
+    title: "Crossfade",
+    subtitleParts: ["Smart"],
+  });
+});
 vi.mock("@/composables/useDSPPresets", () => ({
   useDSPPresets: () => ({
     getPresetName: vi.fn(),
@@ -467,9 +511,12 @@ describe("buildAudioProcessingDetailsDisplay", () => {
         ],
       });
 
-      expect(display.processingStages.map((stage) => stage.title)).toContain(
-        "Crossfade: Unknown",
-      );
+      expect(
+        display.processingStages.find((stage) => stage.key === "crossfade"),
+      ).toMatchObject({
+        title: "Crossfade",
+        subtitleParts: ["Unknown"],
+      });
       expect(display.processingStages[0].details).toContain(
         "Floating-point headroom is available for: Crossfade.",
       );
@@ -526,16 +573,20 @@ describe("buildAudioProcessingDetailsDisplay", () => {
         ],
       },
       sourceFormat,
+      CrossfadeMode.SMART_CROSSFADE,
     );
 
     // both steps are reported, but neither is ours, so the shared path stays direct
     expect(display.processingStages.map((stage) => stage.title)).toEqual([
       "Direct signal path",
       "Volume normalization",
-      "Crossfade: Applied by Test provider",
+      "Crossfade",
     ]);
     const normalization = display.processingStages[1];
     expect(normalization.subtitleParts).toEqual(["Applied by Test provider"]);
+    expect(display.processingStages[2].subtitleParts).toEqual([
+      "Applied by Test provider",
+    ]);
     // our target and measurement describe neither, so there is nothing to list
     expect(normalization.details).toEqual([]);
   });
@@ -833,6 +884,7 @@ describe("buildAudioProcessingDetailsDisplay", () => {
 function buildDisplay(
   chain: Partial<AudioProcessingChain> = {},
   format = makeFormat(),
+  crossfadeIntent?: CrossfadeMode,
 ) {
   return buildAudioProcessingDetailsDisplay(
     audioProcessingChain(chain),
@@ -842,6 +894,7 @@ function buildDisplay(
       audio_format: format,
     }),
     dependencies,
+    crossfadeIntent,
   );
 }
 

--- a/tests/composables/useAudioProcessingDetails.test.ts
+++ b/tests/composables/useAudioProcessingDetails.test.ts
@@ -45,49 +45,6 @@ vi.mock("@/plugins/api", async () => {
   };
 });
 
-it.each([
-  [CrossfadeMode.SMART_CROSSFADE, "Smart"],
-  [CrossfadeMode.STANDARD_CROSSFADE, "Standard"],
-])(
-  "shows %s crossfade intent before a transition is reported",
-  (crossfadeIntent, label) => {
-    const display = buildDisplay(
-      {
-        queue_processing: audioQueueProcessing({
-          crossfade_mode: CrossfadeMode.DISABLED,
-        }),
-      },
-      makeFormat(),
-      crossfadeIntent,
-    );
-
-    expect(
-      display.processingStages.find((stage) => stage.key === "crossfade"),
-    ).toMatchObject({
-      title: "Crossfade",
-      subtitleParts: [label],
-    });
-  },
-);
-
-it("prefers crossfade intent over the reported fallback mode", () => {
-  const display = buildDisplay(
-    {
-      queue_processing: audioQueueProcessing({
-        crossfade_mode: CrossfadeMode.STANDARD_CROSSFADE,
-      }),
-    },
-    makeFormat(),
-    CrossfadeMode.SMART_CROSSFADE,
-  );
-
-  expect(
-    display.processingStages.find((stage) => stage.key === "crossfade"),
-  ).toMatchObject({
-    title: "Crossfade",
-    subtitleParts: ["Smart"],
-  });
-});
 vi.mock("@/composables/useDSPPresets", () => ({
   useDSPPresets: () => ({
     getPresetName: vi.fn(),
@@ -546,6 +503,50 @@ describe("buildAudioProcessingDetailsDisplay", () => {
     expect(display.processingStages[0].details).not.toContain(
       "Floating-point headroom is available for: Crossfade.",
     );
+  });
+
+  it.each([
+    [CrossfadeMode.SMART_CROSSFADE, "Smart"],
+    [CrossfadeMode.STANDARD_CROSSFADE, "Standard"],
+  ])(
+    "shows %s crossfade intent before a transition is reported",
+    (crossfadeIntent, label) => {
+      const display = buildDisplay(
+        {
+          queue_processing: audioQueueProcessing({
+            crossfade_mode: CrossfadeMode.DISABLED,
+          }),
+        },
+        makeFormat(),
+        crossfadeIntent,
+      );
+
+      expect(
+        display.processingStages.find((stage) => stage.key === "crossfade"),
+      ).toMatchObject({
+        title: "Crossfade",
+        subtitleParts: [label],
+      });
+    },
+  );
+
+  it("prefers crossfade intent over the reported fallback mode", () => {
+    const display = buildDisplay(
+      {
+        queue_processing: audioQueueProcessing({
+          crossfade_mode: CrossfadeMode.STANDARD_CROSSFADE,
+        }),
+      },
+      makeFormat(),
+      CrossfadeMode.SMART_CROSSFADE,
+    );
+
+    expect(
+      display.processingStages.find((stage) => stage.key === "crossfade"),
+    ).toMatchObject({
+      title: "Crossfade",
+      subtitleParts: ["Smart"],
+    });
   });
 
   it("keeps the path direct when the source handled the processing", () => {

--- a/tests/layouts/PlayerFullscreenHeaderControls.test.ts
+++ b/tests/layouts/PlayerFullscreenHeaderControls.test.ts
@@ -72,14 +72,20 @@ describe("PlayerFullscreenHeaderControls", () => {
   });
 
   it("does not animate a fade the source applied", () => {
-    // smart_fades_active only reflects the queue setting: none of our timing is
-    // applied here, so the twinkle would claim a fade we did not render
     seedQueue(CrossfadeMode.SOURCE);
 
     const icon = mountControls().findComponent(CrossfadeIcon);
 
-    expect(icon.props("active")).toBe(true);
     expect(icon.props("smart")).toBe(false);
+  });
+
+  it("does not animate a standard fade", () => {
+    seedQueue(CrossfadeMode.STANDARD_CROSSFADE);
+    queue.value!.smart_fades_active = false;
+
+    expect(mountControls().findComponent(CrossfadeIcon).props("smart")).toBe(
+      false,
+    );
   });
 
   it("animates our own smart fade", () => {
@@ -90,12 +96,13 @@ describe("PlayerFullscreenHeaderControls", () => {
     );
   });
 
-  it("names the service that applies the fade", () => {
+  it("mirrors the source fade details in the tooltip", () => {
     seedQueue(CrossfadeMode.SOURCE);
 
     const text = mountControls().text();
 
-    expect(text).toContain("Spotify applies the fade to this track");
-    expect(text).not.toContain("The fade timing is chosen automatically");
+    expect(text).toContain("Crossfade");
+    expect(text).toContain("Applied by Spotify");
+    expect(text).not.toContain("Disable crossfade");
   });
 });


### PR DESCRIPTION
# What does this implement/fix?

Crossfade details were presented inconsistently between the stream path and fullscreen controls, and Music Assistant's selected mode could be missing until a transition occurred.

- Show Crossfade with Smart, Standard, or Applied by the source on a consistent detail line.
- Show the selected crossfade intent in the stream path.
- Reserve the animated icon for smart fades.

**Related issue (if applicable):**

- N/A

**Related backend PR (if applicable):**

- N/A

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm lint:check` passes.
- [x] `pnpm test:run` passes, and tests have been added/updated where applicable.
- [x] `pnpm build` passes.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.