### PR TITLE
Show shuffle and repeat failures again, except the expected one

### DIFF
--- a/src/plugins/api/index.ts
+++ b/src/plugins/api/index.ts
@@ -89,10 +89,10 @@ export interface CommandOptions {
    * best-effort command whose failure the caller handles (or expects) itself.
    *
    * Pass a predicate for a command where only some failures are expected: it is
-   * evaluated against the error when it arrives. The returned promise rejects
-   * either way.
+   * evaluated when the error arrives, not when the command is sent. The
+   * returned promise rejects either way.
    */
-  suppressGlobalError?: boolean | ((error: ErrorResultMessage) => boolean);
+  suppressGlobalError?: boolean | (() => boolean);
 }
 
 export interface PlayMediaOptions {
@@ -2853,8 +2853,7 @@ export class MusicAssistantApi {
     if ("error_code" in msg) {
       // always handle error (as we may be missing a resolve promise for this command)
       msg = msg as ErrorResultMessage;
-      const suppress = resultPromise?.suppressGlobalError;
-      if (typeof suppress === "function" ? suppress(msg) : suppress) {
+      if (this.isGlobalErrorSuppressed(resultPromise?.suppressGlobalError)) {
         // The caller opted out of global error handling (expected/best-effort
         // failure); it still receives the rejection below.
         console.debug("[resultMessage]", msg);
@@ -3504,11 +3503,31 @@ export class MusicAssistantApi {
   }
 
   /**
+   * Whether an error result skips the global console.error + error toast.
+   *
+   * A caller's predicate must never take down the message pump or the command
+   * still waiting on this reply, so one that throws falls back to showing the
+   * failure.
+   */
+  private isGlobalErrorSuppressed(
+    suppress: CommandOptions["suppressGlobalError"],
+  ): boolean {
+    if (typeof suppress !== "function") return !!suppress;
+    try {
+      return suppress();
+    } catch (err) {
+      console.error("[resultMessage] suppression check failed", err);
+      return false;
+    }
+  }
+
+  /**
    * Whether a player has since moved on from the source a command named.
    *
    * Identifies the server's refusal of a command aimed at a source that stopped
-   * playing: the player is moved on before the command is handled, so the state
-   * update has landed by the time the refusal comes back.
+   * playing. The player is moved on before the command is handled, and both
+   * messages share one ordered queue, so the state update has always landed by
+   * the time the refusal comes back.
    */
   private hasMovedOnFrom(playerId: string, sourceId: string): boolean {
     const player = this.players[playerId];

--- a/src/plugins/api/index.ts
+++ b/src/plugins/api/index.ts
@@ -2,6 +2,7 @@ import { store } from "../store";
 
 import { computed, reactive, ref } from "vue";
 import { toast } from "vue-sonner";
+import { resolveActiveSourceId } from "@/composables/activeSource";
 import {
   resetServerTime,
   serverNow,
@@ -82,6 +83,18 @@ const TRANSLATIONS_SCHEMA_VERSION = 32;
 // The shuffle argument on player_queues/play_media landed in API schema 51.
 const PLAY_MEDIA_SHUFFLE_SCHEMA_VERSION = 51;
 
+export interface CommandOptions {
+  /**
+   * Skip the global console.error + error toast for an error result. Use for a
+   * best-effort command whose failure the caller handles (or expects) itself.
+   *
+   * Pass a predicate for a command where only some failures are expected: it is
+   * evaluated against the error when it arrives. The returned promise rejects
+   * either way.
+   */
+  suppressGlobalError?: boolean | ((error: ErrorResultMessage) => boolean);
+}
+
 export interface PlayMediaOptions {
   start_item?: PlayableMediaItemType | string;
   queue_id?: string;
@@ -149,7 +162,7 @@ export class MusicAssistantApi {
     {
       resolve: (result: unknown) => void;
       reject: (err: unknown) => void;
-      suppressGlobalError?: boolean;
+      suppressGlobalError?: CommandOptions["suppressGlobalError"];
     }
   >;
 
@@ -1563,7 +1576,7 @@ export class MusicAssistantApi {
     media_item: MediaItemTypeOrItemMapping,
     fully_played?: boolean,
     seconds_played?: number,
-    options?: { suppressGlobalError?: boolean },
+    options?: CommandOptions,
   ): Promise<void> {
     // optimistically update the local object so the UI reflects the new state;
     // keep resume_position_ms present (instead of deleting the key) because
@@ -1585,7 +1598,7 @@ export class MusicAssistantApi {
   }
   public markItemUnPlayed(
     media_item: MediaItemTypeOrItemMapping,
-    options?: { suppressGlobalError?: boolean },
+    options?: CommandOptions,
   ): Promise<void> {
     // optimistically update the local object so the UI reflects the new state
     if (itemSupportsPlayLog(media_item)) {
@@ -1811,8 +1824,8 @@ export class MusicAssistantApi {
    * A live external source orders its own session, an MA queue orders its own
    * items. Pass the source the command was aimed at (`resolveActiveSourceId`):
    * the server refuses it when that source is no longer the one playing, which
-   * is the guard doing its job rather than a failure to report, so the refusal
-   * is swallowed instead of toasted.
+   * is the guard doing its job rather than a failure to report, so that refusal
+   * alone stays quiet. Anything else that went wrong is toasted as usual.
    */
   public playerCommandShuffle(
     playerId: string,
@@ -1823,7 +1836,7 @@ export class MusicAssistantApi {
       playerId,
       "shuffle",
       { shuffle_enabled, source_id },
-      { suppressGlobalError: true },
+      { suppressGlobalError: () => this.hasMovedOnFrom(playerId, source_id) },
     ).catch(() => undefined);
   }
   /**
@@ -1841,7 +1854,7 @@ export class MusicAssistantApi {
       playerId,
       "repeat",
       { repeat_mode, source_id },
-      { suppressGlobalError: true },
+      { suppressGlobalError: () => this.hasMovedOnFrom(playerId, source_id) },
     ).catch(() => undefined);
   }
 
@@ -2009,7 +2022,7 @@ export class MusicAssistantApi {
     player_id: string,
     command: string,
     args?: Record<string, unknown>,
-    options?: { suppressGlobalError?: boolean },
+    options?: CommandOptions,
   ): Promise<void> {
     /*
       Handle command to player
@@ -2840,7 +2853,8 @@ export class MusicAssistantApi {
     if ("error_code" in msg) {
       // always handle error (as we may be missing a resolve promise for this command)
       msg = msg as ErrorResultMessage;
-      if (resultPromise?.suppressGlobalError) {
+      const suppress = resultPromise?.suppressGlobalError;
+      if (typeof suppress === "function" ? suppress(msg) : suppress) {
         // The caller opted out of global error handling (expected/best-effort
         // failure); it still receives the rejection below.
         console.debug("[resultMessage]", msg);
@@ -3378,14 +3392,7 @@ export class MusicAssistantApi {
   public sendCommand<Result>(
     command: string,
     args?: Record<string, unknown>,
-    options?: {
-      /**
-       * Suppress the global console.error + error toast for an error result.
-       * Use for best-effort commands where the caller handles (or expects)
-       * failure itself; the returned promise still rejects as usual.
-       */
-      suppressGlobalError?: boolean;
-    },
+    options?: CommandOptions,
   ): Promise<Result> {
     // send command to the server and return promise where the result can be returned
     const cmdId = this._genCmdId();
@@ -3494,6 +3501,18 @@ export class MusicAssistantApi {
     for (const command of pending) {
       command.reject(new ConnectionLostError());
     }
+  }
+
+  /**
+   * Whether a player has since moved on from the source a command named.
+   *
+   * Identifies the server's refusal of a command aimed at a source that stopped
+   * playing: the player is moved on before the command is handled, so the state
+   * update has landed by the time the refusal comes back.
+   */
+  private hasMovedOnFrom(playerId: string, sourceId: string): boolean {
+    const player = this.players[playerId];
+    return !!player && resolveActiveSourceId(player) !== sourceId;
   }
 
   private _genCmdId(): string {

--- a/tests/plugins/api/index.test.ts
+++ b/tests/plugins/api/index.test.ts
@@ -3,6 +3,7 @@ import {
   CoreState,
   type DSPConfig,
   type ErrorResultMessage,
+  type Player,
   RepeatMode,
   type ServerInfoMessage,
   type SuccessResultMessage,
@@ -234,26 +235,89 @@ describe("MusicAssistantApi error handling", () => {
     });
   });
 
-  // a refusal is the guard doing its job, and the server localizes it down to a
-  // generic "the command failed", so putting it in front of the user only
-  // confuses — the control was simply aimed at something that stopped playing
-  it("swallows a refused ordering command without a toast", async () => {
-    const consoleError = vi
-      .spyOn(console, "error")
-      .mockImplementation(() => {});
-    vi.spyOn(console, "debug").mockImplementation(() => {});
-    const command = api.playerCommandShuffle("player-1", true, "gone");
+  describe("a refused ordering command", () => {
+    // the server refuses every one of these with the same code and the same
+    // localized "the command failed", so the player's own state is what tells
+    // the guard doing its job apart from something that actually went wrong
+    const playerOn = (activeSource: string | null) => {
+      api.players["player-1"] = {
+        player_id: "player-1",
+        active_source: activeSource,
+      } as Player;
+    };
 
-    transport.receive(
-      createErrorResult(
-        transport.lastCommand,
-        "The source this was meant for is no longer playing on Kitchen.",
-      ),
-    );
+    const refuse = () => {
+      vi.spyOn(console, "debug").mockImplementation(() => {});
+      const consoleError = vi
+        .spyOn(console, "error")
+        .mockImplementation(() => {});
+      transport.receive(
+        createErrorResult(transport.lastCommand, "The command failed."),
+      );
+      return consoleError;
+    };
 
-    await expect(command).resolves.toBeUndefined();
-    expect(consoleError).not.toHaveBeenCalled();
-    expect(mockToastError).not.toHaveBeenCalled();
+    // the control was aimed at something that stopped playing, so the refusal
+    // is expected; putting it in front of the user would only confuse
+    it.each([
+      ["shuffle", () => api.playerCommandShuffle("player-1", true, "gone")],
+      [
+        "repeat",
+        () => api.playerCommandRepeat("player-1", RepeatMode.ALL, "gone"),
+      ],
+    ])("stays quiet when the player moved on (%s)", async (_name, send) => {
+      playerOn("took-over");
+      const command = send();
+
+      const consoleError = refuse();
+
+      await expect(command).resolves.toBeUndefined();
+      expect(consoleError).not.toHaveBeenCalled();
+      expect(mockToastError).not.toHaveBeenCalled();
+    });
+
+    // still the source it was aimed at, so something genuinely went wrong
+    // (a device or provider error) and the user deserves to hear about it
+    it.each([
+      ["shuffle", () => api.playerCommandShuffle("player-1", true, "playing")],
+      [
+        "repeat",
+        () => api.playerCommandRepeat("player-1", RepeatMode.ALL, "playing"),
+      ],
+    ])("surfaces a real failure (%s)", async (_name, send) => {
+      playerOn("playing");
+      const command = send();
+
+      const consoleError = refuse();
+
+      await expect(command).resolves.toBeUndefined();
+      expect(consoleError).toHaveBeenCalled();
+      expect(mockToastError).toHaveBeenCalledWith("The command failed.");
+    });
+
+    // the whole point: the source moves between the click and the reply, so a
+    // decision taken when the command was sent would get this backwards
+    it("decides when the refusal arrives, not when the command was sent", async () => {
+      playerOn("playing");
+      const command = api.playerCommandShuffle("player-1", true, "playing");
+
+      playerOn("took-over");
+      const consoleError = refuse();
+
+      await expect(command).resolves.toBeUndefined();
+      expect(consoleError).not.toHaveBeenCalled();
+      expect(mockToastError).not.toHaveBeenCalled();
+    });
+
+    // nothing to compare against, so fall back to telling the user
+    it("surfaces a failure for a player it does not know", async () => {
+      const command = api.playerCommandShuffle("player-1", true, "gone");
+
+      refuse();
+
+      await expect(command).resolves.toBeUndefined();
+      expect(mockToastError).toHaveBeenCalledWith("The command failed.");
+    });
   });
 
   it("rejects in-flight commands when the connection closes", async () => {

--- a/tests/plugins/api/index.test.ts
+++ b/tests/plugins/api/index.test.ts
@@ -247,14 +247,16 @@ describe("MusicAssistantApi error handling", () => {
     };
 
     const refuse = () => {
-      vi.spyOn(console, "debug").mockImplementation(() => {});
+      const consoleDebug = vi
+        .spyOn(console, "debug")
+        .mockImplementation(() => {});
       const consoleError = vi
         .spyOn(console, "error")
         .mockImplementation(() => {});
       transport.receive(
         createErrorResult(transport.lastCommand, "The command failed."),
       );
-      return consoleError;
+      return { consoleDebug, consoleError };
     };
 
     // the control was aimed at something that stopped playing, so the refusal
@@ -269,11 +271,13 @@ describe("MusicAssistantApi error handling", () => {
       playerOn("took-over");
       const command = send();
 
-      const consoleError = refuse();
+      const { consoleDebug, consoleError } = refuse();
 
       await expect(command).resolves.toBeUndefined();
       expect(consoleError).not.toHaveBeenCalled();
       expect(mockToastError).not.toHaveBeenCalled();
+      // the quiet branch ran, rather than the error never being handled at all
+      expect(consoleDebug).toHaveBeenCalled();
     });
 
     // still the source it was aimed at, so something genuinely went wrong
@@ -288,7 +292,7 @@ describe("MusicAssistantApi error handling", () => {
       playerOn("playing");
       const command = send();
 
-      const consoleError = refuse();
+      const { consoleError } = refuse();
 
       await expect(command).resolves.toBeUndefined();
       expect(consoleError).toHaveBeenCalled();
@@ -302,7 +306,31 @@ describe("MusicAssistantApi error handling", () => {
       const command = api.playerCommandShuffle("player-1", true, "playing");
 
       playerOn("took-over");
-      const consoleError = refuse();
+      const { consoleError } = refuse();
+
+      await expect(command).resolves.toBeUndefined();
+      expect(consoleError).not.toHaveBeenCalled();
+      expect(mockToastError).not.toHaveBeenCalled();
+    });
+
+    // a player playing nothing but its own queue reports no active_source, and
+    // the server resolves that to the player's own id — so the id the control
+    // named still matches and the failure is real
+    it("surfaces a real failure on a player's own queue", async () => {
+      playerOn(null);
+      const command = api.playerCommandShuffle("player-1", true, "player-1");
+
+      refuse();
+
+      await expect(command).resolves.toBeUndefined();
+      expect(mockToastError).toHaveBeenCalledWith("The command failed.");
+    });
+
+    it("stays quiet when a player fell back to its own queue", async () => {
+      playerOn(null);
+      const command = api.playerCommandShuffle("player-1", true, "gone");
+
+      const { consoleError } = refuse();
 
       await expect(command).resolves.toBeUndefined();
       expect(consoleError).not.toHaveBeenCalled();
@@ -318,6 +346,34 @@ describe("MusicAssistantApi error handling", () => {
       await expect(command).resolves.toBeUndefined();
       expect(mockToastError).toHaveBeenCalledWith("The command failed.");
     });
+  });
+
+  // the predicate runs inside the message pump, so a throwing one must not take
+  // the reply (or the command waiting on it) with it
+  it("surfaces the failure when a suppression predicate throws", async () => {
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    const command = api.sendCommand("test/throwing", undefined, {
+      suppressGlobalError: () => {
+        throw new Error("predicate blew up");
+      },
+    });
+    const rejection = expect(command).rejects.toMatchObject({
+      message: "Visible failure",
+    });
+
+    transport.receive(
+      createErrorResult(transport.lastCommand, "Visible failure"),
+    );
+
+    await rejection;
+    expect(mockToastError).toHaveBeenCalledWith("Visible failure");
+    expect(consoleError).toHaveBeenCalledWith(
+      "[resultMessage] suppression check failed",
+      expect.any(Error),
+    );
+    expect(api["commands"].size).toBe(0);
   });
 
   it("rejects in-flight commands when the connection closes", async () => {


### PR DESCRIPTION
# What does this implement/fix?

Follow-up to #2650. The server refuses a shuffle or repeat command whose named source has stopped playing — that refusal is the guard working as intended and should not bother the user. It was silenced by swallowing *every* failure of those two commands, so a genuine one (a device or provider error) also left the user with nothing: the button just didn't move and no message appeared.

The refusal can't be told apart from a real failure on the wire — they share an error code, and with server-side translations both arrive as the same generic "The command to the player failed." So the decision is made from the player's own state when the error comes back: if the player has moved on from the source the command named, stay quiet; otherwise show it.

**Related issue (if applicable):**

- n/a

**Related backend PR (if applicable):**

- n/a — frontend only

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

### Changes

- `suppressGlobalError` now also takes a predicate, evaluated when the error arrives instead of when the command is sent.
- Shuffle and repeat use it to silence only the stale-source refusal; every other failure is logged and toasted again.
- Pulled the repeated `{ suppressGlobalError?: boolean }` option shape into a named `CommandOptions`.

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm lint:check` passes.
- [x] `pnpm test:run` passes, and tests have been added/updated where applicable.
- [x] `pnpm build` passes.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
