### PR TITLE
Share the artist page's hero, row registry and editor with other detail pages

### DIFF
--- a/src/components/artist/ArtistHero.vue
+++ b/src/components/artist/ArtistHero.vue
@@ -1,155 +1,99 @@
 <template>
-  <header class="artist-hero" :class="{ 'artist-hero--phone': isPhone }">
-    <div
-      v-if="backdropStyle"
-      class="artist-hero__backdrop"
-      :style="backdropStyle"
-    ></div>
-    <div class="artist-hero__scrim"></div>
-    <Toolbar
-      class="artist-hero__toolbar"
-      :icon="ArrowLeft"
-      :icon-action="backButtonClick"
-      :enforce-overflow-menu="true"
-      :menu-items="menuItems"
-    >
-      <template #append>
-        <button
-          v-if="item && canEditLibrary"
-          type="button"
-          class="artist-hero__fav"
-          :class="{ 'artist-hero__fav--on': item.favorite }"
-          :aria-label="favoriteButtonLabel"
-          :aria-pressed="item.favorite ? 'true' : 'false'"
-          :title="favoriteButtonLabel"
-          @click="api.toggleFavorite(item)"
-        >
-          <IconHeartFilled v-if="item.favorite" :size="20" />
-          <IconHeart v-else :stroke-width="2" :size="20" />
-        </button>
-      </template>
-    </Toolbar>
-
-    <div v-if="!item" class="artist-hero__body">
-      <Skeleton class="h-12 w-80 max-w-[60%]" />
-    </div>
-    <div v-else class="artist-hero__body">
-      <div class="artist-hero__main">
-        <img
-          v-if="artistLogo"
-          class="artist-hero__logo"
-          :src="artistLogo"
-          alt=""
-        />
-        <h1 :class="artistLogo ? 'sr-only' : 'artist-hero__name'">
-          {{ item.name }}
-        </h1>
-
-        <div class="artist-hero__actions">
-          <MenuButton
-            ref="playButton"
-            :text="playButtonText"
-            :menu-button-label="`${$t('more_options')}: ${$t('play')}`"
-            :loading="playActionInProgress"
-            @click="playButtonClick()"
-            @menu="playButtonClick(true)"
-          />
-          <button
-            v-if="api.supportsPlayMediaShuffle"
-            type="button"
-            class="artist-hero__button"
-            :disabled="!store.activePlayer"
-            :aria-label="$t('shuffle')"
-            :title="$t('shuffle')"
-            @click="api.playMedia(item, undefined, { shuffle: true })"
-          >
-            <Shuffle :size="isPhone ? 18 : 16" />
-            <span v-if="!isPhone">{{ $t("shuffle") }}</span>
-          </button>
-          <button
-            v-if="radioRelevant(item)"
-            type="button"
-            class="artist-hero__button"
-            :disabled="!radioSupported(item)"
-            :aria-label="$t('artist_radio')"
-            :title="$t('artist_radio')"
-            @click="gotoRadio(item)"
-          >
-            <Radio :size="isPhone ? 18 : 16" />
-            <span v-if="!isPhone">{{ $t("artist_radio") }}</span>
-          </button>
-        </div>
-      </div>
-
-      <div
-        v-if="chipsShown || genres.length || artistKind"
-        class="artist-hero__aside"
+  <DetailHero
+    class="artist-hero"
+    :class="{ 'artist-hero--phone': isPhone }"
+    :item="item"
+    :backdrop="backdrop"
+    :height="440"
+    :phone-height="340"
+    @edit-rows="emit('edit-rows')"
+  >
+    <template #toolbar-append>
+      <button
+        v-if="item && canEditLibrary"
+        type="button"
+        class="artist-hero__fav"
+        :class="{ 'artist-hero__fav--on': item.favorite }"
+        :aria-label="favoriteButtonLabel"
+        :aria-pressed="item.favorite ? 'true' : 'false'"
+        :title="favoriteButtonLabel"
+        @click="api.toggleFavorite(item)"
       >
-        <div v-if="chipsShown" class="artist-hero__chips">
-          <span class="artist-hero__chip">
-            <template v-for="(provider, index) in providers" :key="provider.id">
-              <span v-if="index > 0" class="artist-hero__chip-sep">·</span>
-              <ProviderIcon :domain="provider.domain" :size="14" />
-              {{ provider.name }}
-            </template>
-          </span>
-        </div>
-        <div v-if="genres.length" class="artist-hero__genres">
-          <template v-for="(genre, index) in genres" :key="genre.item_id">
-            <span v-if="index > 0">,&nbsp;</span>
-            <button
-              type="button"
-              class="artist-hero__genre"
-              @click="(e: MouseEvent) => genreClick(e, genre)"
-            >
-              {{ genre.name }}
-            </button>
-          </template>
-        </div>
-        <div v-if="artistKind" class="artist-hero__kind">{{ artistKind }}</div>
+        <IconHeartFilled v-if="item.favorite" :size="20" />
+        <IconHeart v-else :stroke-width="2" :size="20" />
+      </button>
+    </template>
+
+    <template v-if="item" #main>
+      <img
+        v-if="artistLogo"
+        class="artist-hero__logo"
+        :src="artistLogo"
+        alt=""
+      />
+      <h1 :class="artistLogo ? 'sr-only' : 'artist-hero__name'">
+        {{ item.name }}
+      </h1>
+
+      <div class="artist-hero__actions">
+        <DetailHeroPlayButton :item="item" />
+        <DetailHeroButton
+          v-if="api.supportsPlayMediaShuffle"
+          :icon="Shuffle"
+          :label="$t('shuffle')"
+          :icon-only="isPhone"
+          :disabled="!store.activePlayer"
+          @click="api.playMedia(item, undefined, { shuffle: true })"
+        />
+        <DetailHeroButton
+          v-if="radioRelevant(item)"
+          :icon="Radio"
+          :label="$t('artist_radio')"
+          :icon-only="isPhone"
+          :disabled="!radioSupported(item)"
+          @click="gotoRadio(item)"
+        />
       </div>
-    </div>
-  </header>
+    </template>
+
+    <template v-if="item" #aside>
+      <div v-if="chipsShown" class="artist-hero__chips">
+        <span class="artist-hero__chip">
+          <template v-for="(provider, index) in providers" :key="provider.id">
+            <span v-if="index > 0" class="artist-hero__chip-sep">·</span>
+            <ProviderIcon :domain="provider.domain" :size="14" />
+            {{ provider.name }}
+          </template>
+        </span>
+      </div>
+      <DetailHeroGenres :item="item" />
+      <div v-if="artistKind" class="artist-hero__kind">{{ artistKind }}</div>
+    </template>
+  </DetailHero>
 </template>
 
 <script setup lang="ts">
-import MenuButton from "@/components/MenuButton.vue";
+import DetailHero from "@/components/details/DetailHero.vue";
+import DetailHeroButton from "@/components/details/DetailHeroButton.vue";
+import DetailHeroGenres from "@/components/details/DetailHeroGenres.vue";
+import DetailHeroPlayButton from "@/components/details/DetailHeroPlayButton.vue";
 import ProviderIcon from "@/components/ProviderIcon.vue";
-import Toolbar from "@/components/Toolbar.vue";
-import { Skeleton } from "@/components/ui/skeleton";
-import { useUserPreferences } from "@/composables/userPreferences";
-import type { ContextMenuItem } from "@/helpers/context_menu_item";
-import {
-  handleMediaItemClick,
-  handlePlayBtnClick,
-} from "@/helpers/media_item_actions";
-import { backFromMediaDetails } from "@/helpers/navigation";
 import { gotoRadio, radioRelevant, radioSupported } from "@/helpers/radio";
-import { getImageThumbForItem, getPlayerName } from "@/helpers/utils";
-import { getContextMenuItems } from "@/layouts/default/ItemContextMenu.vue";
+import { getImageThumbForItem } from "@/helpers/utils";
 import { api } from "@/plugins/api";
 import {
   ArtistType,
   ImageType,
-  MediaType,
   Scope,
   type Artist,
-  type Genre,
 } from "@/plugins/api/interfaces";
 import { authManager } from "@/plugins/auth";
 import { isPhoneSizedScreen } from "@/plugins/breakpoint";
 import { $t } from "@/plugins/i18n";
 import { store } from "@/plugins/store";
-import { ArrowLeft, Radio, Rows3, Shuffle } from "@lucide/vue";
+import { Radio, Shuffle } from "@lucide/vue";
 import { IconHeart, IconHeartFilled } from "@tabler/icons-vue";
-import {
-  computed,
-  ref,
-  useTemplateRef,
-  watch,
-  type ComponentPublicInstance,
-} from "vue";
-import { useRouter } from "vue-router";
+import { computed } from "vue";
 
 export interface Props {
   item?: Artist;
@@ -160,22 +104,17 @@ const emit = defineEmits<{
   (e: "edit-rows"): void;
 }>();
 
-const router = useRouter();
-const menuItems = ref<ContextMenuItem[]>([]);
-const genres = ref<Genre[]>([]);
-const playButton = useTemplateRef<ComponentPublicInstance>("playButton");
-
 const isPhone = computed(() => isPhoneSizedScreen());
 
 // wide art (fanart, then landscape) suits the hero; a square thumb is the
 // last resort. No size is passed, so the server serves the original image.
-const backdropStyle = computed(() => {
+const backdrop = computed(() => {
   if (!props.item) return undefined;
-  const image =
+  return (
     getImageThumbForItem(props.item, ImageType.FANART) ||
     getImageThumbForItem(props.item, ImageType.LANDSCAPE) ||
-    getImageThumbForItem(props.item, ImageType.THUMB);
-  return image ? { backgroundImage: `url("${image}")` } : undefined;
+    getImageThumbForItem(props.item, ImageType.THUMB)
+  );
 });
 
 const artistLogo = computed(() =>
@@ -222,158 +161,9 @@ const favoriteButtonLabel = computed(() =>
 const canEditLibrary = computed(() =>
   authManager.hasScope(Scope.LIBRARY_WRITE),
 );
-
-const playButtonText = computed(() =>
-  store.activePlayer
-    ? $t("play_on_player", { player: getPlayerName(store.activePlayer, 20) })
-    : $t("play"),
-);
-
-// The queue playMedia targets are resolved directly, since activePlayerQueue is
-// undefined while an external source is active.
-const playActionInProgress = computed(() => {
-  const player = store.activePlayer;
-  if (!player) return false;
-  const queueId =
-    player.active_source && player.active_source in api.queues
-      ? player.active_source
-      : player.player_id;
-  return (
-    api.queues[queueId]?.extra_attributes?.play_action_in_progress === true
-  );
-});
-
-watch(
-  () => props.item,
-  async (item) => {
-    buildMenu(item);
-    if (!item) {
-      genres.value = [];
-      return;
-    }
-    const loaded = await api
-      .getGenresForMediaItem(MediaType.ARTIST, item.item_id)
-      .catch(() => [] as Genre[]);
-    // a slower response for a previous artist must not replace the current one
-    if (isShown(item)) genres.value = loaded;
-  },
-  { immediate: true },
-);
-
-// pinning or unpinning the artist in the sidebar changes its menu entry
-const { getPreference } = useUserPreferences();
-const shortcutsPreference = getPreference<string[]>("sidebar.shortcuts", []);
-watch(shortcutsPreference, () => buildMenu(props.item));
-
-const backButtonClick = function () {
-  backFromMediaDetails(router);
-};
-
-const playButtonClick = function (forceMenu = false) {
-  if (!props.item) return;
-  // the play menu hangs from the play button, like on the other detail pages
-  const rect = (
-    playButton.value?.$el as HTMLElement | undefined
-  )?.getBoundingClientRect();
-  handlePlayBtnClick(
-    props.item,
-    rect?.right ?? 0,
-    rect?.bottom ?? 0,
-    undefined,
-    forceMenu,
-  );
-};
-
-const genreClick = function (event: MouseEvent, genre: Genre) {
-  handleMediaItemClick(genre, event.clientX, event.clientY);
-};
-
-/** The artist's overflow menu, with the page's own "Edit rows" entry last. */
-async function buildMenu(item?: Artist) {
-  if (!item) {
-    menuItems.value = [];
-    return;
-  }
-  const items = await getContextMenuItems([item], item);
-  if (!isShown(item)) return;
-  menuItems.value = [
-    ...items,
-    { label: "edit_rows", icon: Rows3, action: () => emit("edit-rows") },
-  ];
-}
-
-/** Whether the artist a request was made for is still the one on screen. */
-function isShown(item: Artist): boolean {
-  return props.item?.uri === item.uri;
-}
 </script>
 
 <style scoped>
-.artist-hero {
-  position: relative;
-  height: 440px;
-  overflow: hidden;
-  background-color: rgb(var(--v-theme-background));
-  /* the artwork is darkened, so the hero keeps its light-on-dark text in both
-     themes */
-  color: #fff;
-}
-.artist-hero--phone {
-  height: 340px;
-}
-.artist-hero__backdrop {
-  position: absolute;
-  inset: 0;
-  background-position: center 30%;
-  background-repeat: no-repeat;
-  background-size: cover;
-}
-/* two layers: the artwork is darkened so the hero's light-on-dark text reads in
-   both themes, and only its very bottom blends into the page */
-.artist-hero__scrim {
-  position: absolute;
-  inset: 0;
-  background:
-    linear-gradient(
-      180deg,
-      rgba(0, 0, 0, 0) 96%,
-      rgb(var(--v-theme-background)) 100%
-    ),
-    linear-gradient(
-      180deg,
-      rgba(0, 0, 0, 0.45) 0%,
-      rgba(0, 0, 0, 0.1) 30%,
-      rgba(0, 0, 0, 0.55) 72%,
-      rgba(0, 0, 0, 0.9) 100%
-    );
-}
-.artist-hero--phone .artist-hero__scrim {
-  background:
-    linear-gradient(
-      180deg,
-      rgba(0, 0, 0, 0) 96%,
-      rgb(var(--v-theme-background)) 100%
-    ),
-    linear-gradient(
-      180deg,
-      rgba(0, 0, 0, 0.45) 0%,
-      rgba(0, 0, 0, 0.05) 28%,
-      rgba(0, 0, 0, 0.6) 70%,
-      rgba(0, 0, 0, 0.92) 100%
-    );
-}
-.artist-hero__toolbar {
-  position: relative;
-}
-
-/* the toolbar controls sit on the artwork, so they get their own backdrop
-   instead of the toolbar's transparent one */
-.artist-hero :deep(.v-toolbar__prepend .v-btn),
-.artist-hero :deep(.v-toolbar__append > button) {
-  background-color: rgba(0, 0, 0, 0.35);
-  border-radius: 8px;
-  opacity: 1;
-}
 .artist-hero__fav {
   margin-right: 8px;
   align-items: center;
@@ -396,34 +186,6 @@ function isShown(item: Artist): boolean {
   outline-offset: 2px;
 }
 
-.artist-hero__body {
-  position: absolute;
-  left: 28px;
-  right: 28px;
-  bottom: 24px;
-  display: flex;
-  align-items: flex-end;
-  justify-content: space-between;
-  gap: 24px;
-}
-.artist-hero__main {
-  display: flex;
-  flex: 1 1 auto;
-  flex-direction: column;
-  align-items: flex-start;
-  gap: 14px;
-  min-width: 0;
-}
-/* the facts about the artist line up on the right, bottom-aligned with the buttons */
-.artist-hero__aside {
-  display: flex;
-  flex: 0 1 auto;
-  flex-direction: column;
-  align-items: flex-end;
-  gap: 8px;
-  min-width: 0;
-  text-align: right;
-}
 .artist-hero__chips {
   display: flex;
   align-items: center;
@@ -466,35 +228,10 @@ function isShown(item: Artist): boolean {
   -webkit-box-orient: vertical;
   overflow: hidden;
 }
-.artist-hero__genres {
-  min-width: 0;
-  font-size: 14px;
-  color: rgba(255, 255, 255, 0.85);
-  text-shadow: 0 1px 6px rgba(0, 0, 0, 0.5);
-}
 .artist-hero__kind {
   font-size: 13px;
   color: rgba(255, 255, 255, 0.7);
   text-shadow: 0 1px 6px rgba(0, 0, 0, 0.5);
-}
-/* the genres read as links in the line of text, so the button chrome goes */
-.artist-hero__genre {
-  display: inline;
-  padding: 0;
-  border: 0;
-  background: none;
-  color: inherit;
-  font: inherit;
-  vertical-align: baseline;
-  cursor: pointer;
-}
-.artist-hero__genre:hover {
-  text-decoration: underline;
-}
-.artist-hero__genre:focus-visible {
-  outline: 2px solid rgb(var(--v-theme-primary));
-  outline-offset: 2px;
-  border-radius: 4px;
 }
 
 .artist-hero__actions {
@@ -503,42 +240,7 @@ function isShown(item: Artist): boolean {
   flex-wrap: wrap;
   gap: 8px;
 }
-.artist-hero__button {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  gap: 8px;
-  height: 36px;
-  padding: 0 12px;
-  border: 1px solid rgba(255, 255, 255, 0.25);
-  border-radius: 8px;
-  background: rgba(0, 0, 0, 0.4);
-  color: #fff;
-  font-size: 14px;
-  font-weight: 500;
-  cursor: pointer;
-}
-.artist-hero__button:disabled {
-  cursor: default;
-  opacity: 0.5;
-}
-.artist-hero__button:focus-visible {
-  outline: 2px solid rgb(var(--v-theme-primary));
-  outline-offset: 2px;
-}
 
-.artist-hero--phone .artist-hero__body {
-  left: 16px;
-  right: 16px;
-  bottom: 16px;
-  flex-direction: column;
-  align-items: stretch;
-  gap: 12px;
-}
-.artist-hero--phone .artist-hero__aside {
-  align-items: flex-start;
-  text-align: left;
-}
 .artist-hero--phone .artist-hero__chips {
   justify-content: flex-start;
 }
@@ -551,11 +253,5 @@ function isShown(item: Artist): boolean {
 }
 .artist-hero--phone .artist-hero__actions {
   gap: 10px;
-}
-.artist-hero--phone .artist-hero__button {
-  width: 44px;
-  height: 44px;
-  padding: 0;
-  border-radius: 10px;
 }
 </style>

--- a/src/components/artist/artistData.ts
+++ b/src/components/artist/artistData.ts
@@ -1,3 +1,4 @@
+import type { RowSource } from "@/components/details/rowRegistry";
 import { api } from "@/plugins/api";
 import {
   AlbumType,
@@ -6,20 +7,19 @@ import {
   type ItemMapping,
   type Track,
 } from "@/plugins/api/interfaces";
-import type { ArtistRowSource } from "./artistRows";
 
 /**
  * The artist's releases, from the library or from a single provider's own
  * catalog.
  *
- * `source` follows effectiveArtistRowSource: "library" returns the in-library
+ * `source` follows artistRows.effectiveSource: "library" returns the in-library
  * albums, a provider instance id queries that provider with the artist's id
  * there, so an artist not mapped to it has no releases to show. A provider
  * (non-library) artist always comes from its own provider.
  */
 export async function loadArtistReleases(
   artist: Artist,
-  source: ArtistRowSource,
+  source: RowSource,
 ): Promise<Album[]> {
   if (source === "library" || artist.provider !== "library") {
     return await api.getArtistAlbums(artist.item_id, artist.provider);
@@ -46,7 +46,7 @@ export async function loadArtistLibraryTracks(
 /** The artist's most popular tracks, as reported by `source`. */
 export async function loadArtistTopTracks(
   artist: Artist,
-  source: ArtistRowSource,
+  source: RowSource,
 ): Promise<Track[]> {
   return await api.getArtistTopTracks(
     artist.item_id,
@@ -58,7 +58,7 @@ export async function loadArtistTopTracks(
 /** Artists similar to this one, as reported by `source`. */
 export async function loadSimilarArtists(
   artist: Artist,
-  source: ArtistRowSource,
+  source: RowSource,
 ): Promise<Artist[]> {
   return await api.getSimilarArtists(
     artist.item_id,
@@ -110,7 +110,7 @@ export function appearsOnAlbums(
 }
 
 /** The provider_filter argument for a source, or undefined for "library"/"all". */
-function providerFilterFor(source: ArtistRowSource): string | undefined {
+function providerFilterFor(source: RowSource): string | undefined {
   return source === "library" || source === "all" ? undefined : source;
 }
 
@@ -121,7 +121,7 @@ function providerFilterFor(source: ArtistRowSource): string | undefined {
  */
 function aggregatedProviderFilter(
   artist: Artist,
-  source: ArtistRowSource,
+  source: RowSource,
 ): string | undefined {
   return artist.provider === "library" ? providerFilterFor(source) : undefined;
 }

--- a/src/components/artist/artistRows.ts
+++ b/src/components/artist/artistRows.ts
@@ -1,18 +1,14 @@
-import { setUserPreference } from "@/composables/userPreferences";
 import {
-  readRowsConfig,
-  resolveRowsConfig,
-  withRowHidden,
-  withRowsOrder,
-  writeRowsConfig,
-} from "@/helpers/rowsConfig";
+  createRowRegistry,
+  type RowDefinition,
+  type RowSource,
+} from "@/components/details/rowRegistry";
 import { api } from "@/plugins/api";
 import {
   ProviderFeature,
   ProviderType,
   type Artist,
 } from "@/plugins/api/interfaces";
-import { store } from "@/plugins/store";
 
 export type ArtistRowId =
   | "bio"
@@ -26,18 +22,9 @@ export type ArtistRowId =
   | "provider_mappings"
   | "artwork"; // admins only
 
-// "library" = in-library items, "all" = every provider at once, else a provider instance id
-export type ArtistRowSource = "library" | "all" | (string & {});
-
-export interface ArtistRowDefinition {
-  id: ArtistRowId;
-  labelKey: string;
+export interface ArtistRowDefinition extends RowDefinition<ArtistRowId> {
   // "music" = singers, "audiobook" = authors/narrators, "both" = either
   audience: "music" | "audiobook" | "both";
-  // shown only to a role that manages the library, which is the admin role
-  adminOnly?: boolean;
-  // gets a "Source" picker in Edit rows
-  supportsSource?: boolean;
 }
 
 // Default order, shared by both audiences: filtering out the rows of the other
@@ -95,118 +82,22 @@ export function availableArtistRowIds(
   ).map((row) => row.id);
 }
 
-export function artistRowDefinition(id: ArtistRowId): ArtistRowDefinition {
-  return ARTIST_ROWS_BY_ID[id];
-}
-
 /**
- * The user's row order and hidden rows, resolved against the rows available
- * for this artist. Nothing is hidden by default.
+ * The artist page's rows and the user's customization of them.
+ *
+ * A row's sources are the library for a release row and every provider at once
+ * for a row the server aggregates, then each provider able to supply the row;
+ * the first of them is the default. A provider (non-library) artist offers no
+ * choice and always stays on its own provider.
  */
-export function resolveArtistRows(availableIds: ArtistRowId[]): {
-  order: ArtistRowId[];
-  hidden: Set<ArtistRowId>;
-} {
-  const { order, hidden } = resolveRowsConfig(
-    readRowsConfig(ARTIST_ROWS_PREFERENCE_KEY),
-    availableIds,
-  );
-  return {
-    order: order as ArtistRowId[],
-    hidden: hidden as Set<ArtistRowId>,
-  };
-}
-
-/** Hide or unhide a single row on every artist page. */
-export async function setArtistRowHidden(
-  id: ArtistRowId,
-  hidden: boolean,
-): Promise<void> {
-  await writeRowsConfig(
-    ARTIST_ROWS_PREFERENCE_KEY,
-    withRowHidden(readRowsConfig(ARTIST_ROWS_PREFERENCE_KEY), id, hidden),
-  );
-}
-
-/**
- * Reorder the rows available for this artist. The given ids are rearranged
- * within the positions they already occupy in the full saved order, so rows
- * that don't apply to this artist keep their slots.
- */
-export async function setArtistRowsOrder(
-  orderedIds: ArtistRowId[],
-  availableIds: ArtistRowId[],
-): Promise<void> {
-  const cfg = withRowsOrder(
-    readRowsConfig(ARTIST_ROWS_PREFERENCE_KEY),
-    orderedIds,
-    availableIds,
-  );
-  if (!cfg) return;
-  await writeRowsConfig(ARTIST_ROWS_PREFERENCE_KEY, cfg);
-}
-
-/** Clears both preferences (order/visibility and sources). */
-export async function resetArtistRows(): Promise<void> {
-  await writeRowsConfig(ARTIST_ROWS_PREFERENCE_KEY, {});
-  await setUserPreference(ARTIST_ROW_SOURCES_PREFERENCE_KEY, {});
-}
-
-/** The user's saved source for a row, if any. */
-export function getArtistRowSource(
-  id: ArtistRowId,
-): ArtistRowSource | undefined {
-  const source = savedRowSources()[id];
-  return typeof source === "string" ? source : undefined;
-}
-
-export async function setArtistRowSource(
-  id: ArtistRowId,
-  source: ArtistRowSource | undefined,
-): Promise<void> {
-  const sources = { ...savedRowSources() };
-  if (source) {
-    sources[id] = source;
-  } else {
-    delete sources[id];
-  }
-  await setUserPreference(ARTIST_ROW_SOURCES_PREFERENCE_KEY, sources);
-}
-
-/**
- * The sources a row of this artist can be fed from, in the order a picker lists them: the
- * library for a release row and every provider at once for a row the server aggregates, then
- * each provider able to supply the row. Empty for a row without a source picker and for a
- * provider artist, which stays on its own provider.
- */
-export function artistRowSources(
-  id: ArtistRowId,
-  artist: Artist,
-): ArtistRowSource[] {
-  if (!ARTIST_ROWS_BY_ID[id].supportsSource) return [];
-  return rowSourceCandidates(id, artist);
-}
-
-/**
- * The source that actually feeds a row for this artist: the saved one while it is still among
- * the row's sources, otherwise the default. Provider (non-library) artists always resolve to
- * their own provider. The default is every provider at once where that is offered (the rows
- * the server aggregates), else the library.
- */
-export function effectiveArtistRowSource(
-  id: ArtistRowId,
-  artist: Artist,
-): ArtistRowSource {
-  if (artist.provider !== "library") return artist.provider;
-  const sources = rowSourceCandidates(id, artist);
-  const saved = getArtistRowSource(id);
-  if (saved && sources.includes(saved)) return saved;
-  return sources.includes("all") ? "all" : "library";
-}
-
-const ARTIST_ROWS_BY_ID = Object.fromEntries(
-  ARTIST_ROWS.map((row) => [row.id, row]),
-) as Record<ArtistRowId, ArtistRowDefinition>;
+export const artistRows = createRowRegistry<ArtistRowId, Artist>({
+  rows: ARTIST_ROWS,
+  preferenceKey: ARTIST_ROWS_PREFERENCE_KEY,
+  sourcesPreferenceKey: ARTIST_ROW_SOURCES_PREFERENCE_KEY,
+  sourceCandidates: rowSourceCandidates,
+  defaultSource: (_id, artist, candidates) =>
+    artist.provider === "library" ? candidates[0] : artist.provider,
+});
 
 // rows fed by the artist's releases, in or outside the library
 const RELEASE_ROWS: ArtistRowId[] = ["albums", "singles_eps", "appears_on"];
@@ -222,21 +113,10 @@ const ROW_FEATURES: Partial<Record<ArtistRowId, ProviderFeature>> = {
   similar_artists: ProviderFeature.SIMILAR_ARTISTS,
 };
 
-/** The saved `{ [rowId]: source }` object, empty when unset or invalid. */
-function savedRowSources(): Partial<Record<ArtistRowId, ArtistRowSource>> {
-  const pref =
-    store.currentUser?.preferences?.[ARTIST_ROW_SOURCES_PREFERENCE_KEY];
-  if (!pref || typeof pref !== "object") return {};
-  return pref as Partial<Record<ArtistRowId, ArtistRowSource>>;
-}
-
 /** The sources a row of a library artist could be fed from, whether or not it has a picker. */
-function rowSourceCandidates(
-  id: ArtistRowId,
-  artist: Artist,
-): ArtistRowSource[] {
+function rowSourceCandidates(id: ArtistRowId, artist: Artist): RowSource[] {
   if (artist.provider !== "library") return [];
-  const first: ArtistRowSource = RELEASE_ROWS.includes(id) ? "library" : "all";
+  const first: RowSource = RELEASE_ROWS.includes(id) ? "library" : "all";
   return [first, ...rowSourceProviders(id, artist)];
 }
 

--- a/src/components/details/DetailAdminCard.vue
+++ b/src/components/details/DetailAdminCard.vue
@@ -1,0 +1,76 @@
+<template>
+  <div class="detail-admin">
+    <slot></slot>
+  </div>
+</template>
+
+<style scoped>
+/* the shared admin sections keep their own toolbar and content, but take the
+   page's row title and gutter and sit in a card each; their inline bottom margin
+   is the only spacing they set themselves, hence the override */
+.detail-admin :deep(section) {
+  margin: 16px 28px 0 !important;
+  border-radius: 12px;
+  background: rgba(var(--v-theme-on-surface), 0.04);
+  overflow: hidden;
+}
+.detail-admin :deep(.v-toolbar-title) {
+  font-size: 22px;
+  font-weight: 700;
+  letter-spacing: -0.4px;
+}
+.detail-admin :deep(.v-divider) {
+  display: none;
+}
+/* the lists and image tiles inside sit on the card instead of painting their own surface */
+.detail-admin :deep(.v-container) {
+  padding: 0 12px 12px;
+}
+.detail-admin :deep(.v-list),
+.detail-admin :deep(.panel-item) {
+  background: transparent;
+  box-shadow: none;
+}
+.detail-admin :deep(.v-list) {
+  padding: 0;
+}
+/* uniform square image tiles instead of percentage columns, one row per image type */
+.detail-admin :deep(.v-row) {
+  margin: 0 0 12px;
+  gap: 12px;
+}
+.detail-admin :deep(.v-row:empty) {
+  display: none;
+}
+.detail-admin :deep(.v-col) {
+  flex: 0 0 auto;
+  width: 176px;
+  max-width: 176px;
+  padding: 0;
+}
+.detail-admin :deep(.panel-item) {
+  padding: 8px;
+  /* outweighs the equally-!important radius the card's tile utility carries */
+  border-radius: 12px !important;
+}
+.detail-admin :deep(.panel-item:hover) {
+  background: rgba(var(--v-theme-on-surface), 0.08);
+  box-shadow: none;
+}
+.detail-admin :deep(.panel-item .v-img) {
+  aspect-ratio: 1 / 1;
+  border-radius: 8px;
+}
+.detail-admin :deep(.panel-item .v-img__img) {
+  object-fit: cover;
+}
+
+@media (max-width: 768px) {
+  .detail-admin :deep(section) {
+    margin: 12px 16px 0 !important;
+  }
+  .detail-admin :deep(.v-toolbar-title) {
+    font-size: 19px;
+  }
+}
+</style>

--- a/src/components/details/DetailHero.vue
+++ b/src/components/details/DetailHero.vue
@@ -1,0 +1,224 @@
+<template>
+  <header
+    class="detail-hero"
+    :class="{ 'detail-hero--phone': isPhone }"
+    :style="{
+      '--detail-hero-height': `${height}px`,
+      '--detail-hero-phone-height': `${phoneHeight}px`,
+    }"
+  >
+    <div
+      v-if="backdropStyle"
+      class="detail-hero__backdrop"
+      :style="backdropStyle"
+    ></div>
+    <div class="detail-hero__scrim"></div>
+    <Toolbar
+      class="detail-hero__toolbar"
+      :icon="ArrowLeft"
+      :icon-action="backButtonClick"
+      :enforce-overflow-menu="true"
+      :menu-items="menuItems"
+    >
+      <template #append>
+        <slot name="toolbar-append"></slot>
+      </template>
+    </Toolbar>
+
+    <div v-if="!item" class="detail-hero__body">
+      <Skeleton class="h-12 w-80 max-w-[60%]" />
+    </div>
+    <div v-else class="detail-hero__body">
+      <div class="detail-hero__main">
+        <slot name="main"></slot>
+      </div>
+      <div v-if="$slots.aside" class="detail-hero__aside">
+        <slot name="aside"></slot>
+      </div>
+    </div>
+  </header>
+</template>
+
+<script setup lang="ts">
+import Toolbar from "@/components/Toolbar.vue";
+import { Skeleton } from "@/components/ui/skeleton";
+import { useUserPreferences } from "@/composables/userPreferences";
+import type { ContextMenuItem } from "@/helpers/context_menu_item";
+import { backFromMediaDetails } from "@/helpers/navigation";
+import { getContextMenuItems } from "@/layouts/default/ItemContextMenu.vue";
+import type { MediaItemType } from "@/plugins/api/interfaces";
+import { isPhoneSizedScreen } from "@/plugins/breakpoint";
+import { ArrowLeft, Rows3 } from "@lucide/vue";
+import { computed, ref, watch } from "vue";
+import { useRouter } from "vue-router";
+
+export interface Props {
+  // undefined while the page loads: a skeleton stands in and there is no menu
+  item?: MediaItemType;
+  // the artwork painted behind the text, as an image url
+  backdrop?: string;
+  height?: number;
+  phoneHeight?: number;
+}
+const props = withDefaults(defineProps<Props>(), {
+  item: undefined,
+  backdrop: undefined,
+  height: 440,
+  phoneHeight: 340,
+});
+
+const emit = defineEmits<{
+  (e: "edit-rows"): void;
+}>();
+
+const router = useRouter();
+const menuItems = ref<ContextMenuItem[]>([]);
+
+const isPhone = computed(() => isPhoneSizedScreen());
+
+const backdropStyle = computed(() =>
+  props.backdrop ? { backgroundImage: `url("${props.backdrop}")` } : undefined,
+);
+
+watch(() => props.item, buildMenu, { immediate: true });
+
+// pinning or unpinning the item in the sidebar changes its menu entry
+const { getPreference } = useUserPreferences();
+const shortcutsPreference = getPreference<string[]>("sidebar.shortcuts", []);
+watch(shortcutsPreference, () => buildMenu(props.item));
+
+const backButtonClick = function () {
+  backFromMediaDetails(router);
+};
+
+/** The item's overflow menu, with the page's own "Edit rows" entry last. */
+async function buildMenu(item?: MediaItemType) {
+  if (!item) {
+    menuItems.value = [];
+    return;
+  }
+  const items = await getContextMenuItems([item], item);
+  // a slower response for a previous item must not replace the current one
+  if (props.item?.uri !== item.uri) return;
+  menuItems.value = [
+    ...items,
+    { label: "edit_rows", icon: Rows3, action: () => emit("edit-rows") },
+  ];
+}
+</script>
+
+<style scoped>
+.detail-hero {
+  position: relative;
+  height: var(--detail-hero-height);
+  overflow: hidden;
+  background-color: rgb(var(--v-theme-background));
+  /* the artwork is darkened, so the hero keeps its light-on-dark text in both
+     themes */
+  color: #fff;
+}
+.detail-hero--phone {
+  height: var(--detail-hero-phone-height);
+}
+.detail-hero__backdrop {
+  position: absolute;
+  inset: 0;
+  background-position: center 30%;
+  background-repeat: no-repeat;
+  background-size: cover;
+}
+/* two layers: the artwork is darkened so the hero's light-on-dark text reads in
+   both themes, and only its very bottom blends into the page */
+.detail-hero__scrim {
+  position: absolute;
+  inset: 0;
+  background:
+    linear-gradient(
+      180deg,
+      rgba(0, 0, 0, 0) 96%,
+      rgb(var(--v-theme-background)) 100%
+    ),
+    linear-gradient(
+      180deg,
+      rgba(0, 0, 0, 0.45) 0%,
+      rgba(0, 0, 0, 0.1) 30%,
+      rgba(0, 0, 0, 0.55) 72%,
+      rgba(0, 0, 0, 0.9) 100%
+    );
+}
+.detail-hero--phone .detail-hero__scrim {
+  background:
+    linear-gradient(
+      180deg,
+      rgba(0, 0, 0, 0) 96%,
+      rgb(var(--v-theme-background)) 100%
+    ),
+    linear-gradient(
+      180deg,
+      rgba(0, 0, 0, 0.45) 0%,
+      rgba(0, 0, 0, 0.05) 28%,
+      rgba(0, 0, 0, 0.6) 70%,
+      rgba(0, 0, 0, 0.92) 100%
+    );
+}
+.detail-hero__toolbar {
+  position: relative;
+}
+
+/* the toolbar controls sit on the artwork, so they get their own backdrop
+   instead of the toolbar's transparent one */
+.detail-hero :deep(.v-toolbar__prepend .v-btn),
+.detail-hero :deep(.v-toolbar__append > button) {
+  background-color: rgba(0, 0, 0, 0.35);
+  border-radius: 8px;
+  opacity: 1;
+}
+
+.detail-hero__body {
+  position: absolute;
+  left: 28px;
+  right: 28px;
+  bottom: 24px;
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 24px;
+}
+.detail-hero__main {
+  display: flex;
+  flex: 1 1 auto;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 14px;
+  min-width: 0;
+}
+/* the facts about the item line up on the right, bottom-aligned with the buttons */
+.detail-hero__aside {
+  display: flex;
+  flex: 0 1 auto;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 8px;
+  min-width: 0;
+  text-align: right;
+}
+
+/* an aside whose only child rendered nothing (Vue leaves a comment node there,
+   which :empty ignores) takes no gap of the body's either */
+.detail-hero__aside:empty {
+  display: none;
+}
+
+.detail-hero--phone .detail-hero__body {
+  left: 16px;
+  right: 16px;
+  bottom: 16px;
+  flex-direction: column;
+  align-items: stretch;
+  gap: 12px;
+}
+.detail-hero--phone .detail-hero__aside {
+  align-items: flex-start;
+  text-align: left;
+}
+</style>

--- a/src/components/details/DetailHeroButton.vue
+++ b/src/components/details/DetailHeroButton.vue
@@ -1,0 +1,81 @@
+<template>
+  <button
+    type="button"
+    class="detail-hero-button"
+    :class="{
+      'detail-hero-button--phone': isPhone,
+      'detail-hero-button--pressed': pressed,
+    }"
+    :disabled="disabled"
+    :aria-label="label"
+    :aria-pressed="
+      pressed === undefined ? undefined : pressed ? 'true' : 'false'
+    "
+    :title="label"
+    @click="emit('click', $event)"
+  >
+    <component :is="icon" :size="isPhone ? 18 : 16" />
+    <span v-if="!iconOnly">{{ label }}</span>
+  </button>
+</template>
+
+<script setup lang="ts">
+import { isPhoneSizedScreen } from "@/plugins/breakpoint";
+import { computed, type Component } from "vue";
+
+export interface Props {
+  icon: Component;
+  // always the accessible name; visible beside the icon unless `iconOnly`
+  label: string;
+  iconOnly?: boolean;
+  disabled?: boolean;
+  // set for a toggle (aria-pressed); when on, the icon takes the primary colour
+  pressed?: boolean;
+}
+withDefaults(defineProps<Props>(), {
+  iconOnly: false,
+  disabled: false,
+  pressed: undefined,
+});
+
+const emit = defineEmits<{
+  (e: "click", event: MouseEvent): void;
+}>();
+
+const isPhone = computed(() => isPhoneSizedScreen());
+</script>
+
+<style scoped>
+.detail-hero-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  height: 36px;
+  padding: 0 12px;
+  border: 1px solid rgba(255, 255, 255, 0.25);
+  border-radius: 8px;
+  background: rgba(0, 0, 0, 0.4);
+  color: #fff;
+  font-size: 14px;
+  font-weight: 500;
+  cursor: pointer;
+}
+.detail-hero-button:disabled {
+  cursor: default;
+  opacity: 0.5;
+}
+.detail-hero-button:focus-visible {
+  outline: 2px solid rgb(var(--v-theme-primary));
+  outline-offset: 2px;
+}
+.detail-hero-button--pressed svg {
+  color: rgb(var(--v-theme-primary));
+}
+.detail-hero-button--phone {
+  width: 44px;
+  height: 44px;
+  padding: 0;
+  border-radius: 10px;
+}
+</style>

--- a/src/components/details/DetailHeroGenres.vue
+++ b/src/components/details/DetailHeroGenres.vue
@@ -1,0 +1,72 @@
+<template>
+  <div v-if="genres.length" class="detail-hero-genres">
+    <template v-for="(genre, index) in genres" :key="genre.item_id">
+      <span v-if="index > 0">,&nbsp;</span>
+      <button
+        type="button"
+        class="detail-hero-genres__genre"
+        @click="(e: MouseEvent) => genreClick(e, genre)"
+      >
+        {{ genre.name }}
+      </button>
+    </template>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { handleMediaItemClick } from "@/helpers/media_item_actions";
+import { api } from "@/plugins/api";
+import type { Genre, MediaItemType } from "@/plugins/api/interfaces";
+import { ref, watch } from "vue";
+
+export interface Props {
+  item: MediaItemType;
+}
+const props = defineProps<Props>();
+
+const genres = ref<Genre[]>([]);
+
+watch(
+  () => props.item,
+  async (item) => {
+    const loaded = await api
+      .getGenresForMediaItem(item.media_type, item.item_id)
+      .catch(() => [] as Genre[]);
+    // a slower response for a previous item must not replace the current one
+    if (props.item.uri === item.uri) genres.value = loaded;
+  },
+  { immediate: true },
+);
+
+const genreClick = function (event: MouseEvent, genre: Genre) {
+  handleMediaItemClick(genre, event.clientX, event.clientY);
+};
+</script>
+
+<style scoped>
+.detail-hero-genres {
+  min-width: 0;
+  font-size: 14px;
+  color: rgba(255, 255, 255, 0.85);
+  text-shadow: 0 1px 6px rgba(0, 0, 0, 0.5);
+}
+/* the genres read as links in the line of text, so the button chrome goes */
+.detail-hero-genres__genre {
+  display: inline;
+  padding: 0;
+  border: 0;
+  background: none;
+  color: inherit;
+  font: inherit;
+  vertical-align: baseline;
+  cursor: pointer;
+}
+.detail-hero-genres__genre:hover {
+  text-decoration: underline;
+}
+.detail-hero-genres__genre:focus-visible {
+  outline: 2px solid rgb(var(--v-theme-primary));
+  outline-offset: 2px;
+  border-radius: 4px;
+}
+</style>

--- a/src/components/details/DetailHeroPlayButton.vue
+++ b/src/components/details/DetailHeroPlayButton.vue
@@ -1,0 +1,62 @@
+<template>
+  <MenuButton
+    ref="playButton"
+    :text="playButtonText"
+    :menu-button-label="`${$t('more_options')}: ${$t('play')}`"
+    :loading="playActionInProgress"
+    @click="playButtonClick()"
+    @menu="playButtonClick(true)"
+  />
+</template>
+
+<script setup lang="ts">
+import MenuButton from "@/components/MenuButton.vue";
+import { handlePlayBtnClick } from "@/helpers/media_item_actions";
+import { getPlayerName } from "@/helpers/utils";
+import { api } from "@/plugins/api";
+import type { MediaItemType } from "@/plugins/api/interfaces";
+import { $t } from "@/plugins/i18n";
+import { store } from "@/plugins/store";
+import { computed, useTemplateRef, type ComponentPublicInstance } from "vue";
+
+export interface Props {
+  item: MediaItemType;
+}
+const props = defineProps<Props>();
+
+const playButton = useTemplateRef<ComponentPublicInstance>("playButton");
+
+const playButtonText = computed(() =>
+  store.activePlayer
+    ? $t("play_on_player", { player: getPlayerName(store.activePlayer, 20) })
+    : $t("play"),
+);
+
+// The queue playMedia targets are resolved directly, since activePlayerQueue is
+// undefined while an external source is active.
+const playActionInProgress = computed(() => {
+  const player = store.activePlayer;
+  if (!player) return false;
+  const queueId =
+    player.active_source && player.active_source in api.queues
+      ? player.active_source
+      : player.player_id;
+  return (
+    api.queues[queueId]?.extra_attributes?.play_action_in_progress === true
+  );
+});
+
+const playButtonClick = function (forceMenu = false) {
+  // the play menu hangs from the play button, like on the other detail pages
+  const rect = (
+    playButton.value?.$el as HTMLElement | undefined
+  )?.getBoundingClientRect();
+  handlePlayBtnClick(
+    props.item,
+    rect?.right ?? 0,
+    rect?.bottom ?? 0,
+    undefined,
+    forceMenu,
+  );
+};
+</script>

--- a/src/components/details/RowsEditor.vue
+++ b/src/components/details/RowsEditor.vue
@@ -11,7 +11,7 @@
             {{ $t("edit_rows") }}
           </DialogTitle>
           <DialogDescription class="rows-editor__subtitle text-[13px]">
-            {{ $t("edit_rows_subtitle") }}
+            {{ subtitle }}
           </DialogDescription>
         </div>
         <Button
@@ -34,11 +34,14 @@
       </div>
 
       <div v-if="!isPhone" class="rows-editor__preview">
-        <div class="rows-editor__avatar">
-          <MediaItemThumb :item="artist" size="56" :rounded="false" />
+        <div
+          class="rows-editor__avatar"
+          :class="{ 'rows-editor__avatar--round': roundAvatar }"
+        >
+          <MediaItemThumb :item="item" size="56" :rounded="false" />
         </div>
         <div class="rows-editor__heading">
-          <span class="rows-editor__title">{{ artist.name }}</span>
+          <span class="rows-editor__title">{{ item.name }}</span>
           <span class="rows-editor__subtitle">
             {{ $t("rows_shown", { shown: shownCount, total: rows.length }) }}
           </span>
@@ -170,19 +173,8 @@
   </Dialog>
 </template>
 
-<script setup lang="ts">
-import {
-  artistRowDefinition,
-  artistRowSources,
-  effectiveArtistRowSource,
-  resolveArtistRows,
-  setArtistRowHidden,
-  setArtistRowSource,
-  setArtistRowsOrder,
-  resetArtistRows,
-  type ArtistRowId,
-  type ArtistRowSource,
-} from "@/components/artist/artistRows";
+<script setup lang="ts" generic="Id extends string, Item extends MediaItemType">
+import type { RowRegistry, RowSource } from "@/components/details/rowRegistry";
 import MediaItemThumb from "@/components/MediaItemThumb.vue";
 import PanelDragHandle from "@/components/PanelDragHandle.vue";
 import ProviderIcon from "@/components/ProviderIcon.vue";
@@ -205,7 +197,7 @@ import { SheetContent } from "@/components/ui/sheet";
 import { Switch } from "@/components/ui/switch";
 import { useListDragReorder } from "@/composables/useListDragReorder";
 import { api } from "@/plugins/api";
-import type { Artist } from "@/plugins/api/interfaces";
+import type { MediaItemType } from "@/plugins/api/interfaces";
 import { isPhoneSizedScreen } from "@/plugins/breakpoint";
 import { $t } from "@/plugins/i18n";
 import {
@@ -219,31 +211,39 @@ import {
 } from "@lucide/vue";
 import { computed, ref } from "vue";
 
-export interface Props {
-  artist: Artist;
-  // the rows that apply to this artist, in default order
-  availableIds: ArtistRowId[];
-  // per-row "what feeds it" text supplied by the page, e.g. "11 · newest first"
-  rowMeta?: Partial<Record<ArtistRowId, string>>;
-}
-const props = withDefaults(defineProps<Props>(), { rowMeta: undefined });
+const props = withDefaults(
+  defineProps<{
+    // shown in the desktop preview, and what the rows' sources are computed from
+    item: Item;
+    registry: RowRegistry<Id, Item>;
+    // the rows that apply to this item, in default order
+    availableIds: Id[];
+    // per-row "what feeds it" text supplied by the page, e.g. "11 · newest first"
+    rowMeta?: Partial<Record<Id, string>>;
+    // what the customization applies to, already translated by the page
+    subtitle: string;
+    // artists are portraits, so their preview avatar is a circle
+    roundAvatar?: boolean;
+  }>(),
+  { rowMeta: undefined, roundAvatar: false },
+);
 
 const open = defineModel<boolean>("open", { default: false });
 
 interface SourceOption {
-  value: ArtistRowSource;
+  value: RowSource;
   label: string;
   // provider domain, for the icon beside a provider option
   domain?: string;
 }
 
 interface EditorRow {
-  id: ArtistRowId;
+  id: Id;
   title: string;
   meta: string;
   hidden: boolean;
   // the source feeding the row, undefined when it has no source picker
-  source?: ArtistRowSource;
+  source?: RowSource;
 }
 
 const listEl = ref<HTMLElement | null>(null);
@@ -270,14 +270,15 @@ const chrome = computed(() =>
 // reads the user's preferences from the store, so a toggle, a drop or a reset
 // re-renders the list from what was just saved
 const rows = computed<EditorRow[]>(() => {
-  const { order, hidden } = resolveArtistRows(props.availableIds);
+  const { order, hidden } = props.registry.resolve(props.availableIds);
   return order.map((id) => {
-    const source = artistRowDefinition(id).supportsSource
-      ? effectiveArtistRowSource(id, props.artist)
+    const definition = props.registry.definition(id);
+    const source = definition.supportsSource
+      ? props.registry.effectiveSource(id, props.item)
       : undefined;
     return {
       id,
-      title: $t(artistRowDefinition(id).labelKey),
+      title: $t(definition.labelKey),
       meta: rowMetaText(id, source),
       hidden: hidden.has(id),
       source,
@@ -317,31 +318,31 @@ const dropGapOffset = computed(() => {
 });
 
 /** The label of a source: the library, every provider, or one of them. */
-function sourceLabel(source: ArtistRowSource): string {
+function sourceLabel(source: RowSource): string {
   if (source === "library") return $t("source_library");
   if (source === "all") return $t("source_all");
   return api.providers[source]?.name ?? source;
 }
 
 /** The sources offered for a row, in the order the picker lists them. */
-function sourceOptions(id: ArtistRowId): SourceOption[] {
-  return artistRowSources(id, props.artist).map((source) => ({
+function sourceOptions(id: Id): SourceOption[] {
+  return props.registry.sources(id, props.item).map((source) => ({
     value: source,
     label: sourceLabel(source),
     domain: api.providers[source]?.domain,
   }));
 }
 
-function selectSource(id: ArtistRowId, source: unknown) {
-  if (typeof source === "string") setArtistRowSource(id, source);
+function selectSource(id: Id, source: unknown) {
+  if (typeof source === "string") props.registry.setSource(id, source);
 }
 
-function setHidden(id: ArtistRowId, hidden: boolean) {
-  setArtistRowHidden(id, hidden);
+function setHidden(id: Id, hidden: boolean) {
+  props.registry.setHidden(id, hidden);
 }
 
 function reset() {
-  resetArtistRows();
+  props.registry.reset();
 }
 
 /** Moves the row at `from` to position `to`, by drop or by arrow key. */
@@ -350,7 +351,7 @@ function moveRow(from: number, to: number) {
   const ids = rows.value.map((row) => row.id);
   const [moved] = ids.splice(from, 1);
   ids.splice(to, 0, moved);
-  setArtistRowsOrder(ids, props.availableIds);
+  props.registry.setOrder(ids, props.availableIds);
 }
 
 function slotStyle(index: number) {
@@ -364,8 +365,8 @@ function slotStyle(index: number) {
 }
 
 /** What feeds a row, below its title. */
-function rowMetaText(id: ArtistRowId, source?: ArtistRowSource): string {
-  if (artistRowDefinition(id).adminOnly) return $t("admin_only");
+function rowMetaText(id: Id, source?: RowSource): string {
+  if (props.registry.definition(id).adminOnly) return $t("admin_only");
   const parts = source ? [sourceLabel(source)] : [];
   const meta = props.rowMeta?.[id];
   if (meta) parts.push(meta);
@@ -411,6 +412,8 @@ function rowMetaText(id: ArtistRowId, source?: ArtistRowSource): string {
   height: 56px;
   flex: none;
   overflow: hidden;
+}
+.rows-editor__avatar--round {
   border-radius: 999px;
 }
 

--- a/src/components/details/rowRegistry.ts
+++ b/src/components/details/rowRegistry.ts
@@ -1,0 +1,163 @@
+import { setUserPreference } from "@/composables/userPreferences";
+import {
+  readRowsConfig,
+  resolveRowsConfig,
+  withRowHidden,
+  withRowsOrder,
+  writeRowsConfig,
+} from "@/helpers/rowsConfig";
+import { api } from "@/plugins/api";
+import { store } from "@/plugins/store";
+
+// "library" = in-library items, "all" = every provider at once, else a provider instance id
+export type RowSource = "library" | "all" | (string & {});
+
+export interface RowDefinition<Id extends string> {
+  id: Id;
+  labelKey: string;
+  // shown only to a role that manages the library, which is the admin role
+  adminOnly?: boolean;
+  // gets a "Source" picker in Edit rows
+  supportsSource?: boolean;
+}
+
+export interface RowRegistryConfig<Id extends string, Item> {
+  rows: readonly RowDefinition<Id>[];
+  // the user preference holding the row order and visibility, e.g. "artist.rows"
+  preferenceKey: string;
+  // the user preference holding the per-row sources, e.g. "artist.rowSources";
+  // absent when no row has a source picker
+  sourcesPreferenceKey?: string;
+  // the sources a row of this item could be fed from, in the order a picker lists them;
+  // [] when the item leaves no choice (default: () => [])
+  sourceCandidates?: (id: Id, item: Item) => RowSource[];
+  // the source feeding a row when nothing valid is saved (default: candidates[0] ?? "library")
+  defaultSource?: (id: Id, item: Item, candidates: RowSource[]) => RowSource;
+}
+
+export interface RowRegistry<Id extends string, Item> {
+  readonly rows: readonly RowDefinition<Id>[];
+  readonly preferenceKey: string;
+  readonly sourcesPreferenceKey?: string;
+  definition(id: Id): RowDefinition<Id>;
+  /**
+   * The user's row order and hidden rows, resolved against the rows available
+   * right now. Nothing is hidden by default.
+   */
+  resolve(availableIds: Id[]): { order: Id[]; hidden: Set<Id> };
+  /** Hide or unhide a single row on every page of this kind. */
+  setHidden(id: Id, hidden: boolean): Promise<void>;
+  /**
+   * Reorder the rows available right now. The given ids are rearranged within
+   * the positions they already occupy in the full saved order, so rows that
+   * don't apply to this item keep their slots.
+   */
+  setOrder(orderedIds: Id[], availableIds: Id[]): Promise<void>;
+  /** Clears both preferences (order/visibility and sources). */
+  reset(): Promise<void>;
+  /** The user's saved source for a row, if any. */
+  getSource(id: Id): RowSource | undefined;
+  setSource(id: Id, source: RowSource | undefined): Promise<void>;
+  /** The sources offered in the picker for a row of this item; [] unless the row supportsSource. */
+  sources(id: Id, item: Item): RowSource[];
+  /**
+   * The source that actually feeds a row for this item: the saved one while it
+   * is still among the candidates, otherwise the default.
+   */
+  effectiveSource(id: Id, item: Item): RowSource;
+}
+
+/**
+ * The per-user row customization of one kind of detail page (order, hidden
+ * rows, per-row sources), stored in the current user's preferences.
+ */
+export function createRowRegistry<Id extends string, Item>(
+  config: RowRegistryConfig<Id, Item>,
+): RowRegistry<Id, Item> {
+  const { rows, preferenceKey, sourcesPreferenceKey } = config;
+  const sourceCandidates = config.sourceCandidates ?? (() => []);
+  const defaultSource =
+    config.defaultSource ??
+    ((_id, _item, candidates: RowSource[]) => candidates[0] ?? "library");
+  const byId = Object.fromEntries(rows.map((row) => [row.id, row])) as Record<
+    Id,
+    RowDefinition<Id>
+  >;
+
+  /** The saved `{ [rowId]: source }` object, empty when unset or invalid. */
+  const savedSources = function (): Partial<Record<Id, RowSource>> {
+    if (!sourcesPreferenceKey) return {};
+    const pref = store.currentUser?.preferences?.[sourcesPreferenceKey];
+    if (!pref || typeof pref !== "object") return {};
+    return pref as Partial<Record<Id, RowSource>>;
+  };
+
+  const getSource = function (id: Id): RowSource | undefined {
+    const source = savedSources()[id];
+    return typeof source === "string" ? source : undefined;
+  };
+
+  return {
+    rows,
+    preferenceKey,
+    sourcesPreferenceKey,
+    definition: (id) => byId[id],
+    resolve(availableIds) {
+      const { order, hidden } = resolveRowsConfig(
+        readRowsConfig(preferenceKey),
+        availableIds,
+      );
+      return { order: order as Id[], hidden: hidden as Set<Id> };
+    },
+    async setHidden(id, hidden) {
+      await writeRowsConfig(
+        preferenceKey,
+        withRowHidden(readRowsConfig(preferenceKey), id, hidden),
+      );
+    },
+    async setOrder(orderedIds, availableIds) {
+      const cfg = withRowsOrder(
+        readRowsConfig(preferenceKey),
+        orderedIds,
+        availableIds,
+      );
+      if (!cfg) return;
+      await writeRowsConfig(preferenceKey, cfg);
+    },
+    async reset() {
+      await writeRowsConfig(preferenceKey, {});
+      if (sourcesPreferenceKey)
+        await setUserPreference(sourcesPreferenceKey, {});
+    },
+    getSource,
+    async setSource(id, source) {
+      if (!sourcesPreferenceKey) return;
+      const sources = { ...savedSources() };
+      if (source) {
+        sources[id] = source;
+      } else {
+        delete sources[id];
+      }
+      await setUserPreference(sourcesPreferenceKey, sources);
+    },
+    sources(id, item) {
+      if (!byId[id].supportsSource) return [];
+      return sourceCandidates(id, item);
+    },
+    effectiveSource(id, item) {
+      const candidates = sourceCandidates(id, item);
+      const saved = getSource(id);
+      if (saved && candidates.includes(saved)) return saved;
+      return defaultSource(id, item, candidates);
+    },
+  };
+}
+
+/** The provider behind a row's source, when a single one feeds it (undefined for "library"/"all"). */
+export function rowSourceProvider(
+  source?: RowSource,
+): { name: string; domain: string } | undefined {
+  if (!source || source === "all" || source === "library") return undefined;
+  const provider = api.getProvider(source);
+  return provider && { name: provider.name, domain: provider.domain };
+}

--- a/src/composables/useArtistRowData.ts
+++ b/src/composables/useArtistRowData.ts
@@ -7,12 +7,12 @@ import {
   loadSimilarArtists,
   sortReleasesNewestFirst,
 } from "@/components/artist/artistData";
+import { artistRows, type ArtistRowId } from "@/components/artist/artistRows";
 import {
-  effectiveArtistRowSource,
-  type ArtistRowId,
-  type ArtistRowSource,
-} from "@/components/artist/artistRows";
-import { api } from "@/plugins/api";
+  rowSourceProvider,
+  type RowSource,
+} from "@/components/details/rowRegistry";
+import { mappingsIdentity, useRowRequests } from "@/composables/useRowRequests";
 import type {
   Album,
   Artist,
@@ -36,17 +36,24 @@ export function useArtistRowData(
 ) {
   // Row data per source: two rows fed by the same source share one request and
   // a source change in the editor loads the new one. Absent = still loading.
-  const releases = ref(new Map<ArtistRowSource, Album[]>());
-  const topTracks = ref(new Map<ArtistRowSource, Track[]>());
-  const similarArtists = ref(new Map<ArtistRowSource, Artist[]>());
+  const releases = ref(new Map<RowSource, Album[]>());
+  const topTracks = ref(new Map<RowSource, Track[]>());
+  const similarArtists = ref(new Map<RowSource, Artist[]>());
   const libraryTracks = ref<Track[]>();
 
-  // the requests already sent for the artist currently shown, as "<kind>:<source>"
-  let requested = new Set<string>();
+  // a new artist, or new provider mappings, start from empty rows; anything
+  // else (a favorite toggle, a metadata update) keeps what is already loaded
+  const { fetchOnce } = useRowRequests(artist, mappingsIdentity, () => {
+    releases.value = new Map();
+    topTracks.value = new Map();
+    similarArtists.value = new Map();
+    libraryTracks.value = undefined;
+    loadRowData();
+  });
 
-  const rowSource = function (rowId: ArtistRowId): ArtistRowSource | undefined {
+  const rowSource = function (rowId: ArtistRowId): RowSource | undefined {
     if (!artist.value) return undefined;
-    return effectiveArtistRowSource(rowId, artist.value);
+    return artistRows.effectiveSource(rowId, artist.value);
   };
 
   const albumsSource = computed(() => rowSource("albums"));
@@ -56,7 +63,7 @@ export function useArtistRowData(
   const similarArtistsSource = computed(() => rowSource("similar_artists"));
 
   // releases sorted newest first, from the source that feeds the given row
-  const sortedReleases = function (source?: ArtistRowSource) {
+  const sortedReleases = function (source?: RowSource) {
     const items = sourceItems(releases.value, source);
     return items ? sortReleasesNewestFirst(items) : undefined;
   };
@@ -106,24 +113,10 @@ export function useArtistRowData(
   );
 
   const topTracksProvider = computed(() =>
-    sourceProvider(topTracksSource.value),
+    rowSourceProvider(topTracksSource.value),
   );
   const similarArtistsProvider = computed(() =>
-    sourceProvider(similarArtistsSource.value),
-  );
-
-  // a new artist, or new provider mappings, start from empty rows; anything
-  // else (a favorite toggle, a metadata update) keeps what is already loaded
-  watch(
-    () => artist.value && rowsIdentity(artist.value),
-    () => {
-      releases.value = new Map();
-      topTracks.value = new Map();
-      similarArtists.value = new Map();
-      libraryTracks.value = undefined;
-      requested = new Set();
-      loadRowData();
-    },
+    rowSourceProvider(similarArtistsSource.value),
   );
 
   // unhiding a row or switching its source in the editor loads what it needs,
@@ -142,41 +135,32 @@ export function useArtistRowData(
 
   /** Request what the visible rows need, skipping what is already on its way. */
   function loadRowData() {
-    const shown = artist.value;
-    if (!shown) return;
+    if (!artist.value) return;
     const rows = visibleRows.value;
     // the top tracks row shows the latest release from the albums source
     if (rows.includes("albums") || rows.includes("top_tracks")) {
-      fetchReleases(shown, albumsSource.value!);
+      fetchReleases(albumsSource.value!);
     }
-    if (rows.includes("singles_eps"))
-      fetchReleases(shown, singlesSource.value!);
+    if (rows.includes("singles_eps")) fetchReleases(singlesSource.value!);
     if (rows.includes("appears_on")) {
-      fetchReleases(shown, appearsOnSource.value!);
-      fetchLibraryTracks(shown);
+      fetchReleases(appearsOnSource.value!);
+      fetchLibraryTracks();
     }
     if (rows.includes("top_tracks")) {
-      fetchLibraryTracks(shown);
-      fetchTopTracks(shown, topTracksSource.value!);
+      fetchLibraryTracks();
+      fetchTopTracks(topTracksSource.value!);
     }
     if (rows.includes("similar_artists")) {
-      fetchSimilarArtists(shown, similarArtistsSource.value!);
+      fetchSimilarArtists(similarArtistsSource.value!);
     }
   }
 
-  function fetchReleases(artist: Artist, source: ArtistRowSource) {
-    return fetchInto(
-      artist,
-      "releases",
-      source,
-      releases.value,
-      loadArtistReleases,
-    );
+  function fetchReleases(source: RowSource) {
+    return fetchInto("releases", source, releases.value, loadArtistReleases);
   }
 
-  function fetchTopTracks(artist: Artist, source: ArtistRowSource) {
+  function fetchTopTracks(source: RowSource) {
     return fetchInto(
-      artist,
       "top_tracks",
       source,
       topTracks.value,
@@ -184,9 +168,8 @@ export function useArtistRowData(
     );
   }
 
-  function fetchSimilarArtists(artist: Artist, source: ArtistRowSource) {
+  function fetchSimilarArtists(source: RowSource) {
     return fetchInto(
-      artist,
       "similar_artists",
       source,
       similarArtists.value,
@@ -194,33 +177,26 @@ export function useArtistRowData(
     );
   }
 
-  async function fetchLibraryTracks(artist: Artist) {
-    if (requested.has("library_tracks")) return;
-    requested.add("library_tracks");
-    const identity = rowsIdentity(artist);
-    const items = await orEmpty(loadArtistLibraryTracks(artist));
-    if (stillShown(identity)) libraryTracks.value = items;
+  function fetchLibraryTracks() {
+    return fetchOnce(
+      "library_tracks",
+      (artist) => loadArtistLibraryTracks(artist),
+      (items) => (libraryTracks.value = items),
+    );
   }
 
   /** One request per kind and source, kept for every row that shares it. */
-  async function fetchInto<T>(
-    artist: Artist,
+  function fetchInto<T>(
     kind: string,
-    source: ArtistRowSource,
-    cache: Map<ArtistRowSource, T[]>,
-    load: (artist: Artist, source: ArtistRowSource) => Promise<T[]>,
+    source: RowSource,
+    cache: Map<RowSource, T[]>,
+    load: (artist: Artist, source: RowSource) => Promise<T[]>,
   ) {
-    const key = `${kind}:${source}`;
-    if (requested.has(key)) return;
-    requested.add(key);
-    const identity = rowsIdentity(artist);
-    const items = await orEmpty(load(artist, source));
-    if (stillShown(identity)) cache.set(source, items);
-  }
-
-  /** Whether a finished request still belongs to the artist (and mappings) on screen. */
-  function stillShown(identity: string): boolean {
-    return !!artist.value && rowsIdentity(artist.value) === identity;
+    return fetchOnce(
+      `${kind}:${source}`,
+      (artist) => load(artist, source),
+      (items) => cache.set(source, items),
+    );
   }
 
   return {
@@ -237,27 +213,12 @@ export function useArtistRowData(
   };
 }
 
-/** What the rows are loaded from: the artist and the providers it is mapped to. */
-function rowsIdentity(artist: Artist): string {
-  const mappings = artist.provider_mappings
-    .map((mapping) => `${mapping.provider_instance}:${mapping.item_id}`)
-    .sort();
-  return [artist.uri, ...mappings].join("|");
-}
-
 /** The cached items of a source, undefined while unknown or still loading. */
 function sourceItems<T>(
-  cache: Map<ArtistRowSource, T[]>,
-  source?: ArtistRowSource,
+  cache: Map<RowSource, T[]>,
+  source?: RowSource,
 ): T[] | undefined {
   return source ? cache.get(source) : undefined;
-}
-
-/** The provider behind a row's source, when a single one feeds it. */
-function sourceProvider(source?: ArtistRowSource) {
-  if (!source || source === "all" || source === "library") return undefined;
-  const provider = api.getProvider(source);
-  return provider && { name: provider.name, domain: provider.domain };
 }
 
 /** The library tracks of the newest releases first, the top-tracks fallback. */
@@ -268,14 +229,4 @@ function newestLibraryTracks(tracks: Track[]): Track[] {
 /** The release year of a track's album, 0 when it carries none. */
 function albumYear(track: Track): number {
   return (track.album && "year" in track.album && track.album.year) || 0;
-}
-
-/** A failing provider must not blank the page, so its row just stays empty. */
-async function orEmpty<T>(request: Promise<T[]>): Promise<T[]> {
-  try {
-    return await request;
-  } catch (err) {
-    console.error("[useArtistRowData] failed to load a row", err);
-    return [];
-  }
 }

--- a/src/composables/useRowRequests.ts
+++ b/src/composables/useRowRequests.ts
@@ -1,0 +1,66 @@
+import type { ProviderMapping } from "@/plugins/api/interfaces";
+import { watch, type Ref } from "vue";
+
+/**
+ * One request per key for the item on screen.
+ *
+ * `identity` is what the rows are loaded from; when it changes, the requests
+ * made so far are forgotten and `onReset` runs so the page can clear its caches
+ * and reload. A response that arrives after the identity changed is dropped.
+ */
+export function useRowRequests<Item>(
+  item: Ref<Item | undefined>,
+  identity: (item: Item) => string,
+  onReset: () => void,
+) {
+  // the requests already sent for the item currently shown
+  let requested = new Set<string>();
+
+  watch(
+    () => item.value && identity(item.value),
+    () => {
+      requested = new Set();
+      onReset();
+    },
+  );
+
+  /**
+   * Runs `load` unless `key` was requested for this item before; `store` gets
+   * the result only while the item is still shown. A failing request stores [].
+   */
+  async function fetchOnce<T>(
+    key: string,
+    load: (item: Item) => Promise<T[]>,
+    store: (items: T[]) => void,
+  ): Promise<void> {
+    const shown = item.value;
+    if (!shown || requested.has(key)) return;
+    requested.add(key);
+    const requestedFor = identity(shown);
+    const items = await orEmpty(load(shown));
+    if (item.value && identity(item.value) === requestedFor) store(items);
+  }
+
+  return { fetchOnce };
+}
+
+/** What a media item's rows are loaded from: the item and the providers it is mapped to. */
+export function mappingsIdentity(item: {
+  uri: string;
+  provider_mappings: ProviderMapping[];
+}): string {
+  const mappings = item.provider_mappings
+    .map((mapping) => `${mapping.provider_instance}:${mapping.item_id}`)
+    .sort();
+  return [item.uri, ...mappings].join("|");
+}
+
+/** A failing provider must not blank the page, so its row just stays empty. */
+async function orEmpty<T>(request: Promise<T[]>): Promise<T[]> {
+  try {
+    return await request;
+  } catch (err) {
+    console.error("[useRowRequests] failed to load a row", err);
+    return [];
+  }
+}

--- a/src/views/ArtistDetails.vue
+++ b/src/views/ArtistDetails.vue
@@ -129,32 +129,34 @@
         />
 
         <!-- provider mapping details -->
-        <div v-else-if="rowId === 'provider_mappings'" class="artist-admin">
+        <DetailAdminCard v-else-if="rowId === 'provider_mappings'">
           <ProviderDetails :item-details="itemDetails" />
-        </div>
+        </DetailAdminCard>
 
         <!-- media images -->
-        <div
+        <DetailAdminCard
           v-else-if="
             rowId === 'artwork' &&
             itemDetails.provider == 'library' &&
             itemDetails.metadata?.images
           "
-          class="artist-admin"
         >
           <MediaItemImages
             v-model="itemDetails.metadata.images"
             @update:model-value="UpdateItemInDb"
           />
-        </div>
+        </DetailAdminCard>
       </template>
     </template>
-    <ArtistRowsEditor
+    <RowsEditor
       v-if="itemDetails"
       v-model:open="rowsEditorOpen"
-      :artist="itemDetails"
+      :item="itemDetails"
+      :registry="artistRows"
       :available-ids="availableRows"
       :row-meta="rowMeta"
+      :subtitle="$t('edit_rows_subtitle')"
+      round-avatar
     />
     <br />
   </section>
@@ -164,14 +166,15 @@
 import ArtistBioRow from "@/components/artist/ArtistBioRow.vue";
 import ArtistHero from "@/components/artist/ArtistHero.vue";
 import ArtistReleaseShelf from "@/components/artist/ArtistReleaseShelf.vue";
-import ArtistRowsEditor from "@/components/artist/ArtistRowsEditor.vue";
 import {
+  artistRows,
   availableArtistRowIds,
-  resolveArtistRows,
   type ArtistRowId,
 } from "@/components/artist/artistRows";
 import ArtistSimilarShelf from "@/components/artist/ArtistSimilarShelf.vue";
 import ArtistTopTracksRow from "@/components/artist/ArtistTopTracksRow.vue";
+import DetailAdminCard from "@/components/details/DetailAdminCard.vue";
+import RowsEditor from "@/components/details/RowsEditor.vue";
 import ItemsListing, { LoadDataParams } from "@/components/ItemsListing.vue";
 import MediaItemImages from "@/components/MediaItemImages.vue";
 import ProviderDetails from "@/components/ProviderDetails.vue";
@@ -216,7 +219,7 @@ const availableRows = computed(() =>
 
 // reads the user's preferences from the store, so the page follows the editor
 const visibleRows = computed(() => {
-  const { order, hidden } = resolveArtistRows(availableRows.value);
+  const { order, hidden } = artistRows.resolve(availableRows.value);
   return order.filter((rowId) => !hidden.has(rowId));
 });
 
@@ -422,74 +425,3 @@ function listingRoute(listing: string): RouteLocationRaw | undefined {
   };
 }
 </script>
-
-<style scoped>
-/* the shared admin sections keep their own toolbar and content, but take the
-   page's row title and gutter and sit in a card each; their inline bottom margin
-   is the only spacing they set themselves, hence the override */
-.artist-admin :deep(section) {
-  margin: 16px 28px 0 !important;
-  border-radius: 12px;
-  background: rgba(var(--v-theme-on-surface), 0.04);
-  overflow: hidden;
-}
-.artist-admin :deep(.v-toolbar-title) {
-  font-size: 22px;
-  font-weight: 700;
-  letter-spacing: -0.4px;
-}
-.artist-admin :deep(.v-divider) {
-  display: none;
-}
-/* the lists and image tiles inside sit on the card instead of painting their own surface */
-.artist-admin :deep(.v-container) {
-  padding: 0 12px 12px;
-}
-.artist-admin :deep(.v-list),
-.artist-admin :deep(.panel-item) {
-  background: transparent;
-  box-shadow: none;
-}
-.artist-admin :deep(.v-list) {
-  padding: 0;
-}
-/* uniform square image tiles instead of percentage columns, one row per image type */
-.artist-admin :deep(.v-row) {
-  margin: 0 0 12px;
-  gap: 12px;
-}
-.artist-admin :deep(.v-row:empty) {
-  display: none;
-}
-.artist-admin :deep(.v-col) {
-  flex: 0 0 auto;
-  width: 176px;
-  max-width: 176px;
-  padding: 0;
-}
-.artist-admin :deep(.panel-item) {
-  padding: 8px;
-  /* outweighs the equally-!important radius the card's tile utility carries */
-  border-radius: 12px !important;
-}
-.artist-admin :deep(.panel-item:hover) {
-  background: rgba(var(--v-theme-on-surface), 0.08);
-  box-shadow: none;
-}
-.artist-admin :deep(.panel-item .v-img) {
-  aspect-ratio: 1 / 1;
-  border-radius: 8px;
-}
-.artist-admin :deep(.panel-item .v-img__img) {
-  object-fit: cover;
-}
-
-@media (max-width: 768px) {
-  .artist-admin :deep(section) {
-    margin: 12px 16px 0 !important;
-  }
-  .artist-admin :deep(.v-toolbar-title) {
-    font-size: 19px;
-  }
-}
-</style>

--- a/src/views/ArtistListing.vue
+++ b/src/views/ArtistListing.vue
@@ -32,10 +32,7 @@ import {
   loadArtistLibraryTracks,
   loadArtistReleases,
 } from "@/components/artist/artistData";
-import {
-  artistRowDefinition,
-  effectiveArtistRowSource,
-} from "@/components/artist/artistRows";
+import { artistRows } from "@/components/artist/artistRows";
 import ItemsListing, { LoadDataParams } from "@/components/ItemsListing.vue";
 import { goBack } from "@/helpers/navigation";
 import { api } from "@/plugins/api";
@@ -117,7 +114,7 @@ const config = computed<ListingConfig | undefined>(() => {
     case "albums":
       return {
         ...listingDefaults(),
-        labelKey: artistRowDefinition("albums").labelKey,
+        labelKey: artistRows.definition("albums").labelKey,
         path: "artistalbums",
         showAlbumTypeFilter: true,
         emptyMessage: $t("artist_no_library_albums"),
@@ -129,7 +126,7 @@ const config = computed<ListingConfig | undefined>(() => {
     case "singles":
       return {
         ...listingDefaults(),
-        labelKey: artistRowDefinition("singles_eps").labelKey,
+        labelKey: artistRows.definition("singles_eps").labelKey,
         path: "artistsingles",
         loadItems: async (params: LoadDataParams) =>
           (await loadReleases("singles_eps", params)).filter((album) =>
@@ -157,7 +154,7 @@ const config = computed<ListingConfig | undefined>(() => {
     case "appears_on":
       return {
         ...listingDefaults(),
-        labelKey: artistRowDefinition("appears_on").labelKey,
+        labelKey: artistRows.definition("appears_on").labelKey,
         path: "artistappearson",
         showFavoritesOnlyFilter: false,
         showProviderFilter: false,
@@ -197,7 +194,8 @@ async function loadReleases(
 ) {
   if (!itemDetails.value) return [];
   const source =
-    params.provider?.[0] ?? effectiveArtistRowSource(rowId, itemDetails.value);
+    params.provider?.[0] ??
+    artistRows.effectiveSource(rowId, itemDetails.value);
   return await loadArtistReleases(itemDetails.value, source);
 }
 
@@ -210,7 +208,7 @@ async function loadAppearsOn(): Promise<MediaItemType[]> {
     loadArtistLibraryTracks(itemDetails.value),
     loadArtistReleases(
       itemDetails.value,
-      effectiveArtistRowSource("appears_on", itemDetails.value),
+      artistRows.effectiveSource("appears_on", itemDetails.value),
     ),
   ]);
   return appearsOnAlbums(

--- a/tests/components/artist/artistRows.test.ts
+++ b/tests/components/artist/artistRows.test.ts
@@ -23,16 +23,8 @@ vi.mock("@/composables/userPreferences", () => ({
 import {
   ARTIST_ROWS_PREFERENCE_KEY,
   ARTIST_ROW_SOURCES_PREFERENCE_KEY,
-  artistRowDefinition,
-  artistRowSources,
+  artistRows,
   availableArtistRowIds,
-  effectiveArtistRowSource,
-  getArtistRowSource,
-  resetArtistRows,
-  resolveArtistRows,
-  setArtistRowHidden,
-  setArtistRowSource,
-  setArtistRowsOrder,
   type ArtistRowId,
 } from "@/components/artist/artistRows";
 import {
@@ -109,12 +101,12 @@ describe("artistRows", () => {
     });
   });
 
-  describe("artistRowSources", () => {
+  describe("sources", () => {
     it("lists the library and the capable providers for a release row, never every provider at once", () => {
       addProvider("spotify--abc", [ProviderFeature.ARTIST_ALBUMS]);
       addProvider("tidal--def", []);
       expect(
-        artistRowSources("albums", mappedTo("spotify--abc", "tidal--def")),
+        artistRows.sources("albums", mappedTo("spotify--abc", "tidal--def")),
       ).toEqual(["library", "spotify--abc"]);
     });
 
@@ -126,23 +118,23 @@ describe("artistRows", () => {
         ProviderType.METADATA,
       );
       expect(
-        artistRowSources("similar_artists", mappedTo("spotify--abc")),
+        artistRows.sources("similar_artists", mappedTo("spotify--abc")),
       ).toEqual(["all", "lastfm--ghi", "spotify--abc"]);
     });
 
     it("offers nothing for a provider artist or a row without a picker", () => {
       addProvider("spotify--abc", [ProviderFeature.ARTIST_ALBUMS]);
       const providerArtist = artist({ provider: "spotify--abc" });
-      expect(artistRowSources("albums", providerArtist)).toEqual([]);
-      expect(artistRowSources("appears_on", mappedTo("spotify--abc"))).toEqual(
-        [],
-      );
+      expect(artistRows.sources("albums", providerArtist)).toEqual([]);
+      expect(
+        artistRows.sources("appears_on", mappedTo("spotify--abc")),
+      ).toEqual([]);
     });
   });
 
-  describe("artistRowDefinition", () => {
+  describe("definition", () => {
     it("returns the row's label and source support", () => {
-      expect(artistRowDefinition("albums")).toEqual({
+      expect(artistRows.definition("albums")).toEqual({
         id: "albums",
         labelKey: "albums",
         audience: "music",
@@ -151,9 +143,9 @@ describe("artistRows", () => {
     });
   });
 
-  describe("resolveArtistRows", () => {
+  describe("resolve", () => {
     it("returns the default order with nothing hidden without preferences", () => {
-      const { order, hidden } = resolveArtistRows(MUSIC_ROWS);
+      const { order, hidden } = artistRows.resolve(MUSIC_ROWS);
       expect(order).toEqual(MUSIC_ROWS);
       expect(hidden.size).toBe(0);
     });
@@ -165,7 +157,7 @@ describe("artistRows", () => {
           order: ["albums", "bio", "top_tracks"],
         },
       });
-      const { order, hidden } = resolveArtistRows(MUSIC_ROWS);
+      const { order, hidden } = artistRows.resolve(MUSIC_ROWS);
       // the rows the user never ordered follow their default sibling: albums
       expect(order).toEqual([
         "albums",
@@ -185,15 +177,15 @@ describe("artistRows", () => {
           order: ["audiobooks", "albums"],
         },
       });
-      const { order, hidden } = resolveArtistRows(MUSIC_ROWS);
+      const { order, hidden } = artistRows.resolve(MUSIC_ROWS);
       expect(order).not.toContain("audiobooks");
       expect(hidden.size).toBe(0);
     });
   });
 
-  describe("setArtistRowHidden / setArtistRowsOrder / resetArtistRows", () => {
+  describe("setHidden / setOrder / reset", () => {
     it("persists the hidden row", async () => {
-      await setArtistRowHidden("appears_on", true);
+      await artistRows.setHidden("appears_on", true);
       expect(mockSetUserPreference).toHaveBeenLastCalledWith(
         ARTIST_ROWS_PREFERENCE_KEY,
         expect.objectContaining({ hidden: ["appears_on"], shown: [] }),
@@ -209,7 +201,7 @@ describe("artistRows", () => {
         "appears_on",
         "similar_artists",
       ];
-      await setArtistRowsOrder(reordered, MUSIC_ROWS);
+      await artistRows.setOrder(reordered, MUSIC_ROWS);
       expect(mockSetUserPreference).toHaveBeenLastCalledWith(
         ARTIST_ROWS_PREFERENCE_KEY,
         expect.objectContaining({ order: reordered }),
@@ -217,12 +209,12 @@ describe("artistRows", () => {
     });
 
     it("ignores an order containing unknown rows", async () => {
-      await setArtistRowsOrder(["audiobooks"], MUSIC_ROWS);
+      await artistRows.setOrder(["audiobooks"], MUSIC_ROWS);
       expect(mockSetUserPreference).not.toHaveBeenCalled();
     });
 
     it("clears both preferences", async () => {
-      await resetArtistRows();
+      await artistRows.reset();
       expect(mockSetUserPreference).toHaveBeenCalledWith(
         ARTIST_ROWS_PREFERENCE_KEY,
         { hidden: [], shown: [], order: [] },
@@ -236,20 +228,20 @@ describe("artistRows", () => {
 
   describe("row sources", () => {
     it("reads and writes a single row's source", async () => {
-      expect(getArtistRowSource("albums")).toBeUndefined();
+      expect(artistRows.getSource("albums")).toBeUndefined();
 
       setPreferences({
         [ARTIST_ROW_SOURCES_PREFERENCE_KEY]: { albums: "spotify--abc" },
       });
-      expect(getArtistRowSource("albums")).toBe("spotify--abc");
+      expect(artistRows.getSource("albums")).toBe("spotify--abc");
 
-      await setArtistRowSource("top_tracks", "library");
+      await artistRows.setSource("top_tracks", "library");
       expect(mockSetUserPreference).toHaveBeenLastCalledWith(
         ARTIST_ROW_SOURCES_PREFERENCE_KEY,
         { albums: "spotify--abc", top_tracks: "library" },
       );
 
-      await setArtistRowSource("albums", undefined);
+      await artistRows.setSource("albums", undefined);
       expect(mockSetUserPreference).toHaveBeenLastCalledWith(
         ARTIST_ROW_SOURCES_PREFERENCE_KEY,
         {},
@@ -257,18 +249,22 @@ describe("artistRows", () => {
     });
   });
 
-  describe("effectiveArtistRowSource", () => {
+  describe("effectiveSource", () => {
     it("defaults the release rows to the library", () => {
       const libraryArtist = artist();
-      expect(effectiveArtistRowSource("albums", libraryArtist)).toBe("library");
-      expect(effectiveArtistRowSource("singles_eps", libraryArtist)).toBe(
+      expect(artistRows.effectiveSource("albums", libraryArtist)).toBe(
+        "library",
+      );
+      expect(artistRows.effectiveSource("singles_eps", libraryArtist)).toBe(
         "library",
       );
     });
 
     it("defaults the server-aggregated rows to every provider", () => {
-      expect(effectiveArtistRowSource("top_tracks", artist())).toBe("all");
-      expect(effectiveArtistRowSource("similar_artists", artist())).toBe("all");
+      expect(artistRows.effectiveSource("top_tracks", artist())).toBe("all");
+      expect(artistRows.effectiveSource("similar_artists", artist())).toBe(
+        "all",
+      );
     });
 
     it("uses the saved source when a mapped provider can supply the row", () => {
@@ -276,9 +272,9 @@ describe("artistRows", () => {
         [ARTIST_ROW_SOURCES_PREFERENCE_KEY]: { albums: "spotify--abc" },
       });
       addProvider("spotify--abc", [ProviderFeature.ARTIST_ALBUMS]);
-      expect(effectiveArtistRowSource("albums", mappedTo("spotify--abc"))).toBe(
-        "spotify--abc",
-      );
+      expect(
+        artistRows.effectiveSource("albums", mappedTo("spotify--abc")),
+      ).toBe("spotify--abc");
     });
 
     it("falls back to the default when the saved provider lacks the row's feature", () => {
@@ -287,7 +283,7 @@ describe("artistRows", () => {
       });
       addProvider("spotify--abc", [ProviderFeature.ARTIST_ALBUMS]);
       expect(
-        effectiveArtistRowSource("top_tracks", mappedTo("spotify--abc")),
+        artistRows.effectiveSource("top_tracks", mappedTo("spotify--abc")),
       ).toBe("all");
     });
 
@@ -295,9 +291,9 @@ describe("artistRows", () => {
       setPreferences({
         [ARTIST_ROW_SOURCES_PREFERENCE_KEY]: { albums: "spotify--gone" },
       });
-      expect(effectiveArtistRowSource("albums", mappedTo("spotify--abc"))).toBe(
-        "library",
-      );
+      expect(
+        artistRows.effectiveSource("albums", mappedTo("spotify--abc")),
+      ).toBe("library");
     });
 
     it("ignores an 'all' saved for a release row while the discography existed", () => {
@@ -307,8 +303,8 @@ describe("artistRows", () => {
           top_tracks: "all",
         },
       });
-      expect(effectiveArtistRowSource("albums", artist())).toBe("library");
-      expect(effectiveArtistRowSource("top_tracks", artist())).toBe("all");
+      expect(artistRows.effectiveSource("albums", artist())).toBe("library");
+      expect(artistRows.effectiveSource("top_tracks", artist())).toBe("all");
     });
 
     it("keeps a provider artist on its own provider", () => {
@@ -319,7 +315,7 @@ describe("artistRows", () => {
         provider: "spotify--abc",
         artist_type: ArtistType.SINGER,
       });
-      expect(effectiveArtistRowSource("albums", providerArtist)).toBe(
+      expect(artistRows.effectiveSource("albums", providerArtist)).toBe(
         "spotify--abc",
       );
     });

--- a/tests/components/details/RowsEditor.test.ts
+++ b/tests/components/details/RowsEditor.test.ts
@@ -1,5 +1,6 @@
-import ArtistRowsEditor from "@/components/artist/ArtistRowsEditor.vue";
-import type { ArtistRowId } from "@/components/artist/artistRows";
+import { artistRows, type ArtistRowId } from "@/components/artist/artistRows";
+import type { RowRegistry } from "@/components/details/rowRegistry";
+import RowsEditor from "@/components/details/RowsEditor.vue";
 import {
   ProviderFeature,
   ProviderType,
@@ -12,12 +13,12 @@ import { artist } from "../../fixtures/artist";
 const {
   apiMock,
   buttonStub,
-  mockEffectiveArtistRowSource,
+  mockEffectiveSource,
   mockIsPhoneSizedScreen,
-  mockResetArtistRows,
-  mockResolveArtistRows,
-  mockSetArtistRowHidden,
-  mockSetArtistRowSource,
+  mockReset,
+  mockResolve,
+  mockSetHidden,
+  mockSetSource,
   passthrough,
 } = vi.hoisted(() => ({
   passthrough: { template: "<div><slot /></div>" },
@@ -25,12 +26,12 @@ const {
   apiMock: {
     providers: {} as Record<string, unknown>,
   },
-  mockEffectiveArtistRowSource: vi.fn(),
+  mockEffectiveSource: vi.fn(),
   mockIsPhoneSizedScreen: vi.fn(),
-  mockResetArtistRows: vi.fn(),
-  mockResolveArtistRows: vi.fn(),
-  mockSetArtistRowHidden: vi.fn(),
-  mockSetArtistRowSource: vi.fn(),
+  mockReset: vi.fn(),
+  mockResolve: vi.fn(),
+  mockSetHidden: vi.fn(),
+  mockSetSource: vi.fn(),
 }));
 
 vi.mock("@/plugins/api", () => ({ api: apiMock }));
@@ -40,17 +41,6 @@ vi.mock("@/plugins/api", () => ({ api: apiMock }));
 vi.mock("@/plugins/i18n", async (importOriginal) => ({
   ...(await importOriginal<typeof import("@/plugins/i18n")>()),
   $t: (key: string) => key,
-}));
-
-// the registry itself (labels, which rows get a source picker) stays real; only
-// the preference reads and writes are stubbed
-vi.mock("@/components/artist/artistRows", async (importOriginal) => ({
-  ...(await importOriginal<typeof import("@/components/artist/artistRows")>()),
-  resolveArtistRows: mockResolveArtistRows,
-  effectiveArtistRowSource: mockEffectiveArtistRowSource,
-  setArtistRowHidden: mockSetArtistRowHidden,
-  setArtistRowSource: mockSetArtistRowSource,
-  resetArtistRows: mockResetArtistRows,
 }));
 
 vi.mock("@/plugins/breakpoint", async (importOriginal) => ({
@@ -128,9 +118,27 @@ const ARTIST: Artist = artist({
   ],
 });
 
+// the artist registry itself (labels, which rows get a source picker and which
+// sources they offer) stays real; only the preference reads and writes are stubbed
+const registry: RowRegistry<ArtistRowId, Artist> = {
+  ...artistRows,
+  resolve: mockResolve,
+  effectiveSource: mockEffectiveSource,
+  setHidden: mockSetHidden,
+  setSource: mockSetSource,
+  reset: mockReset,
+};
+
 function mountEditor(availableIds: ArtistRowId[], item: Artist = ARTIST) {
-  return mount(ArtistRowsEditor, {
-    props: { open: true, artist: item, availableIds },
+  return mount(RowsEditor, {
+    props: {
+      open: true,
+      item,
+      registry,
+      availableIds,
+      subtitle: "edit_rows_subtitle",
+      roundAvatar: true,
+    },
     global: { mocks: { $t: (key: string) => key } },
   });
 }
@@ -143,7 +151,7 @@ function buttonWithText(wrapper: VueWrapper, text: string) {
   return wrapper.findAll("button").find((btn) => btn.text().includes(text));
 }
 
-describe("ArtistRowsEditor", () => {
+describe("RowsEditor", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     // the sources on offer come from the providers the artist is mapped to that
@@ -161,15 +169,15 @@ describe("ArtistRowsEditor", () => {
       },
     };
     mockIsPhoneSizedScreen.mockReturnValue(false);
-    mockEffectiveArtistRowSource.mockReturnValue("all");
-    mockResolveArtistRows.mockImplementation((availableIds: ArtistRowId[]) => ({
+    mockEffectiveSource.mockReturnValue("all");
+    mockResolve.mockImplementation((availableIds: ArtistRowId[]) => ({
       order: availableIds,
       hidden: new Set<ArtistRowId>(),
     }));
   });
 
   it("renders the rows in the saved order, hidden ones dimmed in place", () => {
-    mockResolveArtistRows.mockReturnValue({
+    mockResolve.mockReturnValue({
       order: ["albums", "bio", "top_tracks"],
       hidden: new Set(["bio"]),
     });
@@ -189,18 +197,25 @@ describe("ArtistRowsEditor", () => {
     );
   });
 
+  it("shows the page's subtitle and a round avatar for a portrait", () => {
+    const wrapper = mountEditor(["bio"]);
+
+    expect(wrapper.text()).toContain("edit_rows_subtitle");
+    expect(wrapper.find(".rows-editor__avatar--round").exists()).toBe(true);
+  });
+
   it("hides a row from its eye toggle and shows it again", async () => {
-    mockResolveArtistRows.mockReturnValue({
+    mockResolve.mockReturnValue({
       order: ["albums", "bio"],
       hidden: new Set(["bio"]),
     });
 
     const wrapper = mountEditor(["bio", "albums"]);
     await wrapper.get('[aria-label="hide_row"]').trigger("click");
-    expect(mockSetArtistRowHidden).toHaveBeenCalledWith("albums", true);
+    expect(mockSetHidden).toHaveBeenCalledWith("albums", true);
 
     await wrapper.get('[aria-label="show_row"]').trigger("click");
-    expect(mockSetArtistRowHidden).toHaveBeenCalledWith("bio", false);
+    expect(mockSetHidden).toHaveBeenCalledWith("bio", false);
   });
 
   it("clears both preferences from the reset button", async () => {
@@ -208,7 +223,7 @@ describe("ArtistRowsEditor", () => {
 
     await buttonWithText(wrapper, "reset_to_default")!.trigger("click");
 
-    expect(mockResetArtistRows).toHaveBeenCalled();
+    expect(mockReset).toHaveBeenCalled();
   });
 
   it("closes on done", async () => {
@@ -224,7 +239,7 @@ describe("ArtistRowsEditor", () => {
 
     await wrapper.get('[data-source="spotify--1"]').trigger("click");
 
-    expect(mockSetArtistRowSource).toHaveBeenCalledWith("albums", "spotify--1");
+    expect(mockSetSource).toHaveBeenCalledWith("albums", "spotify--1");
   });
 
   it("offers the library to a release row and every provider at once to an aggregated one", () => {
@@ -259,6 +274,6 @@ describe("ArtistRowsEditor", () => {
     const wrapper = mountEditor(["bio"]);
     await wrapper.get('[role="switch"]').trigger("click");
 
-    expect(mockSetArtistRowHidden).toHaveBeenCalledWith("bio", true);
+    expect(mockSetHidden).toHaveBeenCalledWith("bio", true);
   });
 });

--- a/tests/components/details/rowRegistry.test.ts
+++ b/tests/components/details/rowRegistry.test.ts
@@ -1,0 +1,191 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { storeMock, mockSetUserPreference, mockGetProvider } = vi.hoisted(
+  () => ({
+    storeMock: {
+      currentUser: null as { preferences?: Record<string, unknown> } | null,
+    },
+    mockSetUserPreference: vi.fn(),
+    mockGetProvider: vi.fn(),
+  }),
+);
+
+vi.mock("@/plugins/store", () => ({
+  store: storeMock,
+}));
+
+vi.mock("@/plugins/api", () => ({
+  api: { getProvider: mockGetProvider },
+}));
+
+vi.mock("@/composables/userPreferences", () => ({
+  setUserPreference: mockSetUserPreference,
+}));
+
+import {
+  createRowRegistry,
+  rowSourceProvider,
+  type RowSource,
+} from "@/components/details/rowRegistry";
+
+type RowId = "with_picker" | "plain" | "admin";
+
+// the item decides what a row can be fed from
+interface Item {
+  candidates: RowSource[];
+}
+
+const ROWS_KEY = "test.rows";
+const SOURCES_KEY = "test.rowSources";
+
+const registry = createRowRegistry<RowId, Item>({
+  rows: [
+    { id: "with_picker", labelKey: "with_picker", supportsSource: true },
+    { id: "plain", labelKey: "plain" },
+    { id: "admin", labelKey: "admin", adminOnly: true },
+  ],
+  preferenceKey: ROWS_KEY,
+  sourcesPreferenceKey: SOURCES_KEY,
+  sourceCandidates: (_id, item) => item.candidates,
+});
+
+const ITEM: Item = { candidates: ["all", "spotify--abc"] };
+
+function setPreferences(preferences: Record<string, unknown>) {
+  storeMock.currentUser = { preferences };
+}
+
+describe("rowRegistry", () => {
+  beforeEach(() => {
+    mockSetUserPreference.mockReset();
+    mockGetProvider.mockReset();
+    setPreferences({});
+  });
+
+  it("exposes its rows and preference keys", () => {
+    expect(registry.rows.map((row) => row.id)).toEqual([
+      "with_picker",
+      "plain",
+      "admin",
+    ]);
+    expect(registry.preferenceKey).toBe(ROWS_KEY);
+    expect(registry.sourcesPreferenceKey).toBe(SOURCES_KEY);
+    expect(registry.definition("admin")).toEqual({
+      id: "admin",
+      labelKey: "admin",
+      adminOnly: true,
+    });
+  });
+
+  it("offers the candidates only to a row with a picker", () => {
+    expect(registry.sources("with_picker", ITEM)).toEqual(ITEM.candidates);
+    expect(registry.sources("plain", ITEM)).toEqual([]);
+  });
+
+  it("feeds a row from its first candidate by default", () => {
+    expect(registry.effectiveSource("with_picker", ITEM)).toBe("all");
+  });
+
+  it("uses the saved source while it is among the candidates", () => {
+    setPreferences({ [SOURCES_KEY]: { with_picker: "spotify--abc" } });
+    expect(registry.getSource("with_picker")).toBe("spotify--abc");
+    expect(registry.effectiveSource("with_picker", ITEM)).toBe("spotify--abc");
+  });
+
+  it("ignores a saved source that is no longer among the candidates", () => {
+    setPreferences({ [SOURCES_KEY]: { with_picker: "spotify--gone" } });
+    expect(registry.effectiveSource("with_picker", ITEM)).toBe("all");
+  });
+
+  it("falls back to the library when the item offers no candidates", () => {
+    const bare = createRowRegistry<RowId, Item>({
+      rows: registry.rows,
+      preferenceKey: ROWS_KEY,
+      sourcesPreferenceKey: SOURCES_KEY,
+    });
+    expect(bare.sources("with_picker", ITEM)).toEqual([]);
+    expect(bare.effectiveSource("with_picker", ITEM)).toBe("library");
+  });
+
+  it("lets the page decide the default source", () => {
+    const own = createRowRegistry<RowId, Item>({
+      rows: registry.rows,
+      preferenceKey: ROWS_KEY,
+      sourcesPreferenceKey: SOURCES_KEY,
+      sourceCandidates: (_id, item) => item.candidates,
+      defaultSource: (_id, _item, candidates) => candidates[1],
+    });
+    expect(own.effectiveSource("with_picker", ITEM)).toBe("spotify--abc");
+  });
+
+  it("resolves the saved order and visibility against the available rows", () => {
+    setPreferences({
+      [ROWS_KEY]: { hidden: ["plain"], order: ["plain", "with_picker"] },
+    });
+    const { order, hidden } = registry.resolve(["with_picker", "plain"]);
+    expect(order).toEqual(["plain", "with_picker"]);
+    expect(hidden).toEqual(new Set(["plain"]));
+  });
+
+  it("writes a row's visibility, order and source", async () => {
+    await registry.setHidden("plain", true);
+    expect(mockSetUserPreference).toHaveBeenLastCalledWith(
+      ROWS_KEY,
+      expect.objectContaining({ hidden: ["plain"] }),
+    );
+
+    await registry.setOrder(["plain", "with_picker"], ["with_picker", "plain"]);
+    expect(mockSetUserPreference).toHaveBeenLastCalledWith(
+      ROWS_KEY,
+      expect.objectContaining({ order: ["plain", "with_picker"] }),
+    );
+
+    await registry.setSource("with_picker", "spotify--abc");
+    expect(mockSetUserPreference).toHaveBeenLastCalledWith(SOURCES_KEY, {
+      with_picker: "spotify--abc",
+    });
+  });
+
+  it("clears both preferences on reset", async () => {
+    await registry.reset();
+    expect(mockSetUserPreference).toHaveBeenCalledWith(ROWS_KEY, {
+      hidden: [],
+      shown: [],
+      order: [],
+    });
+    expect(mockSetUserPreference).toHaveBeenLastCalledWith(SOURCES_KEY, {});
+  });
+
+  it("keeps only the row preference when no row has a source picker", async () => {
+    const plain = createRowRegistry<"plain", Item>({
+      rows: [{ id: "plain", labelKey: "plain" }],
+      preferenceKey: ROWS_KEY,
+    });
+    await plain.setSource("plain", "spotify--abc");
+    await plain.reset();
+    expect(mockSetUserPreference).toHaveBeenCalledTimes(1);
+    expect(mockSetUserPreference).toHaveBeenCalledWith(ROWS_KEY, {
+      hidden: [],
+      shown: [],
+      order: [],
+    });
+  });
+
+  describe("rowSourceProvider", () => {
+    it("names the single provider behind a source", () => {
+      mockGetProvider.mockReturnValue({ name: "Spotify", domain: "spotify" });
+      expect(rowSourceProvider("spotify--abc")).toEqual({
+        name: "Spotify",
+        domain: "spotify",
+      });
+      expect(mockGetProvider).toHaveBeenCalledWith("spotify--abc");
+    });
+
+    it("has none for the library, every provider, or an unknown one", () => {
+      expect(rowSourceProvider("library")).toBeUndefined();
+      expect(rowSourceProvider("all")).toBeUndefined();
+      expect(rowSourceProvider(undefined)).toBeUndefined();
+      expect(rowSourceProvider("spotify--gone")).toBeUndefined();
+    });
+  });
+});

--- a/tests/composables/useArtistRowData.test.ts
+++ b/tests/composables/useArtistRowData.test.ts
@@ -1,8 +1,8 @@
 import {
   ARTIST_ROW_SOURCES_PREFERENCE_KEY,
   type ArtistRowId,
-  type ArtistRowSource,
 } from "@/components/artist/artistRows";
+import type { RowSource } from "@/components/details/rowRegistry";
 import { useArtistRowData } from "@/composables/useArtistRowData";
 import {
   AlbumType,
@@ -35,12 +35,12 @@ const {
     providers: {} as Record<string, unknown>,
   },
   mockLoadArtistReleases:
-    vi.fn<(artist: Artist, source: ArtistRowSource) => Promise<Album[]>>(),
+    vi.fn<(artist: Artist, source: RowSource) => Promise<Album[]>>(),
   mockLoadArtistLibraryTracks: vi.fn<(artist: Artist) => Promise<Track[]>>(),
   mockLoadArtistTopTracks:
-    vi.fn<(artist: Artist, source: ArtistRowSource) => Promise<Track[]>>(),
+    vi.fn<(artist: Artist, source: RowSource) => Promise<Track[]>>(),
   mockLoadSimilarArtists:
-    vi.fn<(artist: Artist, source: ArtistRowSource) => Promise<Artist[]>>(),
+    vi.fn<(artist: Artist, source: RowSource) => Promise<Artist[]>>(),
 }));
 
 vi.mock("@/plugins/api", () => ({ api: mockApi, default: mockApi }));
@@ -93,16 +93,14 @@ async function showArtist(page: RowData, item: Artist) {
 }
 
 /** The user's saved per-row sources, which the editor writes and rows follow. */
-function saveRowSources(
-  sources: Partial<Record<ArtistRowId, ArtistRowSource>>,
-) {
+function saveRowSources(sources: Partial<Record<ArtistRowId, RowSource>>) {
   store.currentUser = user({
     preferences: { [ARTIST_ROW_SOURCES_PREFERENCE_KEY]: sources },
   });
 }
 
 /** The source of every release request that was issued, in order. */
-function releaseSources(): ArtistRowSource[] {
+function releaseSources(): RowSource[] {
   return mockLoadArtistReleases.mock.calls.map(([, source]) => source);
 }
 

--- a/tests/composables/useRowRequests.test.ts
+++ b/tests/composables/useRowRequests.test.ts
@@ -1,0 +1,110 @@
+import { useRowRequests } from "@/composables/useRowRequests";
+import { flushPromises } from "@vue/test-utils";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { effectScope, ref, type EffectScope } from "vue";
+
+interface Item {
+  id: string;
+}
+
+const scopes: EffectScope[] = [];
+
+/** The composable with no item on screen yet. */
+function setupRequests() {
+  const item = ref<Item>();
+  const onReset = vi.fn();
+  const scope = effectScope();
+  scopes.push(scope);
+  const { fetchOnce } = scope.run(() =>
+    useRowRequests(item, (shown) => shown.id, onReset),
+  )!;
+  return { item, onReset, fetchOnce };
+}
+
+/** Puts an item on screen, the way a page does once its details load. */
+async function show(page: ReturnType<typeof setupRequests>, id: string) {
+  page.item.value = { id };
+  await flushPromises();
+}
+
+describe("useRowRequests", () => {
+  afterEach(() => {
+    scopes.splice(0).forEach((scope) => scope.stop());
+    vi.restoreAllMocks();
+  });
+
+  it("requests a key once per item and stores the result", async () => {
+    const page = setupRequests();
+    await show(page, "a");
+    const load = vi.fn().mockResolvedValue(["x"]);
+    const store = vi.fn();
+
+    await page.fetchOnce("rows", load, store);
+    await page.fetchOnce("rows", load, store);
+
+    expect(load).toHaveBeenCalledTimes(1);
+    expect(load).toHaveBeenCalledWith({ id: "a" });
+    expect(store).toHaveBeenCalledTimes(1);
+    expect(store).toHaveBeenCalledWith(["x"]);
+  });
+
+  it("requests nothing while no item is shown", async () => {
+    const page = setupRequests();
+    const load = vi.fn().mockResolvedValue([]);
+
+    await page.fetchOnce("rows", load, vi.fn());
+
+    expect(load).not.toHaveBeenCalled();
+  });
+
+  it("resets and requests again when the identity changes", async () => {
+    const page = setupRequests();
+    await show(page, "a");
+    const load = vi.fn().mockResolvedValue([]);
+    await page.fetchOnce("rows", load, vi.fn());
+    expect(page.onReset).toHaveBeenCalledTimes(1);
+
+    await show(page, "b");
+    await page.fetchOnce("rows", load, vi.fn());
+
+    expect(page.onReset).toHaveBeenCalledTimes(2);
+    expect(load).toHaveBeenCalledTimes(2);
+    expect(load).toHaveBeenLastCalledWith({ id: "b" });
+  });
+
+  it("drops a response that arrives after the identity changed", async () => {
+    const page = setupRequests();
+    await show(page, "a");
+    let resolveLoad: (items: string[]) => void = () => {};
+    const store = vi.fn();
+    const pending = page.fetchOnce(
+      "rows",
+      () =>
+        new Promise<string[]>((resolve) => {
+          resolveLoad = resolve;
+        }),
+      store,
+    );
+
+    await show(page, "b");
+    resolveLoad(["stale"]);
+    await pending;
+
+    expect(store).not.toHaveBeenCalled();
+  });
+
+  it("stores an empty list when the request fails", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    const page = setupRequests();
+    await show(page, "a");
+    const store = vi.fn();
+
+    await page.fetchOnce(
+      "rows",
+      () => Promise.reject(new Error("down")),
+      store,
+    );
+
+    expect(store).toHaveBeenCalledWith([]);
+  });
+});

--- a/tests/views/ArtistDetails.test.ts
+++ b/tests/views/ArtistDetails.test.ts
@@ -52,9 +52,12 @@ vi.mock("@/plugins/i18n", async (importOriginal) => ({
 
 vi.mock("@/components/artist/artistRows", () => ({
   availableArtistRowIds: mockAvailableArtistRowIds,
-  resolveArtistRows: mockResolveArtistRows,
-  effectiveArtistRowSource: () => "all",
-  artistRowSources: () => ["library", "all"],
+  artistRows: {
+    resolve: mockResolveArtistRows,
+    definition: (id: string) => ({ id, labelKey: id }),
+    effectiveSource: () => "all",
+    sources: () => ["library", "all"],
+  },
 }));
 
 // the loaders are mocked, the pure helpers (sorting, single/EP and library


### PR DESCRIPTION
# What does this implement/fix?

Groundwork for giving the track page (and later the album page) the same look as the artist page: the artist page's building blocks move into media-type-generic components under `src/components/details`, and the artist page is rebuilt on top of them without any visible change.

- `rowRegistry.ts`: a page's rows and the user's order, hidden rows and per-row sources, stored in their preferences; the artist rows are now an instance of it
- `RowsEditor.vue`: the "Edit rows" dialog (desktop) and bottom sheet (phone), generic over the registry
- `DetailHero.vue` with `DetailHeroPlayButton`, `DetailHeroButton` and `DetailHeroGenres`: the full-bleed hero shell, its overflow menu with the "Edit rows" entry, and the pieces every hero shares
- `DetailAdminCard.vue`: the card styling of the provider details and artwork sections
- `useRowRequests`: the per-item request bookkeeping behind the row data (one request per key, responses for a previous item dropped)
- Tests moved along and new ones for the generic pieces; the artist page tests keep their scenarios

**Related issue (if applicable):**

- none

**Related backend PR (if applicable):**

- none

## Types of changes

<!--
Tick exactly one box below. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm lint:check` passes.
- [x] `pnpm test:run` passes, and tests have been added/updated where applicable.
- [x] `pnpm build` passes.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
