### PR TITLE
Ux layout refactor and minor fixes

### DIFF
--- a/src/components/ui/sidebar/SidebarTrigger.vue
+++ b/src/components/ui/sidebar/SidebarTrigger.vue
@@ -87,6 +87,7 @@ const isCollapsed = computed(() => state.value === "collapsed");
 .trigger-container--collapsed .navuser-trigger :deep(ul[data-sidebar="menu"]) {
   padding-left: 6px !important;
   padding-right: 6px !important;
+  padding-bottom: 6px !important;
 }
 
 .trigger-container--collapsed

--- a/src/layouts/default/View.vue
+++ b/src/layouts/default/View.vue
@@ -1,9 +1,13 @@
 <template>
   <v-main
     id="cont"
-    :class="['main-layout', { 'main-layout--mobile': store.mobileLayout }]"
+    :class="[
+      'main-layout',
+      { 'main-layout--mobile': store.mobileLayout },
+      { 'main-layout--frameless': store.frameless },
+    ]"
   >
-    <SidebarProvider>
+    <SidebarProvider class="min-h-0">
       <AppSidebar v-if="!store.frameless" />
       <SidebarInset>
         <div
@@ -105,7 +109,18 @@ onMounted(() => {
   /* Reset Vuetify's automatic padding that accounts for drawers */
   padding-top: var(--device-inset-top) !important;
   padding-right: var(--device-inset-right) !important;
+  /* Vuetify measures the fixed footer. Its manual safe-area offset is not part
+     of that measurement, so reserve both before sizing the page scroller. */
+  padding-bottom: calc(
+    var(--v-layout-bottom, 0px) + var(--device-inset-bottom)
+  ) !important;
   padding-left: var(--device-inset-left) !important;
+}
+
+.main-layout--mobile,
+.main-layout--frameless {
+  /* Mobile chrome intentionally overlays the page; frameless has no chrome. */
+  padding-bottom: 0 !important;
 }
 
 .content-section {
@@ -113,7 +128,6 @@ onMounted(() => {
   overflow-y: auto;
   overflow-x: hidden;
   min-height: 0;
-  padding-bottom: calc(110px + var(--device-inset-bottom));
 }
 
 .content-section--mobile {

--- a/tests/layouts/View.test.ts
+++ b/tests/layouts/View.test.ts
@@ -22,6 +22,9 @@ const vuetify = createVuetify({ components, directives });
 // the content section is nested in wrappers that carry no state of their own,
 // so they stand in as plain hosts while every other child is shallow-stubbed
 const host = { template: "<div><slot /></div>" };
+const sidebarProviderHost = {
+  template: '<div data-testid="sidebar-provider"><slot /></div>',
+};
 const blank = { template: "<div />" };
 
 // the app's own party route is guarded on a live server connection, so the
@@ -49,7 +52,11 @@ async function mountAt(path: string) {
     shallow: true,
     global: {
       plugins: [vuetify, router],
-      stubs: { VMain: host, SidebarProvider: host, SidebarInset: host },
+      stubs: {
+        VMain: host,
+        SidebarProvider: sidebarProviderHost,
+        SidebarInset: host,
+      },
     },
   });
   return { section: wrapper.get(".content-section"), router };
@@ -80,6 +87,14 @@ describe("View", () => {
     expect(section.classes()).not.toContain("party-view-active");
   });
 
+  it("allows the sidebar shell to shrink inside the space above the footer", async () => {
+    await mountAt("/");
+
+    expect(
+      wrapper!.get('[data-testid="sidebar-provider"]').classes(),
+    ).toContain("min-h-0");
+  });
+
   it("follows the route without being remounted", async () => {
     // navigating between the app's routes patches this instance in place, so
     // the mark has to track the route rather than settle at first render
@@ -107,5 +122,17 @@ describe("View", () => {
 
     expect(section.classes()).toContain(mod);
     expect(section.classes()).toContain("party-view-active");
+  });
+
+  it.each([
+    ["mobileLayout", "main-layout--mobile"],
+    ["frameless", "main-layout--frameless"],
+  ] as const)("marks the app shell when %s changes", async (flag, mod) => {
+    await mountAt("/");
+
+    store[flag] = true;
+    await nextTick();
+
+    expect(wrapper!.get(".main-layout").classes()).toContain(mod);
   });
 });

--- a/tests/styles/collapsedSidebarAlignment.test.ts
+++ b/tests/styles/collapsedSidebarAlignment.test.ts
@@ -176,6 +176,7 @@ describe("collapsed sidebar alignment", () => {
     const padding = getComputedStyle(menu);
     expect(padding.paddingLeft).not.toBe("");
     expect(padding.paddingLeft).toBe(padding.paddingRight);
+    expect(padding.paddingBottom).toBe(padding.paddingLeft);
     expect(anchor.body).toContain(`- ${padding.paddingLeft})`);
 
     // the rail's button anchor reaches this button too, at the same

--- a/tests/styles/desktopLayout.test.ts
+++ b/tests/styles/desktopLayout.test.ts
@@ -1,0 +1,60 @@
+// jsdom leaves var() unresolved in computed styles, so this cascade is only
+// observable under happy-dom
+// @vitest-environment happy-dom
+import viewSource from "@/layouts/default/View.vue?raw";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+const FOOTER_HEIGHT = "104px";
+const DEVICE_INSET = "24px";
+
+let appStyles: HTMLStyleElement;
+
+function extractStyle(source: string) {
+  return source.match(/<style scoped>([\s\S]*?)<\/style>/)?.[1] ?? "";
+}
+
+function normalize(value: string) {
+  return value.replace(/\s+/g, "");
+}
+
+function layout(...modifiers: string[]) {
+  const element = document.createElement("main");
+  element.className = ["main-layout", ...modifiers].join(" ");
+  document.body.appendChild(element);
+  return getComputedStyle(element);
+}
+
+describe("desktop app shell", () => {
+  beforeEach(() => {
+    appStyles = document.createElement("style");
+    appStyles.textContent = extractStyle(viewSource);
+    document.head.appendChild(appStyles);
+    document.documentElement.style.setProperty(
+      "--v-layout-bottom",
+      FOOTER_HEIGHT,
+    );
+    document.documentElement.style.setProperty(
+      "--device-inset-bottom",
+      DEVICE_INSET,
+    );
+  });
+
+  afterEach(() => {
+    appStyles.remove();
+    document.documentElement.removeAttribute("style");
+    document.body.innerHTML = "";
+  });
+
+  it("reserves the measured footer and safe area outside the scroller", () => {
+    expect(normalize(layout().paddingBottom)).toBe(
+      `calc(${FOOTER_HEIGHT}+${DEVICE_INSET})`,
+    );
+  });
+
+  it.each(["main-layout--mobile", "main-layout--frameless"])(
+    "keeps %s full height",
+    (modifier) => {
+      expect(layout(modifier).paddingBottom).toBe("0px");
+    },
+  );
+});


### PR DESCRIPTION
## What does this implement/fix?

A fairly significant layout fix: changes how the bottom padding and layout of the main content area is calculated so that extra padding is no longer necessary in the content area; and the scroll bar is constrained to the content area itself instead of appearing to slide underneath the player bar.

Also (very minor): fixes bottom padding being absent on profile avatar in left sidebar when collapsed.

### Details

The content area scroll remained the height of the viewport basically because SidebarProvider's 100svh minimum prevented it from shrinking into the space Vuetify reserves for the fixed footer.

The bottom padding made it technically work (content was still visible), but left the scrollbar running behind the player bar.

This fix allows the content shell to shrink, and reserves the measured footer plus the safe-area inset on the main layout.

Removes the compensating desktop bottom padding while preserving the mobile overlay and frameless layouts.

Updates tests and adds regression coverage.

## Screenshot (Video)

After, followed by Before. Note Before's behavior of the scroll handle sliding underneath the player bar.

https://github.com/user-attachments/assets/39c19d23-5737-4bf9-9a84-6f8b94bda694


## Types of changes

<!--
Tick exactly one box below. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm lint:check` passes.
- [x] `pnpm test:run` passes, and tests have been added/updated where applicable.
- [x] `pnpm build` passes.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
