### PR TITLE
Show the right release year for tracks in time zones west of UTC

### DIFF
--- a/src/components/InfoHeader.vue
+++ b/src/components/InfoHeader.vue
@@ -146,7 +146,7 @@
                 color="primary"
                 icon="mdi-calendar"
               />
-              {{ new Date(item.metadata.release_date).getFullYear() }}
+              {{ new Date(item.metadata.release_date).getUTCFullYear() }}
             </v-card-subtitle>
 
             <!-- item artists -->

--- a/src/components/ListviewItemTitle.vue
+++ b/src/components/ListviewItemTitle.vue
@@ -20,7 +20,7 @@
     <span
       v-if="item.media_type == MediaType.TRACK && item.metadata?.release_date"
     >
-      ({{ new Date(item.metadata.release_date).getFullYear() }})
+      ({{ new Date(item.metadata.release_date).getUTCFullYear() }})
     </span>
   </span>
   <!-- explicit icon -->


### PR DESCRIPTION
# What does this implement/fix?

A track's release date arrives from the server as midnight UTC, for example `1978-01-01T00:00:00+00:00`. The two places that show the year read it in the browser's local time, so anyone west of UTC saw the previous year. A track tagged 1978 showed as 1977 in the Americas.

- Read the year in UTC in the track header and in list rows

**Related issue (if applicable):**

- none, found in review

**Related backend PR (if applicable):**

- related backend PR https://github.com/music-assistant/server/pull/6182 (makes the date common for local files, but the bug is already reachable on main)

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm lint:check` passes.
- [ ] `pnpm test:run` passes, and tests have been added/updated where applicable.
- [ ] `pnpm build` passes.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
