### PR TITLE
Keep sidebar shortcuts tidied up after a provider is removed

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -627,11 +627,13 @@ onMounted(async () => {
     }
     // The server rewrites the sidebar shortcuts held on the user when a provider is removed.
     // Refresh before pruning, which saves preferences and would write the old set back.
+    // Without a fresh user there is nothing safe to prune against, so leave it for next time.
     const userInfo = await api.getCurrentUserInfo();
-    if (userInfo) {
-      authManager.setCurrentUser(userInfo);
-      store.currentUser = userInfo;
+    if (!userInfo) {
+      return;
     }
+    authManager.setCurrentUser(userInfo);
+    store.currentUser = userInfo;
     await pruneStaleProviderFilters();
   });
 });

--- a/src/App.vue
+++ b/src/App.vue
@@ -621,13 +621,18 @@ onMounted(async () => {
   });
 
   // Re-prune when the provider set changes at runtime.
-  api.subscribe(EventType.PROVIDERS_UPDATED, () => {
-    if (
-      !authManager.isGuestAccessSession() &&
-      !authManager.isDashboardViewer()
-    ) {
-      void pruneStaleProviderFilters();
+  api.subscribe(EventType.PROVIDERS_UPDATED, async () => {
+    if (authManager.isGuestAccessSession() || authManager.isDashboardViewer()) {
+      return;
     }
+    // The server rewrites the sidebar shortcuts held on the user when a provider is removed.
+    // Refresh before pruning, which saves preferences and would write the old set back.
+    const userInfo = await api.getCurrentUserInfo();
+    if (userInfo) {
+      authManager.setCurrentUser(userInfo);
+      store.currentUser = userInfo;
+    }
+    await pruneStaleProviderFilters();
   });
 });
 

--- a/tests/App.test.ts
+++ b/tests/App.test.ts
@@ -521,6 +521,19 @@ describe("App initialization", () => {
     expect(prunedShortcuts).toEqual(["library://album/1"]);
   });
 
+  it("leaves preferences alone when the user cannot be fetched", async () => {
+    wrapper = await mountApp();
+    mockPruneStaleProviderFilters.mockClear();
+    const stale = store.currentUser;
+    apiMock.getCurrentUserInfo.mockResolvedValue(null);
+
+    await signalProvidersUpdated();
+
+    // pruning saves the whole preference set, so it must not run against the old copy
+    expect(mockPruneStaleProviderFilters).not.toHaveBeenCalled();
+    expect(store.currentUser).toBe(stale);
+  });
+
   it("waits for the startup data before revealing the main app", async () => {
     const serverState = createDeferred<void>();
     const pluginConfigs = createDeferred<ProviderConfig[]>();

--- a/tests/App.test.ts
+++ b/tests/App.test.ts
@@ -16,6 +16,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { toast } from "vue-sonner";
 import { providerConfig } from "./fixtures/providerConfig";
 import { user } from "./fixtures/user";
+import { store } from "@/plugins/store";
 
 const {
   apiMock,
@@ -497,6 +498,27 @@ describe("App initialization", () => {
     await signalProvidersUpdated();
     expect(apiMock.getProviderConfigs).toHaveBeenCalledTimes(8);
     expect(mockPruneStaleProviderFilters).toHaveBeenCalledTimes(2);
+  });
+
+  it("takes the server's copy of the user when the provider set changes", async () => {
+    wrapper = await mountApp();
+    apiMock.getCurrentUserInfo.mockClear();
+    const cleaned = user({
+      preferences: { "sidebar.shortcuts": ["library://album/1"] },
+    });
+    // the prune reads store.currentUser, so record what it would have written back
+    let prunedShortcuts: unknown;
+    mockPruneStaleProviderFilters.mockImplementation(async () => {
+      prunedShortcuts = store.currentUser?.preferences?.["sidebar.shortcuts"];
+    });
+    apiMock.getCurrentUserInfo.mockResolvedValue(cleaned);
+
+    await signalProvidersUpdated();
+
+    expect(apiMock.getCurrentUserInfo).toHaveBeenCalledOnce();
+    expect(store.currentUser).toBe(cleaned);
+    // the refetch has to land first, or the prune writes the old shortcuts back
+    expect(prunedShortcuts).toEqual(["library://album/1"]);
   });
 
   it("waits for the startup data before revealing the main app", async () => {


### PR DESCRIPTION
# What does this implement/fix?

When a music provider is removed, the server now tidies up the sidebar shortcuts that pointed at it. It either points them at the library copy of the item or drops them.

The app holds its own copy of the user, including those shortcuts, and saving any preference sends the whole set back. So the old shortcuts were written straight back over the tidied up ones and returned as if nothing had happened.

The app now takes a fresh copy of the user whenever the set of providers changes, before anything writes preferences back.

- Fetch the user again when the provider set changes and use that copy
- Do it before the provider filter pruning runs, since that saves preferences and would otherwise
  put the old shortcuts back
- Added a test covering both

**Related issue (if applicable):**

- n/a

**Related backend PR (if applicable):**

- https://github.com/music-assistant/server/pull/6124

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm lint:check` passes.
- [x] `pnpm test:run` passes, and tests have been added/updated where applicable.
- [x] `pnpm build` passes.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
