### PR TITLE
Disable autoplay controls while repeat is on

### DIFF
--- a/src/layouts/default/PlayerOSD/AutoplayRepeatLockButton.vue
+++ b/src/layouts/default/PlayerOSD/AutoplayRepeatLockButton.vue
@@ -1,0 +1,40 @@
+<template>
+  <TooltipProvider :delay-duration="200">
+    <Tooltip v-model:open="open">
+      <TooltipTrigger as-child>
+        <button
+          type="button"
+          v-bind="$attrs"
+          class="relative inline-flex items-center justify-center outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]"
+          :aria-describedby="descriptionId"
+          @click.stop.prevent="open = true"
+        >
+          <slot></slot>
+        </button>
+      </TooltipTrigger>
+      <TooltipContent side="bottom" class="z-[10001] max-w-[240px]">
+        {{ description }}
+      </TooltipContent>
+    </Tooltip>
+  </TooltipProvider>
+  <span :id="descriptionId" class="sr-only">{{ description }}</span>
+</template>
+
+<script setup lang="ts">
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { useId, ref } from "vue";
+
+defineOptions({ inheritAttrs: false });
+
+defineProps<{
+  description: string;
+}>();
+
+const open = ref(false);
+const descriptionId = useId();
+</script>

--- a/src/layouts/default/PlayerOSD/PlayerFullscreenHeaderControls.vue
+++ b/src/layouts/default/PlayerOSD/PlayerFullscreenHeaderControls.vue
@@ -82,7 +82,29 @@
 
     <!-- autoplay: direct toggle (primary while enabled). Hidden while dynamic
          mode is active or for infinite streams (autoplay is moot there). -->
-    <TooltipProvider v-if="autoplayApplicable && queue" :delay-duration="200">
+    <AutoplayRepeatLockButton
+      v-if="autoplayApplicable && queue && repeatLocked"
+      :aria-label="$t('autoplay')"
+      aria-checked="false"
+      aria-disabled="true"
+      role="switch"
+      :class="[
+        pillClass,
+        buttonVariants({
+          variant: 'ghost-outline',
+          size: showLabel ? 'xs' : 'icon-xs',
+        }),
+        'text-muted-foreground opacity-70 cursor-help',
+      ]"
+      :description="$t('autoplay_repeat_disabled')"
+    >
+      <AutoplayIcon :size="16" />
+      <span v-if="showLabel">{{ $t("autoplay") }}</span>
+    </AutoplayRepeatLockButton>
+    <TooltipProvider
+      v-else-if="autoplayApplicable && queue"
+      :delay-duration="200"
+    >
       <Tooltip>
         <TooltipTrigger as-child>
           <Button
@@ -169,7 +191,7 @@
 import QualityDetailsBtn from "@/components/QualityDetailsBtn.vue";
 import ShowDashboardButton from "@/components/ShowDashboardButton.vue";
 import SleepTimerBtn from "@/layouts/default/PlayerOSD/PlayerControlBtn/SleepTimerBtn.vue";
-import { Button } from "@/components/ui/button";
+import { Button, buttonVariants } from "@/components/ui/button";
 import {
   Tooltip,
   TooltipContent,
@@ -178,6 +200,7 @@ import {
 } from "@/components/ui/tooltip";
 import AutoplayIcon from "@/layouts/default/PlayerOSD/PlayerControlBtn/AutoplayIcon.vue";
 import CrossfadeIcon from "@/layouts/default/PlayerOSD/PlayerControlBtn/CrossfadeIcon.vue";
+import AutoplayRepeatLockButton from "@/layouts/default/PlayerOSD/AutoplayRepeatLockButton.vue";
 import { useQueueModes } from "@/layouts/default/PlayerOSD/useQueueModes";
 import { useActiveAudioPath } from "@/composables/useActiveAudioPath";
 import { useAudioOverlay } from "@/composables/useAudioOverlay";
@@ -214,6 +237,7 @@ const {
   sources,
   dynamicModeActive,
   autoplayEnabled,
+  repeatLocked,
   autoplayApplicable,
   setAutoplay,
 } = useQueueModes();

--- a/src/layouts/default/PlayerOSD/QueueModeBanner.vue
+++ b/src/layouts/default/PlayerOSD/QueueModeBanner.vue
@@ -152,15 +152,21 @@ const mode = computed<"dynamic" | "autoplay" | null>(() => {
   return null;
 });
 
+// Effective autoplay state: the repeat lock always presents autoplay as off,
+// even if a (older) server still reports the saved preference as enabled.
+const effectiveAutoplay = computed(
+  () => autoplayEnabled.value && !repeatLocked.value,
+);
+
 // Active (primary-tinted) vs muted appearance.
 const active = computed(
-  () => mode.value === "dynamic" || autoplayEnabled.value,
+  () => mode.value === "dynamic" || effectiveAutoplay.value,
 );
 
 const title = computed(() => {
   if (mode.value === "dynamic") return $t("autoplay_dynamic_title");
   if (mode.value === "autoplay")
-    return autoplayEnabled.value
+    return effectiveAutoplay.value
       ? $t("autoplay_on_title")
       : $t("autoplay_off_title");
   return "";

--- a/src/layouts/default/PlayerOSD/QueueModeBanner.vue
+++ b/src/layouts/default/PlayerOSD/QueueModeBanner.vue
@@ -54,7 +54,7 @@
     </div>
 
     <Switch
-      v-if="mode === 'autoplay'"
+      v-if="mode === 'autoplay' && !repeatLocked"
       :model-value="autoplayEnabled"
       class="queue-mode-banner__switch"
       :aria-label="
@@ -62,6 +62,25 @@
       "
       @update:model-value="setAutoplay"
     />
+
+    <AutoplayRepeatLockButton
+      v-else-if="mode === 'autoplay'"
+      :aria-label="$t('autoplay')"
+      aria-checked="false"
+      aria-disabled="true"
+      role="switch"
+      class="queue-mode-banner__switch cursor-help opacity-50"
+      :description="$t('autoplay_repeat_disabled')"
+    >
+      <Switch
+        as="span"
+        :model-value="false"
+        disabled
+        aria-hidden="true"
+        tabindex="-1"
+        class="pointer-events-none"
+      />
+    </AutoplayRepeatLockButton>
 
     <TooltipProvider :delay-duration="200">
       <Tooltip>
@@ -96,6 +115,7 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
+import AutoplayRepeatLockButton from "@/layouts/default/PlayerOSD/AutoplayRepeatLockButton.vue";
 import { useUserPreferences } from "@/composables/userPreferences";
 import { useQueueModes } from "@/layouts/default/PlayerOSD/useQueueModes";
 import type { ItemMapping } from "@/plugins/api/interfaces";
@@ -112,6 +132,7 @@ const {
   sources,
   dynamicModeActive,
   autoplayEnabled,
+  repeatLocked,
   autoplayApplicable,
   setAutoplay,
 } = useQueueModes();
@@ -152,6 +173,7 @@ const description = computed(() => {
   // fallback line shown only when there are no named sources.
   if (mode.value === "dynamic") return $t("autoplay_dynamic_desc");
   if (mode.value === "autoplay") {
+    if (repeatLocked.value) return $t("autoplay_repeat_disabled");
     if (autoplayEnabled.value)
       return seedNames.value
         ? $t("autoplay_on_desc_sources", [seedNames.value])

--- a/src/layouts/default/PlayerOSD/useQueueModes.ts
+++ b/src/layouts/default/PlayerOSD/useQueueModes.ts
@@ -6,6 +6,7 @@
 // duplicated per component.
 import api from "@/plugins/api";
 import { isQueueInfiniteStream } from "@/plugins/api/helpers";
+import { RepeatMode } from "@/plugins/api/interfaces";
 import type { ItemMapping } from "@/plugins/api/interfaces";
 import { store } from "@/plugins/store";
 import { computed } from "vue";
@@ -25,6 +26,13 @@ export function useQueueModes() {
     () => queue.value?.autoplay_enabled === true,
   );
 
+  // Repeat one/all temporarily suppresses autoplay without changing the saved
+  // preference the server keeps for the queue.
+  const repeatLocked = computed(() => {
+    const repeatMode = queue.value?.repeat_mode;
+    return repeatMode === RepeatMode.ONE || repeatMode === RepeatMode.ALL;
+  });
+
   // Autoplay only applies to an active queue playing regular tracks, and is
   // moot while dynamic mode is active (the queue already refills itself) or for
   // infinite streams.
@@ -39,6 +47,7 @@ export function useQueueModes() {
   const setAutoplay = (enabled: boolean) => {
     const q = queue.value;
     if (!q) return;
+    if (enabled && repeatLocked.value) return;
     api.queueCommandAutoplay(q.queue_id, enabled);
   };
 
@@ -47,6 +56,7 @@ export function useQueueModes() {
     sources,
     dynamicModeActive,
     autoplayEnabled,
+    repeatLocked,
     autoplayApplicable,
     setAutoplay,
   };

--- a/src/layouts/default/PlayerOSD/useQueueModes.ts
+++ b/src/layouts/default/PlayerOSD/useQueueModes.ts
@@ -27,8 +27,11 @@ export function useQueueModes() {
   );
 
   // Repeat one/all temporarily suppresses autoplay without changing the saved
-  // preference the server keeps for the queue.
+  // preference the server keeps for the queue. Older servers keep autoplay
+  // running during repeat, so the lock UI only shows when the server actually
+  // enforces it.
   const repeatLocked = computed(() => {
+    if (!api.supportsRepeatAutoplayLock) return false;
     const repeatMode = queue.value?.repeat_mode;
     return repeatMode === RepeatMode.ONE || repeatMode === RepeatMode.ALL;
   });

--- a/src/plugins/api/index.ts
+++ b/src/plugins/api/index.ts
@@ -87,6 +87,9 @@ const PLAY_MEDIA_SHUFFLE_SCHEMA_VERSION = 51;
 // The player_id argument on music/browse landed in API schema 61.
 const BROWSE_PLAYER_ID_SCHEMA_VERSION = 61;
 
+// Repeat one/all masking the effective autoplay flag landed in API schema 69.
+const REPEAT_AUTOPLAY_LOCK_SCHEMA_VERSION = 69;
+
 export interface CommandOptions {
   /**
    * Skip the global console.error + error toast for an error result. Use for a
@@ -2993,6 +2996,14 @@ export class MusicAssistantApi {
     return (
       (this.serverInfo.value?.schema_version ?? 0) >=
       PLAY_MEDIA_SHUFFLE_SCHEMA_VERSION
+    );
+  }
+
+  /** Whether the connected server masks autoplay while repeat one/all is on (schema >= 69). */
+  public get supportsRepeatAutoplayLock(): boolean {
+    return (
+      (this.serverInfo.value?.schema_version ?? 0) >=
+      REPEAT_AUTOPLAY_LOCK_SCHEMA_VERSION
     );
   }
 

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -2250,6 +2250,7 @@
     "autoplay_disable": "Disable Autoplay",
     "autoplay": "Autoplay",
     "autoplay_explanation": "When your queue runs out, additional tracks are added automatically so the music will not stop.",
+    "autoplay_repeat_disabled": "Autoplay has been automatically turned off because repeat is on",
     "autoplay_active": "Autoplay is on.",
     "genre_content_type": {
         "all": "All",

--- a/tests/layouts/AutoplayRepeatLockButton.test.ts
+++ b/tests/layouts/AutoplayRepeatLockButton.test.ts
@@ -1,0 +1,58 @@
+import AutoplayRepeatLockButton from "@/layouts/default/PlayerOSD/AutoplayRepeatLockButton.vue";
+import { enableAutoUnmount, mount } from "@vue/test-utils";
+import { afterEach, describe, expect, it } from "vitest";
+import { nextTick } from "vue";
+
+enableAutoUnmount(afterEach);
+
+const DESCRIPTION =
+  "Autoplay has been automatically turned off because repeat is on";
+
+// The component carries its own TooltipProvider, so it mounts standalone. The
+// tooltip content portals to document.body, so assertions query the document.
+function mountButton() {
+  return mount(AutoplayRepeatLockButton, {
+    props: { description: DESCRIPTION },
+    slots: { default: "<span>icon</span>" },
+    attrs: { "aria-label": "Autoplay", role: "switch" },
+    attachTo: document.body,
+  });
+}
+
+function tooltipContent(): Element | null {
+  return document.querySelector('[data-slot="tooltip-content"]');
+}
+
+describe("AutoplayRepeatLockButton", () => {
+  it("associates the explanation with the trigger for screen readers", () => {
+    const button = mountButton().get("button");
+
+    const describedBy = button.attributes("aria-describedby");
+    expect(describedBy).toBeTruthy();
+    const description = document.getElementById(describedBy!);
+    expect(description?.textContent).toBe(DESCRIPTION);
+
+    // the wiring the parents rely on falls through onto the trigger
+    expect(button.attributes("aria-label")).toBe("Autoplay");
+    expect(button.attributes("role")).toBe("switch");
+  });
+
+  it("opens the explanation on click (tap)", async () => {
+    const wrapper = mountButton();
+    expect(tooltipContent()).toBeNull();
+
+    await wrapper.get("button").trigger("click");
+    await nextTick();
+
+    expect(tooltipContent()?.textContent).toContain(DESCRIPTION);
+  });
+
+  it("opens the explanation on keyboard focus", async () => {
+    const wrapper = mountButton();
+
+    await wrapper.get("button").trigger("focus");
+    await nextTick();
+
+    expect(tooltipContent()?.textContent).toContain(DESCRIPTION);
+  });
+});

--- a/tests/layouts/PlayerFullscreenHeaderControls.test.ts
+++ b/tests/layouts/PlayerFullscreenHeaderControls.test.ts
@@ -1,4 +1,5 @@
 import PlayerFullscreenHeaderControls from "@/layouts/default/PlayerOSD/PlayerFullscreenHeaderControls.vue";
+import AutoplayRepeatLockButton from "@/layouts/default/PlayerOSD/AutoplayRepeatLockButton.vue";
 import CrossfadeIcon from "@/layouts/default/PlayerOSD/PlayerControlBtn/CrossfadeIcon.vue";
 import QualityDetailsBtn from "@/components/QualityDetailsBtn.vue";
 import { CrossfadeMode, type PlayerQueue } from "@/plugins/api/interfaces";
@@ -6,10 +7,13 @@ import { shallowMount } from "@vue/test-utils";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { ref } from "vue";
 
-// Only what the crossfade control reads is mocked; the rest of the header is
-// stubbed out by shallowMount.
+// Only what the crossfade and autoplay controls read is mocked; the rest of
+// the header is stubbed out by shallowMount.
 const queue = ref<Partial<PlayerQueue> | undefined>(undefined);
 const hasActiveAudioPath = ref(false);
+const autoplayApplicable = ref(false);
+const repeatLocked = ref(false);
+const setAutoplay = vi.fn();
 
 vi.mock("@/plugins/api", () => ({
   default: {
@@ -31,8 +35,9 @@ vi.mock("@/layouts/default/PlayerOSD/useQueueModes", () => ({
     sources: ref([]),
     dynamicModeActive: ref(false),
     autoplayEnabled: ref(false),
-    autoplayApplicable: ref(false),
-    setAutoplay: vi.fn(),
+    autoplayApplicable,
+    repeatLocked,
+    setAutoplay,
   }),
 }));
 
@@ -71,10 +76,21 @@ function seedQueue(crossfadeMode: CrossfadeMode): void {
   } as unknown as Partial<PlayerQueue>;
 }
 
+// The autoplay toggle and the crossfade toggle share the Button stub, so the
+// autoplay one is picked out by its accessible name.
+function findAutoplayToggle(wrapper: ReturnType<typeof mountControls>) {
+  return wrapper
+    .findAll("button")
+    .find((button) => button.attributes("aria-label") === "Autoplay");
+}
+
 describe("PlayerFullscreenHeaderControls", () => {
   beforeEach(() => {
     queue.value = undefined;
     hasActiveAudioPath.value = false;
+    autoplayApplicable.value = false;
+    repeatLocked.value = false;
+    setAutoplay.mockClear();
   });
 
   it("does not animate a fade the source applied", () => {
@@ -126,5 +142,38 @@ describe("PlayerFullscreenHeaderControls", () => {
     expect(mountControls().findComponent(QualityDetailsBtn).exists()).toBe(
       false,
     );
+  });
+
+  it("replaces the autoplay toggle with the repeat-lock explanation while repeat is on", () => {
+    seedQueue(CrossfadeMode.SOURCE);
+    autoplayApplicable.value = true;
+    repeatLocked.value = true;
+
+    const wrapper = mountControls();
+    const lock = wrapper.findComponent(AutoplayRepeatLockButton);
+
+    expect(lock.exists()).toBe(true);
+    expect(lock.props("description")).toBe(
+      "Autoplay has been automatically turned off because repeat is on",
+    );
+    expect(findAutoplayToggle(wrapper)).toBeUndefined();
+    expect(setAutoplay).not.toHaveBeenCalled();
+  });
+
+  it("keeps the direct autoplay toggle while repeat is off", async () => {
+    seedQueue(CrossfadeMode.SOURCE);
+    autoplayApplicable.value = true;
+
+    const wrapper = mountControls();
+    const toggle = findAutoplayToggle(wrapper);
+
+    expect(wrapper.findComponent(AutoplayRepeatLockButton).exists()).toBe(
+      false,
+    );
+    expect(toggle).toBeDefined();
+
+    await toggle!.trigger("click");
+
+    expect(setAutoplay).toHaveBeenCalledExactlyOnceWith(true);
   });
 });


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes. -->

Show autoplay as off and unavailable while Repeat One or Repeat All is active, with an explanation on hover, focus or tap. Restore the normal controls when repeat is turned off.

![Autoplay controls disabled while repeat is on](https://github.com/user-attachments/assets/5295eaed-107e-450a-927c-9146f63bb589)

**Related issue (if applicable):**

- related issue https://github.com/music-assistant/support/issues/6367

**Related backend PR (if applicable):**

<!--
Link the music-assistant/server PR when this change relies on new server
behaviour, so the two can be reviewed and released together.
-->

- related backend PR https://github.com/music-assistant/server/pull/6250

## Types of changes

<!--
Tick exactly one box below. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [ ] `pnpm lint:check` passes.
- [ ] `pnpm test:run` passes, and tests have been added/updated where applicable.
- [ ] `pnpm build` passes.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
