### PR TITLE
Drop the plugin logo on built-in discover rows

### DIFF
--- a/src/components/HomeWidgetRows.vue
+++ b/src/components/HomeWidgetRows.vue
@@ -176,7 +176,7 @@
               rowItemsMap.get(row.id) !== undefined
             "
             :title="row.folder.name"
-            :provider="row.folder.provider"
+            :provider="folderProvider(row.folder)"
             :items="rowItemsMap.get(row.id) ?? []"
             :dimmed="editMode && row.hidden"
             :tiles-per-view="tilesPerView"
@@ -250,7 +250,13 @@
                     size="icon-sm"
                     :aria-label="$t('tooltip.hide_provider')"
                   >
-                    <ListFilter />
+                    <span class="relative inline-flex">
+                      <ListFilter />
+                      <span
+                        v-if="rowHasActiveFilter(row)"
+                        :class="ACTIVE_DOT_CLASS"
+                      ></span>
+                    </span>
                   </Button>
                 </template>
               </FacetedFilter>
@@ -397,6 +403,7 @@ import { useListDragReorder } from "@/composables/useListDragReorder";
 import { useOrderedPlayers } from "@/composables/useOrderedPlayers";
 import { panelViewItemResponsive } from "@/helpers/utils";
 import api from "@/plugins/api";
+import { ACTIVE_DOT_CLASS } from "@/constants";
 import {
   EventType,
   PlaybackState,
@@ -504,7 +511,13 @@ watch(
   },
 );
 
-const folderProvider = (folder: RecommendationFolder) => folder.provider || "";
+// The provider whose icon labels a row. Builtin recommendation plugins (e.g.
+// Library Recommendations) aggregate the whole library, so their plugin logo
+// says nothing about the source -- only real music providers get an icon.
+const folderProvider = (folder: RecommendationFolder): string =>
+  api.getProviderManifest(folder.provider)?.builtin
+    ? ""
+    : folder.provider || "";
 
 // Provider instances a user may filter recommendation rows by -- the loaded
 // music providers, which the server limits to the sources the user may use.

--- a/src/components/Toolbar.vue
+++ b/src/components/Toolbar.vue
@@ -122,6 +122,7 @@
 
 <script setup lang="ts">
 import { $t } from "@/plugins/i18n";
+import { ACTIVE_DOT_CLASS } from "@/constants";
 import MenuItemIcon from "@/components/MenuItemIcon.vue";
 import { Button } from "@/components/ui/button";
 import {
@@ -169,9 +170,6 @@ const props = withDefaults(defineProps<Props>(), {
   iconAction: undefined,
   iconLabel: undefined,
 });
-
-const ACTIVE_DOT_CLASS =
-  "bg-primary absolute -top-0.5 -right-0.5 size-1.5 rounded-full";
 
 const overflowMenuOpen = ref(false);
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,5 +1,10 @@
 export const SYNCGROUP_PREFIX = "syncgroup_";
 
+// Small primary-colored badge, positioned over an icon to signal an active
+// filter. Wrap the icon in a `relative inline-flex` span and add this dot.
+export const ACTIVE_DOT_CLASS =
+  "bg-primary absolute -top-0.5 -right-0.5 size-1.5 rounded-full";
+
 // Frontend setting keys that are persisted per-device in localStorage.
 // Every other setting is stored server-side as a per-user preference.
 export const DEVICE_SETTING_KEYS = new Set([


### PR DESCRIPTION
# What does this implement/fix?

The discover page rows fed by the built-in **Library Recommendations** plugin (recently played, in progress, recent albums, favourites…) showed the plugin's own Music Assistant logo next to the filter button. That logo points at a plugin, not a music source, so it just confused people.

This drops that logo on built-in recommendation rows while keeping the real provider icon on rows contributed by an actual music provider (Tidal, YouTube Music, …), where the icon does tell you the source. It also moves the "filter active" signal onto the filter button itself, using the same small blue dot the rest of the app uses.

**Related issue (if applicable):**

- N/A (raised on the forum)

**Related backend PR (if applicable):**

- N/A

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

### Changes

- Hide the provider icon on built-in recommendation rows (Library Recommendations); real music-provider rows keep their icon.
- Show a blue dot on the filter button when a provider filter is active, matching the indicator used elsewhere.
- Share the active-dot style via a single constant instead of duplicating it.

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm lint:check` passes.
- [x] `pnpm test:run` passes, and tests have been added/updated where applicable.
- [x] `pnpm build` passes.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.

Screenshot:

<img width="2080" height="2610" alt="image" src="https://github.com/user-attachments/assets/b07ed254-3582-4dba-8fa9-d35111be731b" />

