### PR TITLE
Scope audio sources in Browse to the selected player

### DIFF
--- a/src/plugins/api/index.ts
+++ b/src/plugins/api/index.ts
@@ -83,6 +83,9 @@ const TRANSLATIONS_SCHEMA_VERSION = 32;
 // The shuffle argument on player_queues/play_media landed in API schema 51.
 const PLAY_MEDIA_SHUFFLE_SCHEMA_VERSION = 51;
 
+// The player_id argument on music/browse landed in API schema 61.
+const BROWSE_PLAYER_ID_SCHEMA_VERSION = 61;
+
 export interface CommandOptions {
   /**
    * Skip the global console.error + error toast for an error result. Use for a
@@ -1485,9 +1488,17 @@ export class MusicAssistantApi {
     }
   }
 
-  public browse(path?: string): Promise<MediaItemType[]> {
+  public browse(path?: string, player_id?: string): Promise<MediaItemType[]> {
     // Browse Music providers.
-    return this.sendCommand("music/browse", { path });
+    // player_id scopes player-bound audio sources to that player;
+    // older servers (schema < 61) don't accept the argument, so omit it there.
+    const supportsPlayerId =
+      (this.serverInfo.value?.schema_version ?? 0) >=
+      BROWSE_PLAYER_ID_SCHEMA_VERSION;
+    return this.sendCommand("music/browse", {
+      path,
+      player_id: supportsPlayerId ? player_id : undefined,
+    });
   }
 
   public search(

--- a/src/views/BrowseView.vue
+++ b/src/views/BrowseView.vue
@@ -31,6 +31,7 @@ import ToolbarHeading, {
 } from "@/components/ToolbarHeading.vue";
 import api from "@/plugins/api";
 import { MediaItemType, MediaType } from "@/plugins/api/interfaces";
+import { store } from "@/plugins/store";
 import { Folder } from "@lucide/vue";
 import { computed, ref } from "vue";
 import { useI18n } from "vue-i18n";
@@ -76,7 +77,10 @@ const breadcrumbItems = computed((): ToolbarHeadingItem[] => {
 });
 
 const loadItems = async function (params: LoadDataParams) {
-  const items: Array<MediaItemType> = await api.browse(props.path);
+  const items: Array<MediaItemType> = await api.browse(
+    props.path,
+    store.activePlayerId,
+  );
   hasOnlyFolders.value = items.every(
     (item) => item.media_type === MediaType.FOLDER,
   );


### PR DESCRIPTION
# What does this implement/fix?

Since the server serves player-bound audio sources per player (Spotify Connect, AirPlay receiver), browsing audio sources listed one entry per connected player. The Browse view now tells the server which player is selected, so only that player's sources are shown; sources not bound to a player (e.g. VBAN) are always listed.

- `api.browse()` accepts an optional `player_id`, only sent to servers that support it (API schema 61+)
- the Browse view passes the currently selected player; with no player selected the listing is unchanged

**Related backend PR (if applicable):**

- related backend PR https://github.com/music-assistant/server/pull/6026

## Types of changes

<!--
Tick exactly one box below. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm lint:check` passes.
- [x] `pnpm test:run` passes, and tests have been added/updated where applicable.
- [x] `pnpm build` passes.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
