### PR TITLE
Document how the shuffle and repeat controls pick the source they act on

### DIFF
--- a/src/composables/activeSource.ts
+++ b/src/composables/activeSource.ts
@@ -10,7 +10,8 @@ import { Player, PlayerSource } from "@/plugins/api/interfaces";
  * issued to it applies to.
  *
  * Pass this to a command that names the source it is aimed at, so it cannot
- * land on whatever took the player since.
+ * land on whatever took the player since. It answers from the player alone, so
+ * state read off a queue has to come from that player's own queue.
  */
 export function resolveActiveSourceId(player: Player): string {
   return player.active_source || player.player_id;

--- a/src/composables/activeSource.ts
+++ b/src/composables/activeSource.ts
@@ -11,7 +11,7 @@ import { Player, PlayerSource } from "@/plugins/api/interfaces";
  *
  * Pass this to a command that names the source it is aimed at, so it cannot
  * land on whatever took the player since. It answers from the player alone, so
- * state read off a queue has to come from that player's own queue.
+ * state read off a queue has to come from the queue playing on that player.
  */
 export function resolveActiveSourceId(player: Player): string {
   return player.active_source || player.player_id;

--- a/src/helpers/player_menu_items.ts
+++ b/src/helpers/player_menu_items.ts
@@ -54,9 +54,9 @@ export const getPlayerSetupMenuItem = (
 
 export const getPlayerMenuItems = (
   player: Player,
-  // the player's own queue, i.e. resolvePlayerQueue(player) — the shuffle and
-  // repeat state and the source those commands are aimed at are both derived
-  // from this pair
+  // the queue playing on this player, i.e. resolvePlayerQueue(player) — the
+  // shuffle and repeat state and the source those commands are aimed at are
+  // both derived from this pair
   playerQueue: PlayerQueue | undefined,
   options: {
     // which surface this menu is rendered on:

--- a/src/helpers/player_menu_items.ts
+++ b/src/helpers/player_menu_items.ts
@@ -54,6 +54,9 @@ export const getPlayerSetupMenuItem = (
 
 export const getPlayerMenuItems = (
   player: Player,
+  // the player's own queue, i.e. resolvePlayerQueue(player) — the shuffle and
+  // repeat state and the source those commands are aimed at are both derived
+  // from this pair
   playerQueue: PlayerQueue | undefined,
   options: {
     // which surface this menu is rendered on:

--- a/src/layouts/default/PlayerOSD/PlayerControlBtn/RepeatBtn.vue
+++ b/src/layouts/default/PlayerOSD/PlayerControlBtn/RepeatBtn.vue
@@ -35,8 +35,9 @@ import { IconRepeat, IconRepeatOff, IconRepeatOnce } from "@tabler/icons-vue";
 // properties
 export interface Props {
   player: Player | undefined;
-  // the player's own queue, i.e. resolvePlayerQueue(player) — the state shown
-  // and the source the command is aimed at are both derived from this pair
+  // the queue playing on this player, i.e. resolvePlayerQueue(player) — the
+  // state shown and the source the command is aimed at are both derived from
+  // this pair
   playerQueue: PlayerQueue | undefined;
   icon?: IconProps;
   size?: number;

--- a/src/layouts/default/PlayerOSD/PlayerControlBtn/RepeatBtn.vue
+++ b/src/layouts/default/PlayerOSD/PlayerControlBtn/RepeatBtn.vue
@@ -35,6 +35,8 @@ import { IconRepeat, IconRepeatOff, IconRepeatOnce } from "@tabler/icons-vue";
 // properties
 export interface Props {
   player: Player | undefined;
+  // the player's own queue, i.e. resolvePlayerQueue(player) — the state shown
+  // and the source the command is aimed at are both derived from this pair
   playerQueue: PlayerQueue | undefined;
   icon?: IconProps;
   size?: number;

--- a/src/layouts/default/PlayerOSD/PlayerControlBtn/ShuffleBtn.vue
+++ b/src/layouts/default/PlayerOSD/PlayerControlBtn/ShuffleBtn.vue
@@ -35,8 +35,9 @@ import { computed, toRef } from "vue";
 // properties
 export interface Props {
   player: Player | undefined;
-  // the player's own queue, i.e. resolvePlayerQueue(player) — the state shown
-  // and the source the command is aimed at are both derived from this pair
+  // the queue playing on this player, i.e. resolvePlayerQueue(player) — the
+  // state shown and the source the command is aimed at are both derived from
+  // this pair
   playerQueue: PlayerQueue | undefined;
   icon?: IconProps;
   size?: number;

--- a/src/layouts/default/PlayerOSD/PlayerControlBtn/ShuffleBtn.vue
+++ b/src/layouts/default/PlayerOSD/PlayerControlBtn/ShuffleBtn.vue
@@ -35,6 +35,8 @@ import { computed, toRef } from "vue";
 // properties
 export interface Props {
   player: Player | undefined;
+  // the player's own queue, i.e. resolvePlayerQueue(player) — the state shown
+  // and the source the command is aimed at are both derived from this pair
   playerQueue: PlayerQueue | undefined;
   icon?: IconProps;
   size?: number;


### PR DESCRIPTION
# What does this implement/fix?

Comment-only follow-up to #2650. The shuffle and repeat controls read their state from the queue (or from a live source when there is no queue), but derive the source the command is aimed at from the player. Those two agree only because every caller passes a player and that same player's queue — an assumption nothing in the code spelled out. Hand them a mismatched pair and you'd get "invert the queue's setting, address the live source", the exact misrouting #2650 fixed.

That pairing can't be broken today (`resolvePlayerQueue` only ever returns the player's own queue), so this just writes the assumption down where the next person will see it instead of changing how the target is worked out.

**Related issue (if applicable):**

- follow-up to #2650

**Related backend PR (if applicable):**

- n/a

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm lint:check` passes.
- [x] `pnpm test:run` passes, and tests have been added/updated where applicable.
- [x] `pnpm build` passes.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
