### PR TITLE
Show audio quality for external sources

### DIFF
--- a/src/components/QualityDetailsBtn.vue
+++ b/src/components/QualityDetailsBtn.vue
@@ -1,6 +1,6 @@
 <template>
   <!-- streaming quality details -->
-  <Popover v-if="audioProcessing && streamDetails">
+  <Popover v-if="activeAudioPath">
     <!-- quality pill/chip trigger; pill = ghost-outline to match the fullscreen
          header controls. A single clean PopoverTrigger so it opens reliably
          inside the fullscreen v-dialog (a Tooltip wrapper here blocked it). -->
@@ -37,9 +37,9 @@
         tabindex="-1"
       >
         <AudioProcessingDetails
-          :chain="audioProcessing"
-          :stream-details="streamDetails"
-          :crossfade-intent="crossfadeIntent"
+          :chain="activeAudioPath.audioProcessing"
+          :stream-details="activeAudioPath.streamDetails"
+          :crossfade-intent="activeAudioPath.crossfadeIntent"
         />
       </div>
     </PopoverContent>
@@ -62,28 +62,17 @@ import {
   qualityTierToColor,
   useStreamQuality,
 } from "@/composables/useStreamQuality";
-import { CrossfadeMode } from "@/plugins/api/interfaces";
+import { useActiveAudioPath } from "@/composables/useActiveAudioPath";
 
 // render the quality indicator as a rounded "pill" (matching the shadcn player
 // header controls) instead of the default square chip
 defineProps<{ pill?: boolean }>();
 
-const streamDetails = computed(
-  () => store.activePlayerQueue?.current_item?.streamdetails,
-);
-const audioProcessing = computed(
-  () => streamDetails.value?.audio_processing ?? undefined,
-);
-const crossfadeIntent = computed(() => {
-  const queue = store.activePlayerQueue;
-  if (!queue?.crossfade_enabled) return CrossfadeMode.DISABLED;
-  return queue.smart_fades_active
-    ? CrossfadeMode.SMART_CROSSFADE
-    : CrossfadeMode.STANDARD_CROSSFADE;
-});
+const { activeAudioPath } = useActiveAudioPath();
 
-const { minOutputQualityTier, maxOutputQualityTier } =
-  useStreamQuality(audioProcessing);
+const { minOutputQualityTier, maxOutputQualityTier } = useStreamQuality(
+  computed(() => activeAudioPath.value?.audioProcessing),
+);
 
 const qualityLabel = computed(() => {
   return qualityTierRangeLabel(
@@ -100,13 +89,16 @@ const qualityDetailsLabel = computed(() =>
 );
 const popoverFocusTarget = ref<HTMLElement>();
 
-// disable the trigger when there is no active queue with items
-const triggerDisabled = computed(
-  () =>
+// disable the trigger when there is no active queue with items; a live
+// source has no queue to check and is gated by the popover's own v-if instead
+const triggerDisabled = computed(() => {
+  if (activeAudioPath.value?.kind !== "queue") return false;
+  return (
     !store.activePlayerQueue ||
     !store.activePlayerQueue?.active ||
-    store.activePlayerQueue?.items == 0,
-);
+    store.activePlayerQueue?.items == 0
+  );
+});
 
 function focusPopoverContent(event: Event): void {
   event.preventDefault();

--- a/src/composables/nowPlayingSource.ts
+++ b/src/composables/nowPlayingSource.ts
@@ -40,7 +40,8 @@ export function useNowPlayingSource() {
   return { nowPlayingSource, albumSubtitle };
 }
 
-function sourceProviderId(sourceId: string): string | undefined {
+/** Provider domain/instance id prefix of a source id, e.g. "spotify" from "spotify://...". */
+export function sourceProviderId(sourceId: string): string | undefined {
   const separator = sourceId.indexOf("://");
   return separator > 0 ? sourceId.slice(0, separator) : undefined;
 }

--- a/src/composables/useActiveAudioPath.ts
+++ b/src/composables/useActiveAudioPath.ts
@@ -1,0 +1,115 @@
+import { computed } from "vue";
+import { resolveExternalSource } from "@/composables/externalSource";
+import { sourceProviderId } from "@/composables/nowPlayingSource";
+import { store } from "@/plugins/store";
+import {
+  AudioNormalizationMeasurementSource,
+  type AudioProcessingChain,
+  CrossfadeMode,
+  MediaType,
+  type StreamDetails,
+  VolumeNormalizationMode,
+} from "@/plugins/api/interfaces";
+
+export interface ActiveAudioPath {
+  streamDetails: StreamDetails;
+  audioProcessing: AudioProcessingChain;
+  // only meaningful for the queue path; the source path reports its own
+  // crossfade behaviour through CrossfadeMode.SOURCE instead
+  crossfadeIntent?: CrossfadeMode;
+  // whether this came from the active queue item or a live external source
+  kind: "queue" | "source";
+}
+
+/**
+ * The audio-path details for whatever is currently playing on the active
+ * player: the active queue item's stream, or — once nothing plays through a
+ * queue (e.g. Spotify Connect) — the player's own external-source snapshot,
+ * adapted into the same shape so callers never need to know which it is.
+ *
+ * This is the single source of truth for both the quality pill's visibility
+ * and its popover content, so they never disagree.
+ */
+export function useActiveAudioPath() {
+  const queueStreamDetails = computed(
+    () => store.curQueueItem?.streamdetails ?? undefined,
+  );
+  const queueAudioProcessing = computed(
+    () => queueStreamDetails.value?.audio_processing ?? undefined,
+  );
+  const queueCrossfadeIntent = computed<CrossfadeMode>(() => {
+    const queue = store.activePlayerQueue;
+    if (!queue?.crossfade_enabled) return CrossfadeMode.DISABLED;
+    return queue.smart_fades_active
+      ? CrossfadeMode.SMART_CROSSFADE
+      : CrossfadeMode.STANDARD_CROSSFADE;
+  });
+
+  // a live external source only counts once no queue item is playing through it
+  const sourceAudio = computed(() => {
+    if (queueAudioProcessing.value) return undefined;
+    return store.activePlayer?.active_source_audio ?? undefined;
+  });
+  const sourceProviderDomain = computed(() => {
+    const source = resolveExternalSource(
+      store.activePlayer,
+      store.activePlayerQueue,
+    );
+    return source ? sourceProviderId(source.id) : undefined;
+  });
+
+  const activeAudioPath = computed<ActiveAudioPath | undefined>(() => {
+    if (queueAudioProcessing.value && queueStreamDetails.value) {
+      return {
+        kind: "queue",
+        streamDetails: queueStreamDetails.value,
+        audioProcessing: queueAudioProcessing.value,
+        crossfadeIntent: queueCrossfadeIntent.value,
+      };
+    }
+    const source = sourceAudio.value;
+    if (!source) return undefined;
+    return {
+      kind: "source",
+      streamDetails: {
+        provider: sourceProviderDomain.value ?? "",
+        item_id: "",
+        audio_format: source.input_format,
+        media_type: MediaType.UNKNOWN,
+        stream_metadata: null,
+        duration: null,
+        audio_processing: null,
+      },
+      audioProcessing: {
+        input_fidelity: source.input_fidelity,
+        queue_processing: {
+          pcm_format: null,
+          normalization:
+            source.volume_normalization_mode === VolumeNormalizationMode.SOURCE
+              ? {
+                  mode: VolumeNormalizationMode.SOURCE,
+                  measurement_source:
+                    AudioNormalizationMeasurementSource.UNKNOWN,
+                  target_lufs: null,
+                  measured_lufs: null,
+                  applied_gain_db: null,
+                }
+              : null,
+          playback_speed: 1,
+          crossfade_mode:
+            source.crossfade_mode === CrossfadeMode.SOURCE
+              ? CrossfadeMode.SOURCE
+              : CrossfadeMode.DISABLED,
+          overlay_active: false,
+        },
+        outputs: source.outputs,
+      },
+    };
+  });
+
+  const hasActiveAudioPath = computed(
+    () => activeAudioPath.value !== undefined,
+  );
+
+  return { activeAudioPath, hasActiveAudioPath };
+}

--- a/src/composables/useActiveAudioPath.ts
+++ b/src/composables/useActiveAudioPath.ts
@@ -45,17 +45,21 @@ export function useActiveAudioPath() {
       : CrossfadeMode.STANDARD_CROSSFADE;
   });
 
-  // a live external source only counts once no queue item is playing through it
+  // a live source only counts once no queue item is active at all — an active
+  // item with processing still pending must not fall back to a stale source
   const sourceAudio = computed(() => {
-    if (queueAudioProcessing.value) return undefined;
+    if (store.curQueueItem) return undefined;
     return store.activePlayer?.active_source_audio ?? undefined;
   });
   const sourceProviderDomain = computed(() => {
-    const source = resolveExternalSource(
-      store.activePlayer,
-      store.activePlayerQueue,
-    );
-    return source ? sourceProviderId(source.id) : undefined;
+    const player = store.activePlayer;
+    const source = resolveExternalSource(player, store.activePlayerQueue);
+    if (source) return sourceProviderId(source.id);
+    // sync/protocol child players may not carry the source_list entry
+    // themselves; active_source still follows the same "<provider>://…" id
+    return player?.active_source
+      ? sourceProviderId(player.active_source)
+      : undefined;
   });
 
   const activeAudioPath = computed<ActiveAudioPath | undefined>(() => {

--- a/src/composables/useStreamQuality.ts
+++ b/src/composables/useStreamQuality.ts
@@ -1,6 +1,7 @@
 import { computed, toValue, type MaybeRefOrGetter } from "vue";
 import {
-  type AudioProcessingChain,
+  type AudioFidelity,
+  type AudioOutputDetails,
   AudioQuality,
 } from "@/plugins/api/interfaces";
 
@@ -74,23 +75,35 @@ export function audioQualityToTier(quality: AudioQuality | string | undefined) {
   }
 }
 
+// the fields either an AudioProcessingChain or an ActiveSourceAudioDetails
+// snapshot carries, which is all this needs to resolve a quality tier
+export interface QualityTierSource {
+  input_fidelity: AudioFidelity;
+  outputs: AudioOutputDetails[];
+}
+
 export function useStreamQuality(
-  audioProcessing: MaybeRefOrGetter<AudioProcessingChain | null | undefined>,
+  source: MaybeRefOrGetter<QualityTierSource | null | undefined>,
 ) {
   const knownOutputQualityTiers = computed(() =>
-    (toValue(audioProcessing)?.outputs ?? [])
+    (toValue(source)?.outputs ?? [])
       .map((output) => audioQualityToTier(output.fidelity.quality))
       .filter((tier) => tier !== QualityTier.UNKNOWN),
+  );
+  // before any output has reported its quality, the input's own fidelity is
+  // the best signal available (e.g. a live source right as it starts)
+  const inputQualityTier = computed(() =>
+    audioQualityToTier(toValue(source)?.input_fidelity.quality),
   );
   const minOutputQualityTier = computed(() =>
     knownOutputQualityTiers.value.length
       ? Math.min(...knownOutputQualityTiers.value)
-      : QualityTier.UNKNOWN,
+      : inputQualityTier.value,
   );
   const maxOutputQualityTier = computed(() =>
     knownOutputQualityTiers.value.length
       ? Math.max(...knownOutputQualityTiers.value)
-      : QualityTier.UNKNOWN,
+      : inputQualityTier.value,
   );
 
   return {

--- a/src/layouts/default/PlayerOSD/PlayerFullscreenHeaderControls.vue
+++ b/src/layouts/default/PlayerOSD/PlayerFullscreenHeaderControls.vue
@@ -4,7 +4,7 @@
     <SleepTimerBtn pill />
 
     <!-- streaming quality details chip (moved up from under the track info) -->
-    <QualityDetailsBtn v-if="store.curQueueItem?.streamdetails" pill />
+    <QualityDetailsBtn v-if="hasActiveAudioPath" pill />
 
     <!-- lyrics: available -> clickable toggle (fully primary while the panel is open) -->
     <TooltipProvider v-if="lyricsState === 'available'" :delay-duration="200">
@@ -179,6 +179,7 @@ import {
 import AutoplayIcon from "@/layouts/default/PlayerOSD/PlayerControlBtn/AutoplayIcon.vue";
 import CrossfadeIcon from "@/layouts/default/PlayerOSD/PlayerControlBtn/CrossfadeIcon.vue";
 import { useQueueModes } from "@/layouts/default/PlayerOSD/useQueueModes";
+import { useActiveAudioPath } from "@/composables/useActiveAudioPath";
 import { useAudioOverlay } from "@/composables/useAudioOverlay";
 import api from "@/plugins/api";
 import {
@@ -204,6 +205,8 @@ const lyricsTooltip = computed(() =>
     ? $t("lyrics_loading")
     : $t("lyrics_unavailable_song"),
 );
+
+const { hasActiveAudioPath } = useActiveAudioPath();
 
 // Shared dynamic/autoplay state (also used by the queue mode banner).
 const {

--- a/src/layouts/default/PlayerOSD/PlayerTrackDetails.vue
+++ b/src/layouts/default/PlayerOSD/PlayerTrackDetails.vue
@@ -101,7 +101,7 @@
       <!-- format -->
       <div
         v-if="
-          streamDetails?.audio_format.content_type &&
+          hasActiveAudioPath &&
           !getBreakpointValue({ breakpoint: 'phone' }) &&
           showQualityDetailsBtn
         "
@@ -204,6 +204,7 @@ import { getBreakpointValue } from "@/plugins/breakpoint";
 import { store } from "@/plugins/store";
 import { computed, onUnmounted, ref, watch } from "vue";
 import { useUserPreferences } from "@/composables/userPreferences";
+import { useActiveAudioPath } from "@/composables/useActiveAudioPath";
 import { useNowPlayingSource } from "@/composables/nowPlayingSource";
 import NowPlayingSourceBadge from "./NowPlayingSourceBadge.vue";
 import PlayerFullscreen from "./PlayerFullscreen.vue";
@@ -258,6 +259,7 @@ onUnmounted(() => updateChapterTimer(false));
 const queueEnded = computed(() => isQueueEnded(store.activePlayerQueue));
 
 const { albumSubtitle } = useNowPlayingSource();
+const { hasActiveAudioPath } = useActiveAudioPath();
 
 // properties
 interface Props {
@@ -281,11 +283,6 @@ const props = withDefaults(defineProps<Props>(), {
   primaryColor: "",
   compact: false,
   titleOpensDetails: false,
-});
-
-// computed properties
-const streamDetails = computed(() => {
-  return store.activePlayerQueue?.current_item?.streamdetails;
 });
 
 // size of the clickable artwork area; cover art fills this via its

--- a/src/plugins/api/interfaces.ts
+++ b/src/plugins/api/interfaces.ts
@@ -1177,6 +1177,16 @@ export interface AudioProcessingChain {
   outputs: AudioOutputDetails[];
 }
 
+// active_source_audio: a compact audio-path snapshot for a live external source
+// (e.g. Spotify Connect) that has no queue item to carry StreamDetails on.
+export interface ActiveSourceAudioDetails {
+  input_format: AudioFormat;
+  input_fidelity: AudioFidelity;
+  crossfade_mode: CrossfadeMode;
+  volume_normalization_mode: VolumeNormalizationMode;
+  outputs: AudioOutputDetails[];
+}
+
 export interface StreamMetadata {
   // mandatory fields
   title: string;
@@ -1453,6 +1463,11 @@ export interface Player {
   // sleep_timer_expires_at: unix (utc) timestamp at which the active sleep timer
   // will stop playback, or null when no sleep timer is set.
   sleep_timer_expires_at: number | null;
+
+  // active_source_audio: audio-path snapshot for a live external source (e.g.
+  // Spotify Connect) playing on active_source; null while a queue item is
+  // playing instead, or while nothing is known yet. Absent on older servers.
+  active_source_audio?: ActiveSourceAudioDetails | null;
 }
 
 // provider

--- a/tests/components/QualityDetailsBtn.test.ts
+++ b/tests/components/QualityDetailsBtn.test.ts
@@ -7,7 +7,9 @@ import {
   CrossfadeMode,
   PlaybackState,
   type PlayerQueue,
+  type QueueItem,
   type StreamDetails,
+  VolumeNormalizationMode,
 } from "@/plugins/api/interfaces";
 import { i18n } from "@/plugins/i18n";
 import {
@@ -15,12 +17,15 @@ import {
   audioOutputDetails,
   audioProcessingChain,
 } from "../fixtures/audioProcessing";
+import { audioFormat } from "../fixtures/audioFormat";
 import { playerQueue } from "../fixtures/playerQueue";
 import { queueItem } from "../fixtures/queueItem";
 import { streamDetails } from "../fixtures/streamDetails";
 
 const storeMock = vi.hoisted(() => ({
+  activePlayer: undefined as { active_source_audio?: unknown } | undefined,
   activePlayerQueue: undefined as PlayerQueue | undefined,
+  curQueueItem: undefined as QueueItem | undefined,
 }));
 
 vi.mock("@/plugins/store", () => ({
@@ -36,7 +41,9 @@ vi.mock("@/components/AudioProcessingDetails.vue", () => ({
 
 beforeEach(() => {
   i18n.global.locale.value = "en";
+  storeMock.activePlayer = undefined;
   storeMock.activePlayerQueue = undefined;
+  storeMock.curQueueItem = undefined;
   document.body.innerHTML = "";
 });
 
@@ -104,6 +111,66 @@ describe("QualityDetailsBtn", () => {
       ).toBe(expectedMode);
     },
   );
+
+  describe("live external source, with no active queue item", () => {
+    it("renders the pill from the output quality range", () => {
+      storeMock.activePlayer = {
+        active_source_audio: {
+          input_format: audioFormat(),
+          input_fidelity: audioFidelity({ quality: AudioQuality.LOW }),
+          crossfade_mode: CrossfadeMode.DISABLED,
+          volume_normalization_mode: VolumeNormalizationMode.DISABLED,
+          outputs: [
+            outputWithQuality(AudioQuality.STANDARD),
+            outputWithQuality(AudioQuality.HI_RES),
+          ],
+        },
+      };
+
+      const wrapper = mountButton();
+
+      expect(wrapper.find('[data-testid="quality-popover"]').exists()).toBe(
+        true,
+      );
+      expect(wrapper.text()).toContain("SQ-HR");
+    });
+
+    it("falls back to the input fidelity before any output has reported one", () => {
+      storeMock.activePlayer = {
+        active_source_audio: {
+          input_format: audioFormat(),
+          input_fidelity: audioFidelity({ quality: AudioQuality.HI_RES }),
+          crossfade_mode: CrossfadeMode.DISABLED,
+          volume_normalization_mode: VolumeNormalizationMode.DISABLED,
+          outputs: [],
+        },
+      };
+
+      expect(mountButton().text()).toContain("HR");
+    });
+
+    it("never disables the trigger, since there is no queue to check", () => {
+      storeMock.activePlayer = {
+        active_source_audio: {
+          input_format: audioFormat(),
+          input_fidelity: audioFidelity(),
+          crossfade_mode: CrossfadeMode.DISABLED,
+          volume_normalization_mode: VolumeNormalizationMode.DISABLED,
+          outputs: [],
+        },
+      };
+
+      expect(mountButton().get("button").attributes("disabled")).toBeFalsy();
+    });
+
+    it("does not render on older servers that never send a source snapshot", () => {
+      storeMock.activePlayer = {};
+
+      expect(
+        mountButton().find('[data-testid="quality-popover"]').exists(),
+      ).toBe(false);
+    });
+  });
 
   it.each([
     { pill: false, side: "top" },
@@ -181,11 +248,15 @@ function makeStreamDetails(): StreamDetails {
   return streamDetails({ provider: "test", item_id: "track-1" });
 }
 
+/** Builds an active queue with the given stream details and wires it (and its
+ * current item) into the store mock, mirroring the real store's derivation. */
 function makeQueue(streamdetails: StreamDetails): PlayerQueue {
-  return playerQueue({
+  const queue = playerQueue({
     // the button stays hidden for an empty queue
     items: 1,
     state: PlaybackState.PLAYING,
     current_item: queueItem({ name: "Track", duration: 180, streamdetails }),
   });
+  storeMock.curQueueItem = queue.current_item ?? undefined;
+  return queue;
 }

--- a/tests/composables/useActiveAudioPath.test.ts
+++ b/tests/composables/useActiveAudioPath.test.ts
@@ -126,6 +126,52 @@ describe("useActiveAudioPath", () => {
     ]);
   });
 
+  it("hides the pill for an active queue item whose processing chain has not arrived yet", () => {
+    // an active queue item with no audio_processing yet must never fall back
+    // to a source snapshot, even a stale one left over from before the queue
+    // took over playback
+    storeMock.curQueueItem = queueItem({
+      streamdetails: streamDetails({ audio_processing: null }),
+    });
+    storeMock.activePlayerQueue = playerQueue();
+    storeMock.activePlayer = player({
+      active_source_audio: {
+        input_format: audioFormat(),
+        input_fidelity: audioFidelity({ quality: AudioQuality.HI_RES }),
+        crossfade_mode: CrossfadeMode.DISABLED,
+        volume_normalization_mode: VolumeNormalizationMode.DISABLED,
+        outputs: [],
+      },
+    });
+
+    const { activeAudioPath, hasActiveAudioPath } = useActiveAudioPath();
+
+    expect(activeAudioPath.value).toBeUndefined();
+    expect(hasActiveAudioPath.value).toBe(false);
+  });
+
+  it("resolves the provider from active_source when the source list entry is missing", () => {
+    // a sync/protocol child player may not carry the source_list entry
+    // itself, but active_source still carries the provider-prefixed id
+    storeMock.activePlayer = player({
+      active_source: "airplay_receiver--1://audio_source/main",
+      source_list: [],
+      active_source_audio: {
+        input_format: audioFormat(),
+        input_fidelity: audioFidelity(),
+        crossfade_mode: CrossfadeMode.DISABLED,
+        volume_normalization_mode: VolumeNormalizationMode.DISABLED,
+        outputs: [],
+      },
+    });
+
+    const { activeAudioPath } = useActiveAudioPath();
+
+    expect(activeAudioPath.value?.streamDetails.provider).toBe(
+      "airplay_receiver--1",
+    );
+  });
+
   it("marks crossfade and normalization as source-applied only in SOURCE mode", () => {
     storeMock.activePlayer = player({
       active_source_audio: {

--- a/tests/composables/useActiveAudioPath.test.ts
+++ b/tests/composables/useActiveAudioPath.test.ts
@@ -1,0 +1,232 @@
+import { reactive } from "vue";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  AudioQuality,
+  CrossfadeMode,
+  type Player,
+  type PlayerQueue,
+  type QueueItem,
+  VolumeNormalizationMode,
+} from "@/plugins/api/interfaces";
+import { audioFidelity, audioOutputDetails } from "../fixtures/audioProcessing";
+import { audioFormat } from "../fixtures/audioFormat";
+import { playerQueue } from "../fixtures/playerQueue";
+import { playerSource } from "../fixtures/playerSource";
+import { queueItem } from "../fixtures/queueItem";
+import { streamDetails } from "../fixtures/streamDetails";
+
+const storeMock = reactive({
+  activePlayer: undefined as Player | undefined,
+  activePlayerQueue: undefined as PlayerQueue | undefined,
+  curQueueItem: undefined as QueueItem | undefined,
+});
+
+vi.mock("@/plugins/store", () => ({ store: storeMock }));
+
+const { useActiveAudioPath } = await import("@/composables/useActiveAudioPath");
+
+/** A player with only the fields the composable reads. */
+function player(overrides: Partial<Player> = {}): Player {
+  return {
+    player_id: "player-1",
+    active_source: "player-1",
+    source_list: [],
+    ...overrides,
+  } as Player;
+}
+
+beforeEach(() => {
+  storeMock.activePlayer = player();
+  storeMock.activePlayerQueue = undefined;
+  storeMock.curQueueItem = undefined;
+});
+
+describe("useActiveAudioPath", () => {
+  it("reports no active path without a queue item or source snapshot", () => {
+    const { activeAudioPath, hasActiveAudioPath } = useActiveAudioPath();
+
+    expect(activeAudioPath.value).toBeUndefined();
+    expect(hasActiveAudioPath.value).toBe(false);
+  });
+
+  it("prefers the active queue item over a source snapshot", () => {
+    const details = streamDetails({
+      audio_processing: {
+        input_fidelity: audioFidelity({ quality: AudioQuality.LOSSLESS }),
+        queue_processing: null,
+        outputs: [],
+      },
+    });
+    storeMock.curQueueItem = queueItem({ streamdetails: details });
+    storeMock.activePlayerQueue = playerQueue({
+      crossfade_enabled: true,
+      smart_fades_active: true,
+    });
+    // a source snapshot is present too, but the queue item must win
+    storeMock.activePlayer = player({
+      active_source_audio: {
+        input_format: audioFormat(),
+        input_fidelity: audioFidelity({ quality: AudioQuality.HI_RES }),
+        crossfade_mode: CrossfadeMode.DISABLED,
+        volume_normalization_mode: VolumeNormalizationMode.DISABLED,
+        outputs: [],
+      },
+    });
+
+    const { activeAudioPath } = useActiveAudioPath();
+
+    expect(activeAudioPath.value).toEqual({
+      kind: "queue",
+      streamDetails: details,
+      audioProcessing: details.audio_processing,
+      crossfadeIntent: CrossfadeMode.SMART_CROSSFADE,
+    });
+  });
+
+  it("omits the source snapshot on older servers that never send it", () => {
+    // active_source_audio absent entirely, as an older server would send
+    storeMock.activePlayer = player();
+
+    const { activeAudioPath, hasActiveAudioPath } = useActiveAudioPath();
+
+    expect(activeAudioPath.value).toBeUndefined();
+    expect(hasActiveAudioPath.value).toBe(false);
+  });
+
+  it("resolves a live source snapshot when no queue item is active", () => {
+    const source = playerSource({
+      id: "spotify_connect--1://audio_source/main",
+      name: "Spotify Connect",
+    });
+    storeMock.activePlayer = player({
+      active_source: source.id,
+      source_list: [source],
+      active_source_audio: {
+        input_format: audioFormat({ sample_rate: 48000 }),
+        input_fidelity: audioFidelity({ quality: AudioQuality.LOSSLESS }),
+        crossfade_mode: CrossfadeMode.DISABLED,
+        volume_normalization_mode: VolumeNormalizationMode.DISABLED,
+        outputs: [audioOutputDetails()],
+      },
+    });
+
+    const { activeAudioPath, hasActiveAudioPath } = useActiveAudioPath();
+
+    expect(hasActiveAudioPath.value).toBe(true);
+    expect(activeAudioPath.value?.kind).toBe("source");
+    expect(activeAudioPath.value?.crossfadeIntent).toBeUndefined();
+    expect(activeAudioPath.value?.streamDetails.provider).toBe(
+      "spotify_connect--1",
+    );
+    expect(activeAudioPath.value?.audioProcessing.input_fidelity.quality).toBe(
+      AudioQuality.LOSSLESS,
+    );
+    expect(activeAudioPath.value?.audioProcessing.outputs).toEqual([
+      audioOutputDetails(),
+    ]);
+  });
+
+  it("marks crossfade and normalization as source-applied only in SOURCE mode", () => {
+    storeMock.activePlayer = player({
+      active_source_audio: {
+        input_format: audioFormat(),
+        input_fidelity: audioFidelity(),
+        crossfade_mode: CrossfadeMode.SOURCE,
+        volume_normalization_mode: VolumeNormalizationMode.SOURCE,
+        outputs: [],
+      },
+    });
+
+    const { activeAudioPath } = useActiveAudioPath();
+    const processing = activeAudioPath.value?.audioProcessing.queue_processing;
+
+    expect(processing?.crossfade_mode).toBe(CrossfadeMode.SOURCE);
+    expect(processing?.normalization?.mode).toBe(
+      VolumeNormalizationMode.SOURCE,
+    );
+  });
+
+  it("never fabricates crossfade or normalization outside SOURCE mode", () => {
+    storeMock.activePlayer = player({
+      active_source_audio: {
+        input_format: audioFormat(),
+        input_fidelity: audioFidelity(),
+        crossfade_mode: CrossfadeMode.STANDARD_CROSSFADE,
+        volume_normalization_mode: VolumeNormalizationMode.FIXED_GAIN,
+        outputs: [],
+      },
+    });
+
+    const { activeAudioPath } = useActiveAudioPath();
+    const processing = activeAudioPath.value?.audioProcessing.queue_processing;
+
+    expect(processing?.crossfade_mode).toBe(CrossfadeMode.DISABLED);
+    expect(processing?.normalization).toBeNull();
+  });
+
+  it("passes grouped outputs through unmodified", () => {
+    const outputs = [
+      audioOutputDetails({ player_ids: ["p1", "p2"] }),
+      audioOutputDetails({ player_ids: ["p3"] }),
+    ];
+    storeMock.activePlayer = player({
+      active_source_audio: {
+        input_format: audioFormat(),
+        input_fidelity: audioFidelity(),
+        crossfade_mode: CrossfadeMode.DISABLED,
+        volume_normalization_mode: VolumeNormalizationMode.DISABLED,
+        outputs,
+      },
+    });
+
+    const { activeAudioPath } = useActiveAudioPath();
+
+    expect(activeAudioPath.value?.audioProcessing.outputs).toEqual(outputs);
+  });
+
+  it("clears reactively when the source snapshot disappears", () => {
+    storeMock.activePlayer = player({
+      active_source_audio: {
+        input_format: audioFormat(),
+        input_fidelity: audioFidelity(),
+        crossfade_mode: CrossfadeMode.DISABLED,
+        volume_normalization_mode: VolumeNormalizationMode.DISABLED,
+        outputs: [],
+      },
+    });
+
+    const { activeAudioPath, hasActiveAudioPath } = useActiveAudioPath();
+    expect(hasActiveAudioPath.value).toBe(true);
+
+    storeMock.activePlayer!.active_source_audio = null;
+
+    expect(hasActiveAudioPath.value).toBe(false);
+    expect(activeAudioPath.value).toBeUndefined();
+  });
+
+  it("switches from a source snapshot to a queue item reactively", () => {
+    storeMock.activePlayer = player({
+      active_source_audio: {
+        input_format: audioFormat(),
+        input_fidelity: audioFidelity(),
+        crossfade_mode: CrossfadeMode.DISABLED,
+        volume_normalization_mode: VolumeNormalizationMode.DISABLED,
+        outputs: [],
+      },
+    });
+    const { activeAudioPath } = useActiveAudioPath();
+    expect(activeAudioPath.value?.kind).toBe("source");
+
+    const details = streamDetails({
+      audio_processing: {
+        input_fidelity: audioFidelity(),
+        queue_processing: null,
+        outputs: [],
+      },
+    });
+    storeMock.curQueueItem = queueItem({ streamdetails: details });
+    storeMock.activePlayerQueue = playerQueue();
+
+    expect(activeAudioPath.value?.kind).toBe("queue");
+  });
+});

--- a/tests/composables/useStreamQuality.test.ts
+++ b/tests/composables/useStreamQuality.test.ts
@@ -78,6 +78,34 @@ describe("stream quality presentation", () => {
     ).toBe(QualityTier.UNKNOWN);
   });
 
+  it("falls back to the input fidelity before any output has reported one", () => {
+    const quality = useStreamQuality(
+      ref(
+        audioProcessingChain({
+          input_fidelity: audioFidelity({ quality: AudioQuality.HI_RES }),
+          outputs: [],
+        }),
+      ),
+    );
+
+    expect(quality.minOutputQualityTier.value).toBe(QualityTier.HIRES);
+    expect(quality.maxOutputQualityTier.value).toBe(QualityTier.HIRES);
+  });
+
+  it("prefers a known output quality over the input fallback", () => {
+    const quality = useStreamQuality(
+      ref(
+        audioProcessingChain({
+          input_fidelity: audioFidelity({ quality: AudioQuality.HI_RES }),
+          outputs: [outputWithQuality(AudioQuality.STANDARD)],
+        }),
+      ),
+    );
+
+    expect(quality.minOutputQualityTier.value).toBe(QualityTier.GOOD);
+    expect(quality.maxOutputQualityTier.value).toBe(QualityTier.GOOD);
+  });
+
   it("returns unknown when all output qualities are unknown", () => {
     const quality = useStreamQuality(
       ref(

--- a/tests/layouts/PlayerFullscreenHeaderControls.test.ts
+++ b/tests/layouts/PlayerFullscreenHeaderControls.test.ts
@@ -1,5 +1,6 @@
 import PlayerFullscreenHeaderControls from "@/layouts/default/PlayerOSD/PlayerFullscreenHeaderControls.vue";
 import CrossfadeIcon from "@/layouts/default/PlayerOSD/PlayerControlBtn/CrossfadeIcon.vue";
+import QualityDetailsBtn from "@/components/QualityDetailsBtn.vue";
 import { CrossfadeMode, type PlayerQueue } from "@/plugins/api/interfaces";
 import { shallowMount } from "@vue/test-utils";
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -8,6 +9,7 @@ import { ref } from "vue";
 // Only what the crossfade control reads is mocked; the rest of the header is
 // stubbed out by shallowMount.
 const queue = ref<Partial<PlayerQueue> | undefined>(undefined);
+const hasActiveAudioPath = ref(false);
 
 vi.mock("@/plugins/api", () => ({
   default: {
@@ -19,6 +21,9 @@ vi.mock("@/plugins/api", () => ({
 vi.mock("@/plugins/store", () => ({ store: { mobileLayout: false } }));
 vi.mock("@/composables/useAudioOverlay", () => ({
   useAudioOverlay: () => ({ openOverlayDialog: vi.fn() }),
+}));
+vi.mock("@/composables/useActiveAudioPath", () => ({
+  useActiveAudioPath: () => ({ hasActiveAudioPath }),
 }));
 vi.mock("@/layouts/default/PlayerOSD/useQueueModes", () => ({
   useQueueModes: () => ({
@@ -69,6 +74,7 @@ function seedQueue(crossfadeMode: CrossfadeMode): void {
 describe("PlayerFullscreenHeaderControls", () => {
   beforeEach(() => {
     queue.value = undefined;
+    hasActiveAudioPath.value = false;
   });
 
   it("does not animate a fade the source applied", () => {
@@ -104,5 +110,21 @@ describe("PlayerFullscreenHeaderControls", () => {
     expect(text).toContain("Crossfade");
     expect(text).toContain("Applied by Spotify");
     expect(text).not.toContain("Disable crossfade");
+  });
+
+  it("shows the quality pill when there is an active audio path", () => {
+    hasActiveAudioPath.value = true;
+
+    expect(mountControls().findComponent(QualityDetailsBtn).exists()).toBe(
+      true,
+    );
+  });
+
+  it("hides the quality pill without an active audio path", () => {
+    hasActiveAudioPath.value = false;
+
+    expect(mountControls().findComponent(QualityDetailsBtn).exists()).toBe(
+      false,
+    );
   });
 });

--- a/tests/layouts/PlayerTrackDetails.test.ts
+++ b/tests/layouts/PlayerTrackDetails.test.ts
@@ -6,7 +6,7 @@ import { EMPTY_COLOR_PALETTE } from "@/helpers/utils";
 import { mount, type VueWrapper } from "@vue/test-utils";
 import { playerSource } from "../fixtures/playerSource";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { nextTick } from "vue";
+import { nextTick, ref } from "vue";
 import { createVuetify } from "vuetify";
 import * as components from "vuetify/components";
 import * as directives from "vuetify/directives";
@@ -45,6 +45,11 @@ vi.mock("@/helpers/now_playing", () => ({
   openCurrentTrackDetails: vi.fn(),
 }));
 
+const hasActiveAudioPath = ref(false);
+vi.mock("@/composables/useActiveAudioPath", () => ({
+  useActiveAudioPath: () => ({ hasActiveAudioPath }),
+}));
+
 vi.mock("@/plugins/store", async () => {
   const { reactive } = await vi.importActual<typeof import("vue")>("vue");
   return {
@@ -75,12 +80,18 @@ const NOW = 1_700_000_000;
 let wrapper: VueWrapper | undefined;
 
 // MarqueeText pulls in resize/intersection observers unrelated to this test.
-function mountDetails(compact: boolean, titleOpensDetails = false) {
+// QualityDetailsBtn is stubbed to keep these mounts focused on this
+// component's own gating, not the popover's internals.
+function mountDetails(
+  compact: boolean,
+  titleOpensDetails = false,
+  showQualityDetailsBtn = false,
+) {
   wrapper = mount(PlayerTrackDetails, {
     props: {
       compact,
       titleOpensDetails,
-      showQualityDetailsBtn: false,
+      showQualityDetailsBtn,
       colorPalette: EMPTY_COLOR_PALETTE,
     },
     global: {
@@ -91,6 +102,9 @@ function mountDetails(compact: boolean, titleOpensDetails = false) {
       },
       stubs: {
         MarqueeText: { template: "<span><slot /></span>" },
+        QualityDetailsBtn: {
+          template: '<div data-testid="quality-details-btn-stub" />',
+        },
       },
     },
   });
@@ -378,5 +392,43 @@ describe("PlayerTrackDetails source badge", () => {
     expect(details.get(".player-track-subtitle-text").text()).toContain(
       "Album",
     );
+  });
+});
+
+describe("PlayerTrackDetails quality pill", () => {
+  afterEach(() => {
+    wrapper?.unmount();
+    wrapper = undefined;
+    hasActiveAudioPath.value = false;
+  });
+
+  it("shows the pill on the full bar when there is an active audio path", () => {
+    hasActiveAudioPath.value = true;
+
+    const details = mountDetails(false, false, true);
+
+    expect(
+      details.find('[data-testid="quality-details-btn-stub"]').exists(),
+    ).toBe(true);
+  });
+
+  it("hides the pill without an active audio path", () => {
+    hasActiveAudioPath.value = false;
+
+    const details = mountDetails(false, false, true);
+
+    expect(
+      details.find('[data-testid="quality-details-btn-stub"]').exists(),
+    ).toBe(false);
+  });
+
+  it("respects the caller's showQualityDetailsBtn opt-out", () => {
+    hasActiveAudioPath.value = true;
+
+    const details = mountDetails(false, false, false);
+
+    expect(
+      details.find('[data-testid="quality-details-btn-stub"]').exists(),
+    ).toBe(false);
   });
 });


### PR DESCRIPTION
## What does this implement/fix?

The audio quality/audio-path pill only ever showed for a track playing from Music Assistant's own queue. When a player is instead casting from a live external source with no queue item (e.g. Spotify Connect), no quality info was shown at all.

This adds the pill for that case too, reusing the same popover and detail views, once the server reports a snapshot of the active source's audio path.

**Related backend PR (if applicable):**

- music-assistant/server#5963 (server-side `Player.active_source_audio` field)

## Types of changes

- [x] Enhancement to an existing feature — `enhancement`

## Changes

- Add the `ActiveSourceAudioDetails` wire type and `Player.active_source_audio`
- Add a shared `useActiveAudioPath` resolver so the pill's visibility and its popover content always agree, whether they come from the queue or a live source
- Fall back to the input fidelity for the compact quality label before any output has reported its own quality yet
- Reuse the existing popover/detail components unchanged, by adapting the source snapshot into the shape they already render
- Older servers that don't send this field yet keep working exactly as before

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm lint:check` passes.
- [x] `pnpm test:run` passes, and tests have been added/updated where applicable.
- [x] `pnpm build` passes.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.