### PR TITLE
Translate the provider stage badge

### DIFF
--- a/src/helpers/provider_config.test.ts
+++ b/src/helpers/provider_config.test.ts
@@ -1,7 +1,8 @@
-import { ProviderStatus } from "@/plugins/api/interfaces";
+import { ProviderStage, ProviderStatus } from "@/plugins/api/interfaces";
 import { describe, expect, it } from "vitest";
 import {
   canReconfigureProvider,
+  getProviderStageTranslationKey,
   getProviderStatusTranslationKey,
   getProviderSupportIssuesUrl,
   providerRequiresReconfiguration,
@@ -50,6 +51,20 @@ describe("provider configuration state", () => {
     [undefined, "settings.provider_status_unknown"],
   ])("maps provider status %s to %s", (status, expected) => {
     expect(getProviderStatusTranslationKey(status)).toBe(expected);
+  });
+
+  it.each([
+    [ProviderStage.ALPHA, "settings.stage.options.alpha"],
+    [ProviderStage.BETA, "settings.stage.options.beta"],
+    [ProviderStage.STABLE, "settings.stage.options.stable"],
+    [ProviderStage.EXPERIMENTAL, "settings.stage.options.experimental"],
+    [ProviderStage.UNMAINTAINED, "settings.stage.options.unmaintained"],
+    [ProviderStage.DEPRECATED, "settings.stage.options.deprecated"],
+    [undefined, undefined],
+    ["", undefined],
+    ["something_new", undefined],
+  ])("maps provider stage %s to %s", (stage, expected) => {
+    expect(getProviderStageTranslationKey(stage)).toBe(expected);
   });
 
   it.each([

--- a/src/helpers/provider_config.ts
+++ b/src/helpers/provider_config.ts
@@ -1,4 +1,4 @@
-import { ProviderStatus } from "@/plugins/api/interfaces";
+import { ProviderStage, ProviderStatus } from "@/plugins/api/interfaces";
 
 const PROVIDER_STATUS_TRANSLATION_KEYS: Record<ProviderStatus, string> = {
   [ProviderStatus.LOADED]: "settings.provider_status_loaded",
@@ -7,6 +7,15 @@ const PROVIDER_STATUS_TRANSLATION_KEYS: Record<ProviderStatus, string> = {
   [ProviderStatus.AUTH_REQUIRED]: "settings.provider_status_auth_required",
   [ProviderStatus.INCOMPATIBLE]: "settings.provider_status_incompatible",
   [ProviderStatus.ERROR]: "settings.provider_status_error",
+};
+
+const PROVIDER_STAGE_TRANSLATION_KEYS: Record<ProviderStage, string> = {
+  [ProviderStage.ALPHA]: "settings.stage.options.alpha",
+  [ProviderStage.BETA]: "settings.stage.options.beta",
+  [ProviderStage.STABLE]: "settings.stage.options.stable",
+  [ProviderStage.EXPERIMENTAL]: "settings.stage.options.experimental",
+  [ProviderStage.UNMAINTAINED]: "settings.stage.options.unmaintained",
+  [ProviderStage.DEPRECATED]: "settings.stage.options.deprecated",
 };
 
 // Support labels predate some provider domains and do not always use the same name.
@@ -42,6 +51,14 @@ export const getProviderStatusTranslationKey = (
 ) =>
   (status && PROVIDER_STATUS_TRANSLATION_KEYS[status]) ??
   "settings.provider_status_unknown";
+
+// Returns undefined for an absent or unrecognised stage so callers can skip the badge
+// entirely rather than render a raw key.
+export const getProviderStageTranslationKey = (
+  stage?: ProviderStage | string | null,
+) =>
+  (stage && PROVIDER_STAGE_TRANSLATION_KEYS[stage as ProviderStage]) ||
+  undefined;
 
 export const getProviderSupportIssuesUrl = (domain: string) => {
   const label = PROVIDER_SUPPORT_LABELS[domain] ?? domain;

--- a/src/helpers/provider_config.ts
+++ b/src/helpers/provider_config.ts
@@ -56,9 +56,15 @@ export const getProviderStatusTranslationKey = (
 // entirely rather than render a raw key.
 export const getProviderStageTranslationKey = (
   stage?: ProviderStage | string | null,
-) =>
-  (stage && PROVIDER_STAGE_TRANSLATION_KEYS[stage as ProviderStage]) ||
-  undefined;
+) => {
+  if (!stage) return undefined;
+  return Object.prototype.hasOwnProperty.call(
+    PROVIDER_STAGE_TRANSLATION_KEYS,
+    stage,
+  )
+    ? PROVIDER_STAGE_TRANSLATION_KEYS[stage as ProviderStage]
+    : undefined;
+};
 
 export const getProviderSupportIssuesUrl = (domain: string) => {
   const label = PROVIDER_SUPPORT_LABELS[domain] ?? domain;

--- a/src/views/settings/AddProviderDialog.vue
+++ b/src/views/settings/AddProviderDialog.vue
@@ -50,7 +50,7 @@
             </div>
             <div class="provider-actions">
               <Badge
-                v-if="getStageLabel(provider.stage)"
+                v-if="getProviderStageTranslationKey(provider.stage)"
                 :variant="getStageVariant(provider.stage)"
                 class="text-uppercase"
               >

--- a/src/views/settings/AddProviderDialog.vue
+++ b/src/views/settings/AddProviderDialog.vue
@@ -50,10 +50,11 @@
             </div>
             <div class="provider-actions">
               <Badge
+                v-if="getStageLabel(provider.stage)"
                 :variant="getStageVariant(provider.stage)"
                 class="text-uppercase"
               >
-                {{ $t(String(provider.stage || "").toLowerCase()) }}
+                {{ getStageLabel(provider.stage) }}
               </Badge>
               <ChevronRight class="h-4 w-4" />
             </div>
@@ -88,6 +89,7 @@ import {
   InputGroupInput,
 } from "@/components/ui/input-group";
 import { preventOnScreenKeyboardOnOpen } from "@/helpers/dialog_focus";
+import { getProviderStageTranslationKey } from "@/helpers/provider_config";
 import { api } from "@/plugins/api";
 import {
   ProviderConfig,
@@ -256,6 +258,11 @@ const addProvider = function (provider: ProviderManifest) {
     kind: "provider",
     domain: provider.domain,
   });
+};
+
+const getStageLabel = function (stage?: string) {
+  const key = getProviderStageTranslationKey(stage);
+  return key ? $t(key) : "";
 };
 
 const getStageVariant = function (

--- a/src/views/settings/Providers.vue
+++ b/src/views/settings/Providers.vue
@@ -105,13 +105,7 @@
               class="mx-1 text-uppercase"
               :color="getStageColor(api.providerManifests[item.domain]?.stage)"
             >
-              {{
-                $t(
-                  String(
-                    api.providerManifests[item.domain]?.stage || "",
-                  ).toLowerCase(),
-                )
-              }}
+              {{ getStageLabel(api.providerManifests[item.domain]?.stage) }}
             </v-chip>
           </div>
         </template>
@@ -180,13 +174,7 @@
               class="mx-1 text-uppercase"
               :color="getStageColor(api.providerManifests[item.domain]?.stage)"
             >
-              {{
-                $t(
-                  String(
-                    api.providerManifests[item.domain]?.stage || "",
-                  ).toLowerCase(),
-                )
-              }}
+              {{ getStageLabel(api.providerManifests[item.domain]?.stage) }}
             </v-chip>
 
             <v-btn
@@ -268,6 +256,7 @@ import { useBackgroundTasks } from "@/composables/background-tasks/useBackground
 import type { ContextMenuItem } from "@/helpers/context_menu_item";
 import {
   canReconfigureProvider,
+  getProviderStageTranslationKey,
   getProviderStatusTranslationKey,
   providerRequiresReconfiguration,
 } from "@/helpers/provider_config";
@@ -392,7 +381,14 @@ const canReconfigure = function (provider: ProviderConfig) {
 };
 
 const shouldShowStageBadge = function (stage?: ProviderStage) {
-  return !!stage && stage !== ProviderStage.STABLE;
+  return (
+    stage !== ProviderStage.STABLE && !!getProviderStageTranslationKey(stage)
+  );
+};
+
+const getStageLabel = function (stage?: ProviderStage) {
+  const key = getProviderStageTranslationKey(stage);
+  return key ? $t(key) : "";
 };
 
 onMounted(() => {

--- a/tests/views/AddProviderDialog.test.ts
+++ b/tests/views/AddProviderDialog.test.ts
@@ -6,6 +6,7 @@ import {
   type VueWrapper,
 } from "@vue/test-utils";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ProviderStage } from "@/plugins/api/interfaces";
 import { providerManifest } from "../fixtures/providerManifest";
 
 const { apiMock, storeMock } = vi.hoisted(() => ({
@@ -60,6 +61,36 @@ describe("AddProviderDialog", () => {
     expect(document.activeElement).toBe(
       document.querySelector("[data-slot='dialog-content']"),
     );
+  });
+
+  it("labels the stage badge from the translated stage key", async () => {
+    apiMock.providerManifests = {
+      local_audio: providerManifest({
+        domain: "local_audio",
+        name: "Local Audio Out",
+        stage: ProviderStage.DEPRECATED,
+      }),
+    };
+
+    await openDialog();
+
+    expect(document.querySelector("[data-slot='badge']")?.textContent).toBe(
+      "settings.stage.options.deprecated",
+    );
+  });
+
+  it("omits the stage badge for a manifest without a stage", async () => {
+    apiMock.providerManifests = {
+      spotify: providerManifest({
+        domain: "spotify",
+        name: "Spotify",
+        stage: undefined as unknown as ProviderStage,
+      }),
+    };
+
+    await openDialog();
+
+    expect(document.querySelector("[data-slot='badge']")).toBeNull();
   });
 });
 

--- a/tests/views/Providers.test.ts
+++ b/tests/views/Providers.test.ts
@@ -1,7 +1,7 @@
 import { flushPromises, shallowMount } from "@vue/test-utils";
 import { ref } from "vue";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { ProviderStatus } from "@/plugins/api/interfaces";
+import { ProviderStage, ProviderStatus } from "@/plugins/api/interfaces";
 import type { MusicAssistantApi } from "@/plugins/api";
 import Providers from "@/views/settings/Providers.vue";
 import { providerConfig } from "../fixtures/providerConfig";
@@ -87,12 +87,17 @@ const ListItemStub = {
   template: `
     <div data-testid="provider-row" @click="$emit('click')">
       <slot name="subtitle" />
+      <slot name="append" />
     </div>
   `,
 };
 
 const SlotStub = {
   template: "<div><slot /></div>",
+};
+
+const ChipStub = {
+  template: '<div data-testid="stage-badge"><slot /></div>',
 };
 
 const ButtonStub = {
@@ -107,6 +112,7 @@ const ButtonStub = {
 beforeEach(() => {
   vi.clearAllMocks();
   apiMock.getProvider.mockReturnValue(undefined);
+  apiMock.providerManifests.spotify.stage = ProviderStage.STABLE;
   apiMock.reloadProvider.mockResolvedValue(undefined);
   apiMock.subscribe.mockReturnValue(vi.fn());
 });
@@ -258,6 +264,22 @@ describe("Providers", () => {
       menuItems.map((item: { label: string }) => item.label),
     ).not.toContain("settings.reconfigure");
   });
+
+  it("labels the stage badge from the translated stage key", async () => {
+    apiMock.providerManifests.spotify.stage = ProviderStage.DEPRECATED;
+
+    const wrapper = await mountProviders(ProviderStatus.LOADED);
+
+    expect(wrapper.get('[data-testid="stage-badge"]').text()).toBe(
+      "settings.stage.options.deprecated",
+    );
+  });
+
+  it("hides the stage badge for a stable provider", async () => {
+    const wrapper = await mountProviders(ProviderStatus.LOADED);
+
+    expect(wrapper.find('[data-testid="stage-badge"]').exists()).toBe(false);
+  });
 });
 
 async function mountProviders(
@@ -295,6 +317,7 @@ async function mountProviders(
         Container: SlotStub,
         ListItem: ListItemStub,
         VBtn: ButtonStub,
+        VChip: ChipStub,
         VList: SlotStub,
       },
     },


### PR DESCRIPTION
The stage badge on the Providers list and in the Add Provider dialog translated the stage by passing the bare stage string as a key — `$t("deprecated")`. No locale defines a top-level `deprecated` / `alpha` / `beta` / `experimental` / `unmaintained` / `stable` key, so every lookup missed. The i18n plugin silences missing-key warnings, vue-i18n returns the key itself, and the badge's `text-uppercase` then makes the raw string read as a plausible English label. Every non-English user sees English.

The real keys are `settings.stage.options.<stage>`, already translated in all 20 locales and already used by the stage filter in `ProviderFilters.vue`. Point both surfaces at them.

- Add `getProviderStageTranslationKey` to `helpers/provider_config.ts`, alongside the existing `getProviderStatusTranslationKey`. It returns `undefined` for an absent or unrecognised stage so callers can skip the badge instead of rendering a raw key.
- Wire up all three badge sites — the list and card views in `Providers.vue`, and the dialog. The dialog had no stage guard at all, so its badge is now `v-if`-guarded; `shouldShowStageBadge` gains the same protection against an unknown stage.

Colours, placement and the stage filter are unchanged, and no new translation keys are added. A `deprecated` provider now shows a red badge reading *Deprecated* in `en`, *Veraltet* in `de`, *Obsolète* in `fr`.

Tests cover the helper's full stage table and assert the rendered badge text in both view suites, so a regression back to the bare-key lookup fails.