### PR TITLE
Show the Home Assistant system account in user management

### DIFF
--- a/src/components/users/EditUserDialog.vue
+++ b/src/components/users/EditUserDialog.vue
@@ -18,7 +18,7 @@
                     :name="field.name"
                     :model-value="field.state.value"
                     :aria-invalid="isInvalid(field)"
-                    :disabled="isSystemUser"
+                    :disabled="isSystemAccount"
                     autocomplete="username"
                     @blur="field.handleBlur"
                     @input="
@@ -29,7 +29,7 @@
                       }
                     "
                   />
-                  <FieldDescription v-if="isSystemUser">
+                  <FieldDescription v-if="isSystemAccount">
                     {{ $t("auth.system_user_hint") }}
                   </FieldDescription>
                   <FieldError
@@ -106,7 +106,7 @@
                   </FieldLabel>
                   <Select
                     :model-value="field.state.value"
-                    :disabled="isCurrentUser || isSystemUser"
+                    :disabled="isCurrentUser || isSystemAccount"
                     @update:model-value="
                       (value) => field.handleChange(value as UserRole)
                     "
@@ -128,7 +128,7 @@
               </template>
             </form.Field>
 
-            <form.Field v-if="!isSystemUser" name="password">
+            <form.Field v-if="!isSystemAccount" name="password">
               <template #default="{ field }">
                 <Field :data-invalid="isInvalid(field)">
                   <FieldLabel :for="field.name">
@@ -162,7 +162,7 @@
             </form.Field>
 
             <form.Field
-              v-if="!isSystemUser && passwordValue"
+              v-if="!isSystemAccount && passwordValue"
               name="confirmPassword"
             >
               <template #default="{ field }">
@@ -263,7 +263,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import { isSystemUser as resolveIsSystemUser } from "@/helpers/users";
+import { isSystemUser } from "@/helpers/users";
 import { editUserSchema } from "@/lib/forms/profile";
 import { api, ApiCommandError } from "@/plugins/api";
 import type { User } from "@/plugins/api/interfaces";
@@ -344,9 +344,9 @@ const isCurrentUser = computed(() => {
   return props.user.user_id === store.currentUser.user_id;
 });
 
-const isSystemUser = computed(() => {
+const isSystemAccount = computed(() => {
   if (!props.user) return false;
-  return resolveIsSystemUser(props.user);
+  return isSystemUser(props.user);
 });
 
 const form = useForm({
@@ -387,11 +387,7 @@ const form = useForm({
       if (value.avatarUrl !== (props.user.avatar_url || "")) {
         updates.avatarUrl = value.avatarUrl;
       }
-      if (
-        value.role !== props.user.role &&
-        !isCurrentUser.value &&
-        !isSystemUser.value
-      ) {
+      if (value.role !== props.user.role && !isCurrentUser.value) {
         updates.role = value.role;
       }
       if (value.password) {

--- a/src/components/users/EditUserDialog.vue
+++ b/src/components/users/EditUserDialog.vue
@@ -18,6 +18,7 @@
                     :name="field.name"
                     :model-value="field.state.value"
                     :aria-invalid="isInvalid(field)"
+                    :disabled="isSystemUser"
                     autocomplete="username"
                     @blur="field.handleBlur"
                     @input="
@@ -28,6 +29,9 @@
                       }
                     "
                   />
+                  <FieldDescription v-if="isSystemUser">
+                    {{ $t("auth.system_user_hint") }}
+                  </FieldDescription>
                   <FieldError
                     v-if="isInvalid(field)"
                     :errors="field.state.meta.errors"
@@ -102,7 +106,7 @@
                   </FieldLabel>
                   <Select
                     :model-value="field.state.value"
-                    :disabled="isCurrentUser"
+                    :disabled="isCurrentUser || isSystemUser"
                     @update:model-value="
                       (value) => field.handleChange(value as UserRole)
                     "
@@ -124,7 +128,7 @@
               </template>
             </form.Field>
 
-            <form.Field name="password">
+            <form.Field v-if="!isSystemUser" name="password">
               <template #default="{ field }">
                 <Field :data-invalid="isInvalid(field)">
                   <FieldLabel :for="field.name">
@@ -157,7 +161,10 @@
               </template>
             </form.Field>
 
-            <form.Field v-if="passwordValue" name="confirmPassword">
+            <form.Field
+              v-if="!isSystemUser && passwordValue"
+              name="confirmPassword"
+            >
               <template #default="{ field }">
                 <Field :data-invalid="isInvalid(field)">
                   <FieldLabel :for="field.name">
@@ -256,6 +263,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import { isSystemUser as resolveIsSystemUser } from "@/helpers/users";
 import { editUserSchema } from "@/lib/forms/profile";
 import { api, ApiCommandError } from "@/plugins/api";
 import type { User } from "@/plugins/api/interfaces";
@@ -308,11 +316,19 @@ const handleFormSubmit = async () => {
   }
 };
 
-const roleOptions = computed(() => [
-  { label: t("auth.admin_role"), value: "admin" },
-  { label: t("auth.user_role"), value: "user" },
-  { label: t("auth.guest_role"), value: "guest" },
-]);
+const roleOptions = computed(() => {
+  const options = [
+    { label: t("auth.admin_role"), value: "admin" },
+    { label: t("auth.user_role"), value: "user" },
+    { label: t("auth.guest_role"), value: "guest" },
+  ];
+  // service is not offered as a choice, only listed to show it for an
+  // account that holds it
+  if (props.user?.role === UserRole.SERVICE) {
+    options.push({ label: t("auth.service_role"), value: "service" });
+  }
+  return options;
+});
 
 const playerOptions = computed(() => {
   return Object.values(api.players)
@@ -326,6 +342,11 @@ const playerOptions = computed(() => {
 const isCurrentUser = computed(() => {
   if (!props.user || !store.currentUser) return false;
   return props.user.user_id === store.currentUser.user_id;
+});
+
+const isSystemUser = computed(() => {
+  if (!props.user) return false;
+  return resolveIsSystemUser(props.user);
 });
 
 const form = useForm({
@@ -366,7 +387,11 @@ const form = useForm({
       if (value.avatarUrl !== (props.user.avatar_url || "")) {
         updates.avatarUrl = value.avatarUrl;
       }
-      if (value.role !== props.user.role && !isCurrentUser.value) {
+      if (
+        value.role !== props.user.role &&
+        !isCurrentUser.value &&
+        !isSystemUser.value
+      ) {
         updates.role = value.role;
       }
       if (value.password) {

--- a/src/helpers/provider_access.test.ts
+++ b/src/helpers/provider_access.test.ts
@@ -1,3 +1,4 @@
+import { HOMEASSISTANT_SYSTEM_USER } from "@/helpers/users";
 import {
   ProviderSharing,
   ProviderType,
@@ -108,9 +109,9 @@ describe("user candidates", () => {
     username: "guest",
     role: UserRole.GUEST,
   });
-  const service = user({
-    user_id: "service",
-    username: "service",
+  const systemAccount = user({
+    user_id: "ha",
+    username: HOMEASSISTANT_SYSTEM_USER,
     role: UserRole.SERVICE,
   });
   const disabled = user({
@@ -118,14 +119,23 @@ describe("user candidates", () => {
     username: "disabled",
     enabled: false,
   });
-  const users = [owner, member, guest, service, disabled];
+  const users = [owner, member, guest, systemAccount, disabled];
 
-  it("offers enabled members as owner, not guests or service accounts", () => {
+  it("offers enabled members as owner, not guests or the Home Assistant account", () => {
     expect(ownerCandidates(users)).toEqual([owner, member]);
   });
 
+  it("offers another service account as owner", () => {
+    const service = user({
+      user_id: "service",
+      username: "service",
+      role: UserRole.SERVICE,
+    });
+    expect(ownerCandidates([service])).toEqual([service]);
+  });
+
   it("offers every enabled member to share with, not guests", () => {
-    expect(shareCandidates(users)).toEqual([owner, member, service]);
+    expect(shareCandidates(users)).toEqual([owner, member, systemAccount]);
   });
 });
 

--- a/src/helpers/provider_access.ts
+++ b/src/helpers/provider_access.ts
@@ -1,3 +1,4 @@
+import { isSystemUser } from "@/helpers/users";
 import {
   type ProviderAccess,
   type ProviderConfig,
@@ -59,13 +60,14 @@ export const getProviderSharingHintTranslationKey = (
   sharing: ProviderSharing,
 ) => PROVIDER_SHARING_HINT_TRANSLATION_KEYS[sharing];
 
-/** The users that may own a music source: enabled members, so no guests or service accounts. */
+/**
+ * The users that may own a music source: every enabled member, so neither the
+ * guests nor the Home Assistant system account.
+ */
 export const ownerCandidates = (users: User[]) =>
   users.filter(
     (user) =>
-      user.enabled &&
-      user.role !== UserRole.GUEST &&
-      user.role !== UserRole.SERVICE,
+      user.enabled && user.role !== UserRole.GUEST && !isSystemUser(user),
   );
 
 /**

--- a/src/helpers/users.ts
+++ b/src/helpers/users.ts
@@ -1,0 +1,8 @@
+import type { User } from "@/plugins/api/interfaces";
+
+/** Username of the Home Assistant integration's system account. */
+export const HOMEASSISTANT_SYSTEM_USER = "homeassistant_system";
+
+/** Whether the user is the Home Assistant integration's system account. */
+export const isSystemUser = (user: User): boolean =>
+  user.username === HOMEASSISTANT_SYSTEM_USER;

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1312,6 +1312,8 @@
         "update_password": "Update password",
         "guest_role": "Guest",
         "service_role": "Service",
+        "system_user": "System",
+        "system_user_hint": "Home Assistant signs in with this account, so its username, role and password can not be changed.",
         "tokens_load_failed": "Failed to load access tokens",
         "users_load_failed": "Failed to load users"
     },

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1313,7 +1313,7 @@
         "guest_role": "Guest",
         "service_role": "Service",
         "system_user": "System",
-        "system_user_hint": "Home Assistant signs in with this account, so its username, role and password can not be changed.",
+        "system_user_hint": "Home Assistant signs in with this account, so its username, role and password cannot be changed.",
         "tokens_load_failed": "Failed to load access tokens",
         "users_load_failed": "Failed to load users"
     },

--- a/src/views/settings/UserManagement.vue
+++ b/src/views/settings/UserManagement.vue
@@ -72,7 +72,7 @@
                       {{ $t("auth.manage_tokens") }}
                     </DropdownMenuItem>
                     <DropdownMenuItem
-                      v-if="!isCurrentUser(user)"
+                      v-if="!isCurrentUser(user) && !isSystemUser(user)"
                       @click.stop="
                         user.enabled
                           ? confirmDisableUser(user)
@@ -89,9 +89,11 @@
                           : $t("auth.enable_user")
                       }}
                     </DropdownMenuItem>
-                    <DropdownMenuSeparator v-if="!isCurrentUser(user)" />
+                    <DropdownMenuSeparator
+                      v-if="!isCurrentUser(user) && !isSystemUser(user)"
+                    />
                     <DropdownMenuItem
-                      v-if="!isCurrentUser(user)"
+                      v-if="!isCurrentUser(user) && !isSystemUser(user)"
                       class="text-destructive focus:text-destructive"
                       @click.stop="confirmDeleteUser(user)"
                     >
@@ -101,9 +103,17 @@
                   </DropdownMenuContent>
                 </DropdownMenu>
               </div>
-              <Badge v-if="!user.enabled" variant="destructive" class="mt-2">
-                {{ $t("auth.disabled") }}
-              </Badge>
+              <div
+                v-if="!user.enabled || isSystemUser(user)"
+                class="flex flex-wrap gap-2 mt-2"
+              >
+                <Badge v-if="!user.enabled" variant="destructive">
+                  {{ $t("auth.disabled") }}
+                </Badge>
+                <Badge v-if="isSystemUser(user)" variant="secondary">
+                  {{ $t("auth.system_user") }}
+                </Badge>
+              </div>
             </div>
           </div>
         </CardContent>
@@ -176,6 +186,7 @@ import DisableUserDialog from "@/components/users/DisableUserDialog.vue";
 import EditUserDialog from "@/components/users/EditUserDialog.vue";
 import ManageTokensDialog from "@/components/users/ManageTokensDialog.vue";
 import RevokeTokenDialog from "@/components/users/RevokeTokenDialog.vue";
+import { isSystemUser } from "@/helpers/users";
 import { api } from "@/plugins/api";
 import type { AuthToken, User } from "@/plugins/api/interfaces";
 import { store } from "@/plugins/store";

--- a/tests/components/users/EditUserDialog.test.ts
+++ b/tests/components/users/EditUserDialog.test.ts
@@ -1,7 +1,7 @@
 import EditUserDialog from "@/components/users/EditUserDialog.vue";
 import { HOMEASSISTANT_SYSTEM_USER } from "@/helpers/users";
 import { type User, UserRole } from "@/plugins/api/interfaces";
-import { mount, type VueWrapper } from "@vue/test-utils";
+import { flushPromises, mount, type VueWrapper } from "@vue/test-utils";
 import { describe, expect, it, vi } from "vitest";
 import { user } from "../../fixtures/user";
 
@@ -27,14 +27,13 @@ vi.mock("vue-i18n", async (importOriginal) => ({
 }));
 
 const passthrough = { template: "<div><slot /></div>" };
-// the real Select relies on reka-ui context its sub-components inject from,
-// so all of it is stubbed together, forwarding just what the tests check
-const selectStub = {
-  name: "SelectStub",
-  props: ["modelValue", "disabled"],
-  emits: ["update:modelValue"],
-  template: "<div><slot /></div>",
-};
+
+const systemAccount = user({
+  user_id: "ha",
+  username: HOMEASSISTANT_SYSTEM_USER,
+  role: UserRole.SERVICE,
+  display_name: "Home Assistant Integration",
+});
 
 function mountDialog(editedUser: User): VueWrapper {
   return mount(EditUserDialog, {
@@ -52,44 +51,49 @@ function mountDialog(editedUser: User): VueWrapper {
         DialogTitle: passthrough,
         Button: passthrough,
         MultiSelect: true,
-        Select: selectStub,
-        SelectTrigger: true,
-        SelectContent: true,
-        SelectItem: true,
-        SelectValue: true,
       },
     },
   });
 }
 
 describe("EditUserDialog", () => {
-  it("locks the system account's username and role, and hides its password fields", () => {
-    const wrapper = mountDialog(
-      user({ username: HOMEASSISTANT_SYSTEM_USER, role: UserRole.SERVICE }),
-    );
+  it("locks the system account's username and role, and hides its password fields", async () => {
+    const wrapper = mountDialog(systemAccount);
+    // the select shows the chosen option's label once its items are registered
+    await flushPromises();
 
-    const usernameInput = wrapper.get<HTMLInputElement>(
-      'input[name="username"]',
-    );
-    expect(usernameInput.attributes("disabled")).toBeDefined();
+    expect(
+      wrapper.get('input[name="username"]').attributes("disabled"),
+    ).toBeDefined();
     expect(wrapper.text()).toContain("auth.system_user_hint");
     expect(wrapper.find('input[type="password"]').exists()).toBe(false);
-    expect(
-      wrapper.findComponent({ name: "SelectStub" }).props("disabled"),
-    ).toBe(true);
+    const roleTrigger = wrapper.get("#role");
+    expect(roleTrigger.attributes("disabled")).toBeDefined();
+    expect(roleTrigger.text()).toContain("auth.service_role");
   });
 
   it("leaves a regular user's username, role and password editable", () => {
     const wrapper = mountDialog(user({ username: "marcel" }));
 
-    const usernameInput = wrapper.get<HTMLInputElement>(
-      'input[name="username"]',
-    );
-    expect(usernameInput.attributes("disabled")).toBeUndefined();
+    expect(
+      wrapper.get('input[name="username"]').attributes("disabled"),
+    ).toBeUndefined();
     expect(wrapper.text()).not.toContain("auth.system_user_hint");
     expect(wrapper.find('input[type="password"]').exists()).toBe(true);
-    expect(
-      wrapper.findComponent({ name: "SelectStub" }).props("disabled"),
-    ).toBe(false);
+    expect(wrapper.get("#role").attributes("disabled")).toBeUndefined();
+  });
+
+  it("sends only the changed display name for the system account", async () => {
+    const wrapper = mountDialog(systemAccount);
+
+    await wrapper.get('input[name="displayName"]').setValue("Home Assistant");
+    await wrapper.get("form").trigger("submit");
+    await flushPromises();
+
+    expect(apiMock.updateUser).toHaveBeenCalledWith(
+      "ha",
+      { displayName: "Home Assistant" },
+      { suppressGlobalError: true },
+    );
   });
 });

--- a/tests/components/users/EditUserDialog.test.ts
+++ b/tests/components/users/EditUserDialog.test.ts
@@ -1,0 +1,95 @@
+import EditUserDialog from "@/components/users/EditUserDialog.vue";
+import { HOMEASSISTANT_SYSTEM_USER } from "@/helpers/users";
+import { type User, UserRole } from "@/plugins/api/interfaces";
+import { mount, type VueWrapper } from "@vue/test-utils";
+import { describe, expect, it, vi } from "vitest";
+import { user } from "../../fixtures/user";
+
+const { apiMock, storeMock } = vi.hoisted(() => ({
+  apiMock: { players: {}, updateUser: vi.fn() },
+  storeMock: { currentUser: { user_id: "admin-1" } },
+}));
+
+vi.mock("@/plugins/api", () => ({
+  api: apiMock,
+  ApiCommandError: class extends Error {},
+}));
+
+vi.mock("@/plugins/store", () => ({ store: storeMock }));
+
+vi.mock("vue-sonner", () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}));
+
+vi.mock("vue-i18n", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("vue-i18n")>()),
+  useI18n: () => ({ t: (key: string) => key }),
+}));
+
+const passthrough = { template: "<div><slot /></div>" };
+// the real Select relies on reka-ui context its sub-components inject from,
+// so all of it is stubbed together, forwarding just what the tests check
+const selectStub = {
+  name: "SelectStub",
+  props: ["modelValue", "disabled"],
+  emits: ["update:modelValue"],
+  template: "<div><slot /></div>",
+};
+
+function mountDialog(editedUser: User): VueWrapper {
+  return mount(EditUserDialog, {
+    props: {
+      modelValue: true,
+      user: editedUser,
+    },
+    global: {
+      mocks: { $t: (key: string) => key },
+      stubs: {
+        Dialog: passthrough,
+        DialogContent: passthrough,
+        DialogFooter: passthrough,
+        DialogHeader: passthrough,
+        DialogTitle: passthrough,
+        Button: passthrough,
+        MultiSelect: true,
+        Select: selectStub,
+        SelectTrigger: true,
+        SelectContent: true,
+        SelectItem: true,
+        SelectValue: true,
+      },
+    },
+  });
+}
+
+describe("EditUserDialog", () => {
+  it("locks the system account's username and role, and hides its password fields", () => {
+    const wrapper = mountDialog(
+      user({ username: HOMEASSISTANT_SYSTEM_USER, role: UserRole.SERVICE }),
+    );
+
+    const usernameInput = wrapper.get<HTMLInputElement>(
+      'input[name="username"]',
+    );
+    expect(usernameInput.attributes("disabled")).toBeDefined();
+    expect(wrapper.text()).toContain("auth.system_user_hint");
+    expect(wrapper.find('input[type="password"]').exists()).toBe(false);
+    expect(
+      wrapper.findComponent({ name: "SelectStub" }).props("disabled"),
+    ).toBe(true);
+  });
+
+  it("leaves a regular user's username, role and password editable", () => {
+    const wrapper = mountDialog(user({ username: "marcel" }));
+
+    const usernameInput = wrapper.get<HTMLInputElement>(
+      'input[name="username"]',
+    );
+    expect(usernameInput.attributes("disabled")).toBeUndefined();
+    expect(wrapper.text()).not.toContain("auth.system_user_hint");
+    expect(wrapper.find('input[type="password"]').exists()).toBe(true);
+    expect(
+      wrapper.findComponent({ name: "SelectStub" }).props("disabled"),
+    ).toBe(false);
+  });
+});

--- a/tests/helpers/users.test.ts
+++ b/tests/helpers/users.test.ts
@@ -1,0 +1,15 @@
+import { HOMEASSISTANT_SYSTEM_USER, isSystemUser } from "@/helpers/users";
+import { user } from "../fixtures/user";
+import { describe, expect, it } from "vitest";
+
+describe("isSystemUser", () => {
+  it("is true for the Home Assistant system account", () => {
+    expect(isSystemUser(user({ username: HOMEASSISTANT_SYSTEM_USER }))).toBe(
+      true,
+    );
+  });
+
+  it("is false for a regular user", () => {
+    expect(isSystemUser(user({ username: "marcel" }))).toBe(false);
+  });
+});

--- a/tests/views/UserManagement.test.ts
+++ b/tests/views/UserManagement.test.ts
@@ -1,0 +1,78 @@
+import { HOMEASSISTANT_SYSTEM_USER } from "@/helpers/users";
+import { UserRole } from "@/plugins/api/interfaces";
+import UserManagement from "@/views/settings/UserManagement.vue";
+import { flushPromises, mount } from "@vue/test-utils";
+import { describe, expect, it, vi } from "vitest";
+import { user } from "../fixtures/user";
+
+const { apiMock, routeMock, routerMock, storeMock } = vi.hoisted(() => ({
+  apiMock: { getAllUsers: vi.fn() },
+  routeMock: { query: {} as Record<string, string> },
+  routerMock: { push: vi.fn(), replace: vi.fn() },
+  storeMock: { currentUser: { user_id: "admin-1" } },
+}));
+
+vi.mock("@/plugins/api", () => ({ api: apiMock }));
+
+vi.mock("@/plugins/store", () => ({ store: storeMock }));
+
+vi.mock("vue-sonner", () => ({
+  toast: { error: vi.fn(), success: vi.fn() },
+}));
+
+vi.mock("vue-router", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("vue-router")>()),
+  useRoute: () => routeMock,
+  useRouter: () => routerMock,
+}));
+
+vi.mock("vue-i18n", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("vue-i18n")>()),
+  useI18n: () => ({ t: (key: string) => key }),
+}));
+
+function mountView() {
+  return mount(UserManagement, {
+    global: {
+      mocks: { $t: (key: string) => key },
+      stubs: {
+        // covered by their own tests; here they only add noise if mounted for real
+        CreateUserDialog: true,
+        EditUserDialog: true,
+        DisableUserDialog: true,
+        DeleteUserDialog: true,
+        ManageTokensDialog: true,
+        RevokeTokenDialog: true,
+        // the menu is opened with pointer interaction jsdom can't drive, and
+        // this test never needs it open
+        DropdownMenu: true,
+        DropdownMenuContent: true,
+        DropdownMenuItem: true,
+        DropdownMenuSeparator: true,
+        DropdownMenuTrigger: true,
+      },
+    },
+  });
+}
+
+describe("UserManagement", () => {
+  it("shows the System badge only on the Home Assistant account's card", async () => {
+    apiMock.getAllUsers.mockResolvedValue([
+      user({
+        user_id: "ha",
+        username: HOMEASSISTANT_SYSTEM_USER,
+        role: UserRole.SERVICE,
+        display_name: "Home Assistant Integration",
+      }),
+      user({ user_id: "marcel", username: "marcel", display_name: "Marcel" }),
+    ]);
+
+    const wrapper = mountView();
+    await flushPromises();
+
+    const cards = wrapper.findAll('[data-slot="card"]');
+    expect(cards).toHaveLength(2);
+    expect(cards[0].text()).toContain("auth.system_user");
+    expect(cards[1].text()).not.toContain("auth.system_user");
+  });
+});

--- a/tests/views/UserManagement.test.ts
+++ b/tests/views/UserManagement.test.ts
@@ -31,8 +31,19 @@ vi.mock("vue-i18n", async (importOriginal) => ({
   useI18n: () => ({ t: (key: string) => key }),
 }));
 
-function mountView() {
-  return mount(UserManagement, {
+const passthrough = { template: "<div><slot /></div>" };
+
+async function mountView() {
+  apiMock.getAllUsers.mockResolvedValue([
+    user({
+      user_id: "ha",
+      username: HOMEASSISTANT_SYSTEM_USER,
+      role: UserRole.SERVICE,
+      display_name: "Home Assistant Integration",
+    }),
+    user({ user_id: "marcel", username: "marcel", display_name: "Marcel" }),
+  ]);
+  const wrapper = mount(UserManagement, {
     global: {
       mocks: { $t: (key: string) => key },
       stubs: {
@@ -43,36 +54,39 @@ function mountView() {
         DeleteUserDialog: true,
         ManageTokensDialog: true,
         RevokeTokenDialog: true,
-        // the menu is opened with pointer interaction jsdom can't drive, and
-        // this test never needs it open
-        DropdownMenu: true,
-        DropdownMenuContent: true,
-        DropdownMenuItem: true,
+        // the test DOM can't open the menu with a pointer, so its content
+        // renders inline and the offered actions can be read from each card
+        DropdownMenu: passthrough,
+        DropdownMenuContent: passthrough,
+        DropdownMenuItem: passthrough,
         DropdownMenuSeparator: true,
-        DropdownMenuTrigger: true,
+        DropdownMenuTrigger: passthrough,
       },
     },
   });
+  await flushPromises();
+  return wrapper;
 }
 
 describe("UserManagement", () => {
   it("shows the System badge only on the Home Assistant account's card", async () => {
-    apiMock.getAllUsers.mockResolvedValue([
-      user({
-        user_id: "ha",
-        username: HOMEASSISTANT_SYSTEM_USER,
-        role: UserRole.SERVICE,
-        display_name: "Home Assistant Integration",
-      }),
-      user({ user_id: "marcel", username: "marcel", display_name: "Marcel" }),
-    ]);
-
-    const wrapper = mountView();
-    await flushPromises();
+    const wrapper = await mountView();
 
     const cards = wrapper.findAll('[data-slot="card"]');
     expect(cards).toHaveLength(2);
     expect(cards[0].text()).toContain("auth.system_user");
     expect(cards[1].text()).not.toContain("auth.system_user");
+  });
+
+  it("offers no disable or delete action for the Home Assistant account", async () => {
+    const wrapper = await mountView();
+
+    const [systemCard, memberCard] = wrapper.findAll('[data-slot="card"]');
+    expect(systemCard.text()).toContain("auth.edit_user");
+    expect(systemCard.text()).toContain("auth.manage_tokens");
+    expect(systemCard.text()).not.toContain("auth.disable_user");
+    expect(systemCard.text()).not.toContain("auth.delete_user");
+    expect(memberCard.text()).toContain("auth.disable_user");
+    expect(memberCard.text()).toContain("auth.delete_user");
   });
 });


### PR DESCRIPTION
# What does this implement/fix?

The Home Assistant integration signs in with a system account, which user management now lists (music-assistant/server#6296). The server refuses to delete or disable it and to change its username, role or password, so user management shows it as a system account without those actions:

- The user card shows a "System" badge and no disable or delete action. Editing and managing its access tokens stay available.
- The edit dialog shows its username and role read-only, with a short explanation, and has no password fields. Its display name, avatar and player filter stay editable.
- The account is recognized by its username, the same check the server uses.

Closes https://github.com/music-assistant/backlog/issues/109

**Related issue (if applicable):**

- related issue https://github.com/music-assistant/backlog/issues/109 (story: https://github.com/music-assistant/backlog/issues/84)

**Related backend PR (if applicable):**

<!--
Link the music-assistant/server PR when this change relies on new server
behaviour, so the two can be reviewed and released together.
-->

- related backend PR https://github.com/music-assistant/server/pull/6296

## Types of changes

<!--
Tick exactly one box below. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm lint:check` passes.
- [x] `pnpm test:run` passes, and tests have been added/updated where applicable.
- [x] `pnpm build` passes.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
