### PR TITLE
Update volume control behavior in PlayerVolume.vue

### DIFF
--- a/src/layouts/default/PlayerOSD/PlayerVolume.vue
+++ b/src/layouts/default/PlayerOSD/PlayerVolume.vue
@@ -55,7 +55,11 @@
             <div class="group-popout-label">
               {{ truncateString(child.name, 20) }}
             </div>
-            <PlayerVolume :player="child" width="100%" />
+            <PlayerVolume
+              :player="child"
+              width="100%"
+              :allow-wheel="allowWheel"
+            />
           </div>
           <!-- Group volume at bottom with divider -->
           <div class="group-popout-divider"></div>
@@ -65,6 +69,7 @@
               :prefer-group-volume="true"
               :enable-popout="false"
               width="100%"
+              :allow-wheel="allowWheel"
             />
           </div>
         </div>


### PR DESCRIPTION
# What does this implement/fix?

Mouse scroll wheel does not work to change the volume on individual speakers or speaker groups in the volume pop-up on the page that slides up when going to the current playing song. 

This change makes the scroll wheel work on these volume controls as it does elsewhere.



**Related issue (if applicable):**

- related issue `<link to issue>`

**Related backend PR (if applicable):**

<!--
Link the music-assistant/server PR when this change relies on new server
behaviour, so the two can be reviewed and released together.
-->

- related backend PR `<link to PR>`

## Types of changes

<!--
Tick exactly one box below. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [X] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [X] The code change is tested and works locally.
- [X] `pnpm lint:check` passes.
- [X] `pnpm test:run` passes, and tests have been added/updated where applicable.
- [X] `pnpm build` passes.
- [X] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
