### PR TITLE
Clearer sharing hints for playlists without an owner

### DIFF
--- a/src/helpers/playlist_access.test.ts
+++ b/src/helpers/playlist_access.test.ts
@@ -11,6 +11,7 @@ import {
   canEditPlaylistItems,
   canManagePlaylist,
   canSharePlaylist,
+  getPlaylistSharingHintTranslationKey,
   isMusicAssistantPlaylist,
 } from "./playlist_access";
 
@@ -39,6 +40,41 @@ const spotifyPlaylist = (overrides = {}) =>
     provider_mappings: [providerMapping({ provider_domain: "spotify" })],
     ...overrides,
   });
+
+describe("getPlaylistSharingHintTranslationKey", () => {
+  it.each(Object.values(ProviderSharing))(
+    "explains sharing %s for a playlist with an owner",
+    (sharing) => {
+      expect(getPlaylistSharingHintTranslationKey(access({ sharing }))).toBe(
+        `playlist_access.hints.${sharing}`,
+      );
+    },
+  );
+
+  it("explains that only the selected members can see a playlist without an owner", () => {
+    expect(
+      getPlaylistSharingHintTranslationKey(
+        access({
+          owner: null,
+          sharing: ProviderSharing.SELECTED,
+          shared_users: ["member"],
+        }),
+      ),
+    ).toBe("playlist_access.hints.selected_no_owner");
+  });
+
+  it("explains that nobody can see a playlist without an owner shared with nobody selected", () => {
+    expect(
+      getPlaylistSharingHintTranslationKey(
+        access({
+          owner: null,
+          sharing: ProviderSharing.SELECTED,
+          shared_users: [],
+        }),
+      ),
+    ).toBe("playlist_access.hints.nobody");
+  });
+});
 
 describe("isMusicAssistantPlaylist", () => {
   it("is true for a playlist of the builtin provider", () => {

--- a/src/helpers/playlist_access.test.ts
+++ b/src/helpers/playlist_access.test.ts
@@ -74,6 +74,15 @@ describe("getPlaylistSharingHintTranslationKey", () => {
       ),
     ).toBe("playlist_access.hints.nobody");
   });
+
+  it.each([ProviderSharing.MEMBERS, ProviderSharing.EVERYONE])(
+    "still explains sharing %s for a playlist without an owner",
+    (sharing) => {
+      expect(
+        getPlaylistSharingHintTranslationKey(access({ owner: null, sharing })),
+      ).toBe(`playlist_access.hints.${sharing}`);
+    },
+  );
 });
 
 describe("isMusicAssistantPlaylist", () => {

--- a/src/helpers/playlist_access.ts
+++ b/src/helpers/playlist_access.ts
@@ -1,9 +1,10 @@
 import {
   type Playlist,
+  type PlaylistAccess,
   ProviderSharing,
   type User,
 } from "@/plugins/api/interfaces";
-import { accessAllows } from "./provider_access";
+import { accessAllows, servesNobody } from "./provider_access";
 
 const PLAYLIST_SHARING_HINT_TRANSLATION_KEYS: Record<ProviderSharing, string> =
   {
@@ -13,10 +14,15 @@ const PLAYLIST_SHARING_HINT_TRANSLATION_KEYS: Record<ProviderSharing, string> =
     [ProviderSharing.EVERYONE]: "playlist_access.hints.everyone",
   };
 
-/** The translation key explaining a sharing choice for a playlist. */
+/** The translation key explaining who can see a playlist with this access. */
 export const getPlaylistSharingHintTranslationKey = (
-  sharing: ProviderSharing,
-) => PLAYLIST_SHARING_HINT_TRANSLATION_KEYS[sharing];
+  access: PlaylistAccess,
+) => {
+  if (servesNobody(access)) return "playlist_access.hints.nobody";
+  if (access.owner === null && access.sharing === ProviderSharing.SELECTED)
+    return "playlist_access.hints.selected_no_owner";
+  return PLAYLIST_SHARING_HINT_TRANSLATION_KEYS[access.sharing];
+};
 
 /** Whether the playlist is one Music Assistant keeps itself: only those carry an access record. */
 export const isMusicAssistantPlaylist = (playlist: Playlist) =>

--- a/src/helpers/provider_access.ts
+++ b/src/helpers/provider_access.ts
@@ -69,9 +69,8 @@ export const isOwnMusicSource = (
 ) => userId !== undefined && config.access?.owner === userId;
 
 /**
- * Whether nobody can use a music source with this access: one without an
- * owner that is private, or shared with selected members while nobody is
- * picked.
+ * Whether nobody can use what this access record guards: it has no owner and
+ * is private, or is shared with selected members while nobody is picked.
  */
 export const servesNobody = (access: ProviderAccess) =>
   access.owner === null &&

--- a/src/layouts/default/PlaylistAccessDialog.vue
+++ b/src/layouts/default/PlaylistAccessDialog.vue
@@ -69,7 +69,7 @@
               </SelectContent>
             </Select>
             <FieldDescription>
-              {{ $t(getPlaylistSharingHintTranslationKey(sharing)) }}
+              {{ $t(getPlaylistSharingHintTranslationKey(formAccess)) }}
             </FieldDescription>
           </Field>
 
@@ -111,7 +111,7 @@
         <Button
           type="submit"
           form="form-playlist-access"
-          :disabled="saving || !canSave"
+          :disabled="saving || servesNobody(formAccess)"
           :loading="saving"
         >
           {{ $t("settings.save") }}
@@ -150,6 +150,7 @@ import MultiSelect from "@/components/users/MultiSelect.vue";
 import { getPlaylistSharingHintTranslationKey } from "@/helpers/playlist_access";
 import {
   getProviderSharingTranslationKey,
+  servesNobody,
   userDisplayName,
 } from "@/helpers/provider_access";
 import { api } from "@/plugins/api";
@@ -235,16 +236,17 @@ const recordOwner = computed(() =>
   canChangeOwner.value ? selectedOwner.value : currentAccess.value.owner,
 );
 
+// the access record the form describes, as it is saved
+const formAccess = computed<PlaylistAccess>(() => ({
+  owner: recordOwner.value,
+  sharing: sharing.value,
+  shared_users:
+    sharing.value === ProviderSharing.SELECTED ? sharedUsers.value : [],
+  collaborative: collaborative.value,
+}));
+
 const ownedByViewer = computed(
   () => recordOwner.value === store.currentUser?.user_id,
-);
-
-// a playlist without an owner has to be shared with somebody
-const canSave = computed(
-  () =>
-    selectedOwner.value !== null ||
-    sharing.value !== ProviderSharing.SELECTED ||
-    sharedUsers.value.length > 0,
 );
 
 watch(showDialog, (open) => {
@@ -279,13 +281,7 @@ const save = async () => {
   if (!playlist.value) return;
   saving.value = true;
   try {
-    await api.setPlaylistAccess(playlist.value.item_id, {
-      owner: recordOwner.value,
-      sharing: sharing.value,
-      shared_users:
-        sharing.value === ProviderSharing.SELECTED ? sharedUsers.value : [],
-      collaborative: collaborative.value,
-    });
+    await api.setPlaylistAccess(playlist.value.item_id, formAccess.value);
     toast.success(t("playlist_access.updated"));
     showDialog.value = false;
   } catch (err) {

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -2134,7 +2134,9 @@
             "private": "Only the owner can see this playlist.",
             "selected": "The owner and the members selected below.",
             "members": "Every signed-in member, guests excluded.",
-            "everyone": "Any user can see this playlist."
+            "everyone": "Any user can see this playlist.",
+            "selected_no_owner": "Only the members selected below.",
+            "nobody": "Nobody can see this playlist until it has an owner or is shared with someone."
         },
         "updated": "Sharing updated"
     },

--- a/tests/layouts/PlaylistAccessDialog.test.ts
+++ b/tests/layouts/PlaylistAccessDialog.test.ts
@@ -166,7 +166,7 @@ describe("PlaylistAccessDialog", () => {
     );
   });
 
-  it("does not save a playlist without an owner shared with nobody", async () => {
+  it("can not save a playlist without an owner until a member is selected to share it with", async () => {
     await openDialog(
       maPlaylist({
         owner: null,
@@ -176,7 +176,53 @@ describe("PlaylistAccessDialog", () => {
       }),
     );
 
+    expect(sharingHint()).toBe("playlist_access.hints.nobody");
     expect(saveButton()!.disabled).toBe(true);
+
+    await openMemberPicker();
+    await pickMember("Member");
+
+    expect(sharingHint()).toBe("playlist_access.hints.selected_no_owner");
+    expect(saveButton()!.disabled).toBe(false);
+  });
+
+  it("explains that only the selected members see a playlist once it has no owner", async () => {
+    await openDialog(maPlaylist(sharedWithMember));
+
+    expect(sharingHint()).toBe("playlist_access.hints.selected");
+
+    await openSelect(ownerTrigger()!);
+    await pickOption("settings.source_access.household");
+
+    expect(sharingHint()).toBe("playlist_access.hints.selected_no_owner");
+    expect(saveButton()!.disabled).toBe(false);
+  });
+
+  it("shares a private playlist with all members once it has no owner", async () => {
+    const wrapper = await openDialog(
+      maPlaylist({
+        owner: "owner-id",
+        sharing: ProviderSharing.PRIVATE,
+        shared_users: [],
+        collaborative: false,
+      }),
+    );
+
+    await openSelect(ownerTrigger()!);
+    await pickOption("settings.source_access.household");
+
+    expect(sharingTrigger()!.textContent).toContain(
+      "settings.source_access.options.members",
+    );
+
+    await submit(wrapper);
+
+    expect(apiMock.setPlaylistAccess).toHaveBeenCalledWith("42", {
+      owner: null,
+      sharing: ProviderSharing.MEMBERS,
+      shared_users: [],
+      collaborative: false,
+    });
   });
 
   it("saves the owner, sharing, members and collaborative flag", async () => {
@@ -241,6 +287,15 @@ function sharingTrigger() {
   return document.querySelector<HTMLElement>("#playlist-access-sharing");
 }
 
+// the sharing field's own hint, not the dialog's full text: a prefix match
+// there would let "hints.selected" pass for "hints.selected_no_owner"
+function sharingHint() {
+  return sharingTrigger()
+    ?.closest("[data-slot='field']")
+    ?.querySelector("[data-slot='field-description']")
+    ?.textContent?.trim();
+}
+
 function saveButton() {
   return document.querySelector<HTMLButtonElement>(
     "button[form='form-playlist-access']",
@@ -263,6 +318,31 @@ function dialogText() {
 
 function optionLabels() {
   return selectOptions().map((item) => item.textContent?.trim());
+}
+
+function memberOptionLabels() {
+  return Array.from(
+    document.querySelectorAll("[data-slot='command-item']"),
+    (item) => item.textContent?.trim(),
+  );
+}
+
+async function openMemberPicker() {
+  document
+    .querySelector<HTMLElement>(
+      "button[aria-label='settings.source_access.select_members']",
+    )!
+    .click();
+  await settle();
+}
+
+async function pickMember(label: string) {
+  const option = Array.from(
+    document.querySelectorAll<HTMLElement>("[data-slot='command-item']"),
+  ).find((item) => item.textContent?.trim() === label);
+  if (!option) throw new Error(`no member "${label}": ${memberOptionLabels()}`);
+  option.click();
+  await settle();
 }
 
 // reka settles the listbox focus on a timer, so a plain flush is not enough


### PR DESCRIPTION
# What does this implement/fix?

The playlist Share dialog described a playlist without an owner as shared with "the owner and the members selected below". And when an admin picked "Selected members" for such a playlist, Save stayed disabled until somebody was picked, without saying why. The music source dialog got both fixes in #2735, this brings the playlist dialog in line.

- A playlist without an owner that is shared with selected members now reads "Only the members selected below."
- While nobody is picked, the dialog says "Nobody can see this playlist until it has an owner or is shared with someone." and Save stays disabled
- Save and the hint use the same check as the music source dialog, so they always agree

No screenshots: playlist sharing isn't in a server release or dev nightly yet.

**Related issue (if applicable):**

- related issue https://github.com/music-assistant/backlog/issues/84

**Related backend PR (if applicable):**

<!--
Link the music-assistant/server PR when this change relies on new server
behaviour, so the two can be reviewed and released together.
-->

- n/a

## Types of changes

<!--
Tick exactly one box below. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm lint:check` passes.
- [x] `pnpm test:run` passes, and tests have been added/updated where applicable.
- [x] `pnpm build` passes.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
