### PR TITLE
No more STABLE badge when adding a provider

### DIFF
--- a/src/helpers/provider_config.test.ts
+++ b/src/helpers/provider_config.test.ts
@@ -6,6 +6,7 @@ import {
   getProviderStatusTranslationKey,
   getProviderSupportIssuesUrl,
   providerRequiresReconfiguration,
+  shouldShowStageBadge,
 } from "./provider_config";
 
 describe("provider configuration state", () => {
@@ -93,6 +94,19 @@ describe("provider configuration state", () => {
     ["something_new", undefined],
   ])("maps provider stage %s to %s", (stage, expected) => {
     expect(getProviderStageTranslationKey(stage)).toBe(expected);
+  });
+
+  it.each([
+    [ProviderStage.STABLE, false],
+    [ProviderStage.ALPHA, true],
+    [ProviderStage.BETA, true],
+    [ProviderStage.EXPERIMENTAL, true],
+    [ProviderStage.UNMAINTAINED, true],
+    [ProviderStage.DEPRECATED, true],
+    [undefined, false],
+    ["something_new", false],
+  ])("badges provider stage %s: %s", (stage, expected) => {
+    expect(shouldShowStageBadge(stage)).toBe(expected);
   });
 
   it.each([

--- a/src/helpers/provider_config.ts
+++ b/src/helpers/provider_config.ts
@@ -77,6 +77,10 @@ export const getProviderStageTranslationKey = (
     : undefined;
 };
 
+// Stable is the norm, so only the stages that warrant a warning get a badge.
+export const shouldShowStageBadge = (stage?: ProviderStage | string | null) =>
+  stage !== ProviderStage.STABLE && !!getProviderStageTranslationKey(stage);
+
 export const getProviderSupportIssuesUrl = (domain: string) => {
   const label = PROVIDER_SUPPORT_LABELS[domain] ?? domain;
   return `https://github.com/music-assistant/support/issues?q=${encodeURIComponent(

--- a/src/views/settings/AddProviderDialog.vue
+++ b/src/views/settings/AddProviderDialog.vue
@@ -50,7 +50,7 @@
             </div>
             <div class="provider-actions">
               <Badge
-                v-if="getProviderStageTranslationKey(provider.stage)"
+                v-if="shouldShowStageBadge(provider.stage)"
                 :variant="getStageVariant(provider.stage)"
                 class="text-uppercase"
               >
@@ -89,7 +89,10 @@ import {
   InputGroupInput,
 } from "@/components/ui/input-group";
 import { preventOnScreenKeyboardOnOpen } from "@/helpers/dialog_focus";
-import { getProviderStageTranslationKey } from "@/helpers/provider_config";
+import {
+  getProviderStageTranslationKey,
+  shouldShowStageBadge,
+} from "@/helpers/provider_config";
 import { api } from "@/plugins/api";
 import {
   ProviderConfig,

--- a/src/views/settings/Providers.vue
+++ b/src/views/settings/Providers.vue
@@ -257,6 +257,7 @@ import {
   getProviderStageTranslationKey,
   getProviderStatusTranslationKey,
   providerRequiresReconfiguration,
+  shouldShowStageBadge,
 } from "@/helpers/provider_config";
 import { openLinkInNewTab } from "@/helpers/utils";
 import { api } from "@/plugins/api";
@@ -375,12 +376,6 @@ const canReconfigure = function (provider: ProviderConfig) {
     provider.status,
     api.providerManifests[provider.domain]?.has_setup_flow,
     provider.enabled,
-  );
-};
-
-const shouldShowStageBadge = function (stage?: ProviderStage) {
-  return (
-    stage !== ProviderStage.STABLE && !!getProviderStageTranslationKey(stage)
   );
 };
 

--- a/tests/views/AddProviderDialog.test.ts
+++ b/tests/views/AddProviderDialog.test.ts
@@ -98,6 +98,13 @@ describe("AddProviderDialog", () => {
     expect(names).toEqual(["Spotify"]);
   });
 
+  it("omits the stage badge for a stable provider", async () => {
+    // stable is the norm, so a badge would be noise on nearly every row
+    await openDialog();
+
+    expect(document.querySelector("[data-slot='badge']")).toBeNull();
+  });
+
   it("omits the stage badge for a manifest without a stage", async () => {
     apiMock.providerManifests = {
       spotify: providerManifest({


### PR DESCRIPTION
# What does this implement/fix?

The "add a music source" / "add a player provider" dialogs showed a STABLE badge on almost every provider in the list. Stable is the default, so that badge carries no information and just adds noise — only providers that are beta, alpha, experimental, unmaintained or deprecated deserve a badge. The installed providers overview already got this right; the add dialog didn't.

**Related issue (if applicable):**

- n/a

**Related backend PR (if applicable):**

- n/a

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

Changes:

- No more STABLE badge in the add provider dialogs; only non-stable stages are badged.
- Moved the "should this stage be badged?" check into the shared provider helper so the dialog and the providers overview can't drift apart again.
- Added tests for the shared check and for the dialog.

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm lint:check` passes.
- [x] `pnpm test:run` passes, and tests have been added/updated where applicable.
- [x] `pnpm build` passes.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
