### PR TITLE
Show pairing codes as dedicated input boxes

### DIFF
--- a/src/plugins/api/interfaces.ts
+++ b/src/plugins/api/interfaces.ts
@@ -515,6 +515,7 @@ export enum ConfigEntryType {
   BOOLEAN = "boolean",
   STRING = "string",
   SECURE_STRING = "secure_string",
+  PAIRING_CODE = "pairing_code",
   INTEGER = "integer",
   FLOAT = "float",
   LABEL = "label",
@@ -704,6 +705,10 @@ export interface ConfigEntry {
   options: ConfigValueOption[];
   // range [optional]: select values within range
   range?: number[] | null;
+  // format [optional]: for PAIRING_CODE entries — '#' digit box, 'X' alphanumeric
+  // (uppercase) box, any other character a rendered separator; the value is the code
+  // without separators
+  format?: string | null;
   // description [optional]: extended description of the setting.
   description?: string | null;
   // help_link [optional]: link to help article.

--- a/src/views/settings/ConfigEntryField.vue
+++ b/src/views/settings/ConfigEntryField.vue
@@ -161,6 +161,15 @@
       @click:clear="onClear"
     />
 
+    <!-- pairing code: one box per code character -->
+    <PairingCodeField
+      v-else-if="confEntry.type == ConfigEntryType.PAIRING_CODE"
+      :entry="confEntry"
+      :label="displayLabel()"
+      :disabled="isFieldDisabled"
+      @update:value="onUpdateValue($event)"
+    />
+
     <!-- value with all options expanded: one button per option -->
     <RadioGroupField
       v-else-if="
@@ -301,6 +310,7 @@ import AlertField from "./fields/AlertField.vue";
 import HassControlPickerField from "./fields/HassControlPickerField.vue";
 import HassControlsField from "./fields/HassControlsField.vue";
 import LabelField from "./fields/LabelField.vue";
+import PairingCodeField from "./fields/PairingCodeField.vue";
 import RadioGroupField from "./fields/RadioGroupField.vue";
 import {
   ConfigEntryUI,

--- a/src/views/settings/fields/PairingCodeField.vue
+++ b/src/views/settings/fields/PairingCodeField.vue
@@ -1,0 +1,319 @@
+<script setup lang="ts">
+import type { ConfigEntryUI } from "@/helpers/config_entry_ui";
+import type { ConfigValueType } from "@/plugins/api/interfaces";
+import { $t } from "@/plugins/i18n";
+import {
+  computed,
+  nextTick,
+  onMounted,
+  ref,
+  watch,
+  type ComponentPublicInstance,
+} from "vue";
+
+const props = defineProps<{
+  entry: ConfigEntryUI;
+  label: string;
+  disabled?: boolean;
+}>();
+
+const emit = defineEmits<{ "update:value": [value: ConfigValueType] }>();
+
+// hard ceiling on rendered boxes; a longer format falls back to the text field
+const MAX_SLOTS = 16;
+
+type LayoutCell =
+  | { type: "slot"; digit: boolean; index: number }
+  | { type: "separator"; text: string };
+
+// the format parsed into code boxes and literal separators, in render order;
+// null when the format is missing or holds no code slot, which switches to the fallback
+const layout = computed<LayoutCell[] | null>(() => {
+  const format = props.entry.format;
+  if (!format) return null;
+  const result: LayoutCell[] = [];
+  let index = 0;
+  for (const char of format) {
+    if (char === "#" || char === "X") {
+      result.push({ type: "slot", digit: char === "#", index });
+      index++;
+    } else {
+      // any other character renders as-is between the boxes
+      const last = result[result.length - 1];
+      if (last?.type === "separator") last.text += char;
+      else result.push({ type: "separator", text: char });
+    }
+  }
+  if (index === 0 || index > MAX_SLOTS) return null;
+  return result;
+});
+
+// digit-only flag per code slot, in code order
+const slotIsDigit = computed(() =>
+  (layout.value ?? []).flatMap((cell) =>
+    cell.type === "slot" ? [cell.digit] : [],
+  ),
+);
+
+const slotCount = computed(() => slotIsDigit.value.length);
+const isNumeric = computed(() => slotIsDigit.value.every(Boolean));
+
+// one entered character per code slot
+const cells = ref<string[]>([]);
+const inputRefs = ref<(HTMLInputElement | null)[]>([]);
+// the value of the last update:value emission; the parent writes it straight back
+// to entry.value, so the watch below must not mistake that echo for an external reset
+let lastEmitted: ConfigValueType | undefined;
+
+seedCells();
+
+onMounted(() => {
+  if (layout.value && !props.disabled) focusFirstEmpty();
+});
+
+// re-served setup-flow steps reuse this component instance (keyed on entry.key),
+// so an externally changed value must resync the boxes instead of keeping stale ones
+watch(
+  () => props.entry.value,
+  (value) => {
+    if (!layout.value || value === lastEmitted) return;
+    if (normalizeCode(value) === cells.value.join("")) return;
+    seedCells();
+    lastEmitted = undefined;
+    if (!props.disabled) focusFirstEmpty();
+  },
+);
+
+function onCellInput(index: number, event: Event) {
+  const input = event.target as HTMLInputElement;
+  // an emptied input (cut, delete over a selection) clears the cell
+  if (input.value === "") {
+    cells.value[index] = "";
+    emitCode();
+    return;
+  }
+  const next = distribute(input.value, index);
+  // the DOM may hold a rejected or overflowing char Vue has no patch for
+  input.value = cells.value[index];
+  emitCode();
+  if (next > index) focusCell(Math.min(next, slotCount.value - 1));
+}
+
+function onCellKeydown(index: number, event: KeyboardEvent) {
+  if (event.key === "Backspace") {
+    event.preventDefault();
+    if (cells.value[index]) {
+      cells.value[index] = "";
+      emitCode();
+    } else if (index > 0) {
+      cells.value[index - 1] = "";
+      emitCode();
+      focusCell(index - 1);
+    }
+  } else if (event.key === "ArrowLeft" && index > 0) {
+    event.preventDefault();
+    focusCell(index - 1);
+  } else if (event.key === "ArrowRight" && index < slotCount.value - 1) {
+    event.preventDefault();
+    focusCell(index + 1);
+  }
+}
+
+function onCellPaste(index: number, event: ClipboardEvent) {
+  const pasted = event.clipboardData?.getData("text") || "";
+  const clean = pasted.toUpperCase().replace(/[^A-Z0-9]/g, "");
+  if (!clean) return;
+  // a paste into the first box, or one holding a full code, replaces everything
+  const start = index === 0 || clean.length >= slotCount.value ? 0 : index;
+  if (start === 0) cells.value = cells.value.map(() => "");
+  const next = distribute(clean, start);
+  emitCode();
+  focusCell(Math.min(next, slotCount.value - 1));
+}
+
+function onCellFocus(event: FocusEvent) {
+  // select the content so typing overwrites instead of appending
+  (event.target as HTMLInputElement).select();
+}
+
+function setInputRef(index: number) {
+  return (el: Element | ComponentPublicInstance | null) => {
+    inputRefs.value[index] = el as HTMLInputElement | null;
+  };
+}
+
+function seedCells() {
+  const code = normalizeCode(props.entry.value);
+  cells.value = Array.from(
+    { length: slotCount.value },
+    (_, index) => code[index] ?? "",
+  );
+}
+
+function normalizeCode(value: unknown): string {
+  return String(value ?? "")
+    .toUpperCase()
+    .replace(/[^A-Z0-9]/g, "")
+    .slice(0, slotCount.value);
+}
+
+// all-or-null: an incomplete code emits null so required-value gating keeps
+// the submit button disabled until every box is filled
+function emitCode() {
+  const value = cells.value.every((cell) => cell) ? cells.value.join("") : null;
+  lastEmitted = value;
+  emit("update:value", value);
+}
+
+// writes text into the cells from startIndex, dropping chars a cell does not
+// accept; returns the index just after the last cell written
+function distribute(text: string, startIndex: number): number {
+  let index = startIndex;
+  for (const char of text) {
+    if (index >= slotCount.value) break;
+    const accepted = acceptChar(char, index);
+    if (accepted === null) continue;
+    cells.value[index] = accepted;
+    index++;
+  }
+  return index;
+}
+
+function acceptChar(char: string, index: number): string | null {
+  const upper = char.toUpperCase();
+  const pattern = slotIsDigit.value[index] ? /^[0-9]$/ : /^[A-Z0-9]$/;
+  return pattern.test(upper) ? upper : null;
+}
+
+function focusCell(index: number) {
+  nextTick(() => {
+    const input = inputRefs.value[index];
+    input?.focus();
+    input?.select();
+  });
+}
+
+function focusFirstEmpty() {
+  const first = cells.value.findIndex((cell) => !cell);
+  focusCell(first === -1 ? slotCount.value - 1 : first);
+}
+</script>
+
+<template>
+  <div v-if="layout" class="pairing-code-field">
+    <v-label class="pairing-code-label">
+      {{ label }}
+    </v-label>
+    <div class="pairing-code-boxes">
+      <template v-for="(cell, position) of layout" :key="position">
+        <span v-if="cell.type === 'separator'" class="pairing-code-separator">
+          {{ cell.text }}
+        </span>
+        <input
+          v-else
+          :ref="setInputRef(cell.index)"
+          class="pairing-code-input"
+          type="text"
+          :value="cells[cell.index]"
+          :inputmode="isNumeric ? 'numeric' : 'text'"
+          :autocomplete="cell.index === 0 ? 'one-time-code' : 'off'"
+          autocapitalize="characters"
+          spellcheck="false"
+          :disabled="disabled"
+          :aria-label="`${label} ${cell.index + 1}/${slotCount}`"
+          @input="onCellInput(cell.index, $event)"
+          @keydown="onCellKeydown(cell.index, $event)"
+          @paste.prevent="onCellPaste(cell.index, $event)"
+          @focus="onCellFocus"
+        />
+      </template>
+    </div>
+  </div>
+
+  <!-- no (valid) format: plain text input so the entry stays usable -->
+  <v-text-field
+    v-else
+    :model-value="entry.value"
+    :placeholder="entry.default_value?.toString()"
+    clearable
+    :disabled="disabled"
+    :label="label"
+    :required="entry.required"
+    :rules="[(v) => !(!v && entry.required) || $t('settings.invalid_input')]"
+    variant="outlined"
+    density="comfortable"
+    class="pairing-code-fallback"
+    @update:model-value="emit('update:value', $event)"
+    @click:clear="emit('update:value', null)"
+  />
+</template>
+
+<style scoped>
+.pairing-code-field {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 4px 0 8px;
+}
+
+.pairing-code-label {
+  font-size: 0.875rem;
+  color: rgba(var(--v-theme-on-surface), 0.7);
+}
+
+.pairing-code-boxes {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.pairing-code-input {
+  width: 44px;
+  height: 48px;
+  min-width: 0;
+  text-align: center;
+  font-family: monospace;
+  font-size: 1.25rem;
+  border: 1px solid rgba(var(--v-border-color), var(--v-border-opacity));
+  border-radius: 10px;
+  background: rgb(var(--v-theme-surface));
+  color: rgb(var(--v-theme-on-surface));
+  caret-color: rgb(var(--v-theme-primary));
+  outline: none;
+}
+
+.pairing-code-input:focus {
+  border-color: rgb(var(--v-theme-primary));
+  outline: 1px solid rgb(var(--v-theme-primary));
+}
+
+.pairing-code-input:disabled {
+  opacity: 0.5;
+}
+
+.pairing-code-separator {
+  font-family: monospace;
+  font-size: 1.25rem;
+  color: rgba(var(--v-theme-on-surface), 0.5);
+  user-select: none;
+}
+
+.pairing-code-fallback :deep(input) {
+  text-align: center;
+  font-family: monospace;
+  letter-spacing: 0.05em;
+}
+
+@media (max-width: 500px) {
+  .pairing-code-boxes {
+    gap: 4px;
+  }
+
+  .pairing-code-input {
+    width: 36px;
+    height: 44px;
+    font-size: 1.1rem;
+  }
+}
+</style>

--- a/src/views/settings/fields/PairingCodeField.vue
+++ b/src/views/settings/fields/PairingCodeField.vue
@@ -1,12 +1,12 @@
 <script setup lang="ts">
+import { Input } from "@/components/ui/input";
 import type { ConfigEntryUI } from "@/helpers/config_entry_ui";
 import type { ConfigValueType } from "@/plugins/api/interfaces";
-import { $t } from "@/plugins/i18n";
 import {
   computed,
   nextTick,
-  onMounted,
   ref,
+  useId,
   watch,
   type ComponentPublicInstance,
 } from "vue";
@@ -58,31 +58,35 @@ const slotIsDigit = computed(() =>
 const slotCount = computed(() => slotIsDigit.value.length);
 const isNumeric = computed(() => slotIsDigit.value.every(Boolean));
 
+const labelId = useId();
+
 // one entered character per code slot
 const cells = ref<string[]>([]);
 const inputRefs = ref<(HTMLInputElement | null)[]>([]);
 // the value of the last update:value emission; the parent writes it straight back
-// to entry.value, so the watch below must not mistake that echo for an external reset
+// to entry.value, so the watch below must not mistake that echo for an external
+// reset — compared normalized because the parent rewrites null to default_value
 let lastEmitted: ConfigValueType | undefined;
 
 seedCells();
-
-onMounted(() => {
-  if (layout.value && !props.disabled) focusFirstEmpty();
-});
 
 // re-served setup-flow steps reuse this component instance (keyed on entry.key),
 // so an externally changed value must resync the boxes instead of keeping stale ones
 watch(
   () => props.entry.value,
   (value) => {
-    if (!layout.value || value === lastEmitted) return;
+    if (!layout.value || normalizeCode(value) === normalizeCode(lastEmitted)) {
+      return;
+    }
     if (normalizeCode(value) === cells.value.join("")) return;
     seedCells();
     lastEmitted = undefined;
     if (!props.disabled) focusFirstEmpty();
   },
 );
+
+// a re-served step may carry a different format for the same entry key
+watch(slotCount, seedCells);
 
 function onCellInput(index: number, event: Event) {
   const input = event.target as HTMLInputElement;
@@ -134,6 +138,11 @@ function onCellPaste(index: number, event: ClipboardEvent) {
 function onCellFocus(event: FocusEvent) {
   // select the content so typing overwrites instead of appending
   (event.target as HTMLInputElement).select();
+}
+
+function onFallbackInput(value: string | number) {
+  // an emptied input reads as a cleared entry
+  emit("update:value", value === "" ? null : String(value));
 }
 
 function setInputRef(index: number) {
@@ -200,19 +209,25 @@ function focusFirstEmpty() {
 </script>
 
 <template>
-  <div v-if="layout" class="pairing-code-field">
-    <v-label class="pairing-code-label">
-      {{ label }}
-    </v-label>
-    <div class="pairing-code-boxes">
+  <div class="flex w-full flex-col gap-2 py-1">
+    <span :id="labelId" class="text-muted-foreground text-sm">{{ label }}</span>
+    <div
+      v-if="layout"
+      role="group"
+      :aria-labelledby="labelId"
+      class="flex flex-wrap items-center gap-2 max-[500px]:gap-1"
+    >
       <template v-for="(cell, position) of layout" :key="position">
-        <span v-if="cell.type === 'separator'" class="pairing-code-separator">
+        <span
+          v-if="cell.type === 'separator'"
+          class="pairing-code-separator text-muted-foreground font-mono text-xl select-none max-[500px]:text-lg"
+        >
           {{ cell.text }}
         </span>
         <input
           v-else
           :ref="setInputRef(cell.index)"
-          class="pairing-code-input"
+          class="pairing-code-input border-input text-foreground selection:bg-primary selection:text-primary-foreground caret-primary dark:bg-input/30 focus:border-ring focus:ring-ring/50 h-12 w-11 min-w-0 rounded-lg border bg-transparent text-center font-mono text-xl shadow-xs transition-[color,box-shadow] outline-none focus:ring-[3px] disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 max-[500px]:h-11 max-[500px]:w-9 max-[500px]:text-lg"
           type="text"
           :value="cells[cell.index]"
           :inputmode="isNumeric ? 'numeric' : 'text'"
@@ -228,92 +243,16 @@ function focusFirstEmpty() {
         />
       </template>
     </div>
+
+    <!-- no (valid) format: plain text input so the entry stays usable -->
+    <Input
+      v-else
+      class="pairing-code-fallback text-center font-mono tracking-wider"
+      :model-value="String(entry.value ?? '')"
+      :placeholder="entry.default_value?.toString()"
+      :disabled="disabled"
+      :aria-labelledby="labelId"
+      @update:model-value="onFallbackInput"
+    />
   </div>
-
-  <!-- no (valid) format: plain text input so the entry stays usable -->
-  <v-text-field
-    v-else
-    :model-value="entry.value"
-    :placeholder="entry.default_value?.toString()"
-    clearable
-    :disabled="disabled"
-    :label="label"
-    :required="entry.required"
-    :rules="[(v) => !(!v && entry.required) || $t('settings.invalid_input')]"
-    variant="outlined"
-    density="comfortable"
-    class="pairing-code-fallback"
-    @update:model-value="emit('update:value', $event)"
-    @click:clear="emit('update:value', null)"
-  />
 </template>
-
-<style scoped>
-.pairing-code-field {
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-  padding: 4px 0 8px;
-}
-
-.pairing-code-label {
-  font-size: 0.875rem;
-  color: rgba(var(--v-theme-on-surface), 0.7);
-}
-
-.pairing-code-boxes {
-  display: flex;
-  align-items: center;
-  flex-wrap: wrap;
-  gap: 8px;
-}
-
-.pairing-code-input {
-  width: 44px;
-  height: 48px;
-  min-width: 0;
-  text-align: center;
-  font-family: monospace;
-  font-size: 1.25rem;
-  border: 1px solid rgba(var(--v-border-color), var(--v-border-opacity));
-  border-radius: 10px;
-  background: rgb(var(--v-theme-surface));
-  color: rgb(var(--v-theme-on-surface));
-  caret-color: rgb(var(--v-theme-primary));
-  outline: none;
-}
-
-.pairing-code-input:focus {
-  border-color: rgb(var(--v-theme-primary));
-  outline: 1px solid rgb(var(--v-theme-primary));
-}
-
-.pairing-code-input:disabled {
-  opacity: 0.5;
-}
-
-.pairing-code-separator {
-  font-family: monospace;
-  font-size: 1.25rem;
-  color: rgba(var(--v-theme-on-surface), 0.5);
-  user-select: none;
-}
-
-.pairing-code-fallback :deep(input) {
-  text-align: center;
-  font-family: monospace;
-  letter-spacing: 0.05em;
-}
-
-@media (max-width: 500px) {
-  .pairing-code-boxes {
-    gap: 4px;
-  }
-
-  .pairing-code-input {
-    width: 36px;
-    height: 44px;
-    font-size: 1.1rem;
-  }
-}
-</style>

--- a/tests/views/ConfigEntryField.test.ts
+++ b/tests/views/ConfigEntryField.test.ts
@@ -232,7 +232,7 @@ describe("ConfigEntryField", () => {
     const wrapper = mountField(pairingCodeEntry(null));
 
     expect(wrapper.findAll("input.pairing-code-input")).toHaveLength(0);
-    expect(wrapper.find(".pairing-code-fallback input").exists()).toBe(true);
+    expect(wrapper.find("input.pairing-code-fallback").exists()).toBe(true);
   });
 
   it("disables a read_only ranged entry while the form itself is enabled", () => {

--- a/tests/views/ConfigEntryField.test.ts
+++ b/tests/views/ConfigEntryField.test.ts
@@ -210,6 +210,31 @@ describe("ConfigEntryField", () => {
     expect(controlStates(mountField(confEntry))).toEqual([true]);
   });
 
+  it("renders a pairing code entry as one box per code character", () => {
+    const wrapper = mountField(pairingCodeEntry());
+
+    expect(wrapper.findComponent({ name: "PairingCodeField" }).exists()).toBe(
+      true,
+    );
+    expect(wrapper.findAll("input.pairing-code-input")).toHaveLength(6);
+  });
+
+  // not part of INTERACTIVE_ENTRIES: that matrix expects exactly one control per entry
+  it("disables every pairing code box", () => {
+    const states = (disabled: boolean) =>
+      controlStates(mountField(pairingCodeEntry(), disabled));
+
+    expect(states(false)).toEqual(Array.from({ length: 6 }, () => false));
+    expect(states(true)).toEqual(Array.from({ length: 6 }, () => true));
+  });
+
+  it("keeps a pairing code entry without a format usable as a text input", () => {
+    const wrapper = mountField(pairingCodeEntry(null));
+
+    expect(wrapper.findAll("input.pairing-code-input")).toHaveLength(0);
+    expect(wrapper.find(".pairing-code-fallback input").exists()).toBe(true);
+  });
+
   it("disables a read_only ranged entry while the form itself is enabled", () => {
     const confEntry = {
       ...rangedEntry(ConfigEntryType.INTEGER),
@@ -268,6 +293,10 @@ function expandedOptionsEntry(): ConfigEntryUI {
       },
     ],
   });
+}
+
+function pairingCodeEntry(format: string | null = "###-###"): ConfigEntryUI {
+  return entry({ key: "pin", type: ConfigEntryType.PAIRING_CODE, format });
 }
 
 function hassControlsEntry(): ConfigEntryUI {

--- a/tests/views/PairingCodeField.test.ts
+++ b/tests/views/PairingCodeField.test.ts
@@ -90,6 +90,17 @@ describe("PairingCodeField", () => {
     },
   );
 
+  // mobile keyboards and OTP autofill can deliver the whole code in one input event
+  it("fills every box from a single input event carrying the full code", async () => {
+    const wrapper = mountField();
+
+    await boxes(wrapper)[0].setValue("123456");
+    await nextTick();
+
+    expect(boxValues(wrapper)).toEqual(["1", "2", "3", "4", "5", "6"]);
+    expect(wrapper.emitted("update:value")).toEqual([["123456"]]);
+  });
+
   it("emits null again when a character is cleared after completion", async () => {
     const wrapper = mountField();
     await typeCode(wrapper, "123456");
@@ -123,7 +134,7 @@ describe("PairingCodeField", () => {
       const wrapper = mountField({ format });
 
       expect(boxes(wrapper)).toHaveLength(0);
-      expect(wrapper.find(".pairing-code-fallback input").exists()).toBe(true);
+      expect(wrapper.find("input.pairing-code-fallback").exists()).toBe(true);
     },
   );
 
@@ -147,6 +158,20 @@ describe("PairingCodeField", () => {
     await nextTick();
 
     expect(boxValues(wrapper)).toEqual(["6", "5", "4", "3", "2", "1"]);
+  });
+
+  it("keeps typed boxes when the parent echoes the null emission back", async () => {
+    const wrapper = mountField();
+    await typeCode(wrapper, "123456");
+    // the parent writes the completed code back to entry.value...
+    await wrapper.setProps({ entry: pairingEntry({ value: "123456" }) });
+
+    await boxes(wrapper)[5].trigger("keydown", { key: "Backspace" });
+    // ...and echoes the null emission back as the (null) default_value
+    await wrapper.setProps({ entry: pairingEntry({ value: null }) });
+    await nextTick();
+
+    expect(boxValues(wrapper)).toEqual(["1", "2", "3", "4", "5", ""]);
   });
 });
 

--- a/tests/views/PairingCodeField.test.ts
+++ b/tests/views/PairingCodeField.test.ts
@@ -1,0 +1,200 @@
+import {
+  enableAutoUnmount,
+  mount,
+  type DOMWrapper,
+  type VueWrapper,
+} from "@vue/test-utils";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { nextTick } from "vue";
+import { createVuetify } from "vuetify";
+import * as components from "vuetify/components";
+import * as directives from "vuetify/directives";
+import { ConfigEntryType, type ConfigEntry } from "@/plugins/api/interfaces";
+import type { ConfigEntryUI } from "@/helpers/config_entry_ui";
+import PairingCodeField from "@/views/settings/fields/PairingCodeField.vue";
+
+vi.mock("@/plugins/i18n", () => ({
+  $t: (key: string) => key,
+}));
+
+const vuetify = createVuetify({ components, directives });
+
+// the field moves real focus between its boxes, so it needs to live in the document
+enableAutoUnmount(afterEach);
+
+describe("PairingCodeField", () => {
+  it("renders a box per code character and the separator", () => {
+    const wrapper = mountField();
+
+    expect(boxes(wrapper)).toHaveLength(6);
+    expect(wrapper.find(".pairing-code-separator").text()).toBe("-");
+  });
+
+  it("emits null until the last digit completes the code", async () => {
+    const wrapper = mountField();
+
+    await typeCode(wrapper, "123456");
+
+    expect(wrapper.emitted("update:value")).toEqual([
+      [null],
+      [null],
+      [null],
+      [null],
+      [null],
+      ["123456"],
+    ]);
+  });
+
+  it("drops a letter typed into a digit box", async () => {
+    const wrapper = mountField();
+    const first = boxes(wrapper)[0];
+    (first.element as HTMLInputElement).focus();
+
+    await first.setValue("a");
+    await nextTick();
+
+    expect(boxValues(wrapper)[0]).toBe("");
+    expect(document.activeElement).toBe(first.element);
+    expect(wrapper.emitted("update:value")).toEqual([[null]]);
+  });
+
+  it("uppercases letters in an alphanumeric format", async () => {
+    const wrapper = mountField({ format: "XXXX-XXXX" });
+
+    await typeCode(wrapper, "abcd1234");
+
+    expect(boxValues(wrapper).join("")).toBe("ABCD1234");
+    expect(wrapper.emitted("update:value")!.at(-1)).toEqual(["ABCD1234"]);
+  });
+
+  it("moves to and clears the previous box on backspace in an empty box", async () => {
+    const wrapper = mountField();
+    await typeCode(wrapper, "123");
+
+    await boxes(wrapper)[3].trigger("keydown", { key: "Backspace" });
+    await nextTick();
+
+    expect(boxValues(wrapper)).toEqual(["1", "2", "", "", "", ""]);
+    expect(document.activeElement).toBe(boxes(wrapper)[2].element);
+  });
+
+  it.each(["123-456", " 123 456 "])(
+    "fills every box from a paste of '%s' into the first box",
+    async (text) => {
+      const wrapper = mountField();
+
+      await paste(wrapper, 0, text);
+
+      expect(boxValues(wrapper)).toEqual(["1", "2", "3", "4", "5", "6"]);
+      expect(wrapper.emitted("update:value")).toEqual([["123456"]]);
+    },
+  );
+
+  it("emits null again when a character is cleared after completion", async () => {
+    const wrapper = mountField();
+    await typeCode(wrapper, "123456");
+
+    await boxes(wrapper)[5].trigger("keydown", { key: "Backspace" });
+
+    expect(wrapper.emitted("update:value")!.at(-1)).toEqual([null]);
+  });
+
+  it("disables every box", () => {
+    const states = (disabled: boolean) =>
+      boxes(mountField({}, disabled)).map(
+        (box) => box.attributes("disabled") !== undefined,
+      );
+
+    expect(states(false)).toEqual(Array.from({ length: 6 }, () => false));
+    expect(states(true)).toEqual(Array.from({ length: 6 }, () => true));
+  });
+
+  it("renders any non-slot character as a literal separator", () => {
+    const wrapper = mountField({ format: "##:##" });
+
+    expect(boxes(wrapper)).toHaveLength(4);
+    expect(wrapper.find(".pairing-code-separator").text()).toBe(":");
+  });
+
+  // "?!" holds no code slot at all, which is the only way a non-empty format is invalid
+  it.each([null, "?!"])(
+    "falls back to a plain text field for format %s",
+    (format) => {
+      const wrapper = mountField({ format });
+
+      expect(boxes(wrapper)).toHaveLength(0);
+      expect(wrapper.find(".pairing-code-fallback input").exists()).toBe(true);
+    },
+  );
+
+  it("uses the numeric keyboard only when every slot is a digit", () => {
+    const inputmodes = (wrapper: VueWrapper) =>
+      boxes(wrapper).map((box) => box.attributes("inputmode"));
+
+    expect(inputmodes(mountField())).toEqual(
+      Array.from({ length: 6 }, () => "numeric"),
+    );
+    expect(inputmodes(mountField({ format: "##XX" }))).toEqual(
+      Array.from({ length: 4 }, () => "text"),
+    );
+  });
+
+  it("resyncs the boxes when the entry value changes externally", async () => {
+    const wrapper = mountField();
+    await typeCode(wrapper, "111111");
+
+    await wrapper.setProps({ entry: pairingEntry({ value: "654321" }) });
+    await nextTick();
+
+    expect(boxValues(wrapper)).toEqual(["6", "5", "4", "3", "2", "1"]);
+  });
+});
+
+function pairingEntry(overrides: Partial<ConfigEntry> = {}): ConfigEntryUI {
+  const base: ConfigEntry = {
+    key: "pin",
+    type: ConfigEntryType.PAIRING_CODE,
+    label: "pin",
+    category: "generic",
+    default_value: null,
+    required: true,
+    options: [],
+    value: null,
+    format: "###-###",
+  };
+  return { ...base, ...overrides };
+}
+
+function mountField(overrides: Partial<ConfigEntry> = {}, disabled = false) {
+  return mount(PairingCodeField, {
+    props: { entry: pairingEntry(overrides), label: "Pairing code", disabled },
+    attachTo: document.body,
+    global: { plugins: [vuetify] },
+  });
+}
+
+function boxes(wrapper: VueWrapper): DOMWrapper<Element>[] {
+  return wrapper.findAll("input.pairing-code-input");
+}
+
+function boxValues(wrapper: VueWrapper): string[] {
+  return boxes(wrapper).map((box) => (box.element as HTMLInputElement).value);
+}
+
+async function typeCode(wrapper: VueWrapper, code: string) {
+  const inputs = boxes(wrapper);
+  for (let i = 0; i < code.length; i++) {
+    await inputs[i].setValue(code[i]);
+  }
+}
+
+/**
+ * Dispatches a paste of `text` on the given box. Built by hand because the
+ * ClipboardEvent constructor offers no way to carry clipboard data in tests.
+ */
+async function paste(wrapper: VueWrapper, index: number, text: string) {
+  const event = new Event("paste", { bubbles: true, cancelable: true });
+  Object.assign(event, { clipboardData: { getData: () => text } });
+  boxes(wrapper)[index].element.dispatchEvent(event);
+  await nextTick();
+}


### PR DESCRIPTION
# What does this implement/fix?

Renders pairing codes (AirPlay PIN, Sendspin PIN) as large per-character input boxes — like a one-time-code field — instead of a plain text field. The server describes the shape via the new `pairing_code` config entry type and its `format` field (`#` = digit, `X` = letter/digit, any other character shows as a separator, e.g. `###-###`).

- new `PairingCodeField` with auto-advance, backspace/arrow navigation, paste support and a numeric mobile keyboard for digit-only codes
- incomplete codes keep the submit button disabled; the submitted value never includes separators
- entries without a usable format fall back to the regular text field

**Related issue (if applicable):**

**Related backend PR (if applicable):**

- related models PR: https://github.com/music-assistant/models/pull/384
- related backend PR: https://github.com/music-assistant/server/pull/6028

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm lint:check` passes.
- [x] `pnpm test:run` passes, and tests have been added/updated where applicable.
- [x] `pnpm build` passes.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
