### PR TITLE
Adding a Random sorting option to album & artists views

### DIFF
--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -847,6 +847,7 @@
         "artist": "Artist",
         "name": "Alphabetically",
         "name_desc": "Alphabetically (descending)",
+        "random": "Random",
         "year_desc": "Release year (descending)",
         "duration_desc": "Duration (descending)",
         "original": "Original",

--- a/src/views/LibraryAlbums.vue
+++ b/src/views/LibraryAlbums.vue
@@ -38,6 +38,7 @@ const total = ref(store.libraryAlbumsCount);
 const sortKeys = [
   "name",
   "name_desc",
+  "random",
   "sort_name",
   "sort_name_desc",
   "year",

--- a/src/views/LibraryArtists.vue
+++ b/src/views/LibraryArtists.vue
@@ -42,6 +42,7 @@ const total = ref<number | undefined>(undefined);
 const sortKeys = [
   "name",
   "name_desc",
+  "random",
   "sort_name",
   "sort_name_desc",
   "timestamp_added",

--- a/tests/views/LibrarySortOptions.test.ts
+++ b/tests/views/LibrarySortOptions.test.ts
@@ -1,0 +1,65 @@
+import LibraryAlbums from "@/views/LibraryAlbums.vue";
+import LibraryArtists from "@/views/LibraryArtists.vue";
+import { mount } from "@/../node_modules/@vue/test-utils";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("vue-i18n", () => ({
+  useI18n: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock("@/components/ItemsListing.vue", () => ({
+  default: {
+    name: "ItemsListing",
+    props: ["sortKeys"],
+    template: "<div />",
+  },
+}));
+
+vi.mock("@/plugins/api", () => ({
+  default: {
+    subscribe: vi.fn(),
+    getLibraryAlbums: vi.fn(),
+    getLibraryArtists: vi.fn(),
+    getLibraryAlbumsCount: vi.fn(),
+    getLibraryArtistsCount: vi.fn(),
+  },
+}));
+
+vi.mock("@/composables/useLibrarySync", () => ({
+  onLibrarySyncCompleted: vi.fn(() => () => undefined),
+}));
+
+vi.mock("@/plugins/store", () => ({
+  store: {
+    libraryAlbumsCount: 0,
+    libraryArtistsCount: 0,
+  },
+}));
+
+describe("library sort options", () => {
+  it("adds a random sort option to album listings", () => {
+    const wrapper = mount(LibraryAlbums, {
+      global: {
+        mocks: {
+          $t: (key: string) => key,
+        },
+      },
+    });
+    expect(
+      wrapper.findComponent({ name: "ItemsListing" }).props("sortKeys"),
+    ).toContain("random");
+  });
+
+  it("adds a random sort option to artist listings", () => {
+    const wrapper = mount(LibraryArtists, {
+      global: {
+        mocks: {
+          $t: (key: string) => key,
+        },
+      },
+    });
+    expect(
+      wrapper.findComponent({ name: "ItemsListing" }).props("sortKeys"),
+    ).toContain("random");
+  });
+});

--- a/tests/views/LibrarySortOptions.test.ts
+++ b/tests/views/LibrarySortOptions.test.ts
@@ -1,6 +1,6 @@
 import LibraryAlbums from "@/views/LibraryAlbums.vue";
 import LibraryArtists from "@/views/LibraryArtists.vue";
-import { mount } from "@/../node_modules/@vue/test-utils";
+import { mount } from "@vue/test-utils";
 import { describe, expect, it, vi } from "vitest";
 
 vi.mock("vue-i18n", () => ({


### PR DESCRIPTION
# What does this implement/fix?

This adds a Random sort option to the Library Albums view. 
<img width="687" height="419" alt="Screenshot 2026-09-11 at 08 28 34" src="https://github.com/user-attachments/assets/d8de642e-ce20-488d-b013-4b3e7c5ff5da" />

When first setting up MA, this is a functionality what I most wanted, I did end up finding it in the Discover page but the Library Albums view is where I expected it to be. 

This should also have a corresponding backend PR as currently the second page of result returns 0 rows, I couldn't easily figure out why and I was curious if this functionality is wanted or it is just me.


## Types of changes

<!--
Tick exactly one box below. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [x] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm lint:check` passes.
- [x] `pnpm test:run` passes, and tests have been added/updated where applicable.
- [x] `pnpm build` passes.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
