### PR TITLE
Allow selecting text in read-only config label fields

### DIFF
--- a/src/views/settings/fields/LabelField.vue
+++ b/src/views/settings/fields/LabelField.vue
@@ -7,6 +7,22 @@ defineProps<{ text: string }>();
 <template>
   <MarkdownText
     :text="text"
-    class="text-muted-foreground bg-muted/50 mt-2 mb-4 rounded-md px-3 py-2 text-sm leading-relaxed"
+    class="selectable-label text-muted-foreground bg-muted/50 mt-2 mb-4 rounded-md px-3 py-2 text-sm leading-relaxed"
   />
 </template>
+
+<style scoped>
+/* Label fields show read-only text the user often needs to copy (callback
+   URLs, tokens, instructions), so opt back in to text selection that
+   global.css disables app-wide. The descendant rule covers the rendered
+   markdown, which global.css targets element-by-element. */
+.selectable-label,
+.selectable-label :deep(*) {
+  -webkit-user-select: text;
+  user-select: text;
+}
+
+.selectable-label {
+  cursor: text;
+}
+</style>


### PR DESCRIPTION
> Auto-triaged from music-assistant/support#6394 and opened as a draft for review.

# What does this implement/fix?

Config label fields (`ConfigEntryType.LABEL`) show read-only informational text that users frequently need to copy, such as the OAuth callback URL in the Spotify setup wizard. `global.css` disables text selection app-wide (`user-select: none`), so this text could not be selected or copied.

This opts label fields back in to text selection, the same way `Diagnostics.vue` already does for log output. The rule also covers the rendered markdown descendants, since the global rule targets each element individually.

**Related issue (if applicable):**

- related issue https://github.com/music-assistant/support/issues/6394

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`

## Checklist

- [ ] The code change is tested and works locally.
- [ ] `pnpm lint:check` passes.
- [ ] `pnpm test:run` passes, and tests have been added/updated where applicable.
- [ ] `pnpm build` passes.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
