### PR TITLE
Surface retired providers correctly in the settings UI

### DIFF
--- a/src/helpers/provider_config.test.ts
+++ b/src/helpers/provider_config.test.ts
@@ -54,6 +54,34 @@ describe("provider configuration state", () => {
   });
 
   it.each([
+    [
+      ProviderStatus.INCOMPATIBLE,
+      ProviderStage.DEPRECATED,
+      "settings.provider_status_retired",
+    ],
+    [
+      ProviderStatus.INCOMPATIBLE,
+      ProviderStage.STABLE,
+      "settings.provider_status_incompatible",
+    ],
+    [
+      ProviderStatus.INCOMPATIBLE,
+      undefined,
+      "settings.provider_status_incompatible",
+    ],
+    // only INCOMPATIBLE is ambiguous; a deprecated provider that still loads
+    // keeps its own status
+    [
+      ProviderStatus.LOADED,
+      ProviderStage.DEPRECATED,
+      "settings.provider_status_loaded",
+    ],
+    [undefined, ProviderStage.DEPRECATED, "settings.provider_status_unknown"],
+  ])("maps status %s at stage %s to %s", (status, stage, expected) => {
+    expect(getProviderStatusTranslationKey(status, stage)).toBe(expected);
+  });
+
+  it.each([
     [ProviderStage.ALPHA, "settings.stage.options.alpha"],
     [ProviderStage.BETA, "settings.stage.options.beta"],
     [ProviderStage.STABLE, "settings.stage.options.stable"],

--- a/src/helpers/provider_config.ts
+++ b/src/helpers/provider_config.ts
@@ -46,11 +46,22 @@ export const providerRequiresReconfiguration = (
   status === ProviderStatus.AUTH_REQUIRED &&
   canReconfigureProvider(status, hasSetupFlow, enabled);
 
+// A retired provider fails to load as INCOMPATIBLE (the server reuses
+// UnsupportedSystemError), so the stage is what tells the two apart.
 export const getProviderStatusTranslationKey = (
   status?: ProviderStatus | null,
-) =>
-  (status && PROVIDER_STATUS_TRANSLATION_KEYS[status]) ??
-  "settings.provider_status_unknown";
+  stage?: ProviderStage | string | null,
+) => {
+  if (
+    status === ProviderStatus.INCOMPATIBLE &&
+    stage === ProviderStage.DEPRECATED
+  )
+    return "settings.provider_status_retired";
+  return (
+    (status && PROVIDER_STATUS_TRANSLATION_KEYS[status]) ??
+    "settings.provider_status_unknown"
+  );
+};
 
 // Returns undefined for an absent or unrecognised stage so callers can skip the badge
 // entirely rather than render a raw key.

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -676,6 +676,7 @@
         },
         "provider_status_auth_required": "Authentication required",
         "provider_status_incompatible": "Not supported on this system",
+        "provider_status_retired": "Retired",
         "provider_status_error": "Setup failed",
         "remove_provider": "Remove provider",
         "remove_provider_confirm": "Remove this provider? This cannot be undone.",

--- a/src/views/settings/AddProviderDialog.vue
+++ b/src/views/settings/AddProviderDialog.vue
@@ -155,17 +155,19 @@ const providerStageOptions = computed(() => [
     label: $t("settings.stage.options.unmaintained"),
     value: ProviderStage.UNMAINTAINED,
   },
-  {
-    label: $t("settings.stage.options.deprecated"),
-    value: ProviderStage.DEPRECATED,
-  },
+  // no deprecated option: those providers never reach this list
 ]);
 
 const availableProviders = computed(() => {
   let providers = Object.values(api.providerManifests);
 
+  // a deprecated provider is retired: it can no longer be set up, so keep it
+  // out of the list even though it is no longer builtin
   providers = providers.filter(
-    (x) => !x.builtin && x.type !== ("core" as ProviderType),
+    (x) =>
+      !x.builtin &&
+      x.type !== ("core" as ProviderType) &&
+      x.stage !== ProviderStage.DEPRECATED,
   );
 
   return providers

--- a/src/views/settings/EditProvider.vue
+++ b/src/views/settings/EditProvider.vue
@@ -36,14 +36,14 @@
           <div class="font-semibold">
             {{ $t("settings.provider_requires_attention") }}
           </div>
-          <div
-            class="mt-0.5 text-sm whitespace-pre-wrap break-words opacity-90"
-          >
-            {{
+          <!-- markdown: a retirement message links to the replacement add-on -->
+          <MarkdownText
+            class="mt-0.5 text-sm opacity-90"
+            :text="
               config.last_error?.message ||
-              $t("settings.provider_status_auth_required")
-            }}
-          </div>
+              $t('settings.provider_status_auth_required')
+            "
+          />
           <div
             v-if="
               config.status === ProviderStatus.INCOMPATIBLE ||
@@ -283,6 +283,7 @@
 </template>
 
 <script setup lang="ts">
+import MarkdownText from "@/components/MarkdownText.vue";
 import ProviderIcon from "@/components/ProviderIcon.vue";
 import ProviderSaveErrorDialog from "@/components/ProviderSaveErrorDialog.vue";
 import { Badge } from "@/components/ui/badge";
@@ -394,7 +395,12 @@ const canToggleEnabled = computed(
 );
 
 const providerStatusLabel = computed(() =>
-  t(getProviderStatusTranslationKey(config.value?.status)),
+  t(
+    getProviderStatusTranslationKey(
+      config.value?.status,
+      providerManifest.value?.stage,
+    ),
+  ),
 );
 
 const providerStatusClass = computed(() =>

--- a/src/views/settings/Providers.vue
+++ b/src/views/settings/Providers.vue
@@ -93,7 +93,7 @@
               :title="
                 isErrorStatus(item.status)
                   ? getErrorText(item)
-                  : statusLabel(item.status)
+                  : statusLabel(item)
               "
             />
             <v-chip
@@ -156,7 +156,7 @@
               :title="
                 isErrorStatus(item.status)
                   ? getErrorText(item)
-                  : statusLabel(item.status)
+                  : statusLabel(item)
               "
             >
               <v-icon
@@ -200,9 +200,7 @@
                 size="16"
                 :color="statusColor(item.status)"
               />
-              <span class="provider-error-text">{{
-                statusLabel(item.status)
-              }}</span>
+              <span class="provider-error-text">{{ statusLabel(item) }}</span>
             </div>
             <div class="provider-error-detail mt-1">
               {{ getErrorText(item) }}
@@ -601,8 +599,13 @@ const statusColor = function (status?: ProviderStatus | null) {
     .otherwise(() => "grey");
 };
 
-const statusLabel = function (status?: ProviderStatus | null) {
-  return $t(getProviderStatusTranslationKey(status));
+const statusLabel = function (item: ProviderConfig) {
+  return $t(
+    getProviderStatusTranslationKey(
+      item.status,
+      api.providerManifests[item.domain]?.stage,
+    ),
+  );
 };
 
 // an error status carries a (user-relevant) reason in last_error

--- a/tests/views/AddProviderDialog.test.ts
+++ b/tests/views/AddProviderDialog.test.ts
@@ -65,18 +65,37 @@ describe("AddProviderDialog", () => {
 
   it("labels the stage badge from the translated stage key", async () => {
     apiMock.providerManifests = {
-      local_audio: providerManifest({
-        domain: "local_audio",
-        name: "Local Audio Out",
-        stage: ProviderStage.DEPRECATED,
+      soundcloud: providerManifest({
+        domain: "soundcloud",
+        name: "SoundCloud",
+        stage: ProviderStage.UNMAINTAINED,
       }),
     };
 
     await openDialog();
 
     expect(document.querySelector("[data-slot='badge']")?.textContent).toBe(
-      "settings.stage.options.deprecated",
+      "settings.stage.options.unmaintained",
     );
+  });
+
+  it("omits a deprecated provider from the list", async () => {
+    apiMock.providerManifests = {
+      local_audio: providerManifest({
+        domain: "local_audio",
+        name: "Local Audio Out",
+        stage: ProviderStage.DEPRECATED,
+      }),
+      spotify: providerManifest({ domain: "spotify", name: "Spotify" }),
+    };
+
+    await openDialog();
+
+    // a retired provider can no longer be set up, so it must not be offered
+    const names = [...document.querySelectorAll(".provider-name")].map(
+      (el) => el.textContent,
+    );
+    expect(names).toEqual(["Spotify"]);
   });
 
   it("omits the stage badge for a manifest without a stage", async () => {

--- a/tests/views/EditProvider.test.ts
+++ b/tests/views/EditProvider.test.ts
@@ -76,12 +76,18 @@ vi.mock("@/plugins/eventbus", () => ({
   eventbus: eventbusMock,
 }));
 
-vi.mock("@/helpers/utils", () => ({
-  getExternalLinkUrl: (url?: string) =>
-    url?.startsWith("http://") || url?.startsWith("https://") ? url : undefined,
-  markdownToHtml: (value: string) => value,
-  openActionUrlEntries: <T>(entries: T) => entries,
-}));
+vi.mock("@/helpers/utils", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/helpers/utils")>();
+  return {
+    getExternalLinkUrl: (url?: string) =>
+      url?.startsWith("http://") || url?.startsWith("https://")
+        ? url
+        : undefined,
+    // the real renderer, so the error banner's markdown is assertable
+    markdownToHtml: actual.markdownToHtml,
+    openActionUrlEntries: <T>(entries: T) => entries,
+  };
+});
 
 vi.mock("@/plugins/i18n", () => ({
   $t: (key: string) => key,
@@ -718,6 +724,34 @@ describe("EditProvider", () => {
     expect(wrapper.text()).not.toContain(
       "settings.provider_requires_attention",
     );
+  });
+
+  it("renders a markdown link in the provider error banner", async () => {
+    // a retired provider's message points at its replacement, so the link has
+    // to survive into the banner
+    const config = spotifyConfig(ProviderStatus.INCOMPATIBLE);
+    config.last_error = {
+      error_code: 1,
+      message:
+        "This provider is retired. Use the [Local Audio add-on](https://example.com/addon) instead.",
+    };
+    apiMock.getProviderConfig.mockResolvedValue(config);
+
+    const wrapper = shallowMount(EditProvider, {
+      props: {
+        instanceId: "spotify--test",
+      },
+      global: {
+        mocks: {
+          $t: (key: string) => key,
+        },
+        stubs: { ...providerDetailsStubs, MarkdownText: false },
+      },
+    });
+    await flushPromises();
+
+    const link = wrapper.get("a[href='https://example.com/addon']");
+    expect(link.text()).toBe("Local Audio add-on");
   });
 
   it("keeps a pending local edit and shows a toast when an action returns no entries", async () => {


### PR DESCRIPTION
# What does this implement/fix?

Frontend half of retiring the built-in Local Audio Out provider.

Server-side, a retired provider is a manifest at stage `deprecated` whose `setup()`
raises `UnsupportedSystemError` carrying a localized retirement message with a markdown
link to the replacement add-on. That maps to `ProviderStatus.INCOMPATIBLE`, which is
permanent and which `EditProvider.vue` already renders with a Remove button. No new error
or status was added to `music-assistant/models`, which leaves three gaps here:

1. **Keep deprecated providers out of the Add Provider dialog.** The retired provider
   loses its `builtin: true` server-side (it has to, so users can remove it), which would
   have made it appear in the add list for the first time — the opposite of what we want.
   `availableProviders` now excludes `ProviderStage.DEPRECATED`. The server also aborts
   `config/providers/setup` for a deprecated manifest, so this is defence in depth.

   I also **removed the `Deprecated` stage filter chip**. With the list filter in place
   that chip can never match anything, so selecting it would just empty the list with no
   way to tell that from "no results" — a dead-end control is worse than a missing one.
   The stage filter resets when the dialog closes, so there is no persisted selection that
   could get stuck on the removed option.

2. **Render the provider error banner as markdown.** The retirement message's link to the
   add-on is the whole point of the message, so it needs to be clickable.
   `EditProvider.vue`'s banner body now goes through `MarkdownText`, the same component
   `SetupFlowDialog.vue` already uses for a setup-flow ABORT reason. The banner keeps its
   layout, icon and destructive colouring; `whitespace-pre-wrap` is dropped because
   `markdownToHtml` already renders with `breaks: true`.

   The list-row error text in `Providers.vue` stays plain text — a truncated cell in a
   list is not the place for a link.

3. **Label a retired provider "Retired", not "Not supported on this system".** This is the
   one real cost of reusing `UnsupportedSystemError`.
   `getProviderStatusTranslationKey` is now stage-aware: `INCOMPATIBLE` at stage
   `deprecated` returns a new `settings.provider_status_retired` key, everything else is
   unchanged. The stage argument is optional, so callers without a manifest still work.
   Both existing call sites (`Providers.vue`, `EditProvider.vue`) already had the manifest
   in hand by domain, so there is no new plumbing.

Only `en.json` gains the new string — the other locale files are Lokalise-managed.

> [!IMPORTANT]
> **Stacked on #2629** ("Translate the provider stage badge"), which touches the same
> three files and is not merged yet. Please merge #2629 first — this PR is branched off it,
> not off `main`.

**Related issue (if applicable):**

- n/a

**Related backend PR (if applicable):**

- related backend PR https://github.com/music-assistant/server/pull/5965

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm lint:check` passes.
- [x] `pnpm test:run` passes, and tests have been added/updated where applicable.
- [x] `pnpm build` passes.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.