### PR TITLE
Clearer wording for music source sharing

### DIFF
--- a/src/components/settings/providers/ProviderAccessDialog.vue
+++ b/src/components/settings/providers/ProviderAccessDialog.vue
@@ -3,7 +3,7 @@
     <DialogContent class="sm:max-w-[480px]">
       <DialogHeader>
         <DialogTitle>
-          {{ $t("settings.source_access.title", { name: sourceName }) }}
+          {{ $t(titleKey, { name: sourceName }) }}
         </DialogTitle>
         <DialogDescription>
           {{ $t("settings.source_access.description") }}
@@ -51,7 +51,9 @@
                   :key="option"
                   :value="option"
                 >
-                  {{ $t(getProviderSharingTranslationKey(option)) }}
+                  {{
+                    $t(getProviderSharingTranslationKey(option, ownedByViewer))
+                  }}
                 </SelectItem>
               </SelectContent>
             </Select>
@@ -127,6 +129,7 @@ import {
   type User,
   type UserSummary,
 } from "@/plugins/api/interfaces";
+import { store } from "@/plugins/store";
 import { computed, ref, watch } from "vue";
 import { useI18n } from "vue-i18n";
 import { toast } from "vue-sonner";
@@ -183,6 +186,14 @@ const sourceName = computed(() => {
   );
 });
 
+// titled like the menu entry that opens it: Access for an admin, Sharing for
+// a member
+const titleKey = computed(() =>
+  props.canChangeOwner
+    ? "settings.source_access.title"
+    : "settings.source_access.share_title",
+);
+
 const selectedOwner = computed(() =>
   owner.value === HOUSEHOLD_OWNER ? null : owner.value,
 );
@@ -211,6 +222,15 @@ const currentAccess = computed(() =>
   effectiveProviderAccess(props.config?.access ?? null),
 );
 
+// an owner may not change the owner, so the record keeps its own
+const recordOwner = computed(() =>
+  canChangeOwner.value ? selectedOwner.value : currentAccess.value.owner,
+);
+
+const ownedByViewer = computed(
+  () => recordOwner.value === store.currentUser?.user_id,
+);
+
 watch(
   () => props.open,
   (open) => {
@@ -229,10 +249,7 @@ const save = async () => {
   saving.value = true;
   try {
     const updated = await api.setProviderAccess(props.config.instance_id, {
-      // an owner may not change the owner, so the record keeps its own
-      owner: canChangeOwner.value
-        ? selectedOwner.value
-        : currentAccess.value.owner,
+      owner: recordOwner.value,
       sharing: sharing.value,
       shared_users:
         sharing.value === ProviderSharing.SELECTED ? sharedUsers.value : [],

--- a/src/components/settings/providers/ProviderAccessDialog.vue
+++ b/src/components/settings/providers/ProviderAccessDialog.vue
@@ -43,7 +43,13 @@
             </FieldLabel>
             <Select v-model="sharing">
               <SelectTrigger id="provider-access-sharing" class="w-full">
-                <SelectValue />
+                <!-- rendered from state, as the select keeps the label an
+                     option had when it mounted -->
+                <SelectValue>
+                  {{
+                    $t(getProviderSharingTranslationKey(sharing, ownedByViewer))
+                  }}
+                </SelectValue>
               </SelectTrigger>
               <SelectContent>
                 <SelectItem

--- a/src/helpers/provider_access.test.ts
+++ b/src/helpers/provider_access.test.ts
@@ -92,13 +92,32 @@ describe("isOwnMusicSource", () => {
 
 describe("sharing translation keys", () => {
   it.each(Object.values(ProviderSharing))("names sharing %s", (sharing) => {
-    expect(getProviderSharingTranslationKey(sharing)).toBe(
+    expect(getProviderSharingTranslationKey(sharing, true)).toBe(
       `settings.source_access.options.${sharing}`,
     );
     expect(getProviderSharingHintTranslationKey(sharing)).toBe(
       `settings.source_access.hints.${sharing}`,
     );
   });
+
+  it("names private sharing as not shared for a viewer that does not own the source", () => {
+    expect(
+      getProviderSharingTranslationKey(ProviderSharing.PRIVATE, false),
+    ).toBe("settings.source_access.options.not_shared");
+  });
+
+  it.each([
+    ProviderSharing.SELECTED,
+    ProviderSharing.MEMBERS,
+    ProviderSharing.EVERYONE,
+  ])(
+    "still names sharing %s for a viewer that does not own the source",
+    (sharing) => {
+      expect(getProviderSharingTranslationKey(sharing, false)).toBe(
+        `settings.source_access.options.${sharing}`,
+      );
+    },
+  );
 });
 
 describe("user candidates", () => {

--- a/src/helpers/provider_access.ts
+++ b/src/helpers/provider_access.ts
@@ -53,8 +53,17 @@ export const isOwnMusicSource = (
   userId: string | undefined,
 ) => userId !== undefined && config.access?.owner === userId;
 
-export const getProviderSharingTranslationKey = (sharing: ProviderSharing) =>
-  PROVIDER_SHARING_TRANSLATION_KEYS[sharing];
+/**
+ * The translation key naming a sharing choice. Private sharing is named from
+ * the viewer's side: as their own for the owner, as not shared for others.
+ */
+export const getProviderSharingTranslationKey = (
+  sharing: ProviderSharing,
+  ownedByViewer: boolean,
+) =>
+  sharing === ProviderSharing.PRIVATE && !ownedByViewer
+    ? "settings.source_access.options.not_shared"
+    : PROVIDER_SHARING_TRANSLATION_KEYS[sharing];
 
 export const getProviderSharingHintTranslationKey = (
   sharing: ProviderSharing,

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -662,22 +662,22 @@
             "title": "Access to {name}",
             "description": "Who this music source belongs to and who else may use it.",
             "owner": "Owner",
-            "owner_hint": "Playback and listening history use the owner's account. A household source has no owner and is managed by administrators.",
-            "household": "Household",
+            "owner_hint": "Playback and listening history use the owner's account. A shared source has no owner and is managed by administrators.",
+            "household": "Shared (no owner)",
             "sharing": "Sharing",
             "shared_users": "Shared with",
             "select_members": "Select members",
             "shared_with_count": "Shared with {count} member | Shared with {count} members",
             "options": {
-                "private": "Private",
+                "private": "Only me",
                 "selected": "Selected members",
                 "members": "All members",
-                "everyone": "Everyone"
+                "everyone": "Everyone, including guests"
             },
             "hints": {
                 "private": "Only the owner can use this source.",
                 "selected": "The owner and the members selected below.",
-                "members": "Every signed-in household member, guests excluded.",
+                "members": "Every signed-in member, guests excluded.",
                 "everyone": "Every user, guests included."
             },
             "updated": "Access updated"

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -662,7 +662,7 @@
             "title": "Access to {name}",
             "description": "Who this music source belongs to and who else may use it.",
             "owner": "Owner",
-            "owner_hint": "Playback and listening history use the owner's account. A shared source has no owner and is managed by administrators.",
+            "owner_hint": "Playback and listening history use the owner's account. A source without an owner is managed by administrators.",
             "household": "Shared (no owner)",
             "sharing": "Sharing",
             "shared_users": "Shared with",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -660,6 +660,7 @@
             "action": "Access",
             "share_action": "Sharing",
             "title": "Access to {name}",
+            "share_title": "Share {name}",
             "description": "Who this music source belongs to and who else may use it.",
             "owner": "Owner",
             "owner_hint": "Playback and listening history use the owner's account. A source without an owner is managed by administrators.",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -672,13 +672,14 @@
                 "private": "Only me",
                 "selected": "Selected members",
                 "members": "All members",
-                "everyone": "Everyone, including guests"
+                "everyone": "Everyone, including guests",
+                "not_shared": "Not shared"
             },
             "hints": {
                 "private": "Only the owner can use this source.",
                 "selected": "The owner and the members selected below.",
                 "members": "Every signed-in member, guests excluded.",
-                "everyone": "Every user, guests included."
+                "everyone": "Any user can use this source."
             },
             "updated": "Access updated"
         },

--- a/src/views/settings/Providers.vue
+++ b/src/views/settings/Providers.vue
@@ -853,7 +853,12 @@ const accessSummary = function (item: ProviderConfig) {
       ? $t("settings.source_access.shared_with_count", sharedCount, {
           named: { count: sharedCount },
         })
-      : $t(getProviderSharingTranslationKey(access.sharing));
+      : $t(
+          getProviderSharingTranslationKey(
+            access.sharing,
+            access.owner === store.currentUser?.user_id,
+          ),
+        );
   if (!managesAllSources.value) return sharing;
   const owner =
     access.owner === null

--- a/src/views/settings/Providers.vue
+++ b/src/views/settings/Providers.vue
@@ -856,7 +856,7 @@ const accessSummary = function (item: ProviderConfig) {
       : $t(
           getProviderSharingTranslationKey(
             access.sharing,
-            access.owner === store.currentUser?.user_id,
+            isOwnMusicSource(item, store.currentUser?.user_id),
           ),
         );
   if (!managesAllSources.value) return sharing;

--- a/tests/components/settings/ProviderAccessDialog.test.ts
+++ b/tests/components/settings/ProviderAccessDialog.test.ts
@@ -2,6 +2,7 @@ import ProviderAccessDialog from "@/components/settings/providers/ProviderAccess
 import { shareCandidates } from "@/helpers/provider_access";
 import {
   ProviderSharing,
+  type User,
   UserRole,
   type UserSummary,
 } from "@/plugins/api/interfaces";
@@ -22,6 +23,7 @@ const { apiMock, storeMock, toastMock } = vi.hoisted(() => ({
     setProviderAccess: vi.fn(),
   },
   storeMock: {
+    currentUser: undefined as User | undefined,
     isTouchscreen: false,
   },
   toastMock: {
@@ -71,6 +73,7 @@ enableAutoUnmount(afterEach);
 
 beforeEach(() => {
   vi.clearAllMocks();
+  storeMock.currentUser = owner;
   storeMock.isTouchscreen = false;
   apiMock.providerManifests = { spotify: { name: "Spotify" } };
   apiMock.providers = {};
@@ -106,6 +109,22 @@ describe("ProviderAccessDialog", () => {
     expect(dialogText()).toContain("Spotify (sam)");
   });
 
+  it("titles the dialog for sharing when a member opens it", async () => {
+    await openDialog(ownedSource, null);
+
+    expect(
+      document.querySelector("[data-slot='dialog-title']")?.textContent,
+    ).toContain("settings.source_access.share_title");
+  });
+
+  it("keeps the access title for an admin without the user list", async () => {
+    await openDialog(ownedSource, null, true);
+
+    expect(
+      document.querySelector("[data-slot='dialog-title']")?.textContent,
+    ).toContain("settings.source_access.title");
+  });
+
   it("starts from the current record", async () => {
     await openDialog(ownedSource, users);
 
@@ -127,6 +146,59 @@ describe("ProviderAccessDialog", () => {
       "settings.source_access.options.everyone",
     );
     expect(sharedUsersField()).toBeNull();
+  });
+
+  it("names private sharing as not shared to a viewer that is not the owner", async () => {
+    storeMock.currentUser = member;
+    await openDialog(
+      providerConfig({
+        domain: "spotify",
+        access: {
+          owner: "owner-id",
+          sharing: ProviderSharing.PRIVATE,
+          shared_users: [],
+        },
+      }),
+      users,
+    );
+
+    await openSelect(sharingTrigger()!);
+
+    expect(optionLabels()).toContain(
+      "settings.source_access.options.not_shared",
+    );
+    expect(optionLabels()).not.toContain(
+      "settings.source_access.options.private",
+    );
+  });
+
+  it("follows the picked owner when naming private sharing", async () => {
+    await openDialog(
+      providerConfig({
+        domain: "spotify",
+        access: {
+          owner: "member-id",
+          sharing: ProviderSharing.PRIVATE,
+          shared_users: [],
+        },
+      }),
+      users,
+    );
+
+    await openSelect(sharingTrigger()!);
+    expect(optionLabels()).toContain(
+      "settings.source_access.options.not_shared",
+    );
+    await pickOption("settings.source_access.options.not_shared");
+
+    await openSelect(ownerTrigger()!);
+    await pickOption("Owner");
+
+    await openSelect(sharingTrigger()!);
+    expect(optionLabels()).toContain("settings.source_access.options.private");
+    expect(optionLabels()).not.toContain(
+      "settings.source_access.options.not_shared",
+    );
   });
 
   it("offers only enabled non-guest users as owner", async () => {

--- a/tests/components/settings/ProviderAccessDialog.test.ts
+++ b/tests/components/settings/ProviderAccessDialog.test.ts
@@ -193,6 +193,9 @@ describe("ProviderAccessDialog", () => {
 
     await openSelect(ownerTrigger()!);
     await pickOption("Owner");
+    expect(sharingTrigger()?.textContent).toContain(
+      "settings.source_access.options.private",
+    );
 
     await openSelect(sharingTrigger()!);
     expect(optionLabels()).toContain("settings.source_access.options.private");

--- a/tests/views/Providers.test.ts
+++ b/tests/views/Providers.test.ts
@@ -381,7 +381,35 @@ describe("Providers", () => {
     });
 
     expect(wrapper.get('[data-testid="provider-access"]').text()).toBe(
-      "user-gone · settings.source_access.options.private",
+      "user-gone · settings.source_access.options.not_shared",
+    );
+  });
+
+  it("names the viewing admin's own private source as only theirs", async () => {
+    const wrapper = await mountProviders(ProviderStatus.LOADED, true, true, {
+      access: {
+        owner: "user-marcel",
+        shared_users: [],
+        sharing: ProviderSharing.PRIVATE,
+      },
+    });
+
+    expect(wrapper.get('[data-testid="provider-access"]').text()).toBe(
+      "Marcel · settings.source_access.options.private",
+    );
+  });
+
+  it("names another member's private source as not shared to the viewing admin", async () => {
+    const wrapper = await mountProviders(ProviderStatus.LOADED, true, true, {
+      access: {
+        owner: "user-sam",
+        shared_users: [],
+        sharing: ProviderSharing.PRIVATE,
+      },
+    });
+
+    expect(wrapper.get('[data-testid="provider-access"]').text()).toBe(
+      "sam · settings.source_access.options.not_shared",
     );
   });
 


### PR DESCRIPTION
# What does this implement/fix?

The sharing controls for music sources called a source without an owner a "Household" source. That word is stiff and translates badly, so the sharing options now say who gets access without naming a group.

- A source without an owner shows as "Shared (no owner)" in the owner picker and in the music sources list
- The owner hint now says "A source without an owner is managed by administrators."
- The sharing options read "Only me", "Selected members", "All members" and "Everyone, including guests"
- "Only me" is shown to the owner only. An admin looking at someone else's private source sees "Not shared", e.g. "Sam · Not shared"
- The hints for all members and everyone read "Every signed-in member, guests excluded." and "Any user can use this source."
- A member who opens the dialog from "Sharing" sees "Share Spotify" as its title. Admins keep "Access to Spotify"

The other locales come from Lokalise.

**Related issue (if applicable):**

- related issue https://github.com/music-assistant/backlog/issues/84

**Related backend PR (if applicable):**

- related backend PR `n/a`

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm lint:check` passes.
- [x] `pnpm test:run` passes, and tests have been added/updated where applicable.
- [x] `pnpm build` passes.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
