### PR TITLE
Add "Space" keybind shortcut to pause(or stop)/resume

### DIFF
--- a/src/components/ItemsListing.vue
+++ b/src/components/ItemsListing.vue
@@ -1771,6 +1771,8 @@ const keyListener = function (e: KeyboardEvent) {
   } else if (
     !searchHasFocus.value &&
     e.key.length == 1 &&
+    // Space belongs to the play/pause shortcut, and no search starts with one
+    e.key != " " &&
     !e.ctrlKey &&
     !e.metaKey
   ) {

--- a/src/composables/usePlayPauseCommand.ts
+++ b/src/composables/usePlayPauseCommand.ts
@@ -1,0 +1,92 @@
+import { computed, ComputedRef, Ref } from "vue";
+import api from "@/plugins/api";
+import {
+  MediaType,
+  PlaybackState,
+  Player,
+  PlayerQueue,
+} from "@/plugins/api/interfaces";
+import { useActiveAudioSource } from "@/composables/activeAudioSource";
+import { useActiveSource } from "@/composables/activeSource";
+
+type PlayerRef = ComputedRef<Player | undefined> | Ref<Player | undefined>;
+type PlayerQueueRef =
+  | ComputedRef<PlayerQueue | undefined>
+  | Ref<PlayerQueue | undefined>;
+
+// Shared by the play button and the spacebar shortcut so they always agree.
+export function usePlayPauseCommand(
+  player: PlayerRef,
+  playerQueue: PlayerQueueRef,
+) {
+  const { activeSource } = useActiveSource(player);
+  const { activeAudioSource } = useActiveAudioSource(player);
+
+  const queueCanPlay = computed(() => {
+    if (!playerQueue.value) return false;
+    return playerQueue.value.items > 0;
+  });
+
+  const playerCanPlay = computed(() => {
+    if (!player.value) return false;
+    if (playerQueue.value?.active) return false;
+    if (!player.value.current_media) return false;
+    return true;
+  });
+
+  const canPlayPause = computed(() => {
+    // AudioSource queue items carry their own capability flags
+    if (activeAudioSource.value) {
+      return activeAudioSource.value.can_play_pause;
+    }
+    // Check if active source can play/pause
+    if (activeSource.value) {
+      return activeSource.value.can_play_pause;
+    }
+    // Fall back to queue or player capabilities
+    return queueCanPlay.value || playerCanPlay.value;
+  });
+
+  // When the current media can't be paused, Stop is the only way to end
+  // playback: AudioSources without pause support, external sources that
+  // don't advertise it, and radio streams.
+  const showStop = computed(() => {
+    if (activeAudioSource.value) return !activeAudioSource.value.can_play_pause;
+    if (player.value?.current_media?.media_type === MediaType.RADIO)
+      return true;
+    if (activeSource.value) return !activeSource.value.can_play_pause;
+    return false;
+  });
+
+  const isPlaying = computed(() => {
+    return player.value?.playback_state == PlaybackState.PLAYING;
+  });
+
+  const isLoading = computed(() => {
+    if (!player.value) return false;
+    return (
+      playerQueue.value?.extra_attributes?.play_action_in_progress === true
+    );
+  });
+
+  const isDisabled = computed(() => {
+    // nothing to address the command to
+    if (!player.value) return true;
+    // an earlier play action is still in flight
+    if (isLoading.value) return true;
+    // Stop is always available while playing, even when pause isn't supported
+    if (isPlaying.value && showStop.value) return false;
+    return !canPlayPause.value;
+  });
+
+  const playPause = () => {
+    if (!player.value) return;
+    if (isPlaying.value && showStop.value) {
+      api.playerCommandStop(player.value.player_id);
+    } else {
+      api.playerCommandPlayPause(player.value.player_id);
+    }
+  };
+
+  return { isPlaying, showStop, isLoading, isDisabled, playPause };
+}

--- a/src/composables/usePlayPauseShortcut.ts
+++ b/src/composables/usePlayPauseShortcut.ts
@@ -1,0 +1,42 @@
+import { computed, onMounted, onUnmounted } from "vue";
+import { usePlayPauseCommand } from "@/composables/usePlayPauseCommand";
+import { store } from "@/plugins/store";
+
+// Whatever holds focus gets Space, but we check what the element is, not what
+// the browser focused: click focus differs per browser and version, and a
+// focused scroller or a tabindex="-1" park must not turn the shortcut off.
+const FOCUSABLE =
+  'a[href], button, input, select, textarea, [contenteditable]:not([contenteditable="false"]), [tabindex]:not([tabindex="-1"])';
+
+function focusedControlOwnsSpace(target: EventTarget | null): boolean {
+  return target instanceof Element && target.matches(FOCUSABLE);
+}
+
+// Space toggles playback on the active player
+export function usePlayPauseShortcut() {
+  const player = computed(() => store.activePlayer);
+  const playerQueue = computed(() => store.activePlayerQueue);
+  const { isDisabled, playPause } = usePlayPauseCommand(player, playerQueue);
+
+  const onKeydown = (event: KeyboardEvent) => {
+    if (event.key !== " ") return;
+    if (event.repeat) return;
+    if (event.metaKey || event.ctrlKey || event.altKey || event.shiftKey)
+      return;
+    if (store.dialogActive || store.showPlayersMenu) return;
+    if (focusedControlOwnsSpace(event.target)) return;
+    if (isDisabled.value) return;
+
+    // Space scrolls the page unless we claim it
+    event.preventDefault();
+    playPause();
+  };
+
+  onMounted(() => {
+    window.addEventListener("keydown", onKeydown);
+  });
+
+  onUnmounted(() => {
+    window.removeEventListener("keydown", onKeydown);
+  });
+}

--- a/src/layouts/default/Default.vue
+++ b/src/layouts/default/Default.vue
@@ -12,6 +12,7 @@
 import MainView from "./View.vue";
 import Footer from "./Footer.vue";
 import ReloadPrompt from "./ReloadPrompt.vue";
+import { usePlayPauseShortcut } from "@/composables/usePlayPauseShortcut";
 import { store } from "@/plugins/store";
 import { watch } from "vue";
 import api from "@/plugins/api";
@@ -19,6 +20,9 @@ import { isSelectablePlayer } from "@/helpers/players";
 import { useRoute } from "vue-router";
 
 const route = useRoute();
+
+usePlayPauseShortcut();
+
 watch(
   // make sure it's retriggered when players array is populated
   [() => route.query.player, () => Object.keys(api.players).length],

--- a/src/layouts/default/PlayerOSD/PlayerControlBtn/PlayBtn.vue
+++ b/src/layouts/default/PlayerOSD/PlayerControlBtn/PlayBtn.vue
@@ -3,11 +3,11 @@
   <Icon
     v-bind="{ ...icon, ...$attrs }"
     class="play-btn-icon"
-    :disabled="!player || isLoading || isDisabled"
+    :disabled="isDisabled"
     :aria-label="playButtonLabel"
     :title="playButtonLabel"
     variant="button"
-    @click="onClick"
+    @click="playPause"
   >
     <Square
       v-if="isPlaying && showStop"
@@ -36,15 +36,8 @@
 import { $t } from "@/plugins/i18n";
 defineOptions({ inheritAttrs: false });
 import Icon, { IconProps } from "@/components/Icon.vue";
-import { useActiveAudioSource } from "@/composables/activeAudioSource";
-import { useActiveSource } from "@/composables/activeSource";
-import api from "@/plugins/api";
-import {
-  MediaType,
-  PlaybackState,
-  Player,
-  PlayerQueue,
-} from "@/plugins/api/interfaces";
+import { usePlayPauseCommand } from "@/composables/usePlayPauseCommand";
+import { Player, PlayerQueue } from "@/plugins/api/interfaces";
 import { Pause, Play, Square } from "@lucide/vue";
 import { computed, toRef } from "vue";
 
@@ -66,76 +59,16 @@ const compProps = withDefaults(defineProps<Props>(), {
   playOffset: 1,
 });
 
-const { activeSource } = useActiveSource(toRef(compProps, "player"));
-const { activeAudioSource } = useActiveAudioSource(toRef(compProps, "player"));
-
-const queueCanPlay = computed(() => {
-  if (!compProps.playerQueue) return false;
-  return compProps.playerQueue.items > 0;
-});
-
-const playerCanPlay = computed(() => {
-  if (!compProps.player) return false;
-  if (compProps.playerQueue?.active) return false;
-  if (!compProps.player.current_media) return false;
-  return true;
-});
-
-const canPlayPause = computed(() => {
-  // AudioSource queue items carry their own capability flags
-  if (activeAudioSource.value) {
-    return activeAudioSource.value.can_play_pause;
-  }
-  // Check if active source can play/pause
-  if (activeSource.value) {
-    return activeSource.value.can_play_pause;
-  }
-  // Fall back to queue or player capabilities
-  return queueCanPlay.value || playerCanPlay.value;
-});
-
-// When the current media can't be paused, surface Stop while playing so the
-// user always has a way to terminate playback. Covers AudioSources without
-// pause support, external sources that don't advertise it, and radio streams.
-const showStop = computed(() => {
-  if (activeAudioSource.value) return !activeAudioSource.value.can_play_pause;
-  if (compProps.player?.current_media?.media_type === MediaType.RADIO)
-    return true;
-  if (activeSource.value) return !activeSource.value.can_play_pause;
-  return false;
-});
-
-const isPlaying = computed(() => {
-  return compProps.player?.playback_state == PlaybackState.PLAYING;
-});
+const { isPlaying, showStop, isLoading, isDisabled, playPause } =
+  usePlayPauseCommand(
+    toRef(compProps, "player"),
+    toRef(compProps, "playerQueue"),
+  );
 
 const playButtonLabel = computed(() => {
   if (isPlaying.value && showStop.value) return $t("stop_playback");
   return isPlaying.value ? $t("pause") : $t("play");
 });
-
-const isLoading = computed(() => {
-  if (!compProps.player) return false;
-  return (
-    compProps.playerQueue?.extra_attributes?.play_action_in_progress === true
-  );
-});
-
-const isDisabled = computed(() => {
-  if (isLoading.value) return true;
-  // Stop is always available while playing, even when pause isn't supported
-  if (isPlaying.value && showStop.value) return false;
-  return !canPlayPause.value;
-});
-
-const onClick = () => {
-  if (!compProps.player) return;
-  if (isPlaying.value && showStop.value) {
-    api.playerCommandStop(compProps.player.player_id);
-  } else {
-    api.playerCommandPlayPause(compProps.player.player_id);
-  }
-};
 </script>
 
 <style>

--- a/tests/composables/usePlayPauseShortcut.test.ts
+++ b/tests/composables/usePlayPauseShortcut.test.ts
@@ -1,0 +1,152 @@
+import { usePlayPauseShortcut } from "@/composables/usePlayPauseShortcut";
+import api from "@/plugins/api";
+import {
+  MediaType,
+  PlaybackState,
+  type Player,
+  type PlayerQueue,
+} from "@/plugins/api/interfaces";
+import { enableAutoUnmount, mount } from "@vue/test-utils";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { playerQueue } from "../fixtures/playerQueue";
+
+vi.mock("@/plugins/api", () => {
+  const api = { playerCommandPlayPause: vi.fn(), playerCommandStop: vi.fn() };
+  return { api, default: api };
+});
+
+const state = vi.hoisted(() => ({
+  storeMock: {
+    dialogActive: false,
+    showPlayersMenu: false,
+    activePlayer: undefined as Player | undefined,
+    activePlayerQueue: undefined as PlayerQueue | undefined,
+  },
+}));
+
+vi.mock("@/plugins/store", () => ({ store: state.storeMock }));
+
+const playerCommandPlayPause = vi.mocked(api.playerCommandPlayPause);
+const playerCommandStop = vi.mocked(api.playerCommandStop);
+
+function player(overrides: Record<string, unknown> = {}): Player {
+  return {
+    player_id: "player-1",
+    active_source: null,
+    source_list: [],
+    playback_state: PlaybackState.PLAYING,
+    current_media: { media_type: MediaType.TRACK },
+    ...overrides,
+  } as unknown as Player;
+}
+
+function space(target?: HTMLElement) {
+  const event = new KeyboardEvent("keydown", { key: " ", bubbles: true });
+  (target ?? window).dispatchEvent(event);
+}
+
+enableAutoUnmount(afterEach);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  state.storeMock.dialogActive = false;
+  state.storeMock.showPlayersMenu = false;
+  state.storeMock.activePlayer = undefined;
+  state.storeMock.activePlayerQueue = undefined;
+});
+
+function mountShortcut() {
+  return mount({
+    setup: () => {
+      usePlayPauseShortcut();
+      return () => null;
+    },
+  });
+}
+
+describe("usePlayPauseShortcut", () => {
+  it("pauses the active player on Space", () => {
+    state.storeMock.activePlayer = player({
+      playback_state: PlaybackState.PLAYING,
+    });
+    mountShortcut();
+
+    space();
+
+    expect(playerCommandPlayPause).toHaveBeenCalledWith("player-1");
+    expect(playerCommandStop).not.toHaveBeenCalled();
+  });
+
+  it("stops instead of pausing a radio stream", () => {
+    state.storeMock.activePlayer = player({
+      playback_state: PlaybackState.PLAYING,
+      current_media: { media_type: MediaType.RADIO },
+    });
+    mountShortcut();
+
+    space();
+
+    expect(playerCommandStop).toHaveBeenCalledWith("player-1");
+    expect(playerCommandPlayPause).not.toHaveBeenCalled();
+  });
+
+  it("ignores Space typed into a text field", () => {
+    state.storeMock.activePlayer = player();
+    mountShortcut();
+    const input = document.createElement("input");
+    document.body.appendChild(input);
+
+    space(input);
+
+    expect(playerCommandPlayPause).not.toHaveBeenCalled();
+    input.remove();
+  });
+
+  // the control activates itself on Space, so acting here too would toggle twice
+  it("leaves Space to a focused control", () => {
+    state.storeMock.activePlayer = player();
+    mountShortcut();
+    const button = document.createElement("div");
+    button.setAttribute("role", "button");
+    button.setAttribute("tabindex", "0");
+    document.body.appendChild(button);
+
+    space(button);
+
+    expect(playerCommandPlayPause).not.toHaveBeenCalled();
+    button.remove();
+  });
+
+  it("ignores Space while a play action is still in flight", () => {
+    state.storeMock.activePlayer = player();
+    // otherwise playable, so the in-flight flag is the only thing stopping it
+    state.storeMock.activePlayerQueue = playerQueue({
+      items: 1,
+      extra_attributes: { play_action_in_progress: true },
+    });
+    mountShortcut();
+
+    space();
+
+    expect(playerCommandPlayPause).not.toHaveBeenCalled();
+  });
+
+  it("ignores Space while a dialog is open", () => {
+    state.storeMock.activePlayer = player();
+    state.storeMock.dialogActive = true;
+    mountShortcut();
+
+    space();
+
+    expect(playerCommandPlayPause).not.toHaveBeenCalled();
+  });
+
+  it("does nothing without an active player", () => {
+    mountShortcut();
+
+    space();
+
+    expect(playerCommandPlayPause).not.toHaveBeenCalled();
+    expect(playerCommandStop).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
# What does this implement/fix?

Add pause (or stop in case of radio) / play on pressing space while not focused on input elements.
Moved play controls and state logic from `PlayBtn.vue` to composable `usePlayPauseCommand.ts`
Register composable key listener in `Default.vue` for space
Add basic tests

## Types of changes

<!--
Tick exactly one box below. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [X] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [X] The code change is tested and works locally.
- [X] `pnpm lint:check` passes.
- [X] `pnpm test:run` passes, and tests have been added/updated where applicable.
- [X] `pnpm build` passes.
- [X] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.