### PR TITLE
Fix loading spinners showing up too small

### DIFF
--- a/src/components/HassEntityPickerDialog.vue
+++ b/src/components/HassEntityPickerDialog.vue
@@ -28,7 +28,7 @@
           v-if="loading && groups.length === 0"
           class="flex justify-center py-10"
         >
-          <Spinner :size="32" class="text-primary" />
+          <Spinner class="text-primary size-8" />
         </div>
         <p v-else-if="error" class="text-destructive py-8 text-center text-sm">
           {{ error }}

--- a/src/components/SetupFlowDialog.vue
+++ b/src/components/SetupFlowDialog.vue
@@ -23,7 +23,7 @@
       <div class="min-h-[120px] flex-1 overflow-y-auto px-5 py-5">
         <!-- Starting / loading state (no step yet) -->
         <div v-if="!step" class="flex items-center justify-center py-8">
-          <Spinner :size="44" class="text-primary" />
+          <Spinner class="text-primary size-11" />
         </div>
 
         <!-- FORM step -->
@@ -114,7 +114,7 @@
               }}</span>
             </div>
             <div class="text-muted-foreground flex items-center gap-2 text-sm">
-              <Spinner :size="18" />
+              <Spinner class="size-4.5" />
               <span>{{ $t("settings.setup_flow.external_waiting") }}</span>
             </div>
             <a
@@ -148,8 +148,7 @@
             />
             <Spinner
               v-if="step.progress === null || step.progress === undefined"
-              :size="52"
-              class="text-primary"
+              class="text-primary size-13"
             />
             <Progress
               v-else

--- a/src/components/party/PartyQueueItem.vue
+++ b/src/components/party/PartyQueueItem.vue
@@ -53,7 +53,7 @@
           :style="{ '--btn-bg': boostBadgeColor }"
           @click.stop="$emit('boost', item)"
         >
-          <Spinner v-if="boosting" :size="16" />
+          <Spinner v-if="boosting" class="size-4" />
           <Rocket v-else :size="16" />
           {{ $t("providers.party.boost") }}
         </Button>

--- a/src/components/party/PartyQueueSection.vue
+++ b/src/components/party/PartyQueueSection.vue
@@ -23,7 +23,7 @@
           class="skip-btn"
           @click="$emit('skip')"
         >
-          <Spinner v-if="skippingSong" :size="16" />
+          <Spinner v-if="skippingSong" class="size-4" />
           <SkipForward v-else :size="16" />
           {{ $t("providers.party.guest_page.skip") }}
           <span

--- a/src/components/party/PartyResultItem.vue
+++ b/src/components/party/PartyResultItem.vue
@@ -48,7 +48,7 @@
           :style="{ '--btn-bg': boostBadgeColor }"
           @click.stop="$emit('addToQueue', item, 'next')"
         >
-          <Spinner v-if="isBoostLoading" :size="16" />
+          <Spinner v-if="isBoostLoading" class="size-4" />
           <Rocket v-else :size="16" />
           {{ $t("providers.party.boost") }}
         </Button>
@@ -62,7 +62,7 @@
           :style="{ '--btn-bg': requestBadgeColor }"
           @click.stop="$emit('addToQueue', item, 'end')"
         >
-          <Spinner v-if="isAddLoading" :size="16" />
+          <Spinner v-if="isAddLoading" class="size-4" />
           <ListPlus v-else :size="16" />
           {{ $t("providers.party.request") }}
         </Button>

--- a/src/components/ui/button-group/index.ts
+++ b/src/components/ui/button-group/index.ts
@@ -5,8 +5,10 @@ export { default as ButtonGroup } from "./ButtonGroup.vue";
 export { default as ButtonGroupSeparator } from "./ButtonGroupSeparator.vue";
 export { default as ButtonGroupText } from "./ButtonGroupText.vue";
 
+// Same reasoning as buttonVariants: a group showing a spinner is busy, so none of
+// its buttons fade - otherwise only the half holding the spinner stays lit.
 export const buttonGroupVariants = cva(
-  "flex w-fit items-stretch [&>*]:focus-visible:z-10 [&>*]:focus-visible:relative [&>[data-slot=select-trigger]:not([class*='w-'])]:w-fit [&>input]:flex-1 has-[select[aria-hidden=true]:last-child]:[&>[data-slot=select-trigger]:last-of-type]:rounded-r-md has-[>[data-slot=button-group]]:gap-2",
+  "flex w-fit items-stretch [&>*]:focus-visible:z-10 [&>*]:focus-visible:relative [&>[data-slot=select-trigger]:not([class*='w-'])]:w-fit [&>input]:flex-1 has-[select[aria-hidden=true]:last-child]:[&>[data-slot=select-trigger]:last-of-type]:rounded-r-md has-[>[data-slot=button-group]]:gap-2 has-[.animate-spin]:[&_button:disabled]:opacity-100",
   {
     variants: {
       orientation: {

--- a/src/components/ui/button/index.ts
+++ b/src/components/ui/button/index.ts
@@ -2,8 +2,10 @@ import { cva, type VariantProps } from "class-variance-authority";
 
 export { default as Button } from "./Button.vue";
 
+// A button showing a spinner is busy, not unavailable, so it keeps full opacity
+// while disabled - a half-transparent spinner is hard to make out.
 export const buttonVariants = cva(
-  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 has-[.animate-spin]:disabled:opacity-100 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
   {
     variants: {
       variant: {

--- a/src/components/ui/spinner/Spinner.vue
+++ b/src/components/ui/spinner/Spinner.vue
@@ -18,6 +18,6 @@ const props = withDefaults(
   <Loader2Icon
     role="status"
     :aria-label="$t('loading_short')"
-    :class="cn('size-4 animate-spin', props.class)"
+    :class="cn('size-4 shrink-0 animate-spin', props.class)"
   />
 </template>

--- a/src/components/ui/spinner/Spinner.vue
+++ b/src/components/ui/spinner/Spinner.vue
@@ -7,11 +7,9 @@ import type { HTMLAttributes } from "vue";
 const props = withDefaults(
   defineProps<{
     class?: HTMLAttributes["class"];
-    size?: number;
   }>(),
   {
     class: undefined,
-    size: undefined,
   },
 );
 </script>
@@ -20,7 +18,6 @@ const props = withDefaults(
   <Loader2Icon
     role="status"
     :aria-label="$t('loading_short')"
-    :size="props.size"
     :class="cn('size-4 animate-spin', props.class)"
   />
 </template>


### PR DESCRIPTION
# What does this implement/fix?

Loading spinners were all rendering at 16px, whatever size the code asked for. The spinner component always applied its own 16px size class, which (because Tailwind's utilities are loaded with `important`) overruled the size that was passed in. So the big spinners in the provider setup dialog and the Home Assistant entity picker showed up as tiny 16px ones.

While in there: a button that is busy no longer fades its spinner to 50%, which made it hard to see.

- Spinners are sized with a `size-*` class now, so the size can no longer be quietly dropped
- Provider setup dialog: the starting, waiting and progress spinners are back at 44px, 18px and 52px
- Home Assistant entity picker: loading spinner back at 32px
- A spinner next to a long label no longer gets squeezed into a sliver
- A button, or a button group, that is showing a spinner stays at full opacity instead of fading out

**Related issue (if applicable):**

- related issue https://github.com/music-assistant/support/issues/6199

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm lint:check` passes.
- [x] `pnpm test:run` passes, and tests have been added/updated where applicable.
- [x] `pnpm build` passes.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
