### PR TITLE
Remove the unused browser targets config file

### DIFF
--- a/.browserslistrc
+++ b/.browserslistrc
@@ -1,4 +1,0 @@
-> 1%
-last 2 versions
-not dead
-not ie 11


### PR DESCRIPTION
# What does this implement/fix?

`.browserslistrc` in the repo root has done nothing since the day it was added, and it actively misleads.

Nothing in the toolchain reads it: there is no PostCSS config, no autoprefixer and no legacy plugin, and Vite does not consult browserslist on its own. The CSS that actually ships is minified by Lightning CSS against `build.cssTarget`, which falls back to Vite's own baseline target.

Because the file resolves to far newer browsers than that baseline, it gives the opposite answer to what the build really does. While fixing #2662 it suggested the mobile player blur needed no `-webkit-backdrop-filter`, where the real build emits one.

- Removed `.browserslistrc`

The built output is byte for byte identical without it, and stays identical even when the file is filled with deliberately ancient browsers.

`.hintrc` is the one file that would give it a purpose, since webhint's `compat-api/css` hint does read browserslist. webhint is not a dependency and does not run anywhere, so it is left alone here.

**Related issue (if applicable):**

- n/a

**Related backend PR (if applicable):**

- n/a

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm lint:check` passes.
- [x] `pnpm test:run` passes, and tests have been added/updated where applicable.
- [x] `pnpm build` passes.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
