### PR TITLE
Add optional copy text button in setup dialog

### DIFF
--- a/src/components/SetupFlowDialog.vue
+++ b/src/components/SetupFlowDialog.vue
@@ -726,7 +726,7 @@ async function copyExternalText() {
   const copyText = step.value?.copy_text;
   if (!copyText) return;
   if (await copyToClipboard(copyText)) {
-    toast.success($t("settings.setup_flow.copied"));
+    toast.success($t("settings.setup_flow.copy_success"));
   } else {
     toast.error($t("settings.setup_flow.copy_failed"));
   }

--- a/src/components/SetupFlowDialog.vue
+++ b/src/components/SetupFlowDialog.vue
@@ -97,6 +97,21 @@
               {{ $t("settings.setup_flow.open_external") }}
             </Button>
             <div
+              v-if="step.copy_text"
+              class="flex items-center gap-2 rounded-md border px-3 py-2"
+            >
+              <code class="font-mono text-sm">{{ step.copy_text }}</code>
+              <Button
+                variant="ghost"
+                size="icon"
+                :aria-label="$t('copy')"
+                :title="$t('copy')"
+                @click="copyExternalText"
+              >
+                <Copy :size="16" />
+              </Button>
+            </div>
+            <div
               v-if="externalHost"
               class="text-muted-foreground flex items-center gap-1.5 text-xs"
             >
@@ -306,6 +321,7 @@ import {
 import { Progress } from "@/components/ui/progress";
 import { Spinner } from "@/components/ui/spinner";
 import { serverNow } from "@/composables/useServerTime";
+import { copyToClipboard } from "@/helpers/utils";
 import {
   allRequiredValuesPresent,
   isEntryDisabled,
@@ -328,6 +344,7 @@ import { store } from "@/plugins/store";
 import {
   CircleCheck,
   Clock,
+  Copy,
   ExternalLink,
   Info,
   Settings2,
@@ -703,6 +720,14 @@ function openExternal() {
   a.setAttribute("target", "_blank");
   a.setAttribute("rel", "noopener");
   a.click();
+}
+
+async function copyExternalText() {
+  const copyText = step.value?.copy_text;
+  if (!copyText) return;
+  if (await copyToClipboard(copyText)) {
+    toast.success($t("settings.setup_flow.copied"));
+  }
 }
 
 function openLink(url: string) {

--- a/src/components/SetupFlowDialog.vue
+++ b/src/components/SetupFlowDialog.vue
@@ -92,10 +92,6 @@
           <div
             class="flex w-full flex-col items-center justify-center gap-4 py-3 text-center"
           >
-            <Button size="lg" @click="openExternal">
-              <ExternalLink :size="18" />
-              {{ $t("settings.setup_flow.open_external") }}
-            </Button>
             <div
               v-if="step.copy_text"
               class="flex w-full max-w-full items-center gap-2 rounded-md border px-3 py-2"
@@ -114,6 +110,10 @@
                 <Copy :size="16" />
               </Button>
             </div>
+            <Button size="lg" @click="openExternal">
+              <ExternalLink :size="18" />
+              {{ $t("settings.setup_flow.open_external") }}
+            </Button>
             <div
               v-if="externalHost"
               class="text-muted-foreground flex items-center gap-1.5 text-xs"

--- a/src/components/SetupFlowDialog.vue
+++ b/src/components/SetupFlowDialog.vue
@@ -98,12 +98,15 @@
             </Button>
             <div
               v-if="step.copy_text"
-              class="flex items-center gap-2 rounded-md border px-3 py-2"
+              class="flex w-full max-w-full items-center gap-2 rounded-md border px-3 py-2"
             >
-              <code class="font-mono text-sm">{{ step.copy_text }}</code>
+              <code class="min-w-0 flex-1 break-all font-mono text-sm">{{
+                step.copy_text
+              }}</code>
               <Button
                 variant="ghost"
                 size="icon"
+                class="shrink-0"
                 :aria-label="$t('copy')"
                 :title="$t('copy')"
                 @click="copyExternalText"

--- a/src/components/SetupFlowDialog.vue
+++ b/src/components/SetupFlowDialog.vue
@@ -107,8 +107,8 @@
                 variant="ghost"
                 size="icon"
                 class="shrink-0"
-                :aria-label="$t('copy')"
-                :title="$t('copy')"
+                :aria-label="$t('settings.setup_flow.copy')"
+                :title="$t('settings.setup_flow.copy')"
                 @click="copyExternalText"
               >
                 <Copy :size="16" />

--- a/src/components/SetupFlowDialog.vue
+++ b/src/components/SetupFlowDialog.vue
@@ -49,6 +49,26 @@
             <AlertDescription>{{ step.errors.base }}</AlertDescription>
           </Alert>
 
+          <div
+            v-if="step.copy_text"
+            class="mb-4 flex w-full max-w-full items-center gap-2 rounded-md border px-3 py-2"
+          >
+            <code class="min-w-0 flex-1 break-all font-mono text-sm">{{
+              step.copy_text
+            }}</code>
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon"
+              class="shrink-0"
+              :aria-label="$t('settings.setup_flow.copy')"
+              :title="$t('settings.setup_flow.copy')"
+              @click="copyExternalText"
+            >
+              <Copy :size="16" />
+            </Button>
+          </div>
+
           <form ref="formRef" @submit.prevent="submit">
             <div
               v-for="entry in visibleFormEntries"

--- a/src/components/SetupFlowDialog.vue
+++ b/src/components/SetupFlowDialog.vue
@@ -727,6 +727,8 @@ async function copyExternalText() {
   if (!copyText) return;
   if (await copyToClipboard(copyText)) {
     toast.success($t("settings.setup_flow.copied"));
+  } else {
+    toast.error($t("settings.setup_flow.copy_failed"));
   }
 }
 

--- a/src/plugins/api/interfaces.ts
+++ b/src/plugins/api/interfaces.ts
@@ -812,6 +812,8 @@ export interface SetupFlowStep {
   last_step?: boolean | null;
   // url [EXTERNAL]: url the user must open (e.g. an OAuth authorize url)
   url?: string | null;
+  // copy_text [EXTERNAL]: optional value the user can copy to the clipboard
+  copy_text?: string | null;
   // progress_text [PROGRESS]: localized status message
   progress_text?: string | null;
   // progress [PROGRESS]: optional completion fraction between 0 and 1

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -770,6 +770,7 @@
             "external_host": "Opens {0}",
             "session_ended_title": "Setup session ended",
             "session_ended_text": "The setup session ended — it may have completed. Check your providers or players to confirm.",
+            "copy": "Copy",
             "copy_success": "Copied to clipboard",
             "copy_failed": "Failed to copy to clipboard"
         },

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -770,7 +770,7 @@
             "external_host": "Opens {0}",
             "session_ended_title": "Setup session ended",
             "session_ended_text": "The setup session ended — it may have completed. Check your providers or players to confirm.",
-            "copied": "Copied to clipboard",
+            "copy_success": "Copied to clipboard",
             "copy_failed": "Failed to copy to clipboard"
         },
         "options": "Options",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -769,7 +769,9 @@
             "external_default_text": "A new browser window will open so you can sign in and authorize Music Assistant. Come back here once you're done — this dialog continues automatically.",
             "external_host": "Opens {0}",
             "session_ended_title": "Setup session ended",
-            "session_ended_text": "The setup session ended — it may have completed. Check your providers or players to confirm."
+            "session_ended_text": "The setup session ended — it may have completed. Check your providers or players to confirm.",
+            "copied": "Copied to clipboard",
+            "copy_failed": "Failed to copy to clipboard"
         },
         "options": "Options",
         "server_clock_offset": "Clock offset (server vs this device)",

--- a/tests/components/SetupFlowDialog.test.ts
+++ b/tests/components/SetupFlowDialog.test.ts
@@ -242,7 +242,9 @@ describe("SetupFlowDialog", () => {
     });
 
     await launchSetupFlow?.({ kind: "player", playerId: "player-1" });
-    await wrapper.get('[aria-label="copy"]').trigger("click");
+    await wrapper
+      .get('[aria-label="settings.setup_flow.copy"]')
+      .trigger("click");
 
     expect(copyToClipboardMock).toHaveBeenCalledExactlyOnceWith("123456");
     expect(toastMock.success).toHaveBeenCalledOnce();
@@ -259,7 +261,9 @@ describe("SetupFlowDialog", () => {
     });
 
     await launchSetupFlow?.({ kind: "player", playerId: "player-1" });
-    await wrapper.get('[aria-label="copy"]').trigger("click");
+    await wrapper
+      .get('[aria-label="settings.setup_flow.copy"]')
+      .trigger("click");
 
     expect(copyToClipboardMock).toHaveBeenCalledExactlyOnceWith("123456");
     expect(toastMock.error).toHaveBeenCalledExactlyOnceWith(

--- a/tests/components/SetupFlowDialog.test.ts
+++ b/tests/components/SetupFlowDialog.test.ts
@@ -248,6 +248,26 @@ describe("SetupFlowDialog", () => {
     expect(toastMock.success).toHaveBeenCalledOnce();
   });
 
+  it("shows an error toast when copying an external step's copy text fails", async () => {
+    copyToClipboardMock.mockResolvedValue(false);
+    apiMock.setupPlayer.mockResolvedValue({
+      ...terminalStep(FlowStepType.EXTERNAL),
+      copy_text: "123456",
+    });
+    const wrapper = shallowMount(SetupFlowDialog, {
+      global: { renderStubDefaultSlot: true },
+    });
+
+    await launchSetupFlow?.({ kind: "player", playerId: "player-1" });
+    await wrapper.get('[aria-label="copy"]').trigger("click");
+
+    expect(copyToClipboardMock).toHaveBeenCalledExactlyOnceWith("123456");
+    expect(toastMock.error).toHaveBeenCalledExactlyOnceWith(
+      "settings.setup_flow.copy_failed",
+    );
+    expect(toastMock.success).not.toHaveBeenCalled();
+  });
+
   it("closes without an abort when a flow finishes silently", async () => {
     apiMock.setupPlayer.mockResolvedValue({
       ...terminalStep(FlowStepType.FINISH),

--- a/tests/components/SetupFlowDialog.test.ts
+++ b/tests/components/SetupFlowDialog.test.ts
@@ -16,43 +16,50 @@ import type { MusicAssistantApi } from "@/plugins/api";
 import type { SetupFlowDialogEvent } from "@/plugins/eventbus";
 import SetupFlowDialog from "@/components/SetupFlowDialog.vue";
 
-const { apiMock, eventbusMock, routerMock, storeMock, toastMock } = vi.hoisted(
-  () => ({
-    apiMock: {
-      abortSetupFlow: vi.fn<MusicAssistantApi["abortSetupFlow"]>(),
-      players: {
-        "player-1": { name: "Living Room" },
+const {
+  apiMock,
+  copyToClipboardMock,
+  eventbusMock,
+  routerMock,
+  storeMock,
+  toastMock,
+} = vi.hoisted(() => ({
+  apiMock: {
+    abortSetupFlow: vi.fn<MusicAssistantApi["abortSetupFlow"]>(),
+    players: {
+      "player-1": { name: "Living Room" },
+    },
+    providerManifests: {},
+    providers: {
+      "spotify--test": {
+        domain: "spotify",
+        name: "Spotify",
       },
-      providerManifests: {},
-      providers: {
-        "spotify--test": {
-          domain: "spotify",
-          name: "Spotify",
-        },
-      },
-      reconfigureProvider: vi.fn<MusicAssistantApi["reconfigureProvider"]>(),
-      setupPlayer: vi.fn<MusicAssistantApi["setupPlayer"]>(),
-      state: {
-        value: "authenticated",
-      },
-      submitSetupFlow: vi.fn<MusicAssistantApi["submitSetupFlow"]>(),
-      subscribeSetupFlow: vi.fn<MusicAssistantApi["subscribeSetupFlow"]>(),
     },
-    eventbusMock: {
-      off: vi.fn(),
-      on: vi.fn(),
+    reconfigureProvider: vi.fn<MusicAssistantApi["reconfigureProvider"]>(),
+    setupPlayer: vi.fn<MusicAssistantApi["setupPlayer"]>(),
+    state: {
+      value: "authenticated",
     },
-    routerMock: {
-      push: vi.fn(),
-    },
-    storeMock: {
-      dialogActive: false,
-    },
-    toastMock: {
-      error: vi.fn(),
-    },
-  }),
-);
+    submitSetupFlow: vi.fn<MusicAssistantApi["submitSetupFlow"]>(),
+    subscribeSetupFlow: vi.fn<MusicAssistantApi["subscribeSetupFlow"]>(),
+  },
+  copyToClipboardMock: vi.fn(),
+  eventbusMock: {
+    off: vi.fn(),
+    on: vi.fn(),
+  },
+  routerMock: {
+    push: vi.fn(),
+  },
+  storeMock: {
+    dialogActive: false,
+  },
+  toastMock: {
+    error: vi.fn(),
+    success: vi.fn(),
+  },
+}));
 
 let launchSetupFlow:
   | ((event: SetupFlowDialogEvent) => Promise<void>)
@@ -76,6 +83,10 @@ vi.mock("@/plugins/i18n", () => ({
 
 vi.mock("@/plugins/store", () => ({
   store: storeMock,
+}));
+
+vi.mock("@/helpers/utils", () => ({
+  copyToClipboard: copyToClipboardMock,
 }));
 
 vi.mock("@/views/settings/ConfigEntryRow.vue", () => ({
@@ -218,6 +229,23 @@ describe("SetupFlowDialog", () => {
         .find("dialog-description-stub")
         .exists(),
     ).toBe(false);
+  });
+
+  it("copies an external step's copy text", async () => {
+    copyToClipboardMock.mockResolvedValue(true);
+    apiMock.setupPlayer.mockResolvedValue({
+      ...terminalStep(FlowStepType.EXTERNAL),
+      copy_text: "123456",
+    });
+    const wrapper = shallowMount(SetupFlowDialog, {
+      global: { renderStubDefaultSlot: true },
+    });
+
+    await launchSetupFlow?.({ kind: "player", playerId: "player-1" });
+    await wrapper.get('[aria-label="copy"]').trigger("click");
+
+    expect(copyToClipboardMock).toHaveBeenCalledExactlyOnceWith("123456");
+    expect(toastMock.success).toHaveBeenCalledOnce();
   });
 
   it("closes without an abort when a flow finishes silently", async () => {

--- a/tests/components/SetupFlowDialog.test.ts
+++ b/tests/components/SetupFlowDialog.test.ts
@@ -250,6 +250,28 @@ describe("SetupFlowDialog", () => {
     expect(toastMock.success).toHaveBeenCalledOnce();
   });
 
+  it("copies a form step's copy text", async () => {
+    copyToClipboardMock.mockResolvedValue(true);
+    apiMock.setupPlayer.mockResolvedValue({
+      ...terminalStep(FlowStepType.FORM),
+      copy_text: "https://example.com/auth",
+      entries: [],
+    });
+    const wrapper = shallowMount(SetupFlowDialog, {
+      global: { renderStubDefaultSlot: true },
+    });
+
+    await launchSetupFlow?.({ kind: "player", playerId: "player-1" });
+    await wrapper
+      .get('[aria-label="settings.setup_flow.copy"]')
+      .trigger("click");
+
+    expect(copyToClipboardMock).toHaveBeenCalledExactlyOnceWith(
+      "https://example.com/auth",
+    );
+    expect(toastMock.success).toHaveBeenCalledOnce();
+  });
+
   it("shows an error toast when copying an external step's copy text fails", async () => {
     copyToClipboardMock.mockResolvedValue(false);
     apiMock.setupPlayer.mockResolvedValue({


### PR DESCRIPTION
# What does this implement/fix?

Adds a copyable text button in a setup flow. This is for convenience of copying setup codes.

<img width="548" height="431" alt="image" src="https://github.com/user-attachments/assets/5c8238fe-3af3-4f19-a891-b6811144e495" />


- related issue `<link to issue>`

https://github.com/music-assistant/models/pull/395
https://github.com/music-assistant/server/pull/6268

## Types of changes

<!--
Tick exactly one box below. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [x] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm lint:check` passes.
- [x] `pnpm test:run` passes, and tests have been added/updated where applicable.
- [x] `pnpm build` passes.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
