### PR TITLE
Scrolling rows on the artist page

### DIFF
--- a/src/components/ItemsListing.vue
+++ b/src/components/ItemsListing.vue
@@ -112,14 +112,53 @@
             <PanelViewSkeleton />
           </v-col>
         </v-row>
+        <ShelfTrack
+          v-else-if="viewMode === 'row'"
+          class="items-row"
+          :tiles-per-view="
+            panelViewItemResponsive($vuetify.display.width) + 0.5
+          "
+        >
+          <PanelViewSkeleton
+            v-for="n in 8"
+            :key="'skeleton-row-' + n"
+            class="items-row__skeleton"
+          />
+        </ShelfTrack>
       </template>
 
+      <!-- row view -->
+      <ShelfTrack
+        v-if="viewMode == 'row' && itemsVisible"
+        ref="rowTrack"
+        class="items-row"
+        :tiles-per-view="panelViewItemResponsive($vuetify.display.width) + 0.5"
+        @end-reached="onRowEndReached"
+      >
+        <PanelviewItem
+          v-for="item in pagedItems"
+          :key="item.uri"
+          :item="item"
+          :fluid="false"
+          :is-selected="isSelected(item)"
+          :show-checkboxes="showCheckboxes && !isParentDirItem(item)"
+          :show-actions="
+            ['tracks', 'albums', 'albumtracks', 'artists', 'genres'].includes(
+              itemtype,
+            )
+          "
+          :show-track-number="showTrackNumber"
+          :is-available="itemIsAvailable(item)"
+          :is-playing="isPlaying(item, itemtype)"
+          :disable-play-button="isPlayActionInProgress"
+          :parent-item="parentItem"
+          :sort-by="params.sortBy"
+          @select="onSelect"
+        />
+      </ShelfTrack>
+
       <v-infinite-scroll
-        v-if="
-          !tempHide &&
-          !(pagedItems.length == 0 && allItemsReceived) &&
-          !(loading && pagedItems.length === 0)
-        "
+        v-if="viewMode != 'row' && itemsVisible"
         :onLoad="loadNextPage"
         :mode="infiniteScroll ? 'intersect' : 'manual'"
         :load-more-text="$t('load_more_items')"
@@ -288,6 +327,7 @@
 import type { Component } from "vue";
 
 import Container from "@/components/Container.vue";
+import ShelfTrack, { type ShelfTrackExpose } from "@/components/ShelfTrack.vue";
 import GenreIcon from "@/components/icons/GenreIcon.vue";
 import ListViewSkeleton from "@/components/skeletons/ListViewSkeleton.vue";
 import PanelViewSkeleton from "@/components/skeletons/PanelViewSkeleton.vue";
@@ -444,7 +484,7 @@ export interface Props {
   restoreState?: boolean;
   onTitleClick?: () => void;
   refreshOnParentUpdate?: boolean;
-  forcedViewMode?: "list" | "panel" | "panel_compact";
+  forcedViewMode?: "list" | "panel" | "panel_compact" | "row";
   toolBarTabs?: ToolBarTab[];
 }
 const props = withDefaults(defineProps<Props>(), {
@@ -1015,6 +1055,21 @@ const loadNextPage = async function ({
   done("ok");
 };
 
+const rowTrack = ref<ShelfTrackExpose | null>(null);
+
+// the row view scrolls horizontally, so it pages off the track's end instead
+// of the (vertical) infinite scroller
+const onRowEndReached = function () {
+  if (
+    loading.value ||
+    allItemsReceived.value ||
+    pagedItems.value.length === 0
+  ) {
+    return;
+  }
+  loadNextPage({ done: () => {} });
+};
+
 const loadAllItems = async function () {
   while (!allItemsReceived.value) {
     // the paging can outlast the listing, so stop fetching once it is gone
@@ -1025,6 +1080,15 @@ const loadAllItems = async function () {
 };
 
 // computed properties
+// hides the items while the listing is suppressed, known to be empty, or
+// still waiting on its first page (the skeletons cover that last case)
+const itemsVisible = computed(
+  () =>
+    !tempHide.value &&
+    !(pagedItems.value.length == 0 && allItemsReceived.value) &&
+    !(loading.value && pagedItems.value.length === 0),
+);
+
 const isSearchActive = computed(() => {
   let searchActive = false;
   if (params.value.search && params.value.search.length !== 0) {
@@ -1572,6 +1636,8 @@ const loadData = async function (
     allItemsReceived.value = false;
     initialDataReceived.value = false;
     newContentAvailable.value = false;
+    // a fresh result set starts at the left again
+    rowTrack.value?.scrollToStart();
   }
 
   try {
@@ -2312,6 +2378,15 @@ defineExpose({
   max-width: 10%;
   flex-basis: 10%;
   padding: 8px;
+}
+.items-row {
+  /* the listing already sits in a padded container, so the shelf only needs
+     to match the panel grid's column padding */
+  --ed-gutter: 8px;
+}
+.items-row__skeleton {
+  flex: 0 0 auto;
+  width: calc(var(--ed-tile-art, 168px) + 16px);
 }
 .content-tabs {
   padding: 10px 16px 0;

--- a/src/components/PanelviewItem.vue
+++ b/src/components/PanelviewItem.vue
@@ -1,6 +1,6 @@
 <template>
   <EditorialMediaCard
-    fluid
+    :fluid="fluid"
     :item="item"
     :is-available="isAvailable"
     :is-selected="isSelected"
@@ -85,6 +85,7 @@ export interface Props {
   disablePlayButton?: boolean;
   parentItem?: MediaItemType;
   sortBy?: string;
+  fluid?: boolean;
 }
 const compProps = withDefaults(defineProps<Props>(), {
   size: 200,
@@ -96,6 +97,7 @@ const compProps = withDefaults(defineProps<Props>(), {
   disablePlayButton: false,
   parentItem: undefined,
   sortBy: undefined,
+  fluid: true,
 });
 
 const emit = defineEmits<{

--- a/src/components/ShelfTrack.vue
+++ b/src/components/ShelfTrack.vue
@@ -1,0 +1,371 @@
+<template>
+  <div
+    class="ed-shelf__viewport"
+    :style="{ '--ed-nav-top': navTop + 'px' }"
+    @mouseenter="hovering = canHover"
+    @mouseleave="hovering = false"
+    @wheel="onWheel"
+  >
+    <!-- prev -->
+    <button
+      v-show="hovering && canLeft"
+      class="ed-shelf__nav ed-shelf__nav--left"
+      :aria-label="$t('tooltip.scroll_left')"
+      @click="scroll(-1)"
+    >
+      <ChevronLeft :size="20" />
+    </button>
+
+    <div
+      ref="track"
+      class="ed-shelf__track ma-scroll"
+      :class="{ 'ed-shelf__track--dragging': dragging }"
+      :style="{
+        '--ed-gap': gap + 'px',
+        ...(tileArt != null ? { '--ed-tile-art': tileArt + 'px' } : {}),
+      }"
+      @scroll="onScroll"
+      @pointerdown="onPointerDown"
+      @pointermove="onPointerMove"
+      @pointerup="onPointerUp"
+      @pointercancel="onPointerUp"
+      @click.capture="onClickCapture"
+      @dragstart.prevent
+    >
+      <slot></slot>
+    </div>
+
+    <!-- next -->
+    <button
+      v-show="hovering && canRight"
+      class="ed-shelf__nav ed-shelf__nav--right"
+      :aria-label="$t('tooltip.scroll_right')"
+      @click="scroll(1)"
+    >
+      <ChevronRight :size="20" />
+    </button>
+  </div>
+</template>
+
+<script lang="ts">
+export interface ShelfTrackExpose {
+  scrollToStart: () => void;
+  alignItemStart: (selector: string) => void;
+}
+</script>
+
+<script setup lang="ts">
+import { getBreakpointValue } from "@/plugins/breakpoint";
+import { ChevronLeft, ChevronRight } from "@lucide/vue";
+import { computed, onBeforeUnmount, onMounted, ref, watch } from "vue";
+
+interface Props {
+  gap?: number;
+  navCenter?: number;
+  tilesPerView?: number;
+}
+const props = withDefaults(defineProps<Props>(), {
+  gap: 14,
+  navCenter: 92,
+  tilesPerView: 0,
+});
+
+const emit = defineEmits<{
+  (e: "endReached"): void;
+}>();
+
+const CARD_PAD = 16;
+const PHONE_GAP = 4;
+const PHONE_CARD_PAD = 8;
+const MIN_ART = 120;
+const MAX_ART = 280;
+const ART_TOP_OFFSET = 12;
+// stands in for a line of text when a wheel reports its delta in lines
+const WHEEL_LINE_HEIGHT = 20;
+
+// Only track hover (for the nav chevrons) on hover-capable devices. On touch
+// devices the emulated mouseenter would mutate the DOM, which makes mobile
+// Safari swallow the first tap as "hover" instead of a click.
+const canHover = window.matchMedia?.("(hover: hover)")?.matches ?? true;
+const track = ref<HTMLElement | null>(null);
+const hovering = ref(false);
+const canLeft = ref(false);
+const canRight = ref(false);
+const tileArt = ref<number | null>(null);
+
+const navTop = computed(() =>
+  tileArt.value != null ? ART_TOP_OFFSET + tileArt.value / 2 : props.navCenter,
+);
+
+function scrollToStart() {
+  const el = track.value;
+  if (!el) return;
+  el.scrollLeft = 0;
+}
+
+function alignItemStart(selector: string) {
+  const el = track.value;
+  if (!el) return;
+  const item = el.querySelector(selector) as HTMLElement | null;
+  if (!item) {
+    scrollToStart();
+    return;
+  }
+  const delta =
+    item.getBoundingClientRect().left - el.getBoundingClientRect().left;
+  el.scrollBy({ left: delta, behavior: "smooth" });
+}
+
+defineExpose<ShelfTrackExpose>({
+  scrollToStart,
+  alignItemStart,
+});
+
+const verticalScrollParent = (el: HTMLElement): HTMLElement => {
+  let node: HTMLElement | null = el.parentElement;
+  while (node) {
+    const { overflowY } = getComputedStyle(node);
+    if (
+      /(auto|scroll|overlay)/.test(overflowY) &&
+      node.scrollHeight > node.clientHeight + 1
+    ) {
+      return node;
+    }
+    node = node.parentElement;
+  }
+  return document.documentElement;
+};
+
+// Firefox reports a wheel notch as lines rather than pixels, so the raw delta
+// has to be converted before it means anything to a scroller.
+const wheelPixels = (e: WheelEvent, scroller: HTMLElement) => {
+  if (e.deltaMode === WheelEvent.DOM_DELTA_LINE) {
+    return e.deltaY * WHEEL_LINE_HEIGHT;
+  }
+  if (e.deltaMode === WheelEvent.DOM_DELTA_PAGE) {
+    return e.deltaY * scroller.clientHeight;
+  }
+  return e.deltaY;
+};
+
+const onWheel = (e: WheelEvent) => {
+  if (Math.abs(e.deltaX) > Math.abs(e.deltaY)) return;
+  e.preventDefault();
+
+  const scroller = verticalScrollParent(e.currentTarget as HTMLElement);
+  const delta = wheelPixels(e, scroller);
+  if (Math.abs(delta) < 1) return;
+
+  scroller.scrollTop += delta;
+};
+
+const updateTileArt = () => {
+  const el = track.value;
+  if (!el || !props.tilesPerView || props.tilesPerView <= 0) {
+    tileArt.value = null;
+    return;
+  }
+  const isPhone = getBreakpointValue({ breakpoint: "bp1", condition: "lt" });
+  const gap = isPhone ? Math.min(props.gap, PHONE_GAP) : props.gap;
+  const cardPad = isPhone ? PHONE_CARD_PAD : CARD_PAD;
+  const size = el.clientWidth / props.tilesPerView - gap - cardPad;
+  tileArt.value = Math.round(Math.max(MIN_ART, Math.min(MAX_ART, size)));
+};
+
+// emitted once per approach of the end zone; growing the content pushes the
+// end back out of reach, which re-arms it for the next page
+let endSignalled = false;
+
+const checkEndReached = (el: HTMLElement) => {
+  const atEnd =
+    el.scrollWidth > el.clientWidth &&
+    el.scrollLeft + el.clientWidth >= el.scrollWidth - el.clientWidth;
+  if (!atEnd) {
+    endSignalled = false;
+    return;
+  }
+  if (endSignalled) return;
+  endSignalled = true;
+  emit("endReached");
+};
+
+const update = () => {
+  const el = track.value;
+  if (!el) return;
+  canLeft.value = el.scrollLeft > 1;
+  canRight.value = el.scrollLeft + el.clientWidth < el.scrollWidth - 1;
+  updateTileArt();
+  checkEndReached(el);
+};
+const onScroll = () => update();
+
+watch(() => props.tilesPerView, updateTileArt);
+
+const scroll = (dir: number) => {
+  const el = track.value;
+  if (!el) return;
+  el.scrollBy({ left: dir * el.clientWidth * 0.8, behavior: "smooth" });
+};
+
+// Click-and-drag panning for mice; touch already pans natively. A pointer only
+// counts as a drag once it passes the threshold, so a click on a tile still
+// reaches the tile.
+const DRAG_THRESHOLD = 6;
+
+const dragging = ref(false);
+let pointerDown = false;
+let dragStartX = 0;
+let dragStartScroll = 0;
+let swallowClick = false;
+
+const onPointerDown = (e: PointerEvent) => {
+  if (e.pointerType !== "mouse" || e.button !== 0) return;
+  pointerDown = true;
+  swallowClick = false;
+  dragStartX = e.clientX;
+  dragStartScroll = track.value?.scrollLeft ?? 0;
+};
+
+const onPointerMove = (e: PointerEvent) => {
+  const el = track.value;
+  if (!pointerDown || !el) return;
+  // the button can be let go outside the track, where our pointerup never
+  // lands; a move with no button held means that gesture is over
+  if (!(e.buttons & 1)) {
+    pointerDown = false;
+    dragging.value = false;
+    return;
+  }
+  const dx = e.clientX - dragStartX;
+  if (!dragging.value) {
+    if (Math.abs(dx) < DRAG_THRESHOLD) return;
+    dragging.value = true;
+    el.setPointerCapture(e.pointerId);
+  }
+  el.scrollLeft = dragStartScroll - dx;
+};
+
+const onPointerUp = () => {
+  const el = track.value;
+  pointerDown = false;
+  // a gesture that never moved the row is still a click, which keeps short
+  // rows and rows already at their end clickable
+  swallowClick = dragging.value && !!el && el.scrollLeft !== dragStartScroll;
+  dragging.value = false;
+};
+
+const onClickCapture = (e: MouseEvent) => {
+  if (!swallowClick) return;
+  swallowClick = false;
+  e.stopPropagation();
+  e.preventDefault();
+};
+
+let ro: ResizeObserver | undefined;
+onMounted(() => {
+  update();
+  window.addEventListener("resize", update);
+  if (track.value && "ResizeObserver" in window) {
+    ro = new ResizeObserver(update);
+    ro.observe(track.value);
+  }
+});
+onBeforeUnmount(() => {
+  window.removeEventListener("resize", update);
+  ro?.disconnect();
+});
+</script>
+
+<style scoped>
+.ed-shelf__viewport {
+  /* the gutter and card padding are inherited when this sits inside an
+     EditorialShelf; the fallbacks keep a standalone track looking the same */
+  --ed-track-gutter: var(--ed-gutter, 28px);
+  --ed-track-pad: var(--ed-card-pad, 8px);
+  position: relative;
+  padding-left: calc(var(--ed-track-gutter) - var(--ed-track-pad));
+  padding-right: var(--ed-track-gutter);
+}
+.ed-shelf__track {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--ed-gap, 14px);
+  position: relative;
+  overflow-x: auto;
+  overflow-y: visible;
+  overscroll-behavior-x: contain;
+  padding-block: 4px;
+  /* pan-y too: a vertical swipe starting on a tile must scroll the page */
+  touch-action: pan-x pan-y;
+  scroll-snap-type: x proximity;
+  overflow-anchor: none;
+  scroll-padding-inline: calc(var(--ed-track-gutter) - var(--ed-track-pad));
+}
+.ed-shelf__track::after {
+  content: "";
+  flex: 0 0 calc(var(--ed-track-gutter) - var(--ed-gap, 14px));
+}
+.ed-shelf__track--dragging {
+  cursor: grabbing;
+  user-select: none;
+  /* snapping while the pointer drives scrollLeft fights the drag */
+  scroll-snap-type: none;
+}
+.ma-scroll {
+  scrollbar-width: none;
+}
+.ma-scroll::-webkit-scrollbar {
+  display: none;
+}
+
+.ed-shelf__nav {
+  position: absolute;
+  top: var(--ed-nav-top, 96px);
+  transform: translateY(-50%);
+  z-index: 3;
+  width: 38px;
+  height: 38px;
+  border-radius: 999px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  color: rgb(var(--v-theme-on-background));
+  background: rgb(var(--v-theme-panel));
+  border: 1px solid rgba(var(--v-theme-on-surface), 0.12);
+  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.25);
+  transition:
+    background 0.15s ease,
+    transform 0.15s ease;
+}
+.ed-shelf__nav:hover {
+  background: rgb(var(--v-theme-surface));
+}
+.ed-shelf__nav:active {
+  transform: translateY(-50%) scale(0.94);
+}
+.ed-shelf__nav--left {
+  left: 12px;
+}
+.ed-shelf__nav--right {
+  right: 12px;
+}
+
+@media (max-width: 600px) {
+  .ed-shelf__viewport {
+    --ed-track-gutter: var(--ed-gutter, 16px);
+  }
+  .ed-shelf__nav {
+    display: none;
+  }
+}
+
+@media (max-width: 500px) {
+  .ed-shelf__viewport {
+    --ed-track-pad: var(--ed-card-pad, 4px);
+  }
+  .ed-shelf__track {
+    gap: 4px;
+  }
+}
+</style>

--- a/src/components/discover/EditorialShelf.vue
+++ b/src/components/discover/EditorialShelf.vue
@@ -1,10 +1,5 @@
 <template>
-  <section
-    class="ed-shelf"
-    :class="{ 'ed-shelf--dimmed': dimmed }"
-    @mouseenter="hovering = canHover"
-    @mouseleave="hovering = false"
-  >
+  <section class="ed-shelf" :class="{ 'ed-shelf--dimmed': dimmed }">
     <div class="ed-shelf__head">
       <slot name="header">
         <div class="ed-shelf__titles">
@@ -28,43 +23,14 @@
       </div>
     </div>
 
-    <div
-      class="ed-shelf__viewport"
-      :style="{ '--ed-nav-top': navTop + 'px' }"
-      @wheel="onWheel"
+    <ShelfTrack
+      ref="shelfTrack"
+      :gap="gap"
+      :nav-center="navCenter"
+      :tiles-per-view="tilesPerView"
     >
-      <!-- prev -->
-      <button
-        v-show="hovering && canLeft"
-        class="ed-shelf__nav ed-shelf__nav--left"
-        :aria-label="$t('tooltip.scroll_left')"
-        @click="scroll(-1)"
-      >
-        <ChevronLeft :size="20" />
-      </button>
-
-      <div
-        ref="track"
-        class="ed-shelf__track ma-scroll"
-        :style="{
-          '--ed-gap': gap + 'px',
-          ...(tileArt != null ? { '--ed-tile-art': tileArt + 'px' } : {}),
-        }"
-        @scroll="onScroll"
-      >
-        <slot></slot>
-      </div>
-
-      <!-- next -->
-      <button
-        v-show="hovering && canRight"
-        class="ed-shelf__nav ed-shelf__nav--right"
-        :aria-label="$t('tooltip.scroll_right')"
-        @click="scroll(1)"
-      >
-        <ChevronRight :size="20" />
-      </button>
-    </div>
+      <slot></slot>
+    </ShelfTrack>
   </section>
 </template>
 
@@ -77,9 +43,8 @@ export interface EditorialShelfExpose {
 
 <script setup lang="ts">
 import ProviderIcon from "@/components/ProviderIcon.vue";
-import { getBreakpointValue } from "@/plugins/breakpoint";
-import { ChevronLeft, ChevronRight } from "@lucide/vue";
-import { computed, onBeforeUnmount, onMounted, ref, watch } from "vue";
+import ShelfTrack, { type ShelfTrackExpose } from "@/components/ShelfTrack.vue";
+import { ref } from "vue";
 
 interface Props {
   title?: string;
@@ -90,7 +55,7 @@ interface Props {
   dimmed?: boolean;
   tilesPerView?: number;
 }
-const props = withDefaults(defineProps<Props>(), {
+withDefaults(defineProps<Props>(), {
   title: "",
   subtitle: "",
   provider: "",
@@ -100,118 +65,12 @@ const props = withDefaults(defineProps<Props>(), {
   tilesPerView: 0,
 });
 
-const CARD_PAD = 16;
-const PHONE_GAP = 4;
-const PHONE_CARD_PAD = 8;
-const MIN_ART = 120;
-const MAX_ART = 280;
-const ART_TOP_OFFSET = 12;
-
-// Only track hover (for the nav chevrons) on hover-capable devices. On touch
-// devices the emulated mouseenter would mutate the DOM, which makes mobile
-// Safari swallow the first tap as "hover" instead of a click.
-const canHover = window.matchMedia?.("(hover: hover)")?.matches ?? true;
-const track = ref<HTMLElement | null>(null);
-const hovering = ref(false);
-const canLeft = ref(false);
-const canRight = ref(false);
-const tileArt = ref<number | null>(null);
-
-const navTop = computed(() =>
-  tileArt.value != null ? ART_TOP_OFFSET + tileArt.value / 2 : props.navCenter,
-);
-
-const verticalScrollParent = (el: HTMLElement): HTMLElement => {
-  let node: HTMLElement | null = el.parentElement;
-  while (node) {
-    const { overflowY } = getComputedStyle(node);
-    if (
-      /(auto|scroll|overlay)/.test(overflowY) &&
-      node.scrollHeight > node.clientHeight + 1
-    ) {
-      return node;
-    }
-    node = node.parentElement;
-  }
-  return document.documentElement;
-};
-
-const onWheel = (e: WheelEvent) => {
-  if (Math.abs(e.deltaX) > Math.abs(e.deltaY)) return;
-  e.preventDefault();
-
-  if (Math.abs(e.deltaY) < 1) return;
-
-  const scroller = verticalScrollParent(e.currentTarget as HTMLElement);
-  scroller.scrollTop += e.deltaY;
-};
-
-const updateTileArt = () => {
-  const el = track.value;
-  if (!el || !props.tilesPerView || props.tilesPerView <= 0) {
-    tileArt.value = null;
-    return;
-  }
-  const isPhone = getBreakpointValue({ breakpoint: "bp1", condition: "lt" });
-  const gap = isPhone ? Math.min(props.gap, PHONE_GAP) : props.gap;
-  const cardPad = isPhone ? PHONE_CARD_PAD : CARD_PAD;
-  const size = el.clientWidth / props.tilesPerView - gap - cardPad;
-  tileArt.value = Math.round(Math.max(MIN_ART, Math.min(MAX_ART, size)));
-};
-
-const update = () => {
-  const el = track.value;
-  if (!el) return;
-  canLeft.value = el.scrollLeft > 1;
-  canRight.value = el.scrollLeft + el.clientWidth < el.scrollWidth - 1;
-  updateTileArt();
-};
-const onScroll = () => update();
-
-watch(() => props.tilesPerView, updateTileArt);
-
-const scroll = (dir: number) => {
-  const el = track.value;
-  if (!el) return;
-  el.scrollBy({ left: dir * el.clientWidth * 0.8, behavior: "smooth" });
-};
-
-function scrollToStart() {
-  const el = track.value;
-  if (!el) return;
-  el.scrollLeft = 0;
-}
-
-function alignItemStart(selector: string) {
-  const el = track.value;
-  if (!el) return;
-  const item = el.querySelector(selector) as HTMLElement | null;
-  if (!item) {
-    scrollToStart();
-    return;
-  }
-  const delta =
-    item.getBoundingClientRect().left - el.getBoundingClientRect().left;
-  el.scrollBy({ left: delta, behavior: "smooth" });
-}
+const shelfTrack = ref<ShelfTrackExpose | null>(null);
 
 defineExpose<EditorialShelfExpose>({
-  scrollToStart,
-  alignItemStart,
-});
-
-let ro: ResizeObserver | undefined;
-onMounted(() => {
-  update();
-  window.addEventListener("resize", update);
-  if (track.value && "ResizeObserver" in window) {
-    ro = new ResizeObserver(update);
-    ro.observe(track.value);
-  }
-});
-onBeforeUnmount(() => {
-  window.removeEventListener("resize", update);
-  ro?.disconnect();
+  scrollToStart: () => shelfTrack.value?.scrollToStart(),
+  alignItemStart: (selector: string) =>
+    shelfTrack.value?.alignItemStart(selector),
 });
 </script>
 
@@ -275,70 +134,6 @@ onBeforeUnmount(() => {
   opacity: 0.4;
 }
 
-.ed-shelf__viewport {
-  position: relative;
-  padding-left: calc(var(--ed-gutter) - var(--ed-card-pad));
-  padding-right: var(--ed-gutter);
-}
-.ed-shelf__track {
-  display: flex;
-  align-items: flex-start;
-  gap: var(--ed-gap, 14px);
-  position: relative;
-  overflow-x: auto;
-  overflow-y: visible;
-  overscroll-behavior-x: contain;
-  padding-block: 4px;
-  /* pan-y too: a vertical swipe starting on a tile must scroll the page */
-  touch-action: pan-x pan-y;
-  scroll-snap-type: x proximity;
-  overflow-anchor: none;
-  scroll-padding-inline: calc(var(--ed-gutter) - var(--ed-card-pad));
-}
-.ed-shelf__track::after {
-  content: "";
-  flex: 0 0 calc(var(--ed-gutter) - var(--ed-gap, 14px));
-}
-.ma-scroll {
-  scrollbar-width: none;
-}
-.ma-scroll::-webkit-scrollbar {
-  display: none;
-}
-
-.ed-shelf__nav {
-  position: absolute;
-  top: var(--ed-nav-top, 96px);
-  transform: translateY(-50%);
-  z-index: 3;
-  width: 38px;
-  height: 38px;
-  border-radius: 999px;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  cursor: pointer;
-  color: rgb(var(--v-theme-on-background));
-  background: rgb(var(--v-theme-panel));
-  border: 1px solid rgba(var(--v-theme-on-surface), 0.12);
-  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.25);
-  transition:
-    background 0.15s ease,
-    transform 0.15s ease;
-}
-.ed-shelf__nav:hover {
-  background: rgb(var(--v-theme-surface));
-}
-.ed-shelf__nav:active {
-  transform: translateY(-50%) scale(0.94);
-}
-.ed-shelf__nav--left {
-  left: 12px;
-}
-.ed-shelf__nav--right {
-  right: 12px;
-}
-
 @media (max-width: 600px) {
   .ed-shelf {
     --ed-gutter: 16px;
@@ -350,17 +145,11 @@ onBeforeUnmount(() => {
   .ed-shelf__title {
     font-size: 19px;
   }
-  .ed-shelf__nav {
-    display: none;
-  }
 }
 
 @media (max-width: 500px) {
   .ed-shelf {
     --ed-card-pad: 4px;
-  }
-  .ed-shelf__track {
-    gap: 4px;
   }
 }
 </style>

--- a/src/views/ArtistDetails.vue
+++ b/src/views/ArtistDetails.vue
@@ -80,6 +80,7 @@
           'sort_name_desc',
           'year_desc',
         ]"
+        forced-view-mode="row"
         :title="$t('artist_all_albums')"
         :subtitle="$t('on_provider', [activeAlbumProvider])"
         :allow-collapse="true"
@@ -124,6 +125,7 @@
         :show-refresh-button="false"
         :load-items="loadArtistTopAlbums"
         :sort-keys="['original', 'name', 'year', 'year_desc']"
+        forced-view-mode="row"
         :title="$t('artist_topalbums')"
         :subtitle="$t('on_provider', [activeTopAlbumProvider])"
         :allow-collapse="true"
@@ -158,6 +160,7 @@
         :provider-filter-options="similarArtistsProviderIds"
         :show-refresh-button="false"
         :load-items="loadSimilarArtists"
+        forced-view-mode="row"
         :title="$t('similar_artists')"
         :subtitle="$t('on_provider', [activeSimilarArtistsProvider])"
         :allow-collapse="true"


### PR DESCRIPTION
# What does this implement/fix?

The albums, top albums and similar artists lists on the artist page were shown as tall grids. Each one took up a lot of vertical space, so getting to the sections further down meant a long scroll past rows of covers you were not looking for.

Those three lists are now single rows that scroll sideways, the same way the rows on the home and discover pages work.

- Show albums, top albums and similar artists as one scrolling row each
- Scroll a row by dragging it with the mouse, by the arrows that appear when you hover, or by swiping on a phone or tablet
- Load the next batch of items when you reach the end of a row
- Move the shared row behaviour into its own component so the artist page and the discover shelves use the same code
- Fix the mouse wheel over these rows in Firefox, which moved the page a few pixels at a time instead of a normal step. The rows on the home and discover pages get that fix too

<img width="1646" height="927" alt="image" src="https://github.com/user-attachments/assets/86278725-66a4-4a22-a5a3-d2d2d3688c2f" />

**Related issue (if applicable):**

- Discord discussion https://discord.com/channels/753947050995089438/1004642314968367124/1524351413457518704

**Related backend PR (if applicable):**

- N/A

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm lint:check` passes.
- [x] `pnpm test:run` passes, and tests have been added/updated where applicable.
- [x] `pnpm build` passes.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
