### PR TITLE
Show each user only the actions their role allows

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -264,6 +264,8 @@ const handleLocalConnect = async (serverAddress: string) => {
 };
 
 let initializationCompleted = false;
+// the sorted scopes of the user's role at the last completed initialization
+let initializedRoleScopes: string[] | undefined;
 
 const refreshPluginEnabledState = async (domain: string) => {
   try {
@@ -370,6 +372,16 @@ const completeInitialization = async () => {
   store.serverInfo = serverInfo;
   // the scopes the role of the user grants, for the parts of the ui gated on one
   store.roleScopes = await api.getRoleScopes();
+  const userRoleScopes = [...(store.roleScopes[userInfo.role] ?? [])].sort();
+  if (
+    initializedRoleScopes &&
+    userRoleScopes.join() !== initializedRoleScopes.join()
+  ) {
+    // Screens read what the role allows once, when they open, so a reconnect
+    // that brings other scopes starts the app afresh.
+    window.location.reload();
+    return;
+  }
 
   const isGuestAccessSession = authManager.isGuestAccessSession();
   const isDashboardViewer = authManager.isDashboardViewer();
@@ -431,6 +443,7 @@ const completeInitialization = async () => {
   // from the URL hash. The router config already redirects "/" to "/discover"
   api.state.value = ConnectionState.INITIALIZED;
   initializationCompleted = true;
+  initializedRoleScopes = userRoleScopes;
   await initializeWebPlayerModeSync();
 
   // Initialize companion app integration

--- a/src/App.vue
+++ b/src/App.vue
@@ -61,7 +61,12 @@ import {
   resetMediaSession,
 } from "@/helpers/mediaSession";
 import { api, ConnectionState } from "@/plugins/api";
-import { CoreState, EventType, ProviderType } from "@/plugins/api/interfaces";
+import {
+  CoreState,
+  EventType,
+  ProviderType,
+  Scope,
+} from "@/plugins/api/interfaces";
 import { toast } from "vue-sonner";
 import { getDeviceName } from "@/plugins/api/helpers";
 import authManager from "@/plugins/auth";
@@ -410,7 +415,8 @@ const completeInitialization = async () => {
 
   if (
     (onboardRequested || serverInfo.onboard_done === false) &&
-    userInfo.role === "admin"
+    // the wizard sets up every kind of provider
+    authManager.hasScope(Scope.CONFIG_PROVIDERS_WRITE)
   ) {
     router.push({ name: "onboarding" });
   } else if (isGuestAccessSession) {

--- a/src/App.vue
+++ b/src/App.vue
@@ -264,8 +264,8 @@ const handleLocalConnect = async (serverAddress: string) => {
 };
 
 let initializationCompleted = false;
-// the sorted scopes of the user's role at the last completed initialization
-let initializedRoleScopes: string[] | undefined;
+// the user's role and its sorted scopes at the last completed initialization
+let initializedAccess: string | undefined;
 
 const refreshPluginEnabledState = async (domain: string) => {
   try {
@@ -372,13 +372,14 @@ const completeInitialization = async () => {
   store.serverInfo = serverInfo;
   // the scopes the role of the user grants, for the parts of the ui gated on one
   store.roleScopes = await api.getRoleScopes();
-  const userRoleScopes = [...(store.roleScopes[userInfo.role] ?? [])].sort();
-  if (
-    initializedRoleScopes &&
-    userRoleScopes.join() !== initializedRoleScopes.join()
-  ) {
+  // sharing tells a guest from a member by the role itself, so the role counts too
+  const userAccess = [
+    userInfo.role,
+    ...[...(store.roleScopes[userInfo.role] ?? [])].sort(),
+  ].join(" ");
+  if (initializedAccess !== undefined && userAccess !== initializedAccess) {
     // Screens read what the role allows once, when they open, so a reconnect
-    // that brings other scopes starts the app afresh.
+    // that brings another role or other scopes starts the app afresh.
     window.location.reload();
     return;
   }
@@ -443,7 +444,7 @@ const completeInitialization = async () => {
   // from the URL hash. The router config already redirects "/" to "/discover"
   api.state.value = ConnectionState.INITIALIZED;
   initializationCompleted = true;
-  initializedRoleScopes = userRoleScopes;
+  initializedAccess = userAccess;
   await initializeWebPlayerModeSync();
 
   // Initialize companion app integration

--- a/src/components/DynamicItemSample.vue
+++ b/src/components/DynamicItemSample.vue
@@ -60,7 +60,7 @@
             }}
           </EmptyDescription>
         </EmptyHeader>
-        <EmptyContent v-if="isPlaylist">
+        <EmptyContent v-if="isPlaylist && canEditRules">
           <Button variant="outline" size="sm" @click="emit('edit-rules')">
             <SlidersHorizontal class="h-3.5 w-3.5 mr-1.5" />
             {{ $t("smart_playlist.edit_rules") }}
@@ -89,6 +89,7 @@ import { itemIsAvailable } from "@/plugins/api/helpers";
 import {
   MediaType,
   PlaybackState,
+  Scope,
   type Audiobook,
   type MediaItemType,
   type Playlist,
@@ -96,6 +97,7 @@ import {
   type Radio,
   type Track,
 } from "@/plugins/api/interfaces";
+import { authManager } from "@/plugins/auth";
 import { store } from "@/plugins/store";
 import { Music2, SlidersHorizontal } from "@lucide/vue";
 import { computed, ref, watch } from "vue";
@@ -110,6 +112,8 @@ const emit = defineEmits<{ (e: "edit-rules"): void }>();
 const isPlaylist = computed(
   () => props.itemDetails.media_type === MediaType.PLAYLIST,
 );
+// editing the rules of a smart playlist changes the library
+const canEditRules = computed(() => authManager.hasScope(Scope.LIBRARY_WRITE));
 
 const loading = ref(true);
 const tracks = ref<(Track | Radio | PodcastEpisode | Audiobook)[]>([]);

--- a/src/components/InfoHeader.vue
+++ b/src/components/InfoHeader.vue
@@ -371,6 +371,7 @@
             >
               <!-- favorite (heart) icon -->
               <button
+                v-if="canEditLibrary"
                 type="button"
                 class="favorite-icon-button"
                 :aria-label="$t('tooltip.favorite')"
@@ -396,7 +397,7 @@
                 v-if="
                   item.media_type === MediaType.GENRE &&
                   item.provider === 'library' &&
-                  isAdmin
+                  canManageLibrary
                 "
                 :size="22"
                 class="cursor-pointer"
@@ -408,7 +409,7 @@
                 v-if="
                   item.media_type === MediaType.GENRE &&
                   item.provider === 'library' &&
-                  isAdmin
+                  canManageLibrary
                 "
                 :size="22"
                 class="cursor-pointer ml-2"
@@ -539,6 +540,7 @@ import {
   ImageType,
   MediaCollection,
   MediaType,
+  Scope,
   Track,
 } from "@/plugins/api/interfaces";
 import { authManager } from "@/plugins/auth";
@@ -627,7 +629,7 @@ watch(shortcutsPreference, async () => {
 const showGenreChipContextMenu = (evt: Event, genre: Genre) => {
   if (
     !compProps.item ||
-    !isAdmin.value ||
+    !canManageLibrary.value ||
     compProps.item.provider !== "library"
   )
     return;
@@ -755,7 +757,12 @@ const artistLogo = computed(() => {
   return getImageThumbForItem(compProps.item, ImageType.LOGO);
 });
 
-const isAdmin = computed(() => authManager.isAdmin());
+const canManageLibrary = computed(() =>
+  authManager.hasScope(Scope.LIBRARY_MANAGE),
+);
+const canEditLibrary = computed(() =>
+  authManager.hasScope(Scope.LIBRARY_WRITE),
+);
 const favoriteButtonLabel = computed(() =>
   compProps.item?.favorite ? $t("favorites_remove") : $t("favorites_add"),
 );

--- a/src/components/ListviewItem.vue
+++ b/src/components/ListviewItem.vue
@@ -276,6 +276,7 @@
           getBreakpointValue('bp3') &&
           'favorite' in item &&
           showFavorite &&
+          canEditLibrary &&
           item.media_type != MediaType.COLLECTION &&
           !$vuetify.display.mobile
         "
@@ -324,9 +325,11 @@ import {
   AlbumType,
   ContentType,
   MediaType,
+  Scope,
   type MediaCollection,
   type MediaItemType,
 } from "@/plugins/api/interfaces";
+import { authManager } from "@/plugins/auth";
 import { getBreakpointValue } from "@/plugins/breakpoint";
 import { $t } from "@/plugins/i18n";
 import { useMediaQuery } from "@vueuse/core";
@@ -391,6 +394,10 @@ const compProps = withDefaults(defineProps<Props>(), {
 });
 
 // computed properties
+// favouring an item changes the library
+const canEditLibrary = computed(() =>
+  authManager.hasScope(Scope.LIBRARY_WRITE),
+);
 const collabArtists = computed(() => {
   if (!("artists" in compProps.item) || !compProps.item.artists) return "";
   const albumArtists =

--- a/src/components/PanelviewItem.vue
+++ b/src/components/PanelviewItem.vue
@@ -47,7 +47,9 @@
           {{ item.position }}
         </span>
         <FavouriteButton
-          v-if="getBreakpointValue('bp3') && 'favorite' in item"
+          v-if="
+            getBreakpointValue('bp3') && 'favorite' in item && canEditLibrary
+          "
           :item="item"
         />
         <v-spacer />
@@ -68,7 +70,12 @@ import EditorialMediaCard from "@/components/discover/EditorialMediaCard.vue";
 import FavouriteButton from "@/components/FavoriteButton.vue";
 import { handleMenuBtnClick } from "@/helpers/media_item_actions";
 import { parseBool } from "@/helpers/parse";
-import { ContentType, type MediaItemType } from "@/plugins/api/interfaces";
+import {
+  ContentType,
+  Scope,
+  type MediaItemType,
+} from "@/plugins/api/interfaces";
+import { authManager } from "@/plugins/auth";
 import { getBreakpointValue } from "@/plugins/breakpoint";
 import { $t } from "@/plugins/i18n";
 import { computed } from "vue";
@@ -99,6 +106,11 @@ const compProps = withDefaults(defineProps<Props>(), {
   parentItem: undefined,
   sortBy: undefined,
 });
+
+// favouring an item changes the library
+const canEditLibrary = computed(() =>
+  authManager.hasScope(Scope.LIBRARY_WRITE),
+);
 
 const emit = defineEmits<{
   (e: "select", item: MediaItemType, selected: boolean): void;

--- a/src/components/ProviderDetails.vue
+++ b/src/components/ProviderDetails.vue
@@ -146,6 +146,7 @@ import { api } from "@/plugins/api";
 import {
   MediaType,
   ProviderMapping,
+  Scope,
   type MediaItem,
 } from "@/plugins/api/interfaces";
 import { authManager } from "@/plugins/auth";
@@ -264,7 +265,7 @@ const onMenu = function (evt: Event, providerMapping: ProviderMappingRef) {
   }
   // remove mapping option (only for streaming provider mapping)
   if (
-    authManager.isAdmin() &&
+    authManager.hasScope(Scope.LIBRARY_MANAGE) &&
     api.providers[providerMapping.provider_instance]?.is_streaming_provider
   ) {
     menuItems.push({
@@ -326,7 +327,7 @@ const toolbarMenuItems = computed(() => {
       hide:
         props.itemDetails.provider != "library" ||
         !api.hasStreamingProviders.value ||
-        !authManager.isAdmin(),
+        !authManager.hasScope(Scope.LIBRARY_MANAGE),
     },
     // toggle expand
     {

--- a/src/components/ShowDashboardButton.vue
+++ b/src/components/ShowDashboardButton.vue
@@ -83,6 +83,7 @@ import {
   type DashboardType,
   type EventMessage,
   EventType,
+  Scope,
 } from "@/plugins/api/interfaces";
 import { authManager } from "@/plugins/auth";
 import { $t } from "@/plugins/i18n";
@@ -115,9 +116,17 @@ const loading = ref(false);
 const dashboards = ref<DashboardDevice[]>([]);
 const sessions = ref<DashboardSession[]>([]);
 
+// casting a dashboard lets a device join, which is what users.invite grants
+const canShowDashboards = computed(() =>
+  authManager.hasScope(Scope.USERS_INVITE),
+);
+
 // A dashboard viewer can't cast a dashboard itself; only show once one is registered.
 const showButton = computed(
-  () => !authManager.isDashboardViewer?.() && dashboards.value.length > 0,
+  () =>
+    canShowDashboards.value &&
+    !authManager.isDashboardViewer?.() &&
+    dashboards.value.length > 0,
 );
 
 // Solid primary pill for the active state, matching the fullscreen player header's autoplay/crossfade toggles.
@@ -144,7 +153,7 @@ const unsubscribers: Array<() => void> = [];
 
 onMounted(async () => {
   await waitForApiInitialization();
-  if (unmounted) return;
+  if (unmounted || !canShowDashboards.value) return;
 
   fetchSessions();
   loadDashboards();

--- a/src/components/ai-radio/ShowCard.vue
+++ b/src/components/ai-radio/ShowCard.vue
@@ -1,11 +1,12 @@
 <template>
   <div
-    class="show-card ma-tap"
-    role="button"
-    tabindex="0"
-    @click="emit('customize', show.id)"
-    @keydown.enter.self="emit('customize', show.id)"
-    @keydown.space.self.prevent="emit('customize', show.id)"
+    class="show-card"
+    :class="{ 'show-card--editable ma-tap': canEdit }"
+    :role="canEdit ? 'button' : undefined"
+    :tabindex="canEdit ? 0 : undefined"
+    @click="customize"
+    @keydown.enter.self="customize"
+    @keydown.space.self.prevent="customize"
   >
     <div class="show-card__art">
       <MediaItemThumb
@@ -66,7 +67,7 @@
         </span>
       </span>
 
-      <DropdownMenu>
+      <DropdownMenu v-if="canEdit">
         <DropdownMenuTrigger as-child>
           <Button
             variant="ghost-icon"
@@ -169,7 +170,12 @@ import {
   resolveShowPlayerId,
   slugify,
 } from "@/helpers/ai_radio";
-import type { AIRadioSession, AIRadioStation } from "@/plugins/api/interfaces";
+import {
+  Scope,
+  type AIRadioSession,
+  type AIRadioStation,
+} from "@/plugins/api/interfaces";
+import { authManager } from "@/plugins/auth";
 import { eventbus } from "@/plugins/eventbus";
 import { $t } from "@/plugins/i18n";
 import { store } from "@/plugins/store";
@@ -210,6 +216,12 @@ const {
   reportStartError,
 } = useShows();
 
+// customizing, duplicating and deleting a show takes config.providers.write;
+// playing it does not
+const canEdit = computed(() =>
+  authManager.hasScope(Scope.CONFIG_PROVIDERS_WRITE),
+);
+
 const isStarting = computed(() => startingShowId.value === props.show.id);
 const isStopping = computed(
   () =>
@@ -246,6 +258,10 @@ const lastEndedSession = computed(() => {
     session.status === "stopped" || session.status === "completed";
   return endedLive ? session : undefined;
 });
+
+function customize() {
+  if (canEdit.value) emit("customize", props.show.id);
+}
 
 function sessionRelativeTime(session: AIRadioSession): string {
   return relativeTimeFromIso(session.ended_at || session.created_at);
@@ -369,13 +385,15 @@ function onDelete() {
   width: 100%;
   box-sizing: border-box;
   text-align: left;
-  cursor: pointer;
   background: transparent;
   border: none;
   padding: var(--show-card-pad);
   border-radius: var(--show-card-pad);
   color: rgb(var(--v-theme-on-background));
   transition: background 0.15s ease;
+}
+.show-card--editable {
+  cursor: pointer;
 }
 .show-card:hover {
   background: rgba(var(--v-theme-on-surface), 0.08);

--- a/src/components/artist/ArtistHero.vue
+++ b/src/components/artist/ArtistHero.vue
@@ -15,7 +15,7 @@
     >
       <template #append>
         <button
-          v-if="item"
+          v-if="item && canEditLibrary"
           type="button"
           class="artist-hero__fav"
           :class="{ 'artist-hero__fav--on': item.favorite }"
@@ -132,9 +132,11 @@ import {
   ArtistType,
   ImageType,
   MediaType,
+  Scope,
   type Artist,
   type Genre,
 } from "@/plugins/api/interfaces";
+import { authManager } from "@/plugins/auth";
 import { isPhoneSizedScreen } from "@/plugins/breakpoint";
 import { $t } from "@/plugins/i18n";
 import { store } from "@/plugins/store";
@@ -215,6 +217,10 @@ const artistKind = computed(() => {
 
 const favoriteButtonLabel = computed(() =>
   props.item?.favorite ? $t("favorites_remove") : $t("favorites_add"),
+);
+// favouring an item changes the library
+const canEditLibrary = computed(() =>
+  authManager.hasScope(Scope.LIBRARY_WRITE),
 );
 
 const playButtonText = computed(() =>

--- a/src/components/artist/artistRows.ts
+++ b/src/components/artist/artistRows.ts
@@ -34,6 +34,7 @@ export interface ArtistRowDefinition {
   labelKey: string;
   // "music" = singers, "audiobook" = authors/narrators, "both" = either
   audience: "music" | "audiobook" | "both";
+  // shown only to a role that manages the library, which is the admin role
   adminOnly?: boolean;
   // gets a "Source" picker in Edit rows
   supportsSource?: boolean;
@@ -84,13 +85,13 @@ export const ARTIST_ROW_SOURCES_PREFERENCE_KEY = "artist.rowSources";
 /** Row ids applicable to the given artist type / user, in default order. */
 export function availableArtistRowIds(
   isAudiobookArtist: boolean,
-  isAdmin: boolean,
+  managesLibrary: boolean,
 ): ArtistRowId[] {
   const audience = isAudiobookArtist ? "audiobook" : "music";
   return ARTIST_ROWS.filter(
     (row) =>
       (row.audience === "both" || row.audience === audience) &&
-      (isAdmin || !row.adminOnly),
+      (managesLibrary || !row.adminOnly),
   ).map((row) => row.id);
 }
 

--- a/src/components/genre/GenreExclusionManager.vue
+++ b/src/components/genre/GenreExclusionManager.vue
@@ -1,6 +1,9 @@
 <template>
   <!-- the section only removes exclusions, so it has no purpose without any -->
-  <section v-if="isAdmin && exclusions.length" style="margin-bottom: 10px">
+  <section
+    v-if="canManageLibrary && exclusions.length"
+    style="margin-bottom: 10px"
+  >
     <Toolbar
       :title="exclusionTitle"
       :menu-items="toolbarMenuItems"
@@ -42,7 +45,7 @@ import GenreIcon from "@/components/icons/GenreIcon.vue";
 import ListItem from "@/components/ListItem.vue";
 import Toolbar, { ToolBarMenuItem } from "@/components/Toolbar.vue";
 import { api } from "@/plugins/api";
-import { Genre, MediaType } from "@/plugins/api/interfaces";
+import { Genre, MediaType, Scope } from "@/plugins/api/interfaces";
 import { authManager } from "@/plugins/auth";
 import { eventbus } from "@/plugins/eventbus";
 import { ChevronDown, ChevronUp } from "@lucide/vue";
@@ -58,7 +61,9 @@ const props = defineProps<Props>();
 
 const { t } = useI18n();
 
-const isAdmin = computed(() => authManager.isAdmin());
+const canManageLibrary = computed(() =>
+  authManager.hasScope(Scope.LIBRARY_MANAGE),
+);
 const sectionExpanded = ref(false);
 const operationInProgress = ref(false);
 const exclusions = ref<Genre[]>([]);

--- a/src/components/navigation/NavGettingStarted.vue
+++ b/src/components/navigation/NavGettingStarted.vue
@@ -16,6 +16,7 @@ import {
 } from "@/components/ui/sidebar";
 import { useOnboarding } from "@/composables/useOnboarding";
 import type { OnboardingStepId } from "@/helpers/onboarding";
+import { Scope } from "@/plugins/api/interfaces";
 import { authManager } from "@/plugins/auth";
 import { Circle, CircleCheck, ListChecks } from "@lucide/vue";
 import { computed, onMounted, ref } from "vue";
@@ -42,7 +43,7 @@ const open = ref(false);
 // is counted before the provider configurations say what is set up.
 const visible = computed(
   () =>
-    authManager.isAdmin() &&
+    authManager.hasScope(Scope.CONFIG_PROVIDERS_WRITE) &&
     configsLoaded.value &&
     hasPending.value &&
     !dismissed.value,
@@ -62,7 +63,9 @@ const hideForNow = function () {
 // the checklist is the only reason the sidebar needs the provider
 // configurations, so nobody but an admin ever fetches them
 onMounted(() => {
-  if (authManager.isAdmin()) void loadProviderConfigs();
+  if (authManager.hasScope(Scope.CONFIG_PROVIDERS_WRITE)) {
+    void loadProviderConfigs();
+  }
 });
 </script>
 

--- a/src/components/navigation/utils/getMenuItems.ts
+++ b/src/components/navigation/utils/getMenuItems.ts
@@ -1,6 +1,7 @@
 import ArtistIcon from "@/components/icons/ArtistIcon.vue";
 import GenreIcon from "@/components/icons/GenreIcon.vue";
 import { setUserPreference } from "@/composables/userPreferences";
+import { canOpenAIRadio } from "@/helpers/ai_radio_access";
 import { Scope } from "@/plugins/api/interfaces";
 import { authManager } from "@/plugins/auth";
 import { store } from "@/plugins/store";
@@ -202,7 +203,7 @@ const MENU_ITEM_REGISTRY: MenuItemDefinition[] = [
     path: "/ai-radio",
     isLibraryNode: false,
     group: "plugins",
-    available: () => store.enabledPlugins.has("ai_radio"),
+    available: () => store.enabledPlugins.has("ai_radio") && canOpenAIRadio(),
   },
   {
     id: "milkdrop_visualizer",

--- a/src/components/navigation/utils/getMenuItems.ts
+++ b/src/components/navigation/utils/getMenuItems.ts
@@ -1,6 +1,8 @@
 import ArtistIcon from "@/components/icons/ArtistIcon.vue";
 import GenreIcon from "@/components/icons/GenreIcon.vue";
 import { setUserPreference } from "@/composables/userPreferences";
+import { Scope } from "@/plugins/api/interfaces";
+import { authManager } from "@/plugins/auth";
 import { store } from "@/plugins/store";
 import {
   BookAudio,
@@ -188,7 +190,10 @@ const MENU_ITEM_REGISTRY: MenuItemDefinition[] = [
     path: "/music-quiz",
     isLibraryNode: false,
     group: "plugins",
-    available: () => store.enabledPlugins.has("music_quiz"),
+    // the menu opens the host panel, which takes users.invite
+    available: () =>
+      store.enabledPlugins.has("music_quiz") &&
+      authManager.hasScope(Scope.USERS_INVITE),
   },
   {
     id: "ai_radio",

--- a/src/components/settings/background-tasks/BackgroundTaskDetailsDialog.vue
+++ b/src/components/settings/background-tasks/BackgroundTaskDetailsDialog.vue
@@ -237,9 +237,10 @@ import {
 } from "@/composables/background-tasks/useBackgroundTaskDisplay";
 import {
   type BackgroundTask,
+  Scope,
   TaskStatus,
-  UserRole,
 } from "@/plugins/api/interfaces";
+import { authManager } from "@/plugins/auth";
 import router from "@/plugins/router";
 import { store } from "@/plugins/store";
 
@@ -291,9 +292,9 @@ const scheduleLabel = computed(() => {
   );
 });
 
-const canOpenUsers = computed(() => store.currentUser?.role === UserRole.ADMIN);
-const canEditSchedule = computed(
-  () => store.currentUser?.role === UserRole.ADMIN,
+const canOpenUsers = computed(() => authManager.hasScope(Scope.USERS_READ));
+const canEditSchedule = computed(() =>
+  authManager.hasScope(Scope.SYSTEM_MANAGE),
 );
 
 const resolveUserLabel = (

--- a/src/composables/ai-radio/useHosts.ts
+++ b/src/composables/ai-radio/useHosts.ts
@@ -1,4 +1,5 @@
 import { useShows } from "@/composables/ai-radio/useShows";
+import { canUseQueueDj } from "@/helpers/ai_radio_access";
 import api from "@/plugins/api";
 import type { AIRadioHost, AIRadioSection } from "@/plugins/api/interfaces";
 import { authManager } from "@/plugins/auth";
@@ -41,12 +42,13 @@ const aiRadioAvailable = computed(() =>
   ),
 );
 
-// Prefetch as soon as the provider is there, including when it already is.
+// Prefetch as soon as the provider is there, including when it already is, for
+// the roles that get the queue DJ menu.
 watch(
-  aiRadioAvailable,
-  (available) => {
+  () => aiRadioAvailable.value && canUseQueueDj(),
+  (ready) => {
     // Session-scoped sessions lack the config scopes this needs and never open the queue DJ menu.
-    if (available && authManager.guestSessionKind() === null)
+    if (ready && authManager.guestSessionKind() === null)
       prefetchQueueDjState();
   },
   { immediate: true },

--- a/src/composables/ai-radio/useShows.ts
+++ b/src/composables/ai-radio/useShows.ts
@@ -1,3 +1,4 @@
+import { canUseQueueDj } from "@/helpers/ai_radio_access";
 import api from "@/plugins/api";
 import type {
   AIRadioSection,
@@ -53,13 +54,14 @@ const aiRadioAvailable = computed(() =>
 
 let showSessionStatePrefetched = false;
 
-// Prefetch as soon as the provider is there, so the queue DJ menu can
-// resolve an on-air show's host from anywhere in the app, not just this view.
+// Prefetch as soon as the provider is there, for the roles that get the queue DJ
+// menu, so it can resolve an on-air show's host from anywhere in the app, not
+// just this view.
 watch(
-  aiRadioAvailable,
-  (available) => {
+  () => aiRadioAvailable.value && canUseQueueDj(),
+  (ready) => {
     // Session-scoped sessions lack the config scopes this needs and never open the queue DJ menu.
-    if (available && authManager.guestSessionKind() === null)
+    if (ready && authManager.guestSessionKind() === null)
       prefetchShowSessionState();
   },
   { immediate: true },

--- a/src/composables/background-tasks/useBackgroundTasks.ts
+++ b/src/composables/background-tasks/useBackgroundTasks.ts
@@ -4,8 +4,10 @@ import {
   type BackgroundTask,
   type EventMessage,
   EventType,
+  Scope,
   TaskStatus,
 } from "@/plugins/api/interfaces";
+import { authManager } from "@/plugins/auth";
 
 const MUSIC_SYNC_TASK_DOMAIN = "music_sync";
 
@@ -67,13 +69,18 @@ const refreshTasks = async () => {
 };
 
 export function useBackgroundTasks() {
+  // the task list is only served to a role that may read it
+  const readsTasks = authManager.hasScope(Scope.SYSTEM_READ);
+
   onMounted(() => {
+    if (!readsTasks) return;
     consumerCount += 1;
     subscribeToTaskUpdates();
     void refreshTasks();
   });
 
   onUnmounted(() => {
+    if (!readsTasks) return;
     consumerCount = Math.max(0, consumerCount - 1);
     unsubscribeFromTaskUpdates();
   });

--- a/src/composables/useOnboarding.ts
+++ b/src/composables/useOnboarding.ts
@@ -16,6 +16,7 @@ import { api } from "@/plugins/api";
 import { ApiCommandError } from "@/plugins/api/errors";
 import {
   EventType,
+  Scope,
   type ProviderConfig,
   type ProviderType,
 } from "@/plugins/api/interfaces";
@@ -110,7 +111,8 @@ const { getPreference } = useUserPreferences();
 const intent = getPreference<OnboardingIntent>(ONBOARDING_INTENT_PREFERENCE);
 
 const ctx = computed<OnboardingContext>(() => ({
-  isAdmin: authManager.isAdmin(),
+  // the admin track sets up every kind of provider
+  isAdmin: authManager.hasScope(Scope.CONFIG_PROVIDERS_WRITE),
   providers: (providerConfigs.value ?? []).map((config) => ({
     type: config.type,
     domain: config.domain,

--- a/src/composables/userPreferences.ts
+++ b/src/composables/userPreferences.ts
@@ -1,5 +1,7 @@
 import { computed, ComputedRef } from "vue";
 import { api } from "@/plugins/api";
+import { Scope } from "@/plugins/api/interfaces";
+import { authManager } from "@/plugins/auth";
 import { store } from "@/plugins/store";
 
 export interface ItemsListingPreferences {
@@ -143,6 +145,8 @@ export function useUserPreferences() {
  */
 export async function pruneStaleProviderFilters(): Promise<void> {
   if (!store.currentUser?.preferences) return;
+  // listing the configured providers takes a scope not every role holds
+  if (!authManager.hasScope(Scope.CONFIG_PROVIDERS_READ)) return;
 
   let configuredIds: Set<string>;
   try {

--- a/src/helpers/ai_radio_access.test.ts
+++ b/src/helpers/ai_radio_access.test.ts
@@ -1,0 +1,45 @@
+import { authManager } from "@/plugins/auth";
+import { describe, expect, it, vi } from "vitest";
+import { BUILTIN_ROLE_SCOPES, scopeChecker } from "../../tests/fixtures/scopes";
+import { canOpenAIRadio } from "./ai_radio_access";
+
+const { apiMock } = vi.hoisted(() => ({
+  apiMock: { supportsAIRadioPlaybackScopes: false },
+}));
+
+vi.mock("@/plugins/api", () => ({ api: apiMock }));
+vi.mock("@/plugins/auth", () => ({ authManager: { hasScope: vi.fn() } }));
+
+describe("canOpenAIRadio", () => {
+  it.each([
+    {
+      role: "a member",
+      scopes: BUILTIN_ROLE_SCOPES.user,
+      schema: 74,
+      playbackScopes: false,
+      allowed: false,
+    },
+    {
+      role: "a member",
+      scopes: BUILTIN_ROLE_SCOPES.user,
+      schema: 75,
+      playbackScopes: true,
+      allowed: true,
+    },
+    {
+      role: "an admin",
+      scopes: BUILTIN_ROLE_SCOPES.admin,
+      schema: 74,
+      playbackScopes: false,
+      allowed: true,
+    },
+  ])(
+    "returns $allowed for $role on API schema $schema",
+    ({ scopes, playbackScopes, allowed }) => {
+      vi.mocked(authManager.hasScope).mockImplementation(scopeChecker(scopes));
+      apiMock.supportsAIRadioPlaybackScopes = playbackScopes;
+
+      expect(canOpenAIRadio()).toBe(allowed);
+    },
+  );
+});

--- a/src/helpers/ai_radio_access.test.ts
+++ b/src/helpers/ai_radio_access.test.ts
@@ -1,7 +1,7 @@
 import { authManager } from "@/plugins/auth";
 import { describe, expect, it, vi } from "vitest";
 import { BUILTIN_ROLE_SCOPES, scopeChecker } from "../../tests/fixtures/scopes";
-import { canOpenAIRadio } from "./ai_radio_access";
+import { canOpenAIRadio, canUseQueueDj } from "./ai_radio_access";
 
 const { apiMock } = vi.hoisted(() => ({
   apiMock: { supportsAIRadioPlaybackScopes: false },
@@ -42,4 +42,15 @@ describe("canOpenAIRadio", () => {
       expect(canOpenAIRadio()).toBe(allowed);
     },
   );
+});
+
+describe("canUseQueueDj", () => {
+  it.each([
+    { role: "a member", scopes: BUILTIN_ROLE_SCOPES.user, allowed: true },
+    { role: "a guest", scopes: BUILTIN_ROLE_SCOPES.guest, allowed: false },
+  ])("returns $allowed for $role", ({ scopes, allowed }) => {
+    vi.mocked(authManager.hasScope).mockImplementation(scopeChecker(scopes));
+
+    expect(canUseQueueDj()).toBe(allowed);
+  });
 });

--- a/src/helpers/ai_radio_access.ts
+++ b/src/helpers/ai_radio_access.ts
@@ -9,3 +9,10 @@ import { authManager } from "@/plugins/auth";
 export const canOpenAIRadio = (): boolean =>
   authManager.hasScope(Scope.CONFIG_PROVIDERS_WRITE) ||
   api.supportsAIRadioPlaybackScopes;
+
+/**
+ * Whether the signed-in user gets the AI DJ of a queue: picking its host takes
+ * the host list, which only a role that reads the plugin settings may load.
+ */
+export const canUseQueueDj = (): boolean =>
+  authManager.hasScope(Scope.CONFIG_PROVIDERS_READ);

--- a/src/helpers/ai_radio_access.ts
+++ b/src/helpers/ai_radio_access.ts
@@ -1,0 +1,11 @@
+import { api } from "@/plugins/api";
+import { Scope } from "@/plugins/api/interfaces";
+import { authManager } from "@/plugins/auth";
+
+/**
+ * Whether the signed-in user may open AI Radio: a role that configures it
+ * always may, any other role only on a server that lets it play the stations.
+ */
+export const canOpenAIRadio = (): boolean =>
+  authManager.hasScope(Scope.CONFIG_PROVIDERS_WRITE) ||
+  api.supportsAIRadioPlaybackScopes;

--- a/src/helpers/media_item_actions.ts
+++ b/src/helpers/media_item_actions.ts
@@ -11,7 +11,9 @@ import {
   MediaItemType,
   MediaItemTypeOrItemMapping,
   MediaType,
+  Scope,
 } from "@/plugins/api/interfaces";
+import { authManager } from "@/plugins/auth";
 import { $t } from "@/plugins/i18n";
 import router from "@/plugins/router";
 import { store } from "@/plugins/store";
@@ -195,6 +197,8 @@ export const handleMenuBtnClick = function (
 const readClickSetting = async function (
   key: string,
 ): Promise<string | undefined> {
+  // the defaults apply to a role that may not read the core settings
+  if (!authManager.hasScope(Scope.CONFIG_CORE_READ)) return undefined;
   try {
     const value = await api.getCoreConfigValue("player_queues", key);
     return typeof value === "string" ? value : undefined;

--- a/src/helpers/player_menu_items.ts
+++ b/src/helpers/player_menu_items.ts
@@ -8,6 +8,7 @@ import {
   PlayerQueue,
   PlayerType,
   RepeatMode,
+  Scope,
   PLAYER_CONTROL_NONE,
 } from "@/plugins/api/interfaces";
 import { isSelectablePlayer } from "@/helpers/players";
@@ -249,7 +250,12 @@ export const getPlayerMenuItems = (
   }
 
   // save queue as playlist (queue menu only)
-  if (isQueue && playerQueue?.items && playerQueue.items > 0) {
+  if (
+    isQueue &&
+    playerQueue?.items &&
+    playerQueue.items > 0 &&
+    authManager.hasScope(Scope.LIBRARY_WRITE)
+  ) {
     menuItems.push({
       label: "save_queue_as_playlist",
       labelArgs: [],
@@ -390,8 +396,8 @@ export const getPlayerMenuItems = (
     });
   }
 
-  // open the settings (both menus, admin only)
-  if (authManager.isAdmin()) {
+  // open the settings (both menus, for a role that changes player settings)
+  if (authManager.hasScope(Scope.CONFIG_PLAYERS_WRITE)) {
     const openSettings = (path: string) => () => {
       store.showFullscreenPlayer = false;
       store.showPlayersMenu = false;

--- a/src/helpers/player_menu_items.ts
+++ b/src/helpers/player_menu_items.ts
@@ -31,6 +31,7 @@ import { store } from "@/plugins/store";
 import { getPlayerSetupLabel } from "@/helpers/player_config";
 import { togglePlayerPower } from "@/helpers/player_group_playback";
 import { errorMessage } from "@/helpers/ai_radio";
+import { canUseQueueDj } from "@/helpers/ai_radio_access";
 import { toast } from "vue-sonner";
 
 export const getPlayerSetupMenuItem = (
@@ -306,7 +307,7 @@ export const getPlayerMenuItems = (
     loadQueueDjStatus,
   } = useHosts();
   const { sessions, shows, loadStatus } = useShows();
-  if (isQueue && playerQueue && aiRadioAvailable.value) {
+  if (isQueue && playerQueue && aiRadioAvailable.value && canUseQueueDj()) {
     const queueId = playerQueue.queue_id;
     const runningSession = sessions.value.find(
       (session) => session.status === "running" && session.queue_id === queueId,

--- a/src/helpers/player_settings_actions.ts
+++ b/src/helpers/player_settings_actions.ts
@@ -11,7 +11,9 @@ import {
   PlayerConfig,
   PlayerType,
   ProviderFeature,
+  Scope,
 } from "@/plugins/api/interfaces";
+import { authManager } from "@/plugins/auth";
 import { eventbus } from "@/plugins/eventbus";
 import { $t } from "@/plugins/i18n";
 import router from "@/plugins/router";
@@ -119,7 +121,8 @@ export const getPlayerSettingsMenuItems = (
           `/settings/editprovider/${provider?.instance_id ?? config.provider}`,
         ),
       icon: markRaw(Cog),
-      hide: !provider,
+      // a player provider's settings take config.providers.write
+      hide: !provider || !authManager.hasScope(Scope.CONFIG_PROVIDERS_WRITE),
     },
     {
       label: "settings.documentation",

--- a/src/helpers/settings_sections.test.ts
+++ b/src/helpers/settings_sections.test.ts
@@ -1,0 +1,77 @@
+import { Scope } from "@/plugins/api/interfaces";
+import { describe, expect, it } from "vitest";
+import {
+  BUILTIN_ROLE_SCOPES,
+  OWN_SOURCES_ROLE_SCOPES,
+  scopeChecker,
+} from "../../tests/fixtures/scopes";
+import { availableSettingsSections } from "./settings_sections";
+
+const ALL_SECTIONS = [
+  "music_providers",
+  "player_providers",
+  "metadata_providers",
+  "plugin_providers",
+  "players",
+  "audio_analysis_providers",
+  "profile",
+  "frontend",
+  "users",
+  "remote_access",
+  "system",
+  "about",
+];
+
+function sectionNames(
+  scopes: readonly Scope[],
+  serverVersionAtLeast: (version: string) => boolean = () => true,
+): string[] {
+  return availableSettingsSections(
+    scopeChecker(scopes),
+    serverVersionAtLeast,
+  ).map((section) => section.name);
+}
+
+describe("availableSettingsSections", () => {
+  it("lists every section to an admin", () => {
+    expect(sectionNames(BUILTIN_ROLE_SCOPES.admin)).toEqual(ALL_SECTIONS);
+  });
+
+  it("lists a member its own music sources and its personal settings", () => {
+    expect(sectionNames(BUILTIN_ROLE_SCOPES.user)).toEqual([
+      "music_providers",
+      "profile",
+      "frontend",
+      "about",
+    ]);
+  });
+
+  it("lists a guest its personal settings only", () => {
+    expect(sectionNames(BUILTIN_ROLE_SCOPES.guest)).toEqual([
+      "profile",
+      "frontend",
+      "about",
+    ]);
+  });
+
+  it("lists a role managing its own music sources nothing more to manage", () => {
+    expect(sectionNames(OWN_SOURCES_ROLE_SCOPES)).toEqual([
+      "music_providers",
+      "profile",
+      "frontend",
+      "about",
+    ]);
+  });
+
+  it("lists the users to a role that may read them", () => {
+    expect(
+      sectionNames([...BUILTIN_ROLE_SCOPES.guest, Scope.USERS_READ]),
+    ).toContain("users");
+  });
+
+  it("leaves out a section the server is too old for", () => {
+    expect(
+      sectionNames(BUILTIN_ROLE_SCOPES.admin, (version) => version !== "2.9.0"),
+    ).not.toContain("audio_analysis_providers");
+  });
+});

--- a/src/helpers/settings_sections.ts
+++ b/src/helpers/settings_sections.ts
@@ -1,0 +1,145 @@
+import { Scope } from "@/plugins/api/interfaces";
+import type { RouteLocationRaw } from "vue-router";
+
+export interface SettingsSection {
+  name: string;
+  label: string;
+  description: string;
+  icon: string;
+  color: string;
+  route: RouteLocationRaw;
+  // only a role granting this scope sees the section
+  requiresScope?: Scope;
+  minServerVersion?: string;
+}
+
+// the sections of the settings overview, in display order
+export const SETTINGS_SECTIONS: readonly SettingsSection[] = [
+  {
+    name: "music_providers",
+    label: "settings.music_sources",
+    description: "settings.music_providers_description",
+    icon: "mdi-music",
+    color: "blue",
+    route: { name: "providersettings", query: { types: "music" } },
+    // a member holding the scope manages the music sources it owns here
+    requiresScope: Scope.CONFIG_PROVIDERS_OWN,
+  },
+  {
+    name: "player_providers",
+    label: "settings.playerproviders",
+    description: "settings.player_providers_description",
+    icon: "mdi-speaker-multiple",
+    color: "green",
+    route: { name: "providersettings", query: { types: "player" } },
+    // the provider types share the route a member opens for its own music
+    // sources, managing any other type takes managing every provider
+    requiresScope: Scope.CONFIG_PROVIDERS_WRITE,
+  },
+  {
+    name: "metadata_providers",
+    label: "settings.metadataproviders",
+    description: "settings.metadata_providers_description",
+    icon: "mdi-file-code",
+    color: "indigo",
+    route: { name: "providersettings", query: { types: "metadata" } },
+    requiresScope: Scope.CONFIG_PROVIDERS_WRITE,
+  },
+  {
+    name: "plugin_providers",
+    label: "settings.plugins",
+    description: "settings.plugin_providers_description",
+    icon: "mdi-puzzle",
+    color: "deep-purple",
+    route: { name: "providersettings", query: { types: "plugin" } },
+    requiresScope: Scope.CONFIG_PROVIDERS_WRITE,
+  },
+  {
+    name: "players",
+    label: "settings.players",
+    description: "settings.players_description",
+    icon: "mdi-tune",
+    color: "teal",
+    route: { name: "playersettings" },
+    requiresScope: Scope.CONFIG_PLAYERS_WRITE,
+  },
+  {
+    name: "audio_analysis_providers",
+    label: "settings.audio_analysis_providers",
+    description: "settings.audio_analysis_providers_description",
+    icon: "mdi-waveform",
+    color: "blue",
+    route: { name: "providersettings", query: { types: "audio_analysis" } },
+    requiresScope: Scope.CONFIG_PROVIDERS_WRITE,
+    minServerVersion: "2.9.0",
+  },
+  {
+    name: "profile",
+    label: "auth.profile",
+    description: "settings.profile_description",
+    icon: "mdi-account-cog",
+    color: "indigo",
+    route: { name: "profile" },
+  },
+  {
+    name: "frontend",
+    label: "settings.frontend",
+    description: "settings.frontend_description",
+    icon: "mdi-palette",
+    color: "orange",
+    route: { name: "frontendsettings" },
+  },
+  {
+    name: "users",
+    label: "auth.user_management",
+    description: "settings.users_description",
+    icon: "mdi-account-multiple",
+    color: "teal",
+    route: { name: "usersettings" },
+    requiresScope: Scope.USERS_READ,
+  },
+  {
+    name: "remote_access",
+    label: "settings.remote_access",
+    description: "settings.remote_access_description",
+    icon: "mdi-cloud-lock",
+    color: "deep-purple",
+    route: { name: "remoteaccesssettings" },
+    requiresScope: Scope.SYSTEM_MANAGE,
+  },
+  {
+    name: "system",
+    label: "settings.system",
+    description: "settings.system_description",
+    icon: "mdi-server",
+    color: "purple",
+    route: { name: "systemsettings" },
+    requiresScope: Scope.CONFIG_CORE_WRITE,
+  },
+  {
+    name: "about",
+    label: "settings.about",
+    description: "settings.about_description",
+    icon: "mdi-information-outline",
+    color: "grey-darken-1",
+    route: { name: "aboutsettings" },
+  },
+];
+
+/**
+ * The settings sections the current user may open on the connected server.
+ *
+ * @param hasScope - Whether the role of the current user grants the given scope.
+ * @param serverVersionAtLeast - Whether the connected server runs at least the given version.
+ */
+export function availableSettingsSections(
+  hasScope: (scope: Scope) => boolean,
+  serverVersionAtLeast: (version: string) => boolean,
+): SettingsSection[] {
+  return SETTINGS_SECTIONS.filter(
+    (section) =>
+      (!section.requiresScope || hasScope(section.requiresScope)) &&
+      (!section.minServerVersion ||
+        serverVersionAtLeast(section.minServerVersion)),
+  );
+}

--- a/src/layouts/default/CreatePlaylistDialog.vue
+++ b/src/layouts/default/CreatePlaylistDialog.vue
@@ -89,7 +89,8 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
 import api from "@/plugins/api";
-import { MediaType, ProviderFeature } from "@/plugins/api/interfaces";
+import { MediaType, ProviderFeature, Scope } from "@/plugins/api/interfaces";
+import { authManager } from "@/plugins/auth";
 import { type CreatePlaylistEvent, eventbus } from "@/plugins/eventbus";
 import { $t } from "@/plugins/i18n";
 import router from "@/plugins/router";
@@ -217,13 +218,16 @@ const doSave = async () => {
         showBackgroundTaskToast: false,
       });
       toast.info($t("background_tasks.toast.added"), {
-        action: {
-          label: $t("background_tasks.open"),
-          onClick: () => {
-            store.showFullscreenPlayer = false;
-            router.push({ name: "backgroundtasks" });
-          },
-        },
+        // the task list takes system.read
+        action: authManager.hasScope(Scope.SYSTEM_READ)
+          ? {
+              label: $t("background_tasks.open"),
+              onClick: () => {
+                store.showFullscreenPlayer = false;
+                router.push({ name: "backgroundtasks" });
+              },
+            }
+          : undefined,
       });
       return;
     }

--- a/src/layouts/default/ItemContextMenu.vue
+++ b/src/layouts/default/ItemContextMenu.vue
@@ -538,10 +538,12 @@ export const getContextMenuItems = async function (
     });
   }
 
+  // creates an AI Radio show from the playlist, which takes config.providers.write
   if (
     items.length === 1 &&
     firstItem.media_type === MediaType.PLAYLIST &&
-    store.enabledPlugins.has("ai_radio")
+    store.enabledPlugins.has("ai_radio") &&
+    authManager.hasScope(Scope.CONFIG_PROVIDERS_WRITE)
   ) {
     contextMenuItems.push({
       label: "providers.ai_radio.context.run_with",
@@ -929,6 +931,7 @@ export const getContextMenuItems = async function (
 
   // update metadata
   if (
+    managesLibrary &&
     items.length === 1 &&
     items[0] == parentItem &&
     items[0].media_type !== MediaType.COLLECTION
@@ -974,12 +977,14 @@ export const getContextMenuItems = async function (
       featureMap[item.media_type],
     );
     // For playlists, also check is_editable flag (builtin special playlists are not editable)
-    // and that the user manages the playlist (a personal one is only edited by its owner)
-    const isEditablePlaylist =
-      item.media_type !== MediaType.PLAYLIST ||
-      ((item as Playlist).is_editable !== false &&
-        canManagePlaylist(item as Playlist, store.currentUser, managesLibrary));
-    if (hasBuiltinProvider && supportsEdit && isEditablePlaylist) {
+    // and that the user manages the playlist (a personal one is only edited by its owner);
+    // radios and tracks are edited by a library manager
+    const canEditItem =
+      item.media_type === MediaType.PLAYLIST
+        ? (item as Playlist).is_editable !== false &&
+          canManagePlaylist(item as Playlist, store.currentUser, managesLibrary)
+        : managesLibrary;
+    if (hasBuiltinProvider && supportsEdit && canEditItem) {
       contextMenuItems.push({
         label: labelMap[item.media_type],
         labelArgs: [],
@@ -992,6 +997,7 @@ export const getContextMenuItems = async function (
   }
   // refresh item
   if (
+    managesLibrary &&
     items.length === 1 &&
     items[0].media_type !== MediaType.COLLECTION &&
     (items[0] == parentItem || !itemIsAvailable(items[0]))
@@ -1125,6 +1131,7 @@ export const getContextMenuItems = async function (
   }
   // map to main item (add provider mapping)
   if (
+    managesLibrary &&
     items.length === 1 &&
     parentItem &&
     parentItem.provider == "library" &&
@@ -1160,6 +1167,7 @@ export const getContextMenuItems = async function (
   }
   // link to genre (library items only, non-genre)
   if (
+    managesLibrary &&
     items.every(
       (i) =>
         i.media_type !== MediaType.GENRE &&

--- a/src/layouts/default/ItemContextMenu.vue
+++ b/src/layouts/default/ItemContextMenu.vue
@@ -1316,6 +1316,7 @@ export const getPlaybackContextMenuItems = async function (
   }
   // Default/configured enqueue option at the top (if play from here is not applicable)
   else if (
+    defaultEnqueueOption === undefined ||
     [QueueOption.PLAY, QueueOption.REPLACE].includes(defaultEnqueueOption)
   ) {
     playMenuItems.push({
@@ -1430,19 +1431,19 @@ export const getPlaybackContextMenuItems = async function (
 const LIVE_SOURCE_MEDIA_TYPES = [MediaType.RADIO, MediaType.AUDIO_SOURCE];
 
 /**
- * The configured default enqueue option for the given item's media type.
+ * The configured default enqueue option for the given item's media type, or
+ * undefined for a role that may not read it: a play command without an option
+ * gets the same default from the server.
  *
- * Only "play" and "replace" are configurable, so the result always starts
- * playback right away.
+ * Only "play" and "replace" are configurable, so either way the item starts
+ * playing right away.
  */
 const getDefaultEnqueueOption = async function (
   item: MediaItemTypeOrItemMapping,
-): Promise<QueueOption> {
+): Promise<QueueOption | undefined> {
   // the server's own defaults apply to a role that may not read the core settings
   if (!authManager.hasScope(Scope.CONFIG_CORE_READ)) {
-    return item.media_type === MediaType.TRACK
-      ? QueueOption.PLAY
-      : QueueOption.REPLACE;
+    return undefined;
   }
   const configKey = LIVE_SOURCE_MEDIA_TYPES.includes(item.media_type)
     ? "default_enqueue_option_live_sources"
@@ -1455,11 +1456,11 @@ const getDefaultEnqueueOption = async function (
 
 /**
  * Menu entries for every way the given items can be started or queued, with the
- * configured default marked as selected.
+ * configured default, when known, marked as selected.
  */
 const buildEnqueueMenuItems = function (
   items: MediaItemTypeOrItemMapping[],
-  defaultEnqueueOption: QueueOption,
+  defaultEnqueueOption: QueueOption | undefined,
 ): ContextMenuItem[] {
   return [
     QueueOption.PLAY,
@@ -1492,7 +1493,7 @@ const buildEnqueueMenuItems = function (
  */
 const startAudioSourceMenuItem = function (
   items: MediaItemTypeOrItemMapping[],
-  defaultEnqueueOption: QueueOption,
+  defaultEnqueueOption: QueueOption | undefined,
 ): ContextMenuItem {
   return {
     label: "play_now",

--- a/src/layouts/default/ItemContextMenu.vue
+++ b/src/layouts/default/ItemContextMenu.vue
@@ -501,6 +501,8 @@ export const getContextMenuItems = async function (
 
   const firstItem = items[0];
   const managesLibrary = authManager.hasScope(Scope.LIBRARY_MANAGE);
+  // favorites, library membership, playlists and played state change the library
+  const canEditLibrary = authManager.hasScope(Scope.LIBRARY_WRITE);
 
   // show info
   if (
@@ -668,6 +670,7 @@ export const getContextMenuItems = async function (
   // add to library (genres are excluded: they are managed via the dedicated
   // add-genre dialog and delete/merge actions, not generic library membership)
   if (
+    canEditLibrary &&
     !isItemInLibrary(resolvedItem) &&
     [
       MediaType.ALBUM,
@@ -704,6 +707,7 @@ export const getContextMenuItems = async function (
       canManagePlaylist(item, store.currentUser, managesLibrary),
   );
   if (
+    canEditLibrary &&
     isItemInLibrary(resolvedItem) &&
     managesSelectedPlaylists &&
     [
@@ -748,7 +752,11 @@ export const getContextMenuItems = async function (
     });
   }
   // Favorites handling - supports mixed states like played/unplayed
-  if (items.length > 0 && items.every((item) => "favorite" in item)) {
+  if (
+    canEditLibrary &&
+    items.length > 0 &&
+    items.every((item) => "favorite" in item)
+  ) {
     const favoritableItems = items.filter(
       (item) =>
         [
@@ -833,7 +841,11 @@ export const getContextMenuItems = async function (
   }
 
   // remove from playlist (playlist tracks, radio, podcast, podcast episode, and audiobook items)
-  if (parentItem && parentItem.media_type === MediaType.PLAYLIST) {
+  if (
+    canEditLibrary &&
+    parentItem &&
+    parentItem.media_type === MediaType.PLAYLIST
+  ) {
     const playlist = parentItem as Playlist;
     if (
       (firstItem.media_type === MediaType.TRACK ||
@@ -857,11 +869,12 @@ export const getContextMenuItems = async function (
   }
   // add to playlist action (tracks, albums, radios, podcasts, podcast episodes, and audiobooks)
   if (
-    firstItem.media_type === MediaType.TRACK ||
-    firstItem.media_type === MediaType.ALBUM ||
-    firstItem.media_type === MediaType.RADIO ||
-    firstItem.media_type === MediaType.PODCAST_EPISODE ||
-    firstItem.media_type === MediaType.AUDIOBOOK
+    canEditLibrary &&
+    (firstItem.media_type === MediaType.TRACK ||
+      firstItem.media_type === MediaType.ALBUM ||
+      firstItem.media_type === MediaType.RADIO ||
+      firstItem.media_type === MediaType.PODCAST_EPISODE ||
+      firstItem.media_type === MediaType.AUDIOBOOK)
   ) {
     contextMenuItems.push({
       label: "add_playlist",
@@ -877,7 +890,7 @@ export const getContextMenuItems = async function (
   }
 
   const playLogItem = items.length === 1 ? items[0] : undefined;
-  if (itemSupportsPlayLog(playLogItem)) {
+  if (canEditLibrary && itemSupportsPlayLog(playLogItem)) {
     const item = playLogItem;
     // mark played: anything not yet fully played, including in-progress items
     if (!item.fully_played) {
@@ -1030,6 +1043,7 @@ export const getContextMenuItems = async function (
   // migrate playlist (static library playlists only, to a provider that
   // supports creating playlists and editing their tracks)
   if (
+    canEditLibrary &&
     items.length === 1 &&
     items[0] == parentItem &&
     items[0].media_type === MediaType.PLAYLIST &&
@@ -1055,7 +1069,10 @@ export const getContextMenuItems = async function (
     "provider_mappings" in items[0]
   ) {
     const playlist = items[0] as Playlist;
-    if (canSharePlaylist(playlist, store.currentUser, managesLibrary)) {
+    if (
+      canEditLibrary &&
+      canSharePlaylist(playlist, store.currentUser, managesLibrary)
+    ) {
       contextMenuItems.push({
         label: "share_playlist",
         labelArgs: [],
@@ -1168,7 +1185,7 @@ export const getContextMenuItems = async function (
       (i) => i.media_type === MediaType.GENRE && i.provider === "library",
     ) &&
     genresShareTaxonomy(items.map((i) => (i as Genre).content_type)) &&
-    authManager.isAdmin()
+    managesLibrary
   ) {
     contextMenuItems.push({
       label: "merge_into",
@@ -1189,7 +1206,7 @@ export const getContextMenuItems = async function (
     items.every(
       (i) => i.media_type === MediaType.GENRE && i.provider === "library",
     ) &&
-    authManager.isAdmin()
+    managesLibrary
   ) {
     contextMenuItems.push({
       label: "delete_genre",
@@ -1316,6 +1333,7 @@ export const getPlaybackContextMenuItems = async function (
   });
   // Multi-select mark as played/unplayed for podcast episodes
   if (
+    authManager.hasScope(Scope.LIBRARY_WRITE) &&
     items.length > 1 &&
     items.every((item) => item.media_type === MediaType.PODCAST_EPISODE)
   ) {
@@ -1412,6 +1430,12 @@ const LIVE_SOURCE_MEDIA_TYPES = [MediaType.RADIO, MediaType.AUDIO_SOURCE];
 const getDefaultEnqueueOption = async function (
   item: MediaItemTypeOrItemMapping,
 ): Promise<QueueOption> {
+  // the server's own defaults apply to a role that may not read the core settings
+  if (!authManager.hasScope(Scope.CONFIG_CORE_READ)) {
+    return item.media_type === MediaType.TRACK
+      ? QueueOption.PLAY
+      : QueueOption.REPLACE;
+  }
   const configKey = LIVE_SOURCE_MEDIA_TYPES.includes(item.media_type)
     ? "default_enqueue_option_live_sources"
     : `default_enqueue_option_${item.media_type}`;

--- a/src/layouts/default/PlayerOSD/PlayerControlBtn/FavoriteMenuBtn.vue
+++ b/src/layouts/default/PlayerOSD/PlayerControlBtn/FavoriteMenuBtn.vue
@@ -1,7 +1,7 @@
 <template>
   <!-- reka owns the open state; mirroring it here keeps the trigger's hover
        suppression in step with it -->
-  <DropdownMenu @update:open="menuOpen = $event">
+  <DropdownMenu v-if="canEditLibrary" @update:open="menuOpen = $event">
     <DropdownMenuTrigger as-child>
       <Button
         variant="ghost"
@@ -42,8 +42,10 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { useCurrentItemFavorite } from "@/composables/useCurrentItemFavorite";
 import { usePopoutTriggerHover } from "@/composables/usePopoutTriggerHover";
+import { Scope } from "@/plugins/api/interfaces";
+import { authManager } from "@/plugins/auth";
 import { Heart, PlusCircle } from "@lucide/vue";
-import { ref } from "vue";
+import { computed, ref } from "vue";
 
 export interface Props {
   /** glyph size in px; the button box comes from the call site */
@@ -56,6 +58,10 @@ withDefaults(defineProps<Props>(), {
 
 const { currentItem, isFavorite, toggleFavorite, addToPlaylist } =
   useCurrentItemFavorite();
+// favouring and adding to a playlist both change the library
+const canEditLibrary = computed(() =>
+  authManager.hasScope(Scope.LIBRARY_WRITE),
+);
 
 const menuOpen = ref(false);
 const { suppressHover, onPointerEnter } = usePopoutTriggerHover(

--- a/src/layouts/default/PlayerOSD/QueueModeBanner.vue
+++ b/src/layouts/default/PlayerOSD/QueueModeBanner.vue
@@ -118,7 +118,7 @@ import {
 import AutoplayRepeatLockButton from "@/layouts/default/PlayerOSD/AutoplayRepeatLockButton.vue";
 import { useUserPreferences } from "@/composables/userPreferences";
 import { useQueueModes } from "@/layouts/default/PlayerOSD/useQueueModes";
-import type { ItemMapping } from "@/plugins/api/interfaces";
+import { Scope, type ItemMapping } from "@/plugins/api/interfaces";
 import { authManager } from "@/plugins/auth";
 import { $t } from "@/plugins/i18n";
 import router from "@/plugins/router";
@@ -191,8 +191,10 @@ const description = computed(() => {
   return "";
 });
 
-// The full queue settings page is an admin-only shortcut (matches the menu).
-const canConfigure = computed(() => authManager.isAdmin());
+// The full queue settings page needs the scope to change player settings (matches the menu).
+const canConfigure = computed(() =>
+  authManager.hasScope(Scope.CONFIG_PLAYERS_WRITE),
+);
 
 // Collapsed state is remembered per user (server-side preference, so it syncs
 // across devices). Default expanded so new users get the full explanation; once

--- a/src/plugins/api/index.ts
+++ b/src/plugins/api/index.ts
@@ -97,6 +97,9 @@ const REPEAT_AUTOPLAY_LOCK_SCHEMA_VERSION = 69;
 // The config/providers/share_candidates command landed in API schema 72.
 const SHARE_CANDIDATES_SCHEMA_VERSION = 72;
 
+// Playing AI Radio stations with queues.control instead of config.providers.write landed in API schema 75.
+const AI_RADIO_PLAYBACK_SCOPES_SCHEMA_VERSION = 75;
+
 export interface CommandOptions {
   /**
    * Skip the global console.error + error toast for an error result. Use for a
@@ -2740,19 +2743,23 @@ export class MusicAssistantApi {
 
     // Imported dynamically for the same reason as the router below: auth.ts
     // imports this module statically.
-    void import("../auth").then(({ authManager }) => {
-      toast.info($t("background_tasks.toast.added"), {
-        // the task list takes system.read
-        action: authManager.hasScope(Scope.SYSTEM_READ)
-          ? {
-              label: $t("background_tasks.open"),
-              onClick: () => {
-                void this._openBackgroundTasks();
-              },
-            }
-          : undefined,
+    void import("../auth")
+      // the task list takes system.read
+      .then(({ authManager }) => authManager.hasScope(Scope.SYSTEM_READ))
+      // a chunk gone after a server update only costs the toast its action
+      .catch(() => false)
+      .then((mayOpenTasks) => {
+        toast.info($t("background_tasks.toast.added"), {
+          action: mayOpenTasks
+            ? {
+                label: $t("background_tasks.open"),
+                onClick: () => {
+                  void this._openBackgroundTasks();
+                },
+              }
+            : undefined,
+        });
       });
-    });
   }
 
   private async _openBackgroundTasks(): Promise<void> {
@@ -3077,6 +3084,14 @@ export class MusicAssistantApi {
     return (
       (this.serverInfo.value?.schema_version ?? 0) >=
       SHARE_CANDIDATES_SCHEMA_VERSION
+    );
+  }
+
+  /** Whether the connected server lets a role with queues.control play AI Radio stations (schema >= 75). */
+  public get supportsAIRadioPlaybackScopes(): boolean {
+    return (
+      (this.serverInfo.value?.schema_version ?? 0) >=
+      AI_RADIO_PLAYBACK_SCOPES_SCHEMA_VERSION
     );
   }
 

--- a/src/plugins/api/index.ts
+++ b/src/plugins/api/index.ts
@@ -71,6 +71,7 @@ import {
   RecommendationFolder,
   RemoteAccessInfo,
   RepeatMode,
+  Scope,
   SearchResults,
   SmartPlaylistRules,
   SoundEffect,
@@ -2737,13 +2738,20 @@ export class MusicAssistantApi {
       return;
     }
 
-    toast.info($t("background_tasks.toast.added"), {
-      action: {
-        label: $t("background_tasks.open"),
-        onClick: () => {
-          void this._openBackgroundTasks();
-        },
-      },
+    // Imported dynamically for the same reason as the router below: auth.ts
+    // imports this module statically.
+    void import("../auth").then(({ authManager }) => {
+      toast.info($t("background_tasks.toast.added"), {
+        // the task list takes system.read
+        action: authManager.hasScope(Scope.SYSTEM_READ)
+          ? {
+              label: $t("background_tasks.open"),
+              onClick: () => {
+                void this._openBackgroundTasks();
+              },
+            }
+          : undefined,
+      });
     });
   }
 

--- a/src/plugins/auth.ts
+++ b/src/plugins/auth.ts
@@ -103,10 +103,10 @@ export class AuthManager {
   }
 
   /**
-   * Check if current user is admin
+   * Check if the role of the current user grants every scope, as the admin role does
    */
   isAdmin(): boolean {
-    return store.currentUser?.role === "admin";
+    return this.hasScope(Scope.ALL);
   }
 
   /**

--- a/src/plugins/auth.ts
+++ b/src/plugins/auth.ts
@@ -103,13 +103,6 @@ export class AuthManager {
   }
 
   /**
-   * Check if the role of the current user grants every scope, as the admin role does
-   */
-  isAdmin(): boolean {
-    return this.hasScope(Scope.ALL);
-  }
-
-  /**
    * Check if the role of the current user grants the given scope
    */
   hasScope(scope: Scope): boolean {

--- a/src/plugins/router.ts
+++ b/src/plugins/router.ts
@@ -18,8 +18,6 @@ import { store } from "./store";
 
 declare module "vue-router" {
   interface RouteMeta {
-    // only the admin role may open the route
-    requiresAdmin?: boolean;
     // only a role granting this scope may open the route
     requiresScope?: Scope;
   }
@@ -454,15 +452,18 @@ export const routes: RouteRecordRaw[] = [
           import(
             /* webpackChunkName: "music-quiz" */ "@/views/MusicQuizDashboardView.vue"
           ),
+        // hosting a quiz lets guests join, which is what users.invite grants
+        meta: { requiresScope: Scope.USERS_INVITE },
       },
       {
         path: "/onboarding",
         name: "onboarding",
         component: () =>
           import(/* webpackChunkName: "onboarding" */ "@/views/Onboarding.vue"),
-        // requiresAdmin also makes the guard wait for INITIALIZED, so the first
-        // step is never picked from an empty provider map on a hard reload
-        meta: { requiresAdmin: true },
+        // the wizard sets up every kind of provider; requiresScope also makes
+        // the guard wait for INITIALIZED, so the first step is never picked
+        // from an empty provider map on a hard reload
+        meta: { requiresScope: Scope.CONFIG_PROVIDERS_WRITE },
       },
       {
         path: "/settings",
@@ -501,7 +502,8 @@ export const routes: RouteRecordRaw[] = [
                 /* webpackChunkName: "playersettings" */ "@/views/settings/Players.vue"
               ),
             props: true,
-            meta: { requiresAdmin: true },
+            // guests and members read player configs, these pages change them
+            meta: { requiresScope: Scope.CONFIG_PLAYERS_WRITE },
           },
           {
             path: "system",
@@ -511,7 +513,8 @@ export const routes: RouteRecordRaw[] = [
                 /* webpackChunkName: "systemsettings" */ "@/views/settings/SystemConfig.vue"
               ),
             props: true,
-            meta: { requiresAdmin: true },
+            // members read core settings, the server settings pages change them
+            meta: { requiresScope: Scope.CONFIG_CORE_WRITE },
           },
           {
             path: "audio-analysis",
@@ -521,7 +524,7 @@ export const routes: RouteRecordRaw[] = [
                 /* webpackChunkName: "audioanalysissettings" */ "@/views/settings/AudioAnalysis.vue"
               ),
             props: true,
-            meta: { requiresAdmin: true },
+            meta: { requiresScope: Scope.SYSTEM_MANAGE },
           },
           {
             path: "remote-access",
@@ -531,7 +534,7 @@ export const routes: RouteRecordRaw[] = [
                 /* webpackChunkName: "remoteaccesssettings" */ "@/views/settings/RemoteAccessSettings.vue"
               ),
             props: true,
-            meta: { requiresAdmin: true },
+            meta: { requiresScope: Scope.SYSTEM_MANAGE },
           },
           {
             path: "frontend",
@@ -550,7 +553,7 @@ export const routes: RouteRecordRaw[] = [
                 /* webpackChunkName: "usersettings" */ "@/views/settings/UserManagement.vue"
               ),
             props: true,
-            meta: { requiresAdmin: true },
+            meta: { requiresScope: Scope.USERS_READ },
           },
           {
             path: "about",
@@ -569,7 +572,7 @@ export const routes: RouteRecordRaw[] = [
                 /* webpackChunkName: "diagnostics" */ "@/views/settings/Diagnostics.vue"
               ),
             props: true,
-            meta: { requiresAdmin: true },
+            meta: { requiresScope: Scope.SYSTEM_MANAGE },
           },
           {
             path: "tasks",
@@ -579,6 +582,7 @@ export const routes: RouteRecordRaw[] = [
                 /* webpackChunkName: "backgroundtasks" */ "@/views/settings/BackgroundTasks.vue"
               ),
             props: true,
+            meta: { requiresScope: Scope.SYSTEM_READ },
           },
           {
             path: "genremanagement",
@@ -588,7 +592,7 @@ export const routes: RouteRecordRaw[] = [
                 /* webpackChunkName: "genremanagement" */ "@/views/settings/GenreManagement.vue"
               ),
             props: true,
-            meta: { requiresAdmin: true },
+            meta: { requiresScope: Scope.LIBRARY_MANAGE },
           },
           {
             path: "editprovider/:instanceId",
@@ -609,7 +613,7 @@ export const routes: RouteRecordRaw[] = [
                 /* webpackChunkName: "editplayer" */ "@/views/settings/EditPlayer.vue"
               ),
             props: true,
-            meta: { requiresAdmin: true },
+            meta: { requiresScope: Scope.CONFIG_PLAYERS_WRITE },
           },
           {
             path: "editplayer/:playerId/options",
@@ -619,7 +623,7 @@ export const routes: RouteRecordRaw[] = [
                 /* webpackChunkName: "editplayer" */ "@/views/settings/EditPlayerOptions.vue"
               ),
             props: true,
-            meta: { requiresAdmin: false },
+            meta: { requiresScope: Scope.PLAYERS_CONTROL },
           },
           {
             path: "editplayer/:playerId/dsp",
@@ -629,7 +633,7 @@ export const routes: RouteRecordRaw[] = [
                 /* webpackChunkName: "editdsp" */ "@/views/settings/EditPlayerDsp.vue"
               ),
             props: true,
-            meta: { requiresAdmin: true },
+            meta: { requiresScope: Scope.CONFIG_PLAYERS_WRITE },
           },
           {
             path: "editqueue/:queueId",
@@ -639,7 +643,7 @@ export const routes: RouteRecordRaw[] = [
                 /* webpackChunkName: "editqueue" */ "@/views/settings/EditPlayerQueue.vue"
               ),
             props: true,
-            meta: { requiresAdmin: true },
+            meta: { requiresScope: Scope.CONFIG_PLAYERS_WRITE },
           },
           {
             path: "editcore/:domain",
@@ -649,7 +653,7 @@ export const routes: RouteRecordRaw[] = [
                 /* webpackChunkName: "editcore" */ "@/views/settings/EditCoreConfig.vue"
               ),
             props: true,
-            meta: { requiresAdmin: true },
+            meta: { requiresScope: Scope.CONFIG_CORE_WRITE },
           },
           {
             path: "addgroup/:provider",
@@ -659,7 +663,7 @@ export const routes: RouteRecordRaw[] = [
                 /* webpackChunkName: "addgroup" */ "@/views/settings/AddPlayerGroup.vue"
               ),
             props: true,
-            meta: { requiresAdmin: true },
+            meta: { requiresScope: Scope.CONFIG_PLAYERS_WRITE },
           },
         ],
       },
@@ -723,7 +727,7 @@ router.afterEach((_to, _from, failure) => {
   if (!failure) sessionStorage.removeItem(CHUNK_RELOAD_STORAGE_KEY);
 });
 
-// Navigation guard for admin-only routes and guest mode restrictions
+// Navigation guard for scope-gated routes and guest mode restrictions
 router.beforeEach(async (to) => {
   const guestRedirect = getGuestNavigationRedirect(
     authManager.isGuestAccessSession(),
@@ -750,14 +754,14 @@ router.beforeEach(async (to) => {
     }
   }
 
-  // Check gated routes - every matched route may require the admin role or a scope
-  const requiresAdmin = to.matched.some((record) => record.meta.requiresAdmin);
-  const requiredScope = to.matched.find((record) => record.meta.requiresScope)
-    ?.meta.requiresScope;
+  // Check gated routes - every matched route may require a scope
+  const requiredScopes = to.matched.flatMap((record) =>
+    record.meta.requiresScope ? [record.meta.requiresScope] : [],
+  );
 
-  if (requiresAdmin || requiredScope) {
-    // Wait for API to be initialized before checking admin access
-    // This ensures store.currentUser is set before we check permissions
+  if (requiredScopes.length) {
+    // Wait for API to be initialized before checking access
+    // This ensures store.currentUser and store.roleScopes are set before we check permissions
     if (api.state.value !== ConnectionState.INITIALIZED) {
       // Wait for initialization to complete
       await new Promise<void>((resolve) => {
@@ -784,12 +788,11 @@ router.beforeEach(async (to) => {
       currentUser?.role,
     );
 
-    if (requiresAdmin && (!currentUser || currentUser.role !== "admin")) {
-      console.warn("Admin access required for", to.path);
-      return { name: "discover" };
-    }
-    if (requiredScope && !authManager.hasScope(requiredScope)) {
-      console.warn(`The ${requiredScope} scope is required for`, to.path);
+    const missingScope = requiredScopes.find(
+      (scope) => !authManager.hasScope(scope),
+    );
+    if (missingScope) {
+      console.warn(`The ${missingScope} scope is required for`, to.path);
       return { name: "discover" };
     }
   }

--- a/src/plugins/router.ts
+++ b/src/plugins/router.ts
@@ -1,3 +1,4 @@
+import { canOpenAIRadio } from "@/helpers/ai_radio_access";
 import { getDashboardViewerNavigationRedirect } from "@/helpers/dashboard_viewer_access";
 import { getGuestNavigationRedirect } from "@/helpers/guest_access";
 import { DASHBOARD_VIEWER_PATH_STORAGE_KEY } from "@/helpers/guest_session";
@@ -187,7 +188,7 @@ export const routes: RouteRecordRaw[] = [
               );
             });
           }
-          if (!store.enabledPlugins.has("ai_radio")) {
+          if (!store.enabledPlugins.has("ai_radio") || !canOpenAIRadio()) {
             toast.error($t("providers.ai_radio.toast.unavailable"));
             return { name: "discover" };
           }

--- a/src/views/AIRadioView.vue
+++ b/src/views/AIRadioView.vue
@@ -44,7 +44,7 @@
         </Button>
       </header>
 
-      <div class="space-y-3">
+      <div v-if="canEdit" class="space-y-3">
         <div class="flex items-center justify-between gap-3">
           <h2 class="text-lg font-semibold tracking-tight">
             {{ $t("providers.ai_radio.hosts.title") }}
@@ -91,6 +91,7 @@
         <AlertDescription>
           <p>{{ $t("providers.ai_radio.prereq.description") }}</p>
           <Button
+            v-if="canEdit"
             variant="outline"
             size="sm"
             class="mt-2"
@@ -115,7 +116,7 @@
           <h2 class="text-lg font-semibold tracking-tight">
             {{ $t("providers.ai_radio.gallery.title") }}
           </h2>
-          <Button @click="openCreateDialog()">
+          <Button v-if="canEdit" @click="openCreateDialog()">
             <Plus class="mr-1 h-4 w-4" />
             {{ $t("providers.ai_radio.gallery.add_show") }}
           </Button>
@@ -134,7 +135,7 @@
               {{ $t("providers.ai_radio.gallery.empty_description") }}
             </p>
           </div>
-          <Button @click="openCreateDialog()">
+          <Button v-if="canEdit" @click="openCreateDialog()">
             <Plus class="mr-1 h-4 w-4" />
             {{ $t("providers.ai_radio.gallery.create_cta") }}
           </Button>
@@ -190,6 +191,8 @@ import {
   uniqueHostName,
   type HostDraft,
 } from "@/helpers/ai_radio";
+import { Scope } from "@/plugins/api/interfaces";
+import { authManager } from "@/plugins/auth";
 import { $t } from "@/plugins/i18n";
 import { Plus, RefreshCw, Sparkles, TriangleAlert, X } from "@lucide/vue";
 import { computed, onMounted, onUnmounted, ref, watch } from "vue";
@@ -215,6 +218,12 @@ const {
   dismissNoAiProviderAlert,
 } = useShows();
 const { hosts, presets, loadingHosts, loadHosts, loadPresets } = useHosts();
+
+// everyone plays the shows; creating and changing shows and hosts takes
+// config.providers.write
+const canEdit = computed(() =>
+  authManager.hasScope(Scope.CONFIG_PROVIDERS_WRITE),
+);
 
 const createDialogOpen = ref(false);
 const createDialogInitialPlaylist = ref<PlaylistSelection | undefined>();
@@ -297,6 +306,8 @@ async function closeCustomizeHost() {
 }
 
 function applyRouteQuery() {
+  // both deep links open an editor
+  if (!canEdit.value) return;
   const stationId = getQueryValue(route.query.station_id);
   if (stationId) {
     onCustomize(stationId);
@@ -319,7 +330,7 @@ function applyRouteQuery() {
 async function handleRefresh() {
   try {
     await Promise.all([
-      loadHosts(),
+      ...(canEdit.value ? [loadHosts()] : []),
       loadShows(),
       loadSections(),
       loadStatus(),
@@ -337,7 +348,7 @@ let unmounted = false;
 onMounted(async () => {
   try {
     await Promise.all([
-      loadHosts(),
+      ...(canEdit.value ? [loadHosts()] : []),
       loadShows(),
       loadSections(),
       loadPlaylists(),
@@ -349,8 +360,10 @@ onMounted(async () => {
   // so bail out rather than start a poll loop nothing will stop and rewrite the
   // query of a route this view no longer owns.
   if (unmounted) return;
-  // Best effort: the "Add host" menu still works with just "Blank host" if this fails.
-  void loadPresets().catch(() => {});
+  if (canEdit.value) {
+    // Best effort: the "Add host" menu still works with just "Blank host" if this fails.
+    void loadPresets().catch(() => {});
+  }
   startStatusPolling();
   applyRouteQuery();
 });

--- a/src/views/AlbumDetails.vue
+++ b/src/views/AlbumDetails.vue
@@ -44,7 +44,7 @@
       v-if="
         itemDetails?.provider == 'library' &&
         itemDetails?.metadata?.images &&
-        authManager.isAdmin()
+        authManager.hasScope(Scope.LIBRARY_MANAGE)
       "
       v-model="itemDetails.metadata.images"
       @update:model-value="UpdateItemInDb"
@@ -67,6 +67,7 @@ import {
   EventMessage,
   EventType,
   MediaItemType,
+  Scope,
   type Album,
 } from "@/plugins/api/interfaces";
 import { onBeforeUnmount, onMounted, ref, watch } from "vue";

--- a/src/views/ArtistDetails.vue
+++ b/src/views/ArtistDetails.vue
@@ -183,6 +183,7 @@ import {
   EventType,
   MediaItemType,
   ProviderFeature,
+  Scope,
   type Artist,
 } from "@/plugins/api/interfaces";
 import { authManager } from "@/plugins/auth";
@@ -207,9 +208,10 @@ const isAudiobookArtist = computed(() => {
 
 // the rows the page can render for this artist; the editor lists the same set
 const availableRows = computed(() =>
-  availableArtistRowIds(isAudiobookArtist.value, authManager.isAdmin()).filter(
-    rowApplies,
-  ),
+  availableArtistRowIds(
+    isAudiobookArtist.value,
+    authManager.hasScope(Scope.LIBRARY_MANAGE),
+  ).filter(rowApplies),
 );
 
 // reads the user's preferences from the store, so the page follows the editor

--- a/src/views/GenreDetails.vue
+++ b/src/views/GenreDetails.vue
@@ -165,7 +165,7 @@
     </template>
 
     <GenreAliasManager
-      v-if="itemDetails && isAdmin"
+      v-if="itemDetails && canManageLibrary"
       :genre="itemDetails"
       :existing-genre-names="existingGenreNames"
       @reload="loadItemDetails"
@@ -192,6 +192,7 @@ import {
   MediaItemType,
   MediaItemTypeOrItemMapping,
   MediaType,
+  Scope,
 } from "@/plugins/api/interfaces";
 import { authManager } from "@/plugins/auth";
 import { eventbus } from "@/plugins/eventbus";
@@ -228,7 +229,9 @@ const existingGenreNames = ref<Set<string>>(new Set());
 const { t } = useI18n();
 const router = useRouter();
 
-const isAdmin = computed(() => authManager.isAdmin());
+const canManageLibrary = computed(() =>
+  authManager.hasScope(Scope.LIBRARY_MANAGE),
+);
 
 type GenreViewMode = "discovery" | "list" | "panel" | "panel_compact";
 

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -58,7 +58,9 @@
     <!-- Newly discovered devices that still need setup; Review opens the
          players list filtered down to them. -->
     <Alert
-      v-if="isAdmin && showSetupPrompt && playersNeedingSetup.length > 0"
+      v-if="
+        canConfigurePlayers && showSetupPrompt && playersNeedingSetup.length > 0
+      "
       variant="warning"
       class="mx-7 mb-6 mt-4 flex w-auto items-center gap-3 py-3 pl-4 pr-3 [&>svg]:translate-y-0"
     >
@@ -110,6 +112,7 @@ import Toolbar from "@/components/Toolbar.vue";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
 import { api } from "@/plugins/api";
+import { Scope } from "@/plugins/api/interfaces";
 import { authManager } from "@/plugins/auth";
 import {
   ArrowRight,
@@ -128,7 +131,9 @@ const editMode = ref(false);
 const hasProviderErrors = ref(false);
 const showProviderWarning = ref(true);
 const erroredProviderType = ref<string | null>(null);
-const isAdmin = ref(false);
+const canConfigurePlayers = computed(() =>
+  authManager.hasScope(Scope.CONFIG_PLAYERS_WRITE),
+);
 const showSetupPrompt = ref(true);
 
 const playersNeedingSetup = computed(() =>
@@ -157,8 +162,8 @@ const navigateToProviders = () => {
 };
 
 onMounted(async () => {
-  isAdmin.value = authManager.isAdmin();
-  if (authManager.isAdmin()) {
+  // the warning leads on to every provider type, not just a member's own music sources
+  if (authManager.hasScope(Scope.CONFIG_PROVIDERS_WRITE)) {
     try {
       const configs = await api.getProviderConfigs();
       const firstError = configs.find(

--- a/src/views/LibraryGenres.vue
+++ b/src/views/LibraryGenres.vue
@@ -39,6 +39,7 @@ import {
   EventType,
   Genre,
   MediaType,
+  Scope,
 } from "@/plugins/api/interfaces";
 import { authManager } from "@/plugins/auth";
 import { computed, onBeforeUnmount, onMounted, ref } from "vue";
@@ -99,7 +100,7 @@ const sections = [
 ];
 
 const menuItems = computed<ToolBarMenuItem[]>(() => {
-  if (!authManager.isAdmin()) return [];
+  if (!authManager.hasScope(Scope.LIBRARY_MANAGE)) return [];
   return [
     {
       label: "add_genre",

--- a/src/views/LibraryPlaylists.vue
+++ b/src/views/LibraryPlaylists.vue
@@ -34,7 +34,9 @@ import {
   MediaType,
   type Playlist,
   ProviderFeature,
+  Scope,
 } from "@/plugins/api/interfaces";
+import { authManager } from "@/plugins/auth";
 import { eventbus } from "@/plugins/eventbus";
 import { $t } from "@/plugins/i18n";
 import { store } from "@/plugins/store";
@@ -97,6 +99,8 @@ const setTotals = async function (params: LoadDataParams) {
 };
 
 onMounted(() => {
+  // creating and importing playlists changes the library
+  const canEditLibrary = authManager.hasScope(Scope.LIBRARY_WRITE);
   const playListCreateItems: ToolBarMenuItem[] = [];
   for (const prov of Object.values(api.providers).filter(
     (x) =>
@@ -136,7 +140,7 @@ onMounted(() => {
       overflowAllowed: true,
     });
   }
-  if (playListCreateItems.length) {
+  if (canEditLibrary && playListCreateItems.length) {
     extraMenuItems.value.push({
       label: "create_playlist_on",
       icon: ListPlus,
@@ -145,14 +149,16 @@ onMounted(() => {
     });
   }
   // import playlist from file
-  extraMenuItems.value.push({
-    label: "import_playlist",
-    action: () => {
-      triggerFileImport();
-    },
-    icon: Import,
-    overflowAllowed: true,
-  });
+  if (canEditLibrary) {
+    extraMenuItems.value.push({
+      label: "import_playlist",
+      action: () => {
+        triggerFileImport();
+      },
+      icon: Import,
+      overflowAllowed: true,
+    });
+  }
   // signal if/when items get added/updated/removed within this library
   const unsub = api.subscribe_multi(
     [

--- a/src/views/LibraryRadios.vue
+++ b/src/views/LibraryRadios.vue
@@ -12,16 +12,7 @@
     :title="$t('radios')"
     :show-search-button="true"
     :allow-key-hooks="true"
-    :extra-menu-items="[
-      {
-        label: 'add_url_item',
-        labelArgs: [],
-        action: () => {
-          showAddEditDialog = true;
-        },
-        icon: ListPlus,
-      },
-    ]"
+    :extra-menu-items="extraMenuItems"
     :icon="Radio"
     :restore-state="true"
     :total="total"
@@ -37,12 +28,19 @@
 <script setup lang="ts">
 import AddManualLink from "@/components/AddManualLink.vue";
 import ItemsListing, { LoadDataParams } from "@/components/ItemsListing.vue";
+import type { ToolBarMenuItem } from "@/components/Toolbar.vue";
 import { onLibrarySyncCompleted } from "@/composables/useLibrarySync";
 import api from "@/plugins/api";
-import { EventMessage, EventType, MediaType } from "@/plugins/api/interfaces";
+import {
+  EventMessage,
+  EventType,
+  MediaType,
+  Scope,
+} from "@/plugins/api/interfaces";
+import { authManager } from "@/plugins/auth";
 import { store } from "@/plugins/store";
 import { ListPlus, Radio } from "@lucide/vue";
-import { onBeforeUnmount, onMounted, ref } from "vue";
+import { computed, onBeforeUnmount, onMounted, ref } from "vue";
 
 defineOptions({
   name: "Radios",
@@ -52,6 +50,22 @@ const updateAvailable = ref<boolean>(false);
 const total = ref(store.libraryRadiosCount);
 const showAddEditDialog = ref(false);
 const itemsListing = ref<InstanceType<typeof ItemsListing>>();
+
+// adding a radio station by its url adds it to the library
+const extraMenuItems = computed<ToolBarMenuItem[]>(() =>
+  authManager.hasScope(Scope.LIBRARY_WRITE)
+    ? [
+        {
+          label: "add_url_item",
+          labelArgs: [],
+          action: () => {
+            showAddEditDialog.value = true;
+          },
+          icon: ListPlus,
+        },
+      ]
+    : [],
+);
 
 const sortKeys = [
   "name",

--- a/src/views/LibraryTracks.vue
+++ b/src/views/LibraryTracks.vue
@@ -14,16 +14,7 @@
     :show-search-button="true"
     :show-genre-filter="true"
     :allow-key-hooks="true"
-    :extra-menu-items="[
-      {
-        label: 'add_url_item',
-        labelArgs: [],
-        action: () => {
-          showAddEditDialog = true;
-        },
-        icon: ListPlus,
-      },
-    ]"
+    :extra-menu-items="extraMenuItems"
     :icon="Music2"
     :restore-state="true"
     :total="total"
@@ -39,12 +30,19 @@
 <script setup lang="ts">
 import AddManualLink from "@/components/AddManualLink.vue";
 import ItemsListing, { LoadDataParams } from "@/components/ItemsListing.vue";
+import type { ToolBarMenuItem } from "@/components/Toolbar.vue";
 import { onLibrarySyncCompleted } from "@/composables/useLibrarySync";
 import api from "@/plugins/api";
-import { EventMessage, EventType, MediaType } from "@/plugins/api/interfaces";
+import {
+  EventMessage,
+  EventType,
+  MediaType,
+  Scope,
+} from "@/plugins/api/interfaces";
+import { authManager } from "@/plugins/auth";
 import { store } from "@/plugins/store";
 import { ListPlus, Music2 } from "@lucide/vue";
-import { onBeforeUnmount, onMounted, ref } from "vue";
+import { computed, onBeforeUnmount, onMounted, ref } from "vue";
 
 defineOptions({
   name: "Tracks",
@@ -54,6 +52,22 @@ const updateAvailable = ref<boolean>(false);
 const total = ref(store.libraryTracksCount);
 const showAddEditDialog = ref(false);
 const itemsListing = ref<InstanceType<typeof ItemsListing>>();
+
+// adding a track by its url adds it to the library
+const extraMenuItems = computed<ToolBarMenuItem[]>(() =>
+  authManager.hasScope(Scope.LIBRARY_WRITE)
+    ? [
+        {
+          label: "add_url_item",
+          labelArgs: [],
+          action: () => {
+            showAddEditDialog.value = true;
+          },
+          icon: ListPlus,
+        },
+      ]
+    : [],
+);
 
 const sortKeys = [
   "name",

--- a/src/views/MusicQuizDashboardView.vue
+++ b/src/views/MusicQuizDashboardView.vue
@@ -37,7 +37,7 @@
         </div>
         <div class="flex shrink-0 items-center gap-1">
           <Button
-            v-if="isAdmin && musicQuizProviderInstanceId"
+            v-if="canConfigureMusicQuiz && musicQuizProviderInstanceId"
             variant="ghost"
             size="icon"
             data-testid="music-quiz-settings"
@@ -258,7 +258,7 @@ import {
 } from "@/helpers/music_quiz";
 import type { MusicQuizPlaybackSelection } from "@/helpers/music_quiz_playback";
 import api, { ConnectionState } from "@/plugins/api";
-import { ProviderType } from "@/plugins/api/interfaces";
+import { ProviderType, Scope } from "@/plugins/api/interfaces";
 import { authManager } from "@/plugins/auth";
 import { $t } from "@/plugins/i18n";
 import { Gamepad2, MicVocal, Plus, Settings } from "@lucide/vue";
@@ -375,12 +375,15 @@ const playbackSelection = ref<MusicQuizPlaybackSelection>({
   venuePlayerId: null,
 });
 const musicQuizProviderInstanceId = ref<string | null>(null);
-const isAdmin = computed(() => authManager.isAdmin());
+// the settings shortcut opens the plugin config, which takes managing every provider
+const canConfigureMusicQuiz = computed(() =>
+  authManager.hasScope(Scope.CONFIG_PROVIDERS_WRITE),
+);
 
 watch(
-  isAdmin,
-  (admin) => {
-    if (admin && !musicQuizProviderInstanceId.value) {
+  canConfigureMusicQuiz,
+  (canConfigure) => {
+    if (canConfigure && !musicQuizProviderInstanceId.value) {
       void resolveMusicQuizProviderInstance();
     }
   },

--- a/src/views/PartyDashboardView.vue
+++ b/src/views/PartyDashboardView.vue
@@ -63,8 +63,8 @@
             <Badge
               v-if="qrAvailable"
               variant="warning"
-              class="cursor-pointer"
-              @click="showGuestAccessDialog = true"
+              :class="{ 'cursor-pointer': canManageParty }"
+              @click="openGuestAccessDialog"
             >
               <WifiIcon :size="11" />
               {{ $t("providers.party.guest_access_enabled") }}
@@ -72,8 +72,8 @@
             <Badge
               v-else
               variant="info"
-              class="cursor-pointer"
-              @click="showGuestAccessDialog = true"
+              :class="{ 'cursor-pointer': canManageParty }"
+              @click="openGuestAccessDialog"
             >
               <WifiOff :size="11" />
               {{ $t("providers.party.guest_access_disabled") }}
@@ -109,7 +109,7 @@
           <!-- Non-fullscreen: actions -->
           <template v-if="!isFullscreen">
             <Button
-              v-if="partyInstanceId"
+              v-if="partyInstanceId && canManageParty"
               variant="ghost-icon"
               size="icon-sm"
               :aria-label="$t('tooltip.party_settings')"
@@ -354,8 +354,10 @@ import {
   MediaType,
   PlaybackState,
   QueueItem,
+  Scope,
   Track,
 } from "@/plugins/api/interfaces";
+import { authManager } from "@/plugins/auth";
 import { store } from "@/plugins/store";
 import {
   Droplet,
@@ -406,6 +408,16 @@ let burnInInterval: ReturnType<typeof setInterval> | null = null;
 const accessError = ref("");
 const showGuestAccessDialog = ref(false);
 const guestAccessSaving = ref(false);
+
+// guest access is saved with the party's provider settings, which take
+// config.providers.write
+const canManageParty = computed(() =>
+  authManager.hasScope(Scope.CONFIG_PROVIDERS_WRITE),
+);
+
+const openGuestAccessDialog = () => {
+  if (canManageParty.value) showGuestAccessDialog.value = true;
+};
 
 const toggleGuestAccess = async () => {
   if (!partyInstanceId.value) return;

--- a/src/views/PlaylistDetails.vue
+++ b/src/views/PlaylistDetails.vue
@@ -1,8 +1,8 @@
 <template>
   <InfoHeader :item="itemDetails" :sort-by="listingRef?.sortBy">
-    <template v-if="smartRules || canShare" #append-actions>
+    <template v-if="(smartRules && canEditLibrary) || canShare" #append-actions>
       <Settings2
-        v-if="smartRules"
+        v-if="smartRules && canEditLibrary"
         :size="22"
         class="cursor-pointer"
         :title="$t('smart_playlist.edit_rules')"
@@ -128,10 +128,15 @@ const updateAvailable = ref(false);
 const itemDetails = ref<Playlist>();
 const smartRules = ref<SmartPlaylistRules | null>(null);
 const showEditDialog = ref(false);
+// editing the rules of a smart playlist changes the library
+const canEditLibrary = computed(() =>
+  authManager.hasScope(Scope.LIBRARY_WRITE),
+);
 const listingRef = ref<InstanceType<typeof ItemsListing>>();
 
 const canShare = computed(
   () =>
+    canEditLibrary.value &&
     itemDetails.value !== undefined &&
     canSharePlaylist(
       itemDetails.value,

--- a/src/views/settings/About.vue
+++ b/src/views/settings/About.vue
@@ -4,7 +4,7 @@
     <Card>
       <CardHeader>
         <CardTitle>{{ $t("settings.server_info") }}</CardTitle>
-        <CardAction v-if="isAdmin">
+        <CardAction v-if="canEditServerConfig">
           <Button
             variant="ghost"
             size="icon-sm"
@@ -421,6 +421,7 @@ import {
 import { Item, ItemContent, ItemTitle } from "@/components/ui/item";
 import { useServerTime } from "@/composables/useServerTime";
 import { api } from "@/plugins/api";
+import { Scope } from "@/plugins/api/interfaces";
 import { authManager } from "@/plugins/auth";
 import { store } from "@/plugins/store";
 import { Pencil } from "@lucide/vue";
@@ -436,7 +437,9 @@ const router = useRouter();
 
 const { offsetSeconds: clockOffsetSeconds } = useServerTime();
 
-const isAdmin = computed(() => authManager.isAdmin());
+const canEditServerConfig = computed(() =>
+  authManager.hasScope(Scope.CONFIG_CORE_WRITE),
+);
 
 // older servers only report the (now deprecated) base_url
 const internalUrl = computed(

--- a/src/views/settings/BackgroundTasks.vue
+++ b/src/views/settings/BackgroundTasks.vue
@@ -4,7 +4,7 @@
       <BackgroundTaskFilters @update:search="searchQuery = $event" />
 
       <Button
-        v-if="isAdmin"
+        v-if="canManageTasks"
         class="clear-finished-btn"
         variant="outline"
         @click="clearFinishedTasks"
@@ -113,11 +113,11 @@ import {
   type BackgroundTask,
   type TaskSchedule,
   type User,
+  Scope,
   TaskStatus,
-  UserRole,
 } from "@/plugins/api/interfaces";
+import { authManager } from "@/plugins/auth";
 import { eventbus } from "@/plugins/eventbus";
-import { store } from "@/plugins/store";
 import { Trash2 } from "@lucide/vue";
 import { computed, inject, ref } from "vue";
 import { useI18n } from "vue-i18n";
@@ -141,7 +141,9 @@ const usersLoaded = ref(false);
 
 const { t } = useI18n();
 const viewMode = computed(() => tasksViewMode.viewMode.value);
-const isAdmin = computed(() => store.currentUser?.role === UserRole.ADMIN);
+const canManageTasks = computed(() =>
+  authManager.hasScope(Scope.SYSTEM_MANAGE),
+);
 const {
   loading,
   refreshTasks: refreshTasksState,
@@ -377,11 +379,7 @@ const removeTask = async (task: BackgroundTask) => {
 };
 
 const ensureUserLabelsLoaded = async () => {
-  if (
-    usersLoaded.value ||
-    !store.currentUser ||
-    store.currentUser.role !== UserRole.ADMIN
-  ) {
+  if (usersLoaded.value || !authManager.hasScope(Scope.USERS_READ)) {
     return;
   }
   try {
@@ -494,7 +492,7 @@ const onMenu = (event: Event, task: BackgroundTask) => {
         openScheduleDialog(task);
       },
       icon: "mdi-timer-edit-outline",
-      hide: !isAdmin.value || !canEditTaskSchedule(task),
+      hide: !canManageTasks.value || !canEditTaskSchedule(task),
     },
     {
       label: "background_tasks.run_now",
@@ -502,7 +500,7 @@ const onMenu = (event: Event, task: BackgroundTask) => {
         void runTask(task);
       },
       icon: "mdi-play",
-      hide: !isAdmin.value || !canRunTaskManually(task),
+      hide: !canManageTasks.value || !canRunTaskManually(task),
     },
     {
       label: task.schedule?.enabled
@@ -514,7 +512,7 @@ const onMenu = (event: Event, task: BackgroundTask) => {
       icon: task.schedule?.enabled
         ? "mdi-calendar-remove"
         : "mdi-calendar-check",
-      hide: !isAdmin.value || !isScheduledTask(task),
+      hide: !canManageTasks.value || !isScheduledTask(task),
     },
     {
       label: "background_tasks.retry",
@@ -522,7 +520,8 @@ const onMenu = (event: Event, task: BackgroundTask) => {
         void retryTask(task);
       },
       icon: "mdi-refresh",
-      hide: !isAdmin.value || !(task.allow_retry && isRetryableTask(task)),
+      hide:
+        !canManageTasks.value || !(task.allow_retry && isRetryableTask(task)),
     },
     {
       label: "background_tasks.cancel",
@@ -530,7 +529,8 @@ const onMenu = (event: Event, task: BackgroundTask) => {
         void cancelTask(task);
       },
       icon: "mdi-cancel",
-      hide: !isAdmin.value || !(task.allow_cancel && isCancelableTask(task)),
+      hide:
+        !canManageTasks.value || !(task.allow_cancel && isCancelableTask(task)),
     },
     {
       label: "background_tasks.remove_history",
@@ -539,7 +539,7 @@ const onMenu = (event: Event, task: BackgroundTask) => {
       },
       icon: "mdi-delete",
       color: "error",
-      hide: !isAdmin.value || !canRemoveTask(task),
+      hide: !canManageTasks.value || !canRemoveTask(task),
     },
   ];
 

--- a/src/views/settings/EditProvider.vue
+++ b/src/views/settings/EditProvider.vue
@@ -322,6 +322,7 @@ import {
   EventType,
   ProviderConfig,
   ProviderStatus,
+  Scope,
 } from "@/plugins/api/interfaces";
 import { authManager } from "@/plugins/auth";
 import { eventbus } from "@/plugins/eventbus";
@@ -703,7 +704,7 @@ function isCurrentProvider(instanceId: string) {
 
 function mayManage(providerConfig: ProviderConfig) {
   return (
-    authManager.isAdmin() ||
+    authManager.hasScope(Scope.CONFIG_PROVIDERS_WRITE) ||
     isOwnMusicSource(providerConfig, store.currentUser?.user_id)
   );
 }

--- a/src/views/settings/Players.vue
+++ b/src/views/settings/Players.vue
@@ -155,7 +155,7 @@
         </div>
       </div>
     </Container>
-    <div class="missing-players-hint">
+    <div v-if="canAddPlayerProviders" class="missing-players-hint">
       <v-icon icon="mdi-information-outline" size="16" class="hint-icon" />
       <i18n-t keypath="settings.missing_players_hint" tag="span" scope="global">
         <router-link
@@ -189,7 +189,9 @@ import {
   PlayerConfig,
   PlayerType,
   ProviderFeature,
+  Scope,
 } from "@/plugins/api/interfaces";
+import { authManager } from "@/plugins/auth";
 import { eventbus } from "@/plugins/eventbus";
 import { Plus } from "@lucide/vue";
 import { computed, inject, onBeforeUnmount, ref, watch } from "vue";
@@ -237,6 +239,10 @@ const providersWithCreateGroupSupport = computed(() => {
         : -1,
     );
 });
+// the hint leads to adding player providers, which takes config.providers.write
+const canAddPlayerProviders = computed(() =>
+  authManager.hasScope(Scope.CONFIG_PROVIDERS_WRITE),
+);
 
 // methods
 const loadItems = async function () {

--- a/src/views/settings/Providers.vue
+++ b/src/views/settings/Providers.vue
@@ -360,6 +360,7 @@ import {
   ProviderStage,
   ProviderStatus,
   ProviderType,
+  Scope,
   type User,
   type UserSummary,
 } from "@/plugins/api/interfaces";
@@ -389,7 +390,9 @@ const viewMode = computed(() => providersViewMode.viewMode.value);
 const MIN_PROVIDERS_FOR_SEARCH = 10;
 
 // an admin manages every source, a member only the music sources it owns
-const managesAllSources = computed(() => authManager.isAdmin());
+const managesAllSources = computed(() =>
+  authManager.hasScope(Scope.CONFIG_PROVIDERS_WRITE),
+);
 
 const currentType = computed(() =>
   managesAllSources.value

--- a/src/views/settings/Settings.vue
+++ b/src/views/settings/Settings.vue
@@ -235,6 +235,7 @@ import {
   CardTitle,
 } from "@/components/ui/card";
 import { useUserPreferences } from "@/composables/userPreferences";
+import { availableSettingsSections } from "@/helpers/settings_sections";
 import { api } from "@/plugins/api";
 import { requireServerVersion } from "@/plugins/api/helpers";
 import { ProviderType, Scope } from "@/plugins/api/interfaces";
@@ -417,134 +418,17 @@ provide("systemViewMode", {
   toggleViewMode: toggleSystemViewMode,
 });
 
-const allSettingsSections = [
-  {
-    name: "music_providers",
-    label: "settings.music_sources",
-    description: "settings.music_providers_description",
-    icon: "mdi-music",
-    color: "blue",
-    route: { name: "providersettings", query: { types: "music" } },
-    // a member holding the scope manages the music sources it owns here
-    adminOnly: false,
-    requiresScope: Scope.CONFIG_PROVIDERS_OWN,
-  },
-  {
-    name: "player_providers",
-    label: "settings.playerproviders",
-    description: "settings.player_providers_description",
-    icon: "mdi-speaker-multiple",
-    color: "green",
-    route: { name: "providersettings", query: { types: "player" } },
-    adminOnly: true,
-  },
-  {
-    name: "metadata_providers",
-    label: "settings.metadataproviders",
-    description: "settings.metadata_providers_description",
-    icon: "mdi-file-code",
-    color: "indigo",
-    route: { name: "providersettings", query: { types: "metadata" } },
-    adminOnly: true,
-  },
-  {
-    name: "plugin_providers",
-    label: "settings.plugins",
-    description: "settings.plugin_providers_description",
-    icon: "mdi-puzzle",
-    color: "deep-purple",
-    route: { name: "providersettings", query: { types: "plugin" } },
-    adminOnly: true,
-  },
-  {
-    name: "players",
-    label: "settings.players",
-    description: "settings.players_description",
-    icon: "mdi-tune",
-    color: "teal",
-    route: { name: "playersettings" },
-    adminOnly: true,
-  },
-  {
-    name: "audio_analysis_providers",
-    label: "settings.audio_analysis_providers",
-    description: "settings.audio_analysis_providers_description",
-    icon: "mdi-waveform",
-    color: "blue",
-    route: { name: "providersettings", query: { types: "audio_analysis" } },
-    adminOnly: true,
-    minServerVersion: "2.9.0",
-  },
-  {
-    name: "profile",
-    label: "auth.profile",
-    description: "settings.profile_description",
-    icon: "mdi-account-cog",
-    color: "indigo",
-    route: { name: "profile" },
-    adminOnly: false,
-  },
-  {
-    name: "frontend",
-    label: "settings.frontend",
-    description: "settings.frontend_description",
-    icon: "mdi-palette",
-    color: "orange",
-    route: { name: "frontendsettings" },
-    adminOnly: false,
-  },
-  {
-    name: "users",
-    label: "auth.user_management",
-    description: "settings.users_description",
-    icon: "mdi-account-multiple",
-    color: "teal",
-    route: { name: "usersettings" },
-    adminOnly: true,
-  },
-  {
-    name: "remote_access",
-    label: "settings.remote_access",
-    description: "settings.remote_access_description",
-    icon: "mdi-cloud-lock",
-    color: "deep-purple",
-    route: { name: "remoteaccesssettings" },
-    adminOnly: true,
-  },
-  {
-    name: "system",
-    label: "settings.system",
-    description: "settings.system_description",
-    icon: "mdi-server",
-    color: "purple",
-    route: { name: "systemsettings" },
-    adminOnly: true,
-  },
-  {
-    name: "about",
-    label: "settings.about",
-    description: "settings.about_description",
-    icon: "mdi-information-outline",
-    color: "grey-darken-1",
-    route: { name: "aboutsettings" },
-    adminOnly: false,
-  },
-];
+// the setup wizard sets up every kind of provider, and is reachable again from here
+const canRunOnboarding = computed(() =>
+  authManager.hasScope(Scope.CONFIG_PROVIDERS_WRITE),
+);
 
-const isAdmin = computed(() => authManager.isAdmin());
-
-// the setup wizard is admin-only, and reachable again from here
-const canRunOnboarding = isAdmin;
-
-const settingsSections = computed(() => {
-  return allSettingsSections.filter(
-    (section) =>
-      (!section.adminOnly || isAdmin.value) &&
-      (!section.requiresScope || authManager.hasScope(section.requiresScope)) &&
-      (!section.minServerVersion ||
-        requireServerVersion(section.minServerVersion)),
-  );
-});
+const settingsSections = computed(() =>
+  availableSettingsSections(
+    (scope) => authManager.hasScope(scope),
+    requireServerVersion,
+  ),
+);
 
 const providerSectionNames = [
   "music_providers",
@@ -703,7 +587,12 @@ const breadcrumbItems = computed(() => {
         to: { name: "playersettings" },
       });
     } else if (currentTab === "system") {
-      if (!(name === "backgroundtasks" && !authManager.isAdmin())) {
+      if (
+        !(
+          name === "backgroundtasks" &&
+          !authManager.hasScope(Scope.CONFIG_CORE_WRITE)
+        )
+      ) {
         items.push({
           title: t("settings.system"),
           disabled: name === "systemsettings",

--- a/src/views/settings/Settings.vue
+++ b/src/views/settings/Settings.vue
@@ -568,6 +568,9 @@ const getProviderName = (instanceId: string) => {
 const breadcrumbItems = computed(() => {
   const route = router.currentRoute.value;
   const name = route.name?.toString() || "";
+  // without config.players.write only the player options open, so the crumbs
+  // leading to the players and their settings are plain text
+  const canConfigurePlayers = authManager.hasScope(Scope.CONFIG_PLAYERS_WRITE);
 
   // "Settings" heads the toolbar on its own line, so the trail starts below it
   const items: ToolbarHeadingItem[] = [];
@@ -584,7 +587,7 @@ const breadcrumbItems = computed(() => {
       items.push({
         title: t("settings.players"),
         disabled: name === "playersettings",
-        to: { name: "playersettings" },
+        to: canConfigurePlayers ? { name: "playersettings" } : undefined,
       });
     } else if (currentTab === "system") {
       if (
@@ -679,7 +682,9 @@ const breadcrumbItems = computed(() => {
           // a disabled player is never registered, so it has no name to show
           title: api.players[playerId]?.name || t("settings.player_settings"),
           disabled: name === "editplayer",
-          to: { name: "editplayer", params: { playerId } },
+          to: canConfigurePlayers
+            ? { name: "editplayer", params: { playerId } }
+            : undefined,
         });
         const section = match(name)
           .with("editplayerdsp", () => t("settings.category.dsp"))

--- a/src/views/settings/UserManagement.vue
+++ b/src/views/settings/UserManagement.vue
@@ -8,7 +8,7 @@
           </template>
         </Input>
       </div>
-      <Button @click="showCreateDialog = true">
+      <Button v-if="canManageUsers" @click="showCreateDialog = true">
         <Plus :size="16" />
         {{ $t("auth.create_user") }}
       </Button>
@@ -28,8 +28,10 @@
       <Card
         v-for="user in filteredUsers"
         :key="user.user_id"
-        class="cursor-pointer hover:bg-accent/50 transition-colors"
-        @click="editUser(user)"
+        :class="{
+          'cursor-pointer hover:bg-accent/50 transition-colors': canManageUsers,
+        }"
+        @click="canManageUsers && editUser(user)"
       >
         <CardContent class="px-4 py-0">
           <div class="flex items-center gap-4">
@@ -49,7 +51,7 @@
                     {{ user.username }} • {{ $t(`auth.${user.role}_role`) }}
                   </p>
                 </div>
-                <DropdownMenu>
+                <DropdownMenu v-if="canManageUsers">
                   <DropdownMenuTrigger as-child>
                     <Button
                       variant="ghost"
@@ -188,7 +190,8 @@ import ManageTokensDialog from "@/components/users/ManageTokensDialog.vue";
 import RevokeTokenDialog from "@/components/users/RevokeTokenDialog.vue";
 import { isSystemUser } from "@/helpers/users";
 import { api } from "@/plugins/api";
-import type { AuthToken, User } from "@/plugins/api/interfaces";
+import { Scope, type AuthToken, type User } from "@/plugins/api/interfaces";
+import { authManager } from "@/plugins/auth";
 import { store } from "@/plugins/store";
 
 const { t } = useI18n();
@@ -207,6 +210,8 @@ const userToModify = ref<User | null>(null);
 const userTokens = ref<AuthToken[]>([]);
 const tokenToRevoke = ref<AuthToken | null>(null);
 const lastOpenedQueryUserId = ref<string | null>(null);
+// reading the users takes users.read, changing them users.manage
+const canManageUsers = computed(() => authManager.hasScope(Scope.USERS_MANAGE));
 
 const filteredUsers = computed(() => {
   if (!searchQuery.value) {
@@ -247,7 +252,7 @@ const openUserFromRouteQuery = async () => {
   if (!user) {
     return;
   }
-  editUser(user);
+  if (canManageUsers.value) editUser(user);
   lastOpenedQueryUserId.value = queryUserId;
   await router.replace({ name: "usersettings", query: {} });
 };

--- a/tests/App.test.ts
+++ b/tests/App.test.ts
@@ -493,13 +493,20 @@ describe("App initialization", () => {
       expect(mockRouterPush).toHaveBeenCalledWith({ name: "onboarding" });
     });
 
-    it("leaves a non-admin alone on a server that has not been set up", async () => {
-      apiMock.serverInfo.value.onboard_done = false;
+    it.each([
+      ["a member", BUILTIN_ROLE_SCOPES.user],
+      ["a guest", BUILTIN_ROLE_SCOPES.guest],
+    ])(
+      "leaves %s alone on a server that has not been set up",
+      async (_role, scopes) => {
+        authManagerMock.hasScope.mockImplementation(scopeChecker(scopes));
+        apiMock.serverInfo.value.onboard_done = false;
 
-      wrapper = await mountApp();
+        wrapper = await mountApp();
 
-      expect(mockRouterPush).not.toHaveBeenCalled();
-    });
+        expect(mockRouterPush).not.toHaveBeenCalled();
+      },
+    );
 
     it("stays out of the way once the server is set up", async () => {
       asAdmin();

--- a/tests/App.test.ts
+++ b/tests/App.test.ts
@@ -970,6 +970,14 @@ describe("App initialization", () => {
         role: UserRole.USER,
         roleScopes: { ...ROLE_SCOPES, user: [...BUILTIN_ROLE_SCOPES.guest] },
       },
+      {
+        change: "the user got another role with the same scopes",
+        role: "household_member",
+        roleScopes: {
+          ...ROLE_SCOPES,
+          household_member: [...BUILTIN_ROLE_SCOPES.user],
+        },
+      },
     ])(
       "reloads the app when a reconnect finds $change",
       async ({ role, roleScopes }) => {

--- a/tests/App.test.ts
+++ b/tests/App.test.ts
@@ -939,6 +939,86 @@ describe("App initialization", () => {
     expect(apiMock.requireAuthentication).toHaveBeenCalledOnce();
   });
 
+  describe("reloading for changed permissions", () => {
+    const ROLE_SCOPES = {
+      admin: [...BUILTIN_ROLE_SCOPES.admin],
+      user: [...BUILTIN_ROLE_SCOPES.user],
+    };
+    let reload: ReturnType<typeof vi.spyOn>;
+
+    beforeEach(() => {
+      reload = vi.spyOn(window.location, "reload").mockImplementation(() => {});
+      apiMock.getRoleScopes.mockResolvedValue(ROLE_SCOPES);
+      // like the real one, which a reconnect calls before initializing again
+      authManagerMock.setCurrentUser.mockImplementation((currentUser) => {
+        storeMock.currentUser = currentUser;
+      });
+    });
+
+    afterEach(() => {
+      reload.mockRestore();
+    });
+
+    it.each([
+      {
+        change: "the user got another role",
+        role: UserRole.ADMIN,
+        roleScopes: ROLE_SCOPES,
+      },
+      {
+        change: "the role lost scopes",
+        role: UserRole.USER,
+        roleScopes: { ...ROLE_SCOPES, user: [...BUILTIN_ROLE_SCOPES.guest] },
+      },
+    ])(
+      "reloads the app when a reconnect finds $change",
+      async ({ role, roleScopes }) => {
+        wrapper = await mountApp();
+        apiMock.fetchState.mockClear();
+        const changedUser = user({
+          role,
+          user_id: "user-id",
+          username: "regular-user",
+        });
+        apiMock.authenticateWithToken.mockResolvedValue({ user: changedUser });
+        apiMock.getCurrentUserInfo.mockResolvedValue(changedUser);
+        apiMock.getRoleScopes.mockResolvedValue(roleScopes);
+
+        await reconnectAndInitialize();
+
+        expect(reload).toHaveBeenCalledOnce();
+        // the reloaded app does the rest of the initialization
+        expect(apiMock.fetchState).not.toHaveBeenCalled();
+      },
+    );
+
+    it("keeps the app running when a reconnect finds the same scopes", async () => {
+      wrapper = await mountApp();
+      apiMock.fetchState.mockClear();
+      // the same scopes, listed in another order
+      apiMock.getRoleScopes.mockResolvedValue({
+        ...ROLE_SCOPES,
+        user: [...BUILTIN_ROLE_SCOPES.user].reverse(),
+      });
+
+      await reconnectAndInitialize();
+
+      expect(reload).not.toHaveBeenCalled();
+      expect(apiMock.fetchState).toHaveBeenCalledOnce();
+      expect(apiMock.state.value).toBe("initialized");
+    });
+
+    it("never reloads on the first initialization", async () => {
+      // what the store holds before is no earlier initialization of this app
+      storeMock.currentUser = user({ role: UserRole.ADMIN });
+      storeMock.roleScopes = ROLE_SCOPES;
+
+      wrapper = await mountApp();
+
+      expect(reload).not.toHaveBeenCalled();
+    });
+  });
+
   it("takes the safe area padding over in an ingress session", async () => {
     storeMock.isIngressSession = true;
 
@@ -1104,6 +1184,17 @@ async function reconnect() {
   await startReconnect();
   await flushPromises();
   expect(apiMock.authenticateWithToken).toHaveBeenCalled();
+}
+
+/**
+ * Drive the connection through a reconnect that accepts the token, and have the
+ * app initialize again the way the real api lets it once it authenticated.
+ */
+async function reconnectAndInitialize() {
+  authManagerMock.getToken.mockReturnValue("regular-token");
+  await reconnect();
+  apiMock.state.value = "authenticated";
+  await flushPromises();
 }
 
 /**

--- a/tests/App.test.ts
+++ b/tests/App.test.ts
@@ -15,6 +15,7 @@ import { nextTick } from "vue";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { toast } from "vue-sonner";
 import { providerConfig } from "./fixtures/providerConfig";
+import { BUILTIN_ROLE_SCOPES, scopeChecker } from "./fixtures/scopes";
 import { user } from "./fixtures/user";
 import { store } from "@/plugins/store";
 
@@ -81,6 +82,7 @@ const {
     endRejectedGuestSession: vi.fn(),
     getToken: vi.fn(),
     guestSessionKind: vi.fn(),
+    hasScope: vi.fn(),
     isDashboardViewer: vi.fn(),
     isGuestAccessSession: vi.fn(),
     isMusicQuizGuest: vi.fn(),
@@ -476,6 +478,9 @@ describe("App initialization", () => {
           user_id: "admin-id",
           username: "admin",
         }),
+      );
+      authManagerMock.hasScope.mockImplementation(
+        scopeChecker(BUILTIN_ROLE_SCOPES.admin),
       );
     };
 

--- a/tests/components/BackgroundTaskDetailsDialog.test.ts
+++ b/tests/components/BackgroundTaskDetailsDialog.test.ts
@@ -2,9 +2,19 @@
  * @vitest-environment jsdom
  */
 import BackgroundTaskDetailsDialog from "@/components/settings/background-tasks/BackgroundTaskDetailsDialog.vue";
-import { type BackgroundTask, TaskStatus } from "@/plugins/api/interfaces";
+import {
+  type BackgroundTask,
+  type Scope,
+  TaskScheduleType,
+  TaskStatus,
+} from "@/plugins/api/interfaces";
 import { mount, type VueWrapper } from "@vue/test-utils";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { BUILTIN_ROLE_SCOPES, scopeChecker } from "../fixtures/scopes";
+
+const { hasScope } = vi.hoisted(() => ({
+  hasScope: vi.fn<(scope: Scope) => boolean>(),
+}));
 
 vi.mock("@/plugins/api", () => ({ api: {} }));
 
@@ -20,6 +30,8 @@ vi.mock("@/plugins/store", () => ({
   store: { currentUser: null },
 }));
 
+vi.mock("@/plugins/auth", () => ({ authManager: { hasScope } }));
+
 vi.mock("vue-i18n", async (importOriginal) => {
   const actual = await importOriginal<typeof import("vue-i18n")>();
   return {
@@ -34,6 +46,10 @@ vi.mock("vue-i18n", async (importOriginal) => {
 const passthrough = { template: "<div><slot /></div>" };
 
 describe("BackgroundTaskDetailsDialog", () => {
+  beforeEach(() => {
+    hasScope.mockImplementation(scopeChecker(BUILTIN_ROLE_SCOPES.user));
+  });
+
   it.each([
     TaskStatus.SUCCESS,
     TaskStatus.PARTIAL_SUCCESS,
@@ -66,7 +82,40 @@ describe("BackgroundTaskDetailsDialog", () => {
     expect(wrapper.find(".task-report").exists()).toBe(false);
     expect(wrapper.text()).not.toContain("background_tasks.report_title");
   });
+
+  it("links the users and offers editing the schedule to an admin", () => {
+    hasScope.mockImplementation(scopeChecker(BUILTIN_ROLE_SCOPES.admin));
+
+    const wrapper = mountDialog(scheduledTask());
+
+    expect(wrapper.findAll(".detail-link")).toHaveLength(2);
+    expect(
+      wrapper.find('[title="background_tasks.edit_schedule"]').exists(),
+    ).toBe(true);
+  });
+
+  it("offers a member neither the user links nor editing the schedule", () => {
+    const wrapper = mountDialog(scheduledTask());
+
+    expect(wrapper.find(".detail-link").exists()).toBe(false);
+    expect(
+      wrapper.find('[title="background_tasks.edit_schedule"]').exists(),
+    ).toBe(false);
+  });
 });
+
+function scheduledTask(): BackgroundTask {
+  return makeTask({
+    schedule: {
+      type: TaskScheduleType.DAILY,
+      enabled: true,
+      hour: 3,
+      minute: 0,
+    },
+    user_id: "user-1",
+    last_run_user_id: "user-2",
+  });
+}
 
 function mountDialog(task: BackgroundTask): VueWrapper {
   return mount(BackgroundTaskDetailsDialog, {

--- a/tests/components/DynamicItemSample.test.ts
+++ b/tests/components/DynamicItemSample.test.ts
@@ -1,10 +1,12 @@
 import DynamicItemSample from "@/components/DynamicItemSample.vue";
 import type { MusicAssistantApi } from "@/plugins/api";
 import type { Playlist, Radio } from "@/plugins/api/interfaces";
+import { authManager } from "@/plugins/auth";
 import { flushPromises, mount } from "@vue/test-utils";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { playlist } from "../fixtures/playlist";
 import { radio } from "../fixtures/radio";
+import { BUILTIN_ROLE_SCOPES, scopeChecker } from "../fixtures/scopes";
 import { track } from "../fixtures/track";
 
 const { mockGetPlaylistTracks, mockGetRadioTracks, apiMock } = vi.hoisted(
@@ -33,6 +35,15 @@ vi.mock("@/plugins/store", () => ({
   store: { activePlayer: undefined, curQueueItem: undefined },
 }));
 
+// signed in as a member unless a test says otherwise
+vi.mock("@/plugins/auth", async () => {
+  const { BUILTIN_ROLE_SCOPES, scopeChecker } =
+    await import("../fixtures/scopes");
+  return {
+    authManager: { hasScope: vi.fn(scopeChecker(BUILTIN_ROLE_SCOPES.user)) },
+  };
+});
+
 // the real component pulls in router/toast/breakpoint machinery this suite
 // doesn't need; a minimal stand-in keeps the sample's own tracks assertable
 vi.mock("@/components/ListviewItem.vue", () => ({
@@ -58,6 +69,9 @@ function mountSample(itemDetails: Playlist | Radio) {
 describe("DynamicItemSample", () => {
   beforeEach(() => {
     mockGetPlaylistTracks.mockReset();
+    vi.mocked(authManager.hasScope).mockImplementation(
+      scopeChecker(BUILTIN_ROLE_SCOPES.user),
+    );
     mockGetRadioTracks.mockReset();
   });
 
@@ -106,6 +120,18 @@ describe("DynamicItemSample", () => {
 
     await wrapper.find('[data-slot="button"]').trigger("click");
     expect(wrapper.emitted("edit-rules")).toHaveLength(1);
+  });
+
+  it("offers no rule editing to a role that may not change the library", async () => {
+    vi.mocked(authManager.hasScope).mockImplementation(
+      scopeChecker(BUILTIN_ROLE_SCOPES.guest),
+    );
+    mockGetPlaylistTracks.mockResolvedValue([]);
+    const wrapper = mountSample(playlist({ is_dynamic: true }));
+    await flushPromises();
+
+    expect(wrapper.text()).toContain("smart_playlist.empty_desc");
+    expect(wrapper.find('[data-slot="button"]').exists()).toBe(false);
   });
 
   it("has no rules to edit for an empty dynamic radio", async () => {

--- a/tests/components/NavGettingStarted.test.ts
+++ b/tests/components/NavGettingStarted.test.ts
@@ -12,7 +12,7 @@ const { apiMock, authMock, preferenceState, providerConfigs, routerMock } =
       sendCommand: vi.fn(),
       serverInfo: { value: { onboard_done: false } },
     },
-    authMock: { isAdmin: vi.fn(() => true) },
+    authMock: { hasScope: vi.fn(() => true) },
     // replaced with a real ref by the userPreferences mock factory below
     preferenceState: {
       intent: { value: undefined } as { value?: string },
@@ -114,7 +114,7 @@ describe("NavGettingStarted", () => {
       ...providerConfigs.list,
     ]);
     apiMock.subscribe.mockClear();
-    authMock.isAdmin.mockReturnValue(true);
+    authMock.hasScope.mockReturnValue(true);
     preferenceState.intent.value = undefined;
     routerMock.push.mockReset();
   });
@@ -133,7 +133,7 @@ describe("NavGettingStarted", () => {
   });
 
   it("stays away from anyone who is not an admin", async () => {
-    authMock.isAdmin.mockReturnValue(false);
+    authMock.hasScope.mockReturnValue(false);
 
     const wrapper = await mountChecklist();
 

--- a/tests/components/NavGettingStarted.test.ts
+++ b/tests/components/NavGettingStarted.test.ts
@@ -1,6 +1,7 @@
-import { ProviderType } from "@/plugins/api/interfaces";
+import { ProviderType, type Scope } from "@/plugins/api/interfaces";
 import { flushPromises, mount } from "@vue/test-utils";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { BUILTIN_ROLE_SCOPES, scopeChecker } from "../fixtures/scopes";
 
 const { apiMock, authMock, preferenceState, providerConfigs, routerMock } =
   vi.hoisted(() => ({
@@ -12,7 +13,7 @@ const { apiMock, authMock, preferenceState, providerConfigs, routerMock } =
       sendCommand: vi.fn(),
       serverInfo: { value: { onboard_done: false } },
     },
-    authMock: { hasScope: vi.fn(() => true) },
+    authMock: { hasScope: vi.fn<(scope: Scope) => boolean>() },
     // replaced with a real ref by the userPreferences mock factory below
     preferenceState: {
       intent: { value: undefined } as { value?: string },
@@ -114,7 +115,9 @@ describe("NavGettingStarted", () => {
       ...providerConfigs.list,
     ]);
     apiMock.subscribe.mockClear();
-    authMock.hasScope.mockReturnValue(true);
+    authMock.hasScope.mockImplementation(
+      scopeChecker(BUILTIN_ROLE_SCOPES.admin),
+    );
     preferenceState.intent.value = undefined;
     routerMock.push.mockReset();
   });
@@ -132,8 +135,11 @@ describe("NavGettingStarted", () => {
     wrapper.unmount();
   });
 
-  it("stays away from anyone who is not an admin", async () => {
-    authMock.hasScope.mockReturnValue(false);
+  it.each([
+    ["a member", BUILTIN_ROLE_SCOPES.user],
+    ["a guest", BUILTIN_ROLE_SCOPES.guest],
+  ])("stays away from %s, who is not an admin", async (_role, scopes) => {
+    authMock.hasScope.mockImplementation(scopeChecker(scopes));
 
     const wrapper = await mountChecklist();
 

--- a/tests/components/PlaylistAccessSummary.test.ts
+++ b/tests/components/PlaylistAccessSummary.test.ts
@@ -2,6 +2,7 @@ import PlaylistAccessSummary from "@/components/PlaylistAccessSummary.vue";
 import {
   type PlaylistAccess,
   ProviderSharing,
+  type Scope,
   type User,
   type UserSummary,
 } from "@/plugins/api/interfaces";
@@ -9,6 +10,7 @@ import { flushPromises, mount } from "@vue/test-utils";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { playlist } from "../fixtures/playlist";
 import { providerMapping } from "../fixtures/providerMapping";
+import { BUILTIN_ROLE_SCOPES, scopeChecker } from "../fixtures/scopes";
 import { user } from "../fixtures/user";
 
 const { apiMock, authMock, storeMock } = vi.hoisted(() => ({
@@ -16,7 +18,7 @@ const { apiMock, authMock, storeMock } = vi.hoisted(() => ({
     getShareCandidates: vi.fn(),
   },
   authMock: {
-    hasScope: vi.fn<() => boolean>(),
+    hasScope: vi.fn<(scope: Scope) => boolean>(),
   },
   storeMock: {
     currentUser: undefined as User | undefined,
@@ -60,7 +62,8 @@ const mountSummary = async (item: PlaylistAccess | null) => {
 
 beforeEach(() => {
   vi.clearAllMocks();
-  authMock.hasScope.mockReturnValue(false);
+  // a member, who does not manage the library
+  authMock.hasScope.mockImplementation(scopeChecker(BUILTIN_ROLE_SCOPES.user));
   storeMock.currentUser = user({ user_id: "me" });
   apiMock.getShareCandidates.mockResolvedValue(members);
 });
@@ -85,7 +88,9 @@ describe("PlaylistAccessSummary", () => {
   });
 
   it("names another owner to a library manager", async () => {
-    authMock.hasScope.mockReturnValue(true);
+    authMock.hasScope.mockImplementation(
+      scopeChecker(BUILTIN_ROLE_SCOPES.admin),
+    );
     const wrapper = await mountSummary(
       access({
         owner: "other",

--- a/tests/components/ShowDashboardButton.test.ts
+++ b/tests/components/ShowDashboardButton.test.ts
@@ -3,15 +3,18 @@ import {
   EventType,
   type DashboardType,
   type EventMessage,
+  type Scope,
 } from "@/plugins/api/interfaces";
 import { Check } from "@lucide/vue";
 import { mount } from "@vue/test-utils";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { BUILTIN_ROLE_SCOPES, scopeChecker } from "../fixtures/scopes";
 
 const {
   apiMock,
   mockWaitForApiInitialization,
   isDashboardViewerMock,
+  hasScopeMock,
   toastMock,
   copyToClipboardMock,
 } = vi.hoisted(() => ({
@@ -21,6 +24,7 @@ const {
   },
   mockWaitForApiInitialization: vi.fn(),
   isDashboardViewerMock: vi.fn(() => false),
+  hasScopeMock: vi.fn<(scope: Scope) => boolean>(),
   toastMock: { success: vi.fn(), error: vi.fn() },
   copyToClipboardMock: vi.fn(),
 }));
@@ -35,6 +39,7 @@ vi.mock("@/plugins/api/helpers", () => ({
 
 vi.mock("@/plugins/auth", () => ({
   authManager: {
+    hasScope: hasScopeMock,
     isDashboardViewer: isDashboardViewerMock,
   },
 }));
@@ -135,6 +140,7 @@ describe("ShowDashboardButton", () => {
     mockCommands();
     isDashboardViewerMock.mockReset();
     isDashboardViewerMock.mockReturnValue(false);
+    hasScopeMock.mockImplementation(scopeChecker(BUILTIN_ROLE_SCOPES.user));
     toastMock.success.mockReset();
     toastMock.error.mockReset();
     copyToClipboardMock.mockReset();
@@ -164,6 +170,17 @@ describe("ShowDashboardButton", () => {
     await flushAsync();
 
     expect(wrapper.find("button").exists()).toBe(false);
+  });
+
+  it("renders nothing and asks for no dashboards for a role that may not invite", async () => {
+    hasScopeMock.mockImplementation(scopeChecker(BUILTIN_ROLE_SCOPES.guest));
+
+    const wrapper = mountButton();
+    await flushAsync();
+
+    expect(wrapper.find("button").exists()).toBe(false);
+    expect(apiMock.sendCommand).not.toHaveBeenCalled();
+    expect(apiMock.subscribe).not.toHaveBeenCalled();
   });
 
   it("defers fetching until the API connection is initialized", async () => {

--- a/tests/components/ai-radio/ShowCard.test.ts
+++ b/tests/components/ai-radio/ShowCard.test.ts
@@ -1,10 +1,24 @@
 import ShowCard from "@/components/ai-radio/ShowCard.vue";
+import { DropdownMenu, DropdownMenuItem } from "@/components/ui/dropdown-menu";
 import { useShows } from "@/composables/ai-radio/useShows";
 import type { MusicAssistantApi } from "@/plugins/api";
 import { i18n } from "@/plugins/i18n";
-import type { AIRadioSession, AIRadioStation } from "@/plugins/api/interfaces";
+import type {
+  AIRadioSession,
+  AIRadioStation,
+  Scope,
+} from "@/plugins/api/interfaces";
 import { mount } from "@vue/test-utils";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { BUILTIN_ROLE_SCOPES, scopeChecker } from "../../fixtures/scopes";
+
+const { hasScope } = vi.hoisted(() => ({
+  hasScope: vi.fn<(scope: Scope) => boolean>(),
+}));
+
+vi.mock("@/plugins/auth", () => ({
+  authManager: { guestSessionKind: () => null, hasScope },
+}));
 
 vi.mock("@/plugins/api", () => ({
   default: {
@@ -71,5 +85,39 @@ describe("ShowCard status chip", () => {
     const wrapper = renderCard("en_GB", "running");
 
     expect(wrapper.find(".show-card__status-chip").exists()).toBe(false);
+  });
+});
+
+describe("ShowCard editing rights", () => {
+  // the stubs render their slots, so the menu entries show up as well
+  const mountCard = () =>
+    mount(ShowCard, {
+      props: { show },
+      shallow: true,
+      global: { renderStubDefaultSlot: true },
+    });
+
+  it("lets an admin customize, duplicate and delete the show", async () => {
+    hasScope.mockImplementation(scopeChecker(BUILTIN_ROLE_SCOPES.admin));
+    const wrapper = mountCard();
+
+    expect(wrapper.findAllComponents(DropdownMenuItem)).toHaveLength(3);
+    expect(wrapper.attributes("role")).toBe("button");
+    await wrapper.trigger("click");
+    expect(wrapper.emitted("customize")).toEqual([[show.id]]);
+  });
+
+  it.each([
+    ["a member", BUILTIN_ROLE_SCOPES.user],
+    ["a guest", BUILTIN_ROLE_SCOPES.guest],
+  ])("leaves %s only the play button", async (_role, scopes) => {
+    hasScope.mockImplementation(scopeChecker(scopes));
+    const wrapper = mountCard();
+
+    expect(wrapper.findComponent(DropdownMenu).exists()).toBe(false);
+    expect(wrapper.attributes("role")).toBeUndefined();
+    await wrapper.trigger("click");
+    expect(wrapper.emitted("customize")).toBeUndefined();
+    expect(wrapper.find('[aria-label="Play"]').exists()).toBe(true);
   });
 });

--- a/tests/components/navigation/getMenuItems.test.ts
+++ b/tests/components/navigation/getMenuItems.test.ts
@@ -19,6 +19,18 @@ vi.mock("@/composables/userPreferences", () => ({
   setUserPreference: mockSetUserPreference,
 }));
 
+// signed in as a member unless a test says otherwise
+vi.mock("@/plugins/auth", async () => {
+  const { BUILTIN_ROLE_SCOPES, scopeChecker } =
+    await import("../../fixtures/scopes");
+  return {
+    authManager: { hasScope: vi.fn(scopeChecker(BUILTIN_ROLE_SCOPES.user)) },
+  };
+});
+
+import { authManager } from "@/plugins/auth";
+import { BUILTIN_ROLE_SCOPES, scopeChecker } from "../../fixtures/scopes";
+
 import {
   DEFAULT_MENU_ITEMS,
   getMenuItems,
@@ -68,6 +80,9 @@ describe("getMenuItems (sidebar.menu preference)", () => {
     storeMock.libraryAudiobooksCount = 1;
     storeMock.libraryPodcastsCount = 1;
     storeMock.currentUser = { preferences: {} };
+    vi.mocked(authManager.hasScope).mockImplementation(
+      scopeChecker(BUILTIN_ROLE_SCOPES.user),
+    );
   });
 
   it("shows everything in default order for users without any customization", () => {
@@ -177,6 +192,15 @@ describe("getMenuItems (sidebar.menu preference)", () => {
     setPreferences({ [MENU_PREFERENCE_KEY]: {} });
 
     expect(getIds()).not.toContain("party");
+    expect(getIds()).not.toContain("music_quiz");
+  });
+
+  it("leaves out the Music Quiz for a role that may not host one", () => {
+    vi.mocked(authManager.hasScope).mockImplementation(
+      scopeChecker(BUILTIN_ROLE_SCOPES.guest),
+    );
+    storeMock.enabledPlugins = new Set(["music_quiz"]);
+
     expect(getIds()).not.toContain("music_quiz");
   });
 

--- a/tests/components/navigation/getMenuItems.test.ts
+++ b/tests/components/navigation/getMenuItems.test.ts
@@ -1,7 +1,8 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { MicVocal } from "@lucide/vue";
 
-const { storeMock, mockSetUserPreference } = vi.hoisted(() => ({
+const { apiMock, storeMock, mockSetUserPreference } = vi.hoisted(() => ({
+  apiMock: { supportsAIRadioPlaybackScopes: true },
   storeMock: {
     currentUser: null as { preferences?: Record<string, unknown> } | null,
     enabledPlugins: new Set<string>(),
@@ -13,6 +14,10 @@ const { storeMock, mockSetUserPreference } = vi.hoisted(() => ({
 
 vi.mock("@/plugins/store", () => ({
   store: storeMock,
+}));
+
+vi.mock("@/plugins/api", () => ({
+  api: apiMock,
 }));
 
 vi.mock("@/composables/userPreferences", () => ({
@@ -80,6 +85,7 @@ describe("getMenuItems (sidebar.menu preference)", () => {
     storeMock.libraryAudiobooksCount = 1;
     storeMock.libraryPodcastsCount = 1;
     storeMock.currentUser = { preferences: {} };
+    apiMock.supportsAIRadioPlaybackScopes = true;
     vi.mocked(authManager.hasScope).mockImplementation(
       scopeChecker(BUILTIN_ROLE_SCOPES.user),
     );
@@ -203,6 +209,37 @@ describe("getMenuItems (sidebar.menu preference)", () => {
 
     expect(getIds()).not.toContain("music_quiz");
   });
+
+  it("leaves out AI Radio for a member on API schema 74, where only admins play it", () => {
+    apiMock.supportsAIRadioPlaybackScopes = false;
+    storeMock.enabledPlugins = new Set(["ai_radio"]);
+
+    expect(getIds()).not.toContain("ai_radio");
+  });
+
+  it.each([
+    {
+      role: "a member",
+      scopes: BUILTIN_ROLE_SCOPES.user,
+      schema: 75,
+      playbackScopes: true,
+    },
+    {
+      role: "an admin",
+      scopes: BUILTIN_ROLE_SCOPES.admin,
+      schema: 74,
+      playbackScopes: false,
+    },
+  ])(
+    "offers AI Radio to $role on API schema $schema",
+    ({ scopes, playbackScopes }) => {
+      vi.mocked(authManager.hasScope).mockImplementation(scopeChecker(scopes));
+      apiMock.supportsAIRadioPlaybackScopes = playbackScopes;
+      storeMock.enabledPlugins = new Set(["ai_radio"]);
+
+      expect(getIds()).toContain("ai_radio");
+    },
+  );
 
   it("hides items", async () => {
     await setMenuItemHidden("genres", true);

--- a/tests/composables/ai-radio/prefetchGating.test.ts
+++ b/tests/composables/ai-radio/prefetchGating.test.ts
@@ -2,6 +2,7 @@ import { reactive } from "vue";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { ProviderInstance } from "@/plugins/api/interfaces";
 import { ProviderType } from "@/plugins/api/interfaces";
+import { BUILTIN_ROLE_SCOPES, scopeChecker } from "../../fixtures/scopes";
 
 vi.mock("@/plugins/i18n", () => ({
   $t: (key: string) => key,
@@ -24,7 +25,10 @@ const aiRadioProvider: ProviderInstance = {
 };
 
 /** Mocks @/plugins/api and @/plugins/auth for a fresh module import, returning the sendCommand spy. */
-async function mockApiAndAuth(guestSessionKind: string | null) {
+async function mockApiAndAuth(
+  guestSessionKind: string | null,
+  scopes: Parameters<typeof scopeChecker>[0] = BUILTIN_ROLE_SCOPES.user,
+) {
   const providers = reactive<Record<string, ProviderInstance>>({
     ai_radio: aiRadioProvider,
   });
@@ -34,9 +38,10 @@ async function mockApiAndAuth(guestSessionKind: string | null) {
     api: { providers, sendCommand },
     default: { providers, sendCommand },
   }));
+  const hasScope = scopeChecker(scopes);
   vi.doMock("@/plugins/auth", () => ({
-    authManager: { guestSessionKind: () => guestSessionKind },
-    default: { guestSessionKind: () => guestSessionKind },
+    authManager: { guestSessionKind: () => guestSessionKind, hasScope },
+    default: { guestSessionKind: () => guestSessionKind, hasScope },
   }));
 
   return sendCommand;
@@ -49,7 +54,9 @@ async function flushMicrotasks() {
   await Promise.resolve();
 }
 
-describe("ai_radio prefetch gating for session-scoped sessions", () => {
+// every test imports the composables anew after resetting the module registry,
+// which can take seconds under load
+describe("ai_radio prefetch gating", { timeout: 20_000 }, () => {
   afterEach(() => {
     vi.resetModules();
     vi.doUnmock("@/plugins/api");
@@ -60,6 +67,17 @@ describe("ai_radio prefetch gating for session-scoped sessions", () => {
   it("sends no ai_radio commands for a session-scoped session", async () => {
     vi.resetModules();
     const sendCommand = await mockApiAndAuth("dashboard");
+
+    await import("@/composables/ai-radio/useShows");
+    await import("@/composables/ai-radio/useHosts");
+    await flushMicrotasks();
+
+    expect(sendCommand).not.toHaveBeenCalled();
+  });
+
+  it("sends no ai_radio commands for a role that may not load the hosts", async () => {
+    vi.resetModules();
+    const sendCommand = await mockApiAndAuth(null, BUILTIN_ROLE_SCOPES.guest);
 
     await import("@/composables/ai-radio/useShows");
     await import("@/composables/ai-radio/useHosts");

--- a/tests/composables/ai-radio/useHosts.test.ts
+++ b/tests/composables/ai-radio/useHosts.test.ts
@@ -29,9 +29,17 @@ vi.mock("@/plugins/api", async () => {
   };
 });
 
-vi.mock("@/plugins/auth", () => ({
-  authManager: { isAdmin: () => false, guestSessionKind: () => null },
-}));
+// signed in as a member
+vi.mock("@/plugins/auth", async () => {
+  const { BUILTIN_ROLE_SCOPES, scopeChecker } =
+    await import("../../fixtures/scopes");
+  return {
+    authManager: {
+      guestSessionKind: () => null,
+      hasScope: scopeChecker(BUILTIN_ROLE_SCOPES.user),
+    },
+  };
+});
 
 vi.mock("@/plugins/router", () => ({
   default: { push: vi.fn() },

--- a/tests/composables/useBackgroundTasks.test.ts
+++ b/tests/composables/useBackgroundTasks.test.ts
@@ -1,0 +1,60 @@
+import { useBackgroundTasks } from "@/composables/background-tasks/useBackgroundTasks";
+import type { Scope } from "@/plugins/api/interfaces";
+import { flushPromises, mount } from "@vue/test-utils";
+import { defineComponent, h } from "vue";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  BUILTIN_ROLE_SCOPES,
+  OWN_SOURCES_ROLE_SCOPES,
+  scopeChecker,
+} from "../fixtures/scopes";
+
+const { apiMock, hasScope } = vi.hoisted(() => ({
+  apiMock: { getTasks: vi.fn(), subscribe: vi.fn() },
+  hasScope: vi.fn<(scope: Scope) => boolean>(),
+}));
+
+vi.mock("@/plugins/api", () => ({ api: apiMock }));
+
+vi.mock("@/plugins/auth", () => ({ authManager: { hasScope } }));
+
+function mountConsumer() {
+  return mount(
+    defineComponent({
+      setup() {
+        useBackgroundTasks();
+        return () => h("div");
+      },
+    }),
+  );
+}
+
+describe("useBackgroundTasks", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    apiMock.getTasks.mockResolvedValue([]);
+    apiMock.subscribe.mockReturnValue(vi.fn());
+  });
+
+  it("lists and follows the tasks for a role that may read them", async () => {
+    hasScope.mockImplementation(scopeChecker(BUILTIN_ROLE_SCOPES.user));
+
+    const wrapper = mountConsumer();
+    await flushPromises();
+
+    expect(apiMock.getTasks).toHaveBeenCalledOnce();
+    expect(apiMock.subscribe).toHaveBeenCalledOnce();
+    wrapper.unmount();
+  });
+
+  it("asks nothing of the server for a role that may not read the tasks", async () => {
+    hasScope.mockImplementation(scopeChecker(OWN_SOURCES_ROLE_SCOPES));
+
+    const wrapper = mountConsumer();
+    await flushPromises();
+
+    expect(apiMock.getTasks).not.toHaveBeenCalled();
+    expect(apiMock.subscribe).not.toHaveBeenCalled();
+    wrapper.unmount();
+  });
+});

--- a/tests/composables/useOnboarding.test.ts
+++ b/tests/composables/useOnboarding.test.ts
@@ -20,7 +20,7 @@ const {
     sendCommand: vi.fn(),
     serverInfo: { value: undefined as { onboard_done: boolean } | undefined },
   },
-  authMock: { isAdmin: vi.fn(() => true) },
+  authMock: { hasScope: vi.fn(() => true) },
   // replaced with a real ref by the userPreferences mock factory below, so
   // the composable's computed context follows what a test sets here
   preferenceState: { intent: { value: undefined } as { value?: string } },
@@ -122,7 +122,7 @@ describe("useOnboarding", () => {
     apiMock.sendCommand.mockReset();
     apiMock.sendCommand.mockResolvedValue(undefined);
     apiMock.serverInfo.value = { onboard_done: false };
-    authMock.isAdmin.mockReturnValue(true);
+    authMock.hasScope.mockReturnValue(true);
     routerMock.replace.mockReset();
     setUserPreferenceMock.mockReset();
     toastMock.error.mockReset();

--- a/tests/composables/useOnboarding.test.ts
+++ b/tests/composables/useOnboarding.test.ts
@@ -1,5 +1,6 @@
-import { ProviderType } from "@/plugins/api/interfaces";
+import { ProviderType, type Scope } from "@/plugins/api/interfaces";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { BUILTIN_ROLE_SCOPES, scopeChecker } from "../fixtures/scopes";
 
 const {
   apiMock,
@@ -20,7 +21,7 @@ const {
     sendCommand: vi.fn(),
     serverInfo: { value: undefined as { onboard_done: boolean } | undefined },
   },
-  authMock: { hasScope: vi.fn(() => true) },
+  authMock: { hasScope: vi.fn<(scope: Scope) => boolean>() },
   // replaced with a real ref by the userPreferences mock factory below, so
   // the composable's computed context follows what a test sets here
   preferenceState: { intent: { value: undefined } as { value?: string } },
@@ -122,7 +123,9 @@ describe("useOnboarding", () => {
     apiMock.sendCommand.mockReset();
     apiMock.sendCommand.mockResolvedValue(undefined);
     apiMock.serverInfo.value = { onboard_done: false };
-    authMock.hasScope.mockReturnValue(true);
+    authMock.hasScope.mockImplementation(
+      scopeChecker(BUILTIN_ROLE_SCOPES.admin),
+    );
     routerMock.replace.mockReset();
     setUserPreferenceMock.mockReset();
     toastMock.error.mockReset();
@@ -165,6 +168,19 @@ describe("useOnboarding", () => {
       "plugins",
     ]);
     expect(hasPending.value).toBe(true);
+  });
+
+  it.each([
+    ["a member", BUILTIN_ROLE_SCOPES.user],
+    ["a guest", BUILTIN_ROLE_SCOPES.guest],
+  ])("asks nothing of %s, who is not an admin", async (_role, scopes) => {
+    authMock.hasScope.mockImplementation(scopeChecker(scopes));
+    addProvider("spotify--1", "spotify", ProviderType.MUSIC);
+
+    const { steps, hasPending } = await loadOnboarding();
+
+    expect(steps.value).toEqual([]);
+    expect(hasPending.value).toBe(false);
   });
 
   it("decides nothing before the configurations are in", async () => {

--- a/tests/composables/userPreferences.test.ts
+++ b/tests/composables/userPreferences.test.ts
@@ -27,6 +27,18 @@ vi.mock("@/plugins/store", () => ({
   store: storeMock,
 }));
 
+// signed in as a member unless a test says otherwise
+vi.mock("@/plugins/auth", async () => {
+  const { BUILTIN_ROLE_SCOPES, scopeChecker } =
+    await import("../fixtures/scopes");
+  return {
+    authManager: { hasScope: vi.fn(scopeChecker(BUILTIN_ROLE_SCOPES.user)) },
+  };
+});
+
+import { authManager } from "@/plugins/auth";
+import { BUILTIN_ROLE_SCOPES, scopeChecker } from "../fixtures/scopes";
+
 import {
   pruneStaleProviderFilters,
   useUserPreferences,
@@ -128,6 +140,9 @@ describe("pruneStaleProviderFilters", () => {
     mockGetProviderConfigs.mockResolvedValue([
       { instance_id: "spotify1" } as ProviderConfig,
     ]);
+    vi.mocked(authManager.hasScope).mockImplementation(
+      scopeChecker(BUILTIN_ROLE_SCOPES.user),
+    );
   });
 
   it("drops deconfigured provider ids from both itemsListing and discover row filters", async () => {
@@ -174,5 +189,22 @@ describe("pruneStaleProviderFilters", () => {
     await pruneStaleProviderFilters();
 
     expect(storeMock.currentUser.preferences).toEqual({});
+  });
+
+  it("leaves the filters alone for a role that may not list the providers", async () => {
+    vi.mocked(authManager.hasScope).mockImplementation(
+      scopeChecker(BUILTIN_ROLE_SCOPES.guest),
+    );
+    storeMock.currentUser = {
+      user_id: "u1",
+      preferences: {
+        "discover.hiddenProviders.recently_played": ["removed1"],
+      },
+    };
+
+    await pruneStaleProviderFilters();
+
+    expect(mockGetProviderConfigs).not.toHaveBeenCalled();
+    expect(mockUpdateUser).not.toHaveBeenCalled();
   });
 });

--- a/tests/fixtures/scopes.ts
+++ b/tests/fixtures/scopes.ts
@@ -1,0 +1,42 @@
+import { Scope } from "@/plugins/api/interfaces";
+
+// the scopes the server grants its builtin roles
+const GUEST_SCOPES: readonly Scope[] = [
+  Scope.LIBRARY_READ,
+  Scope.PLAYERS_READ,
+  Scope.PLAYERS_CONTROL,
+  Scope.QUEUES_READ,
+  Scope.QUEUES_CONTROL,
+  Scope.PROVIDERS_READ,
+  Scope.CONFIG_PLAYERS_READ,
+];
+const MEMBER_SCOPES: readonly Scope[] = [
+  ...GUEST_SCOPES,
+  Scope.LIBRARY_WRITE,
+  Scope.CONFIG_PROVIDERS_READ,
+  Scope.CONFIG_CORE_READ,
+  Scope.USERS_INVITE,
+  Scope.SYSTEM_READ,
+  Scope.CONFIG_PROVIDERS_OWN,
+];
+
+export const BUILTIN_ROLE_SCOPES = {
+  admin: [Scope.ALL],
+  user: MEMBER_SCOPES,
+  guest: GUEST_SCOPES,
+} satisfies Record<string, readonly Scope[]>;
+
+// A custom role that holds a single member scope on top of the guest scopes,
+// as the server reports it: managing own music sources implies reading the
+// provider configs.
+export const OWN_SOURCES_ROLE_SCOPES: readonly Scope[] = [
+  ...GUEST_SCOPES,
+  Scope.CONFIG_PROVIDERS_OWN,
+  Scope.CONFIG_PROVIDERS_READ,
+];
+
+/** A scope check for a role granting the given scopes, like AuthManager.hasScope. */
+export const scopeChecker =
+  (scopes: readonly Scope[]) =>
+  (scope: Scope): boolean =>
+    scopes.includes(Scope.ALL) || scopes.includes(scope);

--- a/tests/helpers/mediaItemClickActions.test.ts
+++ b/tests/helpers/mediaItemClickActions.test.ts
@@ -36,6 +36,15 @@ vi.mock("@/plugins/store", () => ({
   },
 }));
 
+// signed in as a member unless a test says otherwise
+vi.mock("@/plugins/auth", async () => {
+  const { BUILTIN_ROLE_SCOPES, scopeChecker } =
+    await import("../fixtures/scopes");
+  return {
+    authManager: { hasScope: vi.fn(scopeChecker(BUILTIN_ROLE_SCOPES.user)) },
+  };
+});
+
 vi.mock("@/plugins/breakpoint", () => ({
   getBreakpointValue: vi.fn(() => false),
 }));
@@ -70,12 +79,14 @@ import {
   handleMediaItemClick,
   handlePlayBtnClick,
 } from "@/helpers/media_item_actions";
+import { authManager } from "@/plugins/auth";
 import { album } from "../fixtures/album";
 import { artist } from "../fixtures/artist";
 import { audioSource } from "../fixtures/audioSource";
 import { genre } from "../fixtures/genre";
 import { playlist } from "../fixtures/playlist";
 import { radio } from "../fixtures/radio";
+import { BUILTIN_ROLE_SCOPES, scopeChecker } from "../fixtures/scopes";
 import { track } from "../fixtures/track";
 
 const playedTrack = track({ item_id: "track1", name: "Track 1" });
@@ -87,6 +98,9 @@ beforeEach(() => {
   mockPlayMedia.mockResolvedValue(undefined);
   mockGetCoreConfigValue.mockReset();
   mockRouterPush.mockReset();
+  vi.mocked(authManager.hasScope).mockImplementation(
+    scopeChecker(BUILTIN_ROLE_SCOPES.user),
+  );
 });
 
 describe("handlePlayBtnClick honours default_play_action_*_track", () => {
@@ -259,5 +273,35 @@ describe("handleMediaItemClick honours default_click_action_*", () => {
       },
     });
     expect(mockPlayMedia).not.toHaveBeenCalled();
+  });
+});
+
+describe("click behaviour for a role that may not read the core settings", () => {
+  beforeEach(() => {
+    vi.mocked(authManager.hasScope).mockImplementation(
+      scopeChecker(BUILTIN_ROLE_SCOPES.guest),
+    );
+  });
+
+  it("plays the playlist from the track without asking the server", async () => {
+    await handlePlayBtnClick(playedTrack, 0, 0, parentPlaylist);
+
+    expect(mockGetCoreConfigValue).not.toHaveBeenCalled();
+    expect(mockPlayMedia).toHaveBeenCalledWith(parentPlaylist.uri, undefined, {
+      start_item: playedTrack.item_id,
+      sort_by: undefined,
+    });
+  });
+
+  it("opens the details view without asking the server", async () => {
+    const item = album({ item_id: "a1" });
+
+    await handleMediaItemClick(item, 0, 0);
+
+    expect(mockGetCoreConfigValue).not.toHaveBeenCalled();
+    expect(mockRouterPush).toHaveBeenCalledWith({
+      name: item.media_type,
+      params: { itemId: item.item_id, provider: item.provider },
+    });
   });
 });

--- a/tests/helpers/migratePlaylistAction.test.ts
+++ b/tests/helpers/migratePlaylistAction.test.ts
@@ -14,8 +14,10 @@ import {
   ProviderFeature,
   ProviderType,
 } from "@/plugins/api/interfaces";
+import { authManager } from "@/plugins/auth";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { playlist } from "../fixtures/playlist";
+import { BUILTIN_ROLE_SCOPES, scopeChecker } from "../fixtures/scopes";
 
 const { apiMock, storeMock, mockEventbusEmit } = vi.hoisted(() => ({
   apiMock: {
@@ -31,9 +33,6 @@ const { apiMock, storeMock, mockEventbusEmit } = vi.hoisted(() => ({
 }));
 
 vi.mock("@/plugins/api", () => ({ default: apiMock, api: apiMock }));
-vi.mock("@/plugins/auth", () => ({
-  authManager: { hasScope: () => false },
-}));
 vi.mock("@/plugins/store", () => ({ store: storeMock }));
 vi.mock("@/plugins/eventbus", () => ({
   eventbus: {
@@ -43,6 +42,14 @@ vi.mock("@/plugins/eventbus", () => ({
   },
 }));
 vi.mock("@/plugins/i18n", () => ({ $t: (key: string) => key }));
+// signed in as a member unless a test says otherwise
+vi.mock("@/plugins/auth", async () => {
+  const { BUILTIN_ROLE_SCOPES, scopeChecker } =
+    await import("../fixtures/scopes");
+  return {
+    authManager: { hasScope: vi.fn(scopeChecker(BUILTIN_ROLE_SCOPES.user)) },
+  };
+});
 
 const builtinProvider = () => ({
   type: ProviderType.MUSIC,
@@ -65,6 +72,9 @@ beforeEach(() => {
   apiMock.providers = { builtin: builtinProvider() };
   apiMock.getProvider.mockImplementation((id: string) => apiMock.providers[id]);
   storeMock.enabledPlugins = new Set();
+  vi.mocked(authManager.hasScope).mockImplementation(
+    scopeChecker(BUILTIN_ROLE_SCOPES.user),
+  );
 });
 
 describe("migrate playlist context menu action", () => {
@@ -118,5 +128,14 @@ describe("migrate playlist context menu action", () => {
     expect(mockEventbusEmit).toHaveBeenCalledWith("migratePlaylistDialog", {
       playlist: item,
     });
+  });
+
+  it("is not offered to a role that may not change the library", async () => {
+    vi.mocked(authManager.hasScope).mockImplementation(
+      scopeChecker(BUILTIN_ROLE_SCOPES.guest),
+    );
+    const item = playlist();
+    const items = await getContextMenuItems([item], item);
+    expect(migrateAction(items)).toBeUndefined();
   });
 });

--- a/tests/helpers/playBtnErrorFeedback.test.ts
+++ b/tests/helpers/playBtnErrorFeedback.test.ts
@@ -30,6 +30,15 @@ vi.mock("@/plugins/store", () => ({
   store: mockStore,
 }));
 
+// signed in as a member
+vi.mock("@/plugins/auth", async () => {
+  const { BUILTIN_ROLE_SCOPES, scopeChecker } =
+    await import("../fixtures/scopes");
+  return {
+    authManager: { hasScope: vi.fn(scopeChecker(BUILTIN_ROLE_SCOPES.user)) },
+  };
+});
+
 vi.mock("@/plugins/breakpoint", () => ({
   getBreakpointValue: vi.fn(() => false),
 }));

--- a/tests/helpers/playFromHereSort.test.ts
+++ b/tests/helpers/playFromHereSort.test.ts
@@ -37,6 +37,15 @@ vi.mock("@/plugins/store", () => ({
   },
 }));
 
+// signed in as a member
+vi.mock("@/plugins/auth", async () => {
+  const { BUILTIN_ROLE_SCOPES, scopeChecker } =
+    await import("../fixtures/scopes");
+  return {
+    authManager: { hasScope: vi.fn(scopeChecker(BUILTIN_ROLE_SCOPES.user)) },
+  };
+});
+
 vi.mock("@/plugins/breakpoint", () => ({
   getBreakpointValue: vi.fn(() => false),
 }));

--- a/tests/helpers/playMenuShuffle.test.ts
+++ b/tests/helpers/playMenuShuffle.test.ts
@@ -37,6 +37,15 @@ vi.mock("@/plugins/store", () => ({
   store: mockStore,
 }));
 
+// signed in as a member
+vi.mock("@/plugins/auth", async () => {
+  const { BUILTIN_ROLE_SCOPES, scopeChecker } =
+    await import("../fixtures/scopes");
+  return {
+    authManager: { hasScope: vi.fn(scopeChecker(BUILTIN_ROLE_SCOPES.user)) },
+  };
+});
+
 vi.mock("@/plugins/eventbus", () => ({
   eventbus: {
     on: vi.fn(),

--- a/tests/helpers/player_menu_items.test.ts
+++ b/tests/helpers/player_menu_items.test.ts
@@ -499,6 +499,18 @@ describe("getPlayerMenuItems ai dj", () => {
     expect(menuItems.map((item) => item.label)).not.toContain("ai_dj");
   });
 
+  it("omits the ai_dj entry for a role that may not load the hosts", () => {
+    hasScope.mockImplementation(scopeChecker(BUILTIN_ROLE_SCOPES.guest));
+    aiRadioAvailableRef.value = true;
+    hostsRef.value = [makeHost()];
+
+    const menuItems = getPlayerMenuItems(makePlayer(), makeQueue(), {
+      context: "queue",
+    });
+
+    expect(menuItems.map((item) => item.label)).not.toContain("ai_dj");
+  });
+
   it("lists one entry per host plus an off entry when ai_radio is available", () => {
     aiRadioAvailableRef.value = true;
     hostsRef.value = [

--- a/tests/helpers/player_menu_items.test.ts
+++ b/tests/helpers/player_menu_items.test.ts
@@ -16,17 +16,19 @@ import {
   type PlayerQueue,
   type PlayerSource,
   RepeatMode,
+  Scope,
 } from "@/plugins/api/interfaces";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { playerQueue } from "../fixtures/playerQueue";
 import { playerSource } from "../fixtures/playerSource";
+import { BUILTIN_ROLE_SCOPES, scopeChecker } from "../fixtures/scopes";
 
 const {
   aiRadioAvailableRef,
   announcementAvailableRef,
   emitEvent,
+  hasScope,
   hostsRef,
-  isAdmin,
   loadHosts,
   loadQueueDjStatus,
   loadStatus,
@@ -42,8 +44,8 @@ const {
   aiRadioAvailableRef: { value: false },
   announcementAvailableRef: { value: false },
   emitEvent: vi.fn(),
+  hasScope: vi.fn<(scope: Scope) => boolean>(),
   hostsRef: { value: [] as AIRadioHost[] },
-  isAdmin: vi.fn(),
   loadHosts: vi.fn().mockResolvedValue(undefined),
   loadQueueDjStatus: vi.fn().mockResolvedValue(undefined),
   loadStatus: vi.fn().mockResolvedValue(undefined),
@@ -73,7 +75,7 @@ vi.mock("@/plugins/api", () => ({
 
 vi.mock("@/plugins/auth", () => ({
   authManager: {
-    isAdmin,
+    hasScope,
   },
 }));
 
@@ -140,6 +142,11 @@ vi.mock("vue-sonner", () => ({
     error: vi.fn(),
   },
 }));
+
+// a member unless a test says otherwise
+beforeEach(() => {
+  hasScope.mockImplementation(scopeChecker(BUILTIN_ROLE_SCOPES.user));
+});
 
 function makePlayer(overrides: Partial<Player> = {}): Player {
   return {
@@ -281,7 +288,7 @@ describe("getPlayerMenuItems settings shortcuts", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
-    isAdmin.mockReturnValue(true);
+    hasScope.mockImplementation(scopeChecker(BUILTIN_ROLE_SCOPES.admin));
     storeMock.showFullscreenPlayer = true;
     storeMock.showPlayersMenu = true;
   });
@@ -367,14 +374,47 @@ describe("getPlayerMenuItems settings shortcuts", () => {
     ).toEqual(["settings.player_settings", "settings.category.dsp"]);
   });
 
-  it("keeps the settings out of a non-admin's menu", () => {
-    isAdmin.mockReturnValue(false);
+  it("keeps the settings out of a member's menu", () => {
+    hasScope.mockImplementation(scopeChecker(BUILTIN_ROLE_SCOPES.user));
 
     const menuItems = getPlayerMenuItems(makePlayer(), makeQueue(), {
       context: "player",
     });
 
     expect(menuItems.map((item) => item.label)).not.toContain("open_settings");
+  });
+
+  it("offers the settings to any role that may change player settings", () => {
+    hasScope.mockImplementation(
+      scopeChecker([...BUILTIN_ROLE_SCOPES.guest, Scope.CONFIG_PLAYERS_WRITE]),
+    );
+
+    const menuItems = getPlayerMenuItems(makePlayer(), makeQueue(), {
+      context: "player",
+    });
+
+    expect(openSettingsItem(menuItems)).toBeDefined();
+  });
+});
+
+describe("getPlayerMenuItems save queue as playlist", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  const labels = () =>
+    getPlayerMenuItems(makePlayer(), makeQueue({ items: 3 }), {
+      context: "queue",
+    }).map((item) => item.label);
+
+  it("offers saving the queue to a member", () => {
+    expect(labels()).toContain("save_queue_as_playlist");
+  });
+
+  it("keeps saving the queue from a role that may not change the library", () => {
+    hasScope.mockImplementation(scopeChecker(BUILTIN_ROLE_SCOPES.guest));
+
+    expect(labels()).not.toContain("save_queue_as_playlist");
   });
 });
 

--- a/tests/helpers/player_settings_actions.test.ts
+++ b/tests/helpers/player_settings_actions.test.ts
@@ -4,6 +4,7 @@ import {
   PlayerType,
   ProviderFeature,
   ProviderType,
+  Scope,
   type Player,
   type PlayerConfig,
   type PlayerOption,
@@ -11,32 +12,45 @@ import {
 } from "@/plugins/api/interfaces";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { providerManifest } from "../fixtures/providerManifest";
+import { BUILTIN_ROLE_SCOPES, scopeChecker } from "../fixtures/scopes";
 
-const { apiMock, emitEvent, routerPush, setPreference, storeMock, toastMock } =
-  vi.hoisted(() => ({
-    apiMock: {
-      getProvider: vi.fn(),
-      getProviderManifest: vi.fn(),
-      players: {} as Record<string, unknown>,
-      queues: {} as Record<string, unknown>,
-      removePlayer: vi.fn(),
-      savePlayerConfig: vi.fn(),
-    },
-    emitEvent: vi.fn(),
-    routerPush: vi.fn(),
-    setPreference: vi.fn(),
-    storeMock: {
-      activePlayerId: undefined as string | undefined,
-    },
-    toastMock: {
-      error: vi.fn(),
-      success: vi.fn(),
-    },
-  }));
+const {
+  apiMock,
+  emitEvent,
+  hasScope,
+  routerPush,
+  setPreference,
+  storeMock,
+  toastMock,
+} = vi.hoisted(() => ({
+  apiMock: {
+    getProvider: vi.fn(),
+    getProviderManifest: vi.fn(),
+    players: {} as Record<string, unknown>,
+    queues: {} as Record<string, unknown>,
+    removePlayer: vi.fn(),
+    savePlayerConfig: vi.fn(),
+  },
+  emitEvent: vi.fn(),
+  hasScope: vi.fn<(scope: Scope) => boolean>(),
+  routerPush: vi.fn(),
+  setPreference: vi.fn(),
+  storeMock: {
+    activePlayerId: undefined as string | undefined,
+  },
+  toastMock: {
+    error: vi.fn(),
+    success: vi.fn(),
+  },
+}));
 
 vi.mock("@/plugins/api", () => ({
   api: apiMock,
   default: apiMock,
+}));
+
+vi.mock("@/plugins/auth", () => ({
+  authManager: { hasScope },
 }));
 
 vi.mock("@/plugins/eventbus", () => ({
@@ -82,6 +96,11 @@ const SECTION_LABELS = [
   "open_dsp_settings",
   "player_options.open",
 ];
+
+// an admin unless a test says otherwise
+beforeEach(() => {
+  hasScope.mockImplementation(scopeChecker(BUILTIN_ROLE_SCOPES.admin));
+});
 
 describe("getPlayerSettingsMenuItems sections", () => {
   beforeEach(() => {
@@ -283,6 +302,40 @@ describe("getPlayerSettingsMenuItems actions", () => {
     // it was not the player that left, so nothing about the selection changes
     expect(setPreference).not.toHaveBeenCalled();
   });
+});
+
+describe("getPlayerSettingsMenuItems provider settings", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    registerPlayer();
+    apiMock.getProvider.mockReturnValue(providerInstance());
+    apiMock.getProviderManifest.mockReturnValue(providerManifest());
+  });
+
+  const offersProviderSettings = () =>
+    visibleLabels(getPlayerSettingsMenuItems(playerConfig())).includes(
+      "settings.provider_settings",
+    );
+
+  it("links an admin to the settings of the player provider", () => {
+    expect(offersProviderSettings()).toBe(true);
+  });
+
+  it.each([
+    { role: "a member", scopes: BUILTIN_ROLE_SCOPES.user },
+    { role: "a guest", scopes: BUILTIN_ROLE_SCOPES.guest },
+    {
+      role: "a role that only changes player settings",
+      scopes: [...BUILTIN_ROLE_SCOPES.guest, Scope.CONFIG_PLAYERS_WRITE],
+    },
+  ])(
+    "keeps $role away from the settings of the player provider",
+    ({ scopes }) => {
+      hasScope.mockImplementation(scopeChecker(scopes));
+
+      expect(offersProviderSettings()).toBe(false);
+    },
+  );
 });
 
 /**

--- a/tests/helpers/playlistAccessActions.test.ts
+++ b/tests/helpers/playlistAccessActions.test.ts
@@ -15,11 +15,13 @@ import {
   ProviderFeature,
   ProviderSharing,
   ProviderType,
+  type Scope,
   type User,
 } from "@/plugins/api/interfaces";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { playlist } from "../fixtures/playlist";
 import { providerMapping } from "../fixtures/providerMapping";
+import { BUILTIN_ROLE_SCOPES, scopeChecker } from "../fixtures/scopes";
 import { user } from "../fixtures/user";
 
 const { apiMock, authMock, storeMock, mockEventbusEmit } = vi.hoisted(() => ({
@@ -30,7 +32,7 @@ const { apiMock, authMock, storeMock, mockEventbusEmit } = vi.hoisted(() => ({
     players: {},
   },
   authMock: {
-    hasScope: vi.fn<() => boolean>(),
+    hasScope: vi.fn<(scope: Scope) => boolean>(),
   },
   storeMock: {
     currentUser: undefined as User | undefined,
@@ -70,7 +72,8 @@ const shareAction = (items: ContextMenuItem[]): ContextMenuItem | undefined =>
 
 beforeEach(() => {
   vi.clearAllMocks();
-  authMock.hasScope.mockReturnValue(false);
+  // a member, who may change the library but does not manage all of it
+  authMock.hasScope.mockImplementation(scopeChecker(BUILTIN_ROLE_SCOPES.user));
   storeMock.currentUser = user({ user_id: "me" });
   apiMock.providers = {
     builtin: {
@@ -97,7 +100,9 @@ describe("share playlist context menu action", () => {
   });
 
   it("is offered to a library manager for another member's playlist", async () => {
-    authMock.hasScope.mockReturnValue(true);
+    authMock.hasScope.mockImplementation(
+      scopeChecker(BUILTIN_ROLE_SCOPES.admin),
+    );
     const items = await getContextMenuItems([maPlaylist("other")]);
 
     expect(shareAction(items)).toBeDefined();
@@ -109,8 +114,19 @@ describe("share playlist context menu action", () => {
     expect(shareAction(items)).toBeUndefined();
   });
 
+  it("is not offered to an owner whose role may not change the library", async () => {
+    authMock.hasScope.mockImplementation(
+      scopeChecker(BUILTIN_ROLE_SCOPES.guest),
+    );
+    const items = await getContextMenuItems([maPlaylist("me")]);
+
+    expect(shareAction(items)).toBeUndefined();
+  });
+
   it("is not offered for a playlist of a music source", async () => {
-    authMock.hasScope.mockReturnValue(true);
+    authMock.hasScope.mockImplementation(
+      scopeChecker(BUILTIN_ROLE_SCOPES.admin),
+    );
     const item = playlist({
       provider_mappings: [providerMapping({ provider_domain: "spotify" })],
     });
@@ -120,7 +136,9 @@ describe("share playlist context menu action", () => {
   });
 
   it("leaves a playlist mapping without provider mappings alone", async () => {
-    authMock.hasScope.mockReturnValue(true);
+    authMock.hasScope.mockImplementation(
+      scopeChecker(BUILTIN_ROLE_SCOPES.admin),
+    );
     const mapping = {
       item_id: "1",
       provider: "library",

--- a/tests/layouts/CreatePlaylistDialog.test.ts
+++ b/tests/layouts/CreatePlaylistDialog.test.ts
@@ -1,0 +1,116 @@
+/**
+ * Saving a queue as a playlist runs as a background task; its toast offers the
+ * task list only to a role that may read it.
+ */
+import CreatePlaylistDialog from "@/layouts/default/CreatePlaylistDialog.vue";
+import type { Scope } from "@/plugins/api/interfaces";
+import type { CreatePlaylistEvent } from "@/plugins/eventbus";
+import { enableAutoUnmount, flushPromises, mount } from "@vue/test-utils";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { BUILTIN_ROLE_SCOPES, scopeChecker } from "../fixtures/scopes";
+
+const { apiMock, eventHandlers, hasScope, routerPush, storeMock, toastMock } =
+  vi.hoisted(() => ({
+    apiMock: {
+      getProvider: vi.fn(),
+      queueCommandSaveAsPlaylist: vi.fn(),
+    },
+    eventHandlers: new Map<string, (event: CreatePlaylistEvent) => void>(),
+    hasScope: vi.fn<(scope: Scope) => boolean>(),
+    routerPush: vi.fn(),
+    storeMock: { dialogActive: false, showFullscreenPlayer: true },
+    toastMock: { error: vi.fn(), info: vi.fn(), success: vi.fn() },
+  }));
+
+vi.mock("@/plugins/api", () => ({ api: apiMock, default: apiMock }));
+vi.mock("@/plugins/auth", () => ({ authManager: { hasScope } }));
+vi.mock("@/plugins/eventbus", () => ({
+  eventbus: {
+    on: (event: string, handler: (payload: CreatePlaylistEvent) => void) =>
+      eventHandlers.set(event, handler),
+    off: (event: string) => eventHandlers.delete(event),
+  },
+}));
+vi.mock("@/plugins/i18n", () => ({ $t: (key: string) => key }));
+vi.mock("@/plugins/router", () => ({ default: { push: routerPush } }));
+vi.mock("@/plugins/store", () => ({ store: storeMock }));
+vi.mock("vue-sonner", () => ({ toast: toastMock }));
+
+enableAutoUnmount(afterEach);
+
+const passthroughStub = { template: "<div><slot /></div>" };
+
+interface TaskToastOptions {
+  action?: { label: string; onClick: () => void };
+}
+
+/**
+ * Save the queue as a playlist through the dialog and hand back the options of
+ * the toast announcing the task.
+ */
+async function saveQueueAsPlaylist(): Promise<TaskToastOptions> {
+  const wrapper = mount(CreatePlaylistDialog, {
+    global: {
+      stubs: {
+        Button: { template: "<button><slot /></button>" },
+        Dialog: passthroughStub,
+        DialogContent: passthroughStub,
+        DialogDescription: passthroughStub,
+        DialogFooter: passthroughStub,
+        DialogHeader: passthroughStub,
+        DialogTitle: passthroughStub,
+        Input: {
+          props: ["modelValue"],
+          emits: ["update:modelValue"],
+          template:
+            '<input :value="modelValue" @input="$emit(\'update:modelValue\', $event.target.value)" />',
+        },
+        Label: passthroughStub,
+      },
+    },
+  });
+  eventHandlers.get("createPlaylist")?.({ queueId: "kitchen" });
+  await flushPromises();
+  await wrapper.get("input").setValue("Road trip");
+  await wrapper
+    .findAll("button")
+    .find((button) => button.text() === "settings.save")
+    ?.trigger("click");
+  await flushPromises();
+  expect(apiMock.queueCommandSaveAsPlaylist).toHaveBeenCalledWith(
+    "kitchen",
+    "Road trip",
+    { showBackgroundTaskToast: false },
+  );
+  return toastMock.info.mock.calls[0][1];
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  apiMock.queueCommandSaveAsPlaylist.mockResolvedValue({});
+  storeMock.showFullscreenPlayer = true;
+});
+
+describe("CreatePlaylistDialog saving a queue", () => {
+  it.each([
+    { role: "an admin", scopes: BUILTIN_ROLE_SCOPES.admin },
+    { role: "a member", scopes: BUILTIN_ROLE_SCOPES.user },
+  ])("offers $role the task list with the task toast", async ({ scopes }) => {
+    hasScope.mockImplementation(scopeChecker(scopes));
+
+    const toast = await saveQueueAsPlaylist();
+    toast.action?.onClick();
+
+    expect(toast.action?.label).toBe("background_tasks.open");
+    expect(storeMock.showFullscreenPlayer).toBe(false);
+    expect(routerPush).toHaveBeenCalledWith({ name: "backgroundtasks" });
+  });
+
+  it("leaves the task list out of the task toast for a guest", async () => {
+    hasScope.mockImplementation(scopeChecker(BUILTIN_ROLE_SCOPES.guest));
+
+    const toast = await saveQueueAsPlaylist();
+
+    expect(toast.action).toBeUndefined();
+  });
+});

--- a/tests/layouts/FavoriteMenuBtn.test.ts
+++ b/tests/layouts/FavoriteMenuBtn.test.ts
@@ -5,9 +5,11 @@ import {
   type PlayableMediaItemType,
   type QueueItem,
 } from "@/plugins/api/interfaces";
+import { authManager } from "@/plugins/auth";
 import { eventbus } from "@/plugins/eventbus";
 import { store } from "@/plugins/store";
 import { queueItem } from "../fixtures/queueItem";
+import { BUILTIN_ROLE_SCOPES, scopeChecker } from "../fixtures/scopes";
 import { track } from "../fixtures/track";
 import { enableAutoUnmount, flushPromises, mount } from "@vue/test-utils";
 import {
@@ -34,6 +36,15 @@ vi.mock("@/plugins/api", () => {
 });
 
 vi.mock("@/plugins/eventbus", () => ({ eventbus: { emit: vi.fn() } }));
+
+// signed in as a member unless a test says otherwise
+vi.mock("@/plugins/auth", async () => {
+  const { BUILTIN_ROLE_SCOPES, scopeChecker } =
+    await import("../fixtures/scopes");
+  return {
+    authManager: { hasScope: vi.fn(scopeChecker(BUILTIN_ROLE_SCOPES.user)) },
+  };
+});
 
 const addItemToFavorites = vi.mocked(api.addItemToFavorites);
 const removeItemFromFavorites = vi.mocked(api.removeItemFromFavorites);
@@ -138,6 +149,9 @@ enableAutoUnmount(afterEach);
 
 beforeEach(async () => {
   vi.clearAllMocks();
+  vi.mocked(authManager.hasScope).mockImplementation(
+    scopeChecker(BUILTIN_ROLE_SCOPES.user),
+  );
   await setPlaying(track());
 });
 
@@ -158,6 +172,17 @@ describe("FavoriteMenuBtn", () => {
       expect(text).toContain("add_playlist");
     },
   );
+
+  it("is not offered to a role that may not change the library", () => {
+    vi.mocked(authManager.hasScope).mockImplementation(
+      scopeChecker(BUILTIN_ROLE_SCOPES.guest),
+    );
+
+    const wrapper = mountButton();
+
+    expect(wrapper.find("button").exists()).toBe(false);
+    expect(wrapper.text()).not.toContain("favorites_add");
+  });
 
   it("adds the playing item to the favourites", async () => {
     const item = track();

--- a/tests/layouts/ItemContextMenuHydration.test.ts
+++ b/tests/layouts/ItemContextMenuHydration.test.ts
@@ -28,10 +28,16 @@ const { apiMock, emittedMenus, storeMock } = vi.hoisted(() => ({
 }));
 
 vi.mock("@/plugins/api", () => ({ default: apiMock, api: apiMock }));
-vi.mock("@/plugins/auth", () => ({
-  authManager: { hasScope: () => false },
-}));
 vi.mock("@/plugins/store", () => ({ store: storeMock }));
+// signed in as a member
+vi.mock("@/plugins/auth", async () => {
+  const { BUILTIN_ROLE_SCOPES, scopeChecker } =
+    await import("../fixtures/scopes");
+  return {
+    authManager: { hasScope: vi.fn(scopeChecker(BUILTIN_ROLE_SCOPES.user)) },
+  };
+});
+
 vi.mock("@/plugins/eventbus", () => ({
   eventbus: {
     on: vi.fn(),

--- a/tests/layouts/ItemContextMenuPlayback.test.ts
+++ b/tests/layouts/ItemContextMenuPlayback.test.ts
@@ -5,10 +5,12 @@ import {
 } from "@/layouts/default/ItemContextMenu.vue";
 import type { ContextMenuDialogEvent } from "@/plugins/eventbus";
 import { QueueOption } from "@/plugins/api/interfaces";
+import { authManager } from "@/plugins/auth";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { audioSource } from "../fixtures/audioSource";
 import { providerMapping } from "../fixtures/providerMapping";
 import { radio } from "../fixtures/radio";
+import { BUILTIN_ROLE_SCOPES, scopeChecker } from "../fixtures/scopes";
 import { track } from "../fixtures/track";
 
 const { apiMock, emittedMenus, storeMock } = vi.hoisted(() => ({
@@ -28,6 +30,14 @@ const { apiMock, emittedMenus, storeMock } = vi.hoisted(() => ({
 
 vi.mock("@/plugins/api", () => ({ default: apiMock, api: apiMock }));
 vi.mock("@/plugins/store", () => ({ store: storeMock }));
+// signed in as a member unless a test says otherwise
+vi.mock("@/plugins/auth", async () => {
+  const { BUILTIN_ROLE_SCOPES, scopeChecker } =
+    await import("../fixtures/scopes");
+  return {
+    authManager: { hasScope: vi.fn(scopeChecker(BUILTIN_ROLE_SCOPES.user)) },
+  };
+});
 vi.mock("@/plugins/eventbus", () => ({
   eventbus: {
     on: vi.fn(),
@@ -45,6 +55,9 @@ beforeEach(() => {
   vi.clearAllMocks();
   emittedMenus.length = 0;
   apiMock.getCoreConfigValue.mockResolvedValue(QueueOption.REPLACE);
+  vi.mocked(authManager.hasScope).mockImplementation(
+    scopeChecker(BUILTIN_ROLE_SCOPES.user),
+  );
 });
 
 describe("getPlaybackContextMenuItems", () => {
@@ -106,4 +119,40 @@ describe("showPlayMenuForMediaItem", () => {
 
     expect(emittedItems()).toHaveLength(5);
   });
+});
+
+describe("the play menu for a role that may not read the core settings", () => {
+  beforeEach(() => {
+    vi.mocked(authManager.hasScope).mockImplementation(
+      scopeChecker(BUILTIN_ROLE_SCOPES.guest),
+    );
+  });
+
+  it("starts an audio source the server's default way without asking it", async () => {
+    const source = audioSource({ provider_mappings: mappings });
+
+    const items = await getPlaybackContextMenuItems([source]);
+    items[0].action?.();
+
+    expect(apiMock.getCoreConfigValue).not.toHaveBeenCalled();
+    expect(apiMock.playMedia).toHaveBeenCalledWith(
+      [source.uri],
+      QueueOption.REPLACE,
+    );
+  });
+
+  // the enqueue options are listed as play, next, add, replace, replace next
+  it.each([
+    { item: track({ provider_mappings: mappings }), selected: 0 },
+    { item: radio({ provider_mappings: mappings }), selected: 3 },
+  ])(
+    "marks the server's default for a $item.media_type without asking it",
+    async ({ item, selected }) => {
+      const items = await getPlaybackContextMenuItems([item]);
+      const options = items.find((x) => x.label == "enqueue")?.subItems ?? [];
+
+      expect(apiMock.getCoreConfigValue).not.toHaveBeenCalled();
+      expect(options.findIndex((x) => x.selected)).toBe(selected);
+    },
+  );
 });

--- a/tests/layouts/ItemContextMenuPlayback.test.ts
+++ b/tests/layouts/ItemContextMenuPlayback.test.ts
@@ -135,24 +135,31 @@ describe("the play menu for a role that may not read the core settings", () => {
     items[0].action?.();
 
     expect(apiMock.getCoreConfigValue).not.toHaveBeenCalled();
-    expect(apiMock.playMedia).toHaveBeenCalledWith(
-      [source.uri],
-      QueueOption.REPLACE,
-    );
+    expect(apiMock.playMedia).toHaveBeenCalledWith([source.uri], undefined);
   });
 
-  // the enqueue options are listed as play, next, add, replace, replace next
+  it("plays a track now the server's default way without asking it", async () => {
+    const item = track({ provider_mappings: mappings });
+
+    const items = await getPlaybackContextMenuItems([item]);
+    items.find((x) => x.label == "play_now")?.action?.();
+
+    expect(apiMock.getCoreConfigValue).not.toHaveBeenCalled();
+    expect(apiMock.playMedia).toHaveBeenCalledWith([item.uri], undefined);
+  });
+
   it.each([
-    { item: track({ provider_mappings: mappings }), selected: 0 },
-    { item: radio({ provider_mappings: mappings }), selected: 3 },
+    { item: track({ provider_mappings: mappings }) },
+    { item: radio({ provider_mappings: mappings }) },
   ])(
-    "marks the server's default for a $item.media_type without asking it",
-    async ({ item, selected }) => {
+    "marks none of the enqueue options for a $item.media_type",
+    async ({ item }) => {
       const items = await getPlaybackContextMenuItems([item]);
       const options = items.find((x) => x.label == "enqueue")?.subItems ?? [];
 
       expect(apiMock.getCoreConfigValue).not.toHaveBeenCalled();
-      expect(options.findIndex((x) => x.selected)).toBe(selected);
+      expect(options).toHaveLength(5);
+      expect(options.some((x) => x.selected)).toBe(false);
     },
   );
 });

--- a/tests/layouts/ItemContextMenuScopes.test.ts
+++ b/tests/layouts/ItemContextMenuScopes.test.ts
@@ -1,17 +1,19 @@
 /**
- * The item context menu only offers the changes to the library that the role
- * of the user may make.
+ * The item context menu only offers the changes that the role of the user may
+ * make.
  */
 import { getContextMenuItems } from "@/layouts/default/ItemContextMenu.vue";
-import type {
-  MediaItemType,
-  MediaItemTypeOrItemMapping,
-  Scope,
+import {
+  type MediaItemType,
+  type MediaItemTypeOrItemMapping,
+  ProviderFeature,
+  type Scope,
 } from "@/plugins/api/interfaces";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { genre } from "../fixtures/genre";
 import { playlist } from "../fixtures/playlist";
 import { providerMapping } from "../fixtures/providerMapping";
+import { radio } from "../fixtures/radio";
 import {
   BUILTIN_ROLE_SCOPES,
   OWN_SOURCES_ROLE_SCOPES,
@@ -70,6 +72,7 @@ async function offeredLabels(
 
 beforeEach(() => {
   vi.clearAllMocks();
+  storeMock.enabledPlugins.clear();
 });
 
 describe("library changes in the item context menu", () => {
@@ -121,5 +124,91 @@ describe("genre management in the item context menu", () => {
 
     expect(offered).not.toContain("merge_into");
     expect(offered).not.toContain("delete_genre");
+  });
+});
+
+describe("library management in the item context menu", () => {
+  const LIBRARY_MANAGEMENT = [
+    "update_metadata",
+    "refresh_item",
+    "map_provider_mapping",
+    "link_to_genre",
+    "edit_track",
+    "edit_radio",
+  ];
+  // library items as their details pages show them, added through the builtin provider
+  const builtinMapping = providerMapping({
+    provider_domain: "builtin",
+    provider_instance: "builtin",
+  });
+  const libraryTrack = track({
+    item_id: "5",
+    provider_mappings: [builtinMapping],
+  });
+  const libraryRadio = radio({
+    item_id: "6",
+    provider_mappings: [builtinMapping],
+  });
+  // the track as a music source lists it, to map onto the library track
+  const sourceTrack = track({
+    item_id: "p1",
+    provider: "test_provider--1",
+    provider_mappings: [providerMapping()],
+  });
+
+  beforeEach(() => {
+    apiMock.getProvider.mockReturnValue({
+      supported_features: [
+        ProviderFeature.LIBRARY_TRACKS_EDIT,
+        ProviderFeature.LIBRARY_RADIOS_EDIT,
+      ],
+    });
+  });
+
+  async function offeredManagement(): Promise<string[]> {
+    const offered = [
+      ...(await offeredLabels([libraryTrack], libraryTrack)),
+      ...(await offeredLabels([libraryRadio], libraryRadio)),
+      ...(await offeredLabels([sourceTrack], libraryTrack)),
+    ];
+    return LIBRARY_MANAGEMENT.filter((label) => offered.includes(label));
+  }
+
+  it("is offered to an admin", async () => {
+    hasScope.mockImplementation(scopeChecker(BUILTIN_ROLE_SCOPES.admin));
+
+    expect(await offeredManagement()).toEqual(LIBRARY_MANAGEMENT);
+  });
+
+  it.each([
+    { role: "a member", scopes: BUILTIN_ROLE_SCOPES.user },
+    { role: "a guest", scopes: BUILTIN_ROLE_SCOPES.guest },
+  ])("is not offered to $role", async ({ scopes }) => {
+    hasScope.mockImplementation(scopeChecker(scopes));
+
+    expect(await offeredManagement()).toEqual([]);
+  });
+});
+
+describe("creating an AI Radio show from a playlist", () => {
+  const RUN_WITH = "providers.ai_radio.context.run_with";
+
+  beforeEach(() => {
+    storeMock.enabledPlugins.add("ai_radio");
+  });
+
+  it("is offered to an admin", async () => {
+    hasScope.mockImplementation(scopeChecker(BUILTIN_ROLE_SCOPES.admin));
+
+    expect(await offeredLabels([playlist()])).toContain(RUN_WITH);
+  });
+
+  it.each([
+    { role: "a member", scopes: BUILTIN_ROLE_SCOPES.user },
+    { role: "a guest", scopes: BUILTIN_ROLE_SCOPES.guest },
+  ])("is not offered to $role", async ({ scopes }) => {
+    hasScope.mockImplementation(scopeChecker(scopes));
+
+    expect(await offeredLabels([playlist()])).not.toContain(RUN_WITH);
   });
 });

--- a/tests/layouts/ItemContextMenuScopes.test.ts
+++ b/tests/layouts/ItemContextMenuScopes.test.ts
@@ -1,0 +1,125 @@
+/**
+ * The item context menu only offers the changes to the library that the role
+ * of the user may make.
+ */
+import { getContextMenuItems } from "@/layouts/default/ItemContextMenu.vue";
+import type {
+  MediaItemType,
+  MediaItemTypeOrItemMapping,
+  Scope,
+} from "@/plugins/api/interfaces";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { genre } from "../fixtures/genre";
+import { playlist } from "../fixtures/playlist";
+import { providerMapping } from "../fixtures/providerMapping";
+import {
+  BUILTIN_ROLE_SCOPES,
+  OWN_SOURCES_ROLE_SCOPES,
+  scopeChecker,
+} from "../fixtures/scopes";
+import { track } from "../fixtures/track";
+
+const { apiMock, hasScope, storeMock } = vi.hoisted(() => ({
+  apiMock: {
+    providers: {
+      "test_provider--1": { available: true, supported_features: [] },
+    } as Record<string, unknown>,
+    getProvider: vi.fn(),
+    getLibraryItem: vi.fn(),
+    players: {},
+  },
+  hasScope: vi.fn<(scope: Scope) => boolean>(),
+  storeMock: {
+    enabledPlugins: new Set<string>(),
+  },
+}));
+
+vi.mock("@/plugins/api", () => ({ default: apiMock, api: apiMock }));
+vi.mock("@/plugins/store", () => ({ store: storeMock }));
+vi.mock("@/plugins/auth", () => ({ authManager: { hasScope } }));
+vi.mock("@/plugins/eventbus", () => ({
+  eventbus: { on: vi.fn(), off: vi.fn(), emit: vi.fn() },
+}));
+vi.mock("@/plugins/i18n", () => ({ $t: (key: string) => key }));
+
+const LIBRARY_CHANGES = [
+  "add_library",
+  "remove_library",
+  "favorites_add",
+  "favorites_remove",
+  "add_playlist",
+  "remove_playlist",
+  "mark_played",
+  "mark_unplayed",
+];
+
+// a library track listed in a playlist the user may edit
+const listedTrack = track({
+  provider_mappings: [providerMapping({ in_library: true })],
+});
+const editablePlaylist = playlist({ item_id: "pl1", is_editable: true });
+
+async function offeredLabels(
+  items: MediaItemTypeOrItemMapping[],
+  parentItem?: MediaItemType,
+): Promise<string[]> {
+  return (await getContextMenuItems(items, parentItem)).map(
+    (item) => item.label,
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("library changes in the item context menu", () => {
+  it("are offered to a member", async () => {
+    hasScope.mockImplementation(scopeChecker(BUILTIN_ROLE_SCOPES.user));
+
+    expect(await offeredLabels([listedTrack], editablePlaylist)).toEqual(
+      expect.arrayContaining([
+        "remove_library",
+        "favorites_add",
+        "add_playlist",
+        "remove_playlist",
+      ]),
+    );
+  });
+
+  it.each([
+    { role: "a guest", scopes: BUILTIN_ROLE_SCOPES.guest },
+    {
+      role: "a role that manages only its own music sources",
+      scopes: OWN_SOURCES_ROLE_SCOPES,
+    },
+  ])("are not offered to $role", async ({ scopes }) => {
+    hasScope.mockImplementation(scopeChecker(scopes));
+
+    const offered = await offeredLabels([listedTrack], editablePlaylist);
+
+    expect(offered.filter((label) => LIBRARY_CHANGES.includes(label))).toEqual(
+      [],
+    );
+  });
+});
+
+describe("genre management in the item context menu", () => {
+  const genres = [genre({ item_id: "g1" }), genre({ item_id: "g2" })];
+
+  it("is offered to an admin", async () => {
+    hasScope.mockImplementation(scopeChecker(BUILTIN_ROLE_SCOPES.admin));
+
+    expect(await offeredLabels(genres)).toEqual(
+      expect.arrayContaining(["merge_into", "delete_genre"]),
+    );
+  });
+
+  it("is not offered to a member", async () => {
+    hasScope.mockImplementation(scopeChecker(BUILTIN_ROLE_SCOPES.user));
+
+    const offered = await offeredLabels(genres);
+
+    expect(offered).not.toContain("merge_into");
+    expect(offered).not.toContain("delete_genre");
+  });
+});

--- a/tests/layouts/PlayerFullscreen.test.ts
+++ b/tests/layouts/PlayerFullscreen.test.ts
@@ -38,6 +38,15 @@ vi.mock("@/plugins/store", async () => {
   };
 });
 
+// signed in as a member
+vi.mock("@/plugins/auth", async () => {
+  const { BUILTIN_ROLE_SCOPES, scopeChecker } =
+    await import("../fixtures/scopes");
+  return {
+    authManager: { hasScope: vi.fn(scopeChecker(BUILTIN_ROLE_SCOPES.user)) },
+  };
+});
+
 vi.mock("@/composables/useServerTime", () => ({
   // Date.now() is intentional here: the highlight test advances fake wall time.
   serverNow: () => Date.now() / 1000,

--- a/tests/layouts/PlayerSelect.test.ts
+++ b/tests/layouts/PlayerSelect.test.ts
@@ -16,11 +16,11 @@ import { enableAutoUnmount, flushPromises, mount } from "@vue/test-utils";
 import { nextTick } from "vue";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-const { emitEvent, getPreference, isAdmin, preferenceState, setPreference } =
+const { emitEvent, getPreference, hasScope, preferenceState, setPreference } =
   vi.hoisted(() => ({
     emitEvent: vi.fn(),
     getPreference: vi.fn(),
-    isAdmin: vi.fn(() => true),
+    hasScope: vi.fn(() => true),
     preferenceState: {
       values: {} as Record<string, unknown>,
       reactiveValues: undefined as Record<string, unknown> | undefined,
@@ -77,7 +77,7 @@ vi.mock("@/plugins/eventbus", () => ({
 
 vi.mock("@/plugins/auth", () => ({
   authManager: {
-    isAdmin,
+    hasScope,
   },
 }));
 

--- a/tests/layouts/PlaylistAccessDialog.test.ts
+++ b/tests/layouts/PlaylistAccessDialog.test.ts
@@ -2,6 +2,7 @@ import PlaylistAccessDialog from "@/layouts/default/PlaylistAccessDialog.vue";
 import {
   type PlaylistAccess,
   ProviderSharing,
+  type Scope,
   type UserSummary,
 } from "@/plugins/api/interfaces";
 import { eventbus } from "@/plugins/eventbus";
@@ -15,6 +16,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { playlist } from "../fixtures/playlist";
 import { providerMapping } from "../fixtures/providerMapping";
 import { selectOptions } from "../fixtures/rekaSelect";
+import { BUILTIN_ROLE_SCOPES, scopeChecker } from "../fixtures/scopes";
 
 const { apiMock, authMock, storeMock, toastMock } = vi.hoisted(() => ({
   apiMock: {
@@ -22,7 +24,7 @@ const { apiMock, authMock, storeMock, toastMock } = vi.hoisted(() => ({
     setPlaylistAccess: vi.fn(),
   },
   authMock: {
-    hasScope: vi.fn<() => boolean>(),
+    hasScope: vi.fn<(scope: Scope) => boolean>(),
   },
   storeMock: {
     currentUser: undefined,
@@ -83,7 +85,7 @@ beforeEach(() => {
   vi.clearAllMocks();
   storeMock.dialogActive = false;
   storeMock.isTouchscreen = false;
-  authMock.hasScope.mockReturnValue(true);
+  authMock.hasScope.mockImplementation(scopeChecker(BUILTIN_ROLE_SCOPES.admin));
   apiMock.getShareCandidates.mockResolvedValue(members);
   apiMock.setPlaylistAccess.mockResolvedValue(maPlaylist(sharedWithMember));
   document.body.innerHTML = "";
@@ -105,7 +107,9 @@ describe("PlaylistAccessDialog", () => {
   });
 
   it("hides the owner from a member", async () => {
-    authMock.hasScope.mockReturnValue(false);
+    authMock.hasScope.mockImplementation(
+      scopeChecker(BUILTIN_ROLE_SCOPES.user),
+    );
 
     await openDialog(maPlaylist(sharedWithMember));
 

--- a/tests/plugins/api/index.test.ts
+++ b/tests/plugins/api/index.test.ts
@@ -340,6 +340,14 @@ describe("MusicAssistantApi error handling", () => {
     expect(api.supportsShareCandidates).toBe(true);
   });
 
+  it("lets a role with queues.control play AI Radio from schema 75 on", () => {
+    api.serverInfo.value = { ...SERVER_INFO, schema_version: 74 };
+    expect(api.supportsAIRadioPlaybackScopes).toBe(false);
+
+    api.serverInfo.value = { ...SERVER_INFO, schema_version: 75 };
+    expect(api.supportsAIRadioPlaybackScopes).toBe(true);
+  });
+
   describe("a refused ordering command", () => {
     // the server refuses every one of these with the same code and the same
     // localized "the command failed", so the player's own state is what tells
@@ -591,6 +599,24 @@ describe("MusicAssistantApi error handling", () => {
     const toast = await runTaskToast(api, transport);
 
     expect(toast.action).toBeUndefined();
+  });
+
+  describe("with the auth module gone after a server update", () => {
+    beforeEach(() => {
+      vi.doMock("@/plugins/auth", () => {
+        throw new TypeError("Failed to fetch dynamically imported module");
+      });
+    });
+
+    afterEach(() => {
+      vi.doMock("@/plugins/auth", () => ({ authManager: { hasScope } }));
+    });
+
+    it("still shows the task toast, without the task list", async () => {
+      const toast = await runTaskToast(api, transport);
+
+      expect(toast.action).toBeUndefined();
+    });
   });
 
   it("rejects a failed migration without the global error toast", async () => {

--- a/tests/plugins/api/index.test.ts
+++ b/tests/plugins/api/index.test.ts
@@ -7,6 +7,7 @@ import {
   type Player,
   PlaylistMatchPolicy,
   RepeatMode,
+  type Scope,
   type ServerInfoMessage,
   type SuccessResultMessage,
   TaskStatus,
@@ -15,9 +16,11 @@ import {
 import { BaseTransport, TransportState } from "@/plugins/remote/transport";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { playlist } from "../../fixtures/playlist";
+import { BUILTIN_ROLE_SCOPES, scopeChecker } from "../../fixtures/scopes";
 import { userSummary } from "../../fixtures/user";
 
-const { mockToastError, mockToastInfo } = vi.hoisted(() => ({
+const { hasScope, mockToastError, mockToastInfo } = vi.hoisted(() => ({
+  hasScope: vi.fn<(scope: Scope) => boolean>(),
   mockToastError: vi.fn(),
   mockToastInfo: vi.fn(),
 }));
@@ -40,6 +43,10 @@ vi.mock("@/plugins/i18n", () => ({
 
 vi.mock("@/plugins/store", () => ({
   store: {},
+}));
+
+vi.mock("@/plugins/auth", () => ({
+  authManager: { hasScope },
 }));
 
 import {
@@ -108,6 +115,7 @@ describe("MusicAssistantApi error handling", () => {
 
   beforeEach(async () => {
     vi.clearAllMocks();
+    hasScope.mockImplementation(scopeChecker(BUILTIN_ROLE_SCOPES.admin));
     api = new MusicAssistantApi();
     transport = new TestTransport();
     const initialization = api.initialize(transport);
@@ -558,10 +566,31 @@ describe("MusicAssistantApi error handling", () => {
       partial: false,
     });
     await expect(result).resolves.toEqual(task);
-    expect(mockToastInfo).toHaveBeenCalledWith(
-      "background_tasks.toast.added",
-      expect.anything(),
+    await vi.waitFor(() =>
+      expect(mockToastInfo).toHaveBeenCalledWith(
+        "background_tasks.toast.added",
+        expect.anything(),
+      ),
     );
+  });
+
+  it.each([
+    { role: "an admin", scopes: BUILTIN_ROLE_SCOPES.admin },
+    { role: "a member", scopes: BUILTIN_ROLE_SCOPES.user },
+  ])("offers $role the task list with the task toast", async ({ scopes }) => {
+    hasScope.mockImplementation(scopeChecker(scopes));
+
+    const toast = await runTaskToast(api, transport);
+
+    expect(toast.action?.label).toBe("background_tasks.open");
+  });
+
+  it("leaves the task list out of the task toast for a guest", async () => {
+    hasScope.mockImplementation(scopeChecker(BUILTIN_ROLE_SCOPES.guest));
+
+    const toast = await runTaskToast(api, transport);
+
+    expect(toast.action).toBeUndefined();
   });
 
   it("rejects a failed migration without the global error toast", async () => {
@@ -603,6 +632,24 @@ describe("MusicAssistantApi error handling", () => {
     await rejection;
   });
 });
+
+/**
+ * Run a task and hand back the options of the toast announcing it.
+ */
+async function runTaskToast(
+  api: MusicAssistantApi,
+  transport: TestTransport,
+): Promise<{ action?: { label: string } }> {
+  const result = api.runTask("task-1");
+  transport.receive({
+    message_id: transport.lastCommand.message_id!,
+    result: { id: "task-1" },
+    partial: false,
+  });
+  await result;
+  await vi.waitFor(() => expect(mockToastInfo).toHaveBeenCalled());
+  return mockToastInfo.mock.calls[0][1];
+}
 
 function createErrorResult(
   command: CommandMessage,

--- a/tests/plugins/auth.test.ts
+++ b/tests/plugins/auth.test.ts
@@ -279,6 +279,20 @@ describe("AuthManager scopes", () => {
 
     expect(new AuthManager().hasScope(Scope.LIBRARY_READ)).toBe(false);
   });
+
+  it("counts a role granting every scope as admin", () => {
+    store.currentUser = user({ role: UserRole.ADMIN });
+    store.roleScopes = { admin: [Scope.ALL] };
+
+    expect(new AuthManager().isAdmin()).toBe(true);
+  });
+
+  it("tells an admin by the scopes of its role, not by the role's name", () => {
+    store.currentUser = user({ role: UserRole.ADMIN });
+    store.roleScopes = { admin: [Scope.USERS_MANAGE] };
+
+    expect(new AuthManager().isAdmin()).toBe(false);
+  });
 });
 
 function createToken(jti: string, username: string): string {

--- a/tests/plugins/auth.test.ts
+++ b/tests/plugins/auth.test.ts
@@ -279,20 +279,6 @@ describe("AuthManager scopes", () => {
 
     expect(new AuthManager().hasScope(Scope.LIBRARY_READ)).toBe(false);
   });
-
-  it("counts a role granting every scope as admin", () => {
-    store.currentUser = user({ role: UserRole.ADMIN });
-    store.roleScopes = { admin: [Scope.ALL] };
-
-    expect(new AuthManager().isAdmin()).toBe(true);
-  });
-
-  it("tells an admin by the scopes of its role, not by the role's name", () => {
-    store.currentUser = user({ role: UserRole.ADMIN });
-    store.roleScopes = { admin: [Scope.USERS_MANAGE] };
-
-    expect(new AuthManager().isAdmin()).toBe(false);
-  });
 });
 
 function createToken(jti: string, username: string): string {

--- a/tests/plugins/router.test.ts
+++ b/tests/plugins/router.test.ts
@@ -1,6 +1,7 @@
 import { DASHBOARD_VIEWER_PATH_STORAGE_KEY } from "@/helpers/guest_session";
 import { backFromMediaDetails } from "@/helpers/navigation";
 import { ConnectionState } from "@/plugins/api";
+import { Scope } from "@/plugins/api/interfaces";
 import { routes } from "@/plugins/router";
 import {
   NavigationFailureType,
@@ -15,12 +16,17 @@ import {
 } from "vue-router";
 import { nextTick } from "vue";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  BUILTIN_ROLE_SCOPES,
+  OWN_SOURCES_ROLE_SCOPES,
+  scopeChecker,
+} from "../fixtures/scopes";
 
 const mocks = vi.hoisted(() => ({
   afterEachHooks: [] as NavigationHookAfter[],
   apiState: { value: "initialized" },
   globalGuards: [] as NavigationGuardWithThis<undefined>[],
-  hasScope: vi.fn(() => false),
+  hasScope: vi.fn<(scope: Scope) => boolean>(() => false),
   isDashboardViewer: vi.fn(() => false),
   isGuestAccessSession: vi.fn(() => false),
   router: undefined as Router | undefined,
@@ -383,8 +389,9 @@ describe("global navigation guard", () => {
     expect(mocks.store.frameless).toBe(true);
   });
 
-  it("redirects a non-admin away from the system settings", async () => {
+  it("redirects a member away from the system settings", async () => {
     mocks.store.currentUser = { role: "user", username: "listener" };
+    mocks.hasScope.mockImplementation(scopeChecker(BUILTIN_ROLE_SCOPES.user));
 
     await expect(
       invokeGuard(globalGuard, resolveRoute("/settings/system")),
@@ -397,13 +404,32 @@ describe("global navigation guard", () => {
     ).resolves.toEqual({ name: "discover" });
   });
 
-  it("redirects a non-admin when a parent route carries the requirement", async () => {
+  it("redirects a member when a parent route carries the requirement", async () => {
     mocks.store.currentUser = { role: "user", username: "listener" };
+    mocks.hasScope.mockImplementation(scopeChecker(BUILTIN_ROLE_SCOPES.user));
     const to = resolveRoute("/settings/frontend");
     // The requirement counts on every matched record, not just the leaf the
     // user opened, so mark the outermost one.
     to.matched = to.matched.map((record, index) =>
-      index === 0 ? { ...record, meta: { requiresAdmin: true } } : record,
+      index === 0
+        ? { ...record, meta: { requiresScope: Scope.CONFIG_CORE_WRITE } }
+        : record,
+    );
+
+    await expect(invokeGuard(globalGuard, to)).resolves.toEqual({
+      name: "discover",
+    });
+  });
+
+  it("checks the scope of every matched route, not just the first", async () => {
+    mocks.store.currentUser = { role: "user", username: "listener" };
+    mocks.hasScope.mockImplementation(scopeChecker(BUILTIN_ROLE_SCOPES.user));
+    // the outermost record asks a scope members hold, the leaf one they lack
+    const to = resolveRoute("/settings/system");
+    to.matched = to.matched.map((record, index) =>
+      index === 0
+        ? { ...record, meta: { requiresScope: Scope.LIBRARY_READ } }
+        : record,
     );
 
     await expect(invokeGuard(globalGuard, to)).resolves.toEqual({
@@ -413,14 +439,16 @@ describe("global navigation guard", () => {
 
   it("lets an admin into the system settings", async () => {
     mocks.store.currentUser = { role: "admin", username: "owner" };
+    mocks.hasScope.mockImplementation(scopeChecker(BUILTIN_ROLE_SCOPES.admin));
 
     await expect(
       invokeGuard(globalGuard, resolveRoute("/settings/system")),
     ).resolves.toBeUndefined();
   });
 
-  it("lets a non-admin open the player options", async () => {
+  it("lets a member open the player options", async () => {
     mocks.store.currentUser = { role: "user", username: "listener" };
+    mocks.hasScope.mockImplementation(scopeChecker(BUILTIN_ROLE_SCOPES.user));
 
     await expect(
       invokeGuard(
@@ -491,12 +519,13 @@ describe("global navigation guard", () => {
     // The user lands with the connection: a guard that read it too early would
     // have redirected already.
     mocks.store.currentUser = { role: "admin", username: "owner" };
+    mocks.hasScope.mockImplementation(scopeChecker(BUILTIN_ROLE_SCOPES.admin));
     mocks.apiState.value = ConnectionState.INITIALIZED;
 
     await expect(pending.result).resolves.toBeUndefined();
   });
 
-  it("does not wait for the server connection on routes without an admin requirement", async () => {
+  it("does not wait for the server connection on routes without a scope requirement", async () => {
     vi.useFakeTimers();
     mocks.apiState.value = ConnectionState.AUTHENTICATED;
     const pending = trackGuard(
@@ -508,6 +537,59 @@ describe("global navigation guard", () => {
     expect(pending.isSettled()).toBe(true);
     await expect(pending.result).resolves.toBeUndefined();
   });
+});
+
+describe("scope-gated routes", () => {
+  // the builtin roles, and a custom role that manages its own music sources
+  // on top of the guest scopes
+  const ROLE_SCOPES = {
+    ...BUILTIN_ROLE_SCOPES,
+    own_sources: OWN_SOURCES_ROLE_SCOPES,
+  };
+  type Role = keyof typeof ROLE_SCOPES;
+
+  const ROUTE_ACCESS: [path: string, roles: Role[]][] = [
+    ["/settings/providers?types=music", ["admin", "user", "own_sources"]],
+    ["/settings/editprovider/spotify--abc", ["admin", "user", "own_sources"]],
+    ["/settings/players", ["admin"]],
+    ["/settings/editplayer/player-1", ["admin"]],
+    ["/settings/editplayer/player-1/dsp", ["admin"]],
+    ["/settings/editqueue/player-1", ["admin"]],
+    ["/settings/addgroup/sonos--abc", ["admin"]],
+    [
+      "/settings/editplayer/player-1/options",
+      ["admin", "user", "guest", "own_sources"],
+    ],
+    ["/settings/system", ["admin"]],
+    ["/settings/editcore/webserver", ["admin"]],
+    ["/settings/audio-analysis", ["admin"]],
+    ["/settings/remote-access", ["admin"]],
+    ["/settings/diagnostics", ["admin"]],
+    ["/settings/genremanagement", ["admin"]],
+    ["/settings/users", ["admin"]],
+    ["/settings/tasks", ["admin", "user"]],
+    ["/music-quiz", ["admin", "user"]],
+    ["/onboarding", ["admin"]],
+    ["/settings/frontend", ["admin", "user", "guest", "own_sources"]],
+  ];
+
+  describe.each(Object.keys(ROLE_SCOPES) as Role[])(
+    "for the %s role",
+    (role) => {
+      beforeEach(() => {
+        mocks.store.currentUser = { role, username: role };
+        mocks.hasScope.mockImplementation(scopeChecker(ROLE_SCOPES[role]));
+      });
+
+      it.each(ROUTE_ACCESS)("gates %s", async (path, roles) => {
+        await expect(
+          invokeGuard(globalGuard, resolveRoute(path)),
+        ).resolves.toEqual(
+          roles.includes(role) ? undefined : { name: "discover" },
+        );
+      });
+    },
+  );
 });
 
 describe("media details back button", () => {

--- a/tests/plugins/router.test.ts
+++ b/tests/plugins/router.test.ts
@@ -35,6 +35,7 @@ const mocks = vi.hoisted(() => ({
     enabledPlugins: new Set<string>(),
     frameless: false,
   },
+  supportsAIRadioPlaybackScopes: true,
   toastError: vi.fn(),
 }));
 
@@ -44,7 +45,12 @@ vi.mock("@/plugins/api", async () => {
   const { ref } = await vi.importActual<typeof import("vue")>("vue");
   mocks.apiState = ref(mocks.apiState.value);
   return {
-    api: { state: mocks.apiState },
+    api: {
+      state: mocks.apiState,
+      get supportsAIRadioPlaybackScopes() {
+        return mocks.supportsAIRadioPlaybackScopes;
+      },
+    },
     ConnectionState: {
       AUTHENTICATED: "authenticated",
       INITIALIZED: "initialized",
@@ -137,6 +143,7 @@ beforeEach(() => {
   mocks.store.currentUser = undefined;
   mocks.store.enabledPlugins = new Set<string>();
   mocks.store.frameless = false;
+  mocks.supportsAIRadioPlaybackScopes = true;
   sessionStorage.clear();
 });
 
@@ -267,6 +274,46 @@ describe("AI Radio guard", () => {
     ).resolves.toBeUndefined();
     expect(mocks.toastError).not.toHaveBeenCalled();
   });
+
+  it("keeps a member on API schema 74, where only admins play AI Radio, out with a toast", async () => {
+    mocks.store.enabledPlugins = new Set(["ai_radio"]);
+    mocks.hasScope.mockImplementation(scopeChecker(BUILTIN_ROLE_SCOPES.user));
+    mocks.supportsAIRadioPlaybackScopes = false;
+
+    await expect(
+      invokeGuard(aiRadioGuard, resolveRoute("/ai-radio")),
+    ).resolves.toEqual({ name: "discover" });
+    expect(mocks.toastError).toHaveBeenCalledWith(
+      "providers.ai_radio.toast.unavailable",
+    );
+  });
+
+  it.each([
+    {
+      role: "a member",
+      scopes: BUILTIN_ROLE_SCOPES.user,
+      schema: 75,
+      playbackScopes: true,
+    },
+    {
+      role: "an admin",
+      scopes: BUILTIN_ROLE_SCOPES.admin,
+      schema: 74,
+      playbackScopes: false,
+    },
+  ])(
+    "lets $role on API schema $schema into AI Radio",
+    async ({ scopes, playbackScopes }) => {
+      mocks.store.enabledPlugins = new Set(["ai_radio"]);
+      mocks.hasScope.mockImplementation(scopeChecker(scopes));
+      mocks.supportsAIRadioPlaybackScopes = playbackScopes;
+
+      await expect(
+        invokeGuard(aiRadioGuard, resolveRoute("/ai-radio")),
+      ).resolves.toBeUndefined();
+      expect(mocks.toastError).not.toHaveBeenCalled();
+    },
+  );
 
   it("drops the fallback timeout once the server connection is ready", async () => {
     vi.useFakeTimers();

--- a/tests/views/AIRadioView.test.ts
+++ b/tests/views/AIRadioView.test.ts
@@ -1,25 +1,31 @@
+import CreateShowDialog from "@/components/ai-radio/CreateShowDialog.vue";
 import CustomizeHost from "@/components/ai-radio/CustomizeHost.vue";
 import CustomizeShow from "@/components/ai-radio/CustomizeShow.vue";
 import { useHosts } from "@/composables/ai-radio/useHosts";
 import { useShows } from "@/composables/ai-radio/useShows";
-import type { AIRadioHost, AIRadioStation } from "@/plugins/api/interfaces";
+import type {
+  AIRadioHost,
+  AIRadioStation,
+  Scope,
+} from "@/plugins/api/interfaces";
 import AIRadioView from "@/views/AIRadioView.vue";
 import { flushPromises, mount, type VueWrapper } from "@vue/test-utils";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { BUILTIN_ROLE_SCOPES, scopeChecker } from "../fixtures/scopes";
 
 type SendCommand = (
   command: string,
   args?: Record<string, unknown>,
 ) => Promise<unknown>;
 
-const { sendCommand, getLibraryPlaylists, routeMock, routerMock } = vi.hoisted(
-  () => ({
+const { sendCommand, getLibraryPlaylists, hasScope, routeMock, routerMock } =
+  vi.hoisted(() => ({
     sendCommand: vi.fn<SendCommand>(async () => []),
     getLibraryPlaylists: vi.fn(async () => []),
+    hasScope: vi.fn<(scope: Scope) => boolean>(),
     routeMock: { query: { station_id: "show-1" } as Record<string, string> },
     routerMock: { push: vi.fn(), replace: vi.fn() },
-  }),
-);
+  }));
 
 vi.mock("@/plugins/api", () => {
   const mockApi = {
@@ -35,6 +41,10 @@ vi.mock("@/plugins/api", () => {
 
 vi.mock("@/plugins/store", () => ({
   store: { activePlayerId: undefined },
+}));
+
+vi.mock("@/plugins/auth", () => ({
+  authManager: { guestSessionKind: () => null, hasScope },
 }));
 
 vi.mock("vue-router", async (importOriginal) => ({
@@ -177,9 +187,15 @@ async function mountView() {
   return wrapper;
 }
 
+// an admin unless a test says otherwise: only an admin edits shows and hosts
+beforeEach(() => {
+  hasScope.mockImplementation(scopeChecker(BUILTIN_ROLE_SCOPES.admin));
+});
+
 afterEach(() => {
   vi.clearAllMocks();
   onConfirm = undefined;
+  useShows().dismissNoAiProviderAlert();
   routeMock.query = { station_id: STATION_ID };
   useHosts().hosts.value = [];
   useShows().shows.value = [];
@@ -317,4 +333,124 @@ describe("AIRadioView status polling lifecycle", () => {
     // by now the query belongs to whatever route replaced this one
     expect(routerMock.replace).not.toHaveBeenCalled();
   });
+});
+
+describe("AIRadioView editing rights", () => {
+  // A view left mounted keeps following the composables' module state after the
+  // cleanup below clears the page, and trips over its teleported menus.
+  const views: VueWrapper[] = [];
+  const openView = async () => {
+    const view = await mountView();
+    views.push(view);
+    return view;
+  };
+
+  afterEach(() => {
+    for (const view of views.splice(0)) view.unmount();
+  });
+
+  const NON_EDITORS = [
+    ["a member", BUILTIN_ROLE_SCOPES.user],
+    ["a guest", BUILTIN_ROLE_SCOPES.guest],
+  ] as const;
+
+  const requested = (command: string) =>
+    sendCommand.mock.calls.some(([sent]) => sent === command);
+  const headings = (wrapper: VueWrapper) =>
+    wrapper.findAll("h2").map((heading) => heading.text());
+
+  it("lets an admin add hosts and shows and change a show", async () => {
+    routeMock.query = {};
+    setupSendCommand([]);
+    useShows().noAiProviderAlert.value = true;
+    const wrapper = await openView();
+
+    expect(headings(wrapper)).toEqual(["Hosts", "Shows"]);
+    expect(findButtonByText(wrapper, "Add host")).toBeTruthy();
+    expect(findButtonByText(wrapper, "Add show")).toBeTruthy();
+    expect(findButtonByText(wrapper, "Go to Settings → Plugins")).toBeTruthy();
+    expect(wrapper.find('[aria-label="More options"]').exists()).toBe(true);
+    expect(requested("ai_radio/hosts/list")).toBe(true);
+    expect(requested("ai_radio/hosts/presets/list")).toBe(true);
+
+    await wrapper.find(".show-card").trigger("click");
+    await flushPromises();
+    expect(wrapper.findComponent(CustomizeShow).exists()).toBe(true);
+  });
+
+  it.each(NON_EDITORS)(
+    "lets %s play the shows and nothing more",
+    async (_role, scopes) => {
+      hasScope.mockImplementation(scopeChecker(scopes));
+      routeMock.query = {};
+      setupSendCommand([]);
+      useShows().noAiProviderAlert.value = true;
+      const wrapper = await openView();
+
+      expect(headings(wrapper)).toEqual(["Shows"]);
+      expect(findButtonByText(wrapper, "Add show")).toBeUndefined();
+      expect(
+        findButtonByText(wrapper, "Go to Settings → Plugins"),
+      ).toBeUndefined();
+      expect(wrapper.find('[aria-label="More options"]').exists()).toBe(false);
+      expect(wrapper.find('[aria-label="Play"]').exists()).toBe(true);
+      expect(requested("ai_radio/hosts/list")).toBe(false);
+      expect(requested("ai_radio/hosts/presets/list")).toBe(false);
+
+      await wrapper.find(".show-card").trigger("click");
+      await flushPromises();
+      expect(wrapper.findComponent(CustomizeShow).exists()).toBe(false);
+    },
+  );
+
+  it.each([
+    { role: "an admin", scopes: BUILTIN_ROLE_SCOPES.admin, offered: true },
+    { role: "a member", scopes: BUILTIN_ROLE_SCOPES.user, offered: false },
+    { role: "a guest", scopes: BUILTIN_ROLE_SCOPES.guest, offered: false },
+  ])(
+    "offers $role to create the first show: $offered",
+    async ({ scopes, offered }) => {
+      hasScope.mockImplementation(scopeChecker(scopes));
+      routeMock.query = {};
+      // no shows yet
+      sendCommand.mockImplementation(async () => []);
+      const wrapper = await openView();
+
+      expect(!!findButtonByText(wrapper, "Create show")).toBe(offered);
+    },
+  );
+
+  it("opens the create dialog for an admin following a playlist link", async () => {
+    routeMock.query = {
+      source_playlist_id: "42",
+      source_playlist_provider: "library",
+      source_playlist_name: "Road trip",
+    };
+    setupSendCommand([]);
+    const wrapper = await openView();
+
+    expect(wrapper.getComponent(CreateShowDialog).props("open")).toBe(true);
+  });
+
+  it.each(NON_EDITORS)(
+    "opens no editor for %s following a link",
+    async (_role, scopes) => {
+      hasScope.mockImplementation(scopeChecker(scopes));
+      setupSendCommand([]);
+
+      routeMock.query = { station_id: STATION_ID };
+      const showLink = await openView();
+      expect(showLink.findComponent(CustomizeShow).exists()).toBe(false);
+      expect(getShowFetchCount()).toBe(0);
+
+      routeMock.query = {
+        source_playlist_id: "42",
+        source_playlist_provider: "library",
+      };
+      const playlistLink = await openView();
+      expect(playlistLink.getComponent(CreateShowDialog).props("open")).toBe(
+        false,
+      );
+    },
+  );
 });

--- a/tests/views/EditProvider.test.ts
+++ b/tests/views/EditProvider.test.ts
@@ -7,11 +7,13 @@ import {
   ProviderStatus,
   ProviderType,
   type ProviderConfig,
+  type Scope,
 } from "@/plugins/api/interfaces";
 import type { MusicAssistantApi } from "@/plugins/api";
 import { store } from "@/plugins/store";
 import EditProvider from "@/views/settings/EditProvider.vue";
 import { providerConfig } from "../fixtures/providerConfig";
+import { BUILTIN_ROLE_SCOPES, scopeChecker } from "../fixtures/scopes";
 import { user } from "../fixtures/user";
 
 const {
@@ -46,7 +48,7 @@ const {
     subscribe: vi.fn(),
   },
   authMock: {
-    isAdmin: vi.fn(),
+    hasScope: vi.fn<(scope: Scope) => boolean>(),
   },
   eventbusMock: {
     emit: vi.fn(),
@@ -140,7 +142,7 @@ vi.mock("vue-router", async (importOriginal) => {
 beforeEach(() => {
   vi.clearAllMocks();
   providersUpdated = undefined;
-  authMock.isAdmin.mockReturnValue(true);
+  authMock.hasScope.mockImplementation(scopeChecker(BUILTIN_ROLE_SCOPES.admin));
   store.currentUser = undefined;
   apiMock.providerManifests.spotify.allow_disable = true;
   apiMock.providerManifests.spotify.documentation =
@@ -980,7 +982,9 @@ describe("EditProvider", () => {
   });
 
   it("sends a member back to the music sources page after saving", async () => {
-    authMock.isAdmin.mockReturnValue(false);
+    authMock.hasScope.mockImplementation(
+      scopeChecker(BUILTIN_ROLE_SCOPES.user),
+    );
     store.currentUser = user({ user_id: "member-id" });
 
     await mountSavedProvider({
@@ -999,7 +1003,9 @@ describe("EditProvider", () => {
   });
 
   it("sends a member away from a source it does not own", async () => {
-    authMock.isAdmin.mockReturnValue(false);
+    authMock.hasScope.mockImplementation(
+      scopeChecker(BUILTIN_ROLE_SCOPES.user),
+    );
     store.currentUser = user({ user_id: "member-id" });
     apiMock.getProviderConfig.mockResolvedValue({
       ...spotifyConfig(ProviderStatus.LOADED),
@@ -1028,7 +1034,9 @@ describe("EditProvider", () => {
   });
 
   it("lets a member open a source it owns", async () => {
-    authMock.isAdmin.mockReturnValue(false);
+    authMock.hasScope.mockImplementation(
+      scopeChecker(BUILTIN_ROLE_SCOPES.user),
+    );
     store.currentUser = user({ user_id: "member-id" });
     apiMock.getProviderConfig.mockResolvedValue({
       ...spotifyConfig(ProviderStatus.LOADED),

--- a/tests/views/MusicQuizDashboardHostActions.test.ts
+++ b/tests/views/MusicQuizDashboardHostActions.test.ts
@@ -58,11 +58,14 @@ vi.mock("@/plugins/api", () => ({
   },
 }));
 
-vi.mock("@/plugins/auth", () => ({
-  authManager: {
-    isAdmin: () => false,
-  },
-}));
+// signed in as a member
+vi.mock("@/plugins/auth", async () => {
+  const { BUILTIN_ROLE_SCOPES, scopeChecker } =
+    await import("../fixtures/scopes");
+  return {
+    authManager: { hasScope: scopeChecker(BUILTIN_ROLE_SCOPES.user) },
+  };
+});
 
 vi.mock("vue-router", async (importOriginal) => ({
   ...(await importOriginal<typeof import("vue-router")>()),

--- a/tests/views/MusicQuizDashboardView.test.ts
+++ b/tests/views/MusicQuizDashboardView.test.ts
@@ -1,5 +1,9 @@
 import MusicQuizDashboardView from "@/views/MusicQuizDashboardView.vue";
-import { ProviderType, type ProviderConfig } from "@/plugins/api/interfaces";
+import {
+  ProviderType,
+  type ProviderConfig,
+  type Scope,
+} from "@/plugins/api/interfaces";
 import type { MusicAssistantApi } from "@/plugins/api";
 import { flushPromises, mount } from "@vue/test-utils";
 import { nextTick } from "vue";
@@ -59,11 +63,17 @@ vi.mock("@/plugins/api", async () => {
 
 vi.mock("@/plugins/auth", async () => {
   const { ref } = await import("vue");
+  const { BUILTIN_ROLE_SCOPES, scopeChecker } =
+    await import("../fixtures/scopes");
   const isAdmin = ref(false);
   mockAdminState.current = isAdmin;
   return {
     authManager: {
-      isAdmin: () => isAdmin.value,
+      // a member until a test hands out the admin role
+      hasScope: (scope: Scope) =>
+        scopeChecker(
+          isAdmin.value ? BUILTIN_ROLE_SCOPES.admin : BUILTIN_ROLE_SCOPES.user,
+        )(scope),
     },
   };
 });

--- a/tests/views/Onboarding.test.ts
+++ b/tests/views/Onboarding.test.ts
@@ -20,7 +20,7 @@ const {
     sendCommand: vi.fn(),
     serverInfo: { value: { onboard_done: false } },
   },
-  authMock: { isAdmin: vi.fn(() => true) },
+  authMock: { hasScope: vi.fn(() => true) },
   // replaced with a real ref by the userPreferences mock factory below
   preferenceState: {
     intent: { value: undefined } as { value?: string },
@@ -133,7 +133,7 @@ describe("Onboarding wizard", () => {
       ...providerConfigs.list,
     ]);
     apiMock.subscribe.mockClear();
-    authMock.isAdmin.mockReturnValue(true);
+    authMock.hasScope.mockReturnValue(true);
     preferenceState.intent.value = undefined;
     routeState.route.query = {};
     routerMock.push.mockReset();

--- a/tests/views/Onboarding.test.ts
+++ b/tests/views/Onboarding.test.ts
@@ -1,6 +1,7 @@
-import { ProviderType } from "@/plugins/api/interfaces";
+import { ProviderType, type Scope } from "@/plugins/api/interfaces";
 import { flushPromises, mount } from "@vue/test-utils";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { BUILTIN_ROLE_SCOPES, scopeChecker } from "../fixtures/scopes";
 
 const {
   apiMock,
@@ -20,7 +21,7 @@ const {
     sendCommand: vi.fn(),
     serverInfo: { value: { onboard_done: false } },
   },
-  authMock: { hasScope: vi.fn(() => true) },
+  authMock: { hasScope: vi.fn<(scope: Scope) => boolean>() },
   // replaced with a real ref by the userPreferences mock factory below
   preferenceState: {
     intent: { value: undefined } as { value?: string },
@@ -133,7 +134,9 @@ describe("Onboarding wizard", () => {
       ...providerConfigs.list,
     ]);
     apiMock.subscribe.mockClear();
-    authMock.hasScope.mockReturnValue(true);
+    authMock.hasScope.mockImplementation(
+      scopeChecker(BUILTIN_ROLE_SCOPES.admin),
+    );
     preferenceState.intent.value = undefined;
     routeState.route.query = {};
     routerMock.push.mockReset();

--- a/tests/views/PartyDashboardView.test.ts
+++ b/tests/views/PartyDashboardView.test.ts
@@ -1,9 +1,11 @@
+import { AlertDialog } from "@/components/ui/alert-dialog";
 import api from "@/plugins/api";
-import { EventType, PlaybackState } from "@/plugins/api/interfaces";
+import { EventType, PlaybackState, type Scope } from "@/plugins/api/interfaces";
 import { store } from "@/plugins/store";
 import PartyDashboardView from "@/views/PartyDashboardView.vue";
 import { type VueWrapper, flushPromises, mount } from "@vue/test-utils";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { BUILTIN_ROLE_SCOPES, scopeChecker } from "../fixtures/scopes";
 
 // Reactive, so the view's own chrome follows the flag the way it does in the app.
 vi.mock("@/plugins/store", async () => {
@@ -55,9 +57,13 @@ vi.mock("@/plugins/api", () => ({
   },
 }));
 
+const { hasScope } = vi.hoisted(() => ({
+  hasScope: vi.fn<(scope: Scope) => boolean>(),
+}));
+
 // Pulled in transitively via @/helpers/utils; mocked so their module-load side effects (AuthManager reading localStorage) don't leak into this test.
 vi.mock("@/plugins/router", () => ({ default: {} }));
-vi.mock("@/plugins/auth", () => ({ authManager: {}, default: {} }));
+vi.mock("@/plugins/auth", () => ({ authManager: { hasScope }, default: {} }));
 
 vi.mock("vue-router", () => ({ useRouter: () => ({ push: vi.fn() }) }));
 
@@ -115,7 +121,7 @@ function mountViewRaw() {
     global: {
       mocks: { $t: (key: string) => key },
       stubs: {
-        Badge: { template: "<span><slot /></span>" },
+        Badge: { template: '<span data-testid="badge"><slot /></span>' },
         Button: ButtonStub,
         LyricsViewer: true,
         PartyQR: true,
@@ -471,5 +477,53 @@ describe("PartyDashboardView active player", () => {
     await flushPromises();
 
     expect(store.activePlayerId).toBe("the_users_own_pick");
+  });
+});
+
+describe("PartyDashboardView party settings", () => {
+  const GUEST_ACCESS = '[data-testid="badge"]';
+  const PARTY_SETTINGS = '[aria-label="tooltip.party_settings"]';
+  const guestAccessDialogOpen = (view: VueWrapper) =>
+    view.getComponent(AlertDialog).props("open");
+
+  beforeEach(() => {
+    store.frameless = false;
+    api.providers = {
+      "party--1": { domain: "party", instance_id: "party--1" },
+    } as unknown as typeof api.providers;
+  });
+
+  afterEach(() => {
+    wrapper?.unmount();
+    wrapper = undefined;
+    api.providers = {};
+  });
+
+  it("lets an admin switch guest access and open the party settings", async () => {
+    hasScope.mockImplementation(scopeChecker(BUILTIN_ROLE_SCOPES.admin));
+    const view = await mountView();
+
+    const badge = view.get(GUEST_ACCESS);
+    expect(badge.classes()).toContain("cursor-pointer");
+    await badge.trigger("click");
+
+    expect(guestAccessDialogOpen(view)).toBe(true);
+    expect(view.find(PARTY_SETTINGS).exists()).toBe(true);
+  });
+
+  it.each([
+    ["a member", BUILTIN_ROLE_SCOPES.user],
+    ["a guest", BUILTIN_ROLE_SCOPES.guest],
+  ])("only shows %s whether guest access is on", async (_role, scopes) => {
+    hasScope.mockImplementation(scopeChecker(scopes));
+    const view = await mountView();
+
+    const badge = view.get(GUEST_ACCESS);
+    expect(badge.text()).toBe("providers.party.guest_access_enabled");
+    expect(badge.classes()).not.toContain("cursor-pointer");
+    await badge.trigger("click");
+
+    expect(guestAccessDialogOpen(view)).toBe(false);
+    expect(view.find(PARTY_SETTINGS).exists()).toBe(false);
   });
 });

--- a/tests/views/Players.test.ts
+++ b/tests/views/Players.test.ts
@@ -1,13 +1,18 @@
 import Players from "@/views/settings/Players.vue";
 import type { MusicAssistantApi } from "@/plugins/api";
 import type { getPlayerSettingsMenuItems as buildPlayerSettingsMenuItems } from "@/helpers/player_settings_actions";
-import { ProviderType, type PlayerConfig } from "@/plugins/api/interfaces";
+import {
+  ProviderType,
+  Scope,
+  type PlayerConfig,
+} from "@/plugins/api/interfaces";
 import { flushPromises, mount } from "@vue/test-utils";
 import { ref } from "vue";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { providerManifest } from "../fixtures/providerManifest";
+import { BUILTIN_ROLE_SCOPES, scopeChecker } from "../fixtures/scopes";
 
-const { apiMock, emitEvent, getPlayerSettingsMenuItems, routerPush } =
+const { apiMock, emitEvent, getPlayerSettingsMenuItems, hasScope, routerPush } =
   vi.hoisted(() => ({
     apiMock: {
       getPlayerConfigs: vi.fn<MusicAssistantApi["getPlayerConfigs"]>(),
@@ -28,12 +33,17 @@ const { apiMock, emitEvent, getPlayerSettingsMenuItems, routerPush } =
     },
     emitEvent: vi.fn(),
     getPlayerSettingsMenuItems: vi.fn<typeof buildPlayerSettingsMenuItems>(),
+    hasScope: vi.fn<(scope: Scope) => boolean>(),
     routerPush: vi.fn(),
   }));
 
 vi.mock("@/plugins/api", () => ({
   api: apiMock,
   default: apiMock,
+}));
+
+vi.mock("@/plugins/auth", () => ({
+  authManager: { hasScope },
 }));
 
 vi.mock("@/plugins/eventbus", () => ({
@@ -103,6 +113,7 @@ const passthroughStub = {
 describe("Players", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    hasScope.mockImplementation(scopeChecker(BUILTIN_ROLE_SCOPES.admin));
     playerConfig.enabled = true;
     apiMock.players = {
       kitchen: {
@@ -124,6 +135,26 @@ describe("Players", () => {
     apiMock.getProviderManifest.mockReturnValue(providerManifest());
     apiMock.subscribe_multi.mockReturnValue(vi.fn());
     getPlayerSettingsMenuItems.mockReturnValue([{ label: "settings.delete" }]);
+  });
+
+  it("points an admin to the player providers", async () => {
+    const wrapper = await mountPlayers("list");
+
+    expect(wrapper.find(".missing-players-hint").exists()).toBe(true);
+  });
+
+  it.each([
+    { role: "a member", scopes: BUILTIN_ROLE_SCOPES.user },
+    { role: "a guest", scopes: BUILTIN_ROLE_SCOPES.guest },
+    {
+      role: "a role that only changes player settings",
+      scopes: [...BUILTIN_ROLE_SCOPES.guest, Scope.CONFIG_PLAYERS_WRITE],
+    },
+  ])("leaves the player providers out for $role", async ({ scopes }) => {
+    hasScope.mockImplementation(scopeChecker(scopes));
+    const wrapper = await mountPlayers("list");
+
+    expect(wrapper.find(".missing-players-hint").exists()).toBe(false);
   });
 
   it.each([

--- a/tests/views/Providers.test.ts
+++ b/tests/views/Providers.test.ts
@@ -7,12 +7,18 @@ import {
   ProviderStage,
   ProviderStatus,
   ProviderType,
+  type Scope,
   type User,
   UserRole,
 } from "@/plugins/api/interfaces";
 import type { MusicAssistantApi } from "@/plugins/api";
 import Providers from "@/views/settings/Providers.vue";
 import { providerConfig } from "../fixtures/providerConfig";
+import {
+  BUILTIN_ROLE_SCOPES,
+  OWN_SOURCES_ROLE_SCOPES,
+  scopeChecker,
+} from "../fixtures/scopes";
 import { user, userSummary } from "../fixtures/user";
 
 const {
@@ -50,7 +56,7 @@ const {
     supportsShareCandidates: true,
   },
   authMock: {
-    isAdmin: vi.fn<() => boolean>(),
+    hasScope: vi.fn<(scope: Scope) => boolean>(),
   },
   eventbusMock: {
     emit: vi.fn(),
@@ -205,7 +211,7 @@ beforeEach(() => {
   apiMock.reloadProvider.mockResolvedValue(undefined);
   apiMock.subscribe.mockReturnValue(vi.fn());
   apiMock.supportsShareCandidates = true;
-  authMock.isAdmin.mockReturnValue(true);
+  authMock.hasScope.mockImplementation(scopeChecker(BUILTIN_ROLE_SCOPES.admin));
   routeMock.query.types = "music";
   storeMock.currentUser = owner;
 });
@@ -613,7 +619,9 @@ describe("Providers", () => {
 
 describe("Providers for a member", () => {
   beforeEach(() => {
-    authMock.isAdmin.mockReturnValue(false);
+    authMock.hasScope.mockImplementation(
+      scopeChecker(BUILTIN_ROLE_SCOPES.user),
+    );
   });
 
   it("lists only the music sources it owns, whatever type the route asks for", async () => {
@@ -802,11 +810,23 @@ describe("Providers keyboard", () => {
 
 describe("Providers loading", () => {
   it("narrows a member's load to the music sources", async () => {
-    authMock.isAdmin.mockReturnValue(false);
+    authMock.hasScope.mockImplementation(
+      scopeChecker(BUILTIN_ROLE_SCOPES.user),
+    );
 
     await mountWithConfigs([]);
 
     expect(apiMock.getProviderConfigs).toHaveBeenCalledWith(ProviderType.MUSIC);
+  });
+
+  it("gives a role that manages only its own music sources the member view", async () => {
+    authMock.hasScope.mockImplementation(scopeChecker(OWN_SOURCES_ROLE_SCOPES));
+
+    await mountWithConfigs([]);
+
+    expect(apiMock.getProviderConfigs).toHaveBeenCalledWith(ProviderType.MUSIC);
+    expect(apiMock.getAllUsers).not.toHaveBeenCalled();
+    expect(apiMock.getShareCandidates).toHaveBeenCalled();
   });
 
   it("reports a failing load and shows no empty state", async () => {

--- a/tests/views/Settings.test.ts
+++ b/tests/views/Settings.test.ts
@@ -1,0 +1,125 @@
+/**
+ * The breadcrumb trail of the settings pages links only to the pages the role
+ * of the user may open.
+ */
+import type { ToolbarHeadingItem } from "@/components/ToolbarHeading.vue";
+import type { Scope } from "@/plugins/api/interfaces";
+import Settings from "@/views/settings/Settings.vue";
+import { mount } from "@vue/test-utils";
+import { describe, expect, it, vi } from "vitest";
+import { BUILTIN_ROLE_SCOPES, scopeChecker } from "../fixtures/scopes";
+
+const { apiMock, hasScope } = vi.hoisted(() => ({
+  apiMock: {
+    players: { kitchen: { name: "Kitchen" } },
+    providerManifests: {},
+    getProvider: vi.fn(),
+  },
+  hasScope: vi.fn<(scope: Scope) => boolean>(),
+}));
+
+vi.mock("@/plugins/api", () => ({ api: apiMock, default: apiMock }));
+vi.mock("@/plugins/auth", () => ({ authManager: { hasScope } }));
+// the sections are covered where they are decided
+vi.mock("@/helpers/settings_sections", () => ({
+  availableSettingsSections: () => [],
+}));
+vi.mock("@/composables/userPreferences", async () => {
+  const { ref } = await vi.importActual<typeof import("vue")>("vue");
+  return {
+    useUserPreferences: () => ({
+      getPreference: () => ref(undefined),
+      setPreference: vi.fn(),
+    }),
+  };
+});
+vi.mock("vue-router", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("vue-router")>()),
+  useRouter: () => ({
+    currentRoute: {
+      value: {
+        name: "editplayeroptions",
+        params: { playerId: "kitchen" },
+        query: {},
+      },
+    },
+    push: vi.fn(),
+  }),
+}));
+vi.mock("vue-i18n", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("vue-i18n")>()),
+  useI18n: () => ({ t: (key: string) => key }),
+}));
+vi.mock("vuetify", async (importOriginal) => {
+  const { ref } = await vi.importActual<typeof import("vue")>("vue");
+  return {
+    ...(await importOriginal<typeof import("vuetify")>()),
+    useDisplay: () => ({ mobile: ref(false) }),
+  };
+});
+
+const ToolbarHeadingStub = {
+  props: ["title", "to", "items"],
+  template: "<div />",
+};
+
+/**
+ * The trail the settings page hands its heading on the options of a player.
+ */
+function playerOptionsTrail(): ToolbarHeadingItem[] {
+  const wrapper = mount(Settings, {
+    global: {
+      stubs: {
+        Toolbar: {
+          template: '<div><slot name="title" /><slot name="append" /></div>',
+        },
+        ToolbarHeading: ToolbarHeadingStub,
+        RouterView: true,
+        VBtn: true,
+        VDivider: true,
+      },
+    },
+  });
+  return wrapper.getComponent(ToolbarHeadingStub).props("items");
+}
+
+describe("Settings breadcrumbs on the options of a player", () => {
+  it("link an admin to the players and to the settings of the player", () => {
+    hasScope.mockImplementation(scopeChecker(BUILTIN_ROLE_SCOPES.admin));
+
+    expect(playerOptionsTrail()).toEqual([
+      {
+        title: "settings.players",
+        disabled: false,
+        to: { name: "playersettings" },
+      },
+      {
+        title: "Kitchen",
+        disabled: false,
+        to: { name: "editplayer", params: { playerId: "kitchen" } },
+      },
+      { title: "settings.category.options", disabled: true },
+    ]);
+  });
+
+  it.each([
+    ["a member", BUILTIN_ROLE_SCOPES.user],
+    ["a guest", BUILTIN_ROLE_SCOPES.guest],
+  ])(
+    "are plain text for %s, who may only open the options",
+    (_role, scopes) => {
+      hasScope.mockImplementation(scopeChecker(scopes));
+
+      const trail = playerOptionsTrail();
+
+      expect(trail.map(({ title, disabled }) => ({ title, disabled }))).toEqual(
+        [
+          { title: "settings.players", disabled: false },
+          { title: "Kitchen", disabled: false },
+          { title: "settings.category.options", disabled: true },
+        ],
+      );
+      expect(trail.filter((item) => item.to)).toEqual([]);
+    },
+  );
+});

--- a/tests/views/UserManagement.test.ts
+++ b/tests/views/UserManagement.test.ts
@@ -1,20 +1,26 @@
 import { HOMEASSISTANT_SYSTEM_USER } from "@/helpers/users";
-import { UserRole } from "@/plugins/api/interfaces";
+import { Scope, UserRole } from "@/plugins/api/interfaces";
 import UserManagement from "@/views/settings/UserManagement.vue";
 import { flushPromises, mount } from "@vue/test-utils";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { BUILTIN_ROLE_SCOPES, scopeChecker } from "../fixtures/scopes";
 import { user } from "../fixtures/user";
 
-const { apiMock, routeMock, routerMock, storeMock } = vi.hoisted(() => ({
-  apiMock: { getAllUsers: vi.fn() },
-  routeMock: { query: {} as Record<string, string> },
-  routerMock: { push: vi.fn(), replace: vi.fn() },
-  storeMock: { currentUser: { user_id: "admin-1" } },
-}));
+const { apiMock, hasScopeMock, routeMock, routerMock, storeMock } = vi.hoisted(
+  () => ({
+    apiMock: { getAllUsers: vi.fn() },
+    hasScopeMock: vi.fn<(scope: Scope) => boolean>(),
+    routeMock: { query: {} as Record<string, string> },
+    routerMock: { push: vi.fn(), replace: vi.fn() },
+    storeMock: { currentUser: { user_id: "admin-1" } },
+  }),
+);
 
 vi.mock("@/plugins/api", () => ({ api: apiMock }));
 
 vi.mock("@/plugins/store", () => ({ store: storeMock }));
+
+vi.mock("@/plugins/auth", () => ({ authManager: { hasScope: hasScopeMock } }));
 
 vi.mock("vue-sonner", () => ({
   toast: { error: vi.fn(), success: vi.fn() },
@@ -69,6 +75,10 @@ async function mountView() {
 }
 
 describe("UserManagement", () => {
+  beforeEach(() => {
+    hasScopeMock.mockImplementation(scopeChecker(BUILTIN_ROLE_SCOPES.admin));
+  });
+
   it("shows the System badge only on the Home Assistant account's card", async () => {
     const wrapper = await mountView();
 
@@ -88,5 +98,18 @@ describe("UserManagement", () => {
     expect(systemCard.text()).not.toContain("auth.delete_user");
     expect(memberCard.text()).toContain("auth.disable_user");
     expect(memberCard.text()).toContain("auth.delete_user");
+  });
+
+  it("lists the users without a way to change them to a role that only reads them", async () => {
+    hasScopeMock.mockImplementation(
+      scopeChecker([...BUILTIN_ROLE_SCOPES.guest, Scope.USERS_READ]),
+    );
+
+    const wrapper = await mountView();
+
+    expect(wrapper.findAll('[data-slot="card"]')).toHaveLength(2);
+    expect(wrapper.text()).not.toContain("auth.create_user");
+    expect(wrapper.text()).not.toContain("auth.edit_user");
+    expect(wrapper.text()).not.toContain("auth.manage_tokens");
   });
 });


### PR DESCRIPTION
# What does this implement/fix?

The app decided what to show from the role name. Admin-only pages and actions checked for "admin", and member actions checked nothing. The server checks permissions, and admins can now create roles with their own set of them, so the app now follows the permissions of the signed-in user's role. Admins see what they saw before, and members and guests no longer get actions the server refuses them.

- Pages, settings sections and actions are gated on the permission the server requires for them, not on the role name
- Library actions that need "manage library" (refresh item, update metadata, map to main item, link to genre, edit radio or track) are hidden for members, as the server refuses them
- Everyone can play AI Radio stations, and only admins create or edit them (with music-assistant/server#6301). On older servers AI Radio stays with admins
- When an admin changes a user's role, that user's app reloads once with the new permissions
- The AI DJ menu of a queue is only offered to roles that can load its hosts
- The Party dashboard's guest access toggle and settings are only offered to admins
- Links to pages a role can't open, like the player provider settings and the task list, are hidden, and the player settings crumbs become plain text
- Without the permission to read the queue settings, playing an item uses the server's default instead of showing an error

**Related issue (if applicable):**

- related issue https://github.com/music-assistant/backlog/issues/108

**Related backend PR (if applicable):**

<!--
Link the music-assistant/server PR when this change relies on new server
behaviour, so the two can be reviewed and released together.
-->

- related backend PR https://github.com/music-assistant/server/pull/6299 and https://github.com/music-assistant/server/pull/6301

## Types of changes

<!--
Tick exactly one box below. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm lint:check` passes.
- [x] `pnpm test:run` passes, and tests have been added/updated where applicable.
- [x] `pnpm build` passes.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.


