### PR TITLE
Show the server's reason when saving a user fails

### DIFF
--- a/src/components/users/CreateUserDialog.vue
+++ b/src/components/users/CreateUserDialog.vue
@@ -308,6 +308,7 @@ const form = useForm({
         value.role,
         value.displayName || undefined,
         value.playerFilter.length > 0 ? value.playerFilter : undefined,
+        { suppressGlobalError: true },
       );
 
       if (user) {
@@ -319,7 +320,9 @@ const form = useForm({
         toast.error(t("auth.user_create_failed"));
       }
     } catch (error) {
-      toast.error(t("auth.user_create_failed"));
+      toast.error(
+        error instanceof Error ? error.message : t("auth.user_create_failed"),
+      );
     } finally {
       loading.value = false;
     }

--- a/src/components/users/CreateUserDialog.vue
+++ b/src/components/users/CreateUserDialog.vue
@@ -223,7 +223,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { createUserSchema } from "@/lib/forms/profile";
-import { api } from "@/plugins/api";
+import { api, ApiCommandError } from "@/plugins/api";
 import { UserRole } from "@/plugins/api/interfaces";
 import MultiSelect from "./MultiSelect.vue";
 
@@ -302,7 +302,7 @@ const form = useForm({
     loading.value = true;
 
     try {
-      const user = await api.createUser(
+      await api.createUser(
         value.username,
         value.password,
         value.role,
@@ -311,17 +311,15 @@ const form = useForm({
         { suppressGlobalError: true },
       );
 
-      if (user) {
-        toast.success(t("auth.user_created"));
-        form.reset();
-        emit("created");
-        emit("update:modelValue", false);
-      } else {
-        toast.error(t("auth.user_create_failed"));
-      }
+      toast.success(t("auth.user_created"));
+      form.reset();
+      emit("created");
+      emit("update:modelValue", false);
     } catch (error) {
       toast.error(
-        error instanceof Error ? error.message : t("auth.user_create_failed"),
+        error instanceof ApiCommandError && error.details
+          ? error.details
+          : t("auth.user_create_failed"),
       );
     } finally {
       loading.value = false;

--- a/src/components/users/EditUserDialog.vue
+++ b/src/components/users/EditUserDialog.vue
@@ -257,7 +257,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { editUserSchema } from "@/lib/forms/profile";
-import { api } from "@/plugins/api";
+import { api, ApiCommandError } from "@/plugins/api";
 import type { User } from "@/plugins/api/interfaces";
 import { UserRole } from "@/plugins/api/interfaces";
 import { store } from "@/plugins/store";
@@ -389,7 +389,9 @@ const form = useForm({
       emit("update:modelValue", false);
     } catch (error) {
       toast.error(
-        error instanceof Error ? error.message : t("auth.user_update_failed"),
+        error instanceof ApiCommandError && error.details
+          ? error.details
+          : t("auth.user_update_failed"),
       );
     } finally {
       loading.value = false;

--- a/src/components/users/EditUserDialog.vue
+++ b/src/components/users/EditUserDialog.vue
@@ -381,12 +381,16 @@ const form = useForm({
         updates.player_filter = value.playerFilter;
       }
 
-      await api.updateUser(props.user.user_id, updates);
+      await api.updateUser(props.user.user_id, updates, {
+        suppressGlobalError: true,
+      });
       toast.success(t("auth.user_updated"));
       emit("updated");
       emit("update:modelValue", false);
     } catch (error) {
-      toast.error(t("auth.user_update_failed"));
+      toast.error(
+        error instanceof Error ? error.message : t("auth.user_update_failed"),
+      );
     } finally {
       loading.value = false;
     }

--- a/src/plugins/api/errors.ts
+++ b/src/plugins/api/errors.ts
@@ -1,16 +1,21 @@
 /**
  * Rejection value of a failed API command.
  *
- * `message` holds the server's (localized) error details, `error_code` the
- * numeric code to branch on.
+ * `message` is the server's (localized) reason, falling back to the numeric
+ * `error_code` when the server sent no detail. `details` holds that reason
+ * only when the server actually provided one, so callers can tell a real
+ * message apart from the code fallback; `error_code` is the numeric code to
+ * branch on.
  */
 export class ApiCommandError extends Error {
   readonly error_code: number;
+  readonly details?: string;
 
-  constructor(message: string, errorCode: number) {
+  constructor(message: string, errorCode: number, details?: string) {
     super(message);
     this.name = "ApiCommandError";
     this.error_code = errorCode;
+    this.details = details;
   }
 
   // callers render rejections with String(err); keep that the plain server

--- a/src/plugins/api/index.ts
+++ b/src/plugins/api/index.ts
@@ -3217,18 +3217,23 @@ export class MusicAssistantApi {
     role: UserRole,
     displayName?: string,
     playerFilter?: string[],
+    options?: CommandOptions,
   ): Promise<User> {
     // Create a new user (admin only)
     try {
       const result = await this.sendCommand<
         { success?: boolean; user?: User } | User | null | undefined
-      >("auth/user/create", {
-        username,
-        password,
-        role,
-        display_name: displayName,
-        player_filter: playerFilter,
-      });
+      >(
+        "auth/user/create",
+        {
+          username,
+          password,
+          role,
+          display_name: displayName,
+          player_filter: playerFilter,
+        },
+        options,
+      );
 
       if (result == null) {
         throw new Error("Failed to create user");
@@ -3272,6 +3277,7 @@ export class MusicAssistantApi {
       preferences?: Record<string, unknown>;
       player_filter?: string[];
     },
+    options?: CommandOptions,
   ): Promise<User> {
     // Update user using unified update command
     try {
@@ -3289,7 +3295,7 @@ export class MusicAssistantApi {
 
       const result = await this.sendCommand<
         { success?: boolean; user?: User } | User | null | undefined
-      >("auth/user/update", args);
+      >("auth/user/update", args, options);
 
       if (result == null) {
         throw new Error("Failed to update user");
@@ -3319,19 +3325,6 @@ export class MusicAssistantApi {
     } catch (error) {
       console.error("Error updating user:", error);
       throw error;
-    }
-  }
-
-  public async updateUserRole(
-    userId: string,
-    role: UserRole,
-  ): Promise<boolean> {
-    // Update user role using unified update command
-    try {
-      await this.updateUser(userId, { role });
-      return true;
-    } catch (error) {
-      return false;
     }
   }
 

--- a/src/plugins/api/index.ts
+++ b/src/plugins/api/index.ts
@@ -2962,6 +2962,7 @@ export class MusicAssistantApi {
         new ApiCommandError(
           msg.details || String(msg.error_code),
           msg.error_code,
+          msg.details || undefined,
         ),
       );
     } else {

--- a/tests/plugins/api/index.test.ts
+++ b/tests/plugins/api/index.test.ts
@@ -10,6 +10,7 @@ import {
   type ServerInfoMessage,
   type SuccessResultMessage,
   TaskStatus,
+  UserRole,
 } from "@/plugins/api/interfaces";
 import { BaseTransport, TransportState } from "@/plugins/remote/transport";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -167,6 +168,51 @@ describe("MusicAssistantApi error handling", () => {
     expect(consoleDebug).not.toHaveBeenCalled();
   });
 
+  it("lets updateUser suppress the global error toast for the caller", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    const result = api.updateUser(
+      "user-1",
+      { username: "renamed" },
+      { suppressGlobalError: true },
+    );
+
+    expect(transport.lastCommand.command).toBe("auth/user/update");
+    const rejection = expect(result).rejects.toMatchObject({
+      message: "Cannot rename user",
+    });
+
+    transport.receive(
+      createErrorResult(transport.lastCommand, "Cannot rename user"),
+    );
+
+    await rejection;
+    expect(mockToastError).not.toHaveBeenCalled();
+  });
+
+  it("lets createUser suppress the global error toast for the caller", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    const result = api.createUser(
+      "bob",
+      "hunter2",
+      UserRole.USER,
+      undefined,
+      undefined,
+      { suppressGlobalError: true },
+    );
+
+    expect(transport.lastCommand.command).toBe("auth/user/create");
+    const rejection = expect(result).rejects.toMatchObject({
+      message: "Cannot create user",
+    });
+
+    transport.receive(
+      createErrorResult(transport.lastCommand, "Cannot create user"),
+    );
+
+    await rejection;
+    expect(mockToastError).not.toHaveBeenCalled();
+  });
+
   it("rejects with the server error code and renders as the plain message", async () => {
     vi.spyOn(console, "error").mockImplementation(() => {});
     const command = api.sendCommand("test/coded");
@@ -178,6 +224,7 @@ describe("MusicAssistantApi error handling", () => {
     expect((err as ApiCommandError).error_code).toBe(999);
     expect(String(err)).toBe("Boom");
     expect(`${err}`).toBe("Boom");
+    expect((err as ApiCommandError).details).toBe("Boom");
   });
 
   it("falls back to the error code when the server sends no details", async () => {


### PR DESCRIPTION
# What does this implement/fix?

Editing or creating a user can be refused by the server with a clear reason — for example, changing a user who still owns music sources to the guest role. The dialogs only showed a generic "Failed to update/create user" toast (on top of the global one), so the admin never saw *why* it was refused.

- Edit/Create user dialogs now show the server's message, with the generic text as a fallback
- Suppress the now-duplicate global toast for these two commands (one toast instead of two)
- Remove the unused `updateUserRole` helper (it swallowed errors)

**Related issue (if applicable):**

- n/a

**Related backend PR (if applicable):**

- music-assistant/server#6282 (localizes the rejection reason for `auth/user/update`)

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm lint:check` passes.
- [x] `pnpm test:run` passes, and tests have been added/updated where applicable.
- [x] `pnpm build` passes.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.

---
_Generated by [Claude Code](https://claude.ai/code/session_01E2w31kttm2GasFkZwEmNQp)_