### PR TITLE
Improve player card hierarchy and playback status

### DIFF
--- a/src/components/HomeWidgetRows.vue
+++ b/src/components/HomeWidgetRows.vue
@@ -30,6 +30,7 @@
             :gap="12"
             :nav-center="42"
             :dimmed="editMode && row.hidden"
+            style="--ed-card-pad: 0px"
           >
             <template #header>
               <div class="ed-players__head">
@@ -60,21 +61,26 @@
                 <EyeOff v-else />
               </Button>
             </template>
-            <div
-              v-for="player in players"
+            <template
+              v-for="(player, playerIndex) in discoverPlayers"
               :key="player.player_id"
-              class="ed-player-slot"
-              :data-player-id="player.player_id"
             >
-              <PlayerCard
-                :player="player"
-                :show-volume-control="false"
-                :show-menu-button="false"
-                :show-child-volumes="false"
-                :show-group-controls="false"
-                @click="playerClicked(player)"
-              />
-            </div>
+              <div
+                v-if="playerIndex === 1 && hasSelectedShelfPlayer"
+                class="ed-player-divider bg-border h-8 w-px shrink-0 self-center"
+                aria-hidden="true"
+              ></div>
+              <div class="ed-player-slot" :data-player-id="player.player_id">
+                <PlayerCard
+                  :player="player"
+                  :show-volume-control="false"
+                  :show-menu-button="false"
+                  :show-child-volumes="false"
+                  :show-group-controls="false"
+                  @click="playerClicked(player)"
+                />
+              </div>
+            </template>
           </EditorialShelf>
 
           <!-- Top picks row -->
@@ -383,6 +389,7 @@ import {
   isRecommendationRowVisible,
   rowIdsNeedingItems,
 } from "@/components/discover/utils/rowItems";
+import { prioritizeSelectedPlayer } from "@/components/discover/utils/playerShelf";
 import {
   eligibleFilterProviders,
   getRowHiddenProviders,
@@ -453,6 +460,12 @@ const skeletonTileCount = computed(() =>
 );
 
 const players = useOrderedPlayers();
+const discoverPlayers = computed(() =>
+  prioritizeSelectedPlayer(players.value, store.activePlayerId),
+);
+const hasSelectedShelfPlayer = computed(
+  () => discoverPlayers.value[0]?.player_id === store.activePlayerId,
+);
 
 const activeCount = computed(
   () =>
@@ -469,7 +482,7 @@ const setPlayersShelfRef = (el: unknown) => {
 };
 
 const playersOrderKey = computed(() =>
-  players.value.map((p) => p.player_id).join(","),
+  discoverPlayers.value.map((player) => player.player_id).join(","),
 );
 
 function alignPlayersShelf() {
@@ -487,7 +500,7 @@ const showPlayers = computed(() =>
   displayedRows.value.some((row) => row.kind === "players"),
 );
 
-watch(playersOrderKey, () => {
+watch([playersOrderKey, () => store.activePlayerId], () => {
   if (!showPlayers.value) return;
   nextTick(alignPlayersShelf);
 });
@@ -495,14 +508,6 @@ watch(playersOrderKey, () => {
 watch(loading, (isLoading) => {
   if (!isLoading) nextTick(alignPlayersShelf);
 });
-
-watch(
-  () => store.activePlayerId,
-  () => {
-    if (!showPlayers.value) return;
-    nextTick(alignPlayersShelf);
-  },
-);
 
 const folderProvider = (folder: RecommendationFolder) => folder.provider || "";
 

--- a/src/components/PanelDragHandle.vue
+++ b/src/components/PanelDragHandle.vue
@@ -2,7 +2,7 @@
   <div
     ref="handle"
     data-panel-drag-region
-    class="panel-drag-handle relative flex h-8 shrink-0 touch-none cursor-grab items-center justify-center select-none active:cursor-grabbing"
+    class="panel-drag-handle relative flex h-6 shrink-0 touch-none cursor-grab items-center justify-center select-none active:cursor-grabbing"
     role="button"
     tabindex="0"
     :aria-label="$t('close')"

--- a/src/components/PlayerCard.vue
+++ b/src/components/PlayerCard.vue
@@ -6,8 +6,6 @@
       'border-primary bg-primary/15': player.player_id === store.activePlayerId,
       'ring-primary/50 ring-1':
         showSelectedIndicator && player.player_id === store.activePlayerId,
-      'pt-4':
-        showSelectedIndicator && player.player_id === store.activePlayerId,
       'opacity-80':
         !stackMediaDetails &&
         !player.needs_setup &&
@@ -19,13 +17,6 @@
     @contextmenu.prevent.stop="openPlayerMenu"
     @touchstart.passive="onTouchStart"
   >
-    <Badge
-      v-if="showSelectedIndicator && player.player_id === store.activePlayerId"
-      as="span"
-      class="selected-player-badge absolute -top-2 left-3 z-10 h-5 rounded-full px-2.5 py-0 text-[11px] leading-none shadow-xs"
-    >
-      {{ $t("player_tip.selected_player") }}
-    </Badge>
     <div class="flex min-w-0 items-center gap-1">
       <div class="relative flex min-w-0 flex-1">
         <button
@@ -65,6 +56,7 @@
             :member-names="displayedGroupMemberNames"
             :member-layout="groupMemberLayout"
             :playing="isPlaying"
+            :selected="isSelectedPlayer"
           >
             <PlayerDeviceBadge v-if="isBuiltinPlayer(player)" />
           </PlayerCardTitle>
@@ -119,6 +111,7 @@
                 :member-names="displayedGroupMemberNames"
                 :member-layout="groupMemberLayout"
                 :playing="isPlaying"
+                :selected="isSelectedPlayer"
               >
                 <PlayerDeviceBadge v-if="isBuiltinPlayer(player)" />
               </PlayerCardTitle>
@@ -145,7 +138,7 @@
               </p>
               <p
                 v-if="player.powered !== false && mediaByline"
-                class="text-muted-foreground truncate text-xs"
+                class="player-card-media-byline text-foreground/60 truncate text-xs"
               >
                 {{ mediaByline }}
               </p>
@@ -358,6 +351,12 @@ const isPlaying = computed(
   () =>
     props.player.powered !== false &&
     props.player.playback_state === PlaybackState.PLAYING,
+);
+
+const isSelectedPlayer = computed(
+  () =>
+    props.showSelectedIndicator === true &&
+    props.player.player_id === store.activePlayerId,
 );
 
 const useStackedMediaLayout = computed(

--- a/src/components/PlayerCard.vue
+++ b/src/components/PlayerCard.vue
@@ -9,7 +9,9 @@
       'pt-4':
         showSelectedIndicator && player.player_id === store.activePlayerId,
       'opacity-80':
-        !player.needs_setup && player.playback_state === PlaybackState.IDLE,
+        !stackMediaDetails &&
+        !player.needs_setup &&
+        player.playback_state === PlaybackState.IDLE,
       'opacity-60': !player.needs_setup && player.powered === false,
       'opacity-40': !player.available && !player.needs_setup,
     }"
@@ -62,6 +64,7 @@
             :player-name="cardPlayerName"
             :member-names="displayedGroupMemberNames"
             :member-layout="groupMemberLayout"
+            :playing="isPlaying"
           >
             <PlayerDeviceBadge v-if="isBuiltinPlayer(player)" />
           </PlayerCardTitle>
@@ -74,7 +77,12 @@
             "
           >
             <div
-              class="bg-muted flex size-11 shrink-0 items-center justify-center overflow-hidden rounded-md"
+              class="player-card-media flex size-11 shrink-0 items-center justify-center overflow-hidden"
+              :class="{
+                'bg-muted rounded-md': artworkUrl || !useStackedMediaLayout,
+                'player-card-media-placeholder':
+                  useStackedMediaLayout && !artworkUrl,
+              }"
             >
               <img
                 v-if="artworkUrl"
@@ -94,7 +102,13 @@
                   )
                 "
                 :size="24"
-                class="opacity-80"
+                :class="
+                  useStackedMediaLayout
+                    ? hasSelectedMedia
+                      ? 'text-foreground opacity-100'
+                      : 'text-foreground opacity-50'
+                    : 'opacity-80'
+                "
               />
             </div>
 
@@ -104,6 +118,7 @@
                 :player-name="cardPlayerName"
                 :member-names="displayedGroupMemberNames"
                 :member-layout="groupMemberLayout"
+                :playing="isPlaying"
               >
                 <PlayerDeviceBadge v-if="isBuiltinPlayer(player)" />
               </PlayerCardTitle>
@@ -320,15 +335,25 @@ const mediaByline = computed(() =>
     .join(" • "),
 );
 
-const hasMediaDetails = computed(
+const hasSelectedMedia = computed(
   () =>
     props.player.powered !== false &&
-    Boolean(props.player.current_media?.title || mediaByline.value),
+    (props.player.playback_state === PlaybackState.PLAYING ||
+      props.player.playback_state === PlaybackState.PAUSED ||
+      Boolean(
+        props.player.current_media?.title ||
+        mediaByline.value ||
+        props.player.current_media?.image_url,
+      )),
 );
 
-const useStackedMediaLayout = computed(
-  () => props.stackMediaDetails === true && hasMediaDetails.value,
+const isPlaying = computed(
+  () =>
+    props.player.powered !== false &&
+    props.player.playback_state === PlaybackState.PLAYING,
 );
+
+const useStackedMediaLayout = computed(() => props.stackMediaDetails === true);
 
 const canPlayPause = computed(
   () => activeSource.value?.can_play_pause === true,

--- a/src/components/PlayerCard.vue
+++ b/src/components/PlayerCard.vue
@@ -60,7 +60,7 @@
           "
         >
           <PlayerCardTitle
-            v-if="useStackedMediaLayout"
+            v-if="stackMediaDetails"
             :player-name="cardPlayerName"
             :member-names="displayedGroupMemberNames"
             :member-layout="groupMemberLayout"
@@ -69,6 +69,7 @@
             <PlayerDeviceBadge v-if="isBuiltinPlayer(player)" />
           </PlayerCardTitle>
           <div
+            v-if="!stackMediaDetails || hasStackedDetails"
             class="player-card-media-row"
             :class="
               useStackedMediaLayout
@@ -77,6 +78,7 @@
             "
           >
             <div
+              v-if="!stackMediaDetails || hasSelectedMedia"
               class="player-card-media flex size-11 shrink-0 items-center justify-center overflow-hidden"
               :class="{
                 'bg-muted rounded-md': artworkUrl || !useStackedMediaLayout,
@@ -104,9 +106,7 @@
                 :size="24"
                 :class="
                   useStackedMediaLayout
-                    ? hasSelectedMedia
-                      ? 'text-foreground opacity-100'
-                      : 'text-foreground opacity-50'
+                    ? 'text-foreground opacity-100'
                     : 'opacity-80'
                 "
               />
@@ -347,13 +347,22 @@ const hasSelectedMedia = computed(
       )),
 );
 
+const hasStackedDetails = computed(
+  () =>
+    hasSelectedMedia.value ||
+    props.player.needs_setup ||
+    props.player.type === PlayerType.SOURCE,
+);
+
 const isPlaying = computed(
   () =>
     props.player.powered !== false &&
     props.player.playback_state === PlaybackState.PLAYING,
 );
 
-const useStackedMediaLayout = computed(() => props.stackMediaDetails === true);
+const useStackedMediaLayout = computed(
+  () => props.stackMediaDetails === true && hasStackedDetails.value,
+);
 
 const canPlayPause = computed(
   () => activeSource.value?.can_play_pause === true,

--- a/src/components/PlayerCardTitle.vue
+++ b/src/components/PlayerCardTitle.vue
@@ -14,7 +14,7 @@
           class="player-playback-indicator flex size-4 shrink-0 items-center justify-center"
           :class="{
             'text-primary': playing,
-            invisible: !playing,
+            hidden: !playing,
           }"
           role="img"
           :aria-label="playing ? $t('state.playing') : undefined"
@@ -22,6 +22,14 @@
         >
           <AudioLines aria-hidden="true" class="size-4" />
         </span>
+        <Badge
+          v-if="selected && index === 0"
+          as="span"
+          variant="default"
+          class="selected-player-indicator h-5 px-2 py-0 ml-1 text-[11px] leading-none shadow-none"
+        >
+          {{ $t("player_tip.selected") }}
+        </Badge>
         <slot v-if="index === 0"></slot>
       </div>
     </template>
@@ -33,7 +41,7 @@
         class="player-playback-indicator flex size-4 shrink-0 items-center justify-center"
         :class="{
           'text-primary': playing,
-          invisible: !playing,
+          hidden: !playing,
         }"
         role="img"
         :aria-label="playing ? $t('state.playing') : undefined"
@@ -41,6 +49,14 @@
       >
         <AudioLines aria-hidden="true" class="size-4" />
       </span>
+      <Badge
+        v-if="selected"
+        as="span"
+        variant="default"
+        class="selected-player-indicator h-5 px-2 py-0 ml-1 text-[11px] leading-none shadow-none"
+      >
+        {{ $t("player_tip.selected") }}
+      </Badge>
       <slot></slot>
     </div>
     <p
@@ -82,6 +98,8 @@
 import { AudioLines } from "@lucide/vue";
 import { computed, ref, watch } from "vue";
 
+import { Badge } from "@/components/ui/badge";
+
 const props = withDefaults(
   defineProps<{
     playerName: string;
@@ -89,11 +107,13 @@ const props = withDefaults(
     memberLayout?: "subtitle" | "subtitle-list" | "title-list";
     memberLimit?: number;
     playing?: boolean;
+    selected?: boolean;
   }>(),
   {
     memberLayout: "subtitle",
     memberLimit: 2,
     playing: false,
+    selected: false,
   },
 );
 

--- a/src/components/PlayerCardTitle.vue
+++ b/src/components/PlayerCardTitle.vue
@@ -9,12 +9,37 @@
         <span class="player-card-name truncate text-sm leading-5 font-medium">
           {{ name }}
         </span>
+        <span
+          v-if="index === 0"
+          class="player-playback-indicator flex size-4 shrink-0 items-center justify-center"
+          :class="{
+            'text-primary': playing,
+            invisible: !playing,
+          }"
+          role="img"
+          :aria-label="playing ? $t('state.playing') : undefined"
+          :aria-hidden="!playing"
+        >
+          <AudioLines aria-hidden="true" class="size-4" />
+        </span>
         <slot v-if="index === 0"></slot>
       </div>
     </template>
     <div v-else class="flex min-w-0 items-center gap-1.5">
       <span class="player-card-name truncate text-sm font-medium">
         {{ playerName }}
+      </span>
+      <span
+        class="player-playback-indicator flex size-4 shrink-0 items-center justify-center"
+        :class="{
+          'text-primary': playing,
+          invisible: !playing,
+        }"
+        role="img"
+        :aria-label="playing ? $t('state.playing') : undefined"
+        :aria-hidden="!playing"
+      >
+        <AudioLines aria-hidden="true" class="size-4" />
       </span>
       <slot></slot>
     </div>
@@ -54,6 +79,7 @@
 </template>
 
 <script setup lang="ts">
+import { AudioLines } from "@lucide/vue";
 import { computed, ref, watch } from "vue";
 
 const props = withDefaults(
@@ -62,10 +88,12 @@ const props = withDefaults(
     memberNames: string[];
     memberLayout?: "subtitle" | "subtitle-list" | "title-list";
     memberLimit?: number;
+    playing?: boolean;
   }>(),
   {
     memberLayout: "subtitle",
     memberLimit: 2,
+    playing: false,
   },
 );
 

--- a/src/components/discover/utils/playerShelf.ts
+++ b/src/components/discover/utils/playerShelf.ts
@@ -1,0 +1,17 @@
+export function prioritizeSelectedPlayer<T extends { player_id: string }>(
+  players: readonly T[],
+  selectedPlayerId?: string,
+): readonly T[] {
+  if (!selectedPlayerId) return players;
+
+  const selectedIndex = players.findIndex(
+    (player) => player.player_id === selectedPlayerId,
+  );
+  if (selectedIndex <= 0) return players;
+
+  return [
+    players[selectedIndex],
+    ...players.slice(0, selectedIndex),
+    ...players.slice(selectedIndex + 1),
+  ];
+}

--- a/src/composables/useOrderedPlayers.ts
+++ b/src/composables/useOrderedPlayers.ts
@@ -1,19 +1,10 @@
-import {
-  isBuiltinPlayer,
-  isPlayerActive,
-  playerVisible,
-} from "@/helpers/players";
+import { playerVisible } from "@/helpers/players";
 import { api } from "@/plugins/api";
-import { PlaybackState, type Player } from "@/plugins/api/interfaces";
-import { store } from "@/plugins/store";
-import { computed, type MaybeRefOrGetter, toValue } from "vue";
+import { computed } from "vue";
 
 interface OrderedPlayersOptions {
   allowNeedsSetup?: boolean;
   allowSources?: boolean;
-  selectedPlayerFirst?: MaybeRefOrGetter<boolean>;
-  activePlayersFirst?: MaybeRefOrGetter<boolean>;
-  includePausedAsActive?: boolean;
 }
 
 export function useOrderedPlayers(opts?: OrderedPlayersOptions) {
@@ -27,45 +18,10 @@ export function useOrderedPlayers(opts?: OrderedPlayersOptions) {
           opts?.allowSources ?? false,
         ),
       )
-      .sort((left, right) => comparePlayers(left, right, opts)),
+      .sort((left, right) =>
+        left.name.localeCompare(right.name, undefined, {
+          sensitivity: "base",
+        }),
+      ),
   );
-}
-
-function comparePlayers(
-  left: Player,
-  right: Player,
-  opts?: OrderedPlayersOptions,
-) {
-  const priorityDifference =
-    getPlayerPriority(left, opts) - getPlayerPriority(right, opts);
-  if (priorityDifference !== 0) return priorityDifference;
-
-  return left.name.localeCompare(right.name, undefined, {
-    sensitivity: "base",
-  });
-}
-
-function getPlayerPriority(player: Player, opts?: OrderedPlayersOptions) {
-  if (
-    toValue(opts?.selectedPlayerFirst ?? true) &&
-    player.player_id === store.activePlayerId
-  ) {
-    return 0;
-  }
-  if (isBuiltinPlayer(player)) return 1;
-  if (
-    toValue(opts?.activePlayersFirst ?? true) &&
-    isPrioritizedActivePlayer(player, opts)
-  ) {
-    return 2;
-  }
-  return 3;
-}
-
-function isPrioritizedActivePlayer(
-  player: Player,
-  opts?: OrderedPlayersOptions,
-) {
-  if (opts?.includePausedAsActive) return isPlayerActive(player);
-  return player.playback_state === PlaybackState.PLAYING;
 }

--- a/src/layouts/default/Footer.vue
+++ b/src/layouts/default/Footer.vue
@@ -115,6 +115,7 @@ function clearOverlay() {
 .v-footer.mediacontrols-player-default {
   padding-right: var(--device-inset-right) !important;
   padding-left: var(--device-inset-left) !important;
+  box-shadow: 0 0 4px -1px black;
 }
 
 .v-footer.mediacontrols-player-float {

--- a/src/layouts/default/PlayerSelect.vue
+++ b/src/layouts/default/PlayerSelect.vue
@@ -106,7 +106,7 @@
         ref="playerList"
         class="player-volume-scroller min-h-0 flex-1 overflow-y-auto pb-6"
       >
-        <!-- outranks the selected player badge on the cards scrolling underneath -->
+        <!-- keeps search controls above the cards scrolling underneath -->
         <div
           v-if="showSearch"
           class="bg-background sticky top-0 z-20 px-3 pt-3 pb-2"

--- a/src/layouts/default/PlayerSelect.vue
+++ b/src/layouts/default/PlayerSelect.vue
@@ -74,30 +74,6 @@
             </DropdownMenuLabel>
             <DropdownMenuSeparator />
             <DropdownMenuCheckboxItem
-              :model-value="showSelectedPlayerFirst"
-              @select.prevent
-              @update:model-value="
-                setBooleanPreference(
-                  PLAYER_SELECT_PREFERENCES.showSelectedPlayerFirst,
-                  $event,
-                )
-              "
-            >
-              {{ $t("player_select.show_selected_player_first") }}
-            </DropdownMenuCheckboxItem>
-            <DropdownMenuCheckboxItem
-              :model-value="showActivePlayersFirst"
-              @select.prevent
-              @update:model-value="
-                setBooleanPreference(
-                  PLAYER_SELECT_PREFERENCES.showActivePlayersFirst,
-                  $event,
-                )
-              "
-            >
-              {{ $t("player_select.show_active_players_first") }}
-            </DropdownMenuCheckboxItem>
-            <DropdownMenuCheckboxItem
               :model-value="showGroupMemberNames"
               @select.prevent
               @update:model-value="
@@ -236,8 +212,6 @@ const SEARCH_PLAYER_THRESHOLD = 10;
 const BUILTIN_PLAYER_PREFERENCE = "<builtinplayer>";
 const PLAYER_SELECT_PREFERENCES = {
   showVolumeForActivePlayersOnly: "playerSelect.showVolumeForActivePlayersOnly",
-  showSelectedPlayerFirst: "playerSelect.showSelectedPlayerFirst",
-  showActivePlayersFirst: "playerSelect.showActivePlayersFirst",
   showGroupMemberNames: "playerSelect.showGroupMemberNames",
 } as const;
 
@@ -248,14 +222,6 @@ const playerList = ref<HTMLElement>();
 const { getPreference, setPreference } = useUserPreferences();
 const showVolumeForActivePlayersOnly = getPreference<boolean>(
   PLAYER_SELECT_PREFERENCES.showVolumeForActivePlayersOnly,
-  true,
-);
-const showSelectedPlayerFirst = getPreference<boolean>(
-  PLAYER_SELECT_PREFERENCES.showSelectedPlayerFirst,
-  true,
-);
-const showActivePlayersFirst = getPreference<boolean>(
-  PLAYER_SELECT_PREFERENCES.showActivePlayersFirst,
   true,
 );
 const showGroupMemberNames = getPreference<boolean>(
@@ -273,9 +239,6 @@ let autoSelectedPlayerId: string | undefined;
 const orderedPlayers = useOrderedPlayers({
   allowNeedsSetup: true,
   allowSources: true,
-  selectedPlayerFirst: showSelectedPlayerFirst,
-  activePlayersFirst: showActivePlayersFirst,
-  includePausedAsActive: true,
 });
 
 const showSearch = computed(
@@ -328,12 +291,6 @@ watch(
     });
   },
 );
-
-watch(showSelectedPlayerFirst, (showFirst) => {
-  if (!showFirst && store.showPlayersMenu) {
-    void scrollSelectedPlayerIntoView();
-  }
-});
 
 watch(showSearch, (isVisible) => {
   if (!isVisible) playerSearchQuery.value = "";
@@ -550,9 +507,7 @@ function isSelectablePlayerId(playerId: string | null | undefined) {
 }
 
 async function scrollSelectedPlayerIntoView() {
-  if (showSelectedPlayerFirst.value || !store.showPlayersMenu) {
-    return;
-  }
+  if (!store.showPlayersMenu) return;
 
   await nextTick();
   const activePlayerId = store.activePlayerId;

--- a/src/layouts/default/PlayerSelect.vue
+++ b/src/layouts/default/PlayerSelect.vue
@@ -104,7 +104,7 @@
 
       <div
         ref="playerList"
-        class="player-volume-scroller min-h-0 flex-1 overflow-y-auto pb-6"
+        class="player-volume-scroller min-h-0 flex-1 overflow-y-auto pb-3"
       >
         <!-- keeps search controls above the cards scrolling underneath -->
         <div

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1358,6 +1358,7 @@
     "remove_provider_mapping_confirm": "Are you sure you want to remove this provider mapping? This will unlink the item from the current item details. It may come back if you perform a rescan for all provider matches.",
     "map_provider_mapping": "Map this provider entry to the current item",
     "player_tip": {
+        "selected": "Selected",
         "selected_player": "Selected player",
         "currently_playing": "Currently playing on",
         "click_to_change": "Click below to change output device"

--- a/tests/components/PlayerCard.test.ts
+++ b/tests/components/PlayerCard.test.ts
@@ -533,7 +533,7 @@ describe("PlayerCard", () => {
     expect(members.classes()).toContain("text-[11px]");
   });
 
-  it("stacks player identity above loaded media only when requested", () => {
+  it("stacks player identity above media only when requested", () => {
     const player = createPlayer({
       playback_state: PlaybackState.PLAYING,
       current_media: createPlayerMedia({
@@ -571,17 +571,86 @@ describe("PlayerCard", () => {
     );
   });
 
-  it("keeps idle selector cards compact", () => {
+  it("anchors idle selector titles above a minimal faded speaker icon", () => {
     const wrapper = mountPlayerCard(createPlayer(), {
       stackMediaDetails: true,
     });
 
-    expect(wrapper.find(".player-card-main").classes()).not.toContain(
-      "flex-col",
-    );
-    expect(wrapper.find(".player-card-actions").classes()).not.toContain(
+    expect(wrapper.classes()).not.toContain("opacity-80");
+    expect(wrapper.find(".player-card-main").classes()).toContain("flex-col");
+    expect(
+      wrapper.find(".player-card-main > .player-card-title").exists(),
+    ).toBe(true);
+    expect(
+      wrapper.find(".player-card-media-row .player-card-title").exists(),
+    ).toBe(false);
+    expect(wrapper.find(".player-card-actions").classes()).toContain(
       "self-end",
     );
+    const media = wrapper.get(".player-card-media-placeholder");
+    expect(media.classes()).not.toContain("border");
+    expect(media.classes()).not.toContain("bg-muted");
+    expect(media.classes()).not.toContain("rounded-md");
+    expect(media.get(".player-icon").classes()).toContain("opacity-50");
+    expect(media.get(".player-icon").classes()).toContain("text-foreground");
+  });
+
+  it("uses full speaker-icon contrast when media is selected without artwork", () => {
+    const wrapper = mountPlayerCard(
+      createPlayer({
+        playback_state: PlaybackState.PLAYING,
+        current_media: createPlayerMedia({ title: "Hate Me Now" }),
+      }),
+      { stackMediaDetails: true },
+    );
+
+    const icon = wrapper.get(".player-card-media-placeholder .player-icon");
+    expect(icon.classes()).toContain("opacity-100");
+    expect(icon.classes()).toContain("text-foreground");
+  });
+
+  it("reserves a title slot for the playing-state indicator", () => {
+    const idleCard = mountPlayerCard(createPlayer(), {
+      stackMediaDetails: true,
+    });
+    const idleIndicator = idleCard.get(".player-playback-indicator");
+
+    expect(idleIndicator.classes()).toContain("invisible");
+    expect(idleIndicator.attributes("aria-hidden")).toBe("true");
+    idleCard.unmount();
+
+    const playingCard = mountPlayerCard(
+      createPlayer({ playback_state: PlaybackState.PLAYING }),
+      { stackMediaDetails: true },
+    );
+    const playingIndicator = playingCard.get(".player-playback-indicator");
+
+    expect(playingIndicator.classes()).not.toContain("invisible");
+    expect(playingIndicator.classes()).toContain("text-primary");
+    expect(playingIndicator.attributes("aria-label")).toBe("state.playing");
+    expect(playingIndicator.attributes("aria-hidden")).toBe("false");
+    playingCard.unmount();
+
+    const pausedCard = mountPlayerCard(
+      createPlayer({ playback_state: PlaybackState.PAUSED }),
+      { stackMediaDetails: true },
+    );
+    const pausedIndicator = pausedCard.get(".player-playback-indicator");
+
+    expect(pausedIndicator.classes()).toContain("invisible");
+    expect(pausedIndicator.attributes("aria-hidden")).toBe("true");
+  });
+
+  it("shows the playing-state indicator beside names in unstacked cards", () => {
+    const wrapper = mountPlayerCard(
+      createPlayer({ playback_state: PlaybackState.PLAYING }),
+    );
+    const title = wrapper.get(".player-card-media-row .player-card-title");
+    const indicator = title.get(".player-playback-indicator");
+
+    expect(indicator.classes()).not.toContain("invisible");
+    expect(indicator.classes()).toContain("text-primary");
+    expect(indicator.attributes("aria-label")).toBe("state.playing");
   });
 
   it.each([PlaybackState.PLAYING, PlaybackState.PAUSED])(

--- a/tests/components/PlayerCard.test.ts
+++ b/tests/components/PlayerCard.test.ts
@@ -623,7 +623,7 @@ describe("PlayerCard", () => {
     });
     const idleIndicator = idleCard.get(".player-playback-indicator");
 
-    expect(idleIndicator.classes()).toContain("invisible");
+    expect(idleIndicator.classes()).toContain("hidden");
     expect(idleIndicator.attributes("aria-hidden")).toBe("true");
     idleCard.unmount();
 
@@ -633,7 +633,7 @@ describe("PlayerCard", () => {
     );
     const playingIndicator = playingCard.get(".player-playback-indicator");
 
-    expect(playingIndicator.classes()).not.toContain("invisible");
+    expect(playingIndicator.classes()).not.toContain("hidden");
     expect(playingIndicator.classes()).toContain("text-primary");
     expect(playingIndicator.attributes("aria-label")).toBe("state.playing");
     expect(playingIndicator.attributes("aria-hidden")).toBe("false");
@@ -645,7 +645,7 @@ describe("PlayerCard", () => {
     );
     const pausedIndicator = pausedCard.get(".player-playback-indicator");
 
-    expect(pausedIndicator.classes()).toContain("invisible");
+    expect(pausedIndicator.classes()).toContain("hidden");
     expect(pausedIndicator.attributes("aria-hidden")).toBe("true");
   });
 
@@ -656,7 +656,7 @@ describe("PlayerCard", () => {
     const title = wrapper.get(".player-card-media-row .player-card-title");
     const indicator = title.get(".player-playback-indicator");
 
-    expect(indicator.classes()).not.toContain("invisible");
+    expect(indicator.classes()).not.toContain("hidden");
     expect(indicator.classes()).toContain("text-primary");
     expect(indicator.attributes("aria-label")).toBe("state.playing");
   });

--- a/tests/components/PlayerCard.test.ts
+++ b/tests/components/PlayerCard.test.ts
@@ -571,28 +571,23 @@ describe("PlayerCard", () => {
     );
   });
 
-  it("anchors idle selector titles above a minimal faded speaker icon", () => {
+  it("keeps idle selector cards to one line without a speaker icon", () => {
     const wrapper = mountPlayerCard(createPlayer(), {
       stackMediaDetails: true,
     });
 
     expect(wrapper.classes()).not.toContain("opacity-80");
-    expect(wrapper.find(".player-card-main").classes()).toContain("flex-col");
+    expect(wrapper.find(".player-card-main").classes()).not.toContain(
+      "flex-col",
+    );
     expect(
       wrapper.find(".player-card-main > .player-card-title").exists(),
     ).toBe(true);
-    expect(
-      wrapper.find(".player-card-media-row .player-card-title").exists(),
-    ).toBe(false);
-    expect(wrapper.find(".player-card-actions").classes()).toContain(
+    expect(wrapper.find(".player-card-media-row").exists()).toBe(false);
+    expect(wrapper.find(".player-icon").exists()).toBe(false);
+    expect(wrapper.find(".player-card-actions").classes()).not.toContain(
       "self-end",
     );
-    const media = wrapper.get(".player-card-media-placeholder");
-    expect(media.classes()).not.toContain("border");
-    expect(media.classes()).not.toContain("bg-muted");
-    expect(media.classes()).not.toContain("rounded-md");
-    expect(media.get(".player-icon").classes()).toContain("opacity-50");
-    expect(media.get(".player-icon").classes()).toContain("text-foreground");
   });
 
   it("uses full speaker-icon contrast when media is selected without artwork", () => {

--- a/tests/components/PlayerCard.test.ts
+++ b/tests/components/PlayerCard.test.ts
@@ -263,15 +263,22 @@ describe("PlayerCard", () => {
     const wrapper = mountPlayerCard(
       createPlayer({
         player_id: "active",
+        playback_state: PlaybackState.PLAYING,
       }),
       { showSelectedIndicator: true },
     );
 
     expect(wrapper.classes()).toContain("ring-1");
-    expect(wrapper.classes()).toContain("pt-4");
-    const badge = wrapper.get(".selected-player-badge");
-    expect(badge.text()).toBe("player_tip.selected_player");
-    expect(badge.classes()).toContain("rounded-full");
+    expect(wrapper.classes()).not.toContain("pt-4");
+    expect(wrapper.find(".selected-player-badge").exists()).toBe(false);
+    const indicator = wrapper.get(".selected-player-indicator");
+    expect(indicator.text()).toBe("player_tip.selected");
+    expect(indicator.attributes("variant")).toBe("default");
+    expect(
+      wrapper
+        .find(".player-playback-indicator + .selected-player-indicator")
+        .exists(),
+    ).toBe(true);
   });
 
   it("keeps the player details in the selection action name", () => {
@@ -566,6 +573,12 @@ describe("PlayerCard", () => {
     expect(selectorCard.find(".player-card-media-row").text()).toContain(
       "Hate Me Now",
     );
+    expect(selectorCard.get(".player-card-media-byline").classes()).toContain(
+      "text-foreground/60",
+    );
+    expect(
+      selectorCard.get(".player-card-media-byline").classes(),
+    ).not.toContain("text-muted-foreground");
     expect(selectorCard.find(".player-card-actions").classes()).toContain(
       "self-end",
     );

--- a/tests/components/discover/playerShelf.test.ts
+++ b/tests/components/discover/playerShelf.test.ts
@@ -1,0 +1,27 @@
+import { prioritizeSelectedPlayer } from "@/components/discover/utils/playerShelf";
+import { describe, expect, it } from "vitest";
+
+const players = [
+  { player_id: "attic" },
+  { player_id: "kitchen" },
+  { player_id: "office" },
+];
+
+describe("prioritizeSelectedPlayer", () => {
+  it("moves the selected player ahead of the existing order", () => {
+    expect(prioritizeSelectedPlayer(players, "office")).toEqual([
+      { player_id: "office" },
+      { player_id: "attic" },
+      { player_id: "kitchen" },
+    ]);
+  });
+
+  it("preserves the existing order without a visible selection", () => {
+    expect(prioritizeSelectedPlayer(players)).toBe(players);
+    expect(prioritizeSelectedPlayer(players, "unavailable")).toBe(players);
+  });
+
+  it("does not rebuild the list when the selected player is already first", () => {
+    expect(prioritizeSelectedPlayer(players, "attic")).toBe(players);
+  });
+});

--- a/tests/layouts/PlayerSelect.test.ts
+++ b/tests/layouts/PlayerSelect.test.ts
@@ -378,7 +378,7 @@ describe("PlayerSelect", () => {
     webPlayer.player_id = null;
   });
 
-  it("orders the selected player, this device, then active players first", () => {
+  it("orders players alphabetically regardless of selection or playback", () => {
     const activePlayer = createPlayer("active", "Kitchen");
     api.players = {
       office: createPlayer("office", "Office"),
@@ -396,45 +396,7 @@ describe("PlayerSelect", () => {
       wrapper
         .findAll(".player-card")
         .map((card) => card.attributes("data-player-id")),
-    ).toEqual(["active", "builtin", "attic", "bedroom", "lounge", "office"]);
-  });
-
-  it("leaves the selected player in normal list order when pinning is disabled", () => {
-    setPlayerSelectPreference("playerSelect.showSelectedPlayerFirst", false);
-    setPlayerSelectPreference("playerSelect.showActivePlayersFirst", false);
-    const selectedPlayer = createPlayer("selected", "Office");
-    api.players = {
-      kitchen: createPlayer("kitchen", "Kitchen"),
-      selected: selectedPlayer,
-      attic: createPlayer("attic", "Attic"),
-    };
-    store.activePlayerId = selectedPlayer.player_id;
-
-    const wrapper = mountPlayerSelect();
-
-    expect(
-      wrapper
-        .findAll(".player-card")
-        .map((card) => card.attributes("data-player-id")),
-    ).toEqual(["attic", "kitchen", "selected"]);
-  });
-
-  it("leaves active players in normal list order when prioritizing is disabled", () => {
-    setPlayerSelectPreference("playerSelect.showSelectedPlayerFirst", false);
-    setPlayerSelectPreference("playerSelect.showActivePlayersFirst", false);
-    api.players = {
-      office: createPlayer("office", "Office", PlaybackState.PLAYING),
-      bedroom: createPlayer("bedroom", "Bedroom", PlaybackState.PAUSED),
-      attic: createPlayer("attic", "Attic"),
-    };
-
-    const wrapper = mountPlayerSelect();
-
-    expect(
-      wrapper
-        .findAll(".player-card")
-        .map((card) => card.attributes("data-player-id")),
-    ).toEqual(["attic", "bedroom", "office"]);
+    ).toEqual(["attic", "bedroom", "active", "lounge", "office", "builtin"]);
   });
 
   it("waits for a remembered player instead of selecting the web player", async () => {
@@ -613,7 +575,7 @@ describe("PlayerSelect", () => {
     expect(setPreference).not.toHaveBeenCalled();
   });
 
-  it("moves a newly active player to the front", async () => {
+  it("keeps the list order stable when selection and playback change", async () => {
     const kitchen = createPlayer("kitchen", "Kitchen");
     const office = createPlayer("office", "Office");
     api.players = {
@@ -623,13 +585,14 @@ describe("PlayerSelect", () => {
     const wrapper = mountPlayerSelect();
 
     store.activePlayerId = office.player_id;
+    kitchen.playback_state = PlaybackState.PLAYING;
     await nextTick();
 
     expect(
       wrapper
         .findAll(".player-card")
         .map((card) => card.attributes("data-player-id")),
-    ).toEqual(["office", "kitchen"]);
+    ).toEqual(["kitchen", "office"]);
   });
 
   it("shows search only when more than ten players are visible", () => {
@@ -837,17 +800,7 @@ describe("PlayerSelect", () => {
 
     await toggles[0].trigger("click");
     await toggles[1].trigger("click");
-    await toggles[2].trigger("click");
-    await toggles[3].trigger("click");
 
-    expect(setPreference).toHaveBeenCalledWith(
-      "playerSelect.showSelectedPlayerFirst",
-      false,
-    );
-    expect(setPreference).toHaveBeenCalledWith(
-      "playerSelect.showActivePlayersFirst",
-      false,
-    );
     expect(setPreference).toHaveBeenCalledWith(
       "playerSelect.showGroupMemberNames",
       false,
@@ -1086,7 +1039,7 @@ describe("PlayerSelect", () => {
     ).toBe("true");
   });
 
-  it("scrolls the selected player into view when it is not pinned", async () => {
+  it("scrolls the selected player into view in the alphabetical list", async () => {
     const originalScrollIntoView = Object.getOwnPropertyDescriptor(
       HTMLElement.prototype,
       "scrollIntoView",
@@ -1096,8 +1049,6 @@ describe("PlayerSelect", () => {
       configurable: true,
       value: scrollIntoView,
     });
-    setPlayerSelectPreference("playerSelect.showSelectedPlayerFirst", false);
-    setPlayerSelectPreference("playerSelect.showActivePlayersFirst", false);
     const selectedPlayer = createPlayer("selected", "Zulu");
     api.players = {
       attic: createPlayer("attic", "Attic"),


### PR DESCRIPTION
# What does this implement/fix?

This improves the visual hierarchy and clarity of the Players panel and player cards, and reduces usability issues with quickly and easily finding and selecting Players, primarily due to a few key inconsistencies causing unpredictable behavior.

### Changes

tl;dr: redesigns the Player panel and functionality within it holistically.

- Make the layout of the player cards consistent, so the title is always in the same place. This resolves scannability issues.
- Reduce visual noise around the player cards
- Add a "Now playing" indicator to now playing speakers
- **Make the order of Players stable: the selected player no longer moves to the top.** This seems like a big change, but in usage the impact is only positive IMO: the position of players quickly become predictable, and the user can build muscle memory to make switching fast and requiring little thought.
- Even spacing around the panel
- Reduced grab-handle height, more proportional
- Minimal but clear view when no song is active, still clear when selected and still has all actions available
- Also use the same playback indicator on Discover player cards for consistency

## Screenshots

<img width="350" alt="Screenshot From 2026-09-02 21-58-38" src="https://github.com/user-attachments/assets/398d83d6-c446-4b2c-88cc-be97ed8295e7" /> <img width="350" alt="Screenshot From 2026-09-02 21-58-29" src="https://github.com/user-attachments/assets/6729b295-31f4-40b5-aed8-2b58ad8a5c04" />

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm lint:check` passes.
- [x] `pnpm test:run` passes, and tests have been added/updated where applicable.
- [x] `pnpm build` passes.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.