### PR TITLE
Fix permission popups on cast dashboards

### DIFF
--- a/src/composables/ai-radio/useHosts.ts
+++ b/src/composables/ai-radio/useHosts.ts
@@ -1,6 +1,7 @@
 import { useShows } from "@/composables/ai-radio/useShows";
 import api from "@/plugins/api";
 import type { AIRadioHost, AIRadioSection } from "@/plugins/api/interfaces";
+import { authManager } from "@/plugins/auth";
 import { $t } from "@/plugins/i18n";
 import { computed, ref, watch } from "vue";
 import { toast } from "vue-sonner";
@@ -44,7 +45,9 @@ const aiRadioAvailable = computed(() =>
 watch(
   aiRadioAvailable,
   (available) => {
-    if (available) prefetchQueueDjState();
+    // Session-scoped viewers lack the config scopes this needs and never open the queue DJ menu.
+    if (available && authManager.guestSessionKind() === null)
+      prefetchQueueDjState();
   },
   { immediate: true },
 );

--- a/src/composables/ai-radio/useHosts.ts
+++ b/src/composables/ai-radio/useHosts.ts
@@ -45,7 +45,7 @@ const aiRadioAvailable = computed(() =>
 watch(
   aiRadioAvailable,
   (available) => {
-    // Session-scoped viewers lack the config scopes this needs and never open the queue DJ menu.
+    // Session-scoped sessions lack the config scopes this needs and never open the queue DJ menu.
     if (available && authManager.guestSessionKind() === null)
       prefetchQueueDjState();
   },

--- a/src/composables/ai-radio/useShows.ts
+++ b/src/composables/ai-radio/useShows.ts
@@ -58,7 +58,7 @@ let showSessionStatePrefetched = false;
 watch(
   aiRadioAvailable,
   (available) => {
-    // Session-scoped viewers lack the config scopes this needs and never open the queue DJ menu.
+    // Session-scoped sessions lack the config scopes this needs and never open the queue DJ menu.
     if (available && authManager.guestSessionKind() === null)
       prefetchShowSessionState();
   },

--- a/src/composables/ai-radio/useShows.ts
+++ b/src/composables/ai-radio/useShows.ts
@@ -6,6 +6,7 @@ import type {
   AIRadioStatus,
   Playlist,
 } from "@/plugins/api/interfaces";
+import { authManager } from "@/plugins/auth";
 import { $t } from "@/plugins/i18n";
 import { computed, ref, watch } from "vue";
 import { toast } from "vue-sonner";
@@ -57,7 +58,9 @@ let showSessionStatePrefetched = false;
 watch(
   aiRadioAvailable,
   (available) => {
-    if (available) prefetchShowSessionState();
+    // Session-scoped viewers lack the config scopes this needs and never open the queue DJ menu.
+    if (available && authManager.guestSessionKind() === null)
+      prefetchShowSessionState();
   },
   { immediate: true },
 );

--- a/tests/composables/ai-radio/prefetchGating.test.ts
+++ b/tests/composables/ai-radio/prefetchGating.test.ts
@@ -1,0 +1,89 @@
+import { reactive } from "vue";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { ProviderInstance } from "@/plugins/api/interfaces";
+import { ProviderType } from "@/plugins/api/interfaces";
+
+vi.mock("@/plugins/i18n", () => ({
+  $t: (key: string) => key,
+  canonicalizeLocale: (locale: string) => locale.replaceAll("_", "-"),
+  i18n: {
+    global: {
+      locale: { value: "en" },
+    },
+  },
+}));
+
+const aiRadioProvider: ProviderInstance = {
+  type: ProviderType.PLUGIN,
+  domain: "ai_radio",
+  name: "AI Radio",
+  instance_id: "ai_radio",
+  supported_features: [],
+  available: true,
+  is_streaming_provider: null,
+};
+
+/** Mocks @/plugins/api and @/plugins/auth for a fresh module import, returning the sendCommand spy. */
+async function mockApiAndAuth(guestSessionKind: string | null) {
+  const providers = reactive<Record<string, ProviderInstance>>({
+    ai_radio: aiRadioProvider,
+  });
+  const sendCommand = vi.fn().mockResolvedValue({});
+
+  vi.doMock("@/plugins/api", () => ({
+    api: { providers, sendCommand },
+    default: { providers, sendCommand },
+  }));
+  vi.doMock("@/plugins/auth", () => ({
+    authManager: { guestSessionKind: () => guestSessionKind },
+    default: { guestSessionKind: () => guestSessionKind },
+  }));
+
+  return sendCommand;
+}
+
+/** Lets the module-level watcher's synchronous callback finish its async prefetch work. */
+async function flushMicrotasks() {
+  await Promise.resolve();
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+describe("ai_radio prefetch gating for session-scoped sessions", () => {
+  afterEach(() => {
+    vi.resetModules();
+    vi.doUnmock("@/plugins/api");
+    vi.doUnmock("@/plugins/auth");
+    vi.doUnmock("@/plugins/i18n");
+  });
+
+  it("sends no ai_radio commands for a session-scoped session", async () => {
+    vi.resetModules();
+    const sendCommand = await mockApiAndAuth("dashboard");
+
+    await import("@/composables/ai-radio/useShows");
+    await import("@/composables/ai-radio/useHosts");
+    await flushMicrotasks();
+
+    expect(sendCommand).not.toHaveBeenCalled();
+  });
+
+  it("prefetches ai_radio state for a regular session", async () => {
+    vi.resetModules();
+    const sendCommand = await mockApiAndAuth(null);
+
+    await import("@/composables/ai-radio/useShows");
+    await import("@/composables/ai-radio/useHosts");
+    await flushMicrotasks();
+
+    const calledCommands = sendCommand.mock.calls.map((call) => call[0]);
+    expect(calledCommands).toEqual(
+      expect.arrayContaining([
+        "ai_radio/stations/list",
+        "ai_radio/status",
+        "ai_radio/hosts/list",
+        "ai_radio/queue_dj/status",
+      ]),
+    );
+  });
+});

--- a/tests/composables/ai-radio/useHosts.test.ts
+++ b/tests/composables/ai-radio/useHosts.test.ts
@@ -30,7 +30,7 @@ vi.mock("@/plugins/api", async () => {
 });
 
 vi.mock("@/plugins/auth", () => ({
-  authManager: { isAdmin: () => false },
+  authManager: { isAdmin: () => false, guestSessionKind: () => null },
 }));
 
 vi.mock("@/plugins/router", () => ({


### PR DESCRIPTION
# What does this implement/fix?

Cast dashboards (now playing / party) showed "You do not have permission to perform this action" popups right after loading. The module-level watchers in `useShows.ts` and `useHosts.ts` prefetch AI Radio state as soon as an available `ai_radio` provider appears, also for session-scoped viewer sessions. Three of those commands require `CONFIG_PROVIDERS_READ`, which the guest role lacks, so the server refused them and the global error handler toasted each refusal on the dashboard.

- Skip the AI Radio prefetch when the session is session-scoped (dashboard viewer, party guest, music quiz guest); these sessions never open the queue DJ menu that reads the prefetched caches.
- Add a regression test asserting no `ai_radio/*` commands are sent for a session-scoped session, and that the prefetch still runs for regular sessions.
- Extend the auth mock in the existing `useHosts` test with the newly called `guestSessionKind()`.

**Related issue (if applicable):**

- related issue `<link to issue>`

**Related backend PR (if applicable):**

- related backend PR `<link to PR>`

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm lint:check` passes.
- [x] `pnpm test:run` passes, and tests have been added/updated where applicable.
- [x] `pnpm build` passes.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
