### PR TITLE
Fix outdated auto-release workflow comments

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -1,6 +1,6 @@
 name: Auto Release
 
-# Automatically creates a release every night at 01:00 UTC if there are 2+ commits since the last release
+# Automatically creates a release every night at 04:00 Europe/Amsterdam time if there is at least 1 commit since the last release
 # Calculates the next version number (patch increment) and triggers the publish release workflow
 
 on:
@@ -54,7 +54,7 @@ jobs:
               echo "has_commits=true" >> $GITHUB_OUTPUT
             else
               echo "has_commits=false" >> $GITHUB_OUTPUT
-              echo "Only $COMMITS_SINCE commit(s) found. Need at least 2 commits for auto-release."
+              echo "Only $COMMITS_SINCE commit(s) found. Need at least 1 commit for auto-release."
             fi
           fi
         env:


### PR DESCRIPTION
# What does this implement/fix?

The header comment and the skip log message in the nightly auto-release workflow still said it runs at 01:00 UTC and needs 2+ commits. The schedule moved to 04:00 Amsterdam time in e5b93b94 and the threshold dropped to 1 commit in 1d80bb63, but neither text was updated, so both contradicted the code right below them. No behaviour change. Same fix as music-assistant/models#407.

- Header comment now says 04:00 Europe/Amsterdam and at least 1 commit
- Skip log message now says at least 1 commit is needed

**Related issue (if applicable):**

- related issue `n/a`

**Related backend PR (if applicable):**

- related backend PR `n/a`

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm lint:check` passes.
- [x] `pnpm test:run` passes, and tests have been added/updated where applicable.
- [x] `pnpm build` passes.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
