### PR TITLE
Shuffle and repeat no longer apply to something that stopped playing

### DIFF
--- a/src/composables/activeSource.ts
+++ b/src/composables/activeSource.ts
@@ -2,6 +2,21 @@ import { computed, ComputedRef, Ref } from "vue";
 import { Player, PlayerSource } from "@/plugins/api/interfaces";
 
 /**
+ * The id of the source a player is playing, as the server resolves it.
+ *
+ * Music Assistant's own queue is listed under the player's own id, so that is
+ * the answer when nothing has taken the player over. A player hearing its sync
+ * leader or group reports that leader's source, which is also what a command
+ * issued to it applies to.
+ *
+ * Pass this to a command that names the source it is aimed at, so it cannot
+ * land on whatever took the player since.
+ */
+export function resolveActiveSourceId(player: Player): string {
+  return player.active_source || player.player_id;
+}
+
+/**
  * Composable to get the active source from a player
  */
 export function useActiveSource(
@@ -15,7 +30,7 @@ export function useActiveSource(
     const playerObj =
       typeof player === "object" && "value" in player ? player.value : player;
     if (!playerObj?.source_list) return undefined;
-    const activeSourceId = playerObj.active_source || playerObj.player_id;
+    const activeSourceId = resolveActiveSourceId(playerObj);
     return playerObj.source_list.find((source) => source.id === activeSourceId);
   });
 

--- a/src/composables/externalSource.ts
+++ b/src/composables/externalSource.ts
@@ -13,9 +13,9 @@ import { Player, PlayerQueue, PlayerSource } from "@/plugins/api/interfaces";
  *
  * Unlike `useActiveSource`, which answers with whichever source list entry is
  * active and so happily returns the Music Assistant queue's own entry, this
- * narrows to a source that has genuinely taken the player over — callers route
- * a command on the answer rather than merely greying a control out, and sending
- * an MA queue's shuffle to the player command would be wrong.
+ * narrows to a source that has genuinely taken the player over — callers read
+ * what a control shows off the answer, and a queue's own state lives on the
+ * PlayerQueue rather than on its source entry.
  *
  * Pass the queue belonging to the same player, i.e. `resolvePlayerQueue(player)`.
  */

--- a/src/helpers/player_menu_items.ts
+++ b/src/helpers/player_menu_items.ts
@@ -12,6 +12,7 @@ import {
 } from "@/plugins/api/interfaces";
 import { getSleepTimerMenuItem, sleepTimerActive } from "@/helpers/sleep_timer";
 import { resolveExternalSource } from "@/composables/externalSource";
+import { resolveActiveSourceId } from "@/composables/activeSource";
 import { useAnnouncement } from "@/composables/useAnnouncement";
 import { useAudioOverlay } from "@/composables/useAudioOverlay";
 import { visualizerProviderAvailable } from "@/plugins/visualizer-relay";
@@ -115,6 +116,10 @@ export const getPlayerMenuItems = (
     : undefined;
   const repeatSource = externalSource?.can_repeat ? externalSource : undefined;
   const orderableQueue = playerQueue && !isDynamic ? playerQueue : undefined;
+  // the source the shuffle/repeat entries below are built for. Naming it on the
+  // command lets the server refuse one whose source stopped playing while the
+  // menu sat open, rather than let it land on whatever took the player since.
+  const commandSourceId = resolveActiveSourceId(player);
 
   // shuffle (queue menu only; hidden when the dedicated control is visible)
   if (isQueue && (shuffleSource || orderableQueue) && !hideShuffleRepeat) {
@@ -126,25 +131,12 @@ export const getPlayerMenuItems = (
       labelArgs: [],
       action: () => {
         // the menu can sit open while the state moves, and an update lands as
-        // an Object.assign onto these, so both the target and the value are
-        // settled at click time — the source list is a fresh array by then,
-        // hence the re-resolve
-        if (shuffleSource) {
-          const current = resolveExternalSource(player, playerQueue);
-          // the source can end while the menu sits open, and the queue that
-          // takes the player back would otherwise be shuffled by a command
-          // meant for the session — with the value the entry offered inverted
-          if (!current?.can_shuffle) return;
-          api.playerCommandShuffle(
-            player.player_id,
-            current.shuffle_enabled !== true,
-          );
-        } else {
-          api.queueCommandShuffle(
-            orderableQueue!.queue_id,
-            !orderableQueue!.shuffle_enabled,
-          );
-        }
+        // an Object.assign onto these, so the value is settled at click time —
+        // the source list is a fresh array by then, hence the re-resolve
+        const enabled = shuffleSource
+          ? resolveExternalSource(player, playerQueue)?.shuffle_enabled === true
+          : orderableQueue!.shuffle_enabled === true;
+        api.playerCommandShuffle(player.player_id, !enabled, commandSourceId);
       },
       icon: shuffleEnabled ? "mdi-shuffle-disabled" : "mdi-shuffle",
     });
@@ -156,18 +148,6 @@ export const getPlayerMenuItems = (
     const repeatMode = repeatSource
       ? (repeatSource.repeat_mode ?? RepeatMode.OFF)
       : orderableQueue!.repeat_mode;
-    // each entry sets an explicit mode, so only the target of the command has
-    // to be settled at click time rather than the mode itself
-    const setRepeatMode = (mode: RepeatMode) => {
-      if (repeatSource) {
-        // the source can end while the menu sits open; a mode meant for its
-        // session must not land on the queue that took the player back
-        if (!resolveExternalSource(player, playerQueue)?.can_repeat) return;
-        api.playerCommandRepeat(player.player_id, mode);
-      } else {
-        api.queueCommandRepeat(orderableQueue!.queue_id, mode);
-      }
-    };
     menuItems.push({
       label: "select_repeat_mode",
       labelArgs: [],
@@ -182,7 +162,7 @@ export const getPlayerMenuItems = (
         label,
         labelArgs: [],
         action: () => {
-          setRepeatMode(mode);
+          api.playerCommandRepeat(player.player_id, mode, commandSourceId);
         },
         selected: repeatMode == mode,
       })),

--- a/src/layouts/default/PlayerOSD/PlayerControlBtn/RepeatBtn.vue
+++ b/src/layouts/default/PlayerOSD/PlayerControlBtn/RepeatBtn.vue
@@ -24,6 +24,7 @@ defineOptions({ inheritAttrs: false });
 import Icon, { IconProps } from "@/components/Icon.vue";
 import { getValueFromSources } from "@/helpers/utils";
 import { useExternalSource } from "@/composables/externalSource";
+import { resolveActiveSourceId } from "@/composables/activeSource";
 import api from "@/plugins/api";
 import { Player, PlayerQueue, RepeatMode } from "@/plugins/api/interfaces";
 import { isQueueInfiniteStream } from "@/plugins/api/helpers";
@@ -88,6 +89,8 @@ const nextRepeatMode = computed<RepeatMode>(() => {
 // the queue's own reasons for being unavailable.
 const isDisabled = computed(() => {
   if (isLoading.value) return true;
+  // the command is addressed to the player, so there is nothing to send without one
+  if (!compProps.player) return true;
   if (orderingSource.value) return false;
   return (
     !compProps.playerQueue ||
@@ -102,14 +105,15 @@ const repeatTitle = computed<string | undefined>(() =>
   isDynamic.value ? $t("repeat_dynamic_unavailable") : undefined,
 );
 
+// The command names the source the mode being cycled was read from, so it
+// applies to whatever is playing — the live session or the queue — and never to
+// something that took the player in between.
 function cycleRepeatMode() {
-  if (orderingSource.value && compProps.player) {
-    api.playerCommandRepeat(compProps.player.player_id, nextRepeatMode.value);
-    return;
-  }
-  api.queueCommandRepeat(
-    compProps.playerQueue?.queue_id || "",
+  if (!compProps.player) return;
+  api.playerCommandRepeat(
+    compProps.player.player_id,
     nextRepeatMode.value,
+    resolveActiveSourceId(compProps.player),
   );
 }
 </script>

--- a/src/layouts/default/PlayerOSD/PlayerControlBtn/RepeatBtn.vue
+++ b/src/layouts/default/PlayerOSD/PlayerControlBtn/RepeatBtn.vue
@@ -49,9 +49,9 @@ const { externalSource } = useExternalSource(
   toRef(compProps, "playerQueue"),
 );
 
-// An external source that repeats within its own session takes the command
-// instead of the queue; one that cannot leaves the button disabled rather than
-// silently inert.
+// The mode shown comes from an external source that repeats within its own
+// session; one that cannot leaves the button disabled rather than silently
+// inert.
 const orderingSource = computed(() =>
   externalSource.value?.can_repeat ? externalSource.value : undefined,
 );

--- a/src/layouts/default/PlayerOSD/PlayerControlBtn/ShuffleBtn.vue
+++ b/src/layouts/default/PlayerOSD/PlayerControlBtn/ShuffleBtn.vue
@@ -24,6 +24,7 @@ import Icon, { IconProps } from "@/components/Icon.vue";
 import ShuffleIcon from "@/layouts/default/PlayerOSD/PlayerControlBtn/ShuffleIcon.vue";
 import { getValueFromSources } from "@/helpers/utils";
 import { useExternalSource } from "@/composables/externalSource";
+import { resolveActiveSourceId } from "@/composables/activeSource";
 import api from "@/plugins/api";
 import { isQueueInfiniteStream } from "@/plugins/api/helpers";
 import { Player, PlayerQueue } from "@/plugins/api/interfaces";
@@ -89,6 +90,8 @@ const shuffleActive = computed(() =>
 // the queue's own reasons for being unavailable.
 const isDisabled = computed(() => {
   if (isLoading.value) return true;
+  // the command is addressed to the player, so there is nothing to send without one
+  if (!compProps.player) return true;
   if (orderingSource.value) return false;
   return (
     !compProps.playerQueue ||
@@ -106,14 +109,15 @@ const shuffleTitle = computed(() => {
   return shuffleActive.value ? $t("shuffle_disable") : $t("shuffle_enable");
 });
 
+// The command names the source the state being inverted was read from, so it
+// applies to whatever is playing — the live session or the queue — and never to
+// something that took the player in between.
 function toggleShuffle() {
-  if (orderingSource.value && compProps.player) {
-    api.playerCommandShuffle(compProps.player.player_id, !shuffleActive.value);
-    return;
-  }
-  api.queueCommandShuffle(
-    compProps.playerQueue?.queue_id || "",
+  if (!compProps.player) return;
+  api.playerCommandShuffle(
+    compProps.player.player_id,
     !shuffleActive.value,
+    resolveActiveSourceId(compProps.player),
   );
 }
 </script>

--- a/src/layouts/default/PlayerOSD/PlayerControlBtn/ShuffleBtn.vue
+++ b/src/layouts/default/PlayerOSD/PlayerControlBtn/ShuffleBtn.vue
@@ -49,9 +49,8 @@ const { externalSource } = useExternalSource(
   toRef(compProps, "playerQueue"),
 );
 
-// An external source that orders its own session takes the command instead of
-// the queue; one that cannot leaves the button disabled rather than silently
-// inert.
+// The state shown comes from an external source that orders its own session;
+// one that cannot leaves the button disabled rather than silently inert.
 const orderingSource = computed(() =>
   externalSource.value?.can_shuffle ? externalSource.value : undefined,
 );

--- a/src/plugins/api/index.ts
+++ b/src/plugins/api/index.ts
@@ -1805,21 +1805,44 @@ export class MusicAssistantApi {
   public playerCommandSeek(playerId: string, position: number) {
     this.playerCommand(playerId, "seek", { position });
   }
+  /**
+   * Set shuffle on whatever a player is playing.
+   *
+   * A live external source orders its own session, an MA queue orders its own
+   * items. Pass the source the command was aimed at (`resolveActiveSourceId`):
+   * the server refuses it when that source is no longer the one playing, which
+   * is the guard doing its job rather than a failure to report, so the refusal
+   * is swallowed instead of toasted.
+   */
   public playerCommandShuffle(
     playerId: string,
     shuffle_enabled: boolean,
+    source_id: string,
   ): Promise<void> {
-    // Configure shuffle on whatever the player is playing: a live external
-    // source orders its own session, an MA queue orders its own items.
-    return this.playerCommand(playerId, "shuffle", { shuffle_enabled });
+    return this.playerCommand(
+      playerId,
+      "shuffle",
+      { shuffle_enabled, source_id },
+      { suppressGlobalError: true },
+    ).catch(() => undefined);
   }
+  /**
+   * Set the repeat mode on whatever a player is playing.
+   *
+   * Takes and refuses `source_id` the same way {@link playerCommandShuffle}
+   * does.
+   */
   public playerCommandRepeat(
     playerId: string,
     repeat_mode: RepeatMode,
+    source_id: string,
   ): Promise<void> {
-    // Configure repeat on whatever the player is playing: a live external
-    // source repeats within its own session, an MA queue repeats its own items.
-    return this.playerCommand(playerId, "repeat", { repeat_mode });
+    return this.playerCommand(
+      playerId,
+      "repeat",
+      { repeat_mode, source_id },
+      { suppressGlobalError: true },
+    ).catch(() => undefined);
   }
 
   public playerCommandPower(playerId: string, powered: boolean): Promise<void> {
@@ -1986,14 +2009,19 @@ export class MusicAssistantApi {
     player_id: string,
     command: string,
     args?: Record<string, unknown>,
+    options?: { suppressGlobalError?: boolean },
   ): Promise<void> {
     /*
       Handle command to player
     */
-    return this.sendCommand(`players/cmd/${command}`, {
-      player_id,
-      ...args,
-    });
+    return this.sendCommand(
+      `players/cmd/${command}`,
+      {
+        player_id,
+        ...args,
+      },
+      options,
+    );
   }
 
   public removePlayer(playerId: string): Promise<void> {

--- a/tests/helpers/player_menu_items.test.ts
+++ b/tests/helpers/player_menu_items.test.ts
@@ -829,7 +829,7 @@ describe("shuffle and repeat", () => {
 
   // the source can end while the menu sits open, and the player's own queue
   // takes it back — a command meant for the session must not land there
-  it("still names the source that ended while the menu was open", () => {
+  it("still names the shuffle source that ended while the menu was open", () => {
     const player = playerOnSource({ can_shuffle: true, shuffle_enabled: true });
     const item = entry(player, "shuffle_disable");
 
@@ -895,7 +895,7 @@ describe("shuffle and repeat", () => {
     );
   });
 
-  it("still names the source that ended while the menu was open", () => {
+  it("still names the repeat source that ended while the menu was open", () => {
     const player = playerOnSource({ can_repeat: true });
     const item = entry(player, "select_repeat_mode");
 

--- a/tests/helpers/player_menu_items.test.ts
+++ b/tests/helpers/player_menu_items.test.ts
@@ -66,8 +66,6 @@ vi.mock("@/plugins/api", () => ({
     providers: {
       milkdrop_visualizer: { domain: "milkdrop_visualizer", available: true },
     },
-    queueCommandShuffle: vi.fn(),
-    queueCommandRepeat: vi.fn(),
     playerCommandShuffle: vi.fn(),
     playerCommandRepeat: vi.fn(),
   },
@@ -751,11 +749,17 @@ describe("shuffle and repeat", () => {
     );
   }
 
-  it("shuffles the queue when one is playing", () => {
+  // the queue is a source like any other, listed under the player's own id, so
+  // the command names it and the server refuses it once something else has
+  // taken the player
+  it("shuffles the queue through the player when one is playing", () => {
     entry(makePlayer(), "shuffle_enable", makeQueue())?.action?.();
 
-    expect(api.queueCommandShuffle).toHaveBeenCalledWith("kitchen", true);
-    expect(api.playerCommandShuffle).not.toHaveBeenCalled();
+    expect(api.playerCommandShuffle).toHaveBeenCalledWith(
+      "kitchen",
+      true,
+      "kitchen",
+    );
   });
 
   it("shuffles a live source's own session through the player", () => {
@@ -763,8 +767,11 @@ describe("shuffle and repeat", () => {
 
     entry(player, "shuffle_enable")?.action?.();
 
-    expect(api.playerCommandShuffle).toHaveBeenCalledWith("kitchen", true);
-    expect(api.queueCommandShuffle).not.toHaveBeenCalled();
+    expect(api.playerCommandShuffle).toHaveBeenCalledWith(
+      "kitchen",
+      true,
+      SPOTIFY,
+    );
   });
 
   it("reads the shuffle state the source reports", () => {
@@ -772,7 +779,11 @@ describe("shuffle and repeat", () => {
 
     entry(player, "shuffle_disable")?.action?.();
 
-    expect(api.playerCommandShuffle).toHaveBeenCalledWith("kitchen", false);
+    expect(api.playerCommandShuffle).toHaveBeenCalledWith(
+      "kitchen",
+      false,
+      SPOTIFY,
+    );
   });
 
   // the menu can sit open while a websocket update lands; updates Object.assign
@@ -795,7 +806,11 @@ describe("shuffle and repeat", () => {
     ];
     item?.action?.();
 
-    expect(api.playerCommandShuffle).toHaveBeenCalledWith("kitchen", false);
+    expect(api.playerCommandShuffle).toHaveBeenCalledWith(
+      "kitchen",
+      false,
+      SPOTIFY,
+    );
   });
 
   it("shuffles the queue against the state at click time", () => {
@@ -805,12 +820,16 @@ describe("shuffle and repeat", () => {
     queue.shuffle_enabled = true;
     item?.action?.();
 
-    expect(api.queueCommandShuffle).toHaveBeenCalledWith("kitchen", false);
+    expect(api.playerCommandShuffle).toHaveBeenCalledWith(
+      "kitchen",
+      false,
+      "kitchen",
+    );
   });
 
   // the source can end while the menu sits open, and the player's own queue
   // takes it back — a command meant for the session must not land there
-  it("does nothing when the source ended while the menu was open", () => {
+  it("still names the source that ended while the menu was open", () => {
     const player = playerOnSource({ can_shuffle: true, shuffle_enabled: true });
     const item = entry(player, "shuffle_disable");
 
@@ -819,8 +838,35 @@ describe("shuffle and repeat", () => {
     player.source_list = [playerSource({ id: "kitchen", name: "Queue" })];
     item?.action?.();
 
-    expect(api.playerCommandShuffle).not.toHaveBeenCalled();
-    expect(api.queueCommandShuffle).not.toHaveBeenCalled();
+    // whatever value it carries is moot: the command is addressed to the
+    // session that ended, so the server refuses it rather than shuffle the
+    // queue that took the player back
+    expect(api.playerCommandShuffle).toHaveBeenCalledWith(
+      "kitchen",
+      expect.any(Boolean),
+      SPOTIFY,
+    );
+  });
+
+  // the other way around, and the reason the queue names its target too: a
+  // source takes the player while the menu sits open, and the setting would
+  // otherwise land on a queue that is no longer playing and surprise the user
+  // whenever it resumes
+  it("still names the queue a source took over while the menu was open", () => {
+    const player = makePlayer();
+    const item = entry(player, "shuffle_enable", makeQueue());
+
+    player.active_source = SPOTIFY;
+    player.source_list = [
+      playerSource({ id: SPOTIFY, name: "Spotify Connect", can_shuffle: true }),
+    ];
+    item?.action?.();
+
+    expect(api.playerCommandShuffle).toHaveBeenCalledWith(
+      "kitchen",
+      true,
+      "kitchen",
+    );
   });
 
   it("repeats within a live source's own session through the player", () => {
@@ -831,25 +877,25 @@ describe("shuffle and repeat", () => {
     expect(api.playerCommandRepeat).toHaveBeenCalledWith(
       "kitchen",
       RepeatMode.ALL,
+      SPOTIFY,
     );
-    expect(api.queueCommandRepeat).not.toHaveBeenCalled();
   });
 
-  it("repeats the queue when one is playing", () => {
+  it("repeats the queue through the player when one is playing", () => {
     entry(
       makePlayer(),
       "select_repeat_mode",
       makeQueue(),
     )?.subItems?.[1]?.action?.();
 
-    expect(api.queueCommandRepeat).toHaveBeenCalledWith(
+    expect(api.playerCommandRepeat).toHaveBeenCalledWith(
       "kitchen",
       RepeatMode.ALL,
+      "kitchen",
     );
-    expect(api.playerCommandRepeat).not.toHaveBeenCalled();
   });
 
-  it("sets no repeat mode when the source ended while the menu was open", () => {
+  it("still names the source that ended while the menu was open", () => {
     const player = playerOnSource({ can_repeat: true });
     const item = entry(player, "select_repeat_mode");
 
@@ -857,8 +903,11 @@ describe("shuffle and repeat", () => {
     player.source_list = [playerSource({ id: "kitchen", name: "Queue" })];
     item?.subItems?.[1]?.action?.();
 
-    expect(api.playerCommandRepeat).not.toHaveBeenCalled();
-    expect(api.queueCommandRepeat).not.toHaveBeenCalled();
+    expect(api.playerCommandRepeat).toHaveBeenCalledWith(
+      "kitchen",
+      RepeatMode.ALL,
+      SPOTIFY,
+    );
   });
 
   it("marks the repeat mode the source reports", () => {

--- a/tests/layouts/RepeatBtn.test.ts
+++ b/tests/layouts/RepeatBtn.test.ts
@@ -289,11 +289,12 @@ describe("RepeatBtn", () => {
 
       await button(wrapper).trigger("click");
 
-      // the queue's mode is the one cycled on, not the one the source reports
+      // a queue and a live source never both resolve for real, so this pins
+      // which side the mode is read from, not what the command is aimed at
       expect(playerCommandRepeat).toHaveBeenCalledWith(
         "player-1",
         RepeatMode.ALL,
-        "spotify://audio_source/main",
+        expect.any(String),
       );
     });
   });

--- a/tests/layouts/RepeatBtn.test.ts
+++ b/tests/layouts/RepeatBtn.test.ts
@@ -17,16 +17,12 @@ import { queueItem } from "../fixtures/queueItem";
 import { radio } from "../fixtures/radio";
 
 vi.mock("@/plugins/api", () => {
-  const api = {
-    queueCommandRepeat: vi.fn(),
-    playerCommandRepeat: vi.fn(),
-  };
+  const api = { playerCommandRepeat: vi.fn() };
   return { api, default: api };
 });
 
 vi.mock("@/plugins/i18n", () => ({ $t: (key: string) => key }));
 
-const queueCommandRepeat = vi.mocked(api.queueCommandRepeat);
 const playerCommandRepeat = vi.mocked(api.playerCommandRepeat);
 
 // Vuetify is not installed in the test app, and Icon.vue renders its icon
@@ -43,6 +39,12 @@ function player(overrides: Partial<Player> = {}): Player {
     source_list: [],
     ...overrides,
   } as unknown as Player;
+}
+
+/** A player playing Music Assistant's own queue, as the server publishes it. */
+function playerOnQueue() {
+  const own = playerSource({ id: "player-1", name: "Music Assistant Queue" });
+  return player({ active_source: own.id, source_list: [own] });
 }
 
 /** A player taken over by a live external source, as the server publishes it. */
@@ -86,19 +88,29 @@ describe("RepeatBtn", () => {
       { from: RepeatMode.OFF, to: RepeatMode.ALL },
       { from: RepeatMode.ALL, to: RepeatMode.ONE },
       { from: RepeatMode.ONE, to: RepeatMode.OFF },
-    ])("cycles the queue from $from to $to", async ({ from, to }) => {
-      const wrapper = mountButton({
-        playerQueue: playerQueue({ repeat_mode: from }),
-      });
+    ])(
+      // the queue is a source like any other, listed under the player's own id,
+      // so the command names it and the server refuses it once something else
+      // has taken the player
+      "cycles the queue from $from to $to through the player",
+      async ({ from, to }) => {
+        const wrapper = mountButton({
+          player: playerOnQueue(),
+          playerQueue: playerQueue({ repeat_mode: from }),
+        });
 
-      await button(wrapper).trigger("click");
+        await button(wrapper).trigger("click");
 
-      expect(queueCommandRepeat).toHaveBeenCalledWith("queue-1", to);
-      expect(playerCommandRepeat).not.toHaveBeenCalled();
-    });
+        expect(playerCommandRepeat).toHaveBeenCalledWith(
+          "player-1",
+          to,
+          "player-1",
+        );
+      },
+    );
 
     it("is disabled without a queue to repeat", () => {
-      const wrapper = mountButton();
+      const wrapper = mountButton({ player: playerOnQueue() });
 
       expect(isDisabled(wrapper)).toBe(true);
       // nothing is playing, so the button reads off rather than showing the
@@ -108,6 +120,7 @@ describe("RepeatBtn", () => {
 
     it("is disabled on an inactive queue", () => {
       const wrapper = mountButton({
+        player: playerOnQueue(),
         playerQueue: playerQueue({ active: false }),
       });
 
@@ -116,6 +129,7 @@ describe("RepeatBtn", () => {
 
     it("is disabled on an infinite stream", () => {
       const wrapper = mountButton({
+        player: playerOnQueue(),
         playerQueue: playerQueue({
           current_item: queueItem({
             media_item: radio({ media_type: MediaType.RADIO }),
@@ -124,6 +138,13 @@ describe("RepeatBtn", () => {
       });
 
       expect(isDisabled(wrapper)).toBe(true);
+    });
+
+    // the command is addressed to the player, so there is nothing to send
+    it("is disabled without a player", () => {
+      expect(isDisabled(mountButton({ playerQueue: playerQueue() }))).toBe(
+        true,
+      );
     });
   });
 
@@ -138,8 +159,8 @@ describe("RepeatBtn", () => {
       expect(playerCommandRepeat).toHaveBeenCalledWith(
         "player-1",
         RepeatMode.ALL,
+        "spotify://audio_source/main",
       );
-      expect(queueCommandRepeat).not.toHaveBeenCalled();
     });
 
     it("cycles on from the mode the source reports", async () => {
@@ -154,6 +175,7 @@ describe("RepeatBtn", () => {
       expect(playerCommandRepeat).toHaveBeenCalledWith(
         "player-1",
         RepeatMode.ONE,
+        "spotify://audio_source/main",
       );
     });
 
@@ -206,7 +228,6 @@ describe("RepeatBtn", () => {
       await button(wrapper).trigger("click");
 
       expect(playerCommandRepeat).not.toHaveBeenCalled();
-      expect(queueCommandRepeat).not.toHaveBeenCalled();
     });
 
     it("leaves an idle player alone", () => {
@@ -262,17 +283,18 @@ describe("RepeatBtn", () => {
 
     it("prefers the queue whenever one is playing", async () => {
       const wrapper = mountButton({
-        player: playerOnSource(),
-        playerQueue: playerQueue(),
+        player: playerOnSource({ repeat_mode: RepeatMode.ALL }),
+        playerQueue: playerQueue({ repeat_mode: RepeatMode.OFF }),
       });
 
       await button(wrapper).trigger("click");
 
-      expect(queueCommandRepeat).toHaveBeenCalledWith(
-        "queue-1",
+      // the queue's mode is the one cycled on, not the one the source reports
+      expect(playerCommandRepeat).toHaveBeenCalledWith(
+        "player-1",
         RepeatMode.ALL,
+        "spotify://audio_source/main",
       );
-      expect(playerCommandRepeat).not.toHaveBeenCalled();
     });
   });
 });

--- a/tests/layouts/ShuffleBtn.test.ts
+++ b/tests/layouts/ShuffleBtn.test.ts
@@ -292,11 +292,12 @@ describe("ShuffleBtn", () => {
 
       await button(wrapper).trigger("click");
 
-      // the queue's state is the one inverted, not the one the source reports
+      // a queue and a live source never both resolve for real, so this pins
+      // which side the state is read from, not what the command is aimed at
       expect(playerCommandShuffle).toHaveBeenCalledWith(
         "player-1",
         true,
-        "spotify://audio_source/main",
+        expect.any(String),
       );
     });
   });

--- a/tests/layouts/ShuffleBtn.test.ts
+++ b/tests/layouts/ShuffleBtn.test.ts
@@ -16,16 +16,12 @@ import { queueItem } from "../fixtures/queueItem";
 import { radio } from "../fixtures/radio";
 
 vi.mock("@/plugins/api", () => {
-  const api = {
-    queueCommandShuffle: vi.fn(),
-    playerCommandShuffle: vi.fn(),
-  };
+  const api = { playerCommandShuffle: vi.fn() };
   return { api, default: api };
 });
 
 vi.mock("@/plugins/i18n", () => ({ $t: (key: string) => key }));
 
-const queueCommandShuffle = vi.mocked(api.queueCommandShuffle);
 const playerCommandShuffle = vi.mocked(api.playerCommandShuffle);
 
 // Vuetify is not installed in the test app, and Icon.vue renders its icon
@@ -42,6 +38,12 @@ function player(overrides: Partial<Player> = {}): Player {
     source_list: [],
     ...overrides,
   } as unknown as Player;
+}
+
+/** A player playing Music Assistant's own queue, as the server publishes it. */
+function playerOnQueue() {
+  const own = playerSource({ id: "player-1", name: "Music Assistant Queue" });
+  return player({ active_source: own.id, source_list: [own] });
 }
 
 /** A player taken over by a live external source, as the server publishes it. */
@@ -81,31 +83,46 @@ beforeEach(() => {
 
 describe("ShuffleBtn", () => {
   describe("on a Music Assistant queue", () => {
-    it("shuffles the queue", async () => {
-      const wrapper = mountButton({ playerQueue: playerQueue() });
+    // the queue is a source like any other, listed under the player's own id,
+    // so the command names it and the server refuses it once something else
+    // has taken the player
+    it("shuffles the queue through the player", async () => {
+      const wrapper = mountButton({
+        player: playerOnQueue(),
+        playerQueue: playerQueue(),
+      });
 
       await button(wrapper).trigger("click");
 
-      expect(queueCommandShuffle).toHaveBeenCalledWith("queue-1", true);
-      expect(playerCommandShuffle).not.toHaveBeenCalled();
+      expect(playerCommandShuffle).toHaveBeenCalledWith(
+        "player-1",
+        true,
+        "player-1",
+      );
     });
 
     it("turns shuffle back off", async () => {
       const wrapper = mountButton({
+        player: playerOnQueue(),
         playerQueue: playerQueue({ shuffle_enabled: true }),
       });
 
       await button(wrapper).trigger("click");
 
-      expect(queueCommandShuffle).toHaveBeenCalledWith("queue-1", false);
+      expect(playerCommandShuffle).toHaveBeenCalledWith(
+        "player-1",
+        false,
+        "player-1",
+      );
     });
 
     it("is disabled without a queue to shuffle", () => {
-      expect(isDisabled(mountButton())).toBe(true);
+      expect(isDisabled(mountButton({ player: playerOnQueue() }))).toBe(true);
     });
 
     it("is disabled on an inactive queue", () => {
       const wrapper = mountButton({
+        player: playerOnQueue(),
         playerQueue: playerQueue({ active: false }),
       });
 
@@ -114,6 +131,7 @@ describe("ShuffleBtn", () => {
 
     it("is disabled on an infinite stream", () => {
       const wrapper = mountButton({
+        player: playerOnQueue(),
         playerQueue: playerQueue({
           current_item: queueItem({
             media_item: radio({ media_type: MediaType.RADIO }),
@@ -122,6 +140,13 @@ describe("ShuffleBtn", () => {
       });
 
       expect(isDisabled(wrapper)).toBe(true);
+    });
+
+    // the command is addressed to the player, so there is nothing to send
+    it("is disabled without a player", () => {
+      expect(isDisabled(mountButton({ playerQueue: playerQueue() }))).toBe(
+        true,
+      );
     });
   });
 
@@ -133,8 +158,11 @@ describe("ShuffleBtn", () => {
 
       await button(wrapper).trigger("click");
 
-      expect(playerCommandShuffle).toHaveBeenCalledWith("player-1", true);
-      expect(queueCommandShuffle).not.toHaveBeenCalled();
+      expect(playerCommandShuffle).toHaveBeenCalledWith(
+        "player-1",
+        true,
+        "spotify://audio_source/main",
+      );
     });
 
     it("renders the state the source reports", () => {
@@ -176,7 +204,11 @@ describe("ShuffleBtn", () => {
 
       await button(wrapper).trigger("click");
 
-      expect(playerCommandShuffle).toHaveBeenCalledWith("player-1", false);
+      expect(playerCommandShuffle).toHaveBeenCalledWith(
+        "player-1",
+        false,
+        "spotify://audio_source/main",
+      );
     });
 
     // the source has not reported its ordering yet, so the control still has to
@@ -199,7 +231,6 @@ describe("ShuffleBtn", () => {
       await button(wrapper).trigger("click");
 
       expect(playerCommandShuffle).not.toHaveBeenCalled();
-      expect(queueCommandShuffle).not.toHaveBeenCalled();
     });
 
     it("leaves an idle player alone", () => {
@@ -255,14 +286,18 @@ describe("ShuffleBtn", () => {
 
     it("prefers the queue whenever one is playing", async () => {
       const wrapper = mountButton({
-        player: playerOnSource(),
-        playerQueue: playerQueue(),
+        player: playerOnSource({ shuffle_enabled: true }),
+        playerQueue: playerQueue({ shuffle_enabled: false }),
       });
 
       await button(wrapper).trigger("click");
 
-      expect(queueCommandShuffle).toHaveBeenCalledWith("queue-1", true);
-      expect(playerCommandShuffle).not.toHaveBeenCalled();
+      // the queue's state is the one inverted, not the one the source reports
+      expect(playerCommandShuffle).toHaveBeenCalledWith(
+        "player-1",
+        true,
+        "spotify://audio_source/main",
+      );
     });
   });
 });

--- a/tests/plugins/api/index.test.ts
+++ b/tests/plugins/api/index.test.ts
@@ -3,6 +3,7 @@ import {
   CoreState,
   type DSPConfig,
   type ErrorResultMessage,
+  RepeatMode,
   type ServerInfoMessage,
   type SuccessResultMessage,
 } from "@/plugins/api/interfaces";
@@ -209,6 +210,50 @@ describe("MusicAssistantApi error handling", () => {
       partial: false,
     });
     await expect(result).resolves.toEqual(config);
+  });
+
+  // the server refuses a command whose source is no longer playing, so both
+  // carry the source they were aimed at
+  it("names the source a shuffle or repeat was aimed at", () => {
+    api.playerCommandShuffle("player-1", true, "spotify://audio_source/main");
+
+    expect(transport.lastCommand.command).toBe("players/cmd/shuffle");
+    expect(transport.lastCommand.args).toEqual({
+      player_id: "player-1",
+      shuffle_enabled: true,
+      source_id: "spotify://audio_source/main",
+    });
+
+    api.playerCommandRepeat("player-1", RepeatMode.ALL, "player-1");
+
+    expect(transport.lastCommand.command).toBe("players/cmd/repeat");
+    expect(transport.lastCommand.args).toEqual({
+      player_id: "player-1",
+      repeat_mode: RepeatMode.ALL,
+      source_id: "player-1",
+    });
+  });
+
+  // a refusal is the guard doing its job, and the server localizes it down to a
+  // generic "the command failed", so putting it in front of the user only
+  // confuses — the control was simply aimed at something that stopped playing
+  it("swallows a refused ordering command without a toast", async () => {
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    vi.spyOn(console, "debug").mockImplementation(() => {});
+    const command = api.playerCommandShuffle("player-1", true, "gone");
+
+    transport.receive(
+      createErrorResult(
+        transport.lastCommand,
+        "The source this was meant for is no longer playing on Kitchen.",
+      ),
+    );
+
+    await expect(command).resolves.toBeUndefined();
+    expect(consoleError).not.toHaveBeenCalled();
+    expect(mockToastError).not.toHaveBeenCalled();
   });
 
   it("rejects in-flight commands when the connection closes", async () => {


### PR DESCRIPTION
# What does this implement/fix?

Tapping shuffle or repeat in the player menu could apply the setting to the wrong thing. The menu is built when you open it, so if the speaker switched to something else in the meantime — a Spotify Connect session taking over, or that session ending — the command still went to whatever the menu was built for. Nothing looked wrong at the time, but the setting resurfaced later on a queue you never meant to change.

Both controls now say which source they were aimed at, and the server refuses the command when that source is no longer the one playing.

**Related issue (if applicable):**

- n/a

**Related backend PR (if applicable):**

- music-assistant/server#5993 (merged) — adds the `source_id` argument this sends

- Shuffle and repeat name the source they were aimed at, so a command meant for something that has stopped playing is refused instead of landing elsewhere
- Both take the same route whether a live source or the Music Assistant queue is playing
- A refused command stays quiet rather than showing an error that says nothing useful

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm lint:check` passes.
- [x] `pnpm test:run` passes, and tests have been added/updated where applicable.
- [x] `pnpm build` passes.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
