### PR TITLE
One shared code input for remote ID and pairing codes

### DIFF
--- a/src/components/SegmentedCodeInput.vue
+++ b/src/components/SegmentedCodeInput.vue
@@ -274,6 +274,7 @@ function moveCaret(position: CaretPosition) {
 <template>
   <div
     :role="readonly ? undefined : 'group'"
+    :aria-label="readonly ? undefined : ariaLabel"
     class="flex w-full flex-wrap items-center gap-2 max-[500px]:gap-1"
   >
     <template v-for="(cell, position) of renderCells" :key="position">

--- a/src/components/SegmentedCodeInput.vue
+++ b/src/components/SegmentedCodeInput.vue
@@ -1,0 +1,333 @@
+<script setup lang="ts">
+import { sanitizeCode } from "@/helpers/segmented_code";
+import { computed, nextTick, ref, type ComponentPublicInstance } from "vue";
+
+/** A code box holding `length` characters, or a literal rendered between boxes. */
+export type SegmentedCodeCell =
+  | string
+  | { length: number; digitsOnly?: boolean };
+
+const props = defineProps<{
+  /** one entry per code box, in box order */
+  modelValue: string[];
+  /** code boxes and literal separators, in render order */
+  layout: SegmentedCodeCell[];
+  disabled?: boolean;
+  /** render the value as static boxes instead of inputs */
+  readonly?: boolean;
+  /** offer the platform's OTP autofill on the first box */
+  otpAutofill?: boolean;
+  /** base for the per-box aria labels, numbered "label i/n" */
+  ariaLabel?: string;
+  /** extra class on every code box */
+  cellClass?: string;
+  /** extra class on every separator */
+  separatorClass?: string;
+}>();
+
+const emit = defineEmits<{
+  "update:modelValue": [value: string[]];
+  submit: [];
+}>();
+
+type Segment = { length: number; digitsOnly: boolean };
+type RenderCell =
+  | { type: "box"; index: number; segment: Segment }
+  | { type: "separator"; text: string };
+type CaretPosition = { segment: number; offset: number };
+
+const renderCells = computed<RenderCell[]>(() => {
+  let index = 0;
+  return props.layout.map((cell) =>
+    typeof cell === "string"
+      ? { type: "separator" as const, text: cell }
+      : {
+          type: "box" as const,
+          index: index++,
+          segment: {
+            length: cell.length,
+            digitsOnly: cell.digitsOnly ?? false,
+          },
+        },
+  );
+});
+
+const segments = computed<Segment[]>(() =>
+  renderCells.value.flatMap((cell) =>
+    cell.type === "box" ? [cell.segment] : [],
+  ),
+);
+const lastIndex = computed(() => segments.value.length - 1);
+const totalLength = computed(() =>
+  segments.value.reduce((sum, segment) => sum + segment.length, 0),
+);
+const isNumeric = computed(() =>
+  segments.value.every((segment) => segment.digitsOnly),
+);
+
+const boxValues = computed(() =>
+  segments.value.map((_, index) => props.modelValue[index] ?? ""),
+);
+
+const inputRefs = ref<(HTMLInputElement | null)[]>([]);
+
+function onBoxInput(index: number, event: Event) {
+  const input = event.target as HTMLInputElement;
+  // an emptied input (cut, delete over a selection) clears the box
+  if (input.value === "") {
+    update(withValue(index, ""));
+    return;
+  }
+  const segment = segments.value[index];
+  if (segment.length === 1) {
+    // single-char box: distribute what the DOM holds over this and later boxes
+    const { updated, end } = distribute(input.value, index, currentValues());
+    // the DOM may hold a rejected or overflowing char Vue has no patch for
+    input.value = updated[index];
+    update(updated);
+    const next = end.offset > 0 ? end.segment + 1 : index;
+    if (next > index) focusBox(Math.min(next, lastIndex.value));
+    return;
+  }
+  // multi-char box: its DOM value replaces the content, overflow spills onward
+  const clean = sanitizeCode(input.value, segment.digitsOnly);
+  const updated = currentValues();
+  updated[index] = clean.slice(0, segment.length);
+  const overflow = clean.slice(segment.length);
+  if (input.value !== updated[index]) input.value = updated[index];
+  if (overflow && index < lastIndex.value) {
+    const spilled = distribute(overflow, index + 1, updated);
+    update(spilled.updated);
+    moveCaret(spilled.end);
+  } else {
+    update(updated);
+    // auto-advance when the box was typed exactly full
+    if (updated[index].length === segment.length && index < lastIndex.value) {
+      nextTick(() => inputRefs.value[index + 1]?.focus());
+    }
+  }
+}
+
+function onBoxKeydown(index: number, event: KeyboardEvent) {
+  if (event.key === "Enter") {
+    emit("submit");
+    return;
+  }
+  if (segments.value[index].length === 1) {
+    // single-char box: whole-box navigation, backspace clears
+    if (event.key === "Backspace") {
+      event.preventDefault();
+      if (boxValues.value[index]) {
+        update(withValue(index, ""));
+      } else if (index > 0) {
+        update(withValue(index - 1, ""));
+        focusBox(index - 1);
+      }
+    } else if (event.key === "ArrowLeft" && index > 0) {
+      event.preventDefault();
+      focusBox(index - 1);
+    } else if (event.key === "ArrowRight" && index < lastIndex.value) {
+      event.preventDefault();
+      focusBox(index + 1);
+    }
+    return;
+  }
+  // multi-char box: move between boxes only when the caret sits at an edge
+  const input = event.target as HTMLInputElement;
+  const previousEnd = () => ({
+    segment: index - 1,
+    offset: boxValues.value[index - 1].length,
+  });
+  if (
+    event.key === "Backspace" &&
+    input.selectionStart === 0 &&
+    input.selectionEnd === 0 &&
+    index > 0
+  ) {
+    event.preventDefault();
+    moveCaret(previousEnd());
+  } else if (
+    event.key === "ArrowLeft" &&
+    input.selectionStart === 0 &&
+    index > 0
+  ) {
+    event.preventDefault();
+    moveCaret(previousEnd());
+  } else if (
+    event.key === "ArrowRight" &&
+    input.selectionStart === input.value.length &&
+    index < lastIndex.value
+  ) {
+    event.preventDefault();
+    moveCaret({ segment: index + 1, offset: 0 });
+  }
+}
+
+function onBoxPaste(index: number, event: ClipboardEvent) {
+  const pasted = event.clipboardData?.getData("text") || "";
+  const clean = sanitizeCode(pasted);
+  if (!clean) return;
+  // a paste into the first box, or one holding a full code, replaces everything
+  const start = index === 0 || clean.length >= totalLength.value ? 0 : index;
+  const base = start === 0 ? segments.value.map(() => "") : currentValues();
+  const { updated, end } = distribute(clean, start, base);
+  update(updated);
+  if (segments.value[end.segment].length === 1) {
+    const next = end.offset > 0 ? end.segment + 1 : start;
+    focusBox(Math.min(next, lastIndex.value));
+  } else {
+    moveCaret(end);
+  }
+}
+
+function onBoxFocus(index: number, event: FocusEvent) {
+  // single-char boxes select their content so typing overwrites
+  if (segments.value[index].length === 1) {
+    (event.target as HTMLInputElement).select();
+  }
+}
+
+// focuses the first box that still misses characters, or the last when complete
+function focusFirstEmpty() {
+  const values = boxValues.value;
+  const first = segments.value.findIndex(
+    (segment, index) => values[index].length < segment.length,
+  );
+  const target = first === -1 ? lastIndex.value : first;
+  if (segments.value[target].length === 1) {
+    focusBox(target);
+  } else {
+    moveCaret({ segment: target, offset: values[target].length });
+  }
+}
+
+defineExpose({ focusFirstEmpty });
+
+function setInputRef(index: number) {
+  return (el: Element | ComponentPublicInstance | null) => {
+    inputRefs.value[index] = el as HTMLInputElement | null;
+  };
+}
+
+// multi-char boxes share the row proportionally to their capacity
+function boxStyle(segment: Segment) {
+  return segment.length > 1
+    ? { flexGrow: segment.length, flexBasis: "0" }
+    : undefined;
+}
+
+// writes text into the boxes from startIndex, dropping characters a box does
+// not accept; a box that receives anything is replaced whole. Returns the
+// updated values and the position just after the last written character.
+function distribute(text: string, startIndex: number, base: string[]) {
+  const updated = [...base];
+  let index = startIndex;
+  let written = "";
+  let end: CaretPosition = { segment: startIndex, offset: 0 };
+  for (const char of text) {
+    if (index >= segments.value.length) break;
+    const segment = segments.value[index];
+    const accepted = sanitizeCode(char, segment.digitsOnly);
+    if (!accepted) continue;
+    written += accepted;
+    updated[index] = written;
+    end = { segment: index, offset: written.length };
+    if (written.length === segment.length) {
+      index++;
+      written = "";
+    }
+  }
+  return { updated, end };
+}
+
+function currentValues(): string[] {
+  return [...boxValues.value];
+}
+
+function withValue(index: number, value: string): string[] {
+  const updated = currentValues();
+  updated[index] = value;
+  return updated;
+}
+
+function update(updated: string[]) {
+  emit("update:modelValue", updated);
+}
+
+function focusBox(index: number) {
+  nextTick(() => {
+    const input = inputRefs.value[index];
+    input?.focus();
+    input?.select();
+  });
+}
+
+function moveCaret(position: CaretPosition) {
+  nextTick(() => {
+    const input = inputRefs.value[position.segment];
+    input?.focus();
+    input?.setSelectionRange(position.offset, position.offset);
+  });
+}
+</script>
+
+<template>
+  <div
+    :role="readonly ? undefined : 'group'"
+    class="flex w-full flex-wrap items-center gap-2 max-[500px]:gap-1"
+  >
+    <template v-for="(cell, position) of renderCells" :key="position">
+      <span
+        v-if="cell.type === 'separator'"
+        class="text-muted-foreground font-mono text-xl select-none max-[500px]:text-lg"
+        :class="separatorClass"
+      >
+        {{ cell.text }}
+      </span>
+      <div
+        v-else-if="readonly"
+        class="border-input dark:bg-input/30 flex h-12 min-w-0 items-center justify-center rounded-lg border bg-transparent px-1"
+        :class="cellClass"
+        :style="boxStyle(cell.segment)"
+      >
+        <code
+          class="text-foreground font-mono text-base tracking-wider whitespace-nowrap max-[500px]:text-sm"
+        >
+          {{ boxValues[cell.index] }}
+        </code>
+      </div>
+      <input
+        v-else
+        :ref="setInputRef(cell.index)"
+        class="border-input text-foreground selection:bg-primary selection:text-primary-foreground caret-primary dark:bg-input/30 focus:border-ring focus:ring-ring/50 h-12 min-w-0 rounded-lg border bg-transparent text-center font-mono shadow-xs transition-[color,box-shadow] outline-none focus:ring-[3px] disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 max-[500px]:h-11"
+        :class="[
+          cell.segment.length === 1
+            ? 'w-11 text-xl max-[500px]:w-9 max-[500px]:text-lg'
+            : 'px-1 text-base tracking-wider max-[500px]:px-0.5 max-[500px]:text-sm',
+          cellClass,
+        ]"
+        :style="boxStyle(cell.segment)"
+        type="text"
+        :value="boxValues[cell.index]"
+        :maxlength="cell.segment.length > 1 ? cell.segment.length : undefined"
+        :inputmode="isNumeric ? 'numeric' : 'text'"
+        :autocomplete="
+          otpAutofill && cell.index === 0 ? 'one-time-code' : 'off'
+        "
+        autocapitalize="characters"
+        autocorrect="off"
+        spellcheck="false"
+        :disabled="disabled"
+        :aria-label="
+          ariaLabel
+            ? `${ariaLabel} ${cell.index + 1}/${segments.length}`
+            : undefined
+        "
+        @input="onBoxInput(cell.index, $event)"
+        @keydown="onBoxKeydown(cell.index, $event)"
+        @paste.prevent="onBoxPaste(cell.index, $event)"
+        @focus="onBoxFocus(cell.index, $event)"
+      />
+    </template>
+  </div>
+</template>

--- a/src/components/SegmentedCodeInput.vue
+++ b/src/components/SegmentedCodeInput.vue
@@ -30,6 +30,8 @@ const emit = defineEmits<{
   submit: [];
 }>();
 
+defineExpose({ focusFirstEmpty });
+
 type Segment = { length: number; digitsOnly: boolean };
 type RenderCell =
   | { type: "box"; index: number; segment: Segment }
@@ -187,21 +189,19 @@ function onBoxFocus(index: number, event: FocusEvent) {
   }
 }
 
-// focuses the first box that still misses characters, or the last when complete
+// focuses the first box that still misses characters, or the last when complete;
+// deferred so that a caller which just changed modelValue picks the box from the
+// updated value rather than the one still bound at call time
 function focusFirstEmpty() {
-  const values = boxValues.value;
-  const first = segments.value.findIndex(
-    (segment, index) => values[index].length < segment.length,
-  );
-  const target = first === -1 ? lastIndex.value : first;
-  if (segments.value[target].length === 1) {
-    focusBox(target);
-  } else {
-    moveCaret({ segment: target, offset: values[target].length });
-  }
+  nextTick(() => {
+    const values = boxValues.value;
+    const first = segments.value.findIndex(
+      (segment, index) => values[index].length < segment.length,
+    );
+    const target = first === -1 ? lastIndex.value : first;
+    applyFocus({ segment: target, offset: values[target].length });
+  });
 }
-
-defineExpose({ focusFirstEmpty });
 
 function setInputRef(index: number) {
   return (el: Element | ComponentPublicInstance | null) => {
@@ -255,19 +255,24 @@ function update(updated: string[]) {
 }
 
 function focusBox(index: number) {
-  nextTick(() => {
-    const input = inputRefs.value[index];
-    input?.focus();
-    input?.select();
-  });
+  focusAt({ segment: index, offset: 0 });
 }
 
 function moveCaret(position: CaretPosition) {
-  nextTick(() => {
-    const input = inputRefs.value[position.segment];
-    input?.focus();
-    input?.setSelectionRange(position.offset, position.offset);
-  });
+  focusAt(position);
+}
+
+function focusAt(position: CaretPosition) {
+  nextTick(() => applyFocus(position));
+}
+
+// a single-character box selects its content so typing overwrites it; a longer
+// one takes a caret, since it behaves as an ordinary text field
+function applyFocus(position: CaretPosition) {
+  const input = inputRefs.value[position.segment];
+  input?.focus();
+  if (segments.value[position.segment].length === 1) input?.select();
+  else input?.setSelectionRange(position.offset, position.offset);
 }
 </script>
 
@@ -291,8 +296,9 @@ function moveCaret(position: CaretPosition) {
         :class="cellClass"
         :style="boxStyle(cell.segment)"
       >
+        <!-- shrinks with the viewport so a long code keeps fitting its box -->
         <code
-          class="text-foreground font-mono text-base tracking-wider whitespace-nowrap max-[500px]:text-sm"
+          class="text-foreground font-mono text-base tracking-wider whitespace-nowrap max-[768px]:text-[0.85rem] max-[768px]:tracking-[0.02em] max-[500px]:text-xs max-[500px]:tracking-normal"
         >
           {{ boxValues[cell.index] }}
         </code>

--- a/src/helpers/segmented_code.ts
+++ b/src/helpers/segmented_code.ts
@@ -1,0 +1,21 @@
+/**
+ * Strip a code down to its bare characters: uppercased, with separators and
+ * other foreign characters removed.
+ */
+export function sanitizeCode(value: string, digitsOnly = false): string {
+  return value.toUpperCase().replace(digitsOnly ? /[^0-9]/g : /[^A-Z0-9]/g, "");
+}
+
+/**
+ * Split a code into one part per segment length, sanitizing it first.
+ */
+export function splitCode(code: string, lengths: number[]): string[] {
+  const clean = sanitizeCode(code);
+  const parts: string[] = [];
+  let offset = 0;
+  for (const length of lengths) {
+    parts.push(clean.slice(offset, offset + length));
+    offset += length;
+  }
+  return parts;
+}

--- a/src/views/Login.vue
+++ b/src/views/Login.vue
@@ -101,28 +101,13 @@
                       {{ $t("login.scan_qr", "Scan QR") }}
                     </v-btn>
                   </div>
-                  <div class="remote-id-inputs">
-                    <v-text-field
-                      v-for="(_, index) in 4"
-                      :key="index"
-                      :ref="setRemoteIdRef(index)"
-                      :model-value="remoteIdParts[index]"
-                      :maxlength="remoteIdLengths[index]"
-                      variant="outlined"
-                      density="comfortable"
-                      hide-details
-                      :disabled="isConnecting"
-                      bg-color="surface-light"
-                      class="remote-id-input"
-                      :class="`remote-id-input-${index}`"
-                      autocapitalize="characters"
-                      autocorrect="off"
-                      spellcheck="false"
-                      @input="handleRemoteIdInput(index, $event)"
-                      @keydown="handleRemoteIdKeydown(index, $event)"
-                      @paste="handleRemoteIdPaste(index, $event)"
-                    />
-                  </div>
+                  <SegmentedCodeInput
+                    v-model="remoteIdParts"
+                    :layout="remoteIdLayout"
+                    :disabled="isConnecting"
+                    :aria-label="$t('login.remote_id', 'Remote ID')"
+                    @submit="connectToRemote"
+                  />
                   <p
                     v-if="connectionError"
                     class="text-caption text-error mt-2"
@@ -481,14 +466,9 @@ import {
 import type { ITransport } from "@/plugins/remote/transport";
 import { authManager } from "@/plugins/auth";
 import { remoteConnectionManager } from "@/plugins/remote";
-import {
-  type ComponentPublicInstance,
-  computed,
-  nextTick,
-  onMounted,
-  ref,
-  watch,
-} from "vue";
+import SegmentedCodeInput from "@/components/SegmentedCodeInput.vue";
+import { splitCode } from "@/helpers/segmented_code";
+import { computed, nextTick, onMounted, ref, watch } from "vue";
 import { useI18n } from "vue-i18n";
 import { QrcodeStream } from "vue-qrcode-reader";
 import { useRouter } from "vue-router";
@@ -601,7 +581,7 @@ const serverAddress = ref("");
 // Remote ID split into 4 parts: 8-5-5-8 characters
 const remoteIdParts = ref(["", "", "", ""]);
 const remoteIdLengths = [8, 5, 5, 8];
-const remoteIdRefs = ref<(HTMLInputElement | null)[]>([null, null, null, null]);
+const remoteIdLayout = remoteIdLengths.map((length) => ({ length }));
 const remoteId = computed(() => remoteIdParts.value.join(""));
 
 // QR Scanner state
@@ -1687,150 +1667,10 @@ const waitForApiConnection = async (
 };
 
 /**
- * Handle input in remote ID segmented fields
- */
-const handleRemoteIdInput = (index: number, event: Event) => {
-  const input = event.target as HTMLInputElement;
-  // Convert to uppercase and remove non-alphanumeric characters
-  let value = input.value.toUpperCase().replace(/[^A-Z0-9]/g, "");
-  const maxLen = remoteIdLengths[index];
-
-  if (value.length > maxLen) {
-    // Overflow: put excess in next field(s)
-    const overflow = value.slice(maxLen);
-    value = value.slice(0, maxLen);
-    remoteIdParts.value[index] = value;
-
-    if (index < 3 && overflow) {
-      distributeRemoteIdText(overflow, index + 1);
-    }
-  } else {
-    remoteIdParts.value[index] = value;
-
-    // Auto-advance to next field when current is full
-    if (value.length === maxLen && index < 3) {
-      nextTick(() => {
-        remoteIdRefs.value[index + 1]?.focus();
-      });
-    }
-  }
-};
-
-/**
- * Distribute text across remote ID fields starting from a given index
- */
-const distributeRemoteIdText = (text: string, startIndex: number) => {
-  let remaining = text.toUpperCase().replace(/[^A-Z0-9]/g, "");
-  let focusIndex = startIndex;
-
-  for (let i = startIndex; i < 4 && remaining.length > 0; i++) {
-    const maxLen = remoteIdLengths[i];
-    remoteIdParts.value[i] = remaining.slice(0, maxLen);
-    if (remaining.length <= maxLen) {
-      focusIndex = i;
-    }
-    remaining = remaining.slice(maxLen);
-  }
-
-  nextTick(() => {
-    const field = remoteIdRefs.value[focusIndex];
-    field?.focus();
-    // Position cursor at end
-    const len = remoteIdParts.value[focusIndex].length;
-    field?.setSelectionRange(len, len);
-  });
-};
-
-/**
- * Handle keydown in remote ID fields (for backspace navigation)
- */
-const handleRemoteIdKeydown = (index: number, event: KeyboardEvent) => {
-  const input = event.target as HTMLInputElement;
-
-  if (
-    event.key === "Backspace" &&
-    input.selectionStart === 0 &&
-    input.selectionEnd === 0 &&
-    index > 0
-  ) {
-    // Backspace at start of field: move to previous field
-    event.preventDefault();
-    const prevField = remoteIdRefs.value[index - 1];
-    prevField?.focus();
-    const len = remoteIdParts.value[index - 1].length;
-    prevField?.setSelectionRange(len, len);
-  } else if (
-    event.key === "ArrowLeft" &&
-    input.selectionStart === 0 &&
-    index > 0
-  ) {
-    // Left arrow at start: move to previous field
-    event.preventDefault();
-    const prevField = remoteIdRefs.value[index - 1];
-    prevField?.focus();
-    const len = remoteIdParts.value[index - 1].length;
-    prevField?.setSelectionRange(len, len);
-  } else if (
-    event.key === "ArrowRight" &&
-    input.selectionStart === input.value.length &&
-    index < 3
-  ) {
-    // Right arrow at end: move to next field
-    event.preventDefault();
-    const nextField = remoteIdRefs.value[index + 1];
-    nextField?.focus();
-    nextField?.setSelectionRange(0, 0);
-  } else if (event.key === "Enter") {
-    // Enter: submit
-    connectToRemote();
-  }
-};
-
-/**
- * Handle paste in remote ID fields
- */
-const handleRemoteIdPaste = (index: number, event: ClipboardEvent) => {
-  event.preventDefault();
-  const pastedText = event.clipboardData?.getData("text") || "";
-  // Remove dashes and non-alphanumeric, convert to uppercase
-  const cleanText = pastedText.toUpperCase().replace(/[^A-Z0-9]/g, "");
-
-  if (cleanText) {
-    // If pasting into first field with full content, replace all
-    if (index === 0) {
-      // Clear all fields and distribute
-      remoteIdParts.value = ["", "", "", ""];
-      distributeRemoteIdText(cleanText, 0);
-    } else {
-      // Distribute from current field
-      distributeRemoteIdText(cleanText, index);
-    }
-  }
-};
-
-/**
- * Set ref for remote ID input field
- */
-const setRemoteIdRef =
-  (index: number) => (el: Element | ComponentPublicInstance | null) => {
-    const root = el && "$el" in el ? (el.$el as HTMLElement | undefined) : el;
-    remoteIdRefs.value[index] = (root?.querySelector?.("input") ||
-      root) as HTMLInputElement | null;
-  };
-
-/**
  * Set remote ID from a full string (e.g., from localStorage)
  */
 const setRemoteIdFromString = (value: string) => {
-  // Remove dashes and non-alphanumeric, then distribute
-  const cleanText = value.toUpperCase().replace(/[^A-Z0-9]/g, "");
-  let remaining = cleanText;
-
-  for (let i = 0; i < 4; i++) {
-    const maxLen = remoteIdLengths[i];
-    remoteIdParts.value[i] = remaining.slice(0, maxLen);
-    remaining = remaining.slice(maxLen);
-  }
+  remoteIdParts.value = splitCode(value, remoteIdLengths);
 };
 
 /**
@@ -2435,53 +2275,6 @@ onMounted(() => {
 .oauth-btn:hover {
   border-color: var(--primary) !important;
   background: var(--input-focus-bg) !important;
-}
-
-/* Remote ID segmented input */
-.remote-id-inputs {
-  display: flex;
-  gap: 8px;
-  align-items: center;
-}
-
-.remote-id-input {
-  flex: 1;
-  min-width: 0;
-}
-
-.remote-id-input :deep(input) {
-  text-align: center;
-  font-family: monospace;
-  font-size: 1rem;
-  letter-spacing: 0.05em;
-  text-transform: uppercase;
-}
-
-/* Adjust widths proportionally based on character count (8, 5, 5, 8) */
-.remote-id-input-0,
-.remote-id-input-3 {
-  flex: 8;
-}
-
-.remote-id-input-1,
-.remote-id-input-2 {
-  flex: 5;
-}
-
-@media (max-width: 500px) {
-  .remote-id-inputs {
-    gap: 4px;
-  }
-
-  .remote-id-input :deep(input) {
-    font-size: 0.875rem;
-    padding: 0 4px;
-  }
-
-  .remote-id-input :deep(.v-field__input) {
-    min-height: 44px;
-    padding: 0 8px;
-  }
 }
 
 :deep(.v-field) {

--- a/src/views/settings/RemoteAccessSettings.vue
+++ b/src/views/settings/RemoteAccessSettings.vue
@@ -144,16 +144,12 @@
               {{ $t("settings.remote_access_id_explanation") }}
             </p>
             <div class="remote-id-display-wrapper">
-              <div class="remote-id-boxes">
-                <div
-                  v-for="(part, index) in remoteIdParts"
-                  :key="index"
-                  class="remote-id-box"
-                  :class="`remote-id-box-${index}`"
-                >
-                  <code class="remote-id-box-text">{{ part }}</code>
-                </div>
-              </div>
+              <SegmentedCodeInput
+                readonly
+                class="min-w-0 flex-1"
+                :model-value="remoteIdParts"
+                :layout="remoteIdLayout"
+              />
               <v-btn
                 icon="mdi-content-copy"
                 variant="text"
@@ -347,6 +343,8 @@
 <script setup lang="ts">
 import remoteAccessDiagram from "@/assets/remote-access-diagram.svg";
 import Container from "@/components/Container.vue";
+import SegmentedCodeInput from "@/components/SegmentedCodeInput.vue";
+import { splitCode } from "@/helpers/segmented_code";
 import { copyToClipboard } from "@/helpers/utils";
 import { api } from "@/plugins/api";
 import type { RemoteAccessInfo } from "@/plugins/api/interfaces";
@@ -368,16 +366,10 @@ let unmounted = false;
 
 // Split remote ID into 4 parts: 8-5-5-8 characters
 const remoteIdLengths = [8, 5, 5, 8];
-const remoteIdParts = computed(() => {
-  const id = remoteAccessInfo.value?.remote_id || "";
-  const parts: string[] = [];
-  let offset = 0;
-  for (const len of remoteIdLengths) {
-    parts.push(id.slice(offset, offset + len));
-    offset += len;
-  }
-  return parts;
-});
+const remoteIdLayout = remoteIdLengths.map((length) => ({ length }));
+const remoteIdParts = computed(() =>
+  splitCode(remoteAccessInfo.value?.remote_id || "", remoteIdLengths),
+);
 
 onMounted(async () => {
   await loadRemoteAccessInfo();
@@ -663,59 +655,6 @@ watch(
   display: flex;
   align-items: center;
   gap: 12px;
-}
-
-.remote-id-boxes {
-  display: flex;
-  gap: 8px;
-}
-
-.remote-id-box {
-  background: rgba(var(--v-theme-surface), 0.8);
-  border: 1px solid rgba(var(--v-theme-on-surface), 0.12);
-  border-radius: 10px;
-  padding: 12px 8px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  transition:
-    border-color 0.2s ease,
-    background 0.2s ease;
-  min-width: 0;
-}
-
-.remote-id-box:hover {
-  border-color: rgba(var(--v-theme-primary), 0.3);
-  background: rgba(var(--v-theme-surface), 1);
-}
-
-/* Adjust widths proportionally based on character count (8, 5, 5, 8) */
-.remote-id-box-0,
-.remote-id-box-3 {
-  flex: 8;
-}
-
-.remote-id-box-1,
-.remote-id-box-2 {
-  flex: 5;
-}
-
-.remote-id-box-text {
-  font-family:
-    ui-monospace,
-    SFMono-Regular,
-    Menlo,
-    Monaco,
-    Consolas,
-    Liberation Mono,
-    Courier New,
-    monospace;
-  font-size: 1rem;
-  font-weight: 500;
-  letter-spacing: 0.05em;
-  color: rgb(var(--v-theme-on-surface));
-  text-align: center;
-  white-space: nowrap;
 }
 
 .copy-button {

--- a/src/views/settings/RemoteAccessSettings.vue
+++ b/src/views/settings/RemoteAccessSettings.vue
@@ -826,19 +826,6 @@ watch(
     justify-content: flex-start;
   }
 
-  .remote-id-boxes {
-    gap: 6px;
-  }
-
-  .remote-id-box {
-    padding: 10px 4px;
-  }
-
-  .remote-id-box-text {
-    font-size: 0.85rem;
-    letter-spacing: 0.02em;
-  }
-
   .step-item {
     gap: 12px;
   }
@@ -855,19 +842,6 @@ watch(
     flex-direction: column;
     align-items: stretch;
     gap: 8px;
-  }
-
-  .remote-id-boxes {
-    gap: 4px;
-  }
-
-  .remote-id-box {
-    padding: 8px 2px;
-  }
-
-  .remote-id-box-text {
-    font-size: 0.75rem;
-    letter-spacing: 0;
   }
 
   .copy-button {

--- a/src/views/settings/fields/PairingCodeField.vue
+++ b/src/views/settings/fields/PairingCodeField.vue
@@ -1,15 +1,12 @@
 <script setup lang="ts">
+import SegmentedCodeInput, {
+  type SegmentedCodeCell,
+} from "@/components/SegmentedCodeInput.vue";
 import { Input } from "@/components/ui/input";
 import type { ConfigEntryUI } from "@/helpers/config_entry_ui";
+import { sanitizeCode } from "@/helpers/segmented_code";
 import type { ConfigValueType } from "@/plugins/api/interfaces";
-import {
-  computed,
-  nextTick,
-  ref,
-  useId,
-  watch,
-  type ComponentPublicInstance,
-} from "vue";
+import { computed, ref, useId, watch } from "vue";
 
 const props = defineProps<{
   entry: ConfigEntryUI;
@@ -22,47 +19,38 @@ const emit = defineEmits<{ "update:value": [value: ConfigValueType] }>();
 // hard ceiling on rendered boxes; a longer format falls back to the text field
 const MAX_SLOTS = 16;
 
-type LayoutCell =
-  | { type: "slot"; digit: boolean; index: number }
-  | { type: "separator"; text: string };
-
-// the format parsed into code boxes and literal separators, in render order;
-// null when the format is missing or holds no code slot, which switches to the fallback
-const layout = computed<LayoutCell[] | null>(() => {
+// the format parsed into single-character code boxes and literal separators, in
+// render order; null when the format is missing or holds no code slot, which
+// switches to the fallback
+const layout = computed<SegmentedCodeCell[] | null>(() => {
   const format = props.entry.format;
   if (!format) return null;
-  const result: LayoutCell[] = [];
-  let index = 0;
+  const result: SegmentedCodeCell[] = [];
+  let count = 0;
   for (const char of format) {
     if (char === "#" || char === "X") {
-      result.push({ type: "slot", digit: char === "#", index });
-      index++;
+      result.push({ length: 1, digitsOnly: char === "#" });
+      count++;
     } else {
       // any other character renders as-is between the boxes
       const last = result[result.length - 1];
-      if (last?.type === "separator") last.text += char;
-      else result.push({ type: "separator", text: char });
+      if (typeof last === "string") result[result.length - 1] = last + char;
+      else result.push(char);
     }
   }
-  if (index === 0 || index > MAX_SLOTS) return null;
+  if (count === 0 || count > MAX_SLOTS) return null;
   return result;
 });
 
-// digit-only flag per code slot, in code order
-const slotIsDigit = computed(() =>
-  (layout.value ?? []).flatMap((cell) =>
-    cell.type === "slot" ? [cell.digit] : [],
-  ),
+const slotCount = computed(
+  () => (layout.value ?? []).filter((cell) => typeof cell !== "string").length,
 );
-
-const slotCount = computed(() => slotIsDigit.value.length);
-const isNumeric = computed(() => slotIsDigit.value.every(Boolean));
 
 const labelId = useId();
 
 // one entered character per code slot
 const cells = ref<string[]>([]);
-const inputRefs = ref<(HTMLInputElement | null)[]>([]);
+const codeInput = ref<InstanceType<typeof SegmentedCodeInput> | null>(null);
 // the value of the last update:value emission; the parent writes it straight back
 // to entry.value, so the watch below must not mistake that echo for an external
 // reset — compared normalized because the parent rewrites null to default_value
@@ -81,74 +69,25 @@ watch(
     if (normalizeCode(value) === cells.value.join("")) return;
     seedCells();
     lastEmitted = undefined;
-    if (!props.disabled) focusFirstEmpty();
+    if (!props.disabled) codeInput.value?.focusFirstEmpty();
   },
 );
 
 // a re-served step may carry a different format for the same entry key
 watch(slotCount, seedCells);
 
-function onCellInput(index: number, event: Event) {
-  const input = event.target as HTMLInputElement;
-  // an emptied input (cut, delete over a selection) clears the cell
-  if (input.value === "") {
-    cells.value[index] = "";
-    emitCode();
-    return;
-  }
-  const next = distribute(input.value, index);
-  // the DOM may hold a rejected or overflowing char Vue has no patch for
-  input.value = cells.value[index];
-  emitCode();
-  if (next > index) focusCell(Math.min(next, slotCount.value - 1));
-}
-
-function onCellKeydown(index: number, event: KeyboardEvent) {
-  if (event.key === "Backspace") {
-    event.preventDefault();
-    if (cells.value[index]) {
-      cells.value[index] = "";
-      emitCode();
-    } else if (index > 0) {
-      cells.value[index - 1] = "";
-      emitCode();
-      focusCell(index - 1);
-    }
-  } else if (event.key === "ArrowLeft" && index > 0) {
-    event.preventDefault();
-    focusCell(index - 1);
-  } else if (event.key === "ArrowRight" && index < slotCount.value - 1) {
-    event.preventDefault();
-    focusCell(index + 1);
-  }
-}
-
-function onCellPaste(index: number, event: ClipboardEvent) {
-  const pasted = event.clipboardData?.getData("text") || "";
-  const clean = pasted.toUpperCase().replace(/[^A-Z0-9]/g, "");
-  if (!clean) return;
-  // a paste into the first box, or one holding a full code, replaces everything
-  const start = index === 0 || clean.length >= slotCount.value ? 0 : index;
-  if (start === 0) cells.value = cells.value.map(() => "");
-  const next = distribute(clean, start);
-  emitCode();
-  focusCell(Math.min(next, slotCount.value - 1));
-}
-
-function onCellFocus(event: FocusEvent) {
-  // select the content so typing overwrites instead of appending
-  (event.target as HTMLInputElement).select();
+// all-or-null: an incomplete code emits null so required-value gating keeps
+// the submit button disabled until every box is filled
+function onCellsUpdate(parts: string[]) {
+  cells.value = parts;
+  const value = parts.every((cell) => cell) ? parts.join("") : null;
+  lastEmitted = value;
+  emit("update:value", value);
 }
 
 function onFallbackInput(value: string | number) {
   // an emptied input reads as a cleared entry
   emit("update:value", value === "" ? null : String(value));
-}
-
-function setInputRef(index: number) {
-  return (el: Element | ComponentPublicInstance | null) => {
-    inputRefs.value[index] = el as HTMLInputElement | null;
-  };
 }
 
 function seedCells() {
@@ -160,89 +99,26 @@ function seedCells() {
 }
 
 function normalizeCode(value: unknown): string {
-  return String(value ?? "")
-    .toUpperCase()
-    .replace(/[^A-Z0-9]/g, "")
-    .slice(0, slotCount.value);
-}
-
-// all-or-null: an incomplete code emits null so required-value gating keeps
-// the submit button disabled until every box is filled
-function emitCode() {
-  const value = cells.value.every((cell) => cell) ? cells.value.join("") : null;
-  lastEmitted = value;
-  emit("update:value", value);
-}
-
-// writes text into the cells from startIndex, dropping chars a cell does not
-// accept; returns the index just after the last cell written
-function distribute(text: string, startIndex: number): number {
-  let index = startIndex;
-  for (const char of text) {
-    if (index >= slotCount.value) break;
-    const accepted = acceptChar(char, index);
-    if (accepted === null) continue;
-    cells.value[index] = accepted;
-    index++;
-  }
-  return index;
-}
-
-function acceptChar(char: string, index: number): string | null {
-  const upper = char.toUpperCase();
-  const pattern = slotIsDigit.value[index] ? /^[0-9]$/ : /^[A-Z0-9]$/;
-  return pattern.test(upper) ? upper : null;
-}
-
-function focusCell(index: number) {
-  nextTick(() => {
-    const input = inputRefs.value[index];
-    input?.focus();
-    input?.select();
-  });
-}
-
-function focusFirstEmpty() {
-  const first = cells.value.findIndex((cell) => !cell);
-  focusCell(first === -1 ? slotCount.value - 1 : first);
+  return sanitizeCode(String(value ?? "")).slice(0, slotCount.value);
 }
 </script>
 
 <template>
   <div class="flex w-full flex-col gap-2 py-1">
     <span :id="labelId" class="text-muted-foreground text-sm">{{ label }}</span>
-    <div
+    <SegmentedCodeInput
       v-if="layout"
-      role="group"
+      ref="codeInput"
+      :model-value="cells"
+      :layout="layout"
+      :disabled="disabled"
+      otp-autofill
+      :aria-label="label"
       :aria-labelledby="labelId"
-      class="flex flex-wrap items-center gap-2 max-[500px]:gap-1"
-    >
-      <template v-for="(cell, position) of layout" :key="position">
-        <span
-          v-if="cell.type === 'separator'"
-          class="pairing-code-separator text-muted-foreground font-mono text-xl select-none max-[500px]:text-lg"
-        >
-          {{ cell.text }}
-        </span>
-        <input
-          v-else
-          :ref="setInputRef(cell.index)"
-          class="pairing-code-input border-input text-foreground selection:bg-primary selection:text-primary-foreground caret-primary dark:bg-input/30 focus:border-ring focus:ring-ring/50 h-12 w-11 min-w-0 rounded-lg border bg-transparent text-center font-mono text-xl shadow-xs transition-[color,box-shadow] outline-none focus:ring-[3px] disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 max-[500px]:h-11 max-[500px]:w-9 max-[500px]:text-lg"
-          type="text"
-          :value="cells[cell.index]"
-          :inputmode="isNumeric ? 'numeric' : 'text'"
-          :autocomplete="cell.index === 0 ? 'one-time-code' : 'off'"
-          autocapitalize="characters"
-          spellcheck="false"
-          :disabled="disabled"
-          :aria-label="`${label} ${cell.index + 1}/${slotCount}`"
-          @input="onCellInput(cell.index, $event)"
-          @keydown="onCellKeydown(cell.index, $event)"
-          @paste.prevent="onCellPaste(cell.index, $event)"
-          @focus="onCellFocus"
-        />
-      </template>
-    </div>
+      cell-class="pairing-code-input"
+      separator-class="pairing-code-separator"
+      @update:model-value="onCellsUpdate"
+    />
 
     <!-- no (valid) format: plain text input so the entry stays usable -->
     <Input

--- a/tests/components/SegmentedCodeInput.test.ts
+++ b/tests/components/SegmentedCodeInput.test.ts
@@ -1,0 +1,172 @@
+import SegmentedCodeInput from "@/components/SegmentedCodeInput.vue";
+import {
+  enableAutoUnmount,
+  mount,
+  type DOMWrapper,
+  type VueWrapper,
+} from "@vue/test-utils";
+import { afterEach, describe, expect, it } from "vitest";
+import { nextTick } from "vue";
+
+// the per-character mode is exercised through the PairingCodeField suite; this
+// suite covers the multi-character (grouped) mode and the readonly display
+const GROUP_LAYOUT = [{ length: 4 }, { length: 3 }, { length: 4 }];
+
+// the component moves real focus and carets, so it needs to live in the document
+enableAutoUnmount(afterEach);
+
+describe("SegmentedCodeInput (grouped boxes)", () => {
+  it("caps each box at its length via the maxlength attribute", () => {
+    const wrapper = mountInput();
+
+    expect(boxes(wrapper).map((box) => box.attributes("maxlength"))).toEqual([
+      "4",
+      "3",
+      "4",
+    ]);
+  });
+
+  it("sanitizes typed input to bare uppercase characters", async () => {
+    const wrapper = mountInput();
+
+    await boxes(wrapper)[0].setValue("ab-c");
+    await nextTick();
+
+    expect(boxValues(wrapper)).toEqual(["ABC", "", ""]);
+    expect(document.activeElement).not.toBe(boxes(wrapper)[1].element);
+  });
+
+  it("advances to the next box when one is typed full", async () => {
+    const wrapper = mountInput();
+
+    await boxes(wrapper)[0].setValue("abcd");
+    await nextTick();
+
+    expect(boxValues(wrapper)).toEqual(["ABCD", "", ""]);
+    expect(document.activeElement).toBe(boxes(wrapper)[1].element);
+  });
+
+  it("spills overflowing input into the next box", async () => {
+    const wrapper = mountInput();
+
+    await boxes(wrapper)[0].setValue("abcdef");
+    await nextTick();
+
+    expect(boxValues(wrapper)).toEqual(["ABCD", "EF", ""]);
+    const second = boxes(wrapper)[1].element as HTMLInputElement;
+    expect(document.activeElement).toBe(second);
+    expect(second.selectionStart).toBe(2);
+  });
+
+  it("fills every box from a paste of a separated code into the first box", async () => {
+    const wrapper = mountInput();
+
+    await paste(wrapper, 0, " abcd-efg-hijk ");
+
+    expect(boxValues(wrapper)).toEqual(["ABCD", "EFG", "HIJK"]);
+    expect(wrapper.emitted("update:modelValue")).toHaveLength(1);
+    const last = boxes(wrapper)[2].element as HTMLInputElement;
+    expect(document.activeElement).toBe(last);
+    expect(last.selectionStart).toBe(4);
+  });
+
+  it("replaces everything when a full code is pasted into a later box", async () => {
+    const wrapper = mountInput({ modelValue: ["ZZZZ", "ZZZ", "ZZZZ"] });
+
+    await paste(wrapper, 1, "ABCD-EFG-HIJK");
+
+    expect(boxValues(wrapper)).toEqual(["ABCD", "EFG", "HIJK"]);
+  });
+
+  it("distributes a partial paste from the box it lands in", async () => {
+    const wrapper = mountInput({ modelValue: ["ABCD", "", ""] });
+
+    await paste(wrapper, 1, "xy");
+
+    expect(boxValues(wrapper)).toEqual(["ABCD", "XY", ""]);
+  });
+
+  it("moves the caret to the end of the previous box on backspace at the start", async () => {
+    const wrapper = mountInput({ modelValue: ["ABCD", "EFG", ""] });
+    const second = boxes(wrapper)[1].element as HTMLInputElement;
+    second.focus();
+    second.setSelectionRange(0, 0);
+
+    await boxes(wrapper)[1].trigger("keydown", { key: "Backspace" });
+    await nextTick();
+
+    const first = boxes(wrapper)[0].element as HTMLInputElement;
+    expect(document.activeElement).toBe(first);
+    expect(first.selectionStart).toBe(4);
+    // moving the caret must not delete anything
+    expect(boxValues(wrapper)).toEqual(["ABCD", "EFG", ""]);
+    expect(wrapper.emitted("update:modelValue")).toBeUndefined();
+  });
+
+  it("emits submit on Enter", async () => {
+    const wrapper = mountInput();
+
+    await boxes(wrapper)[0].trigger("keydown", { key: "Enter" });
+
+    expect(wrapper.emitted("submit")).toHaveLength(1);
+  });
+
+  it("renders an externally set value (e.g. a scanned or stored code)", async () => {
+    const wrapper = mountInput();
+
+    await wrapper.setProps({ modelValue: ["ABCD", "EFG", "HIJK"] });
+
+    expect(boxValues(wrapper)).toEqual(["ABCD", "EFG", "HIJK"]);
+  });
+
+  it("renders static boxes without inputs in readonly mode", () => {
+    const wrapper = mount(SegmentedCodeInput, {
+      props: {
+        modelValue: ["ABCD", "EFG", "HIJK"],
+        layout: GROUP_LAYOUT,
+        readonly: true,
+      },
+    });
+
+    expect(wrapper.findAll("input")).toHaveLength(0);
+    expect(wrapper.find("[role='group']").exists()).toBe(false);
+    expect(wrapper.text()).toContain("ABCD");
+    expect(wrapper.text()).toContain("HIJK");
+  });
+});
+
+function mountInput(props: Record<string, unknown> = {}): VueWrapper {
+  const wrapper: VueWrapper = mount(SegmentedCodeInput, {
+    props: {
+      modelValue: ["", "", ""],
+      layout: GROUP_LAYOUT,
+      // write emissions back so the component behaves controlled, as in the app
+      "onUpdate:modelValue": (value: string[]) => {
+        wrapper.setProps({ modelValue: value });
+      },
+      ...props,
+    },
+    attachTo: document.body,
+  });
+  return wrapper;
+}
+
+function boxes(wrapper: VueWrapper): DOMWrapper<Element>[] {
+  return wrapper.findAll("input");
+}
+
+function boxValues(wrapper: VueWrapper): string[] {
+  return boxes(wrapper).map((box) => (box.element as HTMLInputElement).value);
+}
+
+/**
+ * Dispatches a paste of `text` on the given box. Built by hand because the
+ * ClipboardEvent constructor offers no way to carry clipboard data in tests.
+ */
+async function paste(wrapper: VueWrapper, index: number, text: string) {
+  const event = new Event("paste", { bubbles: true, cancelable: true });
+  Object.assign(event, { clipboardData: { getData: () => text } });
+  boxes(wrapper)[index].element.dispatchEvent(event);
+  await nextTick();
+  await nextTick();
+}

--- a/tests/components/SegmentedCodeInput.test.ts
+++ b/tests/components/SegmentedCodeInput.test.ts
@@ -78,6 +78,15 @@ describe("SegmentedCodeInput (grouped boxes)", () => {
     expect(boxValues(wrapper)).toEqual(["ABCD", "EFG", "HIJK"]);
   });
 
+  // the last box has nothing to spill into, so the leftovers are dropped
+  it("truncates a paste that lands in the last box", async () => {
+    const wrapper = mountInput();
+
+    await paste(wrapper, 2, "WXYZ1234");
+
+    expect(boxValues(wrapper)).toEqual(["", "", "WXYZ"]);
+  });
+
   it("distributes a partial paste from the box it lands in", async () => {
     const wrapper = mountInput({ modelValue: ["ABCD", "", ""] });
 

--- a/tests/components/SegmentedCodeInput.test.ts
+++ b/tests/components/SegmentedCodeInput.test.ts
@@ -119,6 +119,20 @@ describe("SegmentedCodeInput (grouped boxes)", () => {
     expect(boxValues(wrapper)).toEqual(["ABCD", "EFG", "HIJK"]);
   });
 
+  // aria-label is a declared prop, so it never falls through to the root on its own
+  it("names the group and every box from the aria label", () => {
+    const wrapper = mountInput({ ariaLabel: "Remote ID" });
+
+    expect(wrapper.get("[role='group']").attributes("aria-label")).toBe(
+      "Remote ID",
+    );
+    expect(boxes(wrapper).map((box) => box.attributes("aria-label"))).toEqual([
+      "Remote ID 1/3",
+      "Remote ID 2/3",
+      "Remote ID 3/3",
+    ]);
+  });
+
   it("renders static boxes without inputs in readonly mode", () => {
     const wrapper = mount(SegmentedCodeInput, {
       props: {

--- a/tests/views/PairingCodeField.test.ts
+++ b/tests/views/PairingCodeField.test.ts
@@ -160,6 +160,22 @@ describe("PairingCodeField", () => {
     expect(boxValues(wrapper)).toEqual(["6", "5", "4", "3", "2", "1"]);
   });
 
+  it.each([
+    ["12345", 5],
+    ["9", 1],
+  ])(
+    "focuses the first box left empty by an external value of '%s'",
+    async (value, expected) => {
+      const wrapper = mountField();
+      await typeCode(wrapper, "123456");
+
+      await wrapper.setProps({ entry: pairingEntry({ value }) });
+      await nextTick();
+
+      expect(document.activeElement).toBe(boxes(wrapper)[expected].element);
+    },
+  );
+
   it("keeps typed boxes when the parent echoes the null emission back", async () => {
     const wrapper = mountField();
     await typeCode(wrapper, "123456");


### PR DESCRIPTION
# What does this implement/fix?

The app had three separate hand-written versions of the same "code split into
boxes" input: the pairing code field in the setup flow, the remote ID field on
the login screen, and the read-only remote ID shown in the Remote Access
settings. Each had its own typing, pasting and styling rules, so they looked and
behaved slightly differently.

They now all use one shared component. No change in how any of them work.

**Changes:**

- New `SegmentedCodeInput` component, used by all three places.
- The login remote ID boxes now match the rest of the app's styling (they were
  still using the old Vuetify text fields).
- The read-only remote ID in settings uses the same box styling as the input.
- Removed ~400 lines of duplicated handling for typing, pasting, backspace and
  arrow keys.
- Added tests for the grouped-box behaviour, which was previously untested.

**Related issue (if applicable):**

- n/a

**Related backend PR (if applicable):**

- n/a

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm lint:check` passes.
- [x] `pnpm test:run` passes, and tests have been added/updated where applicable.
- [x] `pnpm build` passes.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
