### PR TITLE
Check the Python package builds in CI

### DIFF
--- a/.github/scripts/verify-python-package.sh
+++ b/.github/scripts/verify-python-package.sh
@@ -24,9 +24,10 @@ if ! grep -Fqx "$MARKER" <<< "$WHEEL_FILES"; then
   exit 1
 fi
 
-# Every sdist entry sits under a <name>-<version>/ directory.
-SDIST_FILES=$(tar -tzf "${SDISTS[0]}")
-if ! grep -Fq "/$MARKER" <<< "$SDIST_FILES"; then
+# Strip the <name>-<version>/ directory every sdist entry sits under, so the
+# marker can be matched whole-line rather than as a substring.
+SDIST_FILES=$(tar -tzf "${SDISTS[0]}" | cut -d/ -f2-)
+if ! grep -Fqx "$MARKER" <<< "$SDIST_FILES"; then
   echo "::error::${SDISTS[0]##*/} does not contain $MARKER."
   exit 1
 fi

--- a/.github/scripts/verify-python-package.sh
+++ b/.github/scripts/verify-python-package.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Check that dist/ holds exactly one wheel and one source distribution, and
+# that both actually ship the built frontend. Run from the repository root
+# after `python3 -m build`.
+#
+# The exit code of `python3 -m build` says nothing about the payload: an
+# absent music_assistant_frontend/ or a broken MANIFEST.in graft still builds
+# cleanly and yields a metadata-only package.
+set -euo pipefail
+shopt -s nullglob
+
+MARKER="music_assistant_frontend/index.html"
+
+WHEELS=(dist/*.whl)
+SDISTS=(dist/*.tar.gz)
+if (( ${#WHEELS[@]} != 1 || ${#SDISTS[@]} != 1 )); then
+  echo "::error::Expected one wheel and one source distribution in dist/."
+  exit 1
+fi
+
+WHEEL_FILES=$(unzip -Z1 "${WHEELS[0]}")
+if ! grep -Fqx "$MARKER" <<< "$WHEEL_FILES"; then
+  echo "::error::${WHEELS[0]##*/} does not contain $MARKER."
+  exit 1
+fi
+
+# Every sdist entry sits under a <name>-<version>/ directory.
+SDIST_FILES=$(tar -tzf "${SDISTS[0]}")
+if ! grep -Fq "/$MARKER" <<< "$SDIST_FILES"; then
+  echo "::error::${SDISTS[0]##*/} does not contain $MARKER."
+  exit 1
+fi
+
+echo "${WHEELS[0]##*/} and ${SDISTS[0]##*/} ship the built frontend."

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -188,6 +188,10 @@ jobs:
           rm -rf dist music_assistant_frontend.egg-info
           python3 -m build
 
+      - name: Verify the package ships the frontend
+        if: steps.inspect_release.outputs.already_published != 'true'
+        run: .github/scripts/verify-python-package.sh
+
       - name: Create or verify tag
         if: steps.inspect_release.outputs.already_published != 'true'
         run: |
@@ -270,20 +274,10 @@ jobs:
         if: steps.inspect_release.outputs.already_published != 'true'
         run: |
           RELEASE_ID="${{ steps.prepare_draft.outputs.release_id }}"
+          # The verify step above already established that dist/ holds exactly
+          # one wheel and one source distribution, both carrying the frontend.
           shopt -s nullglob
-          WHEELS=(dist/*.whl)
-          SDISTS=(dist/*.tar.gz)
-          if (( ${#WHEELS[@]} != 1 || ${#SDISTS[@]} != 1 )); then
-            echo "::error::Expected one wheel and one source distribution."
-            exit 1
-          fi
-          ASSETS=("${WHEELS[@]}" "${SDISTS[@]}")
-          for ASSET in "${ASSETS[@]}"; do
-            if [[ ! -s "$ASSET" ]]; then
-              echo "::error::Release asset $ASSET is empty."
-              exit 1
-            fi
-          done
+          ASSETS=(dist/*.whl dist/*.tar.gz)
 
           read -r RELEASE_TAG IS_DRAFT <<< "$(
             gh api "repos/$GITHUB_REPOSITORY/releases/$RELEASE_ID" \

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -73,29 +73,7 @@ jobs:
         run: python3 -m build
 
       - name: Verify the Python package ships the frontend
-        run: |
-          shopt -s nullglob
-          WHEELS=(dist/*.whl)
-          SDISTS=(dist/*.tar.gz)
-          if (( ${#WHEELS[@]} != 1 || ${#SDISTS[@]} != 1 )); then
-            echo "::error::Expected one wheel and one source distribution in dist/."
-            exit 1
-          fi
-
-          # A missing frontend directory or a broken MANIFEST.in graft still
-          # builds cleanly and yields a metadata-only package, so check the
-          # payload instead of trusting the exit code.
-          WHEEL_FILES=$(unzip -Z1 "${WHEELS[0]}")
-          if ! grep -qx "music_assistant_frontend/index\.html" <<< "$WHEEL_FILES"; then
-            echo "::error::${WHEELS[0]##*/} does not contain music_assistant_frontend/index.html."
-            exit 1
-          fi
-
-          SDIST_FILES=$(tar -tzf "${SDISTS[0]}")
-          if ! grep -qx "[^/]*/music_assistant_frontend/index\.html" <<< "$SDIST_FILES"; then
-            echo "::error::${SDISTS[0]##*/} does not contain music_assistant_frontend/index.html."
-            exit 1
-          fi
+        run: .github/scripts/verify-python-package.sh
 
       # disable typecheck for now
       # - name: Typecheck

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,6 +19,7 @@ permissions:
 
 env:
   NODE_VERSION: "22.x" # set this to the node version to use
+  PYTHON_VERSION: "3.12" # set this to the python version to use
 
 jobs:
   test-and-lint:
@@ -26,6 +27,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Set up Python ${{ env.PYTHON_VERSION }}
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
 
       - name: Install pnpm
         uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
@@ -38,7 +44,9 @@ jobs:
           cache: pnpm
 
       - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+        run: |
+          pnpm install --frozen-lockfile
+          python3 -m pip install build
         env:
           CI: true
 
@@ -56,6 +64,38 @@ jobs:
         run: pnpm build
         env:
           CI: true
+
+      # The Python package wraps the freshly built frontend, so this has to run
+      # after `pnpm build`. Nothing else exercises the packaging config, so
+      # without this a mistake in pyproject.toml or MANIFEST.in first shows up
+      # as a failed release.
+      - name: Build Python package
+        run: python3 -m build
+
+      - name: Verify the Python package ships the frontend
+        run: |
+          shopt -s nullglob
+          WHEELS=(dist/*.whl)
+          SDISTS=(dist/*.tar.gz)
+          if (( ${#WHEELS[@]} != 1 || ${#SDISTS[@]} != 1 )); then
+            echo "::error::Expected one wheel and one source distribution in dist/."
+            exit 1
+          fi
+
+          # A missing frontend directory or a broken MANIFEST.in graft still
+          # builds cleanly and yields a metadata-only package, so check the
+          # payload instead of trusting the exit code.
+          WHEEL_FILES=$(unzip -Z1 "${WHEELS[0]}")
+          if ! grep -qx "music_assistant_frontend/index\.html" <<< "$WHEEL_FILES"; then
+            echo "::error::${WHEELS[0]##*/} does not contain music_assistant_frontend/index.html."
+            exit 1
+          fi
+
+          SDIST_FILES=$(tar -tzf "${SDISTS[0]}")
+          if ! grep -qx "[^/]*/music_assistant_frontend/index\.html" <<< "$SDIST_FILES"; then
+            echo "::error::${SDISTS[0]##*/} does not contain music_assistant_frontend/index.html."
+            exit 1
+          fi
 
       # disable typecheck for now
       # - name: Typecheck


### PR DESCRIPTION
# What does this implement/fix?

Nothing tested the Python package until a release ran, so a mistake in `pyproject.toml` or `MANIFEST.in` first showed up as a failed release instead of a failed PR check. Worse, an empty package builds without error: if the frontend directory is missing or the `MANIFEST.in` graft breaks, `python3 -m build` exits 0 and produces a 4 KB metadata-only wheel. The release workflow would have published that, since it only checked the artifacts were non-empty files.

The package is now built on every PR, right after `pnpm build` (which it needs, since the package wraps the built frontend), and both workflows run a shared script that checks the wheel and sdist actually contain `music_assistant_frontend/index.html`.

## Changes

- Build the Python package as part of the existing test job, adding about 5 seconds to the run.
- Add `.github/scripts/verify-python-package.sh`, which fails when the wheel or sdist is missing the built frontend.
- Call it from the release workflow too, replacing its weaker non-empty-file check.

**Related issue (if applicable):**

- n/a

**Related backend PR (if applicable):**

- n/a

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Maintenance / chore — `maintenance`
- [x] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm lint:check` passes.
- [x] `pnpm test:run` passes, and tests have been added/updated where applicable.
- [x] `pnpm build` passes.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
