### PR TITLE
Keep album art when its metadata provider is turned off

### DIFF
--- a/src/helpers/utils.ts
+++ b/src/helpers/utils.ts
@@ -353,11 +353,13 @@ export const getMediaImageUrl = function (
 };
 
 /**
- * Check if an image provider is available.
+ * Check if an image can still be fetched.
  */
-const imageProviderIsAvailable = function (provider: string) {
-  if (provider === "http" || provider === "builtin") return true;
-  return api.getProvider(provider)?.available === true;
+const imageIsResolvable = function (img: MediaItemImage) {
+  // a full URL stays fetchable without the provider that supplied it
+  if (img.remotely_accessible) return true;
+  if (img.provider === "http" || img.provider === "builtin") return true;
+  return api.getProvider(img.provider)?.available === true;
 };
 
 /**
@@ -392,7 +394,7 @@ export const getMediaItemImage = function (
     "image" in mediaItem &&
     mediaItem.image &&
     mediaItem.image.type == type &&
-    imageProviderIsAvailable(mediaItem.image.provider)
+    imageIsResolvable(mediaItem.image)
   )
     return mediaItem.image;
 
@@ -405,8 +407,7 @@ export const getMediaItemImage = function (
   // handle regular image within mediaitem
   if ("metadata" in mediaItem && mediaItem.metadata.images) {
     for (const img of mediaItem.metadata.images) {
-      if (img.type == type && imageProviderIsAvailable(img.provider))
-        return img;
+      if (img.type == type && imageIsResolvable(img)) return img;
     }
   }
 

--- a/tests/helpers/utils.test.ts
+++ b/tests/helpers/utils.test.ts
@@ -4,6 +4,7 @@ import {
   formatDuration,
   formatRelativeTime,
   getExternalLinkUrl,
+  getMediaItemImage,
   hexToRgb,
   kebabize,
   numberRange,
@@ -13,7 +14,12 @@ import {
   sleep,
   truncateString,
 } from "@/helpers/utils";
-import type { MediaItemPalette } from "@/plugins/api/interfaces";
+import { ImageType } from "@/plugins/api/interfaces";
+import type {
+  MediaItemImage,
+  MediaItemPalette,
+  MediaItemType,
+} from "@/plugins/api/interfaces";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const { apiMock } = vi.hoisted(() => ({
@@ -22,6 +28,7 @@ const { apiMock } = vi.hoisted(() => ({
       value: null as { server_version: string } | null,
     },
     players: {},
+    getProvider: vi.fn(),
   },
 }));
 
@@ -35,6 +42,7 @@ vi.mock("@/plugins/breakpoint", () => ({
 
 beforeEach(() => {
   apiMock.serverInfo.value = null;
+  apiMock.getProvider.mockReset();
 });
 
 afterEach(() => {
@@ -397,6 +405,115 @@ describe("utility functions", () => {
 
     it("handles single number range", () => {
       expect(numberRange(5, 5)).toEqual([5]);
+    });
+  });
+});
+
+describe("getMediaItemImage", () => {
+  const image = function (overrides: Partial<MediaItemImage> = {}) {
+    return {
+      type: ImageType.THUMB,
+      path: "https://theaudiodb.com/cover.jpg",
+      provider: "theaudiodb",
+      remotely_accessible: true,
+      ...overrides,
+    } as MediaItemImage;
+  };
+
+  const albumWithImages = function (images: MediaItemImage[]) {
+    return { metadata: { images } } as unknown as MediaItemType;
+  };
+
+  it("keeps a remotely accessible image when its provider is not loaded", () => {
+    apiMock.getProvider.mockReturnValue(undefined);
+    const img = image();
+
+    expect(getMediaItemImage(albumWithImages([img]))).toBe(img);
+  });
+
+  it("drops a provider relative image when its provider is not loaded", () => {
+    apiMock.getProvider.mockReturnValue(undefined);
+    const img = image({ path: "covers/1.jpg", remotely_accessible: false });
+
+    expect(getMediaItemImage(albumWithImages([img]))).toBeUndefined();
+  });
+
+  it("keeps a provider relative image while its provider is available", () => {
+    apiMock.getProvider.mockReturnValue({ available: true });
+    const img = image({ path: "covers/1.jpg", remotely_accessible: false });
+
+    expect(getMediaItemImage(albumWithImages([img]))).toBe(img);
+  });
+
+  it("skips an unusable image and returns the next usable one", () => {
+    apiMock.getProvider.mockImplementation((provider: string) =>
+      provider === "filesystem" ? { available: true } : undefined,
+    );
+    const unusable = image({
+      path: "covers/1.jpg",
+      remotely_accessible: false,
+    });
+    const usable = image({
+      path: "covers/2.jpg",
+      provider: "filesystem",
+      remotely_accessible: false,
+    });
+
+    expect(getMediaItemImage(albumWithImages([unusable, usable]))).toBe(usable);
+  });
+
+  it("only returns an image of the requested type", () => {
+    apiMock.getProvider.mockReturnValue(undefined);
+    const landscape = image({ type: ImageType.LANDSCAPE });
+
+    expect(
+      getMediaItemImage(albumWithImages([landscape]), ImageType.FANART),
+    ).toBeUndefined();
+  });
+
+  it("falls back to a landscape image when there is no thumb", () => {
+    apiMock.getProvider.mockReturnValue(undefined);
+    const landscape = image({ type: ImageType.LANDSCAPE });
+
+    expect(getMediaItemImage(albumWithImages([landscape]))).toBe(landscape);
+  });
+
+  it("drops an image from a provider that is loaded but unavailable", () => {
+    apiMock.getProvider.mockReturnValue({ available: false });
+    const img = image({ path: "covers/1.jpg", remotely_accessible: false });
+
+    expect(getMediaItemImage(albumWithImages([img]))).toBeUndefined();
+  });
+
+  it("keeps a builtin image without consulting the providers", () => {
+    apiMock.getProvider.mockReturnValue(undefined);
+    const img = image({
+      path: "covers/1.jpg",
+      provider: "builtin",
+      remotely_accessible: false,
+    });
+
+    expect(getMediaItemImage(albumWithImages([img]))).toBe(img);
+    expect(apiMock.getProvider).not.toHaveBeenCalled();
+  });
+
+  describe("image on an item mapping", () => {
+    const mappingWithImage = function (img: MediaItemImage) {
+      return { image: img } as unknown as MediaItemType;
+    };
+
+    it("keeps a remotely accessible image when its provider is not loaded", () => {
+      apiMock.getProvider.mockReturnValue(undefined);
+      const img = image();
+
+      expect(getMediaItemImage(mappingWithImage(img))).toBe(img);
+    });
+
+    it("drops a provider relative image when its provider is not loaded", () => {
+      apiMock.getProvider.mockReturnValue(undefined);
+      const img = image({ path: "covers/1.jpg", remotely_accessible: false });
+
+      expect(getMediaItemImage(mappingWithImage(img))).toBeUndefined();
     });
   });
 });


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes. -->

Images that are already a full web address were being thrown away when the provider that supplied them was disabled, because the check only looked at whether that provider was still loaded. Such an image carries everything needed to fetch it, so it now goes through regardless.

Detail pages hid the problem by falling back to another stored image. Tiles carry a single image, so they dropped to the initials placeholder instead.

- Gate on the image rather than the provider that supplied it
- Keep rejecting images that only the provider can resolve
- Cover the helper with tests

**Related issue (if applicable):**

- related issue https://github.com/music-assistant/support/issues/6216

**Related backend PR (if applicable):**

<!--
Link the music-assistant/server PR when this change relies on new server
behaviour, so the two can be reviewed and released together.
-->

- related backend PR `<link to PR>`

## Types of changes

<!--
Tick exactly one box below. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [X] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [X] The code change is tested and works locally.
- [X] `pnpm lint:check` passes.
- [X] `pnpm test:run` passes, and tests have been added/updated where applicable.
- [X] `pnpm build` passes.
- [X] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
