### PR TITLE
Let members pick who to share a music source with

### DIFF
--- a/src/components/settings/providers/ProviderAccessDialog.vue
+++ b/src/components/settings/providers/ProviderAccessDialog.vue
@@ -118,7 +118,6 @@ import {
   getProviderSharingHintTranslationKey,
   getProviderSharingTranslationKey,
   ownerCandidates,
-  shareCandidates,
   userDisplayName,
 } from "@/helpers/provider_access";
 import { api } from "@/plugins/api";
@@ -126,6 +125,7 @@ import {
   type ProviderConfig,
   ProviderSharing,
   type User,
+  type UserSummary,
 } from "@/plugins/api/interfaces";
 import { computed, ref, watch } from "vue";
 import { useI18n } from "vue-i18n";
@@ -139,9 +139,11 @@ const props = defineProps<{
   open: boolean;
   // the music source to set the access of
   config: ProviderConfig | null;
-  // the users to pick shared members (and an owner) from; null when the
-  // caller can not list them
+  // the users to pick an owner from; null when the caller can not list them
   users: User[] | null;
+  // the members the source can be shared with, the dialog leaves its owner
+  // out; null when the caller can not list them
+  shareCandidates: UserSummary[] | null;
   // whether the caller may hand the source to another owner (an admin), or
   // only change the sharing of its own source
   canChangeOwner: boolean;
@@ -164,7 +166,9 @@ const canChangeOwner = computed(
 );
 
 const canPickSharedUsers = computed(
-  () => props.users !== null && sharing.value === ProviderSharing.SELECTED,
+  () =>
+    props.shareCandidates !== null &&
+    sharing.value === ProviderSharing.SELECTED,
 );
 
 // a source that is not loaded is named by its config, like the list does
@@ -185,20 +189,20 @@ const selectedOwner = computed(() =>
 
 const owners = computed(() => ownerCandidates(props.users ?? []));
 
+// the owner uses the source anyway, so it is not offered
 const shareOptions = computed(() =>
-  shareCandidates(props.users ?? [], selectedOwner.value).map((user) => ({
-    label: userDisplayName(user),
-    value: user.user_id,
-  })),
+  (props.shareCandidates ?? [])
+    .filter((user) => user.user_id !== selectedOwner.value)
+    .map((user) => ({ label: userDisplayName(user), value: user.user_id })),
 );
 
-// without a user list there is nobody to select, so that choice is only kept
-// when it is already the current one
+// without the members to pick from there is nobody to select, so that choice
+// is only kept when it is already the current one
 const sharingOptions = computed(() =>
   Object.values(ProviderSharing).filter(
     (option) =>
       option !== ProviderSharing.SELECTED ||
-      props.users !== null ||
+      props.shareCandidates !== null ||
       currentAccess.value.sharing === ProviderSharing.SELECTED,
   ),
 );

--- a/src/helpers/provider_access.test.ts
+++ b/src/helpers/provider_access.test.ts
@@ -124,12 +124,8 @@ describe("user candidates", () => {
     expect(ownerCandidates(users)).toEqual([owner, member]);
   });
 
-  it("offers every enabled member but the owner to share with", () => {
-    expect(shareCandidates(users, "owner")).toEqual([member, service]);
-  });
-
-  it("offers every enabled member to share a household source with", () => {
-    expect(shareCandidates(users, null)).toEqual([owner, member, service]);
+  it("offers every enabled member to share with, not guests", () => {
+    expect(shareCandidates(users)).toEqual([owner, member, service]);
   });
 });
 

--- a/src/helpers/provider_access.ts
+++ b/src/helpers/provider_access.ts
@@ -69,9 +69,9 @@ export const ownerCandidates = (users: User[]) =>
   );
 
 /**
- * The users a music source can be shared with: every enabled member, as the
- * server lists them to a member. A guest only ever gets the sources shared
- * with everyone.
+ * The users a music source can be shared with, as the server lists them to a
+ * member: every enabled user but the guests, who only ever get the sources
+ * shared with everyone.
  */
 export const shareCandidates = (users: User[]) =>
   users.filter((user) => user.enabled && user.role !== UserRole.GUEST);

--- a/src/helpers/provider_access.ts
+++ b/src/helpers/provider_access.ts
@@ -6,6 +6,7 @@ import {
   ProviderType,
   type User,
   UserRole,
+  type UserSummary,
 } from "@/plugins/api/interfaces";
 
 const PROVIDER_SHARING_TRANSLATION_KEYS: Record<ProviderSharing, string> = {
@@ -68,15 +69,13 @@ export const ownerCandidates = (users: User[]) =>
   );
 
 /**
- * The users a music source can be shared with: every enabled member but its
- * owner. A guest only ever gets the sources shared with everyone.
+ * The users a music source can be shared with: every enabled member, as the
+ * server lists them to a member. A guest only ever gets the sources shared
+ * with everyone.
  */
-export const shareCandidates = (users: User[], owner: string | null) =>
-  users.filter(
-    (user) =>
-      user.enabled && user.role !== UserRole.GUEST && user.user_id !== owner,
-  );
+export const shareCandidates = (users: User[]) =>
+  users.filter((user) => user.enabled && user.role !== UserRole.GUEST);
 
 /** The name a user is shown by. */
-export const userDisplayName = (user: User) =>
+export const userDisplayName = (user: UserSummary) =>
   user.display_name || user.username;

--- a/src/plugins/api/index.ts
+++ b/src/plugins/api/index.ts
@@ -2293,9 +2293,12 @@ export class MusicAssistantApi {
   }
 
   public getShareCandidates(): Promise<UserSummary[]> {
-    // Get every household member a music source can be shared with, the
-    // caller included; check supportsShareCandidates first.
-    return this.sendCommand("config/providers/share_candidates");
+    // Get the users a music source can be shared with, the caller included;
+    // check supportsShareCandidates first.
+    return this.sendCommand("config/providers/share_candidates", undefined, {
+      // callers show their own error toast; avoid a duplicate global one
+      suppressGlobalError: true,
+    });
   }
 
   // PlayerConfig related functions

--- a/src/plugins/api/index.ts
+++ b/src/plugins/api/index.ts
@@ -40,6 +40,7 @@ import {
   type TaskSchedule,
   type Track,
   type User,
+  type UserSummary,
   AlbumType,
   Audiobook,
   AuthProvider,
@@ -90,6 +91,9 @@ const BROWSE_PLAYER_ID_SCHEMA_VERSION = 61;
 
 // Repeat one/all masking the effective autoplay flag landed in API schema 69.
 const REPEAT_AUTOPLAY_LOCK_SCHEMA_VERSION = 69;
+
+// The config/providers/share_candidates command landed in API schema 72.
+const SHARE_CANDIDATES_SCHEMA_VERSION = 72;
 
 export interface CommandOptions {
   /**
@@ -2288,6 +2292,12 @@ export class MusicAssistantApi {
     });
   }
 
+  public getShareCandidates(): Promise<UserSummary[]> {
+    // Get every household member a music source can be shared with, the
+    // caller included; check supportsShareCandidates first.
+    return this.sendCommand("config/providers/share_candidates");
+  }
+
   // PlayerConfig related functions
 
   public async getPlayerConfigs(
@@ -3021,6 +3031,14 @@ export class MusicAssistantApi {
     return (
       (this.serverInfo.value?.schema_version ?? 0) >=
       REPEAT_AUTOPLAY_LOCK_SCHEMA_VERSION
+    );
+  }
+
+  /** Whether the connected server lists who a music source can be shared with (schema >= 72). */
+  public get supportsShareCandidates(): boolean {
+    return (
+      (this.serverInfo.value?.schema_version ?? 0) >=
+      SHARE_CANDIDATES_SCHEMA_VERSION
     );
   }
 

--- a/src/plugins/api/interfaces.ts
+++ b/src/plugins/api/interfaces.ts
@@ -1770,6 +1770,14 @@ export interface User {
   // Use authManager.isPartyGuest() to check for party sessions.
 }
 
+export interface UserSummary {
+  // The public face of a user account, safe to serve to every member.
+  user_id: string;
+  username: string;
+  display_name: string | null;
+  avatar_url: string | null;
+}
+
 export interface AuthToken {
   token_id: string;
   name: string;

--- a/src/views/settings/Providers.vue
+++ b/src/views/settings/Providers.vue
@@ -301,6 +301,7 @@
     v-model:open="showAccessDialog"
     :config="accessDialogConfig"
     :users="managesAllSources ? users : null"
+    :share-candidates="accessShareCandidates"
     :can-change-owner="managesAllSources"
     @saved="loadItems"
   />
@@ -336,6 +337,7 @@ import {
   getProviderSharingTranslationKey,
   hasConfigurableAccess,
   isOwnMusicSource,
+  shareCandidates,
   userDisplayName,
 } from "@/helpers/provider_access";
 import {
@@ -357,6 +359,7 @@ import {
   ProviderStatus,
   ProviderType,
   type User,
+  type UserSummary,
 } from "@/plugins/api/interfaces";
 import { authManager } from "@/plugins/auth";
 import { eventbus } from "@/plugins/eventbus";
@@ -422,11 +425,20 @@ const showAddProviderDialog = ref<boolean>(false);
 const showAccessDialog = ref<boolean>(false);
 const accessDialogConfig = ref<ProviderConfig | null>(null);
 const users = ref<User[]>([]);
+// the members a member may share its sources with, null until listed
+const memberShareCandidates = ref<UserSummary[] | null>(null);
 const { isProviderSyncing } = useBackgroundTasks();
 let unsubProvidersUpdated: (() => void) | undefined;
 
 const usersById = computed(
   () => new Map(users.value.map((user) => [user.user_id, user])),
+);
+
+// an admin picks the members to share with from its own user list
+const accessShareCandidates = computed(() =>
+  managesAllSources.value
+    ? shareCandidates(users.value)
+    : memberShareCandidates.value,
 );
 
 // the providers of the current type (a member's own ones only), before the
@@ -500,6 +512,14 @@ const loadUsers = async function () {
   }
 };
 
+const loadShareCandidates = async function () {
+  try {
+    memberShareCandidates.value = await api.getShareCandidates();
+  } catch {
+    toast.error($t("auth.users_load_failed"));
+  }
+};
+
 const removeProvider = function (providerInstanceId: string) {
   api
     .removeProviderConfig(providerInstanceId)
@@ -559,8 +579,10 @@ onMounted(() => {
   unsubProvidersUpdated = api.subscribe(EventType.PROVIDERS_UPDATED, () => {
     loadItems();
   });
-  // listing the users is an admin call; a member only shares its own sources
+  // listing the users is an admin call, so a member picks from the share
+  // candidates, which older servers do not list
   if (managesAllSources.value) loadUsers();
+  else if (api.supportsShareCandidates) loadShareCandidates();
 });
 
 onBeforeUnmount(() => {

--- a/tests/components/settings/ProviderAccessDialog.test.ts
+++ b/tests/components/settings/ProviderAccessDialog.test.ts
@@ -177,6 +177,16 @@ describe("ProviderAccessDialog", () => {
     });
   });
 
+  it("offers the old owner, not the new one, to share with", async () => {
+    await openDialog(ownedSource, users);
+
+    await openSelect(ownerTrigger()!);
+    await pickOption("Member");
+    await openMemberPicker();
+
+    expect(memberOptionLabels()).toEqual(["Owner"]);
+  });
+
   it("saves a household source without an owner", async () => {
     const wrapper = await openDialog(ownedSource, users);
 

--- a/tests/components/settings/ProviderAccessDialog.test.ts
+++ b/tests/components/settings/ProviderAccessDialog.test.ts
@@ -1,5 +1,10 @@
 import ProviderAccessDialog from "@/components/settings/providers/ProviderAccessDialog.vue";
-import { ProviderSharing, UserRole } from "@/plugins/api/interfaces";
+import { shareCandidates } from "@/helpers/provider_access";
+import {
+  ProviderSharing,
+  UserRole,
+  type UserSummary,
+} from "@/plugins/api/interfaces";
 import {
   enableAutoUnmount,
   flushPromises,
@@ -8,7 +13,7 @@ import {
 } from "@vue/test-utils";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { providerConfig } from "../../fixtures/providerConfig";
-import { user } from "../../fixtures/user";
+import { user, userSummary } from "../../fixtures/user";
 
 const { apiMock, storeMock, toastMock } = vi.hoisted(() => ({
   apiMock: {
@@ -196,9 +201,24 @@ describe("ProviderAccessDialog", () => {
     expect(wrapper.emitted("update:open")).toBeUndefined();
   });
 
-  describe("for an owner that can list the members", () => {
+  describe("for an owner that picks from the share candidates", () => {
+    // the server lists every enabled member, the owner included
+    const candidates = [
+      userSummary({
+        user_id: "owner-id",
+        username: "owner",
+        display_name: "Owner",
+      }),
+      userSummary({
+        user_id: "member-id",
+        username: "member",
+        display_name: "Member",
+      }),
+      userSummary({ user_id: "other-id", username: "other" }),
+    ];
+
     it("picks the members but keeps the owner", async () => {
-      const wrapper = await openDialog(ownedSource, users, false);
+      const wrapper = await openDialog(ownedSource, null, false, candidates);
 
       expect(ownerTrigger()).toBeNull();
       expect(sharedUsersField()).not.toBeNull();
@@ -222,8 +242,9 @@ describe("ProviderAccessDialog", () => {
             shared_users: [],
           },
         }),
-        users,
+        null,
         false,
+        candidates,
       );
 
       await openSelect(sharingTrigger()!);
@@ -231,6 +252,56 @@ describe("ProviderAccessDialog", () => {
       expect(optionLabels()).toContain(
         "settings.source_access.options.selected",
       );
+    });
+
+    it("offers every member but the owner, by name", async () => {
+      await openDialog(ownedSource, null, false, candidates);
+
+      await openMemberPicker();
+
+      expect(memberOptionLabels()).toEqual(["Member", "other"]);
+    });
+
+    it("shares with a picked member", async () => {
+      const wrapper = await openDialog(ownedSource, null, false, candidates);
+
+      await openMemberPicker();
+      await pickMember("other");
+      await submit(wrapper);
+
+      expect(apiMock.setProviderAccess).toHaveBeenCalledWith("spotify--owned", {
+        owner: "owner-id",
+        sharing: ProviderSharing.SELECTED,
+        shared_users: ["member-id", "other-id"],
+      });
+    });
+
+    it("keeps the members on record that are not offered", async () => {
+      // a disabled account is not listed, but keeps its place on the list
+      const wrapper = await openDialog(
+        providerConfig({
+          domain: "spotify",
+          instance_id: "spotify--owned",
+          access: {
+            owner: "owner-id",
+            sharing: ProviderSharing.SELECTED,
+            shared_users: ["member-id", "disabled-id"],
+          },
+        }),
+        null,
+        false,
+        candidates,
+      );
+
+      await openMemberPicker();
+      await pickMember("other");
+      await submit(wrapper);
+
+      expect(apiMock.setProviderAccess).toHaveBeenCalledWith("spotify--owned", {
+        owner: "owner-id",
+        sharing: ProviderSharing.SELECTED,
+        shared_users: ["member-id", "disabled-id", "other-id"],
+      });
     });
   });
 
@@ -292,6 +363,31 @@ function sharedUsersField() {
   );
 }
 
+function memberOptionLabels() {
+  return Array.from(
+    document.querySelectorAll("[data-slot='command-item']"),
+    (item) => item.textContent?.trim(),
+  );
+}
+
+async function openMemberPicker() {
+  document
+    .querySelector<HTMLElement>(
+      "button[aria-label='settings.source_access.select_members']",
+    )!
+    .click();
+  await settle();
+}
+
+async function pickMember(label: string) {
+  const option = Array.from(
+    document.querySelectorAll<HTMLElement>("[data-slot='command-item']"),
+  ).find((item) => item.textContent?.trim() === label);
+  if (!option) throw new Error(`no member "${label}": ${memberOptionLabels()}`);
+  option.click();
+  await settle();
+}
+
 function dialogText() {
   return document.querySelector("[data-slot='dialog-content']")?.textContent;
 }
@@ -343,9 +439,18 @@ async function openDialog(
   config: ReturnType<typeof providerConfig>,
   dialogUsers: ReturnType<typeof user>[] | null,
   canChangeOwner: boolean = dialogUsers !== null,
+  // an admin picks the members to share with from its user list, like the page
+  candidates: UserSummary[] | null = dialogUsers &&
+    shareCandidates(dialogUsers),
 ): Promise<VueWrapper> {
   const wrapper = mount(ProviderAccessDialog, {
-    props: { open: false, config, users: dialogUsers, canChangeOwner },
+    props: {
+      open: false,
+      config,
+      users: dialogUsers,
+      shareCandidates: candidates,
+      canChangeOwner,
+    },
     attachTo: document.body,
     global: {
       mocks: {

--- a/tests/fixtures/user.ts
+++ b/tests/fixtures/user.ts
@@ -1,4 +1,8 @@
-import { type User, UserRole } from "@/plugins/api/interfaces";
+import {
+  type User,
+  UserRole,
+  type UserSummary,
+} from "@/plugins/api/interfaces";
 
 /**
  * A complete user, for tests that only care about a few of its fields but
@@ -16,6 +20,17 @@ export function user(overrides: Partial<User> = {}): User {
     preferences: {},
     provider_filter: [],
     player_filter: [],
+    ...overrides,
+  };
+}
+
+/** A user as the server lists the members a music source can be shared with. */
+export function userSummary(overrides: Partial<UserSummary> = {}): UserSummary {
+  return {
+    user_id: "user-id",
+    username: "user",
+    display_name: null,
+    avatar_url: null,
     ...overrides,
   };
 }

--- a/tests/plugins/api/index.test.ts
+++ b/tests/plugins/api/index.test.ts
@@ -15,6 +15,7 @@ import {
 import { BaseTransport, TransportState } from "@/plugins/remote/transport";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { playlist } from "../../fixtures/playlist";
+import { userSummary } from "../../fixtures/user";
 
 const { mockToastError, mockToastInfo } = vi.hoisted(() => ({
   mockToastError: vi.fn(),
@@ -289,6 +290,31 @@ describe("MusicAssistantApi error handling", () => {
       repeat_mode: RepeatMode.ALL,
       source_id: "player-1",
     });
+  });
+
+  it("lists the members a music source can be shared with", async () => {
+    const candidates = [userSummary({ user_id: "user-sam", username: "sam" })];
+    const result = api.getShareCandidates();
+
+    expect(transport.lastCommand.command).toBe(
+      "config/providers/share_candidates",
+    );
+    expect(transport.lastCommand.args).toBeUndefined();
+
+    transport.receive({
+      message_id: transport.lastCommand.message_id!,
+      result: candidates,
+      partial: false,
+    });
+    await expect(result).resolves.toEqual(candidates);
+  });
+
+  it("lists the share candidates from schema 72 on", () => {
+    api.serverInfo.value = { ...SERVER_INFO, schema_version: 71 };
+    expect(api.supportsShareCandidates).toBe(false);
+
+    api.serverInfo.value = { ...SERVER_INFO, schema_version: 72 };
+    expect(api.supportsShareCandidates).toBe(true);
   });
 
   describe("a refused ordering command", () => {

--- a/tests/plugins/api/index.test.ts
+++ b/tests/plugins/api/index.test.ts
@@ -309,6 +309,21 @@ describe("MusicAssistantApi error handling", () => {
     await expect(result).resolves.toEqual(candidates);
   });
 
+  it("leaves a failing share candidates lookup to its caller", async () => {
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    vi.spyOn(console, "debug").mockImplementation(() => {});
+    const result = api.getShareCandidates();
+    const rejection = expect(result).rejects.toMatchObject({ message: "Boom" });
+
+    transport.receive(createErrorResult(transport.lastCommand, "Boom"));
+
+    await rejection;
+    expect(consoleError).not.toHaveBeenCalled();
+    expect(mockToastError).not.toHaveBeenCalled();
+  });
+
   it("lists the share candidates from schema 72 on", () => {
     api.serverInfo.value = { ...SERVER_INFO, schema_version: 71 };
     expect(api.supportsShareCandidates).toBe(false);

--- a/tests/views/Providers.test.ts
+++ b/tests/views/Providers.test.ts
@@ -8,11 +8,12 @@ import {
   ProviderStatus,
   ProviderType,
   type User,
+  UserRole,
 } from "@/plugins/api/interfaces";
 import type { MusicAssistantApi } from "@/plugins/api";
 import Providers from "@/views/settings/Providers.vue";
 import { providerConfig } from "../fixtures/providerConfig";
-import { user } from "../fixtures/user";
+import { user, userSummary } from "../fixtures/user";
 
 const {
   apiMock,
@@ -27,6 +28,7 @@ const {
     getAllUsers: vi.fn<MusicAssistantApi["getAllUsers"]>(),
     getProvider: vi.fn<MusicAssistantApi["getProvider"]>(),
     getProviderConfigs: vi.fn<MusicAssistantApi["getProviderConfigs"]>(),
+    getShareCandidates: vi.fn<MusicAssistantApi["getShareCandidates"]>(),
     providerManifests: {
       spotify: {
         allow_disable: true,
@@ -44,6 +46,7 @@ const {
     saveProviderConfig: vi.fn<MusicAssistantApi["saveProviderConfig"]>(),
     startSync: vi.fn<MusicAssistantApi["startSync"]>(),
     subscribe: vi.fn(),
+    supportsShareCandidates: true,
   },
   authMock: {
     isAdmin: vi.fn<() => boolean>(),
@@ -72,6 +75,16 @@ const owner = user({
 });
 
 const member = user({ user_id: "user-sam", username: "sam" });
+
+// the share candidates the server lists: every enabled member, the owner included
+const shareCandidates = [
+  userSummary({
+    display_name: "Marcel",
+    user_id: "user-marcel",
+    username: "marcel",
+  }),
+  userSummary({ user_id: "user-sam", username: "sam" }),
+];
 
 vi.mock("@/plugins/api", () => ({
   api: apiMock,
@@ -128,13 +141,18 @@ vi.mock("@/views/settings/AddProviderDialog.vue", () => ({
 // rendered in place of the real dialog, exposing what it was handed
 const AccessDialogStub = vi.hoisted(() => ({
   name: "ProviderAccessDialog",
-  props: ["canChangeOwner", "config", "open", "users"],
+  props: ["canChangeOwner", "config", "open", "shareCandidates", "users"],
   template: `
     <div
       data-testid="access-dialog"
       :data-open="String(open)"
       :data-config="config?.instance_id ?? ''"
       :data-users="users === null ? 'none' : String(users.length)"
+      :data-share-candidates="
+        shareCandidates === null
+          ? 'none'
+          : shareCandidates.map((candidate) => candidate.user_id).join(',')
+      "
       :data-can-change-owner="String(canChangeOwner)"
     />
   `,
@@ -176,11 +194,13 @@ beforeEach(() => {
   vi.clearAllMocks();
   apiMock.getAllUsers.mockResolvedValue([owner, member]);
   apiMock.getProvider.mockReturnValue(undefined);
+  apiMock.getShareCandidates.mockResolvedValue(shareCandidates);
   apiMock.providerManifests.spotify.builtin = false;
   apiMock.providerManifests.spotify.has_setup_flow = true;
   apiMock.providerManifests.spotify.stage = ProviderStage.STABLE;
   apiMock.reloadProvider.mockResolvedValue(undefined);
   apiMock.subscribe.mockReturnValue(vi.fn());
+  apiMock.supportsShareCandidates = true;
   authMock.isAdmin.mockReturnValue(true);
   routeMock.query.types = "music";
   storeMock.currentUser = owner;
@@ -385,7 +405,28 @@ describe("Providers", () => {
     expect(dialog.attributes("data-open")).toBe("true");
     expect(dialog.attributes("data-config")).toBe("spotify--test");
     expect(dialog.attributes("data-users")).toBe("2");
+    expect(dialog.attributes("data-share-candidates")).toBe(
+      "user-marcel,user-sam",
+    );
     expect(dialog.attributes("data-can-change-owner")).toBe("true");
+  });
+
+  it("picks the members to share with from its user list", async () => {
+    apiMock.getAllUsers.mockResolvedValue([
+      owner,
+      member,
+      user({ user_id: "user-guest", username: "guest", role: UserRole.GUEST }),
+      user({ user_id: "user-off", username: "off", enabled: false }),
+    ]);
+
+    const wrapper = await mountProviders(ProviderStatus.LOADED);
+
+    expect(
+      wrapper
+        .get('[data-testid="access-dialog"]')
+        .attributes("data-share-candidates"),
+    ).toBe("user-marcel,user-sam");
+    expect(apiMock.getShareCandidates).not.toHaveBeenCalled();
   });
 
   it("hides the access action for a builtin provider", async () => {
@@ -509,7 +550,7 @@ describe("Providers for a member", () => {
     ).not.toContain("settings.source_access.action");
   });
 
-  it("opens the sharing dialog without a user list", async () => {
+  it("opens the sharing dialog with the members it may share with", async () => {
     const wrapper = await mountWithConfigs([ownSource()]);
 
     const menuItems = await openMenu(wrapper);
@@ -525,6 +566,9 @@ describe("Providers for a member", () => {
     expect(dialog.attributes("data-open")).toBe("true");
     expect(dialog.attributes("data-config")).toBe("spotify--own");
     expect(dialog.attributes("data-users")).toBe("none");
+    expect(dialog.attributes("data-share-candidates")).toBe(
+      "user-marcel,user-sam",
+    );
     expect(dialog.attributes("data-can-change-owner")).toBe("false");
   });
 
@@ -532,6 +576,32 @@ describe("Providers for a member", () => {
     await mountWithConfigs([ownSource()]);
 
     expect(apiMock.getAllUsers).not.toHaveBeenCalled();
+  });
+
+  it("does not ask an older server who it may share with", async () => {
+    apiMock.supportsShareCandidates = false;
+
+    const wrapper = await mountWithConfigs([ownSource()]);
+
+    expect(apiMock.getShareCandidates).not.toHaveBeenCalled();
+    expect(
+      wrapper
+        .get('[data-testid="access-dialog"]')
+        .attributes("data-share-candidates"),
+    ).toBe("none");
+  });
+
+  it("reports a failing lookup of the members it may share with", async () => {
+    apiMock.getShareCandidates.mockRejectedValue(new Error("refused"));
+
+    const wrapper = await mountWithConfigs([ownSource()]);
+
+    expect(toastMock.error).toHaveBeenCalledWith("auth.users_load_failed");
+    expect(
+      wrapper
+        .get('[data-testid="access-dialog"]')
+        .attributes("data-share-candidates"),
+    ).toBe("none");
   });
 
   it("offers only music sources that allow another account", async () => {


### PR DESCRIPTION
# What does this implement/fix?

A member sharing a music source with "Selected members" had nobody to pick from, because listing the users is an admin call. The server now lists the household members a source can be shared with, and the sharing dialog picks from that list.

- Members can choose "Selected members" and pick the members to share their own music source with. The owner itself is not offered.
- Members already on the share list that the server no longer lists, like a disabled account, keep their place when saving.
- Admins keep picking from the full user list, which gives the same members.
- Servers without the new command keep today's dialog.

**Related issue (if applicable):**

- related issue https://github.com/music-assistant/backlog/issues/87 (story https://github.com/music-assistant/backlog/issues/84)

**Related backend PR (if applicable):**

<!--
Link the music-assistant/server PR when this change relies on new server
behaviour, so the two can be reviewed and released together.
-->

- related backend PR https://github.com/music-assistant/server/pull/6284

## Types of changes

<!--
Tick exactly one box below. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm lint:check` passes.
- [x] `pnpm test:run` passes, and tests have been added/updated where applicable.
- [x] `pnpm build` passes.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
