### PR TITLE
Prevent audio session dropping when paused

### DIFF
--- a/src/components/SendspinPlayer.vue
+++ b/src/components/SendspinPlayer.vue
@@ -16,7 +16,7 @@ import {
   isMediaSessionDisabled,
   resetMediaSession,
 } from "@/helpers/mediaSession";
-import { getDeviceName } from "@/plugins/api/helpers";
+import { getDeviceName, resolvePlayerQueue } from "@/plugins/api/helpers";
 import { SendspinPlayer, Codec } from "@sendspin/sendspin-js";
 
 import almostSilentMp3 from "@/assets/almost_silent.mp3";
@@ -436,10 +436,16 @@ function getTargetPlayerId(): string | undefined {
   return store.activePlayerId;
 }
 
+function hasSomethingToPlay(playerId: string): boolean {
+  const queue = resolvePlayerQueue(api.players[playerId]);
+  return !queue || queue.items > 0;
+}
+
 function registerMediaSessionActionHandlers(): void {
   navigator.mediaSession.setActionHandler("play", () => {
     const targetId = getTargetPlayerId();
-    if (!targetId) return;
+    // The server rejects play on an empty queue
+    if (!targetId || !hasSomethingToPlay(targetId)) return;
     api.playerCommandPlay(targetId);
   });
 

--- a/src/components/SendspinPlayer.vue
+++ b/src/components/SendspinPlayer.vue
@@ -174,24 +174,35 @@ watch(
   { immediate: true },
 );
 
+// On desktop sendspin plays through Web Audio, which is not a media element.
+// Once that goes quiet on pause the browser drops the media session and the
+// OS gives the media keys to another app. The silent element keeps the
+// session alive there too. On mobile the sendspin audio element does that.
+const silentAudioBacksSession = computed(
+  () => metadataPlayerId.value === undefined || !isMobileOutput,
+);
+
 watch(
   [
     () => store.activePlayer?.playback_state,
+    () => api.players[props.playerId]?.playback_state,
     mediaSessionDisabled,
     metadataPlayerId,
+    silentAudioBacksSession,
     () => webPlayer.interacted,
   ],
-  ([state, disabled, targetPlayerId, interacted]) => {
+  ([activeState, ownState, disabled, targetPlayerId, backs, interacted]) => {
     if (silentAudioInterval) {
       clearInterval(silentAudioInterval);
       silentAudioInterval = undefined;
     }
-    if (disabled || targetPlayerId !== undefined || !interacted) {
+    if (disabled || !backs || !interacted) {
       silentAudioRef.value?.pause();
       return;
     }
     if (!silentAudioRef.value) return;
 
+    const state = targetPlayerId === undefined ? activeState : ownState;
     if (state === PlaybackState.PLAYING) {
       silentAudioRef.value.play().catch(() => {});
       // Reset to silent portion every 55 seconds to avoid audible tone on loop restart
@@ -215,11 +226,12 @@ watch(
     isPlaying,
     playerState,
     () => store.activePlayer?.playback_state,
+    () => api.players[props.playerId]?.playback_state,
     metadataPlayerId,
     () => webPlayer.interacted,
     mediaSessionDisabled,
   ],
-  ([, pState, , metaPlayerId, interacted, disabled]) => {
+  ([, pState, , ownState, metaPlayerId, interacted, disabled]) => {
     if (disabled) {
       resetMediaSession();
       return;
@@ -228,9 +240,14 @@ watch(
 
     let state: MediaSessionPlaybackState;
     if (metaPlayerId !== undefined) {
-      // Web player is the source - use isPlaying from library
-      // Show as paused if player has error
-      state = isPlaying.value && pState !== "error" ? "playing" : "paused";
+      // Web player is the source. Use the server's player state: the library's
+      // isPlaying only follows stream start/end, so it can stay true while
+      // paused and the OS would then send pause instead of play.
+      // Show as paused if player has error.
+      const playing = ownState
+        ? ownState === PlaybackState.PLAYING
+        : isPlaying.value;
+      state = playing && pState !== "error" ? "playing" : "paused";
     } else {
       // Active player is the source
       const activeState = store.activePlayer?.playback_state;
@@ -272,9 +289,9 @@ onMounted(() => {
 
   registerWebPlayerAudioUnlock(primeAudio);
 
-  // If already showing active player metadata, play silent audio now that silentAudioRef exists
+  // If the silent audio backs the session, play it now that silentAudioRef exists
   if (
-    metadataPlayerId.value === undefined &&
+    silentAudioBacksSession.value &&
     !mediaSessionDisabled.value &&
     webPlayer.interacted &&
     silentAudioRef.value

--- a/tests/components/SendspinPlayer.test.ts
+++ b/tests/components/SendspinPlayer.test.ts
@@ -49,6 +49,7 @@ interface MockQueue {
   queue_id: string;
   state?: PlaybackState;
   active?: boolean;
+  items?: number;
   current_item?: { extra_attributes?: { playback_speed?: number } };
 }
 
@@ -284,7 +285,7 @@ describe("SendspinPlayer MediaSession", () => {
         group_members: [],
       },
     };
-    apiMock.queues = { queue: { queue_id: "queue", active: true } };
+    apiMock.queues = { queue: { queue_id: "queue", active: true, items: 1 } };
     apiMock.queueElapsedTime = { queue: { elapsed_time: 30 } };
     storeMock.activePlayer = {
       player_id: "active-player",
@@ -581,6 +582,19 @@ describe("SendspinPlayer MediaSession", () => {
     expect(actions.every((action) => handlers.get(action) === null)).toBe(true);
   });
 
+  it("ignores play while the web player's queue is empty", () => {
+    apiMock.players["web-player"].playback_state = PlaybackState.IDLE;
+    apiMock.queues.queue.items = 0;
+
+    const wrapper = mount(SendspinPlayer, {
+      props: { playerId: "web-player" },
+    });
+    invokeAction("play");
+
+    expect(mockPlayerCommandPlay).not.toHaveBeenCalled();
+    wrapper.unmount();
+  });
+
   it("limits built-in-only controls to the web player", () => {
     webPlayer.browserControlsMode = BrowserMediaControlsMode.WEB_PLAYER;
     apiMock.players["web-player"].playback_state = PlaybackState.PAUSED;
@@ -868,6 +882,7 @@ function seedPlayingQueue(timing: {
     queue_id: "queue",
     state: PlaybackState.PLAYING,
     active: true,
+    items: 1,
     current_item: {
       extra_attributes: { playback_speed: timing.playback_speed },
     },
@@ -944,7 +959,7 @@ describe("SendspinPlayer silent audio on desktop", () => {
         group_members: [],
       },
     };
-    apiMock.queues = { queue: { queue_id: "queue", active: true } };
+    apiMock.queues = { queue: { queue_id: "queue", active: true, items: 1 } };
     desktopWebPlayer.interacted = true;
     desktopWebPlayer.browserControlsMode = BrowserMediaControlsMode.WEB_PLAYER;
   });

--- a/tests/components/SendspinPlayer.test.ts
+++ b/tests/components/SendspinPlayer.test.ts
@@ -8,6 +8,7 @@ import { nextTick } from "vue";
 import {
   afterAll,
   afterEach,
+  beforeAll,
   beforeEach,
   describe,
   expect,
@@ -115,6 +116,12 @@ const {
     sendspinState: {
       pairingToken: null as string | null,
       lastOptions: null as {
+        onStateChange?: (state: {
+          isPlaying: boolean;
+          volume: number;
+          muted: boolean;
+          playerState: "synchronized" | "error";
+        }) => void;
         reconnect?: { onReconnected?: () => void };
       } | null,
     },
@@ -588,6 +595,29 @@ describe("SendspinPlayer MediaSession", () => {
     wrapper.unmount();
   });
 
+  it("reports the web player paused while its stream is still open", async () => {
+    vi.spyOn(HTMLMediaElement.prototype, "play").mockResolvedValue();
+    mockPrepareSendspinSession.mockResolvedValue(undefined);
+    webPlayer.interacted = true;
+    apiMock.players["web-player"].playback_state = PlaybackState.PAUSED;
+
+    const wrapper = mount(SendspinPlayer, {
+      props: { playerId: "web-player" },
+    });
+    await flushPromises();
+    // The library only drops isPlaying on stream/end, which a pause does not send.
+    sendspinState.lastOptions?.onStateChange?.({
+      isPlaying: true,
+      volume: 100,
+      muted: false,
+      playerState: "synchronized",
+    });
+    await nextTick();
+
+    expect(mediaSession.playbackState).toBe("paused");
+    wrapper.unmount();
+  });
+
   it("targets the selected player when that mode is enabled", () => {
     webPlayer.browserControlsMode = BrowserMediaControlsMode.ACTIVE_PLAYER;
 
@@ -871,6 +901,72 @@ function invokeAction(
 function invokeAllActions(): void {
   for (const action of actions) invokeAction(action);
 }
+
+// isMobileOutput is read once at import, so the desktop variant of the
+// component needs a fresh import under a desktop user agent.
+describe("SendspinPlayer silent audio on desktop", () => {
+  let DesktopSendspinPlayer: typeof SendspinPlayer;
+  let desktopWebPlayer: typeof webPlayer;
+
+  beforeAll(async () => {
+    Object.defineProperty(navigator, "userAgent", {
+      configurable: true,
+      value: "Macintosh",
+    });
+    vi.resetModules();
+    DesktopSendspinPlayer = (await import("@/components/SendspinPlayer.vue"))
+      .default;
+    desktopWebPlayer = (await import("@/plugins/web_player")).webPlayer;
+  });
+
+  afterAll(() => {
+    Object.defineProperty(navigator, "userAgent", {
+      configurable: true,
+      value: "iPhone",
+    });
+  });
+
+  beforeEach(() => {
+    authState.guest = null;
+    mockPrepareSendspinSession.mockReset();
+    mockPrepareSendspinSession.mockReturnValue(new Promise(() => {}));
+    mockUseMediaBrowserMetaData.mockClear();
+    Object.defineProperty(navigator, "mediaSession", {
+      configurable: true,
+      value: mediaSession,
+    });
+    vi.stubGlobal("localStorage", createStorage());
+    apiMock.players = {
+      "web-player": {
+        player_id: "web-player",
+        playback_state: PlaybackState.PLAYING,
+        active_source: "queue",
+        group_members: [],
+      },
+    };
+    apiMock.queues = { queue: { queue_id: "queue", active: true } };
+    desktopWebPlayer.interacted = true;
+    desktopWebPlayer.browserControlsMode = BrowserMediaControlsMode.WEB_PLAYER;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it("backs the web player's media session with the silent audio", () => {
+    const playSpy = vi
+      .spyOn(HTMLMediaElement.prototype, "play")
+      .mockResolvedValue();
+
+    const wrapper = mount(DesktopSendspinPlayer, {
+      props: { playerId: "web-player" },
+    });
+
+    expect(playSpy).toHaveBeenCalled();
+    wrapper.unmount();
+  });
+});
 
 function expectPlayerCommandsNotCalled(): void {
   expect(mockPlayerCommandPlay).not.toHaveBeenCalled();


### PR DESCRIPTION
# What does this implement/fix?

In the browser tab that plays audio, Sendspin outputs through Web Audio, which browsers don't treat as a media element. Once playback paused and the output went quiet, Chrome dropped the media session and macOS handed the play key to Apple Music.

The silent `<audio>` element MA already uses for browser media controls now also backs the session for the web player on desktop, staying registered while paused like other web players do. The declared playback state follows the server's player state instead of the library flag.

**Related issue (if applicable):**

Closes https://github.com/music-assistant/support/issues/6401

## Types of changes

<!--
Tick exactly one box below. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [X] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [X] The code change is tested and works locally.
- [X] `pnpm lint:check` passes.
- [X] `pnpm test:run` passes, and tests have been added/updated where applicable.
- [X] `pnpm build` passes.
- [X] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
