### PR TITLE
Fix duplicate error message when a profile update fails

### DIFF
--- a/src/components/profile/ProfileSettings.vue
+++ b/src/components/profile/ProfileSettings.vue
@@ -226,7 +226,7 @@ import {
 } from "@/components/ui/field";
 import { Input } from "@/components/ui/input";
 import { profileSettingsSchema } from "@/lib/forms/profile";
-import { api } from "@/plugins/api";
+import { api, ApiCommandError } from "@/plugins/api";
 import { store } from "@/plugins/store";
 
 const { t } = useI18n();
@@ -280,7 +280,9 @@ const form = useForm({
         return;
       }
 
-      const updatedUser = await api.updateUser(user.value.user_id, updates);
+      const updatedUser = await api.updateUser(user.value.user_id, updates, {
+        suppressGlobalError: true,
+      });
 
       if (updatedUser) {
         store.currentUser = updatedUser;
@@ -298,8 +300,12 @@ const form = useForm({
         }
         toast.success(t("auth.profile_updated"));
       }
-    } catch (err: unknown) {
-      toast.error(err instanceof Error ? err.message : t("error_generic"));
+    } catch (error) {
+      toast.error(
+        error instanceof ApiCommandError && error.details
+          ? error.details
+          : t("error_generic"),
+      );
     } finally {
       updating.value = false;
     }


### PR DESCRIPTION
# What does this implement/fix?

Saving profile changes that the server rejects showed **two** error toasts: the API plugin's global error handler and the form's own `catch` both fired for the same failure. The profile update now opts out of the global toast, so the user sees a single message — the server's reason when it sends one, otherwise the generic fallback.

Same treatment already applied to the Edit/Create user dialogs in #2724.

**Changes**

- `ProfileSettings.vue`: pass `{ suppressGlobalError: true }` to `api.updateUser`, and on failure show `ApiCommandError.details` (the server's reason) when present, falling back to `t("error_generic")`.

**Related issue (if applicable):**

- n/a — pre-existing minor UX issue, spotted alongside #2724

**Related backend PR (if applicable):**

- n/a — frontend only

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm lint:check` passes.
- [x] `pnpm test:run` passes, and tests have been added/updated where applicable.
- [x] `pnpm build` passes.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.