### PR TITLE
Show audio inputs and devices that need setup

### DIFF
--- a/src/components/PlayerCard.vue
+++ b/src/components/PlayerCard.vue
@@ -29,14 +29,18 @@
         <button
           type="button"
           class="player-select-action focus-visible:ring-ring absolute inset-0 z-0 rounded-md text-left outline-none focus-visible:ring-2"
-          :disabled="!player.available && !player.needs_setup"
+          :disabled="
+            (!player.available && !player.needs_setup) || isInformationalSource
+          "
           @click="emit('click', player)"
         >
           <span class="sr-only">
             {{
               player.needs_setup
                 ? $t("configure_player")
-                : $t("tooltip.select_player")
+                : isInformationalSource
+                  ? $t("player_type.source")
+                  : $t("tooltip.select_player")
             }}:
             {{ accessiblePlayerLabel }}
             <template v-if="player.needs_setup">
@@ -112,6 +116,12 @@
                 <TriangleAlert class="size-3" />
                 {{ $t("settings.setup_required") }}
               </Badge>
+              <p
+                v-if="player.type === PlayerType.SOURCE"
+                class="text-muted-foreground truncate text-xs"
+              >
+                {{ $t("player_type.source") }}
+              </p>
               <p
                 v-if="player.powered !== false && player.current_media?.title"
                 class="truncate text-xs font-medium"
@@ -285,6 +295,11 @@ const artworkFailed = ref(false);
 const { activeSource } = useActiveSource(toRef(props, "player"));
 
 const playerQueue = computed(() => resolvePlayerQueue(props.player));
+
+// a set-up audio input can't be selected for playback; its row only informs
+const isInformationalSource = computed(
+  () => props.player.type === PlayerType.SOURCE && !props.player.needs_setup,
+);
 
 const artworkUrl = computed(() => {
   if (

--- a/src/components/PlayerFilters.vue
+++ b/src/components/PlayerFilters.vue
@@ -12,6 +12,11 @@
         :title="$t('settings.player_type_label')"
         :options="playerTypeOptions"
       />
+      <FacetedFilter
+        v-model="selectedStatuses"
+        :title="$t('settings.player_status_label')"
+        :options="statusOptions"
+      />
     </div>
   </div>
 </template>
@@ -31,10 +36,12 @@ const route = useRoute();
 const searchQuery = ref<string>("");
 const selectedProviders = ref<string[]>([]);
 const selectedPlayerTypes = ref<string[]>([]);
+const selectedStatuses = ref<string[]>([]);
 
 let searchDebounceTimeout: ReturnType<typeof setTimeout> | null = null;
 let providersDebounceTimeout: ReturnType<typeof setTimeout> | null = null;
 let typesDebounceTimeout: ReturnType<typeof setTimeout> | null = null;
+let statusesDebounceTimeout: ReturnType<typeof setTimeout> | null = null;
 
 const providerOptions = computed(() =>
   Object.values(api.providers)
@@ -50,6 +57,14 @@ const playerTypeOptions = computed(() => [
   { label: $t("player_type.player"), value: PlayerType.PLAYER },
   { label: $t("player_type.group"), value: PlayerType.GROUP },
   { label: $t("player_type.stereo_pair"), value: PlayerType.STEREO_PAIR },
+  { label: $t("player_type.source"), value: PlayerType.SOURCE },
+]);
+
+const statusOptions = computed(() => [
+  { label: $t("settings.player_status.available"), value: "available" },
+  { label: $t("settings.player_status.needs_setup"), value: "needs_setup" },
+  { label: $t("settings.player_status.unavailable"), value: "unavailable" },
+  { label: $t("settings.player_status.disabled"), value: "disabled" },
 ]);
 
 // Emits
@@ -57,6 +72,7 @@ const emit = defineEmits<{
   (e: "update:search", value: string): void;
   (e: "update:providers", value: string[]): void;
   (e: "update:types", value: string[]): void;
+  (e: "update:statuses", value: string[]): void;
 }>();
 
 const initializeFromUrl = function () {
@@ -72,6 +88,11 @@ const initializeFromUrl = function () {
   if (route.query.types) {
     const types = route.query.types as string;
     selectedPlayerTypes.value = types.split(",");
+  }
+
+  if (route.query.status) {
+    const statuses = route.query.status as string;
+    selectedStatuses.value = statuses.split(",");
   }
 };
 
@@ -127,6 +148,27 @@ watch(
         query.types = newTypes.join(",");
       } else {
         delete query.types;
+      }
+      router.replace({ query });
+    }, 750);
+  },
+  { deep: true },
+);
+
+watch(
+  selectedStatuses,
+  (newStatuses) => {
+    emit("update:statuses", newStatuses);
+
+    if (statusesDebounceTimeout) {
+      clearTimeout(statusesDebounceTimeout);
+    }
+    statusesDebounceTimeout = setTimeout(() => {
+      const query = { ...route.query };
+      if (newStatuses.length > 0) {
+        query.status = newStatuses.join(",");
+      } else {
+        delete query.status;
       }
       router.replace({ query });
     }, 750);

--- a/src/components/SetupFlowDialog.vue
+++ b/src/components/SetupFlowDialog.vue
@@ -333,6 +333,7 @@ import {
   type ConfigValueType,
   FlowStepType,
   SECURE_STRING_SUBSTITUTE,
+  SILENT_FINISH_STEP_ID,
   type SetupFlowStep,
 } from "@/plugins/api/interfaces";
 import { eventbus, type SetupFlowDialogEvent } from "@/plugins/eventbus";
@@ -593,6 +594,15 @@ function applyStep(newStep: SetupFlowStep) {
   ) {
     completionNotified = true;
     launch.value.onFlowEnded?.(newStep.type === FlowStepType.FINISH);
+  }
+
+  // a silent finish (e.g. a one-click device approval) needs no success screen
+  if (
+    newStep.type === FlowStepType.FINISH &&
+    newStep.step_id === SILENT_FINISH_STEP_ID
+  ) {
+    close(false);
+    return;
   }
 
   if (newStep.type === FlowStepType.FORM) {

--- a/src/composables/useOrderedPlayers.ts
+++ b/src/composables/useOrderedPlayers.ts
@@ -10,6 +10,7 @@ import { computed, type MaybeRefOrGetter, toValue } from "vue";
 
 interface OrderedPlayersOptions {
   allowNeedsSetup?: boolean;
+  allowSources?: boolean;
   selectedPlayerFirst?: MaybeRefOrGetter<boolean>;
   activePlayersFirst?: MaybeRefOrGetter<boolean>;
   includePausedAsActive?: boolean;
@@ -19,7 +20,12 @@ export function useOrderedPlayers(opts?: OrderedPlayersOptions) {
   return computed(() =>
     Object.values(api.players)
       .filter((player) =>
-        playerVisible(player, false, opts?.allowNeedsSetup ?? false),
+        playerVisible(
+          player,
+          false,
+          opts?.allowNeedsSetup ?? false,
+          opts?.allowSources ?? false,
+        ),
       )
       .sort((left, right) => comparePlayers(left, right, opts)),
   );

--- a/src/helpers/player_menu_items.ts
+++ b/src/helpers/player_menu_items.ts
@@ -10,6 +10,7 @@ import {
   RepeatMode,
   PLAYER_CONTROL_NONE,
 } from "@/plugins/api/interfaces";
+import { isSelectablePlayer } from "@/helpers/players";
 import { getSleepTimerMenuItem, sleepTimerActive } from "@/helpers/sleep_timer";
 import { resolveExternalSource } from "@/composables/externalSource";
 import { resolveActiveSourceId } from "@/composables/activeSource";
@@ -215,8 +216,7 @@ export const getPlayerMenuItems = (
           (p) =>
             p.player_id != playerQueue!.queue_id &&
             p.player_id != player.player_id &&
-            p.available &&
-            p.enabled &&
+            isSelectablePlayer(p) &&
             !p.synced_to &&
             !p.hide_in_ui,
         )

--- a/src/helpers/player_settings_actions.ts
+++ b/src/helpers/player_settings_actions.ts
@@ -3,6 +3,7 @@
 // from here so the two never drift apart.
 import type { ContextMenuItem } from "@/helpers/context_menu_item";
 import { getPlayerSetupMenuItem } from "@/helpers/player_menu_items";
+import { isSelectablePlayer } from "@/helpers/players";
 import { openLinkInNewTab } from "@/helpers/utils";
 import { setUserPreference } from "@/composables/userPreferences";
 import { api } from "@/plugins/api";
@@ -209,9 +210,7 @@ function selectFallbackPlayer(playerId: string) {
   store.activePlayerId = Object.values(api.players).find(
     (candidate) =>
       candidate.player_id !== playerId &&
-      candidate.available &&
-      candidate.enabled &&
-      !candidate.needs_setup &&
+      isSelectablePlayer(candidate) &&
       !candidate.hide_in_ui &&
       !candidate.synced_to,
   )?.player_id;

--- a/src/helpers/players.ts
+++ b/src/helpers/players.ts
@@ -35,15 +35,20 @@ export const isPlayerActive = function (player: Player): boolean {
  * Check if the player may be shown to the user.
  *
  * Set allowGroupChilds to also include players that are synced to or part of a
- * group, and allowNeedsSetup to include players that still need to be set up.
+ * group, allowNeedsSetup to include players that still need to be set up, and
+ * allowSources to include capture-only audio input devices.
  */
 export const playerVisible = function (
   player: Player,
   allowGroupChilds = false,
   allowNeedsSetup = false,
+  allowSources = false,
 ): boolean {
   // perform some basic checks if we may use/show the player
   if (!player.enabled) return false;
+  // A capture-only device renders nothing: list it only where it is presented
+  // as an audio input (opt-in via allowSources), never among playback targets.
+  if (player.type === PlayerType.SOURCE && !allowSources) return false;
   if (player.synced_to && !allowGroupChilds) {
     return false;
   }
@@ -74,6 +79,23 @@ export const playerVisible = function (
 };
 
 /**
+ * Check if the player may become the active playback target.
+ *
+ * Capture-only audio inputs are listed for discoverability but never render
+ * audio, so they can never be selected.
+ */
+export const isSelectablePlayer = function (
+  player: Player | null | undefined,
+): boolean {
+  return Boolean(
+    player?.enabled &&
+    player.available &&
+    !player.needs_setup &&
+    player.type !== PlayerType.SOURCE,
+  );
+};
+
+/**
  * Check if the player may be offered as a group member.
  *
  * Hiding a player only removes it from the main listings, so it stays pickable
@@ -87,12 +109,13 @@ export const groupMemberPickerVisible = function (player: Player): boolean {
 /**
  * Check if the player can take part in grouping.
  *
- * Capture-only devices report an unknown type: they exist so the device still
- * has a settings page, but they render nothing, so they are never offered as
- * a group member.
+ * Capture-only devices (audio inputs, or an unknown type from an older server)
+ * render nothing, so they are never offered as a group member.
  */
 export const canBeGroupMember = function (player: Player): boolean {
-  return player.type !== PlayerType.UNKNOWN;
+  return (
+    player.type !== PlayerType.UNKNOWN && player.type !== PlayerType.SOURCE
+  );
 };
 
 /**

--- a/src/layouts/default/Default.vue
+++ b/src/layouts/default/Default.vue
@@ -15,6 +15,7 @@ import ReloadPrompt from "./ReloadPrompt.vue";
 import { store } from "@/plugins/store";
 import { watch } from "vue";
 import api from "@/plugins/api";
+import { isSelectablePlayer } from "@/helpers/players";
 import { useRoute } from "vue-router";
 
 const route = useRoute();
@@ -27,8 +28,9 @@ watch(
     // newActivePlayer can be either player id or player name
     const newPlayerId = Object.values(api.players).find((p) => {
       return (
-        p.player_id.toLowerCase() === newPlayerString ||
-        p.name.toLowerCase() === newPlayerString
+        (p.player_id.toLowerCase() === newPlayerString ||
+          p.name.toLowerCase() === newPlayerString) &&
+        isSelectablePlayer(p)
       );
     })?.player_id;
 

--- a/src/layouts/default/PlayerSelect.vue
+++ b/src/layouts/default/PlayerSelect.vue
@@ -209,9 +209,13 @@ import {
   fullscreenPlayerSelectAnchor,
   playerBarEndAnchor,
 } from "@/helpers/player_bar";
-import { isBuiltinPlayer, isPlayerActive } from "@/helpers/players";
+import {
+  isBuiltinPlayer,
+  isPlayerActive,
+  isSelectablePlayer,
+} from "@/helpers/players";
 import { api } from "@/plugins/api";
-import type { Player } from "@/plugins/api/interfaces";
+import { PlayerType, type Player } from "@/plugins/api/interfaces";
 import { eventbus } from "@/plugins/eventbus";
 import { store } from "@/plugins/store";
 import { webPlayer } from "@/plugins/web_player";
@@ -263,10 +267,12 @@ let lastInteractionWasKeyboard = false;
 let restoreFocusOnClose = false;
 let autoSelectedPlayerId: string | undefined;
 
-// PlayerSelect is the only surface that lists needs_setup players: a click here
-// launches the setup flow (see selectPlayer) instead of selecting/playing them.
+// PlayerSelect is the only surface that lists needs_setup players (a click here
+// launches the setup flow, see selectPlayer) and capture-only audio inputs
+// (informational rows, so the device stays discoverable).
 const orderedPlayers = useOrderedPlayers({
   allowNeedsSetup: true,
+  allowSources: true,
   selectedPlayerFirst: showSelectedPlayerFirst,
   activePlayersFirst: showActivePlayersFirst,
   includePausedAsActive: true,
@@ -418,12 +424,16 @@ function selectPlayer(player: Player) {
       kind: "player",
       playerId: player.player_id,
       onFlowEnded: (finished) => {
-        if (finished) activatePlayer(player.player_id);
+        if (finished && player.type !== PlayerType.SOURCE) {
+          activatePlayer(player.player_id);
+        }
       },
     });
     store.showPlayersMenu = false;
     return;
   }
+  // an audio input can't be a playback target; its row is informational
+  if (player.type === PlayerType.SOURCE) return;
   activatePlayer(player.player_id);
   store.showPlayersMenu = false;
 }
@@ -515,30 +525,28 @@ function selectDefaultPlayer() {
   if (lastPlayerId === BUILTIN_PLAYER_PREFERENCE) return selectBuiltinPlayer();
   if (lastPlayerId) {
     if (!(lastPlayerId in api.players)) return;
-    if (isSelectablePlayer(lastPlayerId)) return lastPlayerId;
+    if (isSelectablePlayerId(lastPlayerId)) return lastPlayerId;
   }
   const builtinPlayerId = selectBuiltinPlayer();
   if (builtinPlayerId) return builtinPlayerId;
   const selectablePlayers = orderedPlayers.value.filter((player) =>
-    isSelectablePlayer(player.player_id),
+    isSelectablePlayerId(player.player_id),
   );
   return (selectablePlayers.find(isPlayerActive) ?? selectablePlayers[0])
     ?.player_id;
 }
 
 function selectBuiltinPlayer() {
-  if (isSelectablePlayer(webPlayer.player_id)) {
+  if (isSelectablePlayerId(webPlayer.player_id)) {
     return webPlayer.player_id;
   }
-  if (isSelectablePlayer(store.companionPlayerId)) {
+  if (isSelectablePlayerId(store.companionPlayerId)) {
     return store.companionPlayerId;
   }
 }
 
-function isSelectablePlayer(playerId: string | null | undefined) {
-  if (!playerId) return false;
-  const player = api.players[playerId];
-  return player?.enabled && player.available && !player.needs_setup;
+function isSelectablePlayerId(playerId: string | null | undefined) {
+  return !!playerId && isSelectablePlayer(api.players[playerId]);
 }
 
 async function scrollSelectedPlayerIntoView() {

--- a/src/plugins/api/interfaces.ts
+++ b/src/plugins/api/interfaces.ts
@@ -371,6 +371,7 @@ export enum PlayerType {
   DISPLAY = "display",
   VISUALIZER = "visualizer",
   LIGHT = "light",
+  SOURCE = "source", // A capture-only device that provides audio input.
   UNKNOWN = "unknown",
 }
 
@@ -781,6 +782,10 @@ export enum FlowStepType {
   // fallback
   UNKNOWN = "unknown",
 }
+
+// step_id a FINISH step carries when there is nothing to report (e.g. a one-click
+// device approval); the setup dialog closes instead of showing a success screen
+export const SILENT_FINISH_STEP_ID = "finish_silent";
 
 export interface SetupFlowStep {
   // A single step of a running setup flow (add/reconfigure a provider or set up a player).

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -68,9 +68,11 @@
         "display": "Screen",
         "visualizer": "Visualizer",
         "light": "Light",
+        "source": "Audio input",
         "unknown": "Unknown"
     },
     "players": "Players",
+    "players_need_setup": "A new device was discovered that needs to be set up | {count} new devices were discovered that need to be set up",
     "playlist": "Playlist",
     "playlist_tracks": "Playlist tracks",
     "playlists": "Playlists",
@@ -89,6 +91,7 @@
     "refresh_item": "Refresh item",
     "remove_library": "Remove from library",
     "remove_playlist": "Remove from playlist",
+    "review": "Review",
     "search": "Search",
     "settings": {
         "add_new": "Add new",
@@ -121,6 +124,13 @@
         "server_logs_load_failed": "Failed to load server logs",
         "player_provider": "Provider",
         "player_settings": "Player settings",
+        "player_status": {
+            "available": "Available",
+            "needs_setup": "Needs setup",
+            "unavailable": "Unavailable",
+            "disabled": "Disabled"
+        },
+        "player_status_label": "Status",
         "player_type_label": "Player type",
         "playerproviders": "Player providers",
         "players": "Players",

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -55,6 +55,41 @@
       </Button>
     </Alert>
 
+    <!-- Newly discovered devices that still need setup; Review opens the
+         players list filtered down to them. -->
+    <Alert
+      v-if="isAdmin && showSetupPrompt && playersNeedingSetup.length > 0"
+      variant="warning"
+      class="mx-7 mb-6 mt-4 flex w-auto items-center gap-3 py-3 pl-4 pr-3 [&>svg]:translate-y-0"
+    >
+      <TriangleAlert class="size-5 shrink-0" />
+      <AlertDescription class="min-w-0 flex-1">
+        {{
+          $t("players_need_setup", playersNeedingSetup.length, {
+            named: { count: playersNeedingSetup.length },
+          })
+        }}
+      </AlertDescription>
+      <Button
+        variant="secondary"
+        size="sm"
+        class="shrink-0"
+        @click="reviewSetupPlayers"
+      >
+        {{ $t("review") }}
+        <ArrowRight class="size-3.5" />
+      </Button>
+      <Button
+        variant="ghost"
+        size="icon-sm"
+        class="shrink-0"
+        :aria-label="$t('close')"
+        @click="showSetupPrompt = false"
+      >
+        <X class="size-4" />
+      </Button>
+    </Alert>
+
     <HomeWidgetRows :edit-mode="editMode" />
 
     <!-- Floating exit button while editing the home screen -->
@@ -82,9 +117,10 @@ import {
   CircleAlert,
   Compass,
   SquarePen,
+  TriangleAlert,
   X,
 } from "@lucide/vue";
-import { onMounted, ref } from "vue";
+import { computed, onMounted, ref } from "vue";
 import { useRouter } from "vue-router";
 
 const router = useRouter();
@@ -92,6 +128,18 @@ const editMode = ref(false);
 const hasProviderErrors = ref(false);
 const showProviderWarning = ref(true);
 const erroredProviderType = ref<string | null>(null);
+const isAdmin = ref(false);
+const showSetupPrompt = ref(true);
+
+const playersNeedingSetup = computed(() =>
+  Object.values(api.players).filter(
+    (player) => player.enabled && player.needs_setup,
+  ),
+);
+
+const reviewSetupPlayers = () => {
+  router.push({ name: "playersettings", query: { status: "needs_setup" } });
+};
 
 const handleHomescreenEditToggle = () => {
   editMode.value = !editMode.value;
@@ -109,6 +157,7 @@ const navigateToProviders = () => {
 };
 
 onMounted(async () => {
+  isAdmin.value = authManager.isAdmin();
   if (authManager.isAdmin()) {
     try {
       const configs = await api.getProviderConfigs();

--- a/src/views/settings/Players.vue
+++ b/src/views/settings/Players.vue
@@ -5,6 +5,7 @@
         @update:search="searchQuery = $event"
         @update:providers="selectedProviders = $event"
         @update:types="selectedPlayerTypes = $event"
+        @update:statuses="selectedStatuses = $event"
       />
       <div class="header-actions">
         <Button
@@ -209,6 +210,7 @@ const playerConfigs = ref<PlayerConfig[]>([]);
 const searchQuery = ref<string>("");
 const selectedProviders = ref<string[]>([]);
 const selectedPlayerTypes = ref<string[]>([]);
+const selectedStatuses = ref<string[]>([]);
 const showAddPlayerGroupDialog = ref<boolean>(false);
 
 // listen for item updates to refresh items when that happens
@@ -337,6 +339,25 @@ const getAllFilteredPlayers = function () {
       const player = api.players[item.player_id];
       const playerType = player?.type ?? PlayerType.PLAYER;
       return selectedPlayerTypes.value.includes(playerType);
+    });
+  }
+
+  if (selectedStatuses.value.length > 0) {
+    filtered = filtered.filter((item) => {
+      const player = api.players[item.player_id];
+      return selectedStatuses.value.some((status) => {
+        if (status === "available") {
+          // serialized available is false while a player needs setup
+          return item.enabled && player?.available;
+        }
+        if (status === "needs_setup") {
+          return item.enabled && player?.needs_setup;
+        }
+        if (status === "unavailable") {
+          return item.enabled && !player?.available && !player?.needs_setup;
+        }
+        return status === "disabled" && !item.enabled;
+      });
     });
   }
 

--- a/tests/components/SetupFlowDialog.test.ts
+++ b/tests/components/SetupFlowDialog.test.ts
@@ -8,6 +8,7 @@ import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   ConfigEntryType,
   FlowStepType,
+  SILENT_FINISH_STEP_ID,
   type ConfigEntry,
   type SetupFlowStep,
 } from "@/plugins/api/interfaces";
@@ -160,6 +161,26 @@ describe("SetupFlowDialog", () => {
       expect(onFlowEnded).toHaveBeenCalledExactlyOnceWith(finished);
     },
   );
+
+  it("closes without an abort when a flow finishes silently", async () => {
+    apiMock.setupPlayer.mockResolvedValue({
+      ...terminalStep(FlowStepType.FINISH),
+      step_id: SILENT_FINISH_STEP_ID,
+    });
+    const onFlowEnded = vi.fn();
+    shallowMount(SetupFlowDialog);
+
+    await launchSetupFlow?.({
+      kind: "player",
+      playerId: "player-1",
+      onFlowEnded,
+    });
+    await flushPromises();
+
+    expect(onFlowEnded).toHaveBeenCalledExactlyOnceWith(true);
+    expect(storeMock.dialogActive).toBe(false);
+    expect(apiMock.abortSetupFlow).not.toHaveBeenCalled();
+  });
 
   it("keeps the pushed step when a stale submit response lands after it", async () => {
     apiMock.reconfigureProvider.mockResolvedValue(formStep());

--- a/tests/helpers/players.test.ts
+++ b/tests/helpers/players.test.ts
@@ -5,6 +5,7 @@ import {
   groupMemberPickerVisible,
   isBuiltinPlayer,
   isPlayerGrouped,
+  isSelectablePlayer,
   playerVisible,
 } from "@/helpers/players";
 import {
@@ -218,6 +219,13 @@ describe("playerVisible", () => {
     expect(playerVisible(createPlayer({ hide_in_ui: true }))).toBe(false);
   });
 
+  it("lists an audio input only where sources are opted in", () => {
+    const player = createPlayer({ type: PlayerType.SOURCE });
+
+    expect(playerVisible(player)).toBe(false);
+    expect(playerVisible(player, false, false, true)).toBe(true);
+  });
+
   it("shows the hidden player of this device", () => {
     const player = createPlayer({
       player_id: "local-web-player",
@@ -333,6 +341,31 @@ describe("canBeGroupMember", () => {
     expect(canBeGroupMember(createPlayer({ type: PlayerType.UNKNOWN }))).toBe(
       false,
     );
+    expect(canBeGroupMember(createPlayer({ type: PlayerType.SOURCE }))).toBe(
+      false,
+    );
+  });
+});
+
+describe("isSelectablePlayer", () => {
+  it("accepts a healthy regular player", () => {
+    expect(isSelectablePlayer(createPlayer())).toBe(true);
+  });
+
+  it("rejects an audio input, even a fully set up one", () => {
+    expect(isSelectablePlayer(createPlayer({ type: PlayerType.SOURCE }))).toBe(
+      false,
+    );
+  });
+
+  it("rejects a player that still needs setup", () => {
+    expect(
+      isSelectablePlayer(createPlayer({ available: false, needs_setup: true })),
+    ).toBe(false);
+  });
+
+  it("rejects a missing player", () => {
+    expect(isSelectablePlayer(undefined)).toBe(false);
   });
 });
 

--- a/tests/layouts/PlayerSelect.test.ts
+++ b/tests/layouts/PlayerSelect.test.ts
@@ -119,6 +119,13 @@ vi.mock("@/helpers/players", () => ({
   isPlayerActive: (player: Player) =>
     player.playback_state === PlaybackState.PLAYING ||
     player.playback_state === PlaybackState.PAUSED,
+  isSelectablePlayer: (player?: Player) =>
+    Boolean(
+      player?.enabled &&
+      player.available &&
+      !player.needs_setup &&
+      player.type !== PlayerType.SOURCE,
+    ),
   playerVisible: () => true,
 }));
 
@@ -676,6 +683,21 @@ describe("PlayerSelect", () => {
 
     expect(store.activePlayerId).toBe(player.player_id);
     expect(store.showPlayersMenu).toBe(false);
+  });
+
+  it("lists an audio input without ever selecting it", async () => {
+    const source = createPlayer("turntable", "Turntable");
+    source.type = PlayerType.SOURCE;
+    api.players = { [source.player_id]: source };
+    const wrapper = mountPlayerSelect();
+
+    // listed for discoverability, but never auto-picked as the default player
+    expect(wrapper.find('[data-player-id="turntable"]').exists()).toBe(true);
+    expect(store.activePlayerId).toBeUndefined();
+
+    await wrapper.find(".select-player").trigger("click");
+
+    expect(store.activePlayerId).toBeUndefined();
   });
 
   it("starts setup instead of selecting a setup-required player", async () => {

--- a/tests/views/Players.test.ts
+++ b/tests/views/Players.test.ts
@@ -186,6 +186,19 @@ describe("Players", () => {
     );
   });
 
+  it("filters the list by player status", async () => {
+    const wrapper = await mountPlayers("list");
+    const filters = wrapper.findComponent({ name: "PlayerFilters" });
+
+    filters.vm.$emit("update:statuses", ["needs_setup"]);
+    await flushPromises();
+    expect(wrapper.find(".player-list-item").exists()).toBe(true);
+
+    filters.vm.$emit("update:statuses", ["available"]);
+    await flushPromises();
+    expect(wrapper.find(".player-list-item").exists()).toBe(false);
+  });
+
   it("drops a deleted player from the list", async () => {
     const wrapper = await mountPlayers("list");
     await wrapper.get(".player-list-item").trigger("contextmenu");


### PR DESCRIPTION
# What does this implement/fix?

Companion to the server's one-click device approval. Capture-only devices (the new `source` player type) show in the player selector as informational audio-input rows: visible for discoverability, a click starts their setup while needed, and they are excluded from selection, auto-pick, transfer-queue targets and player deep links.

The dashboard shows a banner while any device still needs setup; its Review button opens the players settings page, which gained a status filter (Available / Needs setup / Unavailable / Disabled).

A setup flow that finishes with the server's `finish_silent` step id closes the dialog immediately, so a one-click approval drops the user straight back into the app with the approved player selected. Older servers never send that step id, so nothing changes for them.

**Related backend PR (if applicable):**

- related backend PR: https://github.com/music-assistant/server/pull/6035

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [x] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm lint:check` passes.
- [x] `pnpm test:run` passes, and tests have been added/updated where applicable.
- [x] `pnpm build` passes.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
