### PR TITLE
Silence the setuptools warning about the assets directory

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,9 @@ zip-safe  = false
 include-package-data = true
 
 [tool.setuptools.packages.find]
-include = ["music_assistant_frontend"]
+# `pnpm build` writes the bundle here; its assets/ subdirectory has no __init__.py,
+# so the glob relies on namespace discovery to include it.
+include = ["music_assistant_frontend", "music_assistant_frontend.*"]
 
 [tool.codespell]
 ignore-words-list = "provid,hass,followings"


### PR DESCRIPTION
# What does this implement/fix?

Every Python package build printed a setuptools warning that the bundle directory
`music_assistant_frontend/assets` "would be ignored", because the `packages`
configuration only matched the top-level package. The files still shipped (via
`include-package-data` plus the `graft` in `MANIFEST.in`), but the configuration was
ambiguous.

The `assets` subdirectory has no `__init__.py` of its own, so the package glob now
covers it through namespace discovery. The shipped files are unchanged.

**Related issue (if applicable):**

- related issue `n/a`

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm lint:check` passes.
- [x] `pnpm test:run` passes, and tests have been added/updated where applicable.
- [x] `pnpm build` passes.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
