### PR TITLE
Select a player once its setup/pairing flow finishes

### DIFF
--- a/src/components/SetupFlowDialog.vue
+++ b/src/components/SetupFlowDialog.vue
@@ -565,10 +565,10 @@ function applyStep(newStep: SetupFlowStep) {
   if (
     isTerminal.value &&
     !completionNotified &&
-    launch.value?.kind === "reconfigure"
+    (launch.value?.kind === "reconfigure" || launch.value?.kind === "player")
   ) {
     completionNotified = true;
-    launch.value.onFlowEnded?.();
+    launch.value.onFlowEnded?.(newStep.type === FlowStepType.FINISH);
   }
 
   if (newStep.type === FlowStepType.FORM) {

--- a/src/layouts/default/PlayerSelect.vue
+++ b/src/layouts/default/PlayerSelect.vue
@@ -417,16 +417,23 @@ function selectPlayer(player: Player) {
     eventbus.emit("setupFlowDialog", {
       kind: "player",
       playerId: player.player_id,
+      onFlowEnded: (finished) => {
+        if (finished) activatePlayer(player.player_id);
+      },
     });
     store.showPlayersMenu = false;
     return;
   }
+  activatePlayer(player.player_id);
+  store.showPlayersMenu = false;
+}
+
+function activatePlayer(playerId: string) {
   // remember it here as well: picking the player that was already selected
   // automatically leaves store.activePlayerId untouched
   autoSelectedPlayerId = undefined;
-  rememberPlayer(player.player_id);
-  store.activePlayerId = player.player_id;
-  store.showPlayersMenu = false;
+  rememberPlayer(playerId);
+  store.activePlayerId = playerId;
 }
 
 function showVolumeControl(player: Player) {

--- a/src/plugins/eventbus.ts
+++ b/src/plugins/eventbus.ts
@@ -84,6 +84,9 @@ export type PlayerRenameDialogEvent = {
   defaultName?: string | null;
 };
 
+// finished: the flow reached its last step, as opposed to being aborted
+export type SetupFlowEndedCallback = (finished: boolean) => void;
+
 // Launches the setup flow dialog for one of: adding a provider (by domain),
 // reconfiguring a provider instance, or setting up a player.
 export type SetupFlowDialogEvent =
@@ -91,9 +94,9 @@ export type SetupFlowDialogEvent =
   | {
       kind: "reconfigure";
       instanceId: string;
-      onFlowEnded?: () => void;
+      onFlowEnded?: SetupFlowEndedCallback;
     }
-  | { kind: "player"; playerId: string };
+  | { kind: "player"; playerId: string; onFlowEnded?: SetupFlowEndedCallback };
 
 export type Events = {
   contextmenu: ContextMenuDialogEvent;

--- a/src/plugins/eventbus.ts
+++ b/src/plugins/eventbus.ts
@@ -84,7 +84,7 @@ export type PlayerRenameDialogEvent = {
   defaultName?: string | null;
 };
 
-// finished: the flow reached its last step, as opposed to being aborted
+// finished: the flow ended on a FINISH step rather than an ABORT
 export type SetupFlowEndedCallback = (finished: boolean) => void;
 
 // Launches the setup flow dialog for one of: adding a provider (by domain),

--- a/tests/components/SetupFlowDialog.test.ts
+++ b/tests/components/SetupFlowDialog.test.ts
@@ -12,6 +12,7 @@ import {
   type SetupFlowStep,
 } from "@/plugins/api/interfaces";
 import type { MusicAssistantApi } from "@/plugins/api";
+import type { SetupFlowDialogEvent } from "@/plugins/eventbus";
 import SetupFlowDialog from "@/components/SetupFlowDialog.vue";
 
 const { apiMock, eventbusMock, routerMock, storeMock, toastMock } = vi.hoisted(
@@ -26,6 +27,7 @@ const { apiMock, eventbusMock, routerMock, storeMock, toastMock } = vi.hoisted(
         },
       },
       reconfigureProvider: vi.fn<MusicAssistantApi["reconfigureProvider"]>(),
+      setupPlayer: vi.fn<MusicAssistantApi["setupPlayer"]>(),
       state: {
         value: "authenticated",
       },
@@ -49,11 +51,7 @@ const { apiMock, eventbusMock, routerMock, storeMock, toastMock } = vi.hoisted(
 );
 
 let launchSetupFlow:
-  | ((event: {
-      kind: "reconfigure";
-      instanceId: string;
-      onFlowEnded: () => void;
-    }) => Promise<void>)
+  | ((event: SetupFlowDialogEvent) => Promise<void>)
   | undefined;
 
 vi.mock("@/plugins/api", () => ({
@@ -139,6 +137,27 @@ describe("SetupFlowDialog", () => {
       await flushPromises();
 
       expect(onFlowEnded).toHaveBeenCalledOnce();
+    },
+  );
+
+  it.each([
+    { type: FlowStepType.FINISH, finished: true },
+    { type: FlowStepType.ABORT, finished: false },
+  ])(
+    "reports finished=$finished when a player flow ends with $type",
+    async ({ type, finished }) => {
+      apiMock.setupPlayer.mockResolvedValue(terminalStep(type));
+      const onFlowEnded = vi.fn();
+      shallowMount(SetupFlowDialog);
+
+      await launchSetupFlow?.({
+        kind: "player",
+        playerId: "player-1",
+        onFlowEnded,
+      });
+      await flushPromises();
+
+      expect(onFlowEnded).toHaveBeenCalledExactlyOnceWith(finished);
     },
   );
 

--- a/tests/layouts/PlayerSelect.test.ts
+++ b/tests/layouts/PlayerSelect.test.ts
@@ -692,7 +692,48 @@ describe("PlayerSelect", () => {
     expect(emitEvent).toHaveBeenCalledWith("setupFlowDialog", {
       kind: "player",
       playerId: player.player_id,
+      onFlowEnded: expect.any(Function),
     });
+  });
+
+  it.each([
+    { finished: true, selected: "kitchen" },
+    { finished: false, selected: undefined },
+  ])(
+    "selects $selected when its setup flow reports finished=$finished",
+    async ({ finished, selected }) => {
+      const player = createPlayer("kitchen", "Kitchen");
+      player.available = false;
+      player.needs_setup = true;
+      api.players = { [player.player_id]: player };
+      const wrapper = mountPlayerSelect();
+
+      await wrapper.find(".select-player").trigger("click");
+      const event = emitEvent.mock.calls.at(-1)?.[1] as {
+        onFlowEnded: (finished: boolean) => void;
+      };
+      event.onFlowEnded(finished);
+
+      expect(store.activePlayerId).toBe(selected);
+    },
+  );
+
+  it("remembers the player its setup flow finished on", async () => {
+    const player = createPlayer("kitchen", "Kitchen");
+    player.needs_setup = true;
+    api.players = { [player.player_id]: player };
+    const wrapper = mountPlayerSelect();
+
+    await wrapper.find(".select-player").trigger("click");
+    const event = emitEvent.mock.calls.at(-1)?.[1] as {
+      onFlowEnded: (finished: boolean) => void;
+    };
+    event.onFlowEnded(true);
+
+    expect(setPreference).toHaveBeenCalledWith(
+      "activePlayerId",
+      player.player_id,
+    );
   });
 
   it("enables the detailed card layout only in the selector", () => {

--- a/tests/views/EditProvider.test.ts
+++ b/tests/views/EditProvider.test.ts
@@ -711,7 +711,7 @@ describe("EditProvider", () => {
     const setupFlowCall = eventbusMock.emit.mock.calls.find(
       ([event]) => event === "setupFlowDialog",
     );
-    setupFlowCall?.[1].onFlowEnded();
+    setupFlowCall?.[1].onFlowEnded(true);
     await flushPromises();
 
     expect(apiMock.getProviderConfig).toHaveBeenCalledTimes(2);

--- a/tests/views/Providers.test.ts
+++ b/tests/views/Providers.test.ts
@@ -167,7 +167,7 @@ describe("Providers", () => {
     const setupFlowCall = eventbusMock.emit.mock.calls.find(
       ([event]) => event === "setupFlowDialog",
     );
-    setupFlowCall?.[1].onFlowEnded();
+    setupFlowCall?.[1].onFlowEnded(true);
     await flushPromises();
     expect(apiMock.getProviderConfigs).toHaveBeenCalledTimes(2);
   });


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes. -->

Setting up a player from the player selector left it unselected once the flow finished, so you had to reopen the selector and pick it by hand.

The setup flow dialog now reports whether a flow finished or was aborted, and the player selector uses that to select the player it just set up. An abandoned setup leaves the current selection alone.

Flows launched from Settings, the player context menu, or the edit screen are unaffected, because selecting a player was never what those were asking for.

## Types of changes

<!--
Tick exactly one box below. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm lint:check` passes.
- [x] `pnpm test:run` passes, and tests have been added/updated where applicable.
- [x] `pnpm build` passes.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
