### PR TITLE
Share Music Assistant playlists with other members

### DIFF
--- a/src/components/InfoHeader.vue
+++ b/src/components/InfoHeader.vue
@@ -263,7 +263,9 @@
                 icon="mdi-account-music"
               />
               <MarqueeText :sync="marqueeSync">
-                <a style="color: primary">{{ item.owner }}</a>
+                <slot name="owner"
+                  ><a style="color: primary">{{ item.owner }}</a></slot
+                >
               </MarqueeText>
             </v-card-subtitle>
 

--- a/src/components/ItemsListing.vue
+++ b/src/components/ItemsListing.vue
@@ -2204,6 +2204,12 @@ const selectAll = async function () {
 defineExpose({
   sortBy: computed(() => params.value.sortBy),
   reload: () => loadData(true, true),
+  // whether the item is absent while every item of the unfiltered listing is
+  // loaded; a filter leaves items out on purpose
+  isMissing: (uri: string) =>
+    allItemsReceived.value &&
+    !hasActiveFilters.value &&
+    !pagedItems.value.some((i) => i.uri === uri),
 });
 </script>
 

--- a/src/components/PlaylistAccessSummary.vue
+++ b/src/components/PlaylistAccessSummary.vue
@@ -1,0 +1,96 @@
+<!--
+  The access record of a playlist in its compact form:
+  "<owner> · <who it is shared with> · <collaborative>".
+-->
+<template>
+  <span>{{ summary }}</span>
+</template>
+
+<script setup lang="ts">
+import { canSharePlaylist } from "@/helpers/playlist_access";
+import {
+  getProviderSharingTranslationKey,
+  userDisplayName,
+} from "@/helpers/provider_access";
+import { api } from "@/plugins/api";
+import {
+  type Playlist,
+  type PlaylistAccess,
+  ProviderSharing,
+  Scope,
+  type UserSummary,
+} from "@/plugins/api/interfaces";
+import { authManager } from "@/plugins/auth";
+import { $t } from "@/plugins/i18n";
+import { store } from "@/plugins/store";
+import { computed, ref, watch } from "vue";
+
+const props = defineProps<{
+  playlist: Playlist;
+}>();
+
+// the members, to name an owner that is somebody else; null while they are not
+// loaded or the server refused to list them
+const members = ref<UserSummary[] | null>(null);
+
+const summary = computed(() => {
+  const access = props.playlist.access;
+  if (access === null)
+    return `${$t("playlist_access.shared")} · ${$t("settings.source_access.options.everyone")}`;
+  const parts = [ownerName(access.owner), sharedWith(access)];
+  if (access.collaborative) parts.push($t("playlist_access.collaborative"));
+  return parts.join(" · ");
+});
+
+// an owner nobody can name is shown as a playlist without owner
+const ownerName = (ownerId: string | null) => {
+  if (ownerId === null) return $t("playlist_access.shared");
+  if (ownerId === store.currentUser?.user_id)
+    return $t("playlist_access.personal");
+  const owner = members.value?.find((user) => user.user_id === ownerId);
+  return owner ? userDisplayName(owner) : $t("playlist_access.shared");
+};
+
+const sharedWith = (access: PlaylistAccess) => {
+  if (access.sharing !== ProviderSharing.SELECTED)
+    return $t(
+      getProviderSharingTranslationKey(
+        access.sharing,
+        access.owner === store.currentUser?.user_id,
+      ),
+    );
+  const count = access.shared_users.length;
+  return $t("settings.source_access.shared_with_count", count, {
+    named: { count },
+  });
+};
+
+// only a caller that may share the playlist can list the members, so the name
+// of another owner is only asked for then
+const loadMembers = async (playlist: Playlist) => {
+  const ownerId = playlist.access?.owner;
+  if (
+    !ownerId ||
+    ownerId === store.currentUser?.user_id ||
+    !canSharePlaylist(
+      playlist,
+      store.currentUser,
+      authManager.hasScope(Scope.LIBRARY_MANAGE),
+    )
+  )
+    return;
+  try {
+    members.value = await api.getShareCandidates();
+  } catch {
+    members.value = null;
+  }
+};
+
+watch(
+  () => props.playlist.access?.owner,
+  () => loadMembers(props.playlist),
+  {
+    immediate: true,
+  },
+);
+</script>

--- a/src/helpers/playlist_access.test.ts
+++ b/src/helpers/playlist_access.test.ts
@@ -1,0 +1,151 @@
+import {
+  type PlaylistAccess,
+  ProviderSharing,
+  UserRole,
+} from "@/plugins/api/interfaces";
+import { describe, expect, it } from "vitest";
+import { playlist } from "../../tests/fixtures/playlist";
+import { providerMapping } from "../../tests/fixtures/providerMapping";
+import { user } from "../../tests/fixtures/user";
+import {
+  canEditPlaylistItems,
+  canManagePlaylist,
+  canSharePlaylist,
+  isMusicAssistantPlaylist,
+} from "./playlist_access";
+
+const owner = user({ user_id: "owner" });
+const member = user({ user_id: "member" });
+const guest = user({ user_id: "guest", role: UserRole.GUEST });
+
+const access = (overrides: Partial<PlaylistAccess> = {}): PlaylistAccess => ({
+  owner: "owner",
+  sharing: ProviderSharing.PRIVATE,
+  shared_users: [],
+  collaborative: false,
+  ...overrides,
+});
+
+const maPlaylist = (overrides = {}) =>
+  playlist({
+    is_editable: true,
+    provider_mappings: [providerMapping({ provider_domain: "builtin" })],
+    ...overrides,
+  });
+
+const spotifyPlaylist = (overrides = {}) =>
+  playlist({
+    is_editable: true,
+    provider_mappings: [providerMapping({ provider_domain: "spotify" })],
+    ...overrides,
+  });
+
+describe("isMusicAssistantPlaylist", () => {
+  it("is true for a playlist of the builtin provider", () => {
+    expect(isMusicAssistantPlaylist(maPlaylist())).toBe(true);
+  });
+
+  it("is false for a playlist of a music source", () => {
+    expect(isMusicAssistantPlaylist(spotifyPlaylist())).toBe(false);
+  });
+});
+
+describe("canSharePlaylist", () => {
+  it("lets a library manager share any Music Assistant playlist", () => {
+    expect(canSharePlaylist(maPlaylist(), member, true)).toBe(true);
+  });
+
+  it("lets the owner share its own playlist", () => {
+    const item = maPlaylist({ access: access() });
+
+    expect(canSharePlaylist(item, owner, false)).toBe(true);
+  });
+
+  it("does not let another member share it", () => {
+    const item = maPlaylist({ access: access() });
+
+    expect(canSharePlaylist(item, member, false)).toBe(false);
+  });
+
+  it("does not share a playlist of a music source", () => {
+    expect(canSharePlaylist(spotifyPlaylist(), member, true)).toBe(false);
+  });
+});
+
+describe("canManagePlaylist", () => {
+  it("lets everyone manage a playlist without a record", () => {
+    expect(canManagePlaylist(maPlaylist(), guest, false)).toBe(true);
+  });
+
+  it("lets the owner and a library manager manage a personal playlist", () => {
+    const item = maPlaylist({ access: access() });
+
+    expect(canManagePlaylist(item, owner, false)).toBe(true);
+    expect(canManagePlaylist(item, member, true)).toBe(true);
+  });
+
+  it("does not let another member, or nobody, manage it", () => {
+    const item = maPlaylist({
+      access: access({ sharing: ProviderSharing.MEMBERS, collaborative: true }),
+    });
+
+    expect(canManagePlaylist(item, member, false)).toBe(false);
+    expect(canManagePlaylist(item, undefined, false)).toBe(false);
+  });
+});
+
+describe("canEditPlaylistItems", () => {
+  it("lets everyone edit a playlist without a record", () => {
+    expect(canEditPlaylistItems(maPlaylist(), guest, false)).toBe(true);
+  });
+
+  it("never edits a playlist that is not editable", () => {
+    expect(
+      canEditPlaylistItems(maPlaylist({ is_editable: false }), owner, true),
+    ).toBe(false);
+  });
+
+  it("denies a playlist with a record without a signed-in user", () => {
+    expect(
+      canEditPlaylistItems(maPlaylist({ access: access() }), undefined, false),
+    ).toBe(false);
+  });
+
+  it("lets the owner edit its own playlist", () => {
+    expect(
+      canEditPlaylistItems(maPlaylist({ access: access() }), owner, false),
+    ).toBe(true);
+  });
+
+  it("lets a library manager edit it", () => {
+    expect(
+      canEditPlaylistItems(maPlaylist({ access: access() }), member, true),
+    ).toBe(true);
+  });
+
+  it("lets a member it is shared with edit it while collaborative", () => {
+    const item = maPlaylist({
+      access: access({
+        sharing: ProviderSharing.SELECTED,
+        shared_users: ["member"],
+        collaborative: true,
+      }),
+    });
+
+    expect(canEditPlaylistItems(item, member, false)).toBe(true);
+    expect(canEditPlaylistItems(item, user({ user_id: "other" }), false)).toBe(
+      false,
+    );
+  });
+
+  it("does not let a member it is shared with edit it otherwise", () => {
+    const item = maPlaylist({
+      access: access({
+        sharing: ProviderSharing.SELECTED,
+        shared_users: ["member"],
+      }),
+    });
+
+    expect(canEditPlaylistItems(item, member, false)).toBe(false);
+  });
+});

--- a/src/helpers/playlist_access.ts
+++ b/src/helpers/playlist_access.ts
@@ -1,0 +1,68 @@
+import {
+  type Playlist,
+  ProviderSharing,
+  type User,
+} from "@/plugins/api/interfaces";
+import { accessAllows } from "./provider_access";
+
+const PLAYLIST_SHARING_HINT_TRANSLATION_KEYS: Record<ProviderSharing, string> =
+  {
+    [ProviderSharing.PRIVATE]: "playlist_access.hints.private",
+    [ProviderSharing.SELECTED]: "playlist_access.hints.selected",
+    [ProviderSharing.MEMBERS]: "playlist_access.hints.members",
+    [ProviderSharing.EVERYONE]: "playlist_access.hints.everyone",
+  };
+
+/** The translation key explaining a sharing choice for a playlist. */
+export const getPlaylistSharingHintTranslationKey = (
+  sharing: ProviderSharing,
+) => PLAYLIST_SHARING_HINT_TRANSLATION_KEYS[sharing];
+
+/** Whether the playlist is one Music Assistant keeps itself: only those carry an access record. */
+export const isMusicAssistantPlaylist = (playlist: Playlist) =>
+  playlist.provider_mappings.some((m) => m.provider_domain === "builtin");
+
+/** Whether the user may change who owns and sees the playlist: a library manager, or its owner. */
+export const canSharePlaylist = (
+  playlist: Playlist,
+  user: User | undefined,
+  managesLibrary: boolean,
+) =>
+  isMusicAssistantPlaylist(playlist) &&
+  (managesLibrary ||
+    (user !== undefined && playlist.access?.owner === user.user_id));
+
+/**
+ * Whether the user may change the playlist itself, like its details or its
+ * place in the library: everyone without a record, else the owner or a library
+ * manager.
+ */
+export const canManagePlaylist = (
+  playlist: Playlist,
+  user: User | undefined,
+  managesLibrary: boolean,
+) =>
+  playlist.access === null ||
+  managesLibrary ||
+  // without a signed-in user nobody holds the rights a record grants
+  (user !== undefined && playlist.access.owner === user.user_id);
+
+/**
+ * Whether the user may add and remove items: whoever may manage the playlist,
+ * and anyone it is shared with when collaborative.
+ */
+export const canEditPlaylistItems = (
+  playlist: Playlist,
+  user: User | undefined,
+  managesLibrary: boolean,
+) => {
+  if (!playlist.is_editable) return false;
+  if (canManagePlaylist(playlist, user, managesLibrary)) return true;
+  const access = playlist.access;
+  return (
+    access !== null &&
+    access.collaborative &&
+    user !== undefined &&
+    accessAllows(access, user)
+  );
+};

--- a/src/helpers/provider_access.test.ts
+++ b/src/helpers/provider_access.test.ts
@@ -1,5 +1,6 @@
 import { HOMEASSISTANT_SYSTEM_USER } from "@/helpers/users";
 import {
+  type ProviderAccess,
   ProviderSharing,
   ProviderType,
   UserRole,
@@ -9,6 +10,7 @@ import { providerConfig } from "../../tests/fixtures/providerConfig";
 import { providerManifest } from "../../tests/fixtures/providerManifest";
 import { user } from "../../tests/fixtures/user";
 import {
+  accessAllows,
   effectiveProviderAccess,
   getProviderSharingHintTranslationKey,
   getProviderSharingTranslationKey,
@@ -18,6 +20,52 @@ import {
   shareCandidates,
   userDisplayName,
 } from "./provider_access";
+
+describe("accessAllows", () => {
+  const member = user({ user_id: "member" });
+  const guest = user({ user_id: "guest", role: UserRole.GUEST });
+  const record = (overrides: Partial<ProviderAccess> = {}): ProviderAccess => ({
+    owner: "owner",
+    sharing: ProviderSharing.PRIVATE,
+    shared_users: [],
+    ...overrides,
+  });
+
+  it("allows everyone without a record", () => {
+    expect(accessAllows(null, guest)).toBe(true);
+  });
+
+  it("allows the owner whatever the sharing is", () => {
+    expect(accessAllows(record({ owner: "member" }), member)).toBe(true);
+  });
+
+  it("allows nobody else while private", () => {
+    expect(accessAllows(record(), member)).toBe(false);
+  });
+
+  it("allows the selected members only", () => {
+    const access = record({
+      sharing: ProviderSharing.SELECTED,
+      shared_users: ["member"],
+    });
+
+    expect(accessAllows(access, member)).toBe(true);
+    expect(accessAllows(access, user({ user_id: "other" }))).toBe(false);
+  });
+
+  it("allows members but not guests while shared with the members", () => {
+    const access = record({ sharing: ProviderSharing.MEMBERS });
+
+    expect(accessAllows(access, member)).toBe(true);
+    expect(accessAllows(access, guest)).toBe(false);
+  });
+
+  it("allows guests too while shared with everyone", () => {
+    expect(
+      accessAllows(record({ sharing: ProviderSharing.EVERYONE }), guest),
+    ).toBe(true);
+  });
+});
 
 describe("effectiveProviderAccess", () => {
   it("reads a missing record as a household source for everyone", () => {

--- a/src/helpers/provider_access.ts
+++ b/src/helpers/provider_access.ts
@@ -25,6 +25,21 @@ const PROVIDER_SHARING_HINT_TRANSLATION_KEYS: Record<ProviderSharing, string> =
     [ProviderSharing.EVERYONE]: "settings.source_access.hints.everyone",
   };
 
+/** Whether the given user may use what the access record guards, read the way the server does. */
+export const accessAllows = (
+  access: ProviderAccess | null,
+  user: User,
+): boolean => {
+  if (access === null) return true;
+  if (access.owner === user.user_id) return true;
+  if (access.sharing === ProviderSharing.EVERYONE) return true;
+  if (access.sharing === ProviderSharing.MEMBERS)
+    return user.role !== UserRole.GUEST;
+  if (access.sharing === ProviderSharing.SELECTED)
+    return access.shared_users.includes(user.user_id);
+  return false;
+};
+
 /**
  * The access a music source has, with a missing record read the way the
  * server does: a household source available to everyone.

--- a/src/layouts/default/AddToPlaylistDialog.vue
+++ b/src/layouts/default/AddToPlaylistDialog.vue
@@ -90,13 +90,15 @@ import {
   SheetHeader,
   SheetTitle,
 } from "@/components/ui/sheet";
+import { canEditPlaylistItems } from "@/helpers/playlist_access";
 import api from "@/plugins/api";
 import type {
   MediaItemType,
   MediaItemTypeOrItemMapping,
   Playlist,
 } from "@/plugins/api/interfaces";
-import { MediaType, ProviderFeature } from "@/plugins/api/interfaces";
+import { MediaType, ProviderFeature, Scope } from "@/plugins/api/interfaces";
+import { authManager } from "@/plugins/auth";
 import { eventbus, PlaylistDialogEvent } from "@/plugins/eventbus";
 import { $t } from "@/plugins/i18n";
 import { store } from "@/plugins/store";
@@ -154,8 +156,15 @@ const fetchPlaylists = async function () {
   for (const playlist of playlistResults) {
     // skip unavailable playlists
     if (!playlist.provider_mappings.filter((x) => x.available).length) continue;
-    // skip non-editable playlists
-    if (!playlist.is_editable) continue;
+    // skip playlists the user may not add to
+    if (
+      !canEditPlaylistItems(
+        playlist,
+        store.currentUser,
+        authManager.hasScope(Scope.LIBRARY_MANAGE),
+      )
+    )
+      continue;
     // skip playlist that is currently opened (=parentItem)
     if (
       parentItem.value &&

--- a/src/layouts/default/ItemContextMenu.vue
+++ b/src/layouts/default/ItemContextMenu.vue
@@ -276,6 +276,11 @@ import { genresShareTaxonomy } from "@/helpers/genreTaxonomy";
 import { backFromMediaDetails } from "@/helpers/navigation";
 import { playerVisible } from "@/helpers/players";
 import {
+  canEditPlaylistItems,
+  canManagePlaylist,
+  canSharePlaylist,
+} from "@/helpers/playlist_access";
+import {
   gotoRadio,
   radioActionLabelKey,
   radioRelevant,
@@ -302,6 +307,7 @@ import {
   ProviderMapping,
   QueueOption,
   Radio,
+  Scope,
   Track,
 } from "@/plugins/api/interfaces";
 import { authManager } from "@/plugins/auth";
@@ -335,6 +341,7 @@ import {
   PlusCircle,
   RefreshCw,
   RotateCcw,
+  Share2,
   Shuffle,
   SkipForward,
   Sparkles,
@@ -493,6 +500,7 @@ export const getContextMenuItems = async function (
   }
 
   const firstItem = items[0];
+  const managesLibrary = authManager.hasScope(Scope.LIBRARY_MANAGE);
 
   // show info
   if (
@@ -688,9 +696,16 @@ export const getContextMenuItems = async function (
       icon: LibraryBig,
     });
   }
-  // remove from library
+  // remove from library (a personal playlist only by whoever manages it)
+  const managesSelectedPlaylists = items.every(
+    (item) =>
+      item.media_type !== MediaType.PLAYLIST ||
+      !("access" in item) ||
+      canManagePlaylist(item, store.currentUser, managesLibrary),
+  );
   if (
     isItemInLibrary(resolvedItem) &&
+    managesSelectedPlaylists &&
     [
       MediaType.ALBUM,
       MediaType.ARTIST,
@@ -825,7 +840,7 @@ export const getContextMenuItems = async function (
         firstItem.media_type === MediaType.RADIO ||
         firstItem.media_type === MediaType.PODCAST_EPISODE ||
         firstItem.media_type === MediaType.AUDIOBOOK) &&
-      playlist.is_editable
+      canEditPlaylistItems(playlist, store.currentUser, managesLibrary)
     ) {
       contextMenuItems.push({
         label: "remove_playlist",
@@ -946,9 +961,11 @@ export const getContextMenuItems = async function (
       featureMap[item.media_type],
     );
     // For playlists, also check is_editable flag (builtin special playlists are not editable)
+    // and that the user manages the playlist (a personal one is only edited by its owner)
     const isEditablePlaylist =
       item.media_type !== MediaType.PLAYLIST ||
-      (item as Playlist).is_editable !== false;
+      ((item as Playlist).is_editable !== false &&
+        canManagePlaylist(item as Playlist, store.currentUser, managesLibrary));
     if (hasBuiltinProvider && supportsEdit && isEditablePlaylist) {
       contextMenuItems.push({
         label: labelMap[item.media_type],
@@ -1028,6 +1045,24 @@ export const getContextMenuItems = async function (
           eventbus.emit("migratePlaylistDialog", { playlist });
         },
         icon: ArrowRightLeft,
+      });
+    }
+  }
+  // share playlist (a Music Assistant playlist the user owns or manages)
+  if (
+    items.length === 1 &&
+    items[0].media_type === MediaType.PLAYLIST &&
+    "provider_mappings" in items[0]
+  ) {
+    const playlist = items[0] as Playlist;
+    if (canSharePlaylist(playlist, store.currentUser, managesLibrary)) {
+      contextMenuItems.push({
+        label: "share_playlist",
+        labelArgs: [],
+        action: () => {
+          eventbus.emit("playlistAccessDialog", { playlist });
+        },
+        icon: Share2,
       });
     }
   }

--- a/src/layouts/default/PlaylistAccessDialog.vue
+++ b/src/layouts/default/PlaylistAccessDialog.vue
@@ -1,0 +1,315 @@
+<!--
+  Global dialog to set who owns a Music Assistant playlist, who may see it and
+  who may edit it. Because this dialog can be called from various places
+  throughout the app, we steer its visibility through the centralized eventbus.
+-->
+<template>
+  <Dialog :key="dialogKey" v-model:open="showDialog">
+    <DialogContent class="sm:max-w-[480px]">
+      <DialogHeader>
+        <DialogTitle>
+          {{ $t("playlist_access.title", { name: playlist?.name ?? "" }) }}
+        </DialogTitle>
+        <DialogDescription>
+          {{ $t("playlist_access.description") }}
+        </DialogDescription>
+      </DialogHeader>
+      <form id="form-playlist-access" @submit.prevent="save">
+        <FieldGroup>
+          <Field v-if="canChangeOwner">
+            <FieldLabel for="playlist-access-owner">
+              {{ $t("settings.source_access.owner") }}
+            </FieldLabel>
+            <Select v-model="owner">
+              <SelectTrigger id="playlist-access-owner" class="w-full">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem :value="NO_OWNER">
+                  {{ $t("settings.source_access.household") }}
+                </SelectItem>
+                <SelectItem
+                  v-for="user in members ?? []"
+                  :key="user.user_id"
+                  :value="user.user_id"
+                >
+                  {{ userDisplayName(user) }}
+                </SelectItem>
+              </SelectContent>
+            </Select>
+            <FieldDescription>
+              {{ $t("playlist_access.owner_hint") }}
+            </FieldDescription>
+          </Field>
+
+          <Field>
+            <FieldLabel for="playlist-access-sharing">
+              {{ $t("settings.source_access.sharing") }}
+            </FieldLabel>
+            <Select v-model="sharing">
+              <SelectTrigger id="playlist-access-sharing" class="w-full">
+                <!-- rendered from state, as the select keeps the label an
+                     option had when it mounted -->
+                <SelectValue>
+                  {{
+                    $t(getProviderSharingTranslationKey(sharing, ownedByViewer))
+                  }}
+                </SelectValue>
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem
+                  v-for="option in sharingOptions"
+                  :key="option"
+                  :value="option"
+                >
+                  {{
+                    $t(getProviderSharingTranslationKey(option, ownedByViewer))
+                  }}
+                </SelectItem>
+              </SelectContent>
+            </Select>
+            <FieldDescription>
+              {{ $t(getPlaylistSharingHintTranslationKey(sharing)) }}
+            </FieldDescription>
+          </Field>
+
+          <Field v-if="canPickSharedUsers">
+            <FieldLabel>
+              {{ $t("settings.source_access.shared_users") }}
+            </FieldLabel>
+            <MultiSelect
+              v-model="sharedUsers"
+              :options="shareOptions"
+              :placeholder="$t('settings.source_access.select_members')"
+            />
+          </Field>
+
+          <!-- nobody else may edit a playlist that only its owner sees -->
+          <Field
+            v-if="sharing !== ProviderSharing.PRIVATE"
+            orientation="horizontal"
+          >
+            <FieldContent>
+              <FieldLabel for="playlist-access-collaborative">
+                {{ $t("playlist_access.collaborative") }}
+              </FieldLabel>
+              <FieldDescription>
+                {{ $t("playlist_access.collaborative_hint") }}
+              </FieldDescription>
+            </FieldContent>
+            <Switch
+              id="playlist-access-collaborative"
+              v-model="collaborative"
+            />
+          </Field>
+        </FieldGroup>
+      </form>
+      <DialogFooter>
+        <Button variant="outline" @click="showDialog = false">
+          {{ $t("cancel") }}
+        </Button>
+        <Button
+          type="submit"
+          form="form-playlist-access"
+          :disabled="saving || !canSave"
+          :loading="saving"
+        >
+          {{ $t("settings.save") }}
+        </Button>
+      </DialogFooter>
+    </DialogContent>
+  </Dialog>
+</template>
+
+<script setup lang="ts">
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import {
+  Field,
+  FieldContent,
+  FieldDescription,
+  FieldGroup,
+  FieldLabel,
+} from "@/components/ui/field";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Switch } from "@/components/ui/switch";
+import MultiSelect from "@/components/users/MultiSelect.vue";
+import { getPlaylistSharingHintTranslationKey } from "@/helpers/playlist_access";
+import {
+  getProviderSharingTranslationKey,
+  userDisplayName,
+} from "@/helpers/provider_access";
+import { api } from "@/plugins/api";
+import {
+  type Playlist,
+  type PlaylistAccess,
+  ProviderSharing,
+  Scope,
+  type UserSummary,
+} from "@/plugins/api/interfaces";
+import { authManager } from "@/plugins/auth";
+import { type PlaylistAccessDialogEvent, eventbus } from "@/plugins/eventbus";
+import { store } from "@/plugins/store";
+import { computed, onBeforeUnmount, onMounted, ref, watch } from "vue";
+import { useI18n } from "vue-i18n";
+import { toast } from "vue-sonner";
+
+// a select option needs a non-empty value, so a playlist without owner is
+// picked through this stand-in
+const NO_OWNER = "none";
+
+const { t } = useI18n();
+
+const showDialog = ref(false);
+// force Dialog remount via dynamic key to prevent the enter animation from
+// stalling at opacity:0 when opened from a context menu
+const dialogKey = ref(0);
+const playlist = ref<Playlist>();
+// the members to pick an owner and shared members from; null while the caller
+// may not list them
+const members = ref<UserSummary[] | null>(null);
+const owner = ref(NO_OWNER);
+const sharing = ref(ProviderSharing.EVERYONE);
+const sharedUsers = ref<string[]>([]);
+const collaborative = ref(false);
+const saving = ref(false);
+
+const currentAccess = computed<PlaylistAccess>(
+  () =>
+    playlist.value?.access ?? {
+      owner: null,
+      sharing: ProviderSharing.EVERYONE,
+      shared_users: [],
+      collaborative: false,
+    },
+);
+
+const canChangeOwner = computed(
+  () => authManager.hasScope(Scope.LIBRARY_MANAGE) && members.value !== null,
+);
+
+const canPickSharedUsers = computed(
+  () => members.value !== null && sharing.value === ProviderSharing.SELECTED,
+);
+
+const selectedOwner = computed(() =>
+  owner.value === NO_OWNER ? null : owner.value,
+);
+
+const shareOptions = computed(() =>
+  (members.value ?? [])
+    .filter((user) => user.user_id !== selectedOwner.value)
+    .map((user) => ({ label: userDisplayName(user), value: user.user_id })),
+);
+
+const sharingOptions = computed(() =>
+  Object.values(ProviderSharing).filter((option) => {
+    // without a member list there is nobody to select, so that choice is only
+    // kept when it is already the current one
+    if (option === ProviderSharing.SELECTED)
+      return (
+        members.value !== null ||
+        currentAccess.value.sharing === ProviderSharing.SELECTED
+      );
+    // a playlist without an owner has to be shared with somebody
+    if (option === ProviderSharing.PRIVATE) return selectedOwner.value !== null;
+    return true;
+  }),
+);
+
+// an owner may not hand the playlist over, so the record keeps its own
+const recordOwner = computed(() =>
+  canChangeOwner.value ? selectedOwner.value : currentAccess.value.owner,
+);
+
+const ownedByViewer = computed(
+  () => recordOwner.value === store.currentUser?.user_id,
+);
+
+// a playlist without an owner has to be shared with somebody
+const canSave = computed(
+  () =>
+    selectedOwner.value !== null ||
+    sharing.value !== ProviderSharing.SELECTED ||
+    sharedUsers.value.length > 0,
+);
+
+watch(showDialog, (open) => {
+  store.dialogActive = open;
+});
+
+watch(selectedOwner, (ownerId) => {
+  if (ownerId === null) {
+    if (sharing.value === ProviderSharing.PRIVATE)
+      sharing.value = ProviderSharing.MEMBERS;
+    return;
+  }
+  // the owner sees the playlist anyway, so it leaves the shared list once picked
+  sharedUsers.value = sharedUsers.value.filter((id) => id !== ownerId);
+});
+
+onMounted(() => {
+  eventbus.on("playlistAccessDialog", (evt: PlaylistAccessDialogEvent) => {
+    playlist.value = evt.playlist;
+    resetForm();
+    dialogKey.value++;
+    showDialog.value = true;
+    loadMembers();
+  });
+});
+
+onBeforeUnmount(() => {
+  eventbus.off("playlistAccessDialog");
+});
+
+const save = async () => {
+  if (!playlist.value) return;
+  saving.value = true;
+  try {
+    await api.setPlaylistAccess(playlist.value.item_id, {
+      owner: recordOwner.value,
+      sharing: sharing.value,
+      shared_users:
+        sharing.value === ProviderSharing.SELECTED ? sharedUsers.value : [],
+      collaborative: collaborative.value,
+    });
+    toast.success(t("playlist_access.updated"));
+    showDialog.value = false;
+  } catch (err) {
+    toast.error(String(err));
+  } finally {
+    saving.value = false;
+  }
+};
+
+const resetForm = () => {
+  const access = currentAccess.value;
+  members.value = null;
+  owner.value = access.owner ?? NO_OWNER;
+  sharing.value = access.sharing;
+  sharedUsers.value = [...access.shared_users];
+  collaborative.value = access.collaborative;
+};
+
+const loadMembers = async () => {
+  try {
+    members.value = await api.getShareCandidates();
+  } catch {
+    // a plain member may not list the members yet; the dialog then leaves out
+    // what it can not offer
+  }
+};
+</script>

--- a/src/layouts/default/View.vue
+++ b/src/layouts/default/View.vue
@@ -23,6 +23,7 @@
           <create-smart-playlist-dialog />
           <import-playlist-dialog />
           <migrate-playlist-dialog />
+          <playlist-access-dialog />
           <play-announcement-dialog />
           <merge-genre-dialog />
           <delete-genre-dialog />
@@ -76,6 +77,7 @@ import ItemContextMenu from "./ItemContextMenu.vue";
 import MigratePlaylistDialog from "./MigratePlaylistDialog.vue";
 import PlayAnnouncementDialog from "./PlayAnnouncementDialog.vue";
 import PlayerSelect from "./PlayerSelect.vue";
+import PlaylistAccessDialog from "./PlaylistAccessDialog.vue";
 
 const route = useRoute();
 

--- a/src/plugins/api/index.ts
+++ b/src/plugins/api/index.ts
@@ -31,6 +31,7 @@ import {
   type PlayerOptionValueType,
   type PlayerQueue,
   type Playlist,
+  type PlaylistAccess,
   type ProviderInstance,
   type QueueItem,
   type Radio,
@@ -861,6 +862,27 @@ export class MusicAssistantApi {
       item_id,
       provider_instance_id_or_domain,
     });
+  }
+
+  public setPlaylistAccess(
+    item_id: string,
+    access: PlaylistAccess,
+  ): Promise<Playlist> {
+    // Set who owns a Music Assistant playlist, who may see it and who may edit it.
+    // A library manager may set this for any playlist, an owner may only
+    // change the sharing of a playlist it owns. The dialog reports a refused
+    // change itself, so opt out of the global error toast.
+    return this.sendCommand(
+      "music/playlists/set_access",
+      {
+        item_id,
+        owner: access.owner,
+        sharing: access.sharing,
+        shared_users: access.shared_users,
+        collaborative: access.collaborative,
+      },
+      { suppressGlobalError: true },
+    );
   }
 
   public getPlaylistTracks(
@@ -2283,18 +2305,23 @@ export class MusicAssistantApi {
   ): Promise<ProviderConfig> {
     // Set who owns a music source and who else may use it.
     // An admin may set this for any music source, an owner may
-    // only change the sharing of a source it owns.
-    return this.sendCommand("config/providers/set_access", {
-      instance_id,
-      owner: access.owner,
-      sharing: access.sharing,
-      shared_users: access.shared_users,
-    });
+    // only change the sharing of a source it owns. The dialog reports a
+    // refused change itself, so opt out of the global error toast.
+    return this.sendCommand(
+      "config/providers/set_access",
+      {
+        instance_id,
+        owner: access.owner,
+        sharing: access.sharing,
+        shared_users: access.shared_users,
+      },
+      { suppressGlobalError: true },
+    );
   }
 
   public getShareCandidates(): Promise<UserSummary[]> {
-    // Get the users a music source can be shared with, the caller included;
-    // check supportsShareCandidates first.
+    // Get the users a music source or playlist can be shared with, the caller
+    // included; check supportsShareCandidates first.
     return this.sendCommand("config/providers/share_candidates", undefined, {
       // callers show their own error toast; avoid a duplicate global one
       suppressGlobalError: true,

--- a/src/plugins/api/interfaces.ts
+++ b/src/plugins/api/interfaces.ts
@@ -849,6 +849,13 @@ export interface ProviderAccess {
   shared_users: string[];
 }
 
+export interface PlaylistAccess extends ProviderAccess {
+  // Who a Music Assistant playlist serves: its owner, who may see it and who may edit it.
+  // collaborative: everyone the playlist is shared with may also add and remove its
+  // items; otherwise only the owner may
+  collaborative: boolean;
+}
+
 export interface ProviderConfig extends Config {
   // Provider(instance) Configuration.
   type: ProviderType;
@@ -1036,6 +1043,11 @@ export interface Playlist extends MediaItem {
   is_editable: boolean;
   supported_mediatypes: MediaType[];
   is_dynamic: boolean;
+  // access: only Music Assistant's own (builtin) playlists carry a record. null
+  // means everyone: a playlist without a record, or a playlist of a music
+  // source, which follows the access of that source. Its owner is a user id,
+  // unrelated to the display name in owner
+  access: PlaylistAccess | null;
 }
 
 // track matching tier accepted when matching playlist tracks against a

--- a/src/plugins/eventbus.ts
+++ b/src/plugins/eventbus.ts
@@ -71,6 +71,10 @@ export type MigratePlaylistDialogEvent = {
   playlist: Playlist;
 };
 
+export type PlaylistAccessDialogEvent = {
+  playlist: Playlist;
+};
+
 export type CreateSmartPlaylistEvent = {
   providerId?: string;
 };
@@ -116,6 +120,7 @@ export type Events = {
   linkGenreDialog: LinkGenreDialogEvent;
   importPlaylistDialog: ImportPlaylistEvent;
   migratePlaylistDialog: MigratePlaylistDialogEvent;
+  playlistAccessDialog: PlaylistAccessDialogEvent;
   createSmartPlaylist: CreateSmartPlaylistEvent;
   audioOverlayDialog: AudioOverlayDialogEvent;
   playAnnouncementDialog: PlayAnnouncementDialogEvent;

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -2118,6 +2118,23 @@
     "import_playlist_match_policy_best_effort_description": "Prefer an exact match, then the same recording, otherwise accept the closest available match.",
     "party_mode": "Party",
     "edit_playlist": "Edit playlist",
+    "share_playlist": "Share playlist",
+    "playlist_access": {
+        "title": "Share {name}",
+        "description": "Who this playlist belongs to, who may see it and who may edit it.",
+        "owner_hint": "A playlist without an owner is managed by administrators.",
+        "personal": "Personal",
+        "shared": "Shared",
+        "collaborative": "Collaborative",
+        "collaborative_hint": "Everyone the playlist is shared with may also add and remove items.",
+        "hints": {
+            "private": "Only the owner can see this playlist.",
+            "selected": "The owner and the members selected below.",
+            "members": "Every signed-in member, guests excluded.",
+            "everyone": "Any user can see this playlist."
+        },
+        "updated": "Sharing updated"
+    },
     "edit_radio": "Edit radio station",
     "edit_track": "Edit track",
     "uri_read_only": "URI (read-only)",

--- a/src/views/LibraryPlaylists.vue
+++ b/src/views/LibraryPlaylists.vue
@@ -32,6 +32,7 @@ import {
   EventMessage,
   EventType,
   MediaType,
+  type Playlist,
   ProviderFeature,
 } from "@/plugins/api/interfaces";
 import { eventbus } from "@/plugins/eventbus";
@@ -165,6 +166,15 @@ onMounted(() => {
         evt.event === EventType.MEDIA_ITEM_ADDED ||
         evt.event === EventType.MEDIA_ITEM_DELETED
       ) {
+        listingRef.value?.reload?.();
+      } else if (
+        (evt.data as Playlist).access !== null &&
+        listingRef.value?.isMissing((evt.data as Playlist).uri)
+      ) {
+        // the server only announces a playlist to the users who may see it, so
+        // a personal playlist a fully loaded, unfiltered listing lacks was just
+        // shared with the user; one the user may no longer see is not announced
+        // and stays until the next reload
         listingRef.value?.reload?.();
       } else {
         updateAvailable.value = true;

--- a/src/views/PlaylistDetails.vue
+++ b/src/views/PlaylistDetails.vue
@@ -1,12 +1,26 @@
 <template>
   <InfoHeader :item="itemDetails" :sort-by="listingRef?.sortBy">
-    <template v-if="smartRules" #append-actions>
+    <template v-if="smartRules || canShare" #append-actions>
       <Settings2
+        v-if="smartRules"
         :size="22"
         class="cursor-pointer"
         :title="$t('smart_playlist.edit_rules')"
         @click="showEditDialog = true"
       />
+      <Share2
+        v-if="canShare"
+        :size="22"
+        class="cursor-pointer"
+        :title="$t('share_playlist')"
+        @click="openAccessDialog"
+      />
+    </template>
+    <template
+      v-if="itemDetails && isMusicAssistantPlaylist(itemDetails)"
+      #owner
+    >
+      <PlaylistAccessSummary :playlist="itemDetails" />
     </template>
     <template v-if="smartRules" #description-dialog="{ open, onOpenChange }">
       <Dialog :open="open" @update:open="onOpenChange">
@@ -75,6 +89,7 @@
 import DynamicItemSample from "@/components/DynamicItemSample.vue";
 import InfoHeader from "@/components/InfoHeader.vue";
 import ItemsListing, { LoadDataParams } from "@/components/ItemsListing.vue";
+import PlaylistAccessSummary from "@/components/PlaylistAccessSummary.vue";
 import ProviderDetails from "@/components/ProviderDetails.vue";
 import SmartPlaylistRulesView from "@/components/smart_playlist/SmartPlaylistRulesView.vue";
 import {
@@ -84,17 +99,25 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
+import {
+  canSharePlaylist,
+  isMusicAssistantPlaylist,
+} from "@/helpers/playlist_access";
 import EditSmartPlaylistDialog from "@/layouts/default/EditSmartPlaylistDialog.vue";
 import { api } from "@/plugins/api";
 import {
   EventType,
+  Scope,
   type EventMessage,
   type MediaItemType,
   type Playlist,
   type SmartPlaylistRules,
 } from "@/plugins/api/interfaces";
-import { Settings2 } from "@lucide/vue";
-import { onBeforeUnmount, onMounted, ref, watch } from "vue";
+import { authManager } from "@/plugins/auth";
+import { eventbus } from "@/plugins/eventbus";
+import { store } from "@/plugins/store";
+import { Settings2, Share2 } from "@lucide/vue";
+import { computed, onBeforeUnmount, onMounted, ref, watch } from "vue";
 
 export interface Props {
   itemId: string;
@@ -106,6 +129,21 @@ const itemDetails = ref<Playlist>();
 const smartRules = ref<SmartPlaylistRules | null>(null);
 const showEditDialog = ref(false);
 const listingRef = ref<InstanceType<typeof ItemsListing>>();
+
+const canShare = computed(
+  () =>
+    itemDetails.value !== undefined &&
+    canSharePlaylist(
+      itemDetails.value,
+      store.currentUser,
+      authManager.hasScope(Scope.LIBRARY_MANAGE),
+    ),
+);
+
+const openAccessDialog = function () {
+  if (!itemDetails.value) return;
+  eventbus.emit("playlistAccessDialog", { playlist: itemDetails.value });
+};
 
 const loadItemDetails = async function () {
   itemDetails.value = await api.getPlaylist(props.itemId, props.provider);

--- a/tests/components/PlaylistAccessSummary.test.ts
+++ b/tests/components/PlaylistAccessSummary.test.ts
@@ -1,0 +1,116 @@
+import PlaylistAccessSummary from "@/components/PlaylistAccessSummary.vue";
+import {
+  type PlaylistAccess,
+  ProviderSharing,
+  type User,
+  type UserSummary,
+} from "@/plugins/api/interfaces";
+import { flushPromises, mount } from "@vue/test-utils";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { playlist } from "../fixtures/playlist";
+import { providerMapping } from "../fixtures/providerMapping";
+import { user } from "../fixtures/user";
+
+const { apiMock, authMock, storeMock } = vi.hoisted(() => ({
+  apiMock: {
+    getShareCandidates: vi.fn(),
+  },
+  authMock: {
+    hasScope: vi.fn<() => boolean>(),
+  },
+  storeMock: {
+    currentUser: undefined as User | undefined,
+  },
+}));
+
+vi.mock("@/plugins/api", () => ({ api: apiMock, default: apiMock }));
+vi.mock("@/plugins/auth", () => ({ authManager: authMock }));
+vi.mock("@/plugins/store", () => ({ store: storeMock }));
+vi.mock("@/plugins/i18n", () => ({ $t: (key: string) => key }));
+
+const members: UserSummary[] = [
+  {
+    user_id: "other",
+    username: "other",
+    display_name: "Other Member",
+    avatar_url: null,
+  },
+];
+
+const access = (overrides: Partial<PlaylistAccess> = {}): PlaylistAccess => ({
+  owner: "me",
+  sharing: ProviderSharing.PRIVATE,
+  shared_users: [],
+  collaborative: false,
+  ...overrides,
+});
+
+const mountSummary = async (item: PlaylistAccess | null) => {
+  const wrapper = mount(PlaylistAccessSummary, {
+    props: {
+      playlist: playlist({
+        provider_mappings: [providerMapping({ provider_domain: "builtin" })],
+        access: item,
+      }),
+    },
+  });
+  await flushPromises();
+  return wrapper;
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  authMock.hasScope.mockReturnValue(false);
+  storeMock.currentUser = user({ user_id: "me" });
+  apiMock.getShareCandidates.mockResolvedValue(members);
+});
+
+describe("PlaylistAccessSummary", () => {
+  it("reads a playlist without a record as shared with everyone", async () => {
+    const wrapper = await mountSummary(null);
+
+    expect(wrapper.text()).toBe(
+      "playlist_access.shared · settings.source_access.options.everyone",
+    );
+    expect(apiMock.getShareCandidates).not.toHaveBeenCalled();
+  });
+
+  it("calls the user's own playlist personal", async () => {
+    const wrapper = await mountSummary(access());
+
+    expect(wrapper.text()).toBe(
+      "playlist_access.personal · settings.source_access.options.private",
+    );
+    expect(apiMock.getShareCandidates).not.toHaveBeenCalled();
+  });
+
+  it("names another owner to a library manager", async () => {
+    authMock.hasScope.mockReturnValue(true);
+    const wrapper = await mountSummary(
+      access({
+        owner: "other",
+        sharing: ProviderSharing.SELECTED,
+        shared_users: ["me"],
+      }),
+    );
+
+    expect(wrapper.text()).toBe(
+      "Other Member · settings.source_access.shared_with_count",
+    );
+  });
+
+  it("calls another member's playlist shared and flags it collaborative", async () => {
+    const wrapper = await mountSummary(
+      access({
+        owner: "other",
+        sharing: ProviderSharing.MEMBERS,
+        collaborative: true,
+      }),
+    );
+
+    expect(wrapper.text()).toBe(
+      "playlist_access.shared · settings.source_access.options.members · playlist_access.collaborative",
+    );
+    expect(apiMock.getShareCandidates).not.toHaveBeenCalled();
+  });
+});

--- a/tests/fixtures/playlist.ts
+++ b/tests/fixtures/playlist.ts
@@ -21,6 +21,7 @@ export function playlist(overrides: Partial<Playlist> = {}): Playlist {
     is_editable: false,
     supported_mediatypes: [MediaType.TRACK],
     is_dynamic: false,
+    access: null,
     ...overrides,
   });
 }

--- a/tests/helpers/migratePlaylistAction.test.ts
+++ b/tests/helpers/migratePlaylistAction.test.ts
@@ -31,6 +31,9 @@ const { apiMock, storeMock, mockEventbusEmit } = vi.hoisted(() => ({
 }));
 
 vi.mock("@/plugins/api", () => ({ default: apiMock, api: apiMock }));
+vi.mock("@/plugins/auth", () => ({
+  authManager: { hasScope: () => false },
+}));
 vi.mock("@/plugins/store", () => ({ store: storeMock }));
 vi.mock("@/plugins/eventbus", () => ({
   eventbus: {

--- a/tests/helpers/playlistAccessActions.test.ts
+++ b/tests/helpers/playlistAccessActions.test.ts
@@ -1,0 +1,171 @@
+/**
+ * Tests for the context menu actions that depend on who may manage a playlist.
+ *
+ * Sharing is offered for a single Music Assistant playlist to its owner and to
+ * a library manager, from a listing as well as from the details page; editing
+ * and removing a personal playlist are offered to them only.
+ */
+import {
+  getContextMenuItems,
+  type ContextMenuItem,
+} from "@/layouts/default/ItemContextMenu.vue";
+import {
+  type ItemMapping,
+  MediaType,
+  ProviderFeature,
+  ProviderSharing,
+  ProviderType,
+  type User,
+} from "@/plugins/api/interfaces";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { playlist } from "../fixtures/playlist";
+import { providerMapping } from "../fixtures/providerMapping";
+import { user } from "../fixtures/user";
+
+const { apiMock, authMock, storeMock, mockEventbusEmit } = vi.hoisted(() => ({
+  apiMock: {
+    providers: {} as Record<string, unknown>,
+    getProvider: vi.fn(),
+    getLibraryItem: vi.fn(),
+    players: {},
+  },
+  authMock: {
+    hasScope: vi.fn<() => boolean>(),
+  },
+  storeMock: {
+    currentUser: undefined as User | undefined,
+    enabledPlugins: new Set<string>(),
+  },
+  mockEventbusEmit: vi.fn(),
+}));
+
+vi.mock("@/plugins/api", () => ({ default: apiMock, api: apiMock }));
+vi.mock("@/plugins/auth", () => ({ authManager: authMock }));
+vi.mock("@/plugins/store", () => ({ store: storeMock }));
+vi.mock("@/plugins/eventbus", () => ({
+  eventbus: {
+    on: vi.fn(),
+    off: vi.fn(),
+    emit: mockEventbusEmit,
+  },
+}));
+vi.mock("@/plugins/i18n", () => ({ $t: (key: string) => key }));
+
+const maPlaylist = (owner: string) =>
+  playlist({
+    is_editable: true,
+    provider_mappings: [
+      providerMapping({ provider_domain: "builtin", in_library: true }),
+    ],
+    access: {
+      owner,
+      sharing: ProviderSharing.PRIVATE,
+      shared_users: [],
+      collaborative: false,
+    },
+  });
+
+const shareAction = (items: ContextMenuItem[]): ContextMenuItem | undefined =>
+  items.find((x) => x.label === "share_playlist");
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  authMock.hasScope.mockReturnValue(false);
+  storeMock.currentUser = user({ user_id: "me" });
+  apiMock.providers = {
+    builtin: {
+      type: ProviderType.MUSIC,
+      domain: "builtin",
+      instance_id: "builtin",
+      supported_features: [],
+      available: true,
+    },
+  };
+  apiMock.getProvider.mockImplementation((id: string) => apiMock.providers[id]);
+});
+
+describe("share playlist context menu action", () => {
+  it("is offered to the owner from a listing and opens the dialog", async () => {
+    const item = maPlaylist("me");
+    const items = await getContextMenuItems([item]);
+
+    shareAction(items)?.action?.();
+
+    expect(mockEventbusEmit).toHaveBeenCalledWith("playlistAccessDialog", {
+      playlist: item,
+    });
+  });
+
+  it("is offered to a library manager for another member's playlist", async () => {
+    authMock.hasScope.mockReturnValue(true);
+    const items = await getContextMenuItems([maPlaylist("other")]);
+
+    expect(shareAction(items)).toBeDefined();
+  });
+
+  it("is not offered to another member", async () => {
+    const items = await getContextMenuItems([maPlaylist("other")]);
+
+    expect(shareAction(items)).toBeUndefined();
+  });
+
+  it("is not offered for a playlist of a music source", async () => {
+    authMock.hasScope.mockReturnValue(true);
+    const item = playlist({
+      provider_mappings: [providerMapping({ provider_domain: "spotify" })],
+    });
+    const items = await getContextMenuItems([item]);
+
+    expect(shareAction(items)).toBeUndefined();
+  });
+
+  it("leaves a playlist mapping without provider mappings alone", async () => {
+    authMock.hasScope.mockReturnValue(true);
+    const mapping = {
+      item_id: "1",
+      provider: "library",
+      name: "Playlist",
+      media_type: MediaType.PLAYLIST,
+      uri: "library://playlist/1",
+      available: true,
+    } as unknown as ItemMapping;
+    const items = await getContextMenuItems([mapping]);
+
+    expect(shareAction(items)).toBeUndefined();
+  });
+});
+
+describe("edit and remove for a personal playlist", () => {
+  const labels = (items: ContextMenuItem[]) => items.map((x) => x.label);
+
+  beforeEach(() => {
+    apiMock.providers.builtin = {
+      ...(apiMock.providers.builtin as object),
+      supported_features: [ProviderFeature.LIBRARY_PLAYLISTS_EDIT],
+    };
+  });
+
+  it("are offered to the owner on the details page", async () => {
+    const item = maPlaylist("me");
+    const labels_ = labels(await getContextMenuItems([item], item));
+
+    expect(labels_).toContain("edit_playlist");
+    expect(labels_).toContain("remove_library");
+  });
+
+  it("is not offered for a selection that includes another member's playlist", async () => {
+    const labels_ = labels(
+      await getContextMenuItems([maPlaylist("me"), maPlaylist("other")]),
+    );
+
+    expect(labels_).not.toContain("remove_library");
+  });
+
+  it("are not offered to another member it is shared with", async () => {
+    const item = maPlaylist("other");
+    const labels_ = labels(await getContextMenuItems([item], item));
+
+    expect(labels_).not.toContain("edit_playlist");
+    expect(labels_).not.toContain("remove_library");
+  });
+});

--- a/tests/layouts/ItemContextMenu.test.ts
+++ b/tests/layouts/ItemContextMenu.test.ts
@@ -29,6 +29,10 @@ vi.mock("@/plugins/store", () => ({
   store: storeMock,
 }));
 
+vi.mock("@/plugins/auth", () => ({
+  authManager: { hasScope: () => false },
+}));
+
 vi.mock("@/plugins/api", () => ({
   default: {
     players: {},

--- a/tests/layouts/ItemContextMenuHydration.test.ts
+++ b/tests/layouts/ItemContextMenuHydration.test.ts
@@ -28,6 +28,9 @@ const { apiMock, emittedMenus, storeMock } = vi.hoisted(() => ({
 }));
 
 vi.mock("@/plugins/api", () => ({ default: apiMock, api: apiMock }));
+vi.mock("@/plugins/auth", () => ({
+  authManager: { hasScope: () => false },
+}));
 vi.mock("@/plugins/store", () => ({ store: storeMock }));
 vi.mock("@/plugins/eventbus", () => ({
   eventbus: {

--- a/tests/layouts/PlaylistAccessDialog.test.ts
+++ b/tests/layouts/PlaylistAccessDialog.test.ts
@@ -1,0 +1,319 @@
+import PlaylistAccessDialog from "@/layouts/default/PlaylistAccessDialog.vue";
+import {
+  type PlaylistAccess,
+  ProviderSharing,
+  type UserSummary,
+} from "@/plugins/api/interfaces";
+import { eventbus } from "@/plugins/eventbus";
+import {
+  enableAutoUnmount,
+  flushPromises,
+  mount,
+  type VueWrapper,
+} from "@vue/test-utils";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { playlist } from "../fixtures/playlist";
+import { providerMapping } from "../fixtures/providerMapping";
+import { selectOptions } from "../fixtures/rekaSelect";
+
+const { apiMock, authMock, storeMock, toastMock } = vi.hoisted(() => ({
+  apiMock: {
+    getShareCandidates: vi.fn(),
+    setPlaylistAccess: vi.fn(),
+  },
+  authMock: {
+    hasScope: vi.fn<() => boolean>(),
+  },
+  storeMock: {
+    currentUser: undefined,
+    dialogActive: false,
+    isTouchscreen: false,
+  },
+  toastMock: {
+    error: vi.fn(),
+    success: vi.fn(),
+  },
+}));
+
+vi.mock("@/plugins/api", () => ({ api: apiMock, default: apiMock }));
+vi.mock("@/plugins/auth", () => ({ authManager: authMock }));
+vi.mock("@/plugins/store", () => ({ store: storeMock }));
+vi.mock("vue-i18n", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("vue-i18n")>()),
+  useI18n: () => ({ t: (key: string) => key }),
+}));
+vi.mock("vue-sonner", () => ({ toast: toastMock }));
+
+const members: UserSummary[] = [
+  {
+    user_id: "owner-id",
+    username: "owner",
+    display_name: "Owner",
+    avatar_url: null,
+  },
+  {
+    user_id: "member-id",
+    username: "member",
+    display_name: "Member",
+    avatar_url: null,
+  },
+];
+
+const maPlaylist = (access: PlaylistAccess | null) =>
+  playlist({
+    item_id: "42",
+    name: "Road trip",
+    is_editable: true,
+    provider_mappings: [providerMapping({ provider_domain: "builtin" })],
+    access,
+  });
+
+const sharedWithMember: PlaylistAccess = {
+  owner: "owner-id",
+  sharing: ProviderSharing.SELECTED,
+  shared_users: ["member-id"],
+  collaborative: false,
+};
+
+// an open dialog keeps document-level focus trap listeners, so tear it down
+// even when an assertion fails
+enableAutoUnmount(afterEach);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  storeMock.dialogActive = false;
+  storeMock.isTouchscreen = false;
+  authMock.hasScope.mockReturnValue(true);
+  apiMock.getShareCandidates.mockResolvedValue(members);
+  apiMock.setPlaylistAccess.mockResolvedValue(maPlaylist(sharedWithMember));
+  document.body.innerHTML = "";
+});
+
+describe("PlaylistAccessDialog", () => {
+  it("names the playlist in the title", async () => {
+    await openDialog(maPlaylist(sharedWithMember));
+
+    expect(
+      document.querySelector("[data-slot='dialog-title']")?.textContent,
+    ).toContain("playlist_access.title Road trip");
+  });
+
+  it("offers the owner only to a library manager that can list the members", async () => {
+    await openDialog(maPlaylist(sharedWithMember));
+
+    expect(ownerTrigger()).not.toBeNull();
+  });
+
+  it("hides the owner from a member", async () => {
+    authMock.hasScope.mockReturnValue(false);
+
+    await openDialog(maPlaylist(sharedWithMember));
+
+    expect(ownerTrigger()).toBeNull();
+  });
+
+  it("hides the owner while the members can not be listed", async () => {
+    apiMock.getShareCandidates.mockRejectedValue(new Error("refused"));
+
+    await openDialog(maPlaylist(sharedWithMember));
+
+    expect(ownerTrigger()).toBeNull();
+    expect(sharedUsersField()).toBeNull();
+  });
+
+  it("does not offer selected members while the members can not be listed", async () => {
+    apiMock.getShareCandidates.mockRejectedValue(new Error("refused"));
+
+    await openDialog(
+      maPlaylist({ ...sharedWithMember, sharing: ProviderSharing.PRIVATE }),
+    );
+    await openSelect(sharingTrigger()!);
+
+    expect(optionLabels()).not.toContain(
+      "settings.source_access.options.selected",
+    );
+  });
+
+  it("keeps selected members while it is the current choice", async () => {
+    apiMock.getShareCandidates.mockRejectedValue(new Error("refused"));
+
+    await openDialog(maPlaylist(sharedWithMember));
+    await openSelect(sharingTrigger()!);
+
+    expect(optionLabels()).toContain("settings.source_access.options.selected");
+  });
+
+  it("does not offer only me for a playlist without an owner", async () => {
+    await openDialog(
+      maPlaylist({
+        owner: null,
+        sharing: ProviderSharing.MEMBERS,
+        shared_users: [],
+        collaborative: false,
+      }),
+    );
+    await openSelect(sharingTrigger()!);
+
+    expect(optionLabels()).not.toContain(
+      "settings.source_access.options.private",
+    );
+    expect(optionLabels()).not.toContain(
+      "settings.source_access.options.not_shared",
+    );
+  });
+
+  it("does not save a playlist without an owner shared with nobody", async () => {
+    await openDialog(
+      maPlaylist({
+        owner: null,
+        sharing: ProviderSharing.SELECTED,
+        shared_users: [],
+        collaborative: false,
+      }),
+    );
+
+    expect(saveButton()!.disabled).toBe(true);
+  });
+
+  it("saves the owner, sharing, members and collaborative flag", async () => {
+    const wrapper = await openDialog(maPlaylist(sharedWithMember));
+
+    collaborativeSwitch()!.click();
+    await submit(wrapper);
+
+    expect(apiMock.setPlaylistAccess).toHaveBeenCalledWith("42", {
+      owner: "owner-id",
+      sharing: ProviderSharing.SELECTED,
+      shared_users: ["member-id"],
+      collaborative: true,
+    });
+    expect(toastMock.success).toHaveBeenCalledWith("playlist_access.updated");
+  });
+
+  it("drops the shared members when sharing with everyone", async () => {
+    const wrapper = await openDialog(maPlaylist(sharedWithMember));
+
+    await openSelect(sharingTrigger()!);
+    await pickOption("settings.source_access.options.everyone");
+    await submit(wrapper);
+
+    expect(apiMock.setPlaylistAccess).toHaveBeenCalledWith("42", {
+      owner: "owner-id",
+      sharing: ProviderSharing.EVERYONE,
+      shared_users: [],
+      collaborative: false,
+    });
+  });
+
+  it("reads a playlist without a record as shared with everyone", async () => {
+    const wrapper = await openDialog(maPlaylist(null));
+
+    await submit(wrapper);
+
+    expect(apiMock.setPlaylistAccess).toHaveBeenCalledWith("42", {
+      owner: null,
+      sharing: ProviderSharing.EVERYONE,
+      shared_users: [],
+      collaborative: false,
+    });
+  });
+
+  it("reports a refused change and stays open", async () => {
+    apiMock.setPlaylistAccess.mockRejectedValue(new Error("refused"));
+    const wrapper = await openDialog(maPlaylist(sharedWithMember));
+
+    await submit(wrapper);
+
+    expect(toastMock.error).toHaveBeenCalledWith("Error: refused");
+    expect(dialogText()).not.toBeUndefined();
+  });
+});
+
+function ownerTrigger() {
+  return document.querySelector<HTMLElement>("#playlist-access-owner");
+}
+
+function sharingTrigger() {
+  return document.querySelector<HTMLElement>("#playlist-access-sharing");
+}
+
+function saveButton() {
+  return document.querySelector<HTMLButtonElement>(
+    "button[form='form-playlist-access']",
+  );
+}
+
+function collaborativeSwitch() {
+  return document.querySelector<HTMLElement>("#playlist-access-collaborative");
+}
+
+function sharedUsersField() {
+  return document.querySelector(
+    "input[placeholder='settings.source_access.select_members']",
+  );
+}
+
+function dialogText() {
+  return document.querySelector("[data-slot='dialog-content']")?.textContent;
+}
+
+function optionLabels() {
+  return selectOptions().map((item) => item.textContent?.trim());
+}
+
+// reka settles the listbox focus on a timer, so a plain flush is not enough
+async function settle() {
+  await flushPromises();
+  await new Promise((resolve) => setTimeout(resolve, 30));
+  await flushPromises();
+}
+
+// the dialog is portalled out of the wrapper, so its selects are driven
+// through the document rather than through the wrapper
+async function openSelect(trigger: HTMLElement) {
+  trigger.dispatchEvent(
+    new PointerEvent("pointerdown", {
+      bubbles: true,
+      button: 0,
+      pointerType: "mouse",
+    }),
+  );
+  trigger.click();
+  await settle();
+}
+
+async function pickOption(label: string) {
+  const option = selectOptions().find((item) =>
+    item.textContent?.includes(label),
+  );
+  if (!option) throw new Error(`no option "${label}": ${optionLabels()}`);
+  option.dispatchEvent(new PointerEvent("pointerup", { bubbles: true }));
+  await settle();
+}
+
+async function submit(wrapper: VueWrapper) {
+  document
+    .querySelector<HTMLFormElement>("#form-playlist-access")!
+    .dispatchEvent(new Event("submit", { bubbles: true, cancelable: true }));
+  await flushPromises();
+  return wrapper;
+}
+
+async function openDialog(
+  item: ReturnType<typeof playlist>,
+): Promise<VueWrapper> {
+  const wrapper = mount(PlaylistAccessDialog, {
+    attachTo: document.body,
+    global: {
+      mocks: {
+        // the key, plus the playlist name the title interpolates
+        $t: (key: string, params?: { name?: string }) =>
+          params?.name ? `${key} ${params.name}` : key,
+      },
+    },
+  });
+  // the form is filled when the dialog opens, not when it mounts
+  eventbus.emit("playlistAccessDialog", { playlist: item });
+  await flushPromises();
+  return wrapper;
+}


### PR DESCRIPTION
# What does this implement/fix?

Music Assistant playlists now belong to whoever created them and are private by default (server side), but the app had no way to share one. The playlist page now shows who a Music Assistant playlist belongs to and who may see it, and its owner (or an admin) shares it from a dialog that mirrors the one for music sources: only me, selected members, all members, or everyone including guests. A collaborative switch lets everyone the playlist is shared with add and remove items too. Playlists of a music service keep following the sharing of that source.

- Sharing summary and a share action on the playlist page; "Share playlist" in the playlist menu
- Share dialog: owner (admins), sharing, shared members and collaborative, saved through `music/playlists/set_access`; it reuses the sharing wording of the music source dialog
- "Add to playlist" and "Remove from playlist" only offer playlists the user may edit: without an access record, owned, or shared with the user as collaborative; editing or removing a personal playlist is offered to its owner or a library manager only
- The playlist library reloads when a playlist is shared with the user, so it shows up right away
- Members are listed through `config/providers/share_candidates`; when the server refuses that (a regular member today), "Selected members" is not offered

Closes https://github.com/music-assistant/backlog/issues/114

**Related issue (if applicable):**

- related issue https://github.com/music-assistant/backlog/issues/114 (story https://github.com/music-assistant/backlog/issues/84)

**Related backend PR (if applicable):**

- related backend PR https://github.com/music-assistant/server/pull/6285 (and https://github.com/music-assistant/server/pull/6284 for the member list)

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [x] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm lint:check` passes.
- [x] `pnpm test:run` passes, and tests have been added/updated where applicable.
- [x] `pnpm build` passes.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.