### PR TITLE
Remember the artist page view mode across all artists

### DIFF
--- a/src/views/ArtistDetails.vue
+++ b/src/views/ArtistDetails.vue
@@ -7,7 +7,7 @@
       <ItemsListing
         v-if="itemDetails && !loading && itemDetails.provider == 'library'"
         itemtype="artistalbums"
-        :path="`artistalbums.${itemId}.${provider}`"
+        path="artistalbums"
         :parent-item="itemDetails"
         :show-provider="true"
         :show-favorites-only-filter="true"
@@ -34,7 +34,7 @@
       <ItemsListing
         v-if="itemDetails && !loading && itemDetails.provider == 'library'"
         itemtype="artisttracks"
-        :path="`artisttracks.${itemId}.${provider}`"
+        path="artisttracks"
         :parent-item="itemDetails"
         :show-provider="true"
         :show-favorites-only-filter="true"
@@ -169,7 +169,7 @@
       <ItemsListing
         v-if="itemDetails && !loading && itemDetails.provider == 'library'"
         itemtype="artistaudiobooks"
-        :path="`artistaudiobooks.${itemId}.${provider}`"
+        path="artistaudiobooks"
         :parent-item="itemDetails"
         :show-provider="true"
         :show-favorites-only-filter="true"

--- a/tests/views/ArtistDetails.test.ts
+++ b/tests/views/ArtistDetails.test.ts
@@ -1,0 +1,99 @@
+import ArtistDetails from "@/views/ArtistDetails.vue";
+import type { MusicAssistantApi } from "@/plugins/api";
+import { ArtistType, type Artist } from "@/plugins/api/interfaces";
+import { flushPromises, mount, VueWrapper } from "@vue/test-utils";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { artist } from "../fixtures/artist";
+
+const { mockGetArtist, mockSubscribe } = vi.hoisted(() => ({
+  mockGetArtist: vi.fn<MusicAssistantApi["getArtist"]>(),
+  mockSubscribe: vi.fn(() => () => {}),
+}));
+
+vi.mock("@/plugins/api", () => ({
+  api: { getArtist: mockGetArtist, subscribe: mockSubscribe, providers: {} },
+}));
+
+vi.mock("@/components/InfoHeader.vue", () => ({
+  default: { name: "InfoHeader", template: "<div />" },
+}));
+vi.mock("@/components/ProviderDetails.vue", () => ({
+  default: { name: "ProviderDetails", template: "<div />" },
+}));
+vi.mock("@/components/MediaItemImages.vue", () => ({
+  default: { name: "MediaItemImages", template: "<div />" },
+}));
+// the stub renders path/itemtype so tests can read which preference key
+// (see userPreferences.ts's getItemsListingPreferences) each row was given
+vi.mock("@/components/ItemsListing.vue", () => ({
+  default: {
+    name: "ItemsListing",
+    props: ["path", "itemtype"],
+    template:
+      '<div class="items-listing-stub" :data-path="path" :data-itemtype="itemtype" />',
+  },
+}));
+
+async function mountDetails(item: Artist) {
+  mockGetArtist.mockResolvedValue(item);
+  const wrapper = mount(ArtistDetails, {
+    props: { itemId: item.item_id, provider: item.provider },
+    global: { mocks: { $t: (key: string) => key } },
+  });
+  await flushPromises();
+  return wrapper;
+}
+
+// resolves the persisted-preferences path for the listing row of the given
+// itemtype (there is at most one such row per artist in these fixtures)
+function pathFor(wrapper: VueWrapper, itemtype: string) {
+  return wrapper.find(`[data-itemtype="${itemtype}"]`).attributes("data-path");
+}
+
+describe("ArtistDetails", () => {
+  beforeEach(() => {
+    mockGetArtist.mockReset();
+    mockSubscribe.mockReset().mockReturnValue(() => {});
+  });
+
+  it("uses the same albums/tracks listing path for every library artist", async () => {
+    const wrapperA = await mountDetails(
+      artist({ item_id: "artist-a", provider: "library" }),
+    );
+    const wrapperB = await mountDetails(
+      artist({ item_id: "artist-b", provider: "library" }),
+    );
+
+    const albumsPathA = pathFor(wrapperA, "artistalbums");
+    const tracksPathA = pathFor(wrapperA, "artisttracks");
+
+    // the path must not embed the artist id, otherwise each artist gets its
+    // own view mode/sort/filter preferences instead of sharing one
+    expect(albumsPathA).not.toContain("artist-a");
+    expect(tracksPathA).not.toContain("artist-a");
+    expect(albumsPathA).toBe(pathFor(wrapperB, "artistalbums"));
+    expect(tracksPathA).toBe(pathFor(wrapperB, "artisttracks"));
+  });
+
+  it("uses the same audiobooks listing path for every library author/narrator artist", async () => {
+    const wrapperA = await mountDetails(
+      artist({
+        item_id: "author-a",
+        provider: "library",
+        artist_type: ArtistType.AUTHOR,
+      }),
+    );
+    const wrapperB = await mountDetails(
+      artist({
+        item_id: "author-b",
+        provider: "library",
+        artist_type: ArtistType.AUTHOR,
+      }),
+    );
+
+    const audiobooksPathA = pathFor(wrapperA, "artistaudiobooks");
+
+    expect(audiobooksPathA).not.toContain("author-a");
+    expect(audiobooksPathA).toBe(pathFor(wrapperB, "artistaudiobooks"));
+  });
+});


### PR DESCRIPTION
# What does this implement/fix?

On an artist page, the view mode you pick for "albums in library" and "tracks in library" (list, grid, compact grid) was only remembered for that one artist. Open another artist and it was back to the default. Every other listing on the page already remembers your choice once, for all artists.

The three "in library" listings saved their preferences under a key that included the artist id, so view mode, sort order, expand state and filters were all stored per artist. They now use a plain key like the listings next to them.

Also affects the "audiobooks in library" listing on author and narrator pages.

**Related issue (if applicable):**

- Reported on [Discord](https://discord.com/channels/753947050995089438/1083643113484070953/1541536916271399103)

**Related backend PR (if applicable):**

<!--
Link the music-assistant/server PR when this change relies on new server
behaviour, so the two can be reviewed and released together.
-->

- n/a

## Changes

- Artist page: "albums in library", "tracks in library" and "audiobooks in library" now remember view mode, sort order and filters once for all artists
- Added a regression test covering all three listings

## Types of changes

<!--
Tick exactly one box below. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm lint:check` passes.
- [x] `pnpm test:run` passes, and tests have been added/updated where applicable.
- [x] `pnpm build` passes.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
