### PR TITLE
Clean up the Python packaging config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,12 @@
+[build-system]
+requires      = ["setuptools>=77"]
+build-backend = "setuptools.build_meta"
+
 [project]
 name         = "music-assistant-frontend"
 # The version is set by GH action on release
 version = "0.0.0"
-license      = {text = "Apache-2.0"}
+license      = "Apache-2.0"
 description  = "The Music Assistant frontend"
 readme       = "README.md"
 authors      = [

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,0 @@
-# Setuptools v62.3 doesn't support editable installs with just 'pyproject.toml' (PEP 660).
-# Keep this file until it does!


### PR DESCRIPTION
# What does this implement/fix?

Tidies up the Python packaging config at the repo root. No behaviour change:
the built wheel still contains the same 312 files, and the only difference in
the published metadata is that `License:` is now `License-Expression:`.

- `setup.cfg` contained no configuration at all, just a note saying to keep it
  until setuptools could do editable installs from `pyproject.toml` alone.
  Setuptools has been able to do that since 64.0.0 in 2022, and nothing in the
  repo referenced the file.
- `pyproject.toml` had no `[build-system]` table, so pip and `build` were
  quietly falling back to a legacy default backend. It now says what it uses.
- The license was declared in a form setuptools deprecated, which made every
  build print a warning about builds breaking after 2027-Feb-18. Switched to
  the current form, so builds are warning-free again.

Checked locally on Python 3.12 (the version the release workflow uses):
`pip install -e .` works, installing from the built sdist works, and replaying
the release workflow's version rewrite still produces a valid package.

**Related issue (if applicable):**

- related issue `n/a`

**Related backend PR (if applicable):**

- related backend PR `n/a`

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm lint:check` passes.
- [x] `pnpm test:run` passes, and tests have been added/updated where applicable.
- [x] `pnpm build` passes.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
