### PR TITLE
Correct the DSP help text about which filters need stereo

### DIFF
--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -311,7 +311,7 @@
                 "help": "Raises or lowers the level of everything passing through this point in the pipeline."
             },
             "balance": {
-                "help": "Shifts the sound towards the left or right speaker. Only applies to stereo audio."
+                "help": "Shifts the sound towards the left or right speaker."
             },
             "stereo_width": {
                 "help": "Adjusts the stereo image width. Left of center narrows towards mono, right widens the sound.",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -314,7 +314,7 @@
                 "help": "Shifts the sound towards the left or right speaker."
             },
             "stereo_width": {
-                "help": "Adjusts the stereo image width. Left of center narrows towards mono, right widens the sound.",
+                "help": "Adjusts the stereo image width. Left of center narrows towards mono, right widens the sound. Only applies to stereo audio.",
                 "clip_hint": "Widening past Original can raise peaks and cause clipping. Consider adding a Limiter after this filter.",
                 "scale": {
                     "mono": "Mono",
@@ -323,7 +323,7 @@
                 }
             },
             "crossfeed": {
-                "help": "Makes headphone listening feel more natural by gently blending the left and right channels, similar to listening to speakers.",
+                "help": "Makes headphone listening feel more natural by gently blending the left and right channels, similar to listening to speakers. Only applies to stereo audio.",
                 "presets": {
                     "low": "Low",
                     "medium": "Medium",


### PR DESCRIPTION
# What does this implement/fix?

Keeps the DSP help text honest about which filters need stereo audio.

Balance used to say it only applies to stereo audio. The backend PR below makes it work on mono tracks too, so that sentence is now wrong and is removed.

Stereo Width and Crossfeed genuinely do need stereo. Both rely on the two channels carrying different sound, so neither does anything to a mono track, and neither said so. They now do.

Changes:

- Balance no longer claims to be stereo only
- Stereo Width and Crossfeed now say they are

**Related issue (if applicable):**

- n/a

**Related backend PR (if applicable):**

- related backend PR https://github.com/music-assistant/server/pull/6104

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [X] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [X] The code change is tested and works locally.
- [ ] `pnpm lint:check` passes.
- [ ] `pnpm test:run` passes, and tests have been added/updated where applicable.
- [ ] `pnpm build` passes.
- [ ] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
