### PR TITLE
Drag the rows sideways with the mouse

### DIFF
--- a/src/components/HomeWidgetRows.vue
+++ b/src/components/HomeWidgetRows.vue
@@ -680,6 +680,9 @@ const observeHero = () => {
   observedHeroGrid = el;
 };
 
+// the row mounts and unmounts as rows are hidden and shown, so watch the
+// element as well as the content in it
+watch(heroGrid, observeHero);
 watch(heroEntries, () => nextTick(observeHero), { deep: false });
 
 // Assign heroEntries only when the picks actually changed — cheap insurance
@@ -1271,7 +1274,8 @@ onBeforeUnmount(() => {
 .ed-hero-grid::-webkit-scrollbar {
   display: none;
 }
-.ed-hero-grid--dragging {
+/* doubled up so it outranks the .ed-hero-grid rules in the media queries below */
+.ed-hero-grid.ed-hero-grid--dragging {
   cursor: grabbing;
   user-select: none;
   /* snapping fights the drag while the pointer drives scrollLeft */

--- a/src/components/HomeWidgetRows.vue
+++ b/src/components/HomeWidgetRows.vue
@@ -135,7 +135,18 @@
                 <ChevronLeft :size="20" />
               </button>
 
-              <div ref="heroGrid" class="ed-hero-grid" @scroll="updateHeroNav">
+              <div
+                ref="heroGrid"
+                class="ed-hero-grid"
+                :class="{ 'ed-hero-grid--dragging': heroDragging }"
+                @scroll="updateHeroNav"
+                @pointerdown="onHeroPointerDown"
+                @pointermove="onHeroPointerMove"
+                @pointerup="onHeroPointerUp"
+                @pointercancel="onHeroPointerUp"
+                @click.capture="onHeroClickCapture"
+                @dragstart.prevent
+              >
                 <EditorialHeroCard
                   class="ed-hero-grid__lead"
                   :item="heroEntries[0].item"
@@ -393,6 +404,7 @@ import {
 import FacetedFilter from "@/components/FacetedFilter.vue";
 import PlayerCard from "@/components/PlayerCard.vue";
 import { Button } from "@/components/ui/button";
+import { useDragScroll } from "@/composables/useDragScroll";
 import { useListDragReorder } from "@/composables/useListDragReorder";
 import { useOrderedPlayers } from "@/composables/useOrderedPlayers";
 import { panelViewItemResponsive } from "@/helpers/utils";
@@ -635,6 +647,14 @@ const scrollHero = (dir: number) => {
   if (!el) return;
   el.scrollBy({ left: dir * el.clientWidth * 0.8, behavior: "smooth" });
 };
+
+const {
+  dragging: heroDragging,
+  onPointerDown: onHeroPointerDown,
+  onPointerMove: onHeroPointerMove,
+  onPointerUp: onHeroPointerUp,
+  onClickCapture: onHeroClickCapture,
+} = useDragScroll(heroGrid);
 
 let heroRo: ResizeObserver | undefined;
 let observedHeroGrid: HTMLElement | null = null;
@@ -1245,6 +1265,12 @@ onBeforeUnmount(() => {
 }
 .ed-hero-grid::-webkit-scrollbar {
   display: none;
+}
+.ed-hero-grid--dragging {
+  cursor: grabbing;
+  user-select: none;
+  /* snapping fights the drag while the pointer drives scrollLeft */
+  scroll-snap-type: none;
 }
 .ed-hero-grid__lead {
   flex: 1.5 0 520px;

--- a/src/components/HomeWidgetRows.vue
+++ b/src/components/HomeWidgetRows.vue
@@ -136,7 +136,7 @@
               </button>
 
               <div
-                ref="heroGrid"
+                :ref="setHeroGridRef"
                 class="ed-hero-grid"
                 :class="{ 'ed-hero-grid--dragging': heroDragging }"
                 @scroll="updateHeroNav"
@@ -631,6 +631,11 @@ const heroColumns = computed<HeroEntry[][]>(() => {
 // Safari swallow the first tap as "hover" instead of a click.
 const canHover = window.matchMedia?.("(hover: hover)")?.matches ?? true;
 const heroGrid = ref<HTMLElement | null>(null);
+// a plain ref would come back as an array here, since the row is rendered
+// inside the v-for over the rows
+const setHeroGridRef = (el: unknown) => {
+  heroGrid.value = el instanceof HTMLElement ? el : null;
+};
 const heroHovering = ref(false);
 const heroCanLeft = ref(false);
 const heroCanRight = ref(false);

--- a/src/components/discover/EditorialShelf.vue
+++ b/src/components/discover/EditorialShelf.vue
@@ -46,11 +46,18 @@
       <div
         ref="track"
         class="ed-shelf__track ma-scroll"
+        :class="{ 'ed-shelf__track--dragging': dragging }"
         :style="{
           '--ed-gap': gap + 'px',
           ...(tileArt != null ? { '--ed-tile-art': tileArt + 'px' } : {}),
         }"
         @scroll="onScroll"
+        @pointerdown="onPointerDown"
+        @pointermove="onPointerMove"
+        @pointerup="onPointerUp"
+        @pointercancel="onPointerUp"
+        @click.capture="onClickCapture"
+        @dragstart.prevent
       >
         <slot></slot>
       </div>
@@ -77,6 +84,7 @@ export interface EditorialShelfExpose {
 
 <script setup lang="ts">
 import ProviderIcon from "@/components/ProviderIcon.vue";
+import { useDragScroll } from "@/composables/useDragScroll";
 import { getBreakpointValue } from "@/plugins/breakpoint";
 import { ChevronLeft, ChevronRight } from "@lucide/vue";
 import { computed, onBeforeUnmount, onMounted, ref, watch } from "vue";
@@ -175,6 +183,9 @@ const scroll = (dir: number) => {
   if (!el) return;
   el.scrollBy({ left: dir * el.clientWidth * 0.8, behavior: "smooth" });
 };
+
+const { dragging, onPointerDown, onPointerMove, onPointerUp, onClickCapture } =
+  useDragScroll(track);
 
 function scrollToStart() {
   const el = track.value;
@@ -294,6 +305,12 @@ onBeforeUnmount(() => {
   scroll-snap-type: x proximity;
   overflow-anchor: none;
   scroll-padding-inline: calc(var(--ed-gutter) - var(--ed-card-pad));
+}
+.ed-shelf__track--dragging {
+  cursor: grabbing;
+  user-select: none;
+  /* snapping fights the drag while the pointer drives scrollLeft */
+  scroll-snap-type: none;
 }
 .ed-shelf__track::after {
   content: "";

--- a/src/composables/useDragScroll.ts
+++ b/src/composables/useDragScroll.ts
@@ -30,6 +30,8 @@ export function useDragScroll(el: Ref<HTMLElement | null>): DragScroll {
     if (e.pointerType !== "mouse" || e.button !== 0) return;
     pointerDown = true;
     swallowClick = false;
+    // a scroller that unmounted mid-gesture never got its pointerup
+    dragging.value = false;
     startX = e.clientX;
     startScroll = el.value?.scrollLeft ?? 0;
   };

--- a/src/composables/useDragScroll.ts
+++ b/src/composables/useDragScroll.ts
@@ -1,0 +1,83 @@
+import { ref, type Ref } from "vue";
+
+// A gesture only counts as a drag once it travels this far, so a click on a
+// tile still reaches the tile.
+const DRAG_THRESHOLD = 6;
+
+export interface DragScroll {
+  dragging: Ref<boolean>;
+  onPointerDown: (e: PointerEvent) => void;
+  onPointerMove: (e: PointerEvent) => void;
+  onPointerUp: () => void;
+  onClickCapture: (e: MouseEvent) => void;
+}
+
+/**
+ * Click-and-drag panning for a horizontally scrolling element.
+ *
+ * Bind the returned handlers to the scroller (`onClickCapture` on its click
+ * capture phase) and style it off `dragging` while a drag is in progress.
+ * Only a mouse is handled: touch and pen already pan natively.
+ */
+export function useDragScroll(el: Ref<HTMLElement | null>): DragScroll {
+  const dragging = ref(false);
+  let pointerDown = false;
+  let startX = 0;
+  let startScroll = 0;
+  let swallowClick = false;
+
+  const onPointerDown = (e: PointerEvent) => {
+    if (e.pointerType !== "mouse" || e.button !== 0) return;
+    pointerDown = true;
+    swallowClick = false;
+    startX = e.clientX;
+    startScroll = el.value?.scrollLeft ?? 0;
+  };
+
+  const onPointerMove = (e: PointerEvent) => {
+    const node = el.value;
+    if (!pointerDown || !node) return;
+    // the button can be let go outside the scroller, where our pointerup never
+    // lands; a move with no button held means that gesture is over
+    if (!(e.buttons & 1)) {
+      pointerDown = false;
+      dragging.value = false;
+      return;
+    }
+    const dx = e.clientX - startX;
+    if (!dragging.value) {
+      if (Math.abs(dx) < DRAG_THRESHOLD) return;
+      dragging.value = true;
+      node.setPointerCapture(e.pointerId);
+      // the browser began a text selection before the gesture was recognised
+      // as a drag; leaving it painted across the tiles looks broken
+      window.getSelection()?.removeAllRanges();
+    }
+    node.scrollLeft = startScroll - dx;
+  };
+
+  const onPointerUp = () => {
+    const node = el.value;
+    pointerDown = false;
+    // a row with nothing to scroll never moves under the pointer, so the
+    // gesture stays the click it looks like
+    swallowClick =
+      dragging.value && !!node && node.scrollWidth > node.clientWidth;
+    dragging.value = false;
+  };
+
+  const onClickCapture = (e: MouseEvent) => {
+    if (!swallowClick) return;
+    swallowClick = false;
+    e.stopPropagation();
+    e.preventDefault();
+  };
+
+  return {
+    dragging,
+    onPointerDown,
+    onPointerMove,
+    onPointerUp,
+    onClickCapture,
+  };
+}

--- a/tests/composables/useDragScroll.test.ts
+++ b/tests/composables/useDragScroll.test.ts
@@ -1,6 +1,6 @@
 import { useDragScroll } from "@/composables/useDragScroll";
 import { describe, expect, it, vi } from "vitest";
-import { ref } from "vue";
+import { ref, type Ref } from "vue";
 
 interface Scroller {
   scrollLeft: number;
@@ -97,6 +97,41 @@ describe("useDragScroll", () => {
     const next = click();
     drag.onClickCapture(next);
     expect(next.stopPropagation).not.toHaveBeenCalled();
+  });
+
+  it("clears a swallowed click that never arrived", () => {
+    const el = scroller();
+    const drag = setup(el);
+
+    drag.onPointerDown(down(100));
+    drag.onPointerMove(move(40));
+    drag.onPointerUp();
+
+    // no click followed, and the next gesture is a plain click
+    drag.onPointerDown(down(100));
+    drag.onPointerUp();
+
+    const e = click();
+    drag.onClickCapture(e);
+    expect(e.stopPropagation).not.toHaveBeenCalled();
+  });
+
+  it("clears a drag left hanging by a scroller that went away", () => {
+    const el = ref<Scroller | null>(scroller());
+    const drag = useDragScroll(el as unknown as Ref<HTMLElement | null>);
+
+    drag.onPointerDown(down(100));
+    drag.onPointerMove(move(40));
+    expect(drag.dragging.value).toBe(true);
+
+    // the row unmounts mid-drag, so no pointerup ever lands
+    el.value = null;
+    drag.onPointerMove(move(20));
+    expect(drag.dragging.value).toBe(true);
+
+    el.value = scroller();
+    drag.onPointerDown(down(100));
+    expect(drag.dragging.value).toBe(false);
   });
 
   it("keeps a row that has nothing to scroll clickable", () => {

--- a/tests/composables/useDragScroll.test.ts
+++ b/tests/composables/useDragScroll.test.ts
@@ -1,0 +1,143 @@
+import { useDragScroll } from "@/composables/useDragScroll";
+import { describe, expect, it, vi } from "vitest";
+import { ref } from "vue";
+
+interface Scroller {
+  scrollLeft: number;
+  scrollWidth: number;
+  clientWidth: number;
+  setPointerCapture: (pointerId: number) => void;
+}
+
+const scroller = (overrides: Partial<Scroller> = {}) =>
+  ({
+    scrollLeft: 0,
+    scrollWidth: 1000,
+    clientWidth: 400,
+    setPointerCapture: vi.fn(),
+    ...overrides,
+  }) as Scroller;
+
+const down = (clientX: number, overrides: Record<string, unknown> = {}) =>
+  ({
+    pointerType: "mouse",
+    button: 0,
+    pointerId: 1,
+    clientX,
+    ...overrides,
+  }) as unknown as PointerEvent;
+
+const move = (clientX: number, buttons = 1) =>
+  ({ pointerId: 1, clientX, buttons }) as unknown as PointerEvent;
+
+const click = () =>
+  ({
+    stopPropagation: vi.fn(),
+    preventDefault: vi.fn(),
+  }) as unknown as MouseEvent & {
+    stopPropagation: ReturnType<typeof vi.fn>;
+    preventDefault: ReturnType<typeof vi.fn>;
+  };
+
+const setup = (el: Scroller) =>
+  useDragScroll(ref(el as unknown as HTMLElement));
+
+describe("useDragScroll", () => {
+  it("leaves a small movement alone so it stays a click", () => {
+    const el = scroller();
+    const drag = setup(el);
+
+    drag.onPointerDown(down(100));
+    drag.onPointerMove(move(104));
+    drag.onPointerUp();
+
+    expect(drag.dragging.value).toBe(false);
+    expect(el.scrollLeft).toBe(0);
+
+    const e = click();
+    drag.onClickCapture(e);
+    expect(e.stopPropagation).not.toHaveBeenCalled();
+  });
+
+  it("pans the scroller once the movement passes the threshold", () => {
+    const el = scroller({ scrollLeft: 50 });
+    const drag = setup(el);
+
+    drag.onPointerDown(down(100));
+    drag.onPointerMove(move(80));
+
+    expect(drag.dragging.value).toBe(true);
+    expect(el.setPointerCapture).toHaveBeenCalledWith(1);
+    expect(el.scrollLeft).toBe(70);
+  });
+
+  it("swallows the click that ends a drag", () => {
+    const el = scroller();
+    const drag = setup(el);
+
+    drag.onPointerDown(down(100));
+    drag.onPointerMove(move(40));
+    drag.onPointerUp();
+
+    const e = click();
+    drag.onClickCapture(e);
+    expect(e.stopPropagation).toHaveBeenCalled();
+    expect(e.preventDefault).toHaveBeenCalled();
+  });
+
+  it("swallows only that one click", () => {
+    const el = scroller();
+    const drag = setup(el);
+
+    drag.onPointerDown(down(100));
+    drag.onPointerMove(move(40));
+    drag.onPointerUp();
+    drag.onClickCapture(click());
+
+    const next = click();
+    drag.onClickCapture(next);
+    expect(next.stopPropagation).not.toHaveBeenCalled();
+  });
+
+  it("keeps a row that has nothing to scroll clickable", () => {
+    const el = scroller({ scrollWidth: 400, clientWidth: 400 });
+    const drag = setup(el);
+
+    drag.onPointerDown(down(100));
+    drag.onPointerMove(move(40));
+    drag.onPointerUp();
+
+    const e = click();
+    drag.onClickCapture(e);
+    expect(e.stopPropagation).not.toHaveBeenCalled();
+  });
+
+  it("ends the gesture when the button was released off the scroller", () => {
+    const el = scroller();
+    const drag = setup(el);
+
+    drag.onPointerDown(down(100));
+    drag.onPointerMove(move(40));
+    drag.onPointerMove(move(10, 0));
+
+    expect(drag.dragging.value).toBe(false);
+
+    // a later move with the button down again must not resume the old drag
+    drag.onPointerMove(move(200));
+    expect(el.scrollLeft).toBe(60);
+  });
+
+  it("ignores anything that is not a left mouse button", () => {
+    const el = scroller();
+    const drag = setup(el);
+
+    drag.onPointerDown(down(100, { pointerType: "touch" }));
+    drag.onPointerMove(move(40));
+    expect(drag.dragging.value).toBe(false);
+
+    drag.onPointerDown(down(100, { button: 2 }));
+    drag.onPointerMove(move(40));
+    expect(drag.dragging.value).toBe(false);
+    expect(el.scrollLeft).toBe(0);
+  });
+});


### PR DESCRIPTION
# What does this implement/fix?

The rows on the home and discover pages could only be moved with the arrow buttons that appear on hover, or with a trackpad. There was no way to grab a row and pull it along with a normal mouse, which is what most people would try first.

You can now press anywhere on a row and drag it sideways.

While wiring this up it turned out the top picks row was handing back a list instead of the row element, because it is rendered inside the loop over the rows. Nothing that measured that row worked, so its arrow buttons had never appeared. That is fixed here too, so the arrows now show on hover like they do on every other row.

- added a shared drag to scroll helper
- used it on the shelf rows, which covers the home, discover and genre pages and the timeline row
- used it on the top picks row at the top of discover
- fixed the top picks row element reference, which also brings back its arrow buttons
- a small movement still counts as a click, so clicking a card keeps working
- rows too short to scroll are left alone

**Related issue (if applicable):**

- n/a

**Related backend PR (if applicable):**

- n/a

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [X] `pnpm lint:check` passes.
- [X] `pnpm test:run` passes, and tests have been added/updated where applicable.
- [X] `pnpm build` passes.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
