### PR TITLE
Fix playlist import match-policy version gate

### DIFF
--- a/src/plugins/api/index.ts
+++ b/src/plugins/api/index.ts
@@ -99,8 +99,8 @@ export interface CommandOptions {
   suppressGlobalError?: boolean | (() => boolean);
 }
 
-// The match_policy argument on music/playlists/import_playlist landed in API schema 59.
-const IMPORT_PLAYLIST_MATCH_POLICY_SCHEMA_VERSION = 59;
+// The match_policy argument on music/playlists/import_playlist landed in API schema 66.
+const IMPORT_PLAYLIST_MATCH_POLICY_SCHEMA_VERSION = 66;
 
 export interface PlayMediaOptions {
   start_item?: PlayableMediaItemType | string;
@@ -2978,7 +2978,7 @@ export class MusicAssistantApi {
     );
   }
 
-  /** Whether the connected server accepts an explicit match_policy on import_playlist (schema >= 59). */
+  /** Whether the connected server accepts an explicit match_policy on import_playlist (schema >= 66). */
   public get supportsPlaylistMatchPolicy(): boolean {
     return (
       (this.serverInfo.value?.schema_version ?? 0) >=

--- a/tests/layouts/ImportPlaylistDialog.test.ts
+++ b/tests/layouts/ImportPlaylistDialog.test.ts
@@ -139,7 +139,7 @@ describe("ImportPlaylistDialog", () => {
     expect(radioGroup(wrapper).exists()).toBe(false);
   });
 
-  it("hides the match policy picker on servers older than schema 59", async () => {
+  it("hides the match policy picker on servers older than schema 66", async () => {
     apiMock.supportsPlaylistMatchPolicy = false;
     const wrapper = mountDialog();
     open();
@@ -203,7 +203,7 @@ describe("ImportPlaylistDialog", () => {
     );
   });
 
-  it("omits match_policy on servers older than schema 59", async () => {
+  it("omits match_policy on servers older than schema 66", async () => {
     apiMock.supportsPlaylistMatchPolicy = false;
     const wrapper = mountDialog();
     open();

--- a/tests/plugins/api/index.test.ts
+++ b/tests/plugins/api/index.test.ts
@@ -382,7 +382,7 @@ describe("MusicAssistantApi error handling", () => {
   });
 
   it("imports a playlist with the chosen match policy", async () => {
-    api.serverInfo.value = { ...SERVER_INFO, schema_version: 59 };
+    api.serverInfo.value = { ...SERVER_INFO, schema_version: 66 };
     const result = api.importPlaylist(
       "#EXTM3U",
       true,
@@ -420,7 +420,7 @@ describe("MusicAssistantApi error handling", () => {
   });
 
   it("omits match_policy on older servers even when a policy is passed", () => {
-    api.serverInfo.value = { ...SERVER_INFO, schema_version: 58 };
+    api.serverInfo.value = { ...SERVER_INFO, schema_version: 65 };
     api.importPlaylist(
       "#EXTM3U",
       true,
@@ -435,13 +435,13 @@ describe("MusicAssistantApi error handling", () => {
     });
   });
 
-  it("reports playlist match policy support once the server reaches schema 59", () => {
+  it("reports playlist match policy support once the server reaches schema 66", () => {
     expect(api.supportsPlaylistMatchPolicy).toBe(false);
 
-    api.serverInfo.value = { ...SERVER_INFO, schema_version: 59 };
+    api.serverInfo.value = { ...SERVER_INFO, schema_version: 66 };
     expect(api.supportsPlaylistMatchPolicy).toBe(true);
 
-    api.serverInfo.value = { ...SERVER_INFO, schema_version: 58 };
+    api.serverInfo.value = { ...SERVER_INFO, schema_version: 65 };
     expect(api.supportsPlaylistMatchPolicy).toBe(false);
   });
 


### PR DESCRIPTION
# What does this implement/fix?

The playlist import "track matching" option was gated on API schema 59, but the server hasn't reached that schema yet and the actual command support lands later. This meant the frontend could advertise/send an option that current dev servers don't support.

Bumps the gate to schema 66, matching where server support for `match_policy` actually lands.

**Related backend PR (if applicable):**

- related backend PR `music-assistant/server#5986`

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm lint:check` passes.
- [x] `pnpm test:run` passes, and tests have been added/updated where applicable.
- [x] `pnpm build` passes.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.