### PR TITLE
Fix the mobile player blur on Chromium browsers

### DIFF
--- a/src/layouts/default/Footer.vue
+++ b/src/layouts/default/Footer.vue
@@ -94,18 +94,12 @@ function clearOverlay() {
   /* it only exists to soften what is behind it, so it never takes a tap */
   pointer-events: none;
   z-index: 999;
+  /* must stay unprefixed: the minifier keeps only the last of a hand-written
+     pair, and -webkit-backdrop-filter alone is dead in Chromium */
   backdrop-filter: blur(14px);
-  -webkit-backdrop-filter: blur(14px);
   /* the mask is what makes the blur ramp up towards the player instead of
      ending on a visible line */
   mask-image: linear-gradient(
-    to top,
-    #000 0%,
-    #000 35%,
-    rgba(0, 0, 0, 0.55) 65%,
-    transparent 100%
-  );
-  -webkit-mask-image: linear-gradient(
     to top,
     #000 0%,
     #000 35%,

--- a/tests/styles/playerScrim.test.ts
+++ b/tests/styles/playerScrim.test.ts
@@ -97,8 +97,13 @@ describe("player scrim height", () => {
       footerSource.match(/\.player-scrim\s*\{([^}]*)\}/)?.[1] ?? "";
 
     expect(scrimRule).toMatch(/(?:^|\s)backdrop-filter:\s*blur\(14px\)/);
-    expect(scrimRule).toContain("-webkit-backdrop-filter: blur(14px)");
     expect(scrimRule).toMatch(/(?:^|\s)mask-image:\s*linear-gradient/);
+    // the minifier keeps only the last of a hand-written pair, which leaves the
+    // blur on a prefix Chromium does not support
+    expect(
+      scrimRule,
+      "the scrim must not declare a -webkit- prefix of its own",
+    ).not.toMatch(/-webkit-[a-z-]+\s*:/);
     expect(dockRules).not.toContain("backdrop-filter");
     expect(footerSource).not.toMatch(/\.player-scrim::before\s*\{/);
   });


### PR DESCRIPTION
# What does this implement/fix?

On mobile layout the player dock is lifted off the content by a blurred scrim. That blur was missing in Chromium-based browsers (Arc, Chrome, Edge, the Claude preview browser) while it worked fine in Safari and on iOS.

The scrim declared `backdrop-filter` twice — once plain, once with a hand-written `-webkit-` prefix. The CSS minifier treats such a pair as one property and keeps only the last one written, so the shipped stylesheet contained `-webkit-backdrop-filter` alone. Safari understands that; Chromium does not, so the blur silently disappeared there. Every other blurred surface in the app is written unprefixed and gets its prefixes from the build, which is why this was the only one affected.

Only shows up in a real build — the dev server does not minify, so both declarations survive there.

**Related issue (if applicable):**

- n/a

**Related backend PR (if applicable):**

- n/a

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Changes

- Drop the hand-written `-webkit-backdrop-filter` from the player scrim so the build emits both the prefixed and unprefixed forms.
- Drop the scrim's `-webkit-mask-image` alongside it as cleanup — that one was already being emitted correctly.
- Turn the existing scrim test around: it used to require the hand-written prefix, it now refuses one.

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm lint:check` passes.
- [x] `pnpm test:run` passes, and tests have been added/updated where applicable.
- [x] `pnpm build` passes.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
