### PR TITLE
Spot and prevent music sources that nobody can use

### DIFF
--- a/src/components/settings/providers/ProviderAccessDialog.vue
+++ b/src/components/settings/providers/ProviderAccessDialog.vue
@@ -64,7 +64,7 @@
               </SelectContent>
             </Select>
             <FieldDescription>
-              {{ $t(getProviderSharingHintTranslationKey(sharing)) }}
+              {{ $t(getProviderSharingHintTranslationKey(formAccess)) }}
             </FieldDescription>
           </Field>
 
@@ -87,7 +87,7 @@
         <Button
           type="submit"
           form="form-provider-access"
-          :disabled="saving"
+          :disabled="saving || servesNobody(formAccess)"
           :loading="saving"
         >
           {{ $t("settings.save") }}
@@ -126,11 +126,13 @@ import {
   getProviderSharingHintTranslationKey,
   getProviderSharingTranslationKey,
   ownerCandidates,
+  servesNobody,
   userDisplayName,
 } from "@/helpers/provider_access";
 import { providerDisplayName } from "@/helpers/provider_config";
 import { api } from "@/plugins/api";
 import {
+  type ProviderAccess,
   type ProviderConfig,
   ProviderSharing,
   type User,
@@ -214,15 +216,25 @@ const shareOptions = computed(() =>
     .map((user) => ({ label: userDisplayName(user), value: user.user_id })),
 );
 
-// without the members to pick from there is nobody to select, so that choice
-// is only kept when it is already the current one
 const sharingOptions = computed(() =>
-  Object.values(ProviderSharing).filter(
-    (option) =>
-      option !== ProviderSharing.SELECTED ||
-      props.shareCandidates !== null ||
-      currentAccess.value.sharing === ProviderSharing.SELECTED,
-  ),
+  Object.values(ProviderSharing).filter((option) => {
+    // without the members to pick from there is nobody to select, so that
+    // choice is only kept when it is already the current one
+    if (option === ProviderSharing.SELECTED)
+      return (
+        props.shareCandidates !== null ||
+        currentAccess.value.sharing === ProviderSharing.SELECTED
+      );
+    // a source without an owner has to be shared with somebody, so private
+    // sharing is only kept for one that is stored that way already
+    if (option === ProviderSharing.PRIVATE)
+      return (
+        recordOwner.value !== null ||
+        (currentAccess.value.owner === null &&
+          currentAccess.value.sharing === ProviderSharing.PRIVATE)
+      );
+    return true;
+  }),
 );
 
 const currentAccess = computed(() =>
@@ -233,6 +245,14 @@ const currentAccess = computed(() =>
 const recordOwner = computed(() =>
   canChangeOwner.value ? selectedOwner.value : currentAccess.value.owner,
 );
+
+// the access record the form describes, as it is saved
+const formAccess = computed<ProviderAccess>(() => ({
+  owner: recordOwner.value,
+  sharing: sharing.value,
+  shared_users:
+    sharing.value === ProviderSharing.SELECTED ? sharedUsers.value : [],
+}));
 
 const ownedByViewer = computed(
   () => recordOwner.value === store.currentUser?.user_id,
@@ -245,9 +265,15 @@ watch(
   },
 );
 
-// the owner uses the source anyway, so it leaves the shared list once picked
 watch(selectedOwner, (ownerId) => {
-  if (ownerId === null) return;
+  if (ownerId === null) {
+    // private sharing needs an owner, so the source is shared with all members
+    // instead, unless it is stored private without one already
+    if (!sharingOptions.value.includes(sharing.value))
+      sharing.value = ProviderSharing.MEMBERS;
+    return;
+  }
+  // the owner uses the source anyway, so it leaves the shared list once picked
   sharedUsers.value = sharedUsers.value.filter((id) => id !== ownerId);
 });
 
@@ -255,12 +281,10 @@ const save = async () => {
   if (!props.config) return;
   saving.value = true;
   try {
-    const updated = await api.setProviderAccess(props.config.instance_id, {
-      owner: recordOwner.value,
-      sharing: sharing.value,
-      shared_users:
-        sharing.value === ProviderSharing.SELECTED ? sharedUsers.value : [],
-    });
+    const updated = await api.setProviderAccess(
+      props.config.instance_id,
+      formAccess.value,
+    );
     toast.success(t("settings.source_access.updated"));
     emit("saved", updated);
     emit("update:open", false);

--- a/src/helpers/provider_access.test.ts
+++ b/src/helpers/provider_access.test.ts
@@ -17,6 +17,7 @@ import {
   hasConfigurableAccess,
   isOwnMusicSource,
   ownerCandidates,
+  servesNobody,
   shareCandidates,
   userDisplayName,
 } from "./provider_access";
@@ -138,14 +139,56 @@ describe("isOwnMusicSource", () => {
   });
 });
 
+describe("servesNobody", () => {
+  it.each([
+    ["private", ProviderSharing.PRIVATE],
+    ["shared with nobody selected", ProviderSharing.SELECTED],
+  ])("is true for a source without an owner that is %s", (_label, sharing) => {
+    expect(servesNobody({ owner: null, sharing, shared_users: [] })).toBe(true);
+  });
+
+  it.each([
+    [
+      "a source without an owner shared with a selected member",
+      {
+        owner: null,
+        sharing: ProviderSharing.SELECTED,
+        shared_users: ["user-2"],
+      },
+    ],
+    [
+      "a source without an owner shared with all members",
+      { owner: null, sharing: ProviderSharing.MEMBERS, shared_users: [] },
+    ],
+    [
+      "a source without an owner shared with everyone",
+      { owner: null, sharing: ProviderSharing.EVERYONE, shared_users: [] },
+    ],
+    [
+      "a private source with an owner",
+      { owner: "user-1", sharing: ProviderSharing.PRIVATE, shared_users: [] },
+    ],
+    [
+      "a source with an owner shared with nobody selected",
+      { owner: "user-1", sharing: ProviderSharing.SELECTED, shared_users: [] },
+    ],
+  ])("is false for %s", (_label, access) => {
+    expect(servesNobody(access)).toBe(false);
+  });
+});
+
 describe("sharing translation keys", () => {
   it.each(Object.values(ProviderSharing))("names sharing %s", (sharing) => {
     expect(getProviderSharingTranslationKey(sharing, true)).toBe(
       `settings.source_access.options.${sharing}`,
     );
-    expect(getProviderSharingHintTranslationKey(sharing)).toBe(
-      `settings.source_access.hints.${sharing}`,
-    );
+    expect(
+      getProviderSharingHintTranslationKey({
+        owner: "user-1",
+        sharing,
+        shared_users: [],
+      }),
+    ).toBe(`settings.source_access.hints.${sharing}`);
   });
 
   it("names private sharing as not shared for a viewer that does not own the source", () => {
@@ -164,6 +207,45 @@ describe("sharing translation keys", () => {
       expect(getProviderSharingTranslationKey(sharing, false)).toBe(
         `settings.source_access.options.${sharing}`,
       );
+    },
+  );
+
+  it("explains that only the selected members can use a source without an owner", () => {
+    expect(
+      getProviderSharingHintTranslationKey({
+        owner: null,
+        sharing: ProviderSharing.SELECTED,
+        shared_users: ["user-2"],
+      }),
+    ).toBe("settings.source_access.hints.selected_no_owner");
+  });
+
+  it.each([
+    ["private", ProviderSharing.PRIVATE],
+    ["shared with nobody selected", ProviderSharing.SELECTED],
+  ])(
+    "explains that nobody can use a source without an owner that is %s",
+    (_label, sharing) => {
+      expect(
+        getProviderSharingHintTranslationKey({
+          owner: null,
+          sharing,
+          shared_users: [],
+        }),
+      ).toBe("settings.source_access.hints.nobody");
+    },
+  );
+
+  it.each([ProviderSharing.MEMBERS, ProviderSharing.EVERYONE])(
+    "still explains sharing %s for a source without an owner",
+    (sharing) => {
+      expect(
+        getProviderSharingHintTranslationKey({
+          owner: null,
+          sharing,
+          shared_users: [],
+        }),
+      ).toBe(`settings.source_access.hints.${sharing}`);
     },
   );
 });

--- a/src/helpers/provider_access.ts
+++ b/src/helpers/provider_access.ts
@@ -69,6 +69,17 @@ export const isOwnMusicSource = (
 ) => userId !== undefined && config.access?.owner === userId;
 
 /**
+ * Whether nobody can use a music source with this access: one without an
+ * owner that is private, or shared with selected members while nobody is
+ * picked.
+ */
+export const servesNobody = (access: ProviderAccess) =>
+  access.owner === null &&
+  (access.sharing === ProviderSharing.PRIVATE ||
+    (access.sharing === ProviderSharing.SELECTED &&
+      access.shared_users.length === 0));
+
+/**
  * The translation key naming a sharing choice. Private sharing is named from
  * the viewer's side: as their own for the owner, as not shared for others.
  */
@@ -80,9 +91,17 @@ export const getProviderSharingTranslationKey = (
     ? "settings.source_access.options.not_shared"
     : PROVIDER_SHARING_TRANSLATION_KEYS[sharing];
 
+/**
+ * The translation key explaining who can use a music source with this access.
+ */
 export const getProviderSharingHintTranslationKey = (
-  sharing: ProviderSharing,
-) => PROVIDER_SHARING_HINT_TRANSLATION_KEYS[sharing];
+  access: ProviderAccess,
+) => {
+  if (servesNobody(access)) return "settings.source_access.hints.nobody";
+  if (access.owner === null && access.sharing === ProviderSharing.SELECTED)
+    return "settings.source_access.hints.selected_no_owner";
+  return PROVIDER_SHARING_HINT_TRANSLATION_KEYS[access.sharing];
+};
 
 /**
  * The users that may own a music source: every enabled member, so neither the

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -673,7 +673,7 @@
                 "members": "Every signed-in member, guests excluded.",
                 "everyone": "Any user can use this source.",
                 "selected_no_owner": "Only the members selected below.",
-                "nobody": "Nobody can use this source until it has an owner or is shared."
+                "nobody": "Nobody can use this source until it has an owner or is shared with someone."
             },
             "updated": "Access updated",
             "nobody": "Nobody can use this source"

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -671,9 +671,12 @@
                 "private": "Only the owner can use this source.",
                 "selected": "The owner and the members selected below.",
                 "members": "Every signed-in member, guests excluded.",
-                "everyone": "Any user can use this source."
+                "everyone": "Any user can use this source.",
+                "selected_no_owner": "Only the members selected below.",
+                "nobody": "Nobody can use this source until it has an owner or is shared."
             },
-            "updated": "Access updated"
+            "updated": "Access updated",
+            "nobody": "Nobody can use this source"
         },
         "player_providers_description": "Configure player providers for your audio output devices",
         "metadata_providers_description": "Manage metadata providers for artwork and additional info",

--- a/src/views/settings/Providers.vue
+++ b/src/views/settings/Providers.vue
@@ -337,6 +337,7 @@ import {
   getProviderSharingTranslationKey,
   hasConfigurableAccess,
   isOwnMusicSource,
+  servesNobody,
   shareCandidates,
   userDisplayName,
 } from "@/helpers/provider_access";
@@ -842,9 +843,11 @@ const canConfigureAccess = function (item: ProviderConfig) {
 };
 
 // the access record in its compact form: "<owner> · <who it is shared with>",
-// without the owner for a member, which only ever sees its own sources
+// without the owner for a member, which only ever sees its own sources; a
+// source nobody can use says so instead
 const accessSummary = function (item: ProviderConfig) {
   const access = effectiveProviderAccess(item.access);
+  if (servesNobody(access)) return $t("settings.source_access.nobody");
   const sharedCount = access.shared_users.length;
   const sharing =
     access.sharing === ProviderSharing.SELECTED

--- a/tests/components/settings/ProviderAccessDialog.test.ts
+++ b/tests/components/settings/ProviderAccessDialog.test.ts
@@ -275,6 +275,140 @@ describe("ProviderAccessDialog", () => {
     );
   });
 
+  it("does not offer private sharing for a source without an owner", async () => {
+    await openDialog(
+      providerConfig({
+        domain: "spotify",
+        access: {
+          owner: null,
+          sharing: ProviderSharing.EVERYONE,
+          shared_users: [],
+        },
+      }),
+      users,
+    );
+
+    await openSelect(sharingTrigger()!);
+
+    expect(optionLabels()).toEqual([
+      "settings.source_access.options.selected",
+      "settings.source_access.options.members",
+      "settings.source_access.options.everyone",
+    ]);
+  });
+
+  it("keeps private sharing for a source stored private without an owner, and explains why it can not be saved", async () => {
+    await openDialog(
+      providerConfig({
+        domain: "spotify",
+        access: {
+          owner: null,
+          sharing: ProviderSharing.PRIVATE,
+          shared_users: [],
+        },
+      }),
+      users,
+    );
+
+    expect(dialogText()).toContain("settings.source_access.hints.nobody");
+    expect(saveButton()?.disabled).toBe(true);
+
+    await openSelect(sharingTrigger()!);
+    expect(optionLabels()).toContain(
+      "settings.source_access.options.not_shared",
+    );
+  });
+
+  it("shares a private source with all members once it has no owner", async () => {
+    const wrapper = await openDialog(
+      providerConfig({
+        domain: "spotify",
+        instance_id: "spotify--owned",
+        access: {
+          owner: "owner-id",
+          sharing: ProviderSharing.PRIVATE,
+          shared_users: [],
+        },
+      }),
+      users,
+    );
+
+    await openSelect(ownerTrigger()!);
+    await pickOption("settings.source_access.household");
+
+    // read before any select opens again, which would mask a stale label
+    expect(sharingTrigger()?.textContent).toContain(
+      "settings.source_access.options.members",
+    );
+
+    await submit(wrapper);
+
+    expect(apiMock.setProviderAccess).toHaveBeenCalledWith("spotify--owned", {
+      owner: null,
+      sharing: ProviderSharing.MEMBERS,
+      shared_users: [],
+    });
+  });
+
+  it("leaves a private source without an owner as it is when the dialog opens on it", async () => {
+    // the page reuses one dialog for every source, so the form resets from the
+    // source it showed before
+    const wrapper = await openDialog(
+      providerConfig({
+        domain: "spotify",
+        access: {
+          owner: "owner-id",
+          sharing: ProviderSharing.PRIVATE,
+          shared_users: [],
+        },
+      }),
+      users,
+    );
+    await wrapper.setProps({ open: false });
+    await wrapper.setProps({
+      config: providerConfig({
+        domain: "spotify",
+        access: {
+          owner: null,
+          sharing: ProviderSharing.PRIVATE,
+          shared_users: [],
+        },
+      }),
+      open: true,
+    });
+    await flushPromises();
+
+    expect(sharingTrigger()?.textContent).toContain(
+      "settings.source_access.options.not_shared",
+    );
+    expect(sharedUsersField()).toBeNull();
+  });
+
+  it("can not save a source without an owner until a member is selected to share it with", async () => {
+    await openDialog(
+      providerConfig({
+        domain: "spotify",
+        access: {
+          owner: null,
+          sharing: ProviderSharing.SELECTED,
+          shared_users: [],
+        },
+      }),
+      users,
+    );
+
+    expect(dialogText()).toContain("settings.source_access.hints.nobody");
+    expect(saveButton()?.disabled).toBe(true);
+
+    await openMemberPicker();
+    await pickMember("Member");
+
+    expect(dialogText()).toContain(
+      "settings.source_access.hints.selected_no_owner",
+    );
+    expect(saveButton()?.disabled).toBe(false);
+  });
+
   it("reports a refused change and stays open", async () => {
     apiMock.setProviderAccess.mockRejectedValue(new Error("refused"));
     const wrapper = await openDialog(ownedSource, users);
@@ -445,6 +579,12 @@ function sharingTrigger() {
 function sharedUsersField() {
   return document.querySelector(
     "input[placeholder='settings.source_access.select_members']",
+  );
+}
+
+function saveButton() {
+  return document.querySelector<HTMLButtonElement>(
+    "button[form='form-provider-access']",
   );
 }
 

--- a/tests/components/settings/ProviderAccessDialog.test.ts
+++ b/tests/components/settings/ProviderAccessDialog.test.ts
@@ -336,7 +336,6 @@ describe("ProviderAccessDialog", () => {
     await openSelect(ownerTrigger()!);
     await pickOption("settings.source_access.household");
 
-    // read before any select opens again, which would mask a stale label
     expect(sharingTrigger()?.textContent).toContain(
       "settings.source_access.options.members",
     );

--- a/tests/views/Providers.test.ts
+++ b/tests/views/Providers.test.ts
@@ -371,6 +371,36 @@ describe("Providers", () => {
     );
   });
 
+  it("summarizes a music source without an owner shared with selected members", async () => {
+    const wrapper = await mountProviders(ProviderStatus.LOADED, true, true, {
+      access: {
+        owner: null,
+        shared_users: ["user-sam"],
+        sharing: ProviderSharing.SELECTED,
+      },
+    });
+
+    expect(wrapper.get('[data-testid="provider-access"]').text()).toBe(
+      "settings.source_access.household · settings.source_access.shared_with_count",
+    );
+  });
+
+  it.each([
+    ["private", ProviderSharing.PRIVATE],
+    ["shared with nobody selected", ProviderSharing.SELECTED],
+  ])(
+    "says nobody can use a music source without an owner that is %s",
+    async (_label, sharing) => {
+      const wrapper = await mountProviders(ProviderStatus.LOADED, true, true, {
+        access: { owner: null, shared_users: [], sharing },
+      });
+
+      expect(wrapper.get('[data-testid="provider-access"]').text()).toBe(
+        "settings.source_access.nobody",
+      );
+    },
+  );
+
   it("falls back to the raw id of an owner that is not a known user", async () => {
     const wrapper = await mountProviders(ProviderStatus.LOADED, true, true, {
       access: {


### PR DESCRIPTION
# What does this implement/fix?

A music source without an owner that isn't shared with anyone can't be used by anybody, admins included. The server leaves such a source behind when a user who owned a private source is removed. The music sources list showed it as "Shared (no owner) · Not shared", and the Access dialog let an admin create one.

- The list says "Nobody can use this source" for a source without an owner that is private, or shared with selected members while nobody is picked
- The Access dialog only offers private sharing for a source with an owner
- Moving a private source to "Shared (no owner)" switches it to all members, like the playlist dialog does
- The dialog explains why nobody can use a source and won't save one like that
- The sharing hints no longer mention an owner for a source without one

**Related issue (if applicable):**

- related issue https://github.com/music-assistant/backlog/issues/84

**Related backend PR (if applicable):**

- related backend PR https://github.com/music-assistant/server/pull/6300

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm lint:check` passes.
- [x] `pnpm test:run` passes, and tests have been added/updated where applicable.
- [x] `pnpm build` passes.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
