### PR TITLE
Remove playlist import schema gate

### DIFF
--- a/src/layouts/default/ImportPlaylistDialog.vue
+++ b/src/layouts/default/ImportPlaylistDialog.vue
@@ -124,11 +124,7 @@ const musicProviders = computed(() => {
     .sort((a, b) => a.name.localeCompare(b.name));
 });
 
-// older servers always match on the full track title/artist; only offer the
-// policy choice once the server can actually honor it.
-const showMatchPolicy = computed(
-  () => musicProviders.value.length > 0 && api.supportsPlaylistMatchPolicy,
-);
+const showMatchPolicy = computed(() => musicProviders.value.length > 0);
 
 const matchPolicyOptions = computed(() => [
   {

--- a/src/plugins/api/index.ts
+++ b/src/plugins/api/index.ts
@@ -99,9 +99,6 @@ export interface CommandOptions {
   suppressGlobalError?: boolean | (() => boolean);
 }
 
-// The match_policy argument on music/playlists/import_playlist landed in API schema 67.
-const IMPORT_PLAYLIST_MATCH_POLICY_SCHEMA_VERSION = 67;
-
 export interface PlayMediaOptions {
   start_item?: PlayableMediaItemType | string;
   queue_id?: string;
@@ -942,8 +939,7 @@ export class MusicAssistantApi {
       m3u_data,
       library_matching,
       match_providers,
-      // omit on older servers so the call doesn't send an unsupported argument
-      match_policy: this.supportsPlaylistMatchPolicy ? match_policy : undefined,
+      match_policy,
     });
   }
 
@@ -2975,14 +2971,6 @@ export class MusicAssistantApi {
     return (
       (this.serverInfo.value?.schema_version ?? 0) >=
       PLAY_MEDIA_SHUFFLE_SCHEMA_VERSION
-    );
-  }
-
-  /** Whether the connected server accepts an explicit match_policy on import_playlist (schema >= 67). */
-  public get supportsPlaylistMatchPolicy(): boolean {
-    return (
-      (this.serverInfo.value?.schema_version ?? 0) >=
-      IMPORT_PLAYLIST_MATCH_POLICY_SCHEMA_VERSION
     );
   }
 

--- a/src/plugins/api/index.ts
+++ b/src/plugins/api/index.ts
@@ -99,8 +99,8 @@ export interface CommandOptions {
   suppressGlobalError?: boolean | (() => boolean);
 }
 
-// The match_policy argument on music/playlists/import_playlist landed in API schema 66.
-const IMPORT_PLAYLIST_MATCH_POLICY_SCHEMA_VERSION = 66;
+// The match_policy argument on music/playlists/import_playlist landed in API schema 67.
+const IMPORT_PLAYLIST_MATCH_POLICY_SCHEMA_VERSION = 67;
 
 export interface PlayMediaOptions {
   start_item?: PlayableMediaItemType | string;
@@ -2978,7 +2978,7 @@ export class MusicAssistantApi {
     );
   }
 
-  /** Whether the connected server accepts an explicit match_policy on import_playlist (schema >= 66). */
+  /** Whether the connected server accepts an explicit match_policy on import_playlist (schema >= 67). */
   public get supportsPlaylistMatchPolicy(): boolean {
     return (
       (this.serverInfo.value?.schema_version ?? 0) >=

--- a/tests/layouts/ImportPlaylistDialog.test.ts
+++ b/tests/layouts/ImportPlaylistDialog.test.ts
@@ -139,7 +139,7 @@ describe("ImportPlaylistDialog", () => {
     expect(radioGroup(wrapper).exists()).toBe(false);
   });
 
-  it("hides the match policy picker on servers older than schema 66", async () => {
+  it("hides the match policy picker on servers older than schema 67", async () => {
     apiMock.supportsPlaylistMatchPolicy = false;
     const wrapper = mountDialog();
     open();
@@ -203,7 +203,7 @@ describe("ImportPlaylistDialog", () => {
     );
   });
 
-  it("omits match_policy on servers older than schema 66", async () => {
+  it("omits match_policy on servers older than schema 67", async () => {
     apiMock.supportsPlaylistMatchPolicy = false;
     const wrapper = mountDialog();
     open();

--- a/tests/layouts/ImportPlaylistDialog.test.ts
+++ b/tests/layouts/ImportPlaylistDialog.test.ts
@@ -22,7 +22,6 @@ const { apiMock, eventHandlers } = vi.hoisted(() => ({
   apiMock: {
     importPlaylist: vi.fn(),
     providers: {} as Record<string, unknown>,
-    supportsPlaylistMatchPolicy: true,
   },
   eventHandlers: {} as Record<string, (payload: unknown) => void>,
 }));
@@ -105,7 +104,6 @@ enableAutoUnmount(afterEach);
 
 beforeEach(() => {
   vi.clearAllMocks();
-  apiMock.supportsPlaylistMatchPolicy = true;
   apiMock.providers = {
     spotify: musicProvider("spotify--1", "Spotify"),
     tidal: musicProvider("tidal--1", "Tidal"),
@@ -132,15 +130,6 @@ describe("ImportPlaylistDialog", () => {
 
   it("hides the match policy picker when no providers are available", async () => {
     apiMock.providers = {};
-    const wrapper = mountDialog();
-    open();
-    await wrapper.vm.$nextTick();
-
-    expect(radioGroup(wrapper).exists()).toBe(false);
-  });
-
-  it("hides the match policy picker on servers older than schema 67", async () => {
-    apiMock.supportsPlaylistMatchPolicy = false;
     const wrapper = mountDialog();
     open();
     await wrapper.vm.$nextTick();
@@ -200,22 +189,6 @@ describe("ImportPlaylistDialog", () => {
       true,
       ["spotify--1"],
       PlaylistMatchPolicy.SAME_RECORDING,
-    );
-  });
-
-  it("omits match_policy on servers older than schema 67", async () => {
-    apiMock.supportsPlaylistMatchPolicy = false;
-    const wrapper = mountDialog();
-    open();
-    await wrapper.vm.$nextTick();
-
-    await importButton(wrapper).trigger("click");
-
-    expect(apiMock.importPlaylist).toHaveBeenCalledWith(
-      "#EXTM3U",
-      true,
-      undefined,
-      undefined,
     );
   });
 

--- a/tests/plugins/api/index.test.ts
+++ b/tests/plugins/api/index.test.ts
@@ -382,7 +382,7 @@ describe("MusicAssistantApi error handling", () => {
   });
 
   it("imports a playlist with the chosen match policy", async () => {
-    api.serverInfo.value = { ...SERVER_INFO, schema_version: 66 };
+    api.serverInfo.value = { ...SERVER_INFO, schema_version: 67 };
     const result = api.importPlaylist(
       "#EXTM3U",
       true,
@@ -420,7 +420,7 @@ describe("MusicAssistantApi error handling", () => {
   });
 
   it("omits match_policy on older servers even when a policy is passed", () => {
-    api.serverInfo.value = { ...SERVER_INFO, schema_version: 65 };
+    api.serverInfo.value = { ...SERVER_INFO, schema_version: 66 };
     api.importPlaylist(
       "#EXTM3U",
       true,
@@ -435,14 +435,14 @@ describe("MusicAssistantApi error handling", () => {
     });
   });
 
-  it("reports playlist match policy support once the server reaches schema 66", () => {
+  it("reports playlist match policy support once the server reaches schema 67", () => {
     expect(api.supportsPlaylistMatchPolicy).toBe(false);
 
     api.serverInfo.value = { ...SERVER_INFO, schema_version: 66 };
-    expect(api.supportsPlaylistMatchPolicy).toBe(true);
-
-    api.serverInfo.value = { ...SERVER_INFO, schema_version: 65 };
     expect(api.supportsPlaylistMatchPolicy).toBe(false);
+
+    api.serverInfo.value = { ...SERVER_INFO, schema_version: 67 };
+    expect(api.supportsPlaylistMatchPolicy).toBe(true);
   });
 
   it("rejects in-flight commands when the connection closes", async () => {

--- a/tests/plugins/api/index.test.ts
+++ b/tests/plugins/api/index.test.ts
@@ -382,7 +382,6 @@ describe("MusicAssistantApi error handling", () => {
   });
 
   it("imports a playlist with the chosen match policy", async () => {
-    api.serverInfo.value = { ...SERVER_INFO, schema_version: 67 };
     const result = api.importPlaylist(
       "#EXTM3U",
       true,
@@ -417,32 +416,6 @@ describe("MusicAssistantApi error handling", () => {
       library_matching: true,
       match_providers: ["spotify--1"],
     });
-  });
-
-  it("omits match_policy on older servers even when a policy is passed", () => {
-    api.serverInfo.value = { ...SERVER_INFO, schema_version: 66 };
-    api.importPlaylist(
-      "#EXTM3U",
-      true,
-      ["spotify--1"],
-      PlaylistMatchPolicy.EXACT,
-    );
-
-    expect(transport.lastCommand.args).toEqual({
-      m3u_data: "#EXTM3U",
-      library_matching: true,
-      match_providers: ["spotify--1"],
-    });
-  });
-
-  it("reports playlist match policy support once the server reaches schema 67", () => {
-    expect(api.supportsPlaylistMatchPolicy).toBe(false);
-
-    api.serverInfo.value = { ...SERVER_INFO, schema_version: 66 };
-    expect(api.supportsPlaylistMatchPolicy).toBe(false);
-
-    api.serverInfo.value = { ...SERVER_INFO, schema_version: 67 };
-    expect(api.supportsPlaylistMatchPolicy).toBe(true);
   });
 
   it("rejects in-flight commands when the connection closes", async () => {


### PR DESCRIPTION
# What does this implement/fix?

Removes the frontend schema gate for playlist import match policy. The dialog now always shows the policy picker whenever provider matching is available, and `importPlaylist()` always forwards a caller-supplied `match_policy` in lockstep with the backend.

**Related issue (if applicable):**

N/A

**Related backend PR (if applicable):**

- related backend PR https://github.com/music-assistant/server/pull/5986

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm lint:check` passes.
- [x] `pnpm test:run` passes, and tests have been added/updated where applicable.
- [x] `pnpm build` passes.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.