### PR TITLE
Show radio stream artwork in the Party dashboard

### DIFF
--- a/src/helpers/utils.test.ts
+++ b/src/helpers/utils.test.ts
@@ -4,7 +4,7 @@ import type {
   MediaItemType,
   QueueItem,
 } from "@/plugins/api/interfaces";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 // `getProvider` decides whether an image is considered fetchable: an
 // unloaded/disabled provider is absent from the map entirely. `schema_version`
@@ -37,6 +37,8 @@ const albumWith = (images: MediaItemImage[]) =>
   ({ name: "Black to the Blind", metadata: { images } }) as MediaItemType;
 
 describe("getMediaItemImage", () => {
+  afterEach(() => vi.restoreAllMocks());
+
   it("keeps a remote image whose provider is no longer loaded", () => {
     // artwork written by a metadata provider that has since been disabled: the
     // url is self-contained, so the server can still resolve and resize it
@@ -80,6 +82,26 @@ describe("getMediaItemImage", () => {
       provider: "builtin",
       remotely_accessible: true,
     });
+  });
+
+  it("keeps the station's image when the live artwork cannot be loaded", () => {
+    // an http url is blocked as mixed content on an https page, and the proxy
+    // has no route for a url it never issued an id for, so the station's own
+    // image beats live artwork that would only render broken
+    vi.spyOn(window.location, "protocol", "get").mockReturnValue("https:");
+    const stationImage = image(
+      "theaudiodb",
+      true,
+      "https://station.example/a.jpg",
+    );
+    const queueItem = {
+      media_item: albumWith([stationImage]),
+      streamdetails: {
+        stream_metadata: { image_url: "http://stream.example/cover.jpg" },
+      },
+    } as unknown as QueueItem;
+
+    expect(getMediaItemImage(queueItem)).toEqual(stationImage);
   });
 });
 

--- a/src/helpers/utils.test.ts
+++ b/src/helpers/utils.test.ts
@@ -1,19 +1,25 @@
 import { ImageType } from "@/plugins/api/interfaces";
-import type { MediaItemImage, MediaItemType } from "@/plugins/api/interfaces";
+import type {
+  MediaItemImage,
+  MediaItemType,
+  QueueItem,
+} from "@/plugins/api/interfaces";
 import { describe, expect, it, vi } from "vitest";
 
-// only `getProvider` matters here: it decides whether an image is considered
-// fetchable. An unloaded/disabled provider is absent from the map entirely.
+// `getProvider` decides whether an image is considered fetchable: an
+// unloaded/disabled provider is absent from the map entirely. `schema_version`
+// picks the imageproxy dialect, 31 and up serve the opaque id form only.
 vi.mock("@/plugins/api", () => ({
   api: {
     baseUrl: "http://server",
     providers: {},
+    serverInfo: { value: { schema_version: 31 } },
     getProvider: (id: string) =>
       id === "filesystem--loaded" ? { available: true } : undefined,
   },
 }));
 
-const { getMediaItemImage } = await import("./utils");
+const { getMediaItemImage, getMediaItemImageUrl } = await import("./utils");
 
 const image = (
   provider: string,
@@ -56,5 +62,42 @@ describe("getMediaItemImage", () => {
     const img = image("theaudiodb", true, "https://r2.theaudiodb.com/a.jpg");
     const summaryItem = { name: "Berserker", image: img } as MediaItemType;
     expect(getMediaItemImage(summaryItem)).toEqual(img);
+  });
+
+  it("prefers a radio stream's live artwork over the station's own image", () => {
+    // a station's own image is generic, while it plays, the live ICY/stream
+    // metadata carries the artwork for the track actually on air
+    const queueItem = {
+      media_item: albumWith([image("theaudiodb", true, "station.jpg")]),
+      streamdetails: {
+        stream_metadata: { image_url: "https://stream.example/cover.jpg" },
+      },
+    } as unknown as QueueItem;
+
+    expect(getMediaItemImage(queueItem)).toEqual({
+      type: ImageType.THUMB,
+      path: "https://stream.example/cover.jpg",
+      provider: "builtin",
+      remotely_accessible: true,
+    });
+  });
+});
+
+describe("getMediaItemImageUrl", () => {
+  it("addresses an image that has a proxy_id by its opaque id", () => {
+    const img = { ...image("filesystem--loaded", false), proxy_id: "abc123" };
+    expect(getMediaItemImageUrl(img, 256)).toBe(
+      "http://server/imageproxy/abc123?size=256",
+    );
+  });
+
+  it("falls back to the url itself for an image with no proxy_id", () => {
+    // a server that issues opaque ids refuses the legacy path-based form, so
+    // the proxy is no route for an image it never handed an id to, as with
+    // one built from a radio stream's live metadata
+    const img = image("builtin", true, "https://stream.example/cover.jpg");
+    expect(getMediaItemImageUrl(img, 256)).toBe(
+      "https://stream.example/cover.jpg",
+    );
   });
 });

--- a/src/helpers/utils.ts
+++ b/src/helpers/utils.ts
@@ -305,6 +305,9 @@ const normalizeImageProxySize = function (size?: number): number {
  * - If URL is HTTP but frontend is served over HTTPS, proxy through imageproxy
  * - If URL is already an imageproxy URL from another host, transform to use our baseUrl
  * - Otherwise return the URL as-is
+ *
+ * Returns an empty string when there is no url the browser can load, so callers
+ * can fall back to another image instead of rendering a broken one.
  */
 export const getMediaImageUrl = function (
   imageUrl: string | null | undefined,
@@ -343,8 +346,8 @@ export const getMediaImageUrl = function (
 
   if (urlProtocol === "http" && pageProtocol === "https") {
     // Proxy through imageproxy to avoid mixed content issues. The opaque-id
-    // form requires a server-issued proxy_id which we don't have here, so
-    // fall back to the legacy query-string form (still supported).
+    // form requires a server-issued proxy_id which we don't have here
+    if (serverSupportsOpaqueImageProxy()) return "";
     const encUrl = encodeURIComponent(encodeURIComponent(imageUrl));
     return `${api.baseUrl}/imageproxy?path=${encUrl}`;
   }
@@ -390,10 +393,11 @@ export const getMediaItemImage = function (
   // handle QueueItem
   if ("media_item" in mediaItem && mediaItem.media_item) {
     // prefer image_url provided in queueItem's streamdetails
-    if (mediaItem.streamdetails?.stream_metadata?.image_url)
+    const liveImageUrl = mediaItem.streamdetails?.stream_metadata?.image_url;
+    if (liveImageUrl && getMediaImageUrl(liveImageUrl))
       return {
         type: ImageType.THUMB,
-        path: mediaItem.streamdetails.stream_metadata.image_url,
+        path: liveImageUrl,
         provider: "builtin",
         remotely_accessible: true,
       };
@@ -456,21 +460,18 @@ export const getMediaItemImageUrl = function (
     // force imageproxy if image is not remotely accessible or we need a resized thumb
     // Note that we play it safe here and always enforce the proxy if the schema is different
     const normalizedSize = normalizeImageProxySize(size);
-    if (img.proxy_id && serverSupportsOpaqueImageProxy()) {
-      // canonical /imageproxy/<proxy_id>?size= form
-      const params = new URLSearchParams();
-      if (normalizedSize) params.set("size", String(normalizedSize));
-      const qs = params.toString();
-      return qs
-        ? `${api.baseUrl}/imageproxy/${img.proxy_id}?${qs}`
-        : `${api.baseUrl}/imageproxy/${img.proxy_id}`;
+    if (serverSupportsOpaqueImageProxy()) {
+      if (img.proxy_id) {
+        const params = new URLSearchParams();
+        if (normalizedSize) params.set("size", String(normalizedSize));
+        const qs = params.toString();
+        return qs
+          ? `${api.baseUrl}/imageproxy/${img.proxy_id}?${qs}`
+          : `${api.baseUrl}/imageproxy/${img.proxy_id}`;
+      }
+      return img.remotely_accessible ? getMediaImageUrl(img.path) : "";
     }
-    // Schema 31+ servers reject the legacy ?path= form with a 400, so an image
-    // with no proxy_id can only load from its own url, unresized.
-    if (serverSupportsOpaqueImageProxy() && img.remotely_accessible) {
-      return getMediaImageUrl(img.path);
-    }
-    // legacy form, for servers on schema < 31 or images without a proxy_id
+    // legacy form, for servers on schema < 31
     const encUrl = encodeURIComponent(encodeURIComponent(img.path));
     const imageUrl = `${api.baseUrl}/imageproxy?path=${encUrl}&provider=${img.provider}`;
     if (normalizedSize) return imageUrl + `&size=${normalizedSize}`;

--- a/src/helpers/utils.ts
+++ b/src/helpers/utils.ts
@@ -390,10 +390,7 @@ export const getMediaItemImage = function (
   // handle QueueItem
   if ("media_item" in mediaItem && mediaItem.media_item) {
     // prefer image_url provided in queueItem's streamdetails
-    if (
-      "streamdetails" in mediaItem.media_item &&
-      mediaItem.streamdetails?.stream_metadata?.image_url
-    )
+    if (mediaItem.streamdetails?.stream_metadata?.image_url)
       return {
         type: ImageType.THUMB,
         path: mediaItem.streamdetails.stream_metadata.image_url,
@@ -467,6 +464,11 @@ export const getMediaItemImageUrl = function (
       return qs
         ? `${api.baseUrl}/imageproxy/${img.proxy_id}?${qs}`
         : `${api.baseUrl}/imageproxy/${img.proxy_id}`;
+    }
+    // Schema 31+ servers reject the legacy ?path= form with a 400, so an image
+    // with no proxy_id can only load from its own url, unresized.
+    if (serverSupportsOpaqueImageProxy() && img.remotely_accessible) {
+      return getMediaImageUrl(img.path);
     }
     // legacy form, for servers on schema < 31 or images without a proxy_id
     const encUrl = encodeURIComponent(encodeURIComponent(img.path));

--- a/src/views/PartyDashboardView.vue
+++ b/src/views/PartyDashboardView.vue
@@ -344,6 +344,7 @@ import { usePartyConfig } from "@/composables/usePartyConfig";
 import { useVisualizer } from "@/composables/visualizer/useVisualizer";
 import {
   ImageColorPalette,
+  getMediaItemImage,
   getMediaItemImageUrl,
   paletteFromServer,
 } from "@/helpers/utils";
@@ -700,10 +701,12 @@ const fetchQueueItems = async (force = false) => {
   }
 };
 
-// Album art URL for the blurred background element
+// Album art URL for the blurred background element. Resolved the same way as
+// the track cards, so a radio stream blurs its live artwork rather than the
+// station logo sitting on the queue item.
 const albumArtUrl = computed(() => {
-  if (!store.curQueueItem?.image) return "";
-  return getMediaItemImageUrl(store.curQueueItem.image) || "";
+  const img = getMediaItemImage(store.curQueueItem);
+  return img ? getMediaItemImageUrl(img) || "" : "";
 });
 
 // Gradient background style (used when album art is disabled, or as fallback)

--- a/tests/views/PartyDashboardView.test.ts
+++ b/tests/views/PartyDashboardView.test.ts
@@ -1,5 +1,5 @@
 import api from "@/plugins/api";
-import { EventType, PlaybackState } from "@/plugins/api/interfaces";
+import { EventType, ImageType, PlaybackState } from "@/plugins/api/interfaces";
 import { store } from "@/plugins/store";
 import PartyDashboardView from "@/views/PartyDashboardView.vue";
 import { type VueWrapper, flushPromises, mount } from "@vue/test-utils";
@@ -42,18 +42,23 @@ const events = vi.hoisted(() => {
   };
 });
 
-vi.mock("@/plugins/api", () => ({
-  default: {
+vi.mock("@/plugins/api", () => {
+  const api = {
     baseUrl: "",
     players: {},
     providers: {},
     queues: {},
+    // schema 31 and up address images by opaque id, which decides how the
+    // background's artwork url gets built
+    serverInfo: { value: { schema_version: 31 } },
     sendCommand: vi.fn().mockResolvedValue(null),
     subscribe: vi.fn(events.subscribe),
     getPlayerQueueItems: vi.fn().mockResolvedValue([]),
     getTrackLyrics: vi.fn().mockResolvedValue([null, null]),
-  },
-}));
+  };
+  // the view imports the default export, @/helpers/utils the named one
+  return { default: api, api };
+});
 
 // Pulled in transitively via @/helpers/utils; mocked so their module-load side effects (AuthManager reading localStorage) don't leak into this test.
 vi.mock("@/plugins/router", () => ({ default: {} }));
@@ -75,17 +80,20 @@ vi.mock("@/composables/usePartyConfig", () => ({
   }),
 }));
 
-vi.mock("@/composables/visualizer/useVisualizer", () => ({
-  useVisualizer: () => ({
-    visualizerEnabledPref: { value: false },
-    visualizerPresetPref: { value: "" },
-    visualizerBlurPref: { value: 0 },
-    visualizerOpacityPref: { value: 1 },
-    visualizerAvailable: { value: false },
-    visualizerActive: { value: false },
-    toggleVisualizer: vi.fn(),
-  }),
-}));
+vi.mock("@/composables/visualizer/useVisualizer", async () => {
+  const { ref } = await vi.importActual<typeof import("vue")>("vue");
+  return {
+    useVisualizer: () => ({
+      visualizerEnabledPref: ref(false),
+      visualizerPresetPref: ref(""),
+      visualizerBlurPref: ref(0),
+      visualizerOpacityPref: ref(1),
+      visualizerAvailable: ref(false),
+      visualizerActive: ref(false),
+      toggleVisualizer: vi.fn(),
+    }),
+  };
+});
 
 vi.mock("@/composables/lyrics/useLyricsElapsedTime", () => ({
   useLyricsElapsedTime: () => ({ elapsedTime: { value: 0 } }),
@@ -471,5 +479,38 @@ describe("PartyDashboardView active player", () => {
     await flushPromises();
 
     expect(store.activePlayerId).toBe("the_users_own_pick");
+  });
+});
+
+describe("PartyDashboardView background artwork", () => {
+  afterEach(() => {
+    wrapper?.unmount();
+    wrapper = undefined;
+    store.curQueueItem = undefined;
+  });
+
+  it("blurs a radio stream's live artwork, not the station logo", async () => {
+    // the station's own logo sits on the queue item, while the artwork for the
+    // track actually on air arrives as live stream metadata
+    store.curQueueItem = {
+      queue_item_id: "item_1",
+      image: {
+        type: ImageType.THUMB,
+        path: "https://station.example/logo.png",
+        provider: "builtin",
+        remotely_accessible: true,
+        proxy_id: "abc123",
+      },
+      media_item: { name: "The Station", metadata: { images: [] } },
+      streamdetails: {
+        stream_metadata: { image_url: "https://stream.example/cover.jpg" },
+      },
+    } as never;
+
+    const view = await mountView();
+
+    expect(view.get(".background-image").attributes("style")).toContain(
+      "https://stream.example/cover.jpg",
+    );
   });
 });


### PR DESCRIPTION
# What does this implement/fix?

`getMediaItemImage` never used a radio queue item's live `streamdetails.stream_metadata.image_url`, `streamdetails in mediaItem.media_item` check tested the wrong object, so it fell back to the station's static artwork.

`getMediaItemImageUrl` still routed the resulting image through the legacy `/imageproxy?path=&provider=` form when it had no `proxy_id`. Servers on schema 31+ reject that legacy form with a 400, so the image failed to load and fell back to a placeholder. Now falls back to the image's own URL when there's no proxy_id.

#### Before 

<img width="1237" height="963" alt="image" src="https://github.com/user-attachments/assets/e21079b2-4f36-49a9-bcdd-195591a58941" />

#### After

<img width="1273" height="990" alt="image" src="https://github.com/user-attachments/assets/c5ac127e-b626-444a-a6e5-567be2568ae6" />

<!-- Quick description and explanation of changes. -->

**Related issue:**

Closes https://github.com/music-assistant/support/issues/6281

## Types of changes

<!--
Tick exactly one box below. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [X] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [X] The code change is tested and works locally.
- [X] `pnpm lint:check` passes.
- [X] `pnpm test:run` passes, and tests have been added/updated where applicable.
- [X] `pnpm build` passes.
- [X] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
