### PR TITLE
Continue setup as soon as you pick an option

### DIFF
--- a/src/components/SetupFlowDialog.vue
+++ b/src/components/SetupFlowDialog.vue
@@ -231,7 +231,12 @@
           <Button variant="ghost" :disabled="busy" @click="close()">
             {{ $t("cancel") }}
           </Button>
-          <Button :disabled="!canSubmit" @click="submit">
+          <!-- a step that submits on pick has nothing left to confirm -->
+          <Button
+            v-if="!autoAdvanceEntry"
+            :disabled="!canSubmit"
+            @click="submit"
+          >
             <Spinner v-if="busy" class="size-4" />
             {{
               step.last_step
@@ -239,6 +244,12 @@
                 : $t("settings.setup_flow.next")
             }}
           </Button>
+          <div
+            v-else-if="busy"
+            class="flex h-9 items-center justify-center px-4"
+          >
+            <Spinner class="size-4" />
+          </div>
         </template>
 
         <template
@@ -436,6 +447,19 @@ const canSubmit = computed(
   () => !busy.value && allRequiredValuesPresent(formEntries.value),
 );
 
+// A step whose only field is a required list of options has nothing else to
+// fill in, so picking one submits it.
+const autoAdvanceEntry = computed(() => {
+  const interactive = formEntries.value.filter(
+    (entry) => !NON_INTERACTIVE_ENTRY_TYPES.includes(entry.type),
+  );
+  if (interactive.length !== 1) return undefined;
+  const entry = interactive[0];
+  const isExpandedChoice =
+    entry.options.length > 0 && entry.expanded_options && !entry.multi_value;
+  return entry.required && isExpandedChoice ? entry : undefined;
+});
+
 const canOpenInstanceSettings = computed(
   () => launch.value?.kind === "provider" && !!step.value?.result?.instance_id,
 );
@@ -607,6 +631,10 @@ function buildForm(formStep: SetupFlowStep, preserveValues: boolean) {
 
 function onValueUpdate(entry: ConfigEntry, value: ConfigValueType) {
   entry.value = value;
+  if (entry.key === autoAdvanceEntry.value?.key) {
+    // submit() re-checks canSubmit, so the fresh value needs no validation here
+    void submit();
+  }
 }
 
 async function submit() {

--- a/src/components/SetupFlowDialog.vue
+++ b/src/components/SetupFlowDialog.vue
@@ -450,7 +450,7 @@ const canSubmit = computed(
 // A step whose only field is a required list of options has nothing else to
 // fill in, so picking one submits it.
 const autoAdvanceEntry = computed(() => {
-  const interactive = formEntries.value.filter(
+  const interactive = visibleFormEntries.value.filter(
     (entry) => !NON_INTERACTIVE_ENTRY_TYPES.includes(entry.type),
   );
   if (interactive.length !== 1) return undefined;

--- a/src/plugins/api/interfaces.ts
+++ b/src/plugins/api/interfaces.ts
@@ -699,7 +699,8 @@ export interface ConfigEntry {
   // multi_value [optional]: allow multiple values from the list
   multi_value?: boolean;
   // expanded_options [optional]: render the options inline - all of them, with their
-  // descriptions, visible at once (e.g. as a radio group) - instead of behind a dropdown.
+  // descriptions, visible at once - instead of behind a dropdown. A setup flow step whose
+  // only entry is a required one of these submits as soon as an option is picked.
   // Ignored when the entry has no options or is multi_value.
   expanded_options?: boolean;
   // depends_on [optional]: key of another entry that gates this one; an unresolved key counts

--- a/src/views/settings/ConfigEntryField.vue
+++ b/src/views/settings/ConfigEntryField.vue
@@ -161,7 +161,7 @@
       @click:clear="onClear"
     />
 
-    <!-- value with all options expanded: radio group -->
+    <!-- value with all options expanded: one button per option -->
     <RadioGroupField
       v-else-if="
         confEntry.options.length > 0 &&
@@ -170,7 +170,6 @@
       "
       :label="displayLabel()"
       :options="displayOptions"
-      :value="confEntry.value"
       :disabled="isFieldDisabled"
       @update:value="onUpdateValue($event)"
     />

--- a/src/views/settings/fields/RadioGroupField.vue
+++ b/src/views/settings/fields/RadioGroupField.vue
@@ -1,31 +1,20 @@
 <script setup lang="ts">
-import { Label } from "@/components/ui/label";
-import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
+import { Button } from "@/components/ui/button";
 import type {
   ConfigValueOption,
   ConfigValueType,
 } from "@/plugins/api/interfaces";
-import { computed, useId } from "vue";
+import { useId } from "vue";
 
-const props = defineProps<{
+defineProps<{
   label: string;
   options: ConfigValueOption[];
-  value?: ConfigValueType;
   disabled?: boolean;
 }>();
 
 const emit = defineEmits<{ "update:value": [value: ConfigValueType] }>();
 
-const groupId = useId();
-
-// the selection travels as the option's index: option values may be numbers, booleans or
-// null, none of which survive as a radio group's (string) model value
-const selectedIndex = computed(() => {
-  const index = props.options.findIndex(
-    (option) => option.value === props.value,
-  );
-  return index === -1 ? undefined : String(index);
-});
+const labelId = useId();
 
 const optionTitle = (option: ConfigValueOption) =>
   option.title?.toString() || option.value?.toString() || "";
@@ -33,46 +22,33 @@ const optionTitle = (option: ConfigValueOption) =>
 const optionHint = (option: ConfigValueOption) =>
   option.disabled ? option.disabled_reason : option.description;
 
-const onSelect = (index: unknown) => {
-  const option = props.options[Number(index)];
-  if (option) emit("update:value", option.value);
+const onPick = (option: ConfigValueOption) => {
+  emit("update:value", option.value);
 };
 </script>
 
 <template>
   <div class="flex w-full flex-col gap-2 py-1">
-    <span class="text-muted-foreground text-sm">{{ label }}</span>
-    <RadioGroup
-      :model-value="selectedIndex"
-      :disabled="disabled"
-      class="gap-2"
-      @update:model-value="onSelect"
-    >
-      <div
+    <span :id="labelId" class="text-muted-foreground text-sm">{{ label }}</span>
+    <div role="group" :aria-labelledby="labelId" class="flex flex-col gap-2">
+      <Button
         v-for="(option, index) of options"
         :key="index"
-        class="flex items-start gap-3 rounded-md border p-3"
-        :class="{ 'opacity-60': option.disabled }"
+        type="button"
+        variant="outline"
+        :disabled="disabled || option.disabled"
+        data-testid="option-button"
+        class="h-auto flex-col items-start gap-1 p-3 text-left whitespace-normal"
+        @click="onPick(option)"
       >
-        <RadioGroupItem
-          :id="`${groupId}-${index}`"
-          :value="String(index)"
-          :disabled="option.disabled"
-          class="mt-0.5"
-        />
-        <Label
-          :for="`${groupId}-${index}`"
-          class="flex flex-1 flex-col items-start gap-1 font-normal"
+        <span class="text-sm font-medium">{{ optionTitle(option) }}</span>
+        <span
+          v-if="optionHint(option)"
+          class="text-muted-foreground text-xs leading-relaxed whitespace-pre-wrap"
         >
-          <span class="text-sm font-medium">{{ optionTitle(option) }}</span>
-          <span
-            v-if="optionHint(option)"
-            class="text-muted-foreground text-xs leading-relaxed whitespace-pre-wrap"
-          >
-            {{ optionHint(option) }}
-          </span>
-        </Label>
-      </div>
-    </RadioGroup>
+          {{ optionHint(option) }}
+        </span>
+      </Button>
+    </div>
   </div>
 </template>

--- a/tests/components/SetupFlowDialog.test.ts
+++ b/tests/components/SetupFlowDialog.test.ts
@@ -306,7 +306,86 @@ describe("SetupFlowDialog", () => {
 
     expect(submitDisabled(wrapper)).toBe(true);
   });
+
+  it("submits a lone choice step as soon as an option is picked", async () => {
+    apiMock.submitSetupFlow.mockResolvedValue(progressStep("submitted"));
+    const wrapper = await mountFormStep([choiceEntry()]);
+
+    await pickOption(wrapper, "b");
+
+    expect(apiMock.submitSetupFlow).toHaveBeenCalledWith("flow-1", {
+      method: "b",
+    });
+  });
+
+  it("still auto-advances past a label sitting beside the choice", async () => {
+    apiMock.submitSetupFlow.mockResolvedValue(progressStep("submitted"));
+    const wrapper = await mountFormStep([
+      entry({ key: "intro", type: ConfigEntryType.LABEL }),
+      choiceEntry(),
+    ]);
+
+    await pickOption(wrapper, "b");
+
+    expect(apiMock.submitSetupFlow).toHaveBeenCalledOnce();
+  });
+
+  it("drops the confirm button from a step that submits on pick", async () => {
+    const wrapper = await mountFormStep([choiceEntry()]);
+
+    expect(stepFooterLabels(wrapper)).toEqual(["cancel"]);
+  });
+
+  it("shows progress while a step that submits on pick is in flight", async () => {
+    apiMock.submitSetupFlow.mockReturnValue(
+      new Promise<SetupFlowStep>(() => {}),
+    );
+    const wrapper = await mountFormStep([choiceEntry()]);
+
+    await pickOption(wrapper, "b");
+
+    expect(
+      wrapper.find("dialog-footer-stub").findAll("spinner-stub"),
+    ).toHaveLength(1);
+  });
+
+  it("leaves an optional choice to the confirm button", async () => {
+    const wrapper = await mountFormStep([
+      { ...choiceEntry(), required: false },
+    ]);
+
+    await pickOption(wrapper, "b");
+
+    expect(apiMock.submitSetupFlow).not.toHaveBeenCalled();
+    expect(stepFooterLabels(wrapper)).toEqual([
+      "cancel",
+      "settings.setup_flow.next",
+    ]);
+  });
+
+  it("waits for the button when a second field shares the form", async () => {
+    const wrapper = await mountFormStep([
+      choiceEntry(),
+      entry({ key: "note", type: ConfigEntryType.STRING }),
+    ]);
+
+    await pickOption(wrapper, "b");
+
+    expect(apiMock.submitSetupFlow).not.toHaveBeenCalled();
+  });
 });
+
+async function pickOption(wrapper: VueWrapper, value: string) {
+  const row = wrapper
+    .findAllComponents({ name: "ConfigEntryRow" })
+    .find(
+      (candidate) =>
+        (candidate.props("confEntry") as ConfigEntry).key === "method",
+    );
+  if (!row) throw new Error("choice entry not rendered");
+  row.vm.$emit("update:value", value);
+  await flushPromises();
+}
 
 async function mountFormStep(entries: ConfigEntry[]) {
   apiMock.reconfigureProvider.mockResolvedValue(formStep(entries));
@@ -322,6 +401,14 @@ async function mountFormStep(entries: ConfigEntry[]) {
   await flushPromises();
 
   return wrapper;
+}
+
+// the per-field help dialog carries a footer of its own, so scope to the step's
+function stepFooterLabels(wrapper: VueWrapper) {
+  return wrapper
+    .find("dialog-footer-stub")
+    .findAll("button-stub")
+    .map((btn) => btn.text());
 }
 
 function submitDisabled(wrapper: VueWrapper) {
@@ -350,6 +437,19 @@ function formStep(entries: ConfigEntry[] = []): SetupFlowStep {
     step_id: "form",
     type: FlowStepType.FORM,
   };
+}
+
+function choiceEntry(): ConfigEntry {
+  return entry({
+    key: "method",
+    type: ConfigEntryType.STRING,
+    required: true,
+    expanded_options: true,
+    options: [
+      { title: "Code", value: "a" },
+      { title: "Manual", value: "b" },
+    ],
+  });
 }
 
 function entry(

--- a/tests/components/SetupFlowDialog.test.ts
+++ b/tests/components/SetupFlowDialog.test.ts
@@ -363,6 +363,18 @@ describe("SetupFlowDialog", () => {
     ]);
   });
 
+  it("ignores a hidden field when deciding to submit on pick", async () => {
+    apiMock.submitSetupFlow.mockResolvedValue(progressStep("submitted"));
+    const wrapper = await mountFormStep([
+      entry({ key: "token", type: ConfigEntryType.STRING, hidden: true }),
+      choiceEntry(),
+    ]);
+
+    await pickOption(wrapper, "b");
+
+    expect(apiMock.submitSetupFlow).toHaveBeenCalledOnce();
+  });
+
   it("waits for the button when a second field shares the form", async () => {
     const wrapper = await mountFormStep([
       choiceEntry(),

--- a/tests/views/ConfigEntryField.test.ts
+++ b/tests/views/ConfigEntryField.test.ts
@@ -157,19 +157,29 @@ describe("ConfigEntryField", () => {
     const wrapper = mountField(expandedOptionsEntry());
 
     expect(wrapper.find(".v-select").exists()).toBe(false);
-    expect(radioItems(wrapper)).toHaveLength(2);
+    expect(optionButtons(wrapper)).toHaveLength(2);
     // the whole point of the branch: no option (or its description) is hidden behind a click
     expect(wrapper.text()).toContain("FLAC");
     expect(wrapper.text()).toContain("Lossless, at a higher bitrate.");
     expect(wrapper.text()).toContain("Not supported by this player.");
   });
 
-  it("emits the value of the option behind the picked radio", async () => {
+  it("emits the value of the option behind the pressed button", async () => {
     const wrapper = mountField(expandedOptionsEntry());
 
-    await radioItems(wrapper)[0].trigger("click");
+    await optionButtons(wrapper)[0].trigger("click");
 
     expect(wrapper.emitted("update:value")).toEqual([["flac"]]);
+  });
+
+  // the options sit inside the setup flow's form, where a default-type button submits it
+  it("keeps option buttons out of the form's submit path", () => {
+    const wrapper = mountField(expandedOptionsEntry());
+
+    expect(optionButtons(wrapper).map((el) => el.attributes("type"))).toEqual([
+      "button",
+      "button",
+    ]);
   });
 
   it("keeps a multi_value entry on the dropdown", () => {
@@ -180,10 +190,10 @@ describe("ConfigEntryField", () => {
     });
 
     expect(wrapper.find(".v-select").exists()).toBe(true);
-    expect(radioItems(wrapper)).toHaveLength(0);
+    expect(optionButtons(wrapper)).toHaveLength(0);
   });
 
-  it("disables every radio with the form", () => {
+  it("disables every option button with the form", () => {
     expect(controlStates(mountField(expandedOptionsEntry(), true))).toEqual([
       true,
       true,
@@ -311,8 +321,8 @@ function sliderRowStates(wrapper: VueWrapper): Record<string, boolean> {
   };
 }
 
-function radioItems(wrapper: VueWrapper): DOMWrapper<Element>[] {
-  return wrapper.findAll('[data-slot="radio-group-item"]');
+function optionButtons(wrapper: VueWrapper): DOMWrapper<Element>[] {
+  return wrapper.findAll('[data-testid="option-button"]');
 }
 
 function isDisabled(el: Pick<DOMWrapper<Element>, "attributes">): boolean {


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes. -->

Setup steps that ask a single question, like the Spotify playback backend or the Sendspin pairing method, still needed a press of Next after picking an option, even though the pick was the whole answer.

Picking an option now submits the step. Options render as buttons rather than radios, since a radio dot promises a confirm step that no longer exists, and the Next button is hidden on those steps because there is nothing left to confirm.

Which steps behave this way is inferred from the shape of the form: a single required entry with `expanded_options`.

<details>
<summary>Screenshots</summary>

Spotify connect setup:
<img width="640" height="525" alt="Screenshot 2026-08-25 at 09 45 18" src="https://github.com/user-attachments/assets/c517a906-bcfc-43f5-af7f-0065f2c221bc" />
Spotify connect setup spinner:
<img width="640" height="525" alt="Screenshot 2026-08-25 at 12 44 07" src="https://github.com/user-attachments/assets/d482eb3b-aaa7-4652-94dc-4374cf8715a4" />
Sendspin pairing method selector (light mode):
<img width="640" height="525" alt="Screenshot 2026-08-25 at 12 23 09" src="https://github.com/user-attachments/assets/c615494a-044d-47bf-9aa4-9692f5f8cf10" />
Sendspin pairing method selector (dark mode):
<img width="640" height="525" alt="Screenshot 2026-08-25 at 12 23 50" src="https://github.com/user-attachments/assets/4388c94f-cff7-496e-883c-d27d1257783d" />

</details>

## Types of changes

<!--
Tick exactly one box below. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm lint:check` passes.
- [x] `pnpm test:run` passes, and tests have been added/updated where applicable.
- [x] `pnpm build` passes.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
