### PR TITLE
Make AI Radio prefetch gating test deterministic

### DIFF
--- a/src/composables/ai-radio/useHosts.ts
+++ b/src/composables/ai-radio/useHosts.ts
@@ -1,3 +1,4 @@
+import { shouldPrefetchAiRadio } from "@/helpers/ai_radio_prefetch";
 import { useShows } from "@/composables/ai-radio/useShows";
 import api from "@/plugins/api";
 import type { AIRadioHost, AIRadioSection } from "@/plugins/api/interfaces";
@@ -46,7 +47,10 @@ watch(
   aiRadioAvailable,
   (available) => {
     // Session-scoped sessions lack the config scopes this needs and never open the queue DJ menu.
-    if (available && authManager.guestSessionKind() === null)
+    if (
+      available &&
+      shouldPrefetchAiRadio(available, authManager.guestSessionKind())
+    )
       prefetchQueueDjState();
   },
   { immediate: true },

--- a/src/composables/ai-radio/useShows.ts
+++ b/src/composables/ai-radio/useShows.ts
@@ -1,3 +1,4 @@
+import { shouldPrefetchAiRadio } from "@/helpers/ai_radio_prefetch";
 import api from "@/plugins/api";
 import type {
   AIRadioSection,
@@ -59,7 +60,10 @@ watch(
   aiRadioAvailable,
   (available) => {
     // Session-scoped sessions lack the config scopes this needs and never open the queue DJ menu.
-    if (available && authManager.guestSessionKind() === null)
+    if (
+      available &&
+      shouldPrefetchAiRadio(available, authManager.guestSessionKind())
+    )
       prefetchShowSessionState();
   },
   { immediate: true },

--- a/src/helpers/ai_radio_prefetch.test.ts
+++ b/src/helpers/ai_radio_prefetch.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+import { shouldPrefetchAiRadio } from "./ai_radio_prefetch";
+
+describe("shouldPrefetchAiRadio", () => {
+  it("prefetches when the provider is available for a regular session", () => {
+    expect(shouldPrefetchAiRadio(true, null)).toBe(true);
+  });
+
+  it.each(["party", "music_quiz", "dashboard"] as const)(
+    "does not prefetch for a %s session",
+    (guestSessionKind) => {
+      expect(shouldPrefetchAiRadio(true, guestSessionKind)).toBe(false);
+    },
+  );
+
+  it("does not prefetch when the provider is unavailable", () => {
+    expect(shouldPrefetchAiRadio(false, null)).toBe(false);
+  });
+});

--- a/src/helpers/ai_radio_prefetch.ts
+++ b/src/helpers/ai_radio_prefetch.ts
@@ -1,0 +1,13 @@
+import type { GuestSessionKind } from "./guest_session";
+
+/**
+ * AI Radio prefetches require the full account scope, not a session-scoped
+ * guest token. Keep this policy independent from the composables so it can be
+ * tested without importing the API/auth dependency graph.
+ */
+export function shouldPrefetchAiRadio(
+  available: boolean,
+  guestSessionKind: GuestSessionKind | null,
+): boolean {
+  return available && guestSessionKind === null;
+}

--- a/tests/composables/ai-radio/prefetchGating.test.ts
+++ b/tests/composables/ai-radio/prefetchGating.test.ts
@@ -1,7 +1,27 @@
-import { reactive } from "vue";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { flushPromises } from "@vue/test-utils";
+import { describe, expect, it, vi, afterEach } from "vitest";
 import type { ProviderInstance } from "@/plugins/api/interfaces";
 import { ProviderType } from "@/plugins/api/interfaces";
+import { useHosts } from "@/composables/ai-radio/useHosts";
+import { useShows } from "@/composables/ai-radio/useShows";
+import api from "@/plugins/api";
+
+const { guestSessionKind, sendCommand, providers } = vi.hoisted(() => ({
+  guestSessionKind: vi.fn(() => "dashboard" as string | null),
+  sendCommand: vi.fn().mockResolvedValue({}),
+  providers: {} as Record<string, ProviderInstance>,
+}));
+
+vi.mock("@/plugins/api", async () => {
+  const { reactive } = await import("vue");
+  const api = { providers: reactive(providers), sendCommand };
+  return { api, default: api };
+});
+
+vi.mock("@/plugins/auth", () => ({
+  authManager: { guestSessionKind },
+  default: { guestSessionKind },
+}));
 
 vi.mock("@/plugins/i18n", () => ({
   $t: (key: string) => key,
@@ -23,67 +43,82 @@ const aiRadioProvider: ProviderInstance = {
   is_streaming_provider: null,
 };
 
-/** Mocks @/plugins/api and @/plugins/auth for a fresh module import, returning the sendCommand spy. */
-async function mockApiAndAuth(guestSessionKind: string | null) {
-  const providers = reactive<Record<string, ProviderInstance>>({
-    ai_radio: aiRadioProvider,
-  });
-  const sendCommand = vi.fn().mockResolvedValue({});
+const prefetchCommands = [
+  "ai_radio/stations/list",
+  "ai_radio/status",
+  "ai_radio/hosts/list",
+  "ai_radio/queue_dj/status",
+];
 
-  vi.doMock("@/plugins/api", () => ({
-    api: { providers, sendCommand },
-    default: { providers, sendCommand },
-  }));
-  vi.doMock("@/plugins/auth", () => ({
-    authManager: { guestSessionKind: () => guestSessionKind },
-    default: { guestSessionKind: () => guestSessionKind },
-  }));
+const flushWatcher = async () => {
+  await flushPromises();
+  await flushPromises();
+};
 
-  return sendCommand;
-}
+const calledCommands = () =>
+  sendCommand.mock.calls.map((call) => call[0]).sort();
 
-/** Lets the module-level watcher's synchronous callback finish its async prefetch work. */
-async function flushMicrotasks() {
-  await Promise.resolve();
-  await Promise.resolve();
-  await Promise.resolve();
-}
+afterEach(() => {
+  for (const providerId of Object.keys(api.providers)) {
+    delete api.providers[providerId];
+  }
+  sendCommand.mockReset();
+  sendCommand.mockResolvedValue({});
+  guestSessionKind.mockReset();
+  guestSessionKind.mockReturnValue("dashboard");
+});
 
 describe("ai_radio prefetch gating for session-scoped sessions", () => {
-  afterEach(() => {
-    vi.resetModules();
-    vi.doUnmock("@/plugins/api");
-    vi.doUnmock("@/plugins/auth");
-    vi.doUnmock("@/plugins/i18n");
-  });
+  it("gates prefetches by provider and session, and retries after failure", async () => {
+    // Importing the composables once avoids rebuilding their dependency graph
+    // for each session kind while still exercising their module-level watchers.
+    // This file has one integration scenario because the prefetch guards are
+    // intentionally module-singleton state; the policy matrix is unit-tested
+    // independently in src/helpers/ai_radio_prefetch.test.ts.
+    useShows();
+    useHosts();
 
-  it("sends no ai_radio commands for a session-scoped session", async () => {
-    vi.resetModules();
-    const sendCommand = await mockApiAndAuth("dashboard");
+    api.providers.spotify = {
+      domain: "spotify",
+      available: true,
+    } as ProviderInstance;
+    await flushWatcher();
 
-    await import("@/composables/ai-radio/useShows");
-    await import("@/composables/ai-radio/useHosts");
-    await flushMicrotasks();
+    api.providers.ai_radio = { ...aiRadioProvider, available: false };
+    await flushWatcher();
 
     expect(sendCommand).not.toHaveBeenCalled();
-  });
 
-  it("prefetches ai_radio state for a regular session", async () => {
-    vi.resetModules();
-    const sendCommand = await mockApiAndAuth(null);
+    // A session-scoped token must not prefetch even when the provider becomes
+    // available. The auth value is token-derived and is intentionally sampled
+    // at the provider-availability edge.
+    api.providers.ai_radio.available = true;
+    await flushWatcher();
+    expect(sendCommand).not.toHaveBeenCalled();
 
-    await import("@/composables/ai-radio/useShows");
-    await import("@/composables/ai-radio/useHosts");
-    await flushMicrotasks();
+    // A regular session prefetches the exact four cache requests once. Make
+    // every request in the first attempt fail so both composables' guards are
+    // reset and permit a later availability edge to retry.
+    const commandsToFail = new Set(prefetchCommands);
+    sendCommand.mockImplementation(async (command: string) => {
+      if (commandsToFail.delete(command)) {
+        throw new Error("prefetch failed");
+      }
+      return {};
+    });
+    guestSessionKind.mockReturnValue(null);
+    delete api.providers.ai_radio;
+    await flushWatcher();
+    api.providers.ai_radio = aiRadioProvider;
+    await flushWatcher();
+    expect(calledCommands()).toEqual([...prefetchCommands].sort());
 
-    const calledCommands = sendCommand.mock.calls.map((call) => call[0]);
-    expect(calledCommands).toEqual(
-      expect.arrayContaining([
-        "ai_radio/stations/list",
-        "ai_radio/status",
-        "ai_radio/hosts/list",
-        "ai_radio/queue_dj/status",
-      ]),
-    );
+    sendCommand.mockClear();
+    delete api.providers.ai_radio;
+    await flushWatcher();
+    api.providers.ai_radio = aiRadioProvider;
+    await flushWatcher();
+
+    expect(calledCommands()).toEqual([...prefetchCommands].sort());
   });
 });


### PR DESCRIPTION


# What does this implement/fix?

I was working on an unrelated PR and this test kept timing out. Instead of just increasing the timeout from 5s to 10s or whatever, did a very small refactor to extract the session-scope prefetch policy into a pure helper and cover it with fast unit tests. The integration test now imports the AI Radio composables once and exercises reactive provider changes.

## Types of changes

<!--
Tick exactly one box below. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [X] Refactor (no behaviour change) — `refactor`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [X] The code change is tested and works locally.
- [X] `pnpm lint:check` passes.
- [X] `pnpm test:run` passes, and tests have been added/updated where applicable.
- [X] `pnpm build` passes.
- [X] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
