### PR TITLE
Reset scroll position on route change

### DIFF
--- a/src/plugins/router.ts
+++ b/src/plugins/router.ts
@@ -2,7 +2,7 @@ import { getDashboardViewerNavigationRedirect } from "@/helpers/dashboard_viewer
 import { getGuestNavigationRedirect } from "@/helpers/guest_access";
 import { DASHBOARD_VIEWER_PATH_STORAGE_KEY } from "@/helpers/guest_session";
 import { $t } from "@/plugins/i18n";
-import { watch } from "vue";
+import { nextTick, watch } from "vue";
 import {
   createRouter,
   createWebHashHistory,
@@ -785,6 +785,21 @@ router.afterEach((to, from) => {
   ) {
     store.isOnboarding = false;
   }
+});
+
+// Most views share the .content-section scroll container which stays mounted across route changes
+// Prevent the scroll position from staying the same when changing route
+router.afterEach((to, from, failure) => {
+  if (failure) return;
+  // Don't reset on same route
+  if (to.path === from.path) return;
+  if (router.options.history.state.forward != null) return;
+  // nextTick needed because afterEach fires before Vue unmounts the page
+  // Resetting here would wipe its scroll position before it's saved
+  nextTick(() => {
+    const contentSection = document.querySelector(".content-section");
+    if (contentSection) contentSection.scrollTop = 0;
+  });
 });
 
 export default router;

--- a/tests/plugins/router.test.ts
+++ b/tests/plugins/router.test.ts
@@ -524,8 +524,11 @@ describe("scroll reset on navigation", () => {
     setHistoryForward(null);
 
     runAfterEachHooks();
-    await nextTick();
 
+    // afterEach runs before Vue unmounts the page being left, so the reset
+    // has to wait a tick or that page can't save where it was scrolled to
+    expect(el.scrollTop).toBe(200);
+    await nextTick();
     expect(el.scrollTop).toBe(0);
   });
 

--- a/tests/plugins/router.test.ts
+++ b/tests/plugins/router.test.ts
@@ -13,6 +13,7 @@ import {
   type Router,
   type RouterOptions,
 } from "vue-router";
+import { nextTick } from "vue";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
@@ -497,6 +498,78 @@ describe("media details back button", () => {
   );
 });
 
+describe("scroll reset on navigation", () => {
+  function contentSection() {
+    const el = document.createElement("div");
+    el.className = "content-section";
+    document.body.appendChild(el);
+    return el;
+  }
+
+  function setHistoryForward(forward: string | null) {
+    if (!mocks.router)
+      throw new Error("The router module did not create a router");
+    (mocks.router.options.history.state as { forward: string | null }).forward =
+      forward;
+  }
+
+  afterEach(() => {
+    document.querySelector(".content-section")?.remove();
+    setHistoryForward(null);
+  });
+
+  it("scrolls back to the top on a fresh navigation", async () => {
+    const el = contentSection();
+    el.scrollTop = 200;
+    setHistoryForward(null);
+
+    runAfterEachHooks();
+    await nextTick();
+
+    expect(el.scrollTop).toBe(0);
+  });
+
+  it("leaves the scroll position alone when returning via back navigation", async () => {
+    const el = contentSection();
+    el.scrollTop = 200;
+    setHistoryForward("/settings/about");
+
+    runAfterEachHooks();
+    await nextTick();
+
+    expect(el.scrollTop).toBe(200);
+  });
+
+  // filters and searches mirror their state into the query with
+  // router.replace, which must not move the page
+  it("stays put when only the query changed", async () => {
+    const el = contentSection();
+    el.scrollTop = 200;
+    setHistoryForward(null);
+
+    runAfterEachHooks(undefined, {
+      to: "/artists?genre_ids=1",
+      from: "/artists",
+    });
+    await nextTick();
+
+    expect(el.scrollTop).toBe(200);
+  });
+
+  it("does not touch the scroll position on a failed navigation", async () => {
+    const el = contentSection();
+    el.scrollTop = 200;
+    setHistoryForward(null);
+
+    runAfterEachHooks({
+      type: NavigationFailureType.aborted,
+    } as unknown as NavigationFailure);
+    await nextTick();
+
+    expect(el.scrollTop).toBe(200);
+  });
+});
+
 describe("chunk loading recovery", () => {
   let location = locationStub();
 
@@ -643,9 +716,12 @@ async function failNavigationWithChunkError(fullPath: string) {
 /**
  * Run the router's afterEach hooks the way a finished navigation does.
  */
-function runAfterEachHooks(failure?: NavigationFailure) {
-  const to = resolveRoute("/artists");
-  const from = resolveRoute("/discover");
+function runAfterEachHooks(
+  failure?: NavigationFailure,
+  paths: { to: string; from: string } = { to: "/artists", from: "/discover" },
+) {
+  const to = resolveRoute(paths.to);
+  const from = resolveRoute(paths.from);
   for (const hook of mocks.afterEachHooks) {
     hook.call(undefined, to, from, failure);
   }


### PR DESCRIPTION
# What does this implement/fix?

Scroll to the top when route changes "forward" and route path changes
Doesn't trigger on query param or hash change
I checked against existing custom scroll logic like https://github.com/music-assistant/frontend/pull/2625

**Related issue (if applicable):**

- related issue https://github.com/music-assistant/support/issues/6389

## Types of changes

<!--
Tick exactly one box below. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [X] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [X] The code change is tested and works locally.
- [X] `pnpm lint:check` passes.
- [X] `pnpm test:run` passes, and tests have been added/updated where applicable.
- [X] `pnpm build` passes.
- [X] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
