### PR TITLE
Ask before removing a music source from the list

### DIFF
--- a/src/views/settings/Providers.vue
+++ b/src/views/settings/Providers.vue
@@ -528,13 +528,15 @@ const removeProvider = function (config: ProviderConfig) {
     title: $t("settings.remove_provider"),
     message: $t("settings.remove_provider_confirm", [getProviderName(config)]),
     confirmLabel: $t("settings.remove_provider"),
-    onConfirm: () => {
-      api
-        .removeProviderConfig(instanceId)
-        .catch((err) => toast.error(String(err)));
-      providerConfigs.value = providerConfigs.value.filter(
-        (x) => x.instance_id != instanceId,
-      );
+    onConfirm: async () => {
+      try {
+        await api.removeProviderConfig(instanceId);
+        providerConfigs.value = providerConfigs.value.filter(
+          (x) => x.instance_id != instanceId,
+        );
+      } catch (err) {
+        toast.error(String(err));
+      }
     },
   });
 };

--- a/src/views/settings/Providers.vue
+++ b/src/views/settings/Providers.vue
@@ -522,13 +522,21 @@ const loadShareCandidates = async function () {
   }
 };
 
-const removeProvider = function (providerInstanceId: string) {
-  api
-    .removeProviderConfig(providerInstanceId)
-    .catch((err) => toast.error(String(err)));
-  providerConfigs.value = providerConfigs.value.filter(
-    (x) => x.instance_id != providerInstanceId,
-  );
+const removeProvider = function (config: ProviderConfig) {
+  const instanceId = config.instance_id;
+  eventbus.emit("deleteConfirmationDialog", {
+    title: $t("settings.remove_provider"),
+    message: $t("settings.remove_provider_confirm", [getProviderName(config)]),
+    confirmLabel: $t("settings.remove_provider"),
+    onConfirm: () => {
+      api
+        .removeProviderConfig(instanceId)
+        .catch((err) => toast.error(String(err)));
+      providerConfigs.value = providerConfigs.value.filter(
+        (x) => x.instance_id != instanceId,
+      );
+    },
+  });
 };
 
 const openProviderOptions = function (providerInstanceId: string) {
@@ -674,7 +682,7 @@ const onMenu = function (evt: Event, item: ProviderConfig) {
       label: "settings.remove_provider",
       labelArgs: [],
       action: () => {
-        removeProvider(item.instance_id);
+        removeProvider(item);
       },
       icon: "mdi-delete",
       hide: providerManifest.builtin,

--- a/tests/views/Providers.test.ts
+++ b/tests/views/Providers.test.ts
@@ -340,6 +340,28 @@ describe("Providers", () => {
     expect(wrapper.findAll('[data-testid="provider-row"]')).toHaveLength(0);
   });
 
+  it("keeps the provider listed when removing it fails", async () => {
+    // the server still has the source, so the list must not pretend otherwise
+    apiMock.removeProviderConfig.mockRejectedValue(new Error("nope"));
+    const wrapper = await mountProviders(ProviderStatus.LOADED);
+
+    const menuItems = await openMenu(wrapper);
+    menuItems
+      .find(
+        (item: { label: string }) => item.label === "settings.remove_provider",
+      )
+      .action();
+
+    const removeCall = eventbusMock.emit.mock.calls.find(
+      ([event]) => event === "deleteConfirmationDialog",
+    );
+    await removeCall?.[1].onConfirm();
+    await flushPromises();
+
+    expect(toastMock.error).toHaveBeenCalledWith("Error: nope");
+    expect(wrapper.findAll('[data-testid="provider-row"]')).toHaveLength(1);
+  });
+
   it("omits reconfigure from the menu when no setup flow exists", async () => {
     const wrapper = await mountProviders(ProviderStatus.LOADED, false);
 

--- a/tests/views/Providers.test.ts
+++ b/tests/views/Providers.test.ts
@@ -19,6 +19,7 @@ const {
   apiMock,
   authMock,
   eventbusMock,
+  i18nMock,
   routeMock,
   routerMock,
   storeMock,
@@ -53,6 +54,11 @@ const {
   },
   eventbusMock: {
     emit: vi.fn(),
+  },
+  // a spy that returns the key, so the interpolation arguments a message is
+  // given stay assertable
+  i18nMock: {
+    $t: vi.fn((key: string) => key),
   },
   routeMock: {
     query: { types: "music" },
@@ -103,9 +109,7 @@ vi.mock("@/plugins/eventbus", () => ({
   eventbus: eventbusMock,
 }));
 
-vi.mock("@/plugins/i18n", () => ({
-  $t: (key: string) => key,
-}));
+vi.mock("@/plugins/i18n", () => i18nMock);
 
 vi.mock("@/plugins/router", () => ({
   default: routerMock,
@@ -299,6 +303,41 @@ describe("Providers", () => {
     reloadItem.action();
 
     expect(apiMock.reloadProvider).toHaveBeenCalledWith("spotify--test");
+  });
+
+  it("asks for confirmation before removing a provider from the row menu", async () => {
+    // removing a source cannot be undone, so the row menu has to confirm it
+    // just like the provider detail page does
+    apiMock.removeProviderConfig.mockResolvedValue(undefined);
+    // a renamed source must be confirmed under the name the user gave it,
+    // so the custom name has to win over the manifest's "Spotify"
+    const wrapper = await mountProviders(ProviderStatus.LOADED, true, true, {
+      name: "My Spotify",
+    });
+
+    const menuItems = await openMenu(wrapper);
+    menuItems
+      .find(
+        (item: { label: string }) => item.label === "settings.remove_provider",
+      )
+      .action();
+
+    const removeCall = eventbusMock.emit.mock.calls.find(
+      ([event]) => event === "deleteConfirmationDialog",
+    );
+    expect(removeCall?.[1].message).toBe("settings.remove_provider_confirm");
+    // the stubbed $t returns the key, so the name is checked where it is passed
+    expect(i18nMock.$t).toHaveBeenCalledWith(
+      "settings.remove_provider_confirm",
+      ["My Spotify"],
+    );
+    expect(apiMock.removeProviderConfig).not.toHaveBeenCalled();
+
+    await removeCall?.[1].onConfirm();
+    await flushPromises();
+
+    expect(apiMock.removeProviderConfig).toHaveBeenCalledWith("spotify--test");
+    expect(wrapper.findAll('[data-testid="provider-row"]')).toHaveLength(0);
   });
 
   it("omits reconfigure from the menu when no setup flow exists", async () => {


### PR DESCRIPTION
# What does this implement/fix?

Removing a music source cannot be undone — you have to set it up again from scratch. The source's own settings page already asks you to confirm first, but the "Remove" option in the list's row menu removed it straight away, with no way back.

Both entry points now read "Remove", so the two behave the same: the row menu asks first, naming the source you picked.

- Row menu removal now shows the same confirmation dialog as the settings page
- The source is only removed once you confirm
- A source that fails to remove stays in the list instead of disappearing while the server still has it
- Added tests for both the confirmation and the failure case

No new texts — this reuses the strings the settings page already uses. No screenshot: no new UI here, this opens the same confirmation dialog the settings page already shows.

**Related issue (if applicable):**

- n/a

**Related backend PR (if applicable):**

- n/a

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm lint:check` passes.
- [x] `pnpm test:run` passes, and tests have been added/updated where applicable.
- [x] `pnpm build` passes.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
