### PR TITLE
Unify and refine Discover shelf scrolling

### DIFF
--- a/src/components/HomeWidgetRows.vue
+++ b/src/components/HomeWidgetRows.vue
@@ -78,12 +78,14 @@
           </EditorialShelf>
 
           <!-- Top picks row -->
-          <section
+          <EditorialShelf
             v-else-if="row.kind === 'top_picks'"
-            class="ed-section ed-hero-row"
-            :class="{ 'ed-dimmed': editMode && row.hidden }"
+            class="ed-hero-row"
+            :nav-center="160"
+            :dimmed="editMode && row.hidden"
+            style="--ed-card-pad: 0px"
           >
-            <div class="ed-hero-row__head">
+            <template #header>
               <div class="ed-hero-row__title-group">
                 <h2 class="ed-hero-row__title">
                   {{ $t("top_picks_for_you") }}
@@ -100,73 +102,45 @@
                   />
                 </Button>
               </div>
-              <div v-if="editMode" class="ed-edit-controls">
-                <button
-                  class="ed-drag-handle"
-                  :aria-label="$t('queue_reorder')"
-                  @pointerdown.stop.prevent="startItemDrag($event, idx)"
-                  @click.stop
-                >
-                  <GripVertical />
-                </button>
-                <Button
-                  variant="ghost"
-                  size="icon-sm"
-                  :aria-label="$t('tooltip.toggle_top_picks')"
-                  @click="toggleRow(row)"
-                >
-                  <Eye v-if="!row.hidden" />
-                  <EyeOff v-else />
-                </Button>
-              </div>
-            </div>
+            </template>
+            <template v-if="editMode" #actions>
+              <button
+                class="ed-drag-handle"
+                :aria-label="$t('queue_reorder')"
+                @pointerdown.stop.prevent="startItemDrag($event, idx)"
+                @click.stop
+              >
+                <GripVertical />
+              </button>
+              <Button
+                variant="ghost"
+                size="icon-sm"
+                :aria-label="$t('tooltip.toggle_top_picks')"
+                @click="toggleRow(row)"
+              >
+                <Eye v-if="!row.hidden" />
+                <EyeOff v-else />
+              </Button>
+            </template>
+            <EditorialHeroCard
+              class="ed-hero-grid__lead"
+              :item="heroEntries[0].item"
+              :tag="heroEntries[0].tag"
+              large
+            />
             <div
-              class="ed-hero-row__viewport"
-              @mouseenter="heroHovering = canHover"
-              @mouseleave="heroHovering = false"
+              v-for="(col, i) in heroColumns"
+              :key="i"
+              class="ed-hero-grid__col"
             >
-              <!-- prev -->
-              <button
-                v-show="heroHovering && heroCanLeft"
-                class="ed-hero-nav ed-hero-nav--left"
-                :aria-label="$t('tooltip.scroll_left')"
-                @click="scrollHero(-1)"
-              >
-                <ChevronLeft :size="20" />
-              </button>
-
-              <div ref="heroGrid" class="ed-hero-grid" @scroll="updateHeroNav">
-                <EditorialHeroCard
-                  class="ed-hero-grid__lead"
-                  :item="heroEntries[0].item"
-                  :tag="heroEntries[0].tag"
-                  large
-                />
-                <div
-                  v-for="(col, i) in heroColumns"
-                  :key="i"
-                  class="ed-hero-grid__col"
-                >
-                  <EditorialHeroCard
-                    v-for="entry in col"
-                    :key="entry.item.uri"
-                    :item="entry.item"
-                    :tag="entry.tag"
-                  />
-                </div>
-              </div>
-
-              <!-- next -->
-              <button
-                v-show="heroHovering && heroCanRight"
-                class="ed-hero-nav ed-hero-nav--right"
-                :aria-label="$t('tooltip.scroll_right')"
-                @click="scrollHero(1)"
-              >
-                <ChevronRight :size="20" />
-              </button>
+              <EditorialHeroCard
+                v-for="entry in col"
+                :key="entry.item.uri"
+                :item="entry.item"
+                :tag="entry.tag"
+              />
             </div>
-          </section>
+          </EditorialShelf>
 
           <!-- Timeline recommendation -->
           <EditorialTimeline
@@ -408,15 +382,7 @@ import {
 import { getBreakpointValue } from "@/plugins/breakpoint";
 import { $t } from "@/plugins/i18n";
 import { store } from "@/plugins/store";
-import {
-  ChevronLeft,
-  ChevronRight,
-  Eye,
-  EyeOff,
-  GripVertical,
-  ListFilter,
-  RefreshCw,
-} from "@lucide/vue";
+import { Eye, EyeOff, GripVertical, ListFilter, RefreshCw } from "@lucide/vue";
 import {
   computed,
   nextTick,
@@ -611,51 +577,6 @@ const heroColumns = computed<HeroEntry[][]>(() => {
   for (let i = 0; i < rest.length; i += 2) cols.push(rest.slice(i, i + 2));
   return cols;
 });
-
-// --- Top Picks horizontal scroller (lead + columns that overflow on narrower
-// screens) with hover chevrons, mirroring EditorialShelf's nav affordance. ---
-// Only track hover (for the nav chevrons) on hover-capable devices. On touch
-// devices the emulated mouseenter would mutate the DOM, which makes mobile
-// Safari swallow the first tap as "hover" instead of a click.
-const canHover = window.matchMedia?.("(hover: hover)")?.matches ?? true;
-const heroGrid = ref<HTMLElement | null>(null);
-const heroHovering = ref(false);
-const heroCanLeft = ref(false);
-const heroCanRight = ref(false);
-
-const updateHeroNav = () => {
-  const el = heroGrid.value;
-  if (!el) return;
-  heroCanLeft.value = el.scrollLeft > 1;
-  heroCanRight.value = el.scrollLeft + el.clientWidth < el.scrollWidth - 1;
-};
-
-const scrollHero = (dir: number) => {
-  const el = heroGrid.value;
-  if (!el) return;
-  el.scrollBy({ left: dir * el.clientWidth * 0.8, behavior: "smooth" });
-};
-
-let heroRo: ResizeObserver | undefined;
-let observedHeroGrid: HTMLElement | null = null;
-
-const observeHero = () => {
-  const el = heroGrid.value;
-  if (!(el instanceof HTMLElement)) {
-    heroRo?.disconnect();
-    observedHeroGrid = null;
-    return;
-  }
-  updateHeroNav();
-  if (!("ResizeObserver" in window)) return;
-  heroRo ??= new ResizeObserver(updateHeroNav);
-  if (observedHeroGrid === el) return;
-  heroRo.disconnect();
-  heroRo.observe(el);
-  observedHeroGrid = el;
-};
-
-watch(heroEntries, () => nextTick(observeHero), { deep: false });
 
 // Assign heroEntries only when the picks actually changed — cheap insurance
 // against redundant re-renders from repeated builds with identical content.
@@ -995,7 +916,6 @@ onMounted(async () => {
   // Genres is its own row and isn't part of the fast catalog call, so it
   // doesn't gate the page spinner.
   loadGenres();
-  window.addEventListener("resize", updateHeroNav);
 
   // A history back/forward traversal sets `forward` on the entry we're
   // returning to; a fresh navigation leaves it null.
@@ -1012,7 +932,6 @@ onMounted(async () => {
         ".content-section",
       ) as HTMLElement | null;
       if (el) el.scrollTop = snapshot.scrollPos;
-      observeHero();
     });
 
     // Refresh everything in the background so the restored page stays current.
@@ -1021,9 +940,6 @@ onMounted(async () => {
     await refreshShownRowItems();
     if (unmounted) return;
     resolveHeroPicks();
-    nextTick(() => {
-      if (!unmounted) observeHero();
-    });
     return;
   }
 
@@ -1034,21 +950,14 @@ onMounted(async () => {
   await fetchMissingRowItems();
   if (unmounted) return;
   resolveHeroPicks();
-  nextTick(() => {
-    if (!unmounted) observeHero();
-  });
 });
 
 onBeforeUnmount(() => {
   unmounted = true;
-  window.removeEventListener("resize", updateHeroNav);
   unsubscribeRecommendations();
   unsubscribeProviderEvents();
   unsubscribePlaylog();
   cancelScheduledRecommendationRefresh();
-  heroRo?.disconnect();
-  heroRo = undefined;
-  observedHeroGrid = null;
 
   const el = document.querySelector(".content-section");
   prevState = {
@@ -1184,10 +1093,6 @@ onBeforeUnmount(() => {
   overflow: hidden;
 }
 
-.ed-hero-row {
-  padding: 0 28px;
-}
-
 .ed-dimmed {
   opacity: 0.4;
 }
@@ -1196,12 +1101,6 @@ onBeforeUnmount(() => {
   padding: 8px 4px;
   font-size: 0.875rem;
   color: rgba(var(--v-theme-on-surface), 0.6);
-}
-.ed-hero-row__head {
-  display: flex;
-  align-items: baseline;
-  justify-content: space-between;
-  margin-bottom: 14px;
 }
 .ed-hero-row__title-group {
   display: flex;
@@ -1227,24 +1126,13 @@ onBeforeUnmount(() => {
     transform: rotate(360deg);
   }
 }
-.ed-hero-row__viewport {
-  position: relative;
-}
 /* Horizontal scroller: fixed-size lead + columns of 2, so cards don't stretch
    on wide screens. The default viewport shows the lead + 2 columns; the
    remaining columns scroll into view (and fit outright on big screens). */
-.ed-hero-grid {
-  display: flex;
-  gap: 14px;
+.ed-hero-row :deep(.ed-shelf__track) {
   height: 320px;
-  position: relative;
-  overflow-x: auto;
   overflow-y: hidden;
-  scroll-snap-type: x proximity;
-  scrollbar-width: none;
-}
-.ed-hero-grid::-webkit-scrollbar {
-  display: none;
+  padding-block: 0;
 }
 .ed-hero-grid__lead {
   flex: 1.5 0 520px;
@@ -1262,38 +1150,6 @@ onBeforeUnmount(() => {
 .ed-hero-grid__col > * {
   flex: 1;
   min-height: 0;
-}
-.ed-hero-nav {
-  position: absolute;
-  top: 50%;
-  transform: translateY(-50%);
-  z-index: 3;
-  width: 38px;
-  height: 38px;
-  border-radius: 999px;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  cursor: pointer;
-  color: rgb(var(--v-theme-on-background));
-  background: rgb(var(--v-theme-panel));
-  border: 1px solid rgba(var(--v-theme-on-surface), 0.12);
-  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.25);
-  transition:
-    background 0.15s ease,
-    transform 0.15s ease;
-}
-.ed-hero-nav:hover {
-  background: rgb(var(--v-theme-surface));
-}
-.ed-hero-nav:active {
-  transform: translateY(-50%) scale(0.94);
-}
-.ed-hero-nav--left {
-  left: 12px;
-}
-.ed-hero-nav--right {
-  right: 12px;
 }
 
 .ed-genres {
@@ -1326,38 +1182,26 @@ onBeforeUnmount(() => {
   .ed-genres__grid {
     grid-template-columns: repeat(2, 1fr);
   }
-  .ed-hero-grid {
-    display: flex;
+  .ed-hero-row :deep(.ed-shelf__track) {
     height: auto;
     gap: 12px;
-    overflow-x: auto;
     overflow-y: visible;
     scroll-snap-type: x mandatory;
-    /* pan-y too: a vertical swipe starting on a tile must scroll the page */
-    touch-action: pan-x pan-y;
-    scrollbar-width: none;
-    margin-inline: -28px;
-    padding-inline: 28px;
-    /* snap tiles to the gutter so the first tile lines up with the title */
-    scroll-padding-inline: 28px;
-  }
-  .ed-hero-grid::-webkit-scrollbar {
-    display: none;
   }
   .ed-hero-grid__col {
     display: contents;
   }
-  .ed-hero-row .ed-hero-grid :deep(.ed-hero) {
+  .ed-hero-row :deep(.ed-hero) {
     flex: 0 0 44%;
     height: 220px;
     min-height: 0;
     scroll-snap-align: start;
   }
 
-  .ed-hero-row .ed-hero-grid :deep(.ed-hero--large .ed-hero__title) {
+  .ed-hero-row :deep(.ed-hero--large .ed-hero__title) {
     font-size: 18px;
   }
-  .ed-hero-row .ed-hero-grid :deep(.ed-hero--large .ed-hero__content) {
+  .ed-hero-row :deep(.ed-hero--large .ed-hero__content) {
     padding: 16px;
   }
 }
@@ -1366,25 +1210,16 @@ onBeforeUnmount(() => {
   .ed-section {
     margin-bottom: 16px;
   }
-  .ed-hero-row,
   .ed-genres {
     padding-left: 16px;
     padding-right: 16px;
   }
-  .ed-hero-grid {
-    margin-inline: -16px;
-    padding-inline: 16px;
-    scroll-padding-inline: 16px;
-  }
-  .ed-hero-row .ed-hero-grid :deep(.ed-hero) {
+  .ed-hero-row :deep(.ed-hero) {
     flex: 0 0 82%;
     height: 200px;
   }
   .ed-hero-row__title {
     font-size: 22px;
-  }
-  .ed-hero-nav {
-    display: none;
   }
   .ed-drag-ghost {
     left: 16px;

--- a/src/components/HomeWidgetRows.vue
+++ b/src/components/HomeWidgetRows.vue
@@ -1053,6 +1053,7 @@ onBeforeUnmount(() => {
 }
 
 .ed-players {
+  --ed-card-pad: 0px;
   margin-top: 4px;
 }
 .ed-players :deep(.ed-shelf__track) {

--- a/src/components/discover/EditorialShelf.vue
+++ b/src/components/discover/EditorialShelf.vue
@@ -35,8 +35,11 @@
     >
       <!-- prev -->
       <button
-        v-show="hovering && canLeft"
         class="ed-shelf__nav ed-shelf__nav--left"
+        :style="{
+          opacity: leftEdgeOpacity,
+          visibility: leftNavVisible ? 'visible' : 'hidden',
+        }"
         :aria-label="$t('tooltip.scroll_left')"
         @click="scroll(-1)"
       >
@@ -55,10 +58,30 @@
         <slot></slot>
       </div>
 
+      <div
+        class="ed-shelf__overflow-fade ed-shelf__overflow-fade--left"
+        :style="{
+          opacity: leftEdgeOpacity,
+          visibility: leftEdgeOpacity > 0 ? 'visible' : 'hidden',
+        }"
+        aria-hidden="true"
+      ></div>
+      <div
+        class="ed-shelf__overflow-fade ed-shelf__overflow-fade--right"
+        :style="{
+          opacity: rightEdgeOpacity,
+          visibility: rightEdgeOpacity > 0 ? 'visible' : 'hidden',
+        }"
+        aria-hidden="true"
+      ></div>
+
       <!-- next -->
       <button
-        v-show="hovering && canRight"
         class="ed-shelf__nav ed-shelf__nav--right"
+        :style="{
+          opacity: rightEdgeOpacity,
+          visibility: rightNavVisible ? 'visible' : 'hidden',
+        }"
         :aria-label="$t('tooltip.scroll_right')"
         @click="scroll(1)"
       >
@@ -106,6 +129,7 @@ const PHONE_CARD_PAD = 8;
 const MIN_ART = 120;
 const MAX_ART = 280;
 const ART_TOP_OFFSET = 12;
+const DEFAULT_GUTTER = 28;
 
 // Only track hover (for the nav chevrons) on hover-capable devices. On touch
 // devices the emulated mouseenter would mutate the DOM, which makes mobile
@@ -113,12 +137,19 @@ const ART_TOP_OFFSET = 12;
 const canHover = window.matchMedia?.("(hover: hover)")?.matches ?? true;
 const track = ref<HTMLElement | null>(null);
 const hovering = ref(false);
-const canLeft = ref(false);
-const canRight = ref(false);
+const leftEdgeOpacity = ref(0);
+const rightEdgeOpacity = ref(0);
+const gutterWidth = ref(DEFAULT_GUTTER);
 const tileArt = ref<number | null>(null);
 
 const navTop = computed(() =>
   tileArt.value != null ? ART_TOP_OFFSET + tileArt.value / 2 : props.navCenter,
+);
+const leftNavVisible = computed(
+  () => leftEdgeOpacity.value > 0 && (!canHover || hovering.value),
+);
+const rightNavVisible = computed(
+  () => rightEdgeOpacity.value > 0 && (!canHover || hovering.value),
 );
 
 const verticalScrollParent = (el: HTMLElement): HTMLElement => {
@@ -155,18 +186,39 @@ const updateTileArt = () => {
   const isPhone = getBreakpointValue({ breakpoint: "bp1", condition: "lt" });
   const gap = isPhone ? Math.min(props.gap, PHONE_GAP) : props.gap;
   const cardPad = isPhone ? PHONE_CARD_PAD : CARD_PAD;
-  const size = el.clientWidth / props.tilesPerView - gap - cardPad;
+  const trackStyles = getComputedStyle(el);
+  const horizontalInset =
+    (Number.parseFloat(trackStyles.paddingLeft) || 0) +
+    (Number.parseFloat(trackStyles.paddingRight) || 0);
+  const contentWidth = el.clientWidth - horizontalInset;
+  const size = contentWidth / props.tilesPerView - gap - cardPad;
   tileArt.value = Math.round(Math.max(MIN_ART, Math.min(MAX_ART, size)));
 };
 
-const update = () => {
+const updateEdgeOpacity = () => {
   const el = track.value;
   if (!el) return;
-  canLeft.value = el.scrollLeft > 1;
-  canRight.value = el.scrollLeft + el.clientWidth < el.scrollWidth - 1;
+  const maxScroll = Math.max(0, el.scrollWidth - el.clientWidth);
+  const scrollPosition = Math.min(maxScroll, Math.max(0, el.scrollLeft));
+  leftEdgeOpacity.value = Math.min(1, scrollPosition / gutterWidth.value);
+  rightEdgeOpacity.value = Math.min(
+    1,
+    (maxScroll - scrollPosition) / gutterWidth.value,
+  );
+};
+
+const updateLayout = () => {
+  const el = track.value;
+  if (!el) return;
+  const trackStyles = getComputedStyle(el);
+  gutterWidth.value =
+    Number.parseFloat(trackStyles.paddingRight) ||
+    Number.parseFloat(trackStyles.getPropertyValue("--ed-gutter")) ||
+    DEFAULT_GUTTER;
+  updateEdgeOpacity();
   updateTileArt();
 };
-const onScroll = () => update();
+const onScroll = () => updateEdgeOpacity();
 
 watch(() => props.tilesPerView, updateTileArt);
 
@@ -190,8 +242,12 @@ function alignItemStart(selector: string) {
     scrollToStart();
     return;
   }
+  const trackStyles = getComputedStyle(el);
+  const startInset = Number.parseFloat(trackStyles.paddingLeft) || 0;
   const delta =
-    item.getBoundingClientRect().left - el.getBoundingClientRect().left;
+    item.getBoundingClientRect().left -
+    el.getBoundingClientRect().left -
+    startInset;
   el.scrollBy({ left: delta, behavior: "smooth" });
 }
 
@@ -201,17 +257,23 @@ defineExpose<EditorialShelfExpose>({
 });
 
 let ro: ResizeObserver | undefined;
+let mutationObserver: MutationObserver | undefined;
 onMounted(() => {
-  update();
-  window.addEventListener("resize", update);
+  updateLayout();
+  window.addEventListener("resize", updateLayout);
   if (track.value && "ResizeObserver" in window) {
-    ro = new ResizeObserver(update);
+    ro = new ResizeObserver(updateLayout);
     ro.observe(track.value);
+  }
+  if (track.value && "MutationObserver" in window) {
+    mutationObserver = new MutationObserver(updateLayout);
+    mutationObserver.observe(track.value, { childList: true, subtree: true });
   }
 });
 onBeforeUnmount(() => {
-  window.removeEventListener("resize", update);
+  window.removeEventListener("resize", updateLayout);
   ro?.disconnect();
+  mutationObserver?.disconnect();
 });
 </script>
 
@@ -277,10 +339,9 @@ onBeforeUnmount(() => {
 
 .ed-shelf__viewport {
   position: relative;
-  padding-left: calc(var(--ed-gutter) - var(--ed-card-pad));
-  padding-right: var(--ed-gutter);
 }
 .ed-shelf__track {
+  box-sizing: border-box;
   display: flex;
   align-items: flex-start;
   gap: var(--ed-gap, 14px);
@@ -288,16 +349,32 @@ onBeforeUnmount(() => {
   overflow-x: auto;
   overflow-y: visible;
   overscroll-behavior-x: contain;
+  /* Keep resting content on the page grid while letting scrolled content
+     travel through the gutters to the viewport edge. */
   padding-block: 4px;
+  padding-left: calc(var(--ed-gutter) - var(--ed-card-pad));
+  padding-right: var(--ed-gutter);
   /* pan-y too: a vertical swipe starting on a tile must scroll the page */
   touch-action: pan-x pan-y;
   scroll-snap-type: x proximity;
   overflow-anchor: none;
-  scroll-padding-inline: calc(var(--ed-gutter) - var(--ed-card-pad));
+  scroll-padding-left: calc(var(--ed-gutter) - var(--ed-card-pad));
+  scroll-padding-right: var(--ed-gutter);
 }
-.ed-shelf__track::after {
-  content: "";
-  flex: 0 0 calc(var(--ed-gutter) - var(--ed-gap, 14px));
+.ed-shelf__overflow-fade {
+  position: absolute;
+  inset-block: 0;
+  z-index: 2;
+  width: clamp(24px, 3.75vw, 48px);
+  pointer-events: none;
+}
+.ed-shelf__overflow-fade--left {
+  left: 0;
+  background: linear-gradient(to right, var(--background), transparent);
+}
+.ed-shelf__overflow-fade--right {
+  right: 0;
+  background: linear-gradient(to right, transparent, var(--background));
 }
 .ma-scroll {
   scrollbar-width: none;

--- a/src/components/discover/EditorialShelf.vue
+++ b/src/components/discover/EditorialShelf.vue
@@ -58,23 +58,6 @@
         <slot></slot>
       </div>
 
-      <div
-        class="ed-shelf__overflow-fade ed-shelf__overflow-fade--left"
-        :style="{
-          opacity: leftEdgeOpacity,
-          visibility: leftEdgeOpacity > 0 ? 'visible' : 'hidden',
-        }"
-        aria-hidden="true"
-      ></div>
-      <div
-        class="ed-shelf__overflow-fade ed-shelf__overflow-fade--right"
-        :style="{
-          opacity: rightEdgeOpacity,
-          visibility: rightEdgeOpacity > 0 ? 'visible' : 'hidden',
-        }"
-        aria-hidden="true"
-      ></div>
-
       <!-- next -->
       <button
         class="ed-shelf__nav ed-shelf__nav--right"
@@ -360,21 +343,6 @@ onBeforeUnmount(() => {
   overflow-anchor: none;
   scroll-padding-left: calc(var(--ed-gutter) - var(--ed-card-pad));
   scroll-padding-right: var(--ed-gutter);
-}
-.ed-shelf__overflow-fade {
-  position: absolute;
-  inset-block: 0;
-  z-index: 2;
-  width: clamp(24px, 3.75vw, 48px);
-  pointer-events: none;
-}
-.ed-shelf__overflow-fade--left {
-  left: 0;
-  background: linear-gradient(to right, var(--background), transparent);
-}
-.ed-shelf__overflow-fade--right {
-  right: 0;
-  background: linear-gradient(to right, transparent, var(--background));
 }
 .ma-scroll {
   scrollbar-width: none;

--- a/src/components/ui/sidebar/SidebarContent.vue
+++ b/src/components/ui/sidebar/SidebarContent.vue
@@ -23,6 +23,10 @@ const props = defineProps<{
 </template>
 
 <style>
+[data-sidebar="content"] {
+  --scrollbar-track-color: transparent;
+}
+
 /* Collapsed sidebar: remove group padding so icons/images are not clipped */
 [data-collapsible="icon"] [data-sidebar="group"][data-slot="sidebar-group"] {
   padding-right: 0 !important;

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -152,6 +152,11 @@ html {
      leaving the shared stack only stops them raising the next overlay. */
 
 html {
+  --scrollbar-track-color: color-mix(
+    in srgb,
+    rgb(var(--v-theme-background)) 97%,
+    white
+  );
   overflow: hidden;
   /* Nothing here scrolls, so a downward drag no in-page scroller consumes
      chains out of the Home Assistant ingress iframe and its app takes that for
@@ -204,11 +209,11 @@ html {
 /* Auto-hide scrollbars - only visible on hover */
 * {
   scrollbar-width: thin;
-  scrollbar-color: transparent transparent;
+  scrollbar-color: transparent var(--scrollbar-track-color);
 }
 
 *:hover {
-  scrollbar-color: rgba(128, 128, 128, 0.5) transparent;
+  scrollbar-color: rgba(128, 128, 128, 0.5) var(--scrollbar-track-color);
 }
 
 ::-webkit-scrollbar {
@@ -217,7 +222,7 @@ html {
 }
 
 ::-webkit-scrollbar-track {
-  background: transparent;
+  background: var(--scrollbar-track-color);
 }
 
 ::-webkit-scrollbar-thumb {

--- a/tests/components/discover/EditorialShelf.test.ts
+++ b/tests/components/discover/EditorialShelf.test.ts
@@ -1,0 +1,94 @@
+import EditorialShelf from "@/components/discover/EditorialShelf.vue";
+import { mount } from "@vue/test-utils";
+import { describe, expect, it, vi } from "vitest";
+
+describe("EditorialShelf", () => {
+  it("fades each edge only while more content exists in that direction", async () => {
+    const wrapper = mount(EditorialShelf, {
+      global: {
+        mocks: {
+          $t: (key: string) => key,
+        },
+      },
+      slots: {
+        default: '<div class="shelf-item">Item</div>',
+      },
+    });
+    const track = wrapper.get(".ed-shelf__track");
+    Object.defineProperties(track.element, {
+      clientWidth: { configurable: true, value: 200 },
+      scrollWidth: { configurable: true, value: 400 },
+      scrollLeft: { configurable: true, value: 0, writable: true },
+    });
+    await track.trigger("scroll");
+
+    const leftFade = wrapper.get(".ed-shelf__overflow-fade--left");
+    const rightFade = wrapper.get(".ed-shelf__overflow-fade--right");
+    expect(leftFade.attributes("style")).toContain("visibility: hidden");
+    expect(leftFade.attributes("style")).toContain("opacity: 0");
+    expect(rightFade.isVisible()).toBe(true);
+    expect(rightFade.attributes("style")).toContain("opacity: 1");
+    expect(rightFade.attributes("aria-hidden")).toBe("true");
+
+    Object.defineProperty(track.element, "scrollLeft", {
+      configurable: true,
+      value: 14,
+    });
+    await track.trigger("scroll");
+
+    expect(leftFade.isVisible()).toBe(true);
+    expect(leftFade.attributes("style")).toContain("opacity: 0.5");
+    expect(rightFade.isVisible()).toBe(true);
+    await wrapper.get(".ed-shelf").trigger("mouseenter");
+    expect(wrapper.get(".ed-shelf__nav--left").attributes("style")).toContain(
+      "opacity: 0.5",
+    );
+
+    Object.defineProperty(track.element, "scrollLeft", {
+      configurable: true,
+      value: 186,
+    });
+    await track.trigger("scroll");
+
+    expect(leftFade.isVisible()).toBe(true);
+    expect(rightFade.attributes("style")).toContain("opacity: 0.5");
+
+    Object.defineProperty(track.element, "scrollLeft", {
+      configurable: true,
+      value: 200,
+    });
+    await track.trigger("scroll");
+
+    expect(rightFade.attributes("style")).toContain("visibility: hidden");
+    expect(rightFade.attributes("style")).toContain("opacity: 0");
+  });
+
+  it("scrolls an overflowing shelf with its navigation control", async () => {
+    const wrapper = mount(EditorialShelf, {
+      global: {
+        mocks: {
+          $t: (key: string) => key,
+        },
+      },
+      slots: {
+        default: '<div class="shelf-item">Item</div>',
+      },
+    });
+    const track = wrapper.get(".ed-shelf__track");
+    const scrollBy = vi.fn();
+    Object.defineProperties(track.element, {
+      clientWidth: { configurable: true, value: 200 },
+      scrollWidth: { configurable: true, value: 400 },
+      scrollLeft: { configurable: true, value: 0, writable: true },
+      scrollBy: { configurable: true, value: scrollBy },
+    });
+    await track.trigger("scroll");
+    await wrapper.get(".ed-shelf").trigger("mouseenter");
+    await wrapper.get(".ed-shelf__nav--right").trigger("click");
+
+    expect(scrollBy).toHaveBeenCalledWith({
+      left: 160,
+      behavior: "smooth",
+    });
+  });
+});

--- a/tests/components/discover/EditorialShelf.test.ts
+++ b/tests/components/discover/EditorialShelf.test.ts
@@ -3,7 +3,7 @@ import { mount } from "@vue/test-utils";
 import { describe, expect, it, vi } from "vitest";
 
 describe("EditorialShelf", () => {
-  it("fades each edge only while more content exists in that direction", async () => {
+  it("shows navigation only while more content exists in that direction", async () => {
     const wrapper = mount(EditorialShelf, {
       global: {
         mocks: {
@@ -21,14 +21,14 @@ describe("EditorialShelf", () => {
       scrollLeft: { configurable: true, value: 0, writable: true },
     });
     await track.trigger("scroll");
+    await wrapper.get(".ed-shelf").trigger("mouseenter");
 
-    const leftFade = wrapper.get(".ed-shelf__overflow-fade--left");
-    const rightFade = wrapper.get(".ed-shelf__overflow-fade--right");
-    expect(leftFade.attributes("style")).toContain("visibility: hidden");
-    expect(leftFade.attributes("style")).toContain("opacity: 0");
-    expect(rightFade.isVisible()).toBe(true);
-    expect(rightFade.attributes("style")).toContain("opacity: 1");
-    expect(rightFade.attributes("aria-hidden")).toBe("true");
+    const leftNav = wrapper.get(".ed-shelf__nav--left");
+    const rightNav = wrapper.get(".ed-shelf__nav--right");
+    expect(leftNav.attributes("style")).toContain("visibility: hidden");
+    expect(leftNav.attributes("style")).toContain("opacity: 0");
+    expect(rightNav.isVisible()).toBe(true);
+    expect(rightNav.attributes("style")).toContain("opacity: 1");
 
     Object.defineProperty(track.element, "scrollLeft", {
       configurable: true,
@@ -36,13 +36,9 @@ describe("EditorialShelf", () => {
     });
     await track.trigger("scroll");
 
-    expect(leftFade.isVisible()).toBe(true);
-    expect(leftFade.attributes("style")).toContain("opacity: 0.5");
-    expect(rightFade.isVisible()).toBe(true);
-    await wrapper.get(".ed-shelf").trigger("mouseenter");
-    expect(wrapper.get(".ed-shelf__nav--left").attributes("style")).toContain(
-      "opacity: 0.5",
-    );
+    expect(leftNav.isVisible()).toBe(true);
+    expect(leftNav.attributes("style")).toContain("opacity: 0.5");
+    expect(rightNav.isVisible()).toBe(true);
 
     Object.defineProperty(track.element, "scrollLeft", {
       configurable: true,
@@ -50,8 +46,8 @@ describe("EditorialShelf", () => {
     });
     await track.trigger("scroll");
 
-    expect(leftFade.isVisible()).toBe(true);
-    expect(rightFade.attributes("style")).toContain("opacity: 0.5");
+    expect(leftNav.isVisible()).toBe(true);
+    expect(rightNav.attributes("style")).toContain("opacity: 0.5");
 
     Object.defineProperty(track.element, "scrollLeft", {
       configurable: true,
@@ -59,8 +55,8 @@ describe("EditorialShelf", () => {
     });
     await track.trigger("scroll");
 
-    expect(rightFade.attributes("style")).toContain("visibility: hidden");
-    expect(rightFade.attributes("style")).toContain("opacity: 0");
+    expect(rightNav.attributes("style")).toContain("visibility: hidden");
+    expect(rightNav.attributes("style")).toContain("opacity: 0");
   });
 
   it("scrolls an overflowing shelf with its navigation control", async () => {

--- a/tests/styles/collapsedSidebarAlignment.test.ts
+++ b/tests/styles/collapsedSidebarAlignment.test.ts
@@ -8,6 +8,7 @@ import navMainSource from "@/components/navigation/NavMain.vue?raw";
 import navShortcutsSource from "@/components/navigation/NavShortcuts.vue?raw";
 import navUserSource from "@/components/navigation/NavUser.vue?raw";
 import sidebarFooterSource from "@/components/ui/sidebar/SidebarFooter.vue?raw";
+import sidebarContentSource from "@/components/ui/sidebar/SidebarContent.vue?raw";
 import sidebarTriggerSource from "@/components/ui/sidebar/SidebarTrigger.vue?raw";
 import utilities from "@/styles/style.css?inline";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
@@ -94,6 +95,15 @@ describe("collapsed sidebar alignment", () => {
   afterEach(() => {
     triggerStyles.remove();
     document.body.innerHTML = "";
+  });
+
+  it("keeps the navigation scrollbar track transparent", () => {
+    const contentRule = cssRule(
+      styleBlocks(sidebarContentSource)[0],
+      '[data-sidebar="content"]',
+    );
+
+    expect(contentRule.body).toContain("--scrollbar-track-color: transparent");
   });
 
   it("anchors the menu buttons only while the rail is collapsed", () => {


### PR DESCRIPTION
# What does this implement/fix?

Improves the Discover dashboard visual styles, making them scroll all the way to the edge of the screen rather than cut off at the page gutter.

In order to help the effect, I added a subtle distinction to the scrollbar track app-wide. This is tasteful to my eye and is barely noticeable, but helps the edge-to-edge scroll on Discover to feel like there isn't a gap on the right. **However, I am fine leaving this out if we don't like it.**

This also converts the "Top Picks for You" to a proper EditorialShelf, with the same scrolling arrows (on desktop) and the new overlay fade-out shadows. This is generally an improvement for consistent & predictable behavior on Discover regardless, and also allows the removal of a big chunk of bespoke code for the hero.

Minor: also fixed the misaligned position of the Players shelf on the left.

### Screenshots

Desktop:
<img width="100%" alt="Screenshot From 2026-09-05 18-58-14" src="https://github.com/user-attachments/assets/3a91f795-00b0-4c2e-9e90-89c2c55365ed" />

Mobile:
<img width="300" alt="image" src="https://github.com/user-attachments/assets/85799453-a8e8-4a89-976b-e94d86ac231c" />



## Types of changes

<!--
Tick exactly one box below. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm lint:check` passes.
- [x] `pnpm test:run` passes, and tests have been added/updated where applicable.
- [x] `pnpm build` passes.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
