### PR TITLE
Fix item menu not updating position correctly

### DIFF
--- a/src/layouts/default/ItemContextMenu.vue
+++ b/src/layouts/default/ItemContextMenu.vue
@@ -163,9 +163,10 @@ const showPlayMenuHeader = ref<boolean>(false);
 
 const visibleItems = computed(() => items.value.filter((x) => !x.hide));
 
-const reference = computed(() => ({
-  getBoundingClientRect: () => new DOMRect(posX.value, posY.value, 0, 0),
-}));
+const reference = computed(() => {
+  const rect = new DOMRect(posX.value, posY.value, 0, 0);
+  return { getBoundingClientRect: () => rect };
+});
 
 const MenuItemIcon = (props: { icon?: string | Component; size?: number }) => {
   if (!props.icon) return null;


### PR DESCRIPTION
# What does this implement/fix?

Fix item menu not updating position when opening new ones without closing them before

**Related issue (if applicable):**

Closes  https://github.com/music-assistant/support/issues/6388

## Types of changes

<!--
Tick exactly one box below. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [X] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [X] The code change is tested and works locally.
- [X] `pnpm lint:check` passes.
- [X] `pnpm test:run` passes, and tests have been added/updated where applicable.
- [X] `pnpm build` passes.
- [X] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
