### PR TITLE
Clearer wording for the home page warning

### DIFF
--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -553,7 +553,7 @@
         "stay": "Stay",
         "discard": "Discard changes",
         "provider_requires_attention": "Needs attention",
-        "provider_requires_attention_detail": "One or more providers require attention. Please check the provider settings.",
+        "provider_requires_attention_detail": "Something in your settings needs attention.",
         "reconfigure": "Reconfigure",
         "fix_now": "Fix now",
         "web_player_enabled": {
@@ -2103,7 +2103,7 @@
         }
     },
     "not_found_headline": "Oops, this page is off the setlist.",
-    "not_found_subtext": "The track you're looking for got lost between providers. Head back or find something new.",
+    "not_found_subtext": "The track you're looking for got lost between music sources. Head back or find something new.",
     "restore_genre": "Restore",
     "genre_name": "Genre name",
     "export_playlist": "Export playlist",
@@ -2479,7 +2479,7 @@
         "toggle": "Toggle the MilkDrop visualizer",
         "preset_random_favorites": "Random from favorites",
         "toggle_favorite": "Favorite this preset",
-        "provider_missing": "The MilkDrop Visualizer plugin is not installed or unavailable. Add it under Settings > Providers to use the visualizer.",
+        "provider_missing": "The MilkDrop Visualizer plugin is not installed or unavailable. Add it under Settings → Plugins to use the visualizer.",
         "section_general": "Appearance",
         "section_presets": "Presets",
         "quality": "Render quality",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -553,7 +553,7 @@
         "stay": "Stay",
         "discard": "Discard changes",
         "provider_requires_attention": "Needs attention",
-        "provider_requires_attention_detail": "Something in your settings needs attention.",
+        "provider_requires_attention_detail": "One or more of your music sources, players or plugins aren't working.",
         "reconfigure": "Reconfigure",
         "fix_now": "Fix now",
         "web_player_enabled": {
@@ -2479,7 +2479,7 @@
         "toggle": "Toggle the MilkDrop visualizer",
         "preset_random_favorites": "Random from favorites",
         "toggle_favorite": "Favorite this preset",
-        "provider_missing": "The MilkDrop Visualizer plugin is not installed or unavailable. Add it under Settings → Plugins to use the visualizer.",
+        "provider_missing": "The MilkDrop Visualizer plugin isn't available. Check it under Settings → Plugins to use the visualizer.",
         "section_general": "Appearance",
         "section_presets": "Presets",
         "quality": "Render quality",


### PR DESCRIPTION
# What does this implement/fix?

A few messages outside the settings screens still used the internal word "provider". PR #2723 replaced that wording across settings but deliberately left these out of scope, so they were missed.

The home page warning is the main one. It appears whenever anything you configured fails to load, and it used to say "One or more providers require attention. Please check the provider settings." — while a **Fix now** button sitting right next to it already takes you there.

The MilkDrop visualizer message had a second problem: you can only reach that screen when the plugin is already installed and enabled, so telling people to go and add it was advice for a situation they cannot be in.

- Home page warning now says which kind of thing failed, and that it isn't working: "One or more of your music sources, players or plugins aren't working."
- MilkDrop visualizer message now asks you to check the plugin under Settings → Plugins, instead of telling you to add it under a menu entry that no longer exists.
- 404 page says "music sources" instead of "providers".

English wording only — no keys renamed, no code changes, other languages come from Lokalise.

## Screenshot

Home page warning banner:

| | |
|---|---|
| Before | One or more providers require attention. Please check the provider settings. |
| After | One or more of your music sources, players or plugins aren't working. |

**Related issue (if applicable):**

- n/a

**Related backend PR (if applicable):**

- n/a

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm lint:check` passes.
- [x] `pnpm test:run` passes, and tests have been added/updated where applicable.
- [x] `pnpm build` passes.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.